### PR TITLE
fix broken debian package

### DIFF
--- a/src/deb/control/postinst
+++ b/src/deb/control/postinst
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 for filename in /usr/share/corfu/bin/*; do
-    if [ ${filename##*/} == "corfu_server" ]; then
+    if [ $(basename "$filename") == "corfu_server" ]; then
         ln -s /usr/share/corfu/scripts/corfu_server.sh /usr/local/bin/$(basename "$filename")
     else
         ln -s /usr/share/corfu/scripts/cmdlet.sh /usr/local/bin/$(basename "$filename")


### PR DESCRIPTION
currently the postinst package doesn't work on some versions of bash due to parameter expansion issues.
this fix uses basename isntead.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/78)
<!-- Reviewable:end -->
