### PR TITLE
Throw an exception when bootstrapped servers are re-bootstrapped

### DIFF
--- a/src/main/java/org/corfudb/cmdlets/corfu_layouts.java
+++ b/src/main/java/org/corfudb/cmdlets/corfu_layouts.java
@@ -5,6 +5,7 @@ import com.google.gson.GsonBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.LayoutClient;
+import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
@@ -102,7 +103,7 @@ public class corfu_layouts implements ICmdlet {
     }
 
     public void add_layout (CorfuRuntime runtime, Map<String,Object> options)
-            throws NetworkException, QuorumUnreachableException, OutrankedException
+            throws NetworkException, QuorumUnreachableException, OutrankedException, AlreadyBootstrappedException
     {
         checkEndpoint((String) options.get("--endpoint"));
         Layout l;

--- a/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -165,7 +165,8 @@ public class LayoutServer implements IServer {
             break;
             case LAYOUT_BOOTSTRAP:
                 // We are already bootstrapped, bootstrap again is not allowed.
-                r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.NACK));
+                log.warn("Got a request to bootstrap a server which is already bootstrapped, rejecting!");
+                r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.LAYOUT_ALREADY_BOOTSTRAP));
             break;
             case LAYOUT_PREPARE:
             {

--- a/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -98,7 +98,6 @@ implements IServerRouter {
      */
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) {
-        boolean handled = false;
         try {
             // The incoming message should have been transformed to a CorfuMsg earlier in the pipeline.
             CorfuMsg m = ((CorfuMsg) msg);
@@ -115,19 +114,12 @@ implements IServerRouter {
                     // Route the message to the handler.
                     log.trace("Message routed to {}: {}", handler.getClass().getSimpleName(), msg);
                     handler.handleMessage(m, ctx, this);
-                    handled = true;
                 }
             }
         }
         catch (Exception e)
         {
             log.error("Exception during read!" , e);
-        }
-        finally {
-            if (!handled && msg != null)
-            {
-                ((CorfuMsg) msg).release();
-            }
         }
     }
 

--- a/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
@@ -82,7 +82,10 @@ public class CorfuMsg {
         ERROR_TRIMMED(51, CorfuMsg.class, LogUnitServer.class),
         ERROR_OVERWRITE(52, CorfuMsg.class, LogUnitServer.class),
         ERROR_OOS(53, CorfuMsg.class, LogUnitServer.class),
-        ERROR_RANK(54, CorfuMsg.class, LogUnitServer.class)
+        ERROR_RANK(54, CorfuMsg.class, LogUnitServer.class),
+
+        // EXTRA CODES
+        LAYOUT_ALREADY_BOOTSTRAP(60, CorfuMsg.class, LayoutServer.class)
         ;
 
         public final int type;

--- a/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.LayoutMsg;
 import org.corfudb.protocols.wireprotocol.LayoutRankMsg;
+import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.NoBootstrapException;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.view.Layout;
@@ -51,6 +52,11 @@ public class LayoutClient implements IClient {
             case LAYOUT_PROPOSE_REJECT:
                 router.completeExceptionally(msg.getRequestID(),
                         new OutrankedException(((LayoutRankMsg)msg).getRank()));
+                break;
+            case LAYOUT_ALREADY_BOOTSTRAP:
+                router.completeExceptionally(msg.getRequestID(),
+                        new AlreadyBootstrappedException());
+                break;
         }
     }
 
@@ -65,6 +71,7 @@ public class LayoutClient implements IClient {
                     .add(CorfuMsg.CorfuMsgType.LAYOUT_NOBOOTSTRAP)
                     .add(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_REJECT)
                     .add(CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE_REJECT)
+                    .add(CorfuMsg.CorfuMsgType.LAYOUT_ALREADY_BOOTSTRAP)
                     .build();
 
     /**

--- a/src/main/java/org/corfudb/runtime/exceptions/AlreadyBootstrappedException.java
+++ b/src/main/java/org/corfudb/runtime/exceptions/AlreadyBootstrappedException.java
@@ -1,0 +1,12 @@
+package org.corfudb.runtime.exceptions;
+
+/**
+ * Created by mwei on 6/17/16.
+ */
+public class AlreadyBootstrappedException extends Exception {
+
+    public AlreadyBootstrappedException() {
+        super("Server is already bootstrapped");
+    }
+
+}

--- a/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -97,7 +97,7 @@ public class LayoutServerTest extends AbstractServerTest {
         sendMessage(new LayoutMsg(testLayout, CorfuMsg.CorfuMsgType.LAYOUT_BOOTSTRAP));
         sendMessage(new LayoutMsg(testLayout, CorfuMsg.CorfuMsgType.LAYOUT_BOOTSTRAP));
         assertThat(getLastMessage().getMsgType())
-                .isEqualTo(CorfuMsg.CorfuMsgType.NACK);
+                .isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_ALREADY_BOOTSTRAP);
     }
 
     Layout getTestLayout() {

--- a/src/test/java/org/corfudb/runtime/clients/LayoutClientTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/LayoutClientTest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import com.google.common.collect.ImmutableSet;
 import org.corfudb.infrastructure.IServer;
 import org.corfudb.infrastructure.LayoutServer;
+import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.NoBootstrapException;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.view.Layout;
@@ -81,8 +82,8 @@ public class LayoutClientTest extends AbstractClientTest {
     {
         assertThat(client.bootstrapLayout(getTestLayout()).get())
                 .isEqualTo(true);
-        assertThat(client.bootstrapLayout(getTestLayout()).get())
-                .isEqualTo(false);
+        assertThatThrownBy(() -> client.bootstrapLayout(getTestLayout()).get())
+                .hasCauseInstanceOf(AlreadyBootstrappedException.class);
     }
 
     @Test


### PR DESCRIPTION
Previously, calling bootstrap would just return NACK, which is 
passed to the client as false. This patch causes it to return an
exception instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/149)
<!-- Reviewable:end -->
