### PR TITLE
Fix a bug where JVMFLAGS was not being passed by the startup script

### DIFF
--- a/scripts/corfu_server.sh
+++ b/scripts/corfu_server.sh
@@ -38,6 +38,6 @@ fi
 
 # default heap for corfudb
 CORFUDB_HEAP="${CORFUDB_HEAP:-1000}"
-export CORFUDB_JVMFLAGS="-Xmx${CORFUDB_HEAP}m $SERVER_JVMFLAGS"
+export JVMFLAGS="-Xmx${CORFUDB_HEAP}m $SERVER_JVMFLAGS"
 
 "$JAVA" -cp "$CLASSPATH" $JVMFLAGS org.corfudb.infrastructure.CorfuServer $*


### PR DESCRIPTION
Partially addresses #98.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/100)
<!-- Reviewable:end -->
