### PR TITLE
Use only a single file mapping per file.

### DIFF
--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,6 +7,6 @@
     </appender>
 
     <root level="TRACE">
-      <!-- <appender-ref ref="STDOUT" /> -->
+       <!--<appender-ref ref="STDOUT" />-->
     </root>
 </configuration>


### PR DESCRIPTION
Previously we were creating a new mapping per entry, which invoked a system call and was expensive. This patch creates a single large (2GB) mapping per file.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/91)
<!-- Reviewable:end -->
