### PR TITLE
CoW Objects, Primitive Serializer support

### DIFF
--- a/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
+++ b/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
@@ -26,7 +26,8 @@ public class LogEntry implements ICorfuSerializable {
         NOP(0, LogEntry.class),
         SMR(1, SMREntry.class),
         TX(2, TXEntry.class),
-        STREAM_HINT(3, StreamHintEntry.class)
+        STREAM_HINT(3, StreamHintEntry.class),
+        STREAM_COW(4, StreamCOWEntry.class)
         ;
 
         public final int type;

--- a/src/main/java/org/corfudb/protocols/logprotocol/StreamCOWEntry.java
+++ b/src/main/java/org/corfudb/protocols/logprotocol/StreamCOWEntry.java
@@ -1,0 +1,61 @@
+package org.corfudb.protocols.logprotocol;
+
+import com.google.common.collect.Range;
+import com.google.common.collect.TreeRangeSet;
+import io.netty.buffer.ByteBuf;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.util.serializer.Serializers;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Created by mwei on 2/18/16.
+ */
+@ToString(callSuper = true)
+@NoArgsConstructor
+public class StreamCOWEntry extends LogEntry {
+
+    @Getter
+    UUID originalStream;
+
+    @Getter
+    long followUntil;
+
+    public StreamCOWEntry(UUID originalStream, long followUntil)
+    {
+        super(LogEntryType.STREAM_COW);
+        this.originalStream = originalStream;
+        this.followUntil = followUntil;
+    }
+
+    /**
+     * Serialize the message into the given bytebuffer.
+     *
+     * @param buffer The buffer to serialize to.
+     */
+    @Override
+    public void serialize(ByteBuf buffer) {
+        super.serialize(buffer);
+        buffer.writeLong(originalStream.getMostSignificantBits());
+        buffer.writeLong(originalStream.getLeastSignificantBits());
+        buffer.writeLong(followUntil);
+    }
+
+    /**
+     * Parse the rest of the message from the buffer. Classes that extend CorfuMsg
+     * should parse their fields in this method.
+     *
+     * @param buffer
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void deserializeBuffer(ByteBuf buffer, CorfuRuntime rt) {
+        super.deserializeBuffer(buffer, rt);
+        this.originalStream = new UUID(buffer.readLong(), buffer.readLong());
+        this.followUntil = buffer.readLong();
+    }
+}

--- a/src/main/java/org/corfudb/protocols/logprotocol/StreamCOWEntry.java
+++ b/src/main/java/org/corfudb/protocols/logprotocol/StreamCOWEntry.java
@@ -1,15 +1,11 @@
 package org.corfudb.protocols.logprotocol;
 
-import com.google.common.collect.Range;
-import com.google.common.collect.TreeRangeSet;
+
 import io.netty.buffer.ByteBuf;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.util.serializer.Serializers;
-
-import java.util.Set;
 import java.util.UUID;
 
 /**

--- a/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
@@ -225,8 +225,8 @@ public class CorfuSMRObjectProxy<P> {
                     smrObject = originalClass.newInstance();
                 } else {
                     Class[] typeList = Arrays.stream(creationArguments)
-                            .map(x -> x.getClass())
-                            .toArray(s -> new Class[s]);
+                            .map(Object::getClass)
+                            .toArray(Class[]::new);
 
                     originalClass
                             .getDeclaredConstructor(typeList)
@@ -259,8 +259,8 @@ public class CorfuSMRObjectProxy<P> {
                                                                 ).newInstance();
                     } else {
                         Class[] typeList = Arrays.stream(creationArguments)
-                                .map(x -> x.getClass())
-                                .toArray(s -> new Class[s]);
+                                .map(Object::getClass)
+                                .toArray(Class[]::new);
 
                         smrObject = ((Class)((ParameterizedType)pt.getActualTypeArguments()[0]).getRawType())
                                 .getDeclaredConstructor(typeList)
@@ -338,7 +338,12 @@ public class CorfuSMRObjectProxy<P> {
             StackTraceElement[] stack = new Exception().getStackTrace();
             if (stack.length > 6 && stack[6].getClassName().equals("org.corfudb.runtime.object.CorfuSMRObjectProxy"))
             {
-                return superMethod.call();
+                if (isCorfuObject) {
+                    return superMethod.call();
+                }
+                else {
+                    return Mmethod.invoke(getSMRObjectInterceptor().interceptGetSMRObject(null), allArguments);
+                }
             }
             else if (!TransactionalContext.isInTransaction()){
                 // write the update to the stream and map a future for the completion.

--- a/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.object;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.Reflection;
 import javassist.ClassPool;
 import javassist.CtClass;
@@ -390,6 +391,30 @@ public class CorfuSMRObjectProxy<P> {
         return s.substring(0, s.indexOf("("));
     }
 
+    static Map<String, Class> primitiveTypeMap = ImmutableMap.<String, Class>builder()
+            .put("int", Integer.TYPE)
+            .put("long", Long.TYPE)
+            .put("double", Double.TYPE)
+            .put("float", Float.TYPE)
+            .put("bool", Boolean.TYPE)
+            .put("char", Character.TYPE)
+            .put("byte", Byte.TYPE)
+            .put("void", Void.TYPE)
+            .put("short", Short.TYPE)
+            .put("int[]", int[].class)
+            .put("long[]", long[].class)
+            .put("double[]", double[].class)
+            .put("float[]", float[].class)
+            .put("bool[]", boolean[].class)
+            .put("char[]", char[].class)
+            .put("byte[]", byte[].class)
+            .put("short[]", short[].class)
+            .build();
+
+    public static Class<?> getPrimitiveType(String s) {
+        return primitiveTypeMap.get(s);
+    }
+
     public static Class[] getArgumentTypesFromString(String s) {
         String argList = s.substring(s.indexOf("(") + 1, s.length() - 1);
         return Arrays.stream(argList.split(","))
@@ -398,8 +423,11 @@ public class CorfuSMRObjectProxy<P> {
                     try {
                         return Class.forName(x);
                     } catch (ClassNotFoundException cnfe) {
-                        log.warn("Class {} not found", x);
-                        return null;
+                        Class retVal = getPrimitiveType(x);
+                        if (retVal == null) {
+                            log.warn("Class {} not found", x);
+                        }
+                        return retVal;
                     }
                 })
                 .toArray(Class[]::new);

--- a/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
@@ -133,7 +133,11 @@ public class CorfuSMRObjectProxy<P> {
             }
                     DynamicType.Builder<T> bb = new ByteBuddy().subclass(type)
                             .defineField("_corfuStreamID", UUID.class)
-                            .defineField("_corfuSMRProxy", CorfuSMRObjectProxy.class);
+                            .defineField("_corfuSMRProxy", CorfuSMRObjectProxy.class)
+                            .implement(ICorfuSMRObject.class)
+                            .method(ElementMatchers.named("getSMRObject"))
+                            .intercept(MethodDelegation.to(proxy.getSMRObjectInterceptor()));
+
                     try {
                                 bb = bb.method(ElementMatchers.isAnnotatedWith(Mutator.class)
                                 .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Instrumented.class))))
@@ -165,6 +169,7 @@ public class CorfuSMRObjectProxy<P> {
                             .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(MutatorAccessor.class)))
                             .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(DontInstrument.class)))
                             .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Instrumented.class)))
+                            .and(ElementMatchers.not(ElementMatchers.isDeclaredBy(Object.class)))
                             .and(ElementMatchers.not(ElementMatchers.isDefaultMethod())))
                             .intercept(MethodDelegation.to(proxy.getMutatorAccessorInterceptor()))
                             .annotateMethod(instrumentedDescription);

--- a/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
@@ -156,6 +156,7 @@ public class CorfuSMRObjectProxy<P> {
                     bb = bb.method(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Mutator.class))
                             .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Accessor.class)))
                             .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(MutatorAccessor.class)))
+                            .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(DontInstrument.class)))
                             .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Instrumented.class)))
                             .and(ElementMatchers.not(ElementMatchers.isDefaultMethod())))
                             .intercept(MethodDelegation.to(proxy.getMutatorAccessorInterceptor()))

--- a/src/main/java/org/corfudb/runtime/object/DontInstrument.java
+++ b/src/main/java/org/corfudb/runtime/object/DontInstrument.java
@@ -1,0 +1,12 @@
+package org.corfudb.runtime.object;
+
+import java.lang.annotation.*;
+
+/**
+ * Created by mwei on 2/17/16.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface DontInstrument {
+}

--- a/src/main/java/org/corfudb/runtime/view/ObjectOpenOptions.java
+++ b/src/main/java/org/corfudb/runtime/view/ObjectOpenOptions.java
@@ -1,0 +1,8 @@
+package org.corfudb.runtime.view;
+
+/**
+ * Created by mwei on 2/18/16.
+ */
+public enum ObjectOpenOptions {
+    NO_CACHE
+}

--- a/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.view;
 
+import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.TXEntry;
@@ -10,7 +11,8 @@ import org.corfudb.runtime.object.ISMRInterface;
 import org.corfudb.runtime.object.TransactionalContext;
 
 import java.lang.reflect.Field;
-import java.util.UUID;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 /**
@@ -20,6 +22,14 @@ import java.util.function.Supplier;
 @Slf4j
 public class ObjectsView extends AbstractView {
 
+    @Data
+    class ObjectID<T,R> {
+        final UUID streamID;
+        final Class<T> type;
+        final Class<R> overlay;
+    }
+
+    Map<ObjectID, Object> objectCache = new ConcurrentHashMap<>();
 
     public ObjectsView(CorfuRuntime runtime) {
         super(runtime);
@@ -86,8 +96,36 @@ public class ObjectsView extends AbstractView {
      */
     @SuppressWarnings("unchecked")
     public <T, R extends ISMRInterface> T open(@NonNull UUID streamID, @NonNull Class<T> type, Class<R> overlay) {
-        StreamView sv = runtime.getStreamsView().get(streamID);
-        return CorfuSMRObjectProxy.getProxy(type, overlay, sv, runtime);
+        return open(streamID, type, overlay, Collections.emptySet());
+    }
+
+    /** Gets a view of an object in the Corfu instance.
+     *
+     * @param streamID      The stream that the object should be read from.
+     * @param type          The type of the object that should be opened.
+     *                      If the type implements ICorfuSMRObject or implements an interface which implements
+     *                      ISMRInterface, Accessors, Mutator and MutatorAccessor annotations will be respected.
+     *                      Otherwise, the entire object will be wrapped around SMR and it will be assumed that
+     *                      all methods are MutatorAccessors.
+     * @param overlay       The ISMRInterface to overlay on top of the object, if provided.
+     * @param options       The options to use for opening the object.
+     * @param <T>           The type of object to return.
+     * @return              Returns a view of the object in a Corfu instance.
+     */
+    @SuppressWarnings("unchecked")
+    public <T, R extends ISMRInterface> T open(@NonNull UUID streamID, @NonNull Class<T> type, Class<R> overlay,
+                                               Set<ObjectOpenOptions> options) {
+        if (options.contains(ObjectOpenOptions.NO_CACHE))
+        {
+            StreamView sv = runtime.getStreamsView().get(streamID);
+            return CorfuSMRObjectProxy.getProxy(type, overlay, sv, runtime);
+        }
+
+        ObjectID<T,R> oid = new ObjectID(streamID, type, overlay);
+        return (T) objectCache.computeIfAbsent(oid, x -> {
+            StreamView sv = runtime.getStreamsView().get(streamID);
+            return CorfuSMRObjectProxy.getProxy(type, overlay, sv, runtime);
+        });
     }
 
     /** Creates a copy-on-write copy of an object.
@@ -103,9 +141,12 @@ public class ObjectsView extends AbstractView {
             Field f = obj.getClass().getDeclaredField("_corfuSMRProxy");
             f.setAccessible(true);
             CorfuSMRObjectProxy<T> proxy = (CorfuSMRObjectProxy<T>) f.get(obj);
-            StreamView sv = runtime.getStreamsView().copy(proxy.getSv().getStreamID(),
-                    destination, proxy.getTimestamp());
-            return CorfuSMRObjectProxy.getProxy(proxy.getOriginalClass(), null, sv, runtime);
+            ObjectID oid = new ObjectID(destination, proxy.getOriginalClass(), null);
+            return (T) objectCache.computeIfAbsent(oid, x -> {
+                StreamView sv = runtime.getStreamsView().copy(proxy.getSv().getStreamID(),
+                        destination, proxy.getTimestamp());
+                return CorfuSMRObjectProxy.getProxy(proxy.getOriginalClass(), null, sv, runtime);
+            });
         } catch (NoSuchFieldException nsfe) {
             throw new RuntimeException("Object given not a corfu object!");
         } catch (IllegalAccessException iae) {

--- a/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -9,6 +9,7 @@ import org.corfudb.runtime.object.CorfuSMRObjectProxy;
 import org.corfudb.runtime.object.ISMRInterface;
 import org.corfudb.runtime.object.TransactionalContext;
 
+import java.lang.reflect.Field;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -87,6 +88,41 @@ public class ObjectsView extends AbstractView {
     public <T, R extends ISMRInterface> T open(@NonNull UUID streamID, @NonNull Class<T> type, Class<R> overlay) {
         StreamView sv = runtime.getStreamsView().get(streamID);
         return CorfuSMRObjectProxy.getProxy(type, overlay, sv, runtime);
+    }
+
+    /** Creates a copy-on-write copy of an object.
+     *
+     * @param obj           The object that should be copied.
+     * @param destination   The destination ID of the object to be copied.
+     * @param <T>           The type of the object being copied.
+     * @return              A copy-on-write copy of the object.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T copy(@NonNull T obj, @NonNull UUID destination) {
+        try {
+            Field f = obj.getClass().getDeclaredField("_corfuSMRProxy");
+            f.setAccessible(true);
+            CorfuSMRObjectProxy<T> proxy = (CorfuSMRObjectProxy<T>) f.get(obj);
+            StreamView sv = runtime.getStreamsView().copy(proxy.getSv().getStreamID(),
+                    destination, proxy.getTimestamp());
+            return CorfuSMRObjectProxy.getProxy(proxy.getOriginalClass(), null, sv, runtime);
+        } catch (NoSuchFieldException nsfe) {
+            throw new RuntimeException("Object given not a corfu object!");
+        } catch (IllegalAccessException iae) {
+            throw new RuntimeException("Illegal access: misconfiguration?");
+        }
+    }
+
+    /** Creates a copy-on-write copy of an object.
+     *
+     * @param obj           The object that should be copied.
+     * @param destination   The destination stream name of the object to be copied.
+     * @param <T>           The type of the object being copied.
+     * @return              A copy-on-write copy of the object.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T copy(@NonNull T obj, @NonNull String destination) {
+        return copy(obj, CorfuRuntime.getStreamID(destination));
     }
 
     /** Begins a transaction on the current thread.

--- a/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -7,8 +7,10 @@ import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.ObjectOpenOptions;
 import org.junit.Test;
 
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -278,7 +280,8 @@ public class SMRMapTest extends AbstractViewTest {
                 .isEqualTo("b");
         CompletableFuture cf = CompletableFuture.runAsync(() -> {
             Map<String,String> testMap2 = getRuntime().getObjectsView()
-                    .open(UUID.nameUUIDFromBytes("A".getBytes()), SMRMap.class);
+                    .open(UUID.nameUUIDFromBytes("A".getBytes()), SMRMap.class, null,
+                            EnumSet.of(ObjectOpenOptions.NO_CACHE));
             testMap2.put("a", "f");
         });
         cf.join();

--- a/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -118,4 +118,22 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
         });
         executeScheduled(num_threads, 50, TimeUnit.SECONDS);
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canWrapObjectWithPrimitiveTypes()
+            throws Exception {
+        // default layout is chain replication.
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        //begin tests
+        CorfuRuntime r = getRuntime().connect();
+        TestClassWithPrimitives test = r.getObjectsView().open("test", TestClassWithPrimitives.class);
+        test.setPrimitive("hello world".getBytes());
+        assertThat(test.getPrimitive())
+                .isEqualTo("hello world".getBytes());
+    }
 }

--- a/src/test/java/org/corfudb/runtime/object/TestClassWithPrimitives.java
+++ b/src/test/java/org/corfudb/runtime/object/TestClassWithPrimitives.java
@@ -1,0 +1,23 @@
+package org.corfudb.runtime.object;
+
+/**
+ * Created by mwei on 2/18/16.
+ */
+public class TestClassWithPrimitives {
+
+    byte[] a;
+
+    public TestClassWithPrimitives() {
+
+    }
+
+    @Mutator
+    void setPrimitive(byte[] a) {
+        this.a = a;
+    }
+
+    @Accessor
+    byte[] getPrimitive() {
+        return a;
+    }
+}

--- a/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -1,0 +1,49 @@
+package org.corfudb.runtime.view;
+
+import lombok.Getter;
+import org.corfudb.infrastructure.LayoutServer;
+import org.corfudb.infrastructure.LogUnitServer;
+import org.corfudb.infrastructure.SequencerServer;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.SMRMap;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by mwei on 2/18/16.
+ */
+public class ObjectsViewTest extends AbstractViewTest  {
+
+    @Getter
+    final String defaultConfigurationString = getDefaultEndpoint();
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canCopyObject()
+            throws Exception {
+        // default layout is chain replication.
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        //begin tests
+        CorfuRuntime r = getRuntime().connect();
+        Map<String, String> smrMap = r.getObjectsView().open("map a", SMRMap.class);
+        smrMap.put("a", "a");
+        Map<String, String> smrMapCopy = r.getObjectsView().copy(smrMap, "map a copy");
+        smrMapCopy.put("b", "b");
+
+        assertThat(smrMapCopy)
+                .containsEntry("a", "a")
+                .containsEntry("b", "b");
+
+        assertThat(smrMap)
+                .containsEntry("a", "a")
+                .doesNotContainEntry("b", "b");
+    }
+}

--- a/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -6,6 +6,8 @@ import org.corfudb.infrastructure.LogUnitServer;
 import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.object.Accessor;
+import org.corfudb.runtime.object.Mutator;
 import org.junit.Test;
 
 import java.util.Map;
@@ -46,4 +48,5 @@ public class ObjectsViewTest extends AbstractViewTest  {
                 .containsEntry("a", "a")
                 .doesNotContainEntry("b", "b");
     }
+
 }

--- a/src/test/java/org/corfudb/runtime/view/StreamsViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/StreamsViewTest.java
@@ -1,0 +1,63 @@
+package org.corfudb.runtime.view;
+
+import lombok.Getter;
+import org.corfudb.infrastructure.LayoutServer;
+import org.corfudb.infrastructure.LogUnitServer;
+import org.corfudb.infrastructure.SequencerServer;
+import org.corfudb.runtime.CorfuRuntime;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by mwei on 2/18/16.
+ */
+public class StreamsViewTest extends AbstractViewTest {
+    @Getter
+    final String defaultConfigurationString = getDefaultEndpoint();
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canCopyStream()
+            throws Exception {
+        // default layout is chain replication.
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        //begin tests
+        CorfuRuntime r = getRuntime().connect();
+        UUID streamA = CorfuRuntime.getStreamID("stream A");
+        UUID streamACopy = CorfuRuntime.getStreamID("stream A copy");
+        byte[] testPayload = "hello world".getBytes();
+        byte[] testPayloadCopy = "hello world copy".getBytes();
+
+        StreamView sv = r.getStreamsView().get(streamA);
+        sv.write(testPayload);
+
+        assertThat(sv.read().getResult().getPayload(r))
+                .isEqualTo(testPayload);
+        assertThat(sv.read())
+                .isEqualTo(null);
+
+        StreamView svCopy = r.getStreamsView().copy(streamA, streamACopy, sv.getLogPointer()-1L);
+
+        assertThat(svCopy.read().getResult().getPayload(r))
+                .isEqualTo(testPayload);
+        assertThat(svCopy.read())
+                .isEqualTo(null);
+
+        svCopy.write(testPayloadCopy);
+
+        assertThat(svCopy.read().getResult().getPayload(r))
+                .isEqualTo(testPayloadCopy);
+        assertThat(svCopy.read())
+                .isEqualTo(null);
+        assertThat(sv.read())
+                .isEqualTo(null);
+    }
+
+}


### PR DESCRIPTION
Primitive serializer enables faster serialization but only supports primitive types.
CoW objects enable copying an object quickly by referencing a snapshot on the stream.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/97)
<!-- Reviewable:end -->
