### PR TITLE
fix concurrency bug in objectproxy

### DIFF
--- a/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -125,6 +125,10 @@ public class AbstractCorfuTest {
                 f.get();
             }
         } catch (ExecutionException ee) {
+            if (ee.getCause() instanceof Error)
+            {
+                throw (Error) ee.getCause();
+            }
             throw (Exception) ee.getCause();
         }
         catch (InterruptedException ie) {

--- a/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -34,7 +34,7 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .put("--log-path", serviceDir)
                 .put("--memory", false)
                 .put("--single", false)
-                .put("--sync", false)
+                .put("--sync", true)
                 .put("--max-cache", 1000000)
                 .build());
 
@@ -77,7 +77,7 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .put("--log-path", serviceDir)
                 .put("--single", false)
                 .put("--memory", false)
-                .put("--sync", false)
+                .put("--sync", true)
                 .put("--max-cache", 1000000)
                 .build());
         this.router.setServerUnderTest(s2);

--- a/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -50,4 +51,71 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
                 .isEqualTo("b");
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void multipleWritesConsistencyTest()
+            throws Exception {
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        getRuntime().connect();
+
+        Map<String,String> testMap = getRuntime().getObjectsView().open(
+                CorfuRuntime.getStreamID("test"), TreeMap.class);
+        testMap.clear();
+
+        for (int i = 0; i < 10_000; i++) {
+            assertThat(testMap.put(Integer.toString(i), Integer.toString(i)))
+                    .isNull();
+        }
+
+        Map<String,String> testMap2 = getRuntime().getObjectsView().open(
+                CorfuRuntime.getStreamID("test"), TreeMap.class);
+        for (int i = 0; i < 10_000; i++) {
+            assertThat(testMap2.get(Integer.toString(i)))
+                    .isEqualTo(Integer.toString(i));
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void multipleWritesConsistencyTestConcurrent()
+            throws Exception {
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        getRuntime().connect();
+
+
+        Map<String,String> testMap = getRuntime().getObjectsView().open(
+                CorfuRuntime.getStreamID("test"), TreeMap.class);
+        testMap.clear();
+        int num_threads = 5;
+        int num_records = 1_000;
+
+        scheduleConcurrently(num_threads, threadNumber -> {
+            int base = threadNumber * num_records;
+            for (int i = base; i < base + num_records; i++) {
+                assertThat(testMap.put(Integer.toString(i), Integer.toString(i)))
+                        .isEqualTo(null);
+            }
+        });
+        executeScheduled(num_threads, 50, TimeUnit.SECONDS);
+
+        Map<String,String> testMap2 = getRuntime().getObjectsView().open(
+                CorfuRuntime.getStreamID("test"), TreeMap.class);
+
+        scheduleConcurrently(num_threads, threadNumber -> {
+            int base = threadNumber * num_records;
+            for (int i = base; i < base + num_records; i++) {
+                assertThat(testMap2.get(Integer.toString(i)))
+                        .isEqualTo(Integer.toString(i));
+            }
+        });
+        executeScheduled(num_threads, 50, TimeUnit.SECONDS);
+    }
 }


### PR DESCRIPTION
Due to a concurrency bug, the accessormutator would sometimes return an incorrect result. This
patch fixes that bug by using completablefutures to wrap results.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/90)
<!-- Reviewable:end -->
