### PR TITLE
Sync object on first tx read. Improvements to primtive serializer.

### DIFF
--- a/src/main/java/org/corfudb/runtime/object/TransactionalContext.java
+++ b/src/main/java/org/corfudb/runtime/object/TransactionalContext.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import io.netty.channel.RecvByteBufAllocator;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.logprotocol.TXEntry;
@@ -22,6 +23,21 @@ public class TransactionalContext {
 
     @Getter
     UUID transactionID;
+
+    /** The timestamp of the first read in the system.
+     * @return The timestamp of the first read object, which may be null.
+     */
+    @Getter
+    @Setter
+    Long firstReadTimestamp;
+
+    /** Check if the first read timestamp has been set.
+     * @return  Return true, if the timestamp has been set, false otherwise.
+     */
+    public boolean isFirstReadTimestampSet()
+    {
+        return false;
+    }
 
     @SuppressWarnings("unchecked")
     class TransactionalObjectData<T> {

--- a/src/main/java/org/corfudb/util/serializer/PrimitiveSerializer.java
+++ b/src/main/java/org/corfudb/util/serializer/PrimitiveSerializer.java
@@ -1,0 +1,209 @@
+package org.corfudb.util.serializer;
+
+import com.google.common.collect.ImmutableMap;
+import io.netty.buffer.ByteBuf;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.object.ICorfuSMRObject;
+
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Created by mwei on 2/18/16.
+ */
+@Slf4j
+public class PrimitiveSerializer implements ISerializer {
+
+    @FunctionalInterface
+    interface DeserializerFunction<T> {
+        T deserialize(ByteBuf b, CorfuRuntime r);
+    }
+
+    @FunctionalInterface
+    interface SerializerFunction<T> {
+        void serialize(T o, ByteBuf b);
+    }
+
+    enum Primitives {
+        BYTE(0, Byte.class, byte.class, (o,b) -> b.writeByte(o), (b,r) -> b.readByte()),
+        SHORT(1, Short.class, short.class, (o,b) -> b.writeShort(o), (b,r) -> b.readShort()),
+        INTEGER(2, Integer.class, int.class, (o,b) -> b.writeInt(o), (b,r) -> b.readInt()),
+        LONG(3, Long.class, long.class, (o,b) -> b.writeLong(o), (b,r) -> b.readLong()),
+        BOOLEAN(4, Boolean.class, boolean.class, (o,b) -> b.writeBoolean(o), (b,r) -> b.readBoolean()),
+        DOUBLE(5, Double.class, double.class, (o,b) -> b.writeDouble(o), (b,r) -> b.readDouble()),
+        FLOAT(6, Float.class, float.class, (o,b) -> b.writeFloat(o), (b,r) -> b.readFloat()),
+        BYTE_ARRAY(7, byte[].class, Byte[].class, PrimitiveSerializer::writeBytes, PrimitiveSerializer::readBytes),
+        SHORT_ARRAY(8, Short[].class, short[].class, (o,b) -> writeArray(o, b, ByteBuf::writeShort),
+                (b,r) -> readArray(b, ByteBuf::readShort, Short[]::new)),
+        INTEGER_ARRAY(9, Integer[].class, int[].class, (o,b) -> writeArray(o, b, ByteBuf::writeInt),
+                (b,r) -> readArray(b, ByteBuf::readInt, Integer[]::new)),
+        LONG_ARRAY(10, Long[].class, long[].class, (o,b) -> writeArray(o, b, ByteBuf::writeLong),
+                (b,r) -> readArray(b, ByteBuf::readLong, Long[]::new)),
+        BOOLEAN_ARRAY(11, Boolean[].class, boolean[].class,(o,b) -> writeArray(o, b, ByteBuf::writeBoolean),
+                (b,r) -> readArray(b, ByteBuf::readBoolean, Boolean[]::new)),
+        DOUBLE_ARRAY(12, Double[].class, double[].class, (o,b) -> writeArray(o, b, ByteBuf::writeDouble),
+                (b,r) -> readArray(b, ByteBuf::readDouble, Double[]::new)),
+        FLOAT_ARRAY(13, Float[].class, float[].class, (o,b) -> writeArray(o, b, ByteBuf::writeFloat),
+                (b,r) -> readArray(b, ByteBuf::readFloat, Float[]::new)),
+        STRING(14, String.class, null, (o,b) -> {b.writeInt(o.length()); b.writeBytes(o.getBytes());},
+                (b,r) -> {
+                    int length = b.readInt();
+                    byte[] bs = new byte[length];
+                    b.readBytes(bs, 0, length);
+                    return new String(bs);
+                }),
+        CORFU_SMR(15, Object.class, null, (o, b) -> {
+            String className = o.getClass().toString();
+            String SMRClass = className.split("\\$")[0];
+            className = "CorfuSMRObject";
+            byte[] classNameBytes = className.getBytes();
+            b.writeShort(classNameBytes.length);
+            b.writeBytes(classNameBytes);
+            byte[] SMRClassNameBytes = SMRClass.getBytes();
+            b.writeShort(SMRClassNameBytes.length);
+            b.writeBytes(SMRClassNameBytes);
+            try {
+                Field f = o.getClass().getDeclaredField("_corfuStreamID");
+                f.setAccessible(true);
+                UUID id = (UUID) f.get(o);
+                log.trace("Serializing a CorfuObject of type {} as a stream pointer to {}", SMRClass, id);
+                b.writeLong(id.getMostSignificantBits());
+                b.writeLong(id.getLeastSignificantBits());
+            } catch (NoSuchFieldException | IllegalAccessException nsfe)
+            {
+                log.error("Error serializing fields");
+                throw new RuntimeException(nsfe);
+            }
+        },
+                (b,r) -> {
+                    int SMRClassNameLength = b.readShort();
+                    byte[] SMRClassNameBytes = new byte[SMRClassNameLength];
+                    b.readBytes(SMRClassNameBytes, 0, SMRClassNameLength);
+                    String SMRClassName = new String(SMRClassNameBytes);
+                    try {
+                        return r.getObjectsView().open(new UUID(b.readLong(), b.readLong()), Class.forName(SMRClassName));
+                    } catch (ClassNotFoundException cnfe) {
+                        log.error("Exception during deserialization!", cnfe);
+                        throw new RuntimeException(cnfe);
+                    }
+        })
+        ;
+        <T> Primitives(int typeNum, Class<T> classType, Class<?> primitiveClass,
+                       SerializerFunction<T>  serializer, DeserializerFunction<T> deserializer)
+        {
+            this.typeNum = (byte) typeNum;
+            this.classType = classType;
+            this.primitiveClass = primitiveClass;
+            this.serializer = serializer;
+            this.deserializer = deserializer;
+        }
+        @Getter
+        public final byte typeNum;
+        @Getter
+        public final Class<?> classType;
+        @Getter
+        public final Class<?> primitiveClass;
+        @Getter
+        public final SerializerFunction<?> serializer;
+        @Getter
+        public final DeserializerFunction deserializer;
+    }
+
+    public static final Map<Byte, DeserializerFunction> DeserializerMap =
+            Arrays.stream(Primitives.values())
+                    .collect(Collectors.toMap(Primitives::getTypeNum, Primitives::getDeserializer));
+
+    public static final Map<Class, SerializerFunction> SerializerMap = getSerializerMap();
+
+    @SuppressWarnings("unchecked")
+    private static Map<Class, SerializerFunction> getSerializerMap() {
+        ImmutableMap.Builder b = ImmutableMap.<Class, SerializerFunction>builder();
+        Arrays.stream(Primitives.values())
+                .forEach(e -> {
+                            b.put(e.getClassType(), e.getSerializer());
+                                    if (e.getPrimitiveClass() != null) {
+                                        b.put(e.getPrimitiveClass(), e.getSerializer());
+                                    }
+                        }
+                );
+        return b.build();
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T,R> void writeArray(T[] o, ByteBuf b, BiFunction<ByteBuf, R, ByteBuf> applyFunc) {
+        int length = Array.getLength(o);
+        b.writeInt(length);
+        Arrays.stream(o)
+                .forEach(i -> applyFunc.apply(b, (R) i));
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T,R> T[] readArray(ByteBuf b, Function<ByteBuf, T> applyFunc, Function<Integer, T[]> arrayGen) {
+        int length = b.readInt();
+        T[] r = arrayGen.apply(length);
+        for (int i = 0; i < length; i++)
+        {
+            r[i] = applyFunc.apply(b);
+        }
+        return r;
+    }
+
+    static void writeBytes(Object o, ByteBuf b) {
+        int length = Array.getLength(o);
+        b.writeInt(length);
+        b.writeBytes((byte[])o);
+    }
+
+    static byte[] readBytes(ByteBuf b, CorfuRuntime rt) {
+        int length = b.readInt();
+        byte[] bytes = new byte[length];
+        b.readBytes(bytes, 0, length);
+        return bytes;
+    }
+
+
+    /**
+     * Deserialize an object from a given byte buffer.
+     *
+     * @param b The bytebuf to deserialize.
+     * @return The deserialized object.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+        byte type = b.readByte();
+        DeserializerFunction d = DeserializerMap.get(type);
+        return d.deserialize(b, rt);
+    }
+
+    /**
+     * Serialize an object into a given byte buffer.
+     *
+     * @param o The object to serialize.
+     * @param b The bytebuf to serialize it into.
+     */
+    @Override
+    @SuppressWarnings("unchecked")
+    public void serialize(Object o, ByteBuf b) {
+        if (o.getClass().getName().contains("$ByteBuddy$"))
+        {
+            ((SerializerFunction<Object>)Primitives.CORFU_SMR.getSerializer()).serialize(o, b);
+        }
+        else {
+            SerializerFunction f = SerializerMap.get(o.getClass());
+            if (f == null) {
+                throw new RuntimeException("Unsupported class for serialization: " + o.getClass());
+            }
+            f.serialize(o, b);
+        }
+    }
+}

--- a/src/main/java/org/corfudb/util/serializer/Serializers.java
+++ b/src/main/java/org/corfudb/util/serializer/Serializers.java
@@ -19,7 +19,8 @@ public class Serializers {
         // Supported Serializers
         CORFU(0, CorfuSerializer.class),
         JAVA(1, JavaSerializer.class),
-        JSON(2, JSONSerializer.class)
+        JSON(2, JSONSerializer.class),
+        PRIMITIVE(3, PrimitiveSerializer.class)
         ;
 
         public final int type;

--- a/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -7,12 +7,11 @@ import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.ObjectOpenOptions;
+import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -136,4 +135,26 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
         assertThat(test.getPrimitive())
                 .isEqualTo("hello world".getBytes());
     }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canUsePrimitiveSerializer()
+            throws Exception {
+        // default layout is chain replication.
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        //begin tests
+        CorfuRuntime r = getRuntime().connect();
+        TestClassWithPrimitives test = r.getObjectsView().open(CorfuRuntime.getStreamID("test")
+                , TestClassWithPrimitives.class, null,
+                Collections.emptySet(), Serializers.SerializerType.PRIMITIVE);
+        test.setPrimitive("hello world".getBytes());
+        assertThat(test.getPrimitive())
+                .isEqualTo("hello world".getBytes());
+    }
+
 }

--- a/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -82,4 +82,29 @@ public class ObjectsViewTest extends AbstractViewTest  {
         CorfuRuntime r = getRuntime().connect();
         r.getObjectsView().TXAbort();
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canRunLambdaTransaction()
+            throws Exception {
+        // default layout is chain replication.
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        //begin tests
+        CorfuRuntime r = getRuntime().connect();
+        Map<String, String> smrMap = r.getObjectsView().open("map a", SMRMap.class);
+
+        assertThat(r.getObjectsView().executeTX(() -> {
+           smrMap.put("a", "b");
+            assertThat(smrMap)
+                    .containsEntry("a","b");
+            return true;
+        })).isTrue();
+
+        assertThat(smrMap)
+                .containsEntry("a", "b");
+    }
 }

--- a/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -10,10 +10,12 @@ import org.corfudb.runtime.object.Accessor;
 import org.corfudb.runtime.object.Mutator;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Created by mwei on 2/18/16.
@@ -49,4 +51,35 @@ public class ObjectsViewTest extends AbstractViewTest  {
                 .doesNotContainEntry("b", "b");
     }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void cannotCopyNonCorfuObject()
+            throws Exception {
+        // default layout is chain replication.
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        //begin tests
+        CorfuRuntime r = getRuntime().connect();
+        assertThatThrownBy(() -> {
+            r.getObjectsView().copy(new HashMap<String,String>(), CorfuRuntime.getStreamID("test"));
+        }).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canAbortNoTransaction()
+            throws Exception {
+        // default layout is chain replication.
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        wireRouters();
+
+        //begin tests
+        CorfuRuntime r = getRuntime().connect();
+        r.getObjectsView().TXAbort();
+    }
 }


### PR DESCRIPTION
When an object is first read in a transaction, this patch stores the first read to be
sync, and all subsequent reads to respect that sync.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/99)
<!-- Reviewable:end -->
