### PR TITLE
Fix an issue where read-after-read was resolved as a conflict

### DIFF
--- a/src/main/java/org/corfudb/protocols/logprotocol/TXEntry.java
+++ b/src/main/java/org/corfudb/protocols/logprotocol/TXEntry.java
@@ -14,6 +14,7 @@ import org.corfudb.util.serializer.ICorfuSerializable;
 import org.corfudb.util.serializer.Serializers;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Created by mwei on 1/11/16.
@@ -112,7 +113,10 @@ public class TXEntry extends LogEntry {
      */
     public Set<UUID> getAffectedStreams()
     {
-        return txMap.keySet();
+        return txMap.entrySet().stream()
+                .filter(e -> e.getValue().getUpdates().size() != 0)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
     }
 
     /**


### PR DESCRIPTION
Fixes #105, where read-after-read requests were being detected as a conflict
and aborted. This is fixed by making sure read only operations were not added into the writeSet
and counted as a mutation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/107)
<!-- Reviewable:end -->