### PR TITLE
Address space cache, nicer version messages.

### DIFF
--- a/src/main/java/org/corfudb/cmdlets/corfu_as.java
+++ b/src/main/java/org/corfudb/cmdlets/corfu_as.java
@@ -2,6 +2,7 @@ package org.corfudb.cmdlets;
 
 import com.google.common.io.ByteStreams;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.ILogUnitEntry;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.GitRepositoryState;
 import org.docopt.Docopt;
@@ -78,7 +79,8 @@ public class corfu_as implements ICmdlet {
     void read(CorfuRuntime runtime, Map<String,Object> opts)
             throws Exception
     {
-        ReadResult r = runtime.getAddressSpaceView().read(Long.parseLong((String) opts.get("--log-address"))).getResult();
+        ILogUnitEntry r = runtime.getAddressSpaceView()
+                .read(Long.parseLong((String) opts.get("--log-address"))).getResult();
         switch (r.getResultType())
         {
             case EMPTY:

--- a/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -75,6 +75,18 @@ public class CorfuServer {
             + " -h, --help  Show this screen\n"
             + " --version  Show version\n";
 
+    public static void printLogo()
+    {
+        System.out.println(ansi().fg(WHITE).a("▄████████  ▄██████▄     ▄████████    ▄████████ ███    █▄").reset());
+        System.out.println(ansi().fg(WHITE).a("███    ███ ███    ███   ███    ███   ███    ███ ███    ███").reset());
+        System.out.println(ansi().fg(WHITE).a("███    █▀  ███    ███   ███    ███   ███    █▀  ███    ███").reset());
+        System.out.println(ansi().fg(WHITE).a("███        ███    ███  ▄███▄▄▄▄██▀  ▄███▄▄▄     ███    ███").reset());
+        System.out.println(ansi().fg(WHITE).a("███        ███    ███ ▀▀███▀▀▀▀▀   ▀▀███▀▀▀     ███    ███").reset());
+        System.out.println(ansi().fg(WHITE).a("███    █▄  ███    ███ ▀███████████   ███        ███    ███").reset());
+        System.out.println(ansi().fg(WHITE).a("███    ███ ███    ███   ███    ███   ███        ███    ███").reset());
+        System.out.println(ansi().fg(WHITE).a("████████▀   ▀██████▀    ███    ███   ███        ████████▀").reset());
+        System.out.println(ansi().fg(WHITE).a("                        ███    ███").reset());
+    }
     public static void main(String[] args) {
 
         // Parse the options given, using docopt.
@@ -84,6 +96,7 @@ public class CorfuServer {
         int port = Integer.parseInt((String) opts.get("<port>"));
         // Print a nice welcome message.
         AnsiConsole.systemInstall();
+        printLogo();
         System.out.println(ansi().a("Welcome to ").fg(RED).a("CORFU ").fg(MAGENTA).a("SERVER").reset());
         System.out.println(ansi().a("Version ").a(Version.getVersionString()).a(" (").fg(BLUE)
                 .a(GitRepositoryState.getRepositoryState().commitIdAbbrev).reset().a(")"));

--- a/src/main/java/org/corfudb/protocols/logprotocol/TXEntry.java
+++ b/src/main/java/org/corfudb/protocols/logprotocol/TXEntry.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.ILogUnitEntry;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogUnitReadResponseMsg;
 import org.corfudb.runtime.CorfuRuntime;
@@ -90,7 +91,7 @@ public class TXEntry extends LogEntry {
                 // Currently backpointers aren't available so we must scan.
                 for (long i = e.getValue().getLastTimestamp() + 1; i < timestamp; i++)
                 {
-                    LogUnitReadResponseMsg.ReadResult rr = runtime.getAddressSpaceView().read(i).getResult();
+                    ILogUnitEntry rr = runtime.getAddressSpaceView().read(i).getResult();
                     if (rr.getResultType() ==
                             LogUnitReadResponseMsg.ReadResultType.DATA &&
                             ((Set<UUID>) rr.getMetadataMap().get(IMetadata.LogUnitMetadataType.STREAM))

--- a/src/main/java/org/corfudb/protocols/logprotocol/TXEntry.java
+++ b/src/main/java/org/corfudb/protocols/logprotocol/TXEntry.java
@@ -95,10 +95,10 @@ public class TXEntry extends LogEntry {
                     if (rr.getResultType() ==
                             LogUnitReadResponseMsg.ReadResultType.DATA &&
                             ((Set<UUID>) rr.getMetadataMap().get(IMetadata.LogUnitMetadataType.STREAM))
-                                    .contains(e.getKey()))
+                                    .contains(e.getKey()) && e.getValue().getLastTimestamp() != i)
                     {
-                        log.debug("TX aborted due to mutation on stream {} at {}, tx is at {}", e.getKey(),
-                                i, timestamp);
+                        log.debug("TX aborted due to mutation on stream {} at {}, tx is at {}, object read at {}", e.getKey(),
+                                i, timestamp, e.getValue().getLastTimestamp());
                         return true;
                     }
                 }

--- a/src/main/java/org/corfudb/protocols/wireprotocol/ILogUnitEntry.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/ILogUnitEntry.java
@@ -1,0 +1,36 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+import lombok.Getter;
+
+import java.util.EnumMap;
+
+/**
+ * Created by mwei on 2/1/16.
+ */
+public interface ILogUnitEntry extends IMetadata {
+
+    /** Gets the type of result this entry represents.
+     *
+     * @return  The type of result this entry represents.
+     */
+    LogUnitReadResponseMsg.ReadResultType getResultType();
+
+    /** Gets the metadata map.
+     *
+     * @return  A map containing the metadata for this entry.
+     */
+    EnumMap<LogUnitMetadataType, Object> getMetadataMap();
+
+    /** Gets a ByteBuf representing the payload for this data.
+     *
+     * @return  A ByteBuf representing the payload for this data.
+     */
+    ByteBuf getBuffer();
+
+    /** Gets the deserialized payload.
+     *
+     * @return  An object representing the deserialized payload.
+     */
+    Object getPayload();
+}

--- a/src/main/java/org/corfudb/protocols/wireprotocol/LogUnitReadResponseMsg.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/LogUnitReadResponseMsg.java
@@ -56,7 +56,7 @@ public class LogUnitReadResponseMsg extends LogUnitPayloadMsg {
         }
     }
 
-    public static class ReadResult implements IMetadata {
+    public static class ReadResult implements ILogUnitEntry {
 
         /** The backing message for this read result. */
         LogUnitReadResponseMsg msg;

--- a/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -34,6 +34,21 @@ public class CorfuRuntime {
     /** The rate in seconds to retry accessing a layout, in case of a failure. */
     public int retryRate;
 
+    /** Whether or not to disable the cache. */
+    @Getter
+    public boolean cacheDisabled;
+
+    /**
+     * Whether or not to disable the cache
+     * @param disable   True, if the cache should be disabled, false otherwise.
+     * @return          A CorfuRuntime to support chaining.
+     */
+    public CorfuRuntime setCacheDisabled(boolean disable)
+    {
+        this.cacheDisabled = disable;
+        return this;
+    }
+
     /** Get a UUID for a named stream.
      *
      * @param string    The name of the stream.

--- a/src/main/java/org/corfudb/runtime/view/AbstractReplicationView.java
+++ b/src/main/java/org/corfudb/runtime/view/AbstractReplicationView.java
@@ -1,15 +1,15 @@
 package org.corfudb.runtime.view;
 
+import io.netty.buffer.ByteBuf;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
+import org.corfudb.protocols.wireprotocol.ILogUnitEntry;
+import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogUnitReadResponseMsg;
 import org.corfudb.runtime.exceptions.OverwriteException;
 
@@ -43,7 +43,32 @@ public abstract class AbstractReplicationView {
         @Getter
         final long address;
         @Getter
-        final LogUnitReadResponseMsg.ReadResult result;
+        final ILogUnitEntry result;
+    }
+
+    @ToString
+    @RequiredArgsConstructor
+    public static class CachedLogUnitEntry implements ILogUnitEntry
+    {
+        @Getter
+        final LogUnitReadResponseMsg.ReadResultType resultType;
+
+        @Getter
+        final EnumMap<LogUnitMetadataType, Object> metadataMap = new EnumMap<>(IMetadata.LogUnitMetadataType.class);
+
+        @Getter
+        final Object payload;
+
+        /**
+         * Gets a ByteBuf representing the payload for this data.
+         *
+         * @return A ByteBuf representing the payload for this data.
+         */
+        @Override
+        public ByteBuf getBuffer() {
+            log.warn("Attempted to get a buffer of a cached entry!");
+            throw new RuntimeException("Invalid attempt to get the ByteBuf of a cached entry!");
+        }
     }
 
     @Getter

--- a/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -1,6 +1,5 @@
 package org.corfudb.runtime.view;
 
-import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import lombok.Getter;
@@ -8,19 +7,14 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.LogUnitReadResponseMsg;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.OverwriteException;
-import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.util.CFUtils;
-import sun.rmi.runtime.Log;
 
 import java.time.Duration;
-import java.time.temporal.TemporalUnit;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 /** A view of the address space implemented by Corfu.
  *

--- a/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -74,12 +74,14 @@ public class AddressSpaceView extends AbstractView {
         });
 
         // Insert this write to our local cache.
-        AbstractReplicationView.CachedLogUnitEntry cachedEntry =
-                new AbstractReplicationView.CachedLogUnitEntry(LogUnitReadResponseMsg.ReadResultType.DATA,
-                        data);
-        cachedEntry.setBackpointerMap(backpointerMap);
-        cachedEntry.setStreams(stream);
-        readCache.put(address, new AbstractReplicationView.ReadResult(address, cachedEntry));
+        if (!runtime.isCacheDisabled()) {
+            AbstractReplicationView.CachedLogUnitEntry cachedEntry =
+                    new AbstractReplicationView.CachedLogUnitEntry(LogUnitReadResponseMsg.ReadResultType.DATA,
+                            data);
+            cachedEntry.setBackpointerMap(backpointerMap);
+            cachedEntry.setStreams(stream);
+            readCache.put(address, new AbstractReplicationView.ReadResult(address, cachedEntry));
+        }
     }
 
     /**
@@ -90,7 +92,10 @@ public class AddressSpaceView extends AbstractView {
      */
     public AbstractReplicationView.ReadResult read(long address)
     {
-        return readCache.get(address);
+        if (!runtime.isCacheDisabled()) {
+            return readCache.get(address);
+        }
+        return fetch(address);
     }
 
     /**

--- a/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -3,6 +3,8 @@ package org.corfudb.runtime.view;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.LogUnitReadResponseMsg;
 import org.corfudb.runtime.CorfuRuntime;
@@ -31,7 +33,9 @@ public class AddressSpaceView extends AbstractView {
     static LoadingCache<Long, AbstractReplicationView.ReadResult> readCache;
 
     /** Duration before retrying an empty read. */
-    static final Duration emptyDuration = Duration.ofMillis(5000L);
+    @Getter
+    @Setter
+    Duration emptyDuration = Duration.ofMillis(5000L);
 
     public AddressSpaceView(CorfuRuntime runtime)
     {

--- a/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -39,9 +39,7 @@ public class AddressSpaceView extends AbstractView {
         // We don't lock readCache, this should be ok in the rare
         // case we generate a second readCache as it won't be pointed to.
         if (readCache == null) {
-            readCache = Caffeine.newBuilder()
-                    .maximumSize(10_000)
-                    .build(this::cacheFetch);
+            resetCaches();
         }
         else {
             log.debug("Read cache already built, re-using existing read cache.");
@@ -51,7 +49,9 @@ public class AddressSpaceView extends AbstractView {
     /** Reset all in-memory caches. */
     public void resetCaches()
     {
-        readCache.invalidateAll();
+        readCache = Caffeine.newBuilder()
+                .maximumSize(10_000)
+                .build(this::cacheFetch);
     }
 
     /**

--- a/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -1,22 +1,57 @@
 package org.corfudb.runtime.view;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.LogUnitReadResponseMsg;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
+import org.corfudb.util.CFUtils;
+import sun.rmi.runtime.Log;
 
+import java.time.Duration;
+import java.time.temporal.TemporalUnit;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 /** A view of the address space implemented by Corfu.
  *
  * Created by mwei on 12/10/15.
  */
+@Slf4j
 public class AddressSpaceView extends AbstractView {
+
+    /** A cache for read results. */
+    static LoadingCache<Long, AbstractReplicationView.ReadResult> readCache;
+
+    /** Duration before retrying an empty read. */
+    static final Duration emptyDuration = Duration.ofMillis(5000L);
+
     public AddressSpaceView(CorfuRuntime runtime)
     {
         super(runtime);
+        // We don't lock readCache, this should be ok in the rare
+        // case we generate a second readCache as it won't be pointed to.
+        if (readCache == null) {
+            readCache = Caffeine.newBuilder()
+                    .maximumSize(10_000)
+                    .build(this::cacheFetch);
+        }
+        else {
+            log.debug("Read cache already built, re-using existing read cache.");
+        }
+    }
+
+    /** Reset all in-memory caches. */
+    public void resetCaches()
+    {
+        readCache.invalidateAll();
     }
 
     /**
@@ -37,18 +72,60 @@ public class AddressSpaceView extends AbstractView {
                    .write(address, stream, data, backpointerMap);
            return null;
         });
+
+        // Insert this write to our local cache.
+        AbstractReplicationView.CachedLogUnitEntry cachedEntry =
+                new AbstractReplicationView.CachedLogUnitEntry(LogUnitReadResponseMsg.ReadResultType.DATA,
+                        data);
+        cachedEntry.setBackpointerMap(backpointerMap);
+        cachedEntry.setStreams(stream);
+        readCache.put(address, new AbstractReplicationView.ReadResult(address, cachedEntry));
     }
 
     /**
      * Read the given object from an address and streams.
      *
      * @param address An address to read from.
+     * @return        A result, which be cached.
      */
     public AbstractReplicationView.ReadResult read(long address)
     {
+        return readCache.get(address);
+    }
+
+    /**
+     * Fetch an address for insertion into the cache.
+     * @param address An address to read from.
+     * @return        A result to be cached. If the readresult is empty,
+     *                This entry will be scheduled to self invalidate.
+     */
+    private AbstractReplicationView.ReadResult cacheFetch(long address)
+    {
+        log.trace("Cache miss @ {}, fetching.", address);
+        AbstractReplicationView.ReadResult result = fetch(address);
+        if (result.getResult().getResultType() == LogUnitReadResponseMsg.ReadResultType.EMPTY)
+        {
+            //schedule an eviction
+            CompletableFuture.runAsync(() -> {
+                log.trace("Evicting empty entry at {}.", address);
+                CFUtils.runAfter(emptyDuration, () -> {
+                    readCache.invalidate(address);
+                });
+            });
+        }
+        return result;
+    }
+
+    /**
+     * Explicitly fetch a given address, bypassing the cache.
+     * @param address An address to read from.
+     * @return        A result, which will be uncached.
+     */
+    public AbstractReplicationView.ReadResult fetch(long address)
+    {
         return layoutHelper(l -> AbstractReplicationView
-                     .getReplicationView(l, l.getReplicationMode(address))
-                    .read(address)
+                        .getReplicationView(l, l.getReplicationMode(address))
+                        .read(address)
         );
     }
 

--- a/src/main/java/org/corfudb/util/CFUtils.java
+++ b/src/main/java/org/corfudb/util/CFUtils.java
@@ -90,6 +90,15 @@ public class CFUtils {
         return promise;
     }
 
+    /** Schedules a runnable after a given time
+     * @param duration  The duration to timeout after.
+     * @return          A completable future that will time out.
+     */
+    public static void runAfter(Duration duration, Runnable toRun) {
+        final CompletableFuture<Void> promise = new CompletableFuture<>();
+        scheduler.schedule(toRun::run, duration.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
     /** Takes a completable future, and ensures that it completes within a certain duration. If it does
      * not, it is cancelled and completes exceptionally with TimeoutException.
      *  inspired by NoBlogDefFound: http://www.nurkiewicz.com/2014/12/asynchronous-timeouts-with.html

--- a/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -56,7 +56,6 @@ public class SMRMapTest extends AbstractViewTest {
         getRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
-        getRuntime().getObjectsView().TXBegin();
         testMap.clear();
         assertThat(testMap.put("a","a"))
                 .isNull();
@@ -64,7 +63,6 @@ public class SMRMapTest extends AbstractViewTest {
                 .isEqualTo("a");
         assertThat(testMap.get("a"))
                 .isEqualTo("b");
-        getRuntime().getObjectsView().TXEnd();
 
         assertThat(testMap.get("a"))
                 .isEqualTo("b");

--- a/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -56,14 +56,15 @@ public class SMRMapTest extends AbstractViewTest {
         getRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
-        testMap.clear();
+        //testMap.clear();  //TODO: handle the state where the mutator is used (sync at TXBegin?).
+        getRuntime().getObjectsView().TXBegin();
         assertThat(testMap.put("a","a"))
                 .isNull();
         assertThat(testMap.put("a","b"))
                 .isEqualTo("a");
         assertThat(testMap.get("a"))
                 .isEqualTo("b");
-
+        getRuntime().getObjectsView().TXEnd();
         assertThat(testMap.get("a"))
                 .isEqualTo("b");
     }
@@ -101,14 +102,15 @@ public class SMRMapTest extends AbstractViewTest {
                 .setCacheDisabled(false);
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
-        testMap.clear();
+        //testMap.clear();
+        getRuntime().getObjectsView().TXBegin();
         assertThat(testMap.put("a","a"))
                 .isNull();
         assertThat(testMap.put("a","b"))
                 .isEqualTo("a");
         assertThat(testMap.get("a"))
                 .isEqualTo("b");
-
+        getRuntime().getObjectsView().TXEnd();
         assertThat(testMap.get("a"))
                 .isEqualTo("b");
     }

--- a/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -49,4 +49,5 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
         assertThat(testMap2.get("a"))
                 .isEqualTo("b");
     }
+
 }

--- a/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -36,6 +36,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
         routerMap.clear();
         serverMap.clear();
         runtime.parseConfigurationString(getDefaultConfigurationString());
+        runtime.getAddressSpaceView().resetCaches();
     }
 
     /** Wire all registered servers to the correct router.

--- a/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -35,7 +35,8 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
     {
         routerMap.clear();
         serverMap.clear();
-        runtime.parseConfigurationString(getDefaultConfigurationString());
+        runtime.parseConfigurationString(getDefaultConfigurationString())
+                .setCacheDisabled(true); // Disable cache during unit tests to fully stress the system.
         runtime.getAddressSpaceView().resetCaches();
     }
 

--- a/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -33,7 +33,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         assertThat(getRuntime().getAddressSpaceView().read(0).getResult().getResultType())
                 .isEqualTo(LogUnitReadResponseMsg.ReadResultType.EMPTY);
         getRuntime().getLayoutView().getLayout().getLogUnitClient(0, 0).fillHole(0);
-        try {Thread.sleep(1);} catch (InterruptedException e) {// don't do anything
+        try {Thread.sleep(100);} catch (InterruptedException e) {// don't do anything
         }
         assertThat(getRuntime().getAddressSpaceView().read(0).getResult().getResultType())
                 .isEqualTo(LogUnitReadResponseMsg.ReadResultType.FILLED_HOLE);

--- a/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -1,0 +1,41 @@
+package org.corfudb.runtime.view;
+
+import lombok.Getter;
+import org.corfudb.infrastructure.LayoutServer;
+import org.corfudb.infrastructure.LogUnitServer;
+import org.corfudb.infrastructure.SequencerServer;
+import org.corfudb.protocols.wireprotocol.LogUnitReadResponseMsg;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by mwei on 2/1/16.
+ */
+public class AddressSpaceViewTest extends AbstractViewTest {
+
+    @Getter
+    final String defaultConfigurationString = getDefaultEndpoint();
+
+    @Test
+    public void cacheMissTimesOut() {
+        // default layout is chain replication.
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        getRuntime().setCacheDisabled(false).connect();
+
+        getRuntime().getAddressSpaceView().setEmptyDuration(Duration.ofNanos(100));
+        assertThat(getRuntime().getAddressSpaceView().read(0).getResult().getResultType())
+                .isEqualTo(LogUnitReadResponseMsg.ReadResultType.EMPTY);
+        getRuntime().getLayoutView().getLayout().getLogUnitClient(0, 0).fillHole(0);
+        try {Thread.sleep(1);} catch (InterruptedException e) {// don't do anything
+        }
+        assertThat(getRuntime().getAddressSpaceView().read(0).getResult().getResultType())
+                .isEqualTo(LogUnitReadResponseMsg.ReadResultType.FILLED_HOLE);
+    }
+}

--- a/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -49,6 +49,32 @@ public class StreamViewTest extends AbstractViewTest {
 
     @Test
     @SuppressWarnings("unchecked")
+    public void canReadWriteFromCachedStream()
+            throws Exception {
+        // default layout is chain replication.
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        //begin tests
+        CorfuRuntime r = getRuntime().connect()
+                .setCacheDisabled(false);
+        UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
+        byte[] testPayload = "hello world".getBytes();
+
+        StreamView sv = r.getStreamsView().get(streamA);
+        sv.write(testPayload);
+
+        assertThat(sv.read().getResult().getPayload())
+                .isEqualTo("hello world".getBytes());
+
+        assertThat(sv.read())
+                .isEqualTo(null);
+    }
+
+        @Test
+    @SuppressWarnings("unchecked")
     public void streamCanSurviveOverwriteException()
             throws Exception {
         // default layout is chain replication.


### PR DESCRIPTION
This pull request implements address space caching,
which improves the performance of the local client
significantly.

Currently, version messages always show commitid-dirty since the repo 
will be dirty after build. This change inserts the correct build string.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/83)
<!-- Reviewable:end -->
