### PR TITLE
fix stream indexing error and add a unit test to detect the problem in the future. Caffeine updated to 2.0.3 to suppress warning when readresult is null.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.3</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -180,8 +180,7 @@ public class LogUnitServer implements IServer {
         log.trace("Retrieve[{}]", address);
         if (fc == null)
         {
-            log.warn("This is an in-memory log unit, but a load was requested. " +
-                    "This usually indicates data was evicted due to OOM.");
+            log.trace("This is an in-memory log unit, but a load was requested.");
             return null;
         }
         else

--- a/src/main/java/org/corfudb/runtime/view/StreamView.java
+++ b/src/main/java/org/corfudb/runtime/view/StreamView.java
@@ -77,7 +77,7 @@ public class StreamView implements AutoCloseable {
                 //determine whether or not this is a hole
                 long latestToken = runtime.getSequencerView().nextToken(Collections.singleton(streamID), 0);
                 log.trace("Read[{}]: latest token at {}", streamID, latestToken);
-                if (latestToken == thisRead)
+                if (latestToken < thisRead)
                 {
                     logPointer.decrementAndGet();
                     return null;

--- a/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -1,0 +1,49 @@
+package org.corfudb.runtime.view;
+
+import lombok.Getter;
+import org.corfudb.infrastructure.LayoutServer;
+import org.corfudb.infrastructure.LogUnitServer;
+import org.corfudb.infrastructure.SequencerServer;
+import org.corfudb.protocols.wireprotocol.IMetadata;
+import org.corfudb.runtime.CorfuRuntime;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by mwei on 1/8/16.
+ */
+public class StreamViewTest extends AbstractViewTest {
+
+    @Getter
+    final String defaultConfigurationString = getDefaultEndpoint();
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadWriteFromStream()
+            throws Exception {
+        // default layout is chain replication.
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        //begin tests
+        CorfuRuntime r = getRuntime().connect();
+        UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
+        byte[] testPayload = "hello world".getBytes();
+
+        StreamView sv = r.getStreamsView().get(streamA);
+        sv.write(testPayload);
+
+        assertThat(sv.read().getPayload())
+                .isEqualTo("hello world".getBytes());
+
+        assertThat(sv.read())
+                .isEqualTo(null);
+    }
+}


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/72)
<!-- Reviewable:end -->
