### PR TITLE
handling EmptyByteBuf injected by Netty and add debug options to some scripts

### DIFF
--- a/bin/corfuDBStreamSingle.sh
+++ b/bin/corfuDBStreamSingle.sh
@@ -10,12 +10,19 @@ else
     . "$CORFUDBBINDIR"/corfuDBEnv.sh
 fi
 
-if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 {start|stop|restart|status}"
+if [[ "$1" != "debug" && "$#" -ne 1 ]]; then
+    echo "Usage: $0 {start|debug <start-port-num>|stop|restart|status}"
     exit 1
 fi
 
-$CORFUDBBINDIR/corfuDBLaunch.sh streaming_sequencer $1
-$CORFUDBBINDIR/corfuDBLaunch.sh logunit $1
-$CORFUDBBINDIR/corfuDBLaunch.sh streaming_configmaster $1
-
+start_port=$2
+if [ "$#" -eq 1 ]
+then
+    $CORFUDBBINDIR/corfuDBLaunch.sh streaming_sequencer $1
+    $CORFUDBBINDIR/corfuDBLaunch.sh logunit $1
+    $CORFUDBBINDIR/corfuDBLaunch.sh streaming_configmaster $1
+else
+    $CORFUDBBINDIR/corfuDBLaunch.sh streaming_sequencer $1 $((start_port))
+    $CORFUDBBINDIR/corfuDBLaunch.sh logunit $1 $((start_port+1))
+    $CORFUDBBINDIR/corfuDBLaunch.sh streaming_configmaster $1 $((start_port+2))
+fi

--- a/conf/streaming_configmaster.yml
+++ b/conf/streaming_configmaster.yml
@@ -15,7 +15,7 @@ port: 8002
 pagesize: 4096
 epoch: 0
 sequencers:
-    - "cdbsts://localhost:8000"
+    - "nsss://localhost:8000"
 configmasters:
     - "cdbcm://localhost:8002"
 layout:
@@ -25,5 +25,5 @@ layout:
           sealed: -1
           groups:
               - nodes:
-                  - "cdbslu://localhost:8001"
+                  - "nlu://localhost:8001"
           replicas: 1

--- a/conf/streaming_sequencer.yml
+++ b/conf/streaming_sequencer.yml
@@ -8,7 +8,7 @@
 # role - org.corfudb.sharedlog.sequencer.StreamingSequencerServer selects the sequencer
 # port - the port number to run on
 
-role: org.corfudb.infrastructure.StreamingSequencerServer
+role: org.corfudb.infrastructure.NettyStreamingSequencerServer
 port: 8000
 configmaster: http://localhost:8002/corfu
 

--- a/src/main/java/org/corfudb/infrastructure/wireprotocol/NettyCorfuMessageDecoder.java
+++ b/src/main/java/org/corfudb/infrastructure/wireprotocol/NettyCorfuMessageDecoder.java
@@ -1,17 +1,34 @@
 package org.corfudb.infrastructure.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
 import java.util.List;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Created by mwei on 10/1/15.
  */
+@Slf4j
 public class NettyCorfuMessageDecoder extends ByteToMessageDecoder {
+
     @Override
     protected void decode(ChannelHandlerContext channelHandlerContext, ByteBuf byteBuf, List<Object> list) throws Exception {
-        list.add(NettyCorfuMsg.deserialize(byteBuf));
+		list.add(NettyCorfuMsg.deserialize(byteBuf));
     }
+
+	@Override
+	protected void decodeLast(ChannelHandlerContext ctx, ByteBuf in,
+			List<Object> out) throws Exception {
+        //log.info("Netty channel handler context goes inactive, received out size is {}", (out == null) ? null : out.size());
+
+        if (in != Unpooled.EMPTY_BUFFER) {
+            this.decode(ctx, in, out);
+        }
+        // ignore the Netty generated {@link EmptyByteBuf empty ByteBuf message} when channel handler goes inactive (typically happened after each received
+        // burst of batch of messages)
+	}
 }


### PR DESCRIPTION
This pull-request contains these changes:
- changing conf/streaming_configmaster and conf/logunit scripts to use netty logunit server and netty protocol. Without this change, streaming sequencer server will cause client to throw error "java.lang.RuntimeException: NewStreamingSequencer only supports INewStreamSequencer, primary sequencer is of type class org.corfudb.runtime.protocols.sequencers.CorfuDBStreamingSequencerProtocol".

- change NettyCorfuMessageDecoder to handle EmptyByteBuf message injected by Netty after each burst of incoming messages. Without this change, the changes made by one client on a corfuDB object shared by another client can't be sync-ed by the other client, the infinite loop of error caused is "io.netty.handler.codec.DecoderException: java.lang.IndexOutOfBoundsException".

- change scripts bin/corfuDBLaunch.sh and bin/corfuDBStreamingSingle.sh to add a debug option, this enables us to easily launch corfuDB servers in debug mode and attach a debugger to them. Right now, only these two scripts are modified because they are most heavily used.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/55)
<!-- Reviewable:end -->
