### PR TITLE
Fix a concurrency bug where a broken the firstReadTimestamp was not properly updated

### DIFF
--- a/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
+++ b/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
@@ -8,13 +8,14 @@ import org.corfudb.util.serializer.ICorfuSerializable;
 
 import java.util.Arrays;
 import java.util.Map;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**
  * Created by mwei on 1/8/16.
  */
-@ToString
+@ToString(exclude={"runtime","entry"})
 @NoArgsConstructor
 public class LogEntry implements ICorfuSerializable {
 
@@ -103,5 +104,5 @@ public class LogEntry implements ICorfuSerializable {
      * @return  True, if the entry changes the contents of the stream,
      *          False otherwise.
      */
-    public boolean isMutation() { return true; }
+    public boolean isMutation(UUID stream) { return true; }
 }

--- a/src/main/java/org/corfudb/protocols/wireprotocol/ILogUnitEntry.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/ILogUnitEntry.java
@@ -59,6 +59,9 @@ public interface ILogUnitEntry extends IMetadata {
     /** Return the backpointer for a particular stream. */
     default Long getBackpointer(UUID streamID) { return getBackpointerMap().get(streamID); }
 
+    /** Return if this is the first entry in a particular stream. */
+    default boolean isFirstEntry(UUID streamID) { return getBackpointer(streamID) == -1L; }
+
     /** Get an estimate of how large this entry is in memory.
      *
      * @return  An estimate on the size of this object, in bytes.

--- a/src/main/java/org/corfudb/protocols/wireprotocol/LogUnitPayloadMsg.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/LogUnitPayloadMsg.java
@@ -5,6 +5,7 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.CorfuSerializer;
 import org.corfudb.util.serializer.ISerializer;
@@ -12,7 +13,7 @@ import org.corfudb.util.serializer.ISerializer;
 /**
  * Created by mwei on 9/17/15.
  */
-
+@ToString
 public class LogUnitPayloadMsg extends LogUnitMetadataMsg {
 
     /** The default serializer to use */

--- a/src/main/java/org/corfudb/protocols/wireprotocol/LogUnitWriteMsg.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/LogUnitWriteMsg.java
@@ -15,7 +15,7 @@ import java.util.*;
 @Getter
 @Setter
 @NoArgsConstructor
-@ToString
+@ToString(callSuper=true)
 public class LogUnitWriteMsg extends LogUnitPayloadMsg {
 
 

--- a/src/main/java/org/corfudb/runtime/object/ICorfuSMRObject.java
+++ b/src/main/java/org/corfudb/runtime/object/ICorfuSMRObject.java
@@ -37,4 +37,10 @@ public interface ICorfuSMRObject<T> {
         return TransactionalContext.isInTransaction();
     }
 
+    /** Get the stream ID of the object.
+     *
+     * @return          The stream ID of the object.
+     */
+    default UUID getStreamID() { throw new UnprocessedException(); }
+
 }

--- a/src/main/java/org/corfudb/runtime/view/AbstractReplicationView.java
+++ b/src/main/java/org/corfudb/runtime/view/AbstractReplicationView.java
@@ -44,7 +44,7 @@ public abstract class AbstractReplicationView {
         throw new RuntimeException("Unsupported replication mode.");
     }
 
-    @ToString
+    @ToString(exclude={"runtime"})
     @RequiredArgsConstructor
     public static class CachedLogUnitEntry implements ILogUnitEntry
     {

--- a/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -297,7 +297,7 @@ public class ObjectsView extends AbstractView {
         }
 
 
-        TransactionalContext context = TransactionalContext.newContext();
+        TransactionalContext context = TransactionalContext.newContext(runtime);
         context.setStrategy(strategy);
         context.setStartTime(System.currentTimeMillis());
 

--- a/src/main/java/org/corfudb/runtime/view/StreamView.java
+++ b/src/main/java/org/corfudb/runtime/view/StreamView.java
@@ -287,12 +287,10 @@ public class StreamView implements AutoCloseable {
         while (getCurrentContext().logPointer.get() <= latestToken)
         {
             ILogUnitEntry r = read();
-            if (r == null) {
-                log.warn("ReadTo[{}]: Read returned null when it should not have!", streamID);
-                throw new RuntimeException("Unexpected stream state, aborting.");
-            }
-            else {
+            if (r != null) {
                 al.add(r);
+            } else {
+                break;
             }
         }
         return al.toArray(new ILogUnitEntry[al.size()]);

--- a/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -6,9 +6,12 @@ import org.corfudb.infrastructure.LogUnitServer;
 import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.SequencerClient;
+import org.corfudb.runtime.collections.SMRMap;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -187,5 +190,38 @@ public class StreamViewTest extends AbstractViewTest {
 
         assertThat(sv.read())
                 .isEqualTo(null);
+    }
+
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void streamWithHoleFill()
+            throws Exception {
+        CorfuRuntime r = getDefaultRuntime();
+        UUID streamA = CorfuRuntime.getStreamID("stream A");
+
+        byte[] testPayload = "hello world".getBytes();
+        byte[] testPayload2 = "hello world2".getBytes();
+
+        StreamView sv = r.getStreamsView().get(streamA);
+        sv.write(testPayload);
+
+        //generate a stream hole
+        SequencerClient.TokenResponse tr =
+                r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
+        r.getAddressSpaceView().fillHole(tr.getToken());
+
+        tr = r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
+        r.getAddressSpaceView().fillHole(tr.getToken());
+
+        sv.write(testPayload2);
+
+        //make sure we can still read the stream.
+        assertThat(sv.read().getPayload())
+                .isEqualTo(testPayload);
+
+        assertThat(sv.read().getPayload())
+                .isEqualTo(testPayload2);
     }
 }


### PR DESCRIPTION
This patch fixes a concurrency bug where the firstReadTimestamp was being set to the 
latest stream pointer and possibly overwritten by concurrent invocations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/118)
<!-- Reviewable:end -->