### PR TITLE
Refactor SMR Proxy into Proxy and SMR Proxy, fix for nested TX

### DIFF
--- a/src/main/java/org/corfudb/protocols/logprotocol/TXEntry.java
+++ b/src/main/java/org/corfudb/protocols/logprotocol/TXEntry.java
@@ -79,7 +79,7 @@ public class TXEntry extends LogEntry {
 
 
     public boolean checkAbort() {
-        long timestamp = this.getEntry().getAddress();
+        long timestamp = getEntry().getAddress();
         for (Map.Entry<UUID, TXEntry.TXObjectEntry> e : txMap.entrySet()) {
 
             // We need to now check if this object changed since the tx proposer

--- a/src/main/java/org/corfudb/runtime/collections/FGMap.java
+++ b/src/main/java/org/corfudb/runtime/collections/FGMap.java
@@ -70,13 +70,10 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      * @return <tt>true</tt> if this map contains no key-value mappings
      */
     @Override
-    @DontInstrument
+    @TransactionalMethod
     public boolean isEmpty() {
-        getRuntime().getObjectsView().TXBegin();
-        boolean isEmpty = getAllPartitionMaps().stream()
+        return getAllPartitionMaps().stream()
                 .allMatch(Map::isEmpty);
-        getRuntime().getObjectsView().TXEnd();
-        return isEmpty;
     }
 
     /**
@@ -122,13 +119,10 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
      */
     @Override
-    @DontInstrument
+    @TransactionalMethod
     public boolean containsValue(Object value) {
-        getRuntime().getObjectsView().TXBegin();
-        boolean isEmpty = getAllPartitionMaps().stream()
+        return getAllPartitionMaps().stream()
                 .anyMatch(x -> x.containsValue(value));
-        getRuntime().getObjectsView().TXEnd();
-        return isEmpty;
     }
 
     /**
@@ -248,12 +242,10 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      *                                       the specified map prevents it from being stored in this map
      */
     @Override
-    @DontInstrument
+    @TransactionalMethod
     public void putAll(Map<? extends K, ? extends V> m) {
-        getRuntime().getObjectsView().TXBegin();
         m.entrySet().stream()
                 .forEach(e -> getPartition(e.getKey()).put(e.getKey(), e.getValue()));
-        getRuntime().getObjectsView().TXEnd();
     }
 
     /**
@@ -264,12 +256,10 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      *                                       is not supported by this map
      */
     @Override
-    @DontInstrument
+    @TransactionalMethod
     public void clear() {
-        getRuntime().getObjectsView().TXBegin();
         getAllPartitionMaps().stream()
                 .forEach(Map::clear);
-        getRuntime().getObjectsView().TXEnd();
     }
 
     /**
@@ -288,15 +278,12 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      * @return a set view of the keys contained in this map
      */
     @Override
-    @DontInstrument
+    @TransactionalMethod
     public Set<K> keySet() {
-        getRuntime().getObjectsView().TXBegin();
-        Set<K> set = getAllPartitionMaps().stream()
+        return getAllPartitionMaps().stream()
                 .map(Map::keySet)
                 .flatMap(Set::stream)
                 .collect(Collectors.toSet());
-        getRuntime().getObjectsView().TXEnd();
-        return set;
     }
 
     /**
@@ -315,14 +302,12 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      * @return a collection view of the values contained in this map
      */
     @Override
-    @DontInstrument
+    @TransactionalMethod
     public Collection<V> values() {
-        Collection<V> set = getAllPartitionMaps().stream()
+        return getAllPartitionMaps().stream()
                 .map(Map::values)
                 .flatMap(Collection::stream)
                 .collect(Collectors.toSet());
-        getRuntime().getObjectsView().TXEnd();
-        return set;
     }
 
     /**
@@ -342,14 +327,11 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      * @return a set view of the mappings contained in this map
      */
     @Override
-    @DontInstrument
+    @TransactionalMethod
     public Set<Entry<K, V>> entrySet() {
-        getRuntime().getObjectsView().TXBegin();
-        Set<Entry<K,V>> set = getAllPartitionMaps().stream()
+        return getAllPartitionMaps().stream()
                 .map(Map::entrySet)
                 .flatMap(Set::stream)
                 .collect(Collectors.toSet());
-        getRuntime().getObjectsView().TXEnd();
-        return set;
     }
 }

--- a/src/main/java/org/corfudb/runtime/collections/FGMap.java
+++ b/src/main/java/org/corfudb/runtime/collections/FGMap.java
@@ -1,9 +1,6 @@
 package org.corfudb.runtime.collections;
 
-import org.corfudb.runtime.object.DontInstrument;
-import org.corfudb.runtime.object.ICorfuSMRObject;
-import org.corfudb.runtime.object.StaticMappingObject;
-import org.corfudb.runtime.object.TransactionalMethod;
+import org.corfudb.runtime.object.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -11,7 +8,9 @@ import java.util.stream.Collectors;
 /**
  * Created by mwei on 3/29/16.
  */
-public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject> {
+@CorfuObject(constructorType=ConstructorType.PERSISTED,
+        objectType=ObjectType.STATELESS)
+public class FGMap<K,V> implements Map<K,V>, ICorfuObject {
 
     final int numBuckets;
 
@@ -24,7 +23,6 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
         this.numBuckets = 10;
     }
 
-    @DontInstrument
     @SuppressWarnings("unchecked")
     Map<K,V> getPartitionMap(int partition)
     {
@@ -33,13 +31,11 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
                 getStreamID().getLeastSignificantBits() + (partition+1)), SMRMap.class);
     }
 
-    @DontInstrument
     Map<K,V> getPartition(Object key)
     {
         return getPartitionMap(key.hashCode() % numBuckets);
     }
 
-    @DontInstrument
     Set<Map<K,V>> getAllPartitionMaps() {
         Set<Map<K,V>> mapSet = new HashSet<>();
         for (int i = 0; i < numBuckets; i++)
@@ -57,7 +53,7 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      * @return the number of key-value mappings in this map
      */
     @Override
-    @TransactionalMethod
+    @TransactionalMethod(readOnly=true)
     public int size() {
         return getAllPartitionMaps().stream()
                 .mapToInt(Map::size)
@@ -70,7 +66,7 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      * @return <tt>true</tt> if this map contains no key-value mappings
      */
     @Override
-    @TransactionalMethod
+    @TransactionalMethod(readOnly=true)
     public boolean isEmpty() {
         return getAllPartitionMaps().stream()
                 .allMatch(Map::isEmpty);
@@ -94,7 +90,6 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
      */
     @Override
-    @DontInstrument
     public boolean containsKey(Object key) {
         return getPartition(key)
                 .containsKey(key);
@@ -119,7 +114,7 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
      */
     @Override
-    @TransactionalMethod
+    @TransactionalMethod(readOnly=true)
     public boolean containsValue(Object value) {
         return getAllPartitionMaps().stream()
                 .anyMatch(x -> x.containsValue(value));
@@ -151,7 +146,6 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
      */
     @Override
-    @DontInstrument
     public V get(Object key) {
         return getPartition(key).get(key);
     }
@@ -181,7 +175,6 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      *                                       or value prevents it from being stored in this map
      */
     @Override
-    @DontInstrument
     public V put(K key, V value) {
         return getPartition(key).put(key, value);
     }
@@ -217,7 +210,6 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
      */
     @Override
-    @DontInstrument
     public V remove(Object key) {
         return getPartition(key).remove(key);
     }
@@ -278,7 +270,7 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      * @return a set view of the keys contained in this map
      */
     @Override
-    @TransactionalMethod
+    @TransactionalMethod(readOnly=true)
     public Set<K> keySet() {
         return getAllPartitionMaps().stream()
                 .map(Map::keySet)
@@ -302,7 +294,7 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      * @return a collection view of the values contained in this map
      */
     @Override
-    @TransactionalMethod
+    @TransactionalMethod(readOnly=true)
     public Collection<V> values() {
         return getAllPartitionMaps().stream()
                 .map(Map::values)
@@ -327,7 +319,7 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuSMRObject<StaticMappingObject
      * @return a set view of the mappings contained in this map
      */
     @Override
-    @TransactionalMethod
+    @TransactionalMethod(readOnly=true)
     public Set<Entry<K, V>> entrySet() {
         return getAllPartitionMaps().stream()
                 .map(Map::entrySet)

--- a/src/main/java/org/corfudb/runtime/object/ConstructorType.java
+++ b/src/main/java/org/corfudb/runtime/object/ConstructorType.java
@@ -1,0 +1,9 @@
+package org.corfudb.runtime.object;
+
+/**
+ * Created by mwei on 3/30/16.
+ */
+public enum ConstructorType {
+    RUNTIME,
+    PERSISTED
+}

--- a/src/main/java/org/corfudb/runtime/object/CorfuObject.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuObject.java
@@ -1,0 +1,15 @@
+package org.corfudb.runtime.object;
+
+import java.lang.annotation.*;
+
+/**
+ * Created by mwei on 3/30/16.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface CorfuObject {
+    ConstructorType constructorType() default ConstructorType.RUNTIME;
+    ObjectType objectType() default ObjectType.STATELESS;
+    Class underlyingType() default StaticMappingObject.class;
+}

--- a/src/main/java/org/corfudb/runtime/object/CorfuObjectProxy.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuObjectProxy.java
@@ -1,0 +1,84 @@
+package org.corfudb.runtime.object;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.implementation.bind.annotation.AllArguments;
+import net.bytebuddy.implementation.bind.annotation.Origin;
+import net.bytebuddy.implementation.bind.annotation.RuntimeType;
+import net.bytebuddy.implementation.bind.annotation.SuperCall;
+import org.corfudb.protocols.logprotocol.LogEntry;
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.logprotocol.TXEntry;
+import org.corfudb.protocols.wireprotocol.LogUnitReadResponseMsg;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.StreamView;
+import org.corfudb.util.serializer.Serializers;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Created by mwei on 3/30/16.
+ */
+@Slf4j
+public class CorfuObjectProxy<P> {
+
+    /** The underlying streamView for this CorfuObject. */
+    @Getter
+    StreamView sv;
+
+    /** The original class which this class proxies. */
+    @Getter
+    Class<P> originalClass;
+
+    /** The serializer used by this proxy when it is written to the log. */
+    @Getter
+    Serializers.SerializerType serializer;
+
+    /** The runtime used to create this proxy. */
+    @Getter
+    CorfuRuntime runtime;
+
+    /** The current timestamp of this proxy. */
+    @Getter
+    long timestamp;
+
+    /** The generated proxy class that this proxy wraps around. */
+    @Getter
+    @Setter
+    Class<? extends P> generatedClass;
+
+    public CorfuObjectProxy(CorfuRuntime runtime, StreamView sv,
+                            Class<P> originalClass, Serializers.SerializerType serializer) {
+        this.runtime = runtime;
+        this.sv = sv;
+        this.originalClass = originalClass;
+        this.serializer = serializer;
+        this.timestamp = -1L;
+    }
+
+    @RuntimeType
+    public Object handleTransactionalMethod(@SuperCall Callable originalCall,
+                                            @Origin Method method,
+                                            @AllArguments Object[] arguments)
+            throws Exception
+    {
+        runtime.getObjectsView().TXBegin();
+        Object res = originalCall.call();
+        runtime.getObjectsView().TXEnd();
+        return res;
+    }
+
+    synchronized public void sync(P obj, long maxPos) {
+        log.trace("CorfuObjectProxy[{}] sync to pos {}", sv.getStreamID(), maxPos == Long.MAX_VALUE ? "MAX" : maxPos);
+        Arrays.stream(sv.readTo(maxPos));
+    }
+
+    public UUID getStreamID() { return sv.getStreamID(); }
+
+    public CorfuObjectProxy getProxy() { return this; }
+}

--- a/src/main/java/org/corfudb/runtime/object/CorfuProxyBuilder.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuProxyBuilder.java
@@ -1,0 +1,192 @@
+package org.corfudb.runtime.object;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.description.annotation.AnnotationDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.StreamView;
+import org.corfudb.util.serializer.Serializers;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+/**
+ * Created by mwei on 3/30/16.
+ */
+@Slf4j
+public class CorfuProxyBuilder {
+
+    final static AnnotationDescription instrumentedDescription =
+            AnnotationDescription.Builder.ofType(Instrumented.class)
+                    .build();
+
+    final static AnnotationDescription instrumentedObjectDescription =
+            AnnotationDescription.Builder.ofType(InstrumentedCorfuObject.class)
+                    .build();
+
+    public static <T> DynamicType.Builder<T> instrumentSMRMethods(CorfuObjectProxy proxy,
+                                                                  DynamicType.Builder<T> bb) {
+        try {
+            bb = bb.method(ElementMatchers.isAnnotatedWith(Mutator.class)
+                    .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Instrumented.class))))
+                    .intercept(MethodDelegation.to(proxy, "mutator").filter(ElementMatchers.named("interceptMutator")))
+                    .annotateMethod(instrumentedDescription);
+        } catch (NoSuchMethodError nsme) {
+            log.trace("Class {} has no mutators", proxy.getOriginalClass());
+        }
+        try {
+            bb = bb.method(ElementMatchers.isAnnotatedWith(Accessor.class)
+                    .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Instrumented.class))))
+                    .intercept(MethodDelegation.to(proxy, "accessor").filter(ElementMatchers.named("interceptAccessor")))
+                    .annotateMethod(instrumentedDescription);
+        } catch (NoSuchMethodError nsme) {
+            log.trace("Class {} has no accessors", proxy.getOriginalClass());
+        }
+        try {
+            bb = bb.method(ElementMatchers.isAnnotatedWith(MutatorAccessor.class)
+                    .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Instrumented.class))))
+                    .intercept(MethodDelegation.to(proxy, "maccessor").filter(ElementMatchers.named("interceptMutatorAccessor")))
+                    .annotateMethod(instrumentedDescription);
+        } catch (NoSuchMethodError nsme)
+        {
+            log.trace("Class {} has no mutatoraccessors", proxy.getOriginalClass());
+        }
+
+
+        bb = bb.implement(ICorfuSMRObject.class)
+                .method(ElementMatchers.named("getSMRObject"))
+                .intercept(MethodDelegation.to(proxy, "getSMRObject").filter(ElementMatchers.named("interceptGetSMRObject")));
+        return bb;
+    }
+
+    public static <T> DynamicType.Builder<T> instrumentCorfuObjectMethods(CorfuObjectProxy proxy,
+                                                                          DynamicType.Builder<T> bb) {
+        return bb.implement(ICorfuObject.class)
+                .method(ElementMatchers.named("getStreamID"))
+                .intercept(MethodDelegation.to(proxy, "getStreamID").filter(ElementMatchers.named("getStreamID")))
+                .method(ElementMatchers.named("getProxy"))
+                .intercept(MethodDelegation.to(proxy, "getProxy").filter(ElementMatchers.named("getProxy")))
+                .method(ElementMatchers.named("getRuntime"))
+                .intercept(MethodDelegation.to(proxy, "getRuntime").filter(ElementMatchers.named("getRuntime")))
+                .method(ElementMatchers.isAnnotatedWith(TransactionalMethod.class))
+                .intercept(MethodDelegation.to(proxy, "handleTX").filter(ElementMatchers.named("handleTransactionalMethod")));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T,R extends ISMRInterface> Class<? extends T>
+    getProxyClass(CorfuObjectProxy proxy, Class<T> type, Class<R> overlay) {
+        if (type.isAnnotationPresent(CorfuObject.class)) {
+            log.trace("Detected CorfuObject({}), instrumenting methods.", type);
+            CorfuObject corfuAnnotation = type.getAnnotation(CorfuObject.class);
+            DynamicType.Builder<T> b = new ByteBuddy()
+                    .subclass(type);
+
+            b = instrumentCorfuObjectMethods(proxy, b);
+            if (corfuAnnotation.objectType() == ObjectType.SMR) {
+                b = instrumentSMRMethods(proxy, b);
+            }
+
+            Class<? extends T> generatedClass = b.make()
+                    .load(CorfuSMRObjectProxy.class.getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
+                    .getLoaded();
+            proxy.setGeneratedClass(generatedClass);
+            return generatedClass;
+        }
+
+
+        /** TODO: Legacy code which may need cleanup. */
+        else if (Arrays.stream(type.getInterfaces()).anyMatch(ICorfuSMRObject.class::isAssignableFrom))
+        {
+            log.trace("Detected ICorfuSMRObject({}), instrumenting methods.", type);
+
+            DynamicType.Builder<T> b = new ByteBuddy()
+                    .subclass(type);
+
+            b = instrumentCorfuObjectMethods(proxy, b);
+            b = instrumentSMRMethods(proxy, b);
+
+            Class<? extends T> generatedClass = b.make()
+                    .load(CorfuSMRObjectProxy.class.getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
+                    .getLoaded();
+            proxy.generatedClass = generatedClass;
+            return generatedClass;
+        }
+        else if (overlay != null) {
+            log.trace("Detected Overlay({}), instrumenting methods", overlay);
+        }
+        else if (Arrays.stream(type.getInterfaces()).anyMatch(ISMRInterface.class::isAssignableFrom)){
+            ISMRInterface[] iface = Arrays.stream(type.getInterfaces())
+                    .filter(ISMRInterface.class::isAssignableFrom)
+                    .toArray(ISMRInterface[]::new);
+            log.trace("Detected ISMRInterfaces({}), instrumenting methods", iface);
+        }
+        else {
+            log.trace("{} is not an ICorfuSMRObject, no ISMRInterfaces and no overlay provided. " +
+                    "Instrumenting all methods as mutatorAccessors but respecting annotations", type);
+
+            // dump all method annotations
+            log.trace("All methods for {}:", type);
+            if (log.isTraceEnabled()) {
+                Method[] ms = type.getMethods();
+                for (Method m : ms) {
+                    log.trace("{}: {}", m.getName(), m.getAnnotations());
+                }
+            }
+            DynamicType.Builder<T> bb = new ByteBuddy().subclass(type);
+
+            bb = instrumentCorfuObjectMethods(proxy, bb);
+            bb = instrumentSMRMethods(proxy, bb);
+            bb = bb.method(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Mutator.class))
+                    .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Accessor.class)))
+                    .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(MutatorAccessor.class)))
+                    .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(DontInstrument.class)))
+                    .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Instrumented.class)))
+                    .and(ElementMatchers.not(ElementMatchers.isDeclaredBy(Object.class)))
+                    .and(ElementMatchers.not(ElementMatchers.isDefaultMethod())))
+                    .intercept(MethodDelegation.to(proxy, "accessor").filter(ElementMatchers.named("interceptAccessor")))
+                    .annotateMethod(instrumentedDescription);
+
+            bb.annotateType(instrumentedObjectDescription);
+            Class<? extends T> generatedClass =
+                    bb.make().load(CorfuSMRObjectProxy.class.getClassLoader(), ClassLoadingStrategy.Default.WRAPPER)
+                            .getLoaded();
+            proxy.setGeneratedClass(generatedClass.getClass());
+            return generatedClass;
+        }
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    public static <T,R extends ISMRInterface>
+    T getProxy(@NonNull Class<T> type, Class<R> overlay, @NonNull StreamView sv, @NonNull CorfuRuntime runtime,
+               Serializers.SerializerType serializer) {
+        try {
+            CorfuObjectProxy<T> proxy;
+
+            if (type.isAnnotationPresent(CorfuObject.class)) {
+                CorfuObject annotation = type.getAnnotation(CorfuObject.class);
+                if (annotation.objectType() == ObjectType.SMR) {
+                    proxy = new CorfuSMRObjectProxy<>(runtime, sv, type, serializer);
+                }
+                else
+                {
+                    proxy = new CorfuObjectProxy<>(runtime, sv, type, serializer);
+                }
+            } else {
+                proxy = new CorfuSMRObjectProxy<>(runtime, sv, type, serializer);
+            }
+            //read the first entry from the streamview (constructor) if present.
+            T ret = getProxyClass(proxy, type, overlay).newInstance();
+            if (proxy instanceof CorfuSMRObjectProxy) {
+                ((CorfuSMRObjectProxy)proxy).calculateMethodHashTable(ret.getClass());
+            }
+            return ret;
+        } catch (InstantiationException | IllegalAccessException ie) {
+            throw new RuntimeException("Unexpected exception opening object", ie);
+        }
+    }
+}

--- a/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
@@ -378,10 +378,10 @@ public class CorfuSMRObjectProxy<P> extends CorfuObjectProxy<P> {
                 return false;
             }
 
-            // The TX has committed, apply updates for this object.
-            txEntry.getTxMap().get(sv.getStreamID())
-                    .getUpdates().stream()
-                    .forEach(x -> applySMRUpdate(address, x, obj));
+
+                txEntry.getTxMap().get(sv.getStreamID())
+                        .getUpdates().stream()
+                        .forEach(x -> applySMRUpdate(address, x, obj));
 
             return true;
         }

--- a/src/main/java/org/corfudb/runtime/object/ICorfuObject.java
+++ b/src/main/java/org/corfudb/runtime/object/ICorfuObject.java
@@ -1,0 +1,41 @@
+package org.corfudb.runtime.object;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.UnprocessedException;
+
+import java.util.UUID;
+
+/**
+ * Created by mwei on 3/30/16.
+ */
+public interface ICorfuObject {
+
+    /** Returns whether the object is in a transaction. During this time, speculative
+     * updates may be applied until either the commit or abort hook is called.
+     * @return          True, if the object is in a transaction. False, otherwise.
+     */
+    default boolean isInTransaction() {
+        return TransactionalContext.isInTransaction();
+    }
+
+    // These calls are dynamically overridden by the proxy, and should not be
+    // implemented by client classes.
+
+    /** Get the stream ID of the object.
+     *
+     * @return          The stream ID of the object.
+     */
+    default UUID getStreamID() { throw new UnprocessedException(); }
+
+    /** Get the current runtime.
+     *
+     * @return          The runtime of the object.
+     */
+    default CorfuRuntime getRuntime() { throw new UnprocessedException(); }
+
+    /** Get the underlying proxy.
+     *
+     * @return          The underlying proxy for this object.
+     */
+    default CorfuObjectProxy getProxy() { throw new UnprocessedException(); }
+}

--- a/src/main/java/org/corfudb/runtime/object/ICorfuSMRObject.java
+++ b/src/main/java/org/corfudb/runtime/object/ICorfuSMRObject.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 /**
  * Created by mwei on 1/7/16.
  */
-public interface ICorfuSMRObject<T> {
+public interface ICorfuSMRObject<T> extends ICorfuObject {
 
     // These calls are dynamically overridden by the proxy, and should not be
     // implemented by client classes.
@@ -30,29 +30,4 @@ public interface ICorfuSMRObject<T> {
      */
     default T getSMRObject() { throw new UnprocessedException(); }
 
-    /** Returns whether the object is in a transaction. During this time, speculative
-     * updates may be applied until either the commit or abort hook is called.
-     * @return          True, if the object is in a transaction. False, otherwise.
-     */
-    default boolean isInTransaction() {
-        return TransactionalContext.isInTransaction();
-    }
-
-    /** Get the stream ID of the object.
-     *
-     * @return          The stream ID of the object.
-     */
-    default UUID getStreamID() { throw new UnprocessedException(); }
-
-    /** Get the current runtime.
-     *
-     * @return          The runtime of the object.
-     */
-    default CorfuRuntime getRuntime() { throw new UnprocessedException(); }
-
-    /** Get the underlying proxy.
-     *
-     * @return          The underlying proxy for this object.
-     */
-    default CorfuSMRObjectProxy getProxy() { throw new UnprocessedException(); }
 }

--- a/src/main/java/org/corfudb/runtime/object/ObjectType.java
+++ b/src/main/java/org/corfudb/runtime/object/ObjectType.java
@@ -1,0 +1,9 @@
+package org.corfudb.runtime.object;
+
+/**
+ * Created by mwei on 3/30/16.
+ */
+public enum ObjectType {
+    SMR,
+    STATELESS
+}

--- a/src/main/java/org/corfudb/runtime/object/StaticMappingObject.java
+++ b/src/main/java/org/corfudb/runtime/object/StaticMappingObject.java
@@ -2,6 +2,8 @@ package org.corfudb.runtime.object;
 
 /**
  * Created by mwei on 3/29/16.
+ *
+ * A dummy empty class for null SMR.
  */
 public class StaticMappingObject {
 }

--- a/src/main/java/org/corfudb/runtime/object/TransactionalMethod.java
+++ b/src/main/java/org/corfudb/runtime/object/TransactionalMethod.java
@@ -1,6 +1,9 @@
 package org.corfudb.runtime.object;
 
 import java.lang.annotation.*;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
 
 /**
  * Created by mwei on 3/29/16.
@@ -9,4 +12,5 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface TransactionalMethod {
+    boolean readOnly() default false;
 }

--- a/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -10,10 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.TXEntry;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.object.CorfuSMRObjectProxy;
-import org.corfudb.runtime.object.ICorfuSMRObject;
-import org.corfudb.runtime.object.ISMRInterface;
-import org.corfudb.runtime.object.TransactionalContext;
+import org.corfudb.runtime.object.*;
 import org.corfudb.util.LambdaUtils;
 import org.corfudb.util.Utils;
 import org.corfudb.util.serializer.Serializers;
@@ -208,13 +205,13 @@ public class ObjectsView extends AbstractView {
         if (options.contains(ObjectOpenOptions.NO_CACHE))
         {
             StreamView sv = runtime.getStreamsView().get(streamID);
-            return CorfuSMRObjectProxy.getProxy(type, overlay, sv, runtime, serializer);
+            return CorfuProxyBuilder.getProxy(type, overlay, sv, runtime, serializer);
         }
 
         ObjectID<T,R> oid = new ObjectID(streamID, type, overlay);
         return (T) objectCache.computeIfAbsent(oid, x -> {
             StreamView sv = runtime.getStreamsView().get(streamID);
-            return CorfuSMRObjectProxy.getProxy(type, overlay, sv, runtime, serializer);
+            return CorfuProxyBuilder.getProxy(type, overlay, sv, runtime, serializer);
         });
     }
 
@@ -232,7 +229,7 @@ public class ObjectsView extends AbstractView {
             return (T) objectCache.computeIfAbsent(oid, x -> {
                 StreamView sv = runtime.getStreamsView().copy(proxy.getSv().getStreamID(),
                         destination, proxy.getTimestamp());
-                return CorfuSMRObjectProxy.getProxy(proxy.getOriginalClass(), null, sv, runtime, proxy.getSerializer());
+                return CorfuProxyBuilder.getProxy(proxy.getOriginalClass(), null, sv, runtime, proxy.getSerializer());
             });
     }
 

--- a/src/main/java/org/corfudb/util/serializer/JSONSerializer.java
+++ b/src/main/java/org/corfudb/util/serializer/JSONSerializer.java
@@ -7,6 +7,7 @@ import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.object.ICorfuObject;
 import org.corfudb.runtime.object.ICorfuSMRObject;
 
 import java.io.*;
@@ -37,7 +38,7 @@ public class JSONSerializer implements ISerializer {
         {
             return null;
         }
-        else if (className.equals("CorfuSMRObject"))
+        else if (className.equals("CorfuObject"))
         {
             int SMRClassNameLength = b.readShort();
             byte[] SMRClassNameBytes = new byte[SMRClassNameLength];
@@ -74,14 +75,14 @@ public class JSONSerializer implements ISerializer {
         if (className.contains("$ByteBuddy$"))
         {
             String SMRClass = className.split("\\$")[0];
-            className = "CorfuSMRObject";
+            className = "CorfuObject";
             byte[] classNameBytes = className.getBytes();
             b.writeShort(classNameBytes.length);
             b.writeBytes(classNameBytes);
             byte[] SMRClassNameBytes = SMRClass.getBytes();
             b.writeShort(SMRClassNameBytes.length);
             b.writeBytes(SMRClassNameBytes);
-            UUID id = ((ICorfuSMRObject)o).getStreamID();
+            UUID id = ((ICorfuObject)o).getStreamID();
             log.trace("Serializing a CorfuObject of type {} as a stream pointer to {}", SMRClass, id);
             b.writeLong(id.getMostSignificantBits());
             b.writeLong(id.getLeastSignificantBits());

--- a/src/main/java/org/corfudb/util/serializer/PrimitiveSerializer.java
+++ b/src/main/java/org/corfudb/util/serializer/PrimitiveSerializer.java
@@ -64,7 +64,7 @@ public class PrimitiveSerializer implements ISerializer {
         CORFU_SMR(15, Object.class, null, (o, b) -> {
             String className = o.getClass().toString();
             String SMRClass = className.split("\\$")[0];
-            className = "CorfuSMRObject";
+            className = "CorfuObject";
             byte[] classNameBytes = className.getBytes();
             b.writeShort(classNameBytes.length);
             b.writeBytes(classNameBytes);

--- a/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
+++ b/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
@@ -82,6 +82,53 @@ public class FGMapTest extends AbstractViewTest {
 
     @Test
     @SuppressWarnings("unchecked")
+    public void canClear()
+            throws Exception {
+        Map<String,String> testMap = getDefaultRuntime().getObjectsView().open(UUID.randomUUID(), FGMap.class);
+        testMap.clear();
+        assertThat(testMap)
+                .isEmpty();
+
+        for (int i = 0; i < 100; i++)
+        {
+            testMap.put(Integer.toString(i), Integer.toString(i));
+        }
+
+        assertThat(testMap)
+                .hasSize(100);
+
+        testMap.clear();
+        assertThat(testMap)
+                .isEmpty();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canClearInTX()
+            throws Exception {
+        Map<String,String> testMap = getDefaultRuntime().getObjectsView().open(UUID.randomUUID(), FGMap.class);
+        testMap.clear();
+        assertThat(testMap)
+                .isEmpty();
+
+        getRuntime().getObjectsView().TXBegin();
+        for (int i = 0; i < 100; i++)
+        {
+            testMap.put(Integer.toString(i), Integer.toString(i));
+        }
+        testMap.clear();
+        assertThat(testMap)
+                .isEmpty();
+        getRuntime().getObjectsView().TXEnd();
+
+        assertThat(testMap)
+                .hasSize(0);
+
+
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     public void loadsFollowedByGetsConcurrent()
             throws Exception {
         getDefaultRuntime();


### PR DESCRIPTION
This patch refactors the SMR Proxy into a non-SMR Proxy and an SMR proxy.
In addition, the transactionalMethod annotation is improved and nested TXs are
fully supported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/123)
<!-- Reviewable:end -->