### PR TITLE
Add support for persisting constructor arguments.

### DIFF
--- a/src/main/java/org/corfudb/runtime/collections/FGMap.java
+++ b/src/main/java/org/corfudb/runtime/collections/FGMap.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.collections;
 
+import lombok.Getter;
 import org.corfudb.runtime.object.*;
 import sun.misc.CRC16;
 
@@ -14,7 +15,8 @@ import java.util.zip.CRC32;
         objectType=ObjectType.STATELESS)
 public class FGMap<K,V> implements Map<K,V>, ICorfuObject {
 
-    final int numBuckets;
+    @Getter
+    public final int numBuckets;
 
     public FGMap(int numBuckets)
     {

--- a/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
@@ -311,8 +311,8 @@ public class CorfuSMRObjectProxy<P> extends CorfuObjectProxy<P> {
     {
         log.trace("Write update and map future: {} with arguments {}", method, arguments);
         return sv.acquireAndWrite(new SMREntry(method, arguments, serializer),
-                t -> completableFutureMap.put(t, new CompletableFuture<>()),
-               completableFutureMap::remove);
+                t -> {completableFutureMap.put(t.getToken(), new CompletableFuture<>()); return true;},
+               t -> {completableFutureMap.remove(t.getToken()); return true;});
     }
 
     boolean applySMRUpdate(long address, SMREntry entry, P obj)

--- a/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
+++ b/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
@@ -6,8 +6,10 @@ import org.corfudb.infrastructure.LogUnitServer;
 import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.ObjectOpenOptions;
 import org.junit.Test;
 
+import java.util.EnumSet;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -123,9 +125,29 @@ public class FGMapTest extends AbstractViewTest {
 
         assertThat(testMap)
                 .hasSize(0);
-
-
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canVaryBucketCount()
+            throws Exception {
+        FGMap<String,String> testMap = getDefaultRuntime().getObjectsView().open("hello", FGMap.class, 101);
+        testMap.clear();
+        assertThat(testMap)
+                .isEmpty();
+        for (int i = 0; i < 100; i++)
+        {
+            testMap.put(Integer.toString(i), Integer.toString(i));
+        }
+
+        FGMap<String,String> testMap2 = getRuntime().getObjectsView().open("hello", FGMap.class,
+                EnumSet.of(ObjectOpenOptions.NO_CACHE));
+        assertThat(testMap2)
+                .hasSize(100);
+        assertThat(testMap2.getNumBuckets())
+                .isEqualTo(101);
+    }
+
 
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -504,7 +504,7 @@ public class SMRMapTest extends AbstractViewTest {
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
 
         final int num_threads = 5;
-        final int num_records = 20;
+        final int num_records = 0;
         AtomicInteger aborts = new AtomicInteger();
         testMap.clear();
 


### PR DESCRIPTION
This patch add supports for persisting arguments to a constructor. 
This allows for example, the FGMap to be parameterized.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/127)
<!-- Reviewable:end -->