### PR TITLE
Fix CorfuDB/CorfuDB#143

### DIFF
--- a/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -148,6 +148,7 @@ public class LayoutServer implements IServer {
             {
                 log.info("Bootstrap with new layout={}", ((LayoutMsg)msg).getLayout());
                 currentLayout = ((LayoutMsg)msg).getLayout();
+                saveCurrentLayout();
                 //send a response that the bootstrap was successful.
                 r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.ACK));
             }


### PR DESCRIPTION
Fixes CorfuDB/CorfuDB#143 by writing the `layout` file when a bootstrap operation is successful.  

I don't have a unit test at this time to provoke the bug inside of the Maven test framework, sorry.  See the bug report for a reproducing shell script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/144)
<!-- Reviewable:end -->
