### PR TITLE
detect when the UUID of the instance changes and reset all local caches when that occurs.

### DIFF
--- a/src/main/java/org/corfudb/runtime/CorfuDBRuntime.java
+++ b/src/main/java/org/corfudb/runtime/CorfuDBRuntime.java
@@ -382,6 +382,7 @@ public class CorfuDBRuntime implements AutoCloseable {
         closed = true;
         viewManagerThread.interrupt();
     }
+
     /**
      * Retrieves a runnable that provides a view manager thread. The view
      * manager retrieves the view and manages view changes.

--- a/src/main/java/org/corfudb/runtime/view/IStreamAddressSpace.java
+++ b/src/main/java/org/corfudb/runtime/view/IStreamAddressSpace.java
@@ -191,4 +191,9 @@ public interface IStreamAddressSpace {
      * @param prefix    The prefix to be trimmed, inclusive.
      */
     void trim(UUID stream, long prefix);
+
+    /**
+     * Reset all caches.
+     */
+    void resetCaches();
 }

--- a/src/main/java/org/corfudb/runtime/view/LocalCorfuDBInstance.java
+++ b/src/main/java/org/corfudb/runtime/view/LocalCorfuDBInstance.java
@@ -143,7 +143,10 @@ public class LocalCorfuDBInstance implements ICorfuDBInstance {
         /* if the instance ID does not match, reset all the caches. */
         if (!view.getUUID().equals(UUID))
         {
-            /* This region is synchronized to make sure reset happens exactly once */
+            /* This region is synchronized to make sure reset happens exactly once.
+             * One thread will go in and reset all the caches, updating the UUID.
+             * The other threads will see that the UUID has changed and get the view again.
+             */
             synchronized (this) {
                 if (!view.getUUID().equals(UUID) && (UUID != null)) {
                     log.info("Instance has changed from ID {} to {}, resetting all local caches.",

--- a/src/main/java/org/corfudb/runtime/view/StreamAddressSpace.java
+++ b/src/main/java/org/corfudb/runtime/view/StreamAddressSpace.java
@@ -183,6 +183,16 @@ public class StreamAddressSpace implements IStreamAddressSpace {
         }
     }
 
+    /**
+     * Reset all caches.
+     */
+    @Override
+    public void resetCaches() {
+        /* Flush the async loading cache. */
+        cache.synchronous().invalidateAll();
+        log.info("Stream address space loading cache reset.");
+    }
+
 
     StreamAddressEntryCode entryCodeFromReadCode(ReadCode code)
     {

--- a/src/test/java/org/corfudb/runtime/view/StreamAddressSpaceIT.java
+++ b/src/test/java/org/corfudb/runtime/view/StreamAddressSpaceIT.java
@@ -55,6 +55,28 @@ public class StreamAddressSpaceIT {
                 .isEqualTo(true);
     }
 
+    @Test
+    public void resetCacheTest()
+    {
+        IStreamAddressSpace s = instance.getStreamAddressSpace();
+        String test = "hello world";
+        UUID id = UUID.randomUUID();
+        assertThat(instance.getView().getSegments().get(0).getGroups().get(0).get(0).ping())
+                .isTrue();
+
+        s.write(0, Collections.singleton(id), test);
+        IStreamAddressSpace.StreamAddressSpaceEntry entry = s.read(0);
+        assertThat(entry)
+                .isNotNull();
+
+        instance.getConfigurationMaster().resetAll();
+        s.resetCaches();
+
+        entry = s.read(0);
+        assertThat(entry)
+                .isNull();
+    }
+
     @After
     public void tearDown()
     {

--- a/src/test/java/org/corfudb/runtime/view/StreamAddressSpaceIT.java
+++ b/src/test/java/org/corfudb/runtime/view/StreamAddressSpaceIT.java
@@ -55,24 +55,30 @@ public class StreamAddressSpaceIT {
                 .isEqualTo(true);
     }
 
+    /** Test whether or not we can reset the caches */
     @Test
     public void resetCacheTest()
     {
+        /** Get the stream address space to test. */
         IStreamAddressSpace s = instance.getStreamAddressSpace();
         String test = "hello world";
+        /** Write to a random stream. */
         UUID id = UUID.randomUUID();
-        assertThat(instance.getView().getSegments().get(0).getGroups().get(0).get(0).ping())
-                .isTrue();
-
         s.write(0, Collections.singleton(id), test);
+        /** Read, so the entry gets cached. */
         IStreamAddressSpace.StreamAddressSpaceEntry entry = s.read(0);
+        /** The entry should not be null at this point. */
         assertThat(entry)
                 .isNotNull();
 
+        /** Reset the instance, so that nothing is on the log unit anymore. */
         instance.getConfigurationMaster().resetAll();
+        /** Manually reset the cache. The cache should now be empty. */
         s.resetCaches();
 
+        /** Read from the address space, which should now miss in the cache. */
         entry = s.read(0);
+        /** The entry should return NULL, which means that the cache was reset.*/
         assertThat(entry)
                 .isNull();
     }


### PR DESCRIPTION
This fix should prevent a lockup issue when resetAll() is called.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/56)
<!-- Reviewable:end -->
