### PR TITLE
For the FG map, use a Luby-Rackoff transform to randomize the hashCode

### DIFF
--- a/src/main/java/org/corfudb/runtime/collections/FGMap.java
+++ b/src/main/java/org/corfudb/runtime/collections/FGMap.java
@@ -36,7 +36,7 @@ public class FGMap<K,V> implements Map<K,V>, ICorfuObject {
     /** Get a new partition.
      *
      * In order to avoid collisions due to imperfect hashCode() distribution,
-     * we apply the Luby-Rakoff transform to randomize the distribution with
+     * we apply the Luby-Rackoff transform to randomize the distribution with
      * CRC32 and CRC16.
      * @param key
      * @return


### PR DESCRIPTION
Currently, we directly use the Java hashCode to divide into buckets, which
can cause poor distributions (for example, if the hashCode is of an int, and
the items being inserted are multiples of 10). This patch uses
a Luby-Rakoff transform to randmozie the distributions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/125)
<!-- Reviewable:end -->