### PR TITLE
Transaction notifications support

### DIFF
--- a/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -21,6 +21,18 @@ public class TransactionalContext {
     private static final ThreadLocal<Deque<AbstractTransactionalContext>> threadStack = ThreadLocal.withInitial(
             LinkedList<AbstractTransactionalContext>::new);
 
+    @FunctionalInterface
+    public interface TXCompletionMethod {
+        void handle(AbstractTransactionalContext context);
+    }
+
+    @Getter
+    private static final LinkedHashSet<TXCompletionMethod> completionMethods = new LinkedHashSet<>();
+
+    public static void addCompletionMethod(TXCompletionMethod completionMethod) {
+        completionMethods.add(completionMethod);
+    }
+
     /** Returns the transaction stack for the calling thread.
      *
      * @return      The transaction stack for the calling thread.

--- a/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -248,6 +248,9 @@ public class ObjectsView extends AbstractView {
                 if (entry.isAborted()) {
                     throw new TransactionAbortedException();
                 }
+                //otherwise fire the handlers.
+                TransactionalContext.getCompletionMethods().parallelStream()
+                        .forEach(x -> x.handle(context));
             }
         }
     }

--- a/src/test/java/org/corfudb/runtime/object/transactions/TransactionalContextTest.java
+++ b/src/test/java/org/corfudb/runtime/object/transactions/TransactionalContextTest.java
@@ -1,0 +1,42 @@
+package org.corfudb.runtime.object.transactions;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by mwei on 4/26/16.
+ */
+public class TransactionalContextTest extends AbstractViewTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void transactionNotificationsFire() throws Exception {
+        CorfuRuntime cr = getDefaultRuntime();
+
+        final AtomicInteger ai = new AtomicInteger();
+        TransactionalContext.addCompletionMethod((a) -> ai.incrementAndGet());
+
+        assertThat(ai.get())
+                .isEqualTo(0);
+
+        Map<String,String> smrMap = cr.getObjectsView().build()
+                                        .setStreamName("test")
+                                        .setType(SMRMap.class)
+                                        .open();
+
+        cr.getObjectsView().TXBegin();
+        smrMap.put("a", "b");
+        cr.getObjectsView().TXEnd();
+
+        assertThat(ai.get())
+                .isEqualTo(1);
+
+    }
+}

--- a/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -104,7 +104,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
         runtime.setGetRouterFunction(routerMap::get);
     }
 
-    public abstract String getDefaultConfigurationString();
+    public String getDefaultConfigurationString() {return getDefaultEndpoint();}
 
     public String getDefaultEndpoint()
     {


### PR DESCRIPTION
This patch adds support for transaction notifications, which fire at the end of a successful locally proposed transaction

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/138)
<!-- Reviewable:end -->
