### PR TITLE
Fixes empty deb files being put in the repository.

### DIFF
--- a/.travis_scripts/push_deb.sh
+++ b/.travis_scripts/push_deb.sh
@@ -3,7 +3,7 @@
 if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
         echo -e "Shipping deb package..."
-        mvn jdeb:jdeb
+        mvn deploy -DskipTests=true
         gpg --import public.key private.key
 #this is fragile and needs to account for changes in the filename
         DEBNAME="corfu_0.1+${TRAVIS_BUILD_NUMBER}_all.deb"


### PR DESCRIPTION
In order for jdeb to complete successfully, mvn deploy needs to be run.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/80)
<!-- Reviewable:end -->
