### PR TITLE
Don't read past start of the stream

### DIFF
--- a/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -169,6 +169,7 @@ public class SequencerServer implements IServer {
                         lastIssuedMap.compute(id, (k, v) ->{
                                 if (v == null)
                                 {
+                                    mb.put(k, -1L);
                                     return thisIssue + req.getNumTokens() -1;
                                 }
                                 mb.put(k, v);

--- a/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
@@ -21,24 +21,14 @@ public class SequencerViewTest extends AbstractViewTest {
 
     @Test
     public void canAcquireFirstToken() {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime();
         assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
                 .isEqualTo(0);
     }
 
     @Test
     public void tokensAreIncrementing() {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime();
         assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
                 .isEqualTo(0);
         assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
@@ -47,12 +37,7 @@ public class SequencerViewTest extends AbstractViewTest {
 
     @Test
     public void checkTokenWorks() {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime();
         assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
                 .isEqualTo(0);
         assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 0).getToken())
@@ -61,12 +46,7 @@ public class SequencerViewTest extends AbstractViewTest {
 
     @Test
     public void checkStreamTokensWork() {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime();
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         UUID streamB = UUID.nameUUIDFromBytes("stream B".getBytes());
 
@@ -84,21 +64,16 @@ public class SequencerViewTest extends AbstractViewTest {
 
     @Test
     public void checkBackPointersWork() {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime();
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         UUID streamB = UUID.nameUUIDFromBytes("stream B".getBytes());
 
         assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 1).getBackpointerMap())
-                .isEmpty();
+                .containsEntry(streamA, -1L);
         assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 0).getBackpointerMap())
                 .isEmpty();
         assertThat(r.getSequencerView().nextToken(Collections.singleton(streamB), 1).getBackpointerMap())
-                .isEmpty();
+                .containsEntry(streamB, -1L);
         assertThat(r.getSequencerView().nextToken(Collections.singleton(streamB), 0).getBackpointerMap())
                 .isEmpty();
         assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 1).getBackpointerMap())


### PR DESCRIPTION
Due to a bug in the backpointer implementation, the system would
sometime read past the start of the stream in order to resolve it.
This patch tells the sequencer to issue a -1 token the first time a stream
is written to, which denotes the start of the stream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/116)
<!-- Reviewable:end -->