### PR TITLE
Implement sequencer recovery

### DIFF
--- a/src/main/java/org/corfudb/infrastructure/IServer.java
+++ b/src/main/java/org/corfudb/infrastructure/IServer.java
@@ -20,4 +20,11 @@ public interface IServer {
      *
      */
     void reset();
+
+    /** Shutdown the server.
+     *
+     */
+    default void shutdown() {
+
+    }
 }

--- a/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -16,6 +16,7 @@ import org.corfudb.util.Utils;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.IntervalAndSentinelRetry;
 
+import java.io.File;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.FileSystems;
@@ -85,7 +86,7 @@ public class LogUnitServer implements IServer {
         }
         else {
             try {
-                fc = FileChannel.open(FileSystems.getDefault().getPath((String) opts.get("--log-path")),
+                fc = FileChannel.open(FileSystems.getDefault().getPath((String) opts.get("--log-path") + File.separator + "log"),
                         EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE,
                                 StandardOpenOption.CREATE, StandardOpenOption.SPARSE));
                 filePointer = new AtomicLong(fc.size());
@@ -248,7 +249,8 @@ public class LogUnitServer implements IServer {
         log.trace("Eviction[{}]: {}", address, cause);
         if (entry.buffer != null) {
             if (fc == null) {
-                log.warn("This is an in-memory log unit, data@{} will be evicted and lost due to {}!", address, cause);
+                log.warn("This is an in-memory log unit, data@{} will be trimmed and lost due to {}!", address, cause);
+                trimRange.add(Range.closed(address, address));
             } else if (!entry.isPersisted) { //don't persist an entry twice.
                 //evict the data by getting the next pointer.
                 try {

--- a/src/main/java/org/corfudb/util/Utils.java
+++ b/src/main/java/org/corfudb/util/Utils.java
@@ -19,7 +19,16 @@ public class Utils
      * @param toParse
      * @return
      */
-    public static long parseLong(final String toParse) {
+    public static long parseLong(final Object toParseObj) {
+        if (toParseObj instanceof Long)
+        {
+            return (Long) toParseObj;
+        }
+        if (toParseObj instanceof Integer)
+        {
+            return (Integer) toParseObj;
+        }
+        String toParse = (String) toParseObj;
         if (toParse.matches("[0-9]*[A-Za-z]$"))
         {
             long multiplier;

--- a/src/test/java/org/corfudb/infrastructure/SequencerServerAssertions.java
+++ b/src/test/java/org/corfudb/infrastructure/SequencerServerAssertions.java
@@ -1,0 +1,31 @@
+package org.corfudb.infrastructure;
+
+import org.assertj.core.api.AbstractAssert;
+
+/**
+ * Created by mwei on 2/2/16.
+ */
+public class SequencerServerAssertions  extends AbstractAssert<SequencerServerAssertions, SequencerServer> {
+
+    public SequencerServerAssertions(SequencerServer actual)
+    {
+        super(actual, SequencerServerAssertions.class);
+    }
+
+    public static SequencerServerAssertions assertThat(SequencerServer actual)
+    {
+        return new SequencerServerAssertions(actual);
+    }
+
+    public SequencerServerAssertions tokenIsAt(long address) {
+        isNotNull();
+
+        if (actual.globalIndex.get() != address)
+        {
+            failWithMessage("Expected token to be at <%d> but got <%d>!", address, actual.globalIndex.get());
+        }
+
+        return this;
+    }
+
+}

--- a/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
@@ -1,8 +1,6 @@
 package org.corfudb.runtime.view;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 import org.corfudb.infrastructure.LayoutServer;
 import org.corfudb.infrastructure.LogUnitServer;


### PR DESCRIPTION
This patch implements sequencer recovery via checkpointing. 
The sequencer periodically checkpoints its state to a file, and
recovers from that state during a cold start unless initial-token is set.

The checkpoint rate can be set via the --checkpoint command
line option.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/86)
<!-- Reviewable:end -->
