### PR TITLE
Fix a bug where the legacy object proxy code was defaulting to Accessors instead of MutatorAccessors

### DIFF
--- a/src/main/java/org/corfudb/runtime/object/CorfuProxyBuilder.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuProxyBuilder.java
@@ -158,7 +158,7 @@ public class CorfuProxyBuilder {
                     .and(ElementMatchers.not(ElementMatchers.isAnnotatedWith(Instrumented.class)))
                     .and(ElementMatchers.not(ElementMatchers.isDeclaredBy(Object.class)))
                     .and(ElementMatchers.not(ElementMatchers.isDefaultMethod())))
-                    .intercept(MethodDelegation.to(proxy, "accessor").filter(ElementMatchers.named("interceptAccessor")))
+                    .intercept(MethodDelegation.to(proxy, "mutatorAccessor").filter(ElementMatchers.named("interceptMutatorAccessor")))
                     .annotateMethod(instrumentedDescription);
 
             bb.annotateType(instrumentedObjectDescription);

--- a/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -48,6 +48,36 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
     }
 
     @Test
+    public void canOpenObjectWithTwoRuntimes()
+        throws Exception
+    {
+        getDefaultRuntime();
+
+        TestClass testClass = getRuntime().getObjectsView()
+                .build()
+                .setStreamName("test")
+                .setType(TestClass.class)
+                .open();
+
+        testClass.set(52);
+        assertThat(testClass.get())
+                .isEqualTo(52);
+
+        CorfuRuntime runtime2 = new CorfuRuntime();
+        wireExistingRuntimeToTest(runtime2);
+        runtime2.connect();
+
+        TestClass testClass2 = runtime2.getObjectsView()
+                .build()
+                .setStreamName("test")
+                .setType(TestClass.class)
+                .open();
+
+        assertThat(testClass2.get())
+                .isEqualTo(52);
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void multipleWritesConsistencyTest()
             throws Exception {

--- a/src/test/java/org/corfudb/runtime/object/TestClass.java
+++ b/src/test/java/org/corfudb/runtime/object/TestClass.java
@@ -1,0 +1,16 @@
+package org.corfudb.runtime.object;
+
+/**
+ * Created by mwei on 6/21/16.
+ */
+public class TestClass {
+    int testInt;
+
+    public void set(int toSet){
+        testInt = toSet;
+    }
+
+    public int get() {
+        return testInt;
+    }
+}

--- a/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -96,6 +96,12 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
         return getRuntime().connect();
     }
 
+    public CorfuRuntime wireExistingRuntimeToTest(CorfuRuntime runtime) {
+        runtime.layoutServers.add(getDefaultEndpoint());
+        runtime.setGetRouterFunction(routerMap::get);
+        return runtime;
+    }
+
     public AbstractViewTest()
     {
         runtime = new CorfuRuntime();

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="TRACE">
        <!--<appender-ref ref="STDOUT" />-->
     </root>
 </configuration>


### PR DESCRIPTION
An unknown bug was introduced in the legacy instrumentation code which caused the proxy code to default to providing MutatorAccessors instead of Accessors. This would cause automatic instrumentation to fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/153)
<!-- Reviewable:end -->
