### PR TITLE
Fix transaction sync.

### DIFF
--- a/src/main/java/org/corfudb/runtime/object/TransactionalContext.java
+++ b/src/main/java/org/corfudb/runtime/object/TransactionalContext.java
@@ -31,6 +31,14 @@ public class TransactionalContext {
     @Setter
     Long firstReadTimestamp;
 
+    /** Whether or not the tx is doing a first sync and therefore writes should not be
+     * redirected.
+     * @return Whether or not the TX is in sync.
+     */
+    @Getter
+    @Setter
+    boolean inSyncMode;
+
     /** Check if the first read timestamp has been set.
      * @return  Return true, if the timestamp has been set, false otherwise.
      */


### PR DESCRIPTION
Previously, during first sync, sometimes updates would be applied to the
transactional clone object, which would cause updates to be lost. This
patch redirects updates to the underlying smrobject if in a sync.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/101)
<!-- Reviewable:end -->
