### PR TITLE
new unit testing framework which accounts for epochs. Fix issue where ACK message in wrong epoch is ignored.

### DIFF
--- a/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure;
 
 import io.netty.channel.ChannelHandlerContext;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuSetEpochMsg;
@@ -11,11 +12,11 @@ import org.corfudb.protocols.wireprotocol.CorfuSetEpochMsg;
 @Slf4j
 public class BaseServer implements IServer {
 
-    IServerRouter router;
+    IServerRouter serverRouter;
 
     public BaseServer(IServerRouter router)
     {
-        this.router = router;
+        this.serverRouter = router;
     }
 
     @Override
@@ -27,18 +28,18 @@ public class BaseServer implements IServer {
                 break;
             case SET_EPOCH:
                 CorfuSetEpochMsg csem = (CorfuSetEpochMsg) msg;
-                if (csem.getNewEpoch() >= router.getEpoch())
+                if (csem.getNewEpoch() >= serverRouter.getServerEpoch())
                 {
                     log.info("Received SET_EPOCH, moving to new epoch {}", csem.getNewEpoch());
-                    router.setEpoch(csem.getNewEpoch());
-                    router.sendResponse(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.ACK));
+                    serverRouter.setServerEpoch(csem.getNewEpoch());
+                    serverRouter.sendResponse(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.ACK));
                 }
                 else
                 {
                     log.debug("Rejected SET_EPOCH currrent={}, requested={}",
-                            router.getEpoch(), csem.getNewEpoch());
-                    router.sendResponse(ctx, msg, new CorfuSetEpochMsg(CorfuMsg.CorfuMsgType.WRONG_EPOCH,
-                            router.getEpoch()));
+                            serverRouter.getServerEpoch(), csem.getNewEpoch());
+                    serverRouter.sendResponse(ctx, msg, new CorfuSetEpochMsg(CorfuMsg.CorfuMsgType.WRONG_EPOCH,
+                            serverRouter.getServerEpoch()));
                 }
         }
     }

--- a/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -162,7 +162,7 @@ public class CorfuServer {
 
         // Add each role to the router.
         router.addServer(new SequencerServer(opts));
-        router.addServer(new LayoutServer(opts));
+        router.addServer(new LayoutServer(opts, router));
         router.addServer(new LogUnitServer(opts));
 
         // Create the event loops responsible for servicing inbound messages.

--- a/src/main/java/org/corfudb/infrastructure/IServerRouter.java
+++ b/src/main/java/org/corfudb/infrastructure/IServerRouter.java
@@ -10,8 +10,8 @@ public interface IServerRouter {
     void sendResponse(ChannelHandlerContext ctx, CorfuMsg inMsg, CorfuMsg outMsg);
 
     /** Get the current epoch. */
-    long getEpoch();
+    long getServerEpoch();
 
     /** Set the current epoch. */
-    void setEpoch(long newEpoch);
+    void setServerEpoch(long newEpoch);
 }

--- a/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -32,7 +32,7 @@ implements IServerRouter {
     /** The epoch of this router. This is managed by the base server implementation. */
     @Getter
     @Setter
-    long epoch;
+    long serverEpoch;
 
     public NettyServerRouter()
     {
@@ -66,7 +66,7 @@ implements IServerRouter {
     public void sendResponse(ChannelHandlerContext ctx, CorfuMsg inMsg, CorfuMsg outMsg)
     {
         outMsg.copyBaseFields(inMsg);
-        outMsg.setEpoch(epoch);
+        outMsg.setEpoch(serverEpoch);
         ctx.writeAndFlush(outMsg);
         log.trace("Sent response: {}", outMsg);
     }
@@ -80,12 +80,12 @@ implements IServerRouter {
      */
     public boolean validateEpoch(CorfuMsg msg, ChannelHandlerContext ctx)
     {
-        if (!msg.getMsgType().ignoreEpoch && msg.getEpoch() != epoch)
+        if (!msg.getMsgType().ignoreEpoch && msg.getEpoch() != serverEpoch)
         {
             sendResponse(ctx, msg, new CorfuSetEpochMsg(CorfuMsg.CorfuMsgType.WRONG_EPOCH,
-                    getEpoch()));
+                    getServerEpoch()));
             log.trace("Incoming message with wrong epoch, got {}, expected {}, message was: {}",
-                    msg.getEpoch(), epoch, msg);
+                    msg.getEpoch(), serverEpoch, msg);
             return false;
         }
         return true;

--- a/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.TokenRequestMsg;

--- a/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
@@ -42,7 +42,7 @@ public class CorfuMsg {
         PONG(1, CorfuMsg.class, BaseServer.class, true),
         RESET(2, CorfuResetMsg.class, BaseServer.class),
         SET_EPOCH(3, CorfuSetEpochMsg.class, BaseServer.class, true),
-        ACK(4, CorfuMsg.class, BaseServer.class),
+        ACK(4, CorfuMsg.class, BaseServer.class, true),
         WRONG_EPOCH(5, CorfuSetEpochMsg.class, BaseServer.class),
         NACK(6, CorfuMsg.class, BaseServer.class),
 

--- a/src/test/java/org/corfudb/infrastructure/AbstractServerTest.java
+++ b/src/test/java/org/corfudb/infrastructure/AbstractServerTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure;
 
 import com.google.common.collect.ImmutableMap;
+import lombok.Getter;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.junit.Before;
@@ -13,6 +14,7 @@ import java.util.Map;
  */
 public abstract class AbstractServerTest extends AbstractCorfuTest {
 
+    @Getter
     TestServerRouter router;
 
     public AbstractServerTest() {

--- a/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -24,7 +24,7 @@ public class LayoutServerTest extends AbstractServerTest {
 
     @Override
     public IServer getDefaultServer() {
-        return new LayoutServer(defaultOptionsMap());
+        return new LayoutServer(defaultOptionsMap(), getRouter());
     }
 
     @Test
@@ -60,7 +60,7 @@ public class LayoutServerTest extends AbstractServerTest {
                 .put("--memory", true)
                 .put("--log-path", serviceDir)
                 .put("--sync", false)
-                .build());
+                .build(), getRouter());
 
         setServer(ls);
 
@@ -188,7 +188,7 @@ public class LayoutServerTest extends AbstractServerTest {
                 .put("--log-path", serviceDir)
                 .put("--memory", false)
                 .put("--single", false)
-                .build());
+                .build(), getRouter());
 
         setServer(s1);
         bootstrapServer(getTestLayout());
@@ -213,7 +213,7 @@ public class LayoutServerTest extends AbstractServerTest {
                 .put("--log-path", serviceDir)
                 .put("--single", false)
                 .put("--memory", false)
-                .build());
+                .build(), getRouter());
         this.router.setServerUnderTest(s2);
         assertThat(s2)
                 .isInEpoch(100);

--- a/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -14,13 +14,17 @@ import java.util.concurrent.atomic.AtomicLong;
  */
 public class TestServerRouter implements IServerRouter {
 
-    @Setter
     IServer serverUnderTest;
+
+    void setServerUnderTest(IServer server) {
+        serverUnderTest = server;
+    }
+
     AtomicLong requestCounter;
 
     @Getter
     @Setter
-    long epoch;
+    long serverEpoch;
 
     @Getter
     public List<CorfuMsg> responseMessages;
@@ -38,11 +42,13 @@ public class TestServerRouter implements IServerRouter {
 
     @Override
     public void sendResponse(ChannelHandlerContext ctx, CorfuMsg inMsg, CorfuMsg outMsg) {
+        outMsg.setEpoch(serverEpoch);
         this.responseMessages.add(outMsg);
     }
 
     public void sendServerMessage(CorfuMsg msg)
     {
+        msg.setEpoch(serverEpoch);
         msg.setRequestID(requestCounter.getAndIncrement());
         serverUnderTest.handleMessage(msg, null, this);
     }

--- a/src/test/java/org/corfudb/runtime/clients/AbstractClientTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/AbstractClientTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.clients;
 
 import com.google.common.collect.ImmutableMap;
+import lombok.Getter;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.infrastructure.IServer;
 import org.junit.Before;
@@ -13,6 +14,7 @@ import java.util.Set;
  */
 public abstract class AbstractClientTest extends AbstractCorfuTest {
 
+    @Getter
     TestClientRouter router;
 
     @Before

--- a/src/test/java/org/corfudb/runtime/clients/LayoutClientTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/LayoutClientTest.java
@@ -25,7 +25,7 @@ public class LayoutClientTest extends AbstractClientTest {
     @Override
     Set<IServer> getServersForTest() {
         return new ImmutableSet.Builder<IServer>()
-                .add(new LayoutServer(defaultOptionsMap()))
+                .add(new LayoutServer(defaultOptionsMap(), getRouter()))
                 .build();
     }
 
@@ -84,6 +84,19 @@ public class LayoutClientTest extends AbstractClientTest {
                 .isEqualTo(true);
         assertThatThrownBy(() -> client.bootstrapLayout(getTestLayout()).get())
                 .hasCauseInstanceOf(AlreadyBootstrappedException.class);
+    }
+
+    @Test
+    public void canGetNewLayoutInDifferentEpoch()
+            throws Exception
+    {
+        Layout l = getTestLayout();
+        l.setEpoch(42L);
+        assertThat(client.bootstrapLayout(l).get())
+                .isEqualTo(true);
+
+        assertThat(client.getLayout().get().getEpoch())
+                .isEqualTo(42L);
     }
 
     @Test

--- a/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -38,12 +38,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canReadWriteToSingle()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
         testMap.clear();
@@ -70,12 +65,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void loadsFollowedByGets()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
         testMap.clear();
@@ -93,12 +83,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canContainOtherCorfuObjects()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(CorfuRuntime.getStreamID("a"), SMRMap.class);
         testMap.clear();
@@ -125,12 +110,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canContainNullObjects()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(CorfuRuntime.getStreamID("a"), SMRMap.class);
         testMap.clear();
@@ -146,12 +126,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void loadsFollowedByGetsConcurrent()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
 
@@ -188,12 +163,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void collectionsStreamInterface()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
 
@@ -212,12 +182,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canUpdateSingleObjectTransacationally()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
         getRuntime().getObjectsView().TXBegin();
@@ -236,12 +201,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void multipleTXesAreApplied()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
         IntStream.range(0, 10).asLongStream()
@@ -270,12 +230,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void multipleTXesAreAppliedWOAccessors()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
         IntStream.range(0, 10).asLongStream()
@@ -299,12 +254,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void mutatorFollowedByATransaction()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
         testMap.clear();
@@ -324,12 +274,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void objectViewCorrectlyReportsInsideTX()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
         assertThat(getRuntime().getObjectsView().TXActive())
                 .isFalse();
         getRuntime().getObjectsView().TXBegin();
@@ -344,12 +289,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canUpdateSingleObjectTransacationallyWhenCached()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect()
+        getDefaultRuntime().connect()
                 .setCacheDisabled(false);
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
@@ -370,12 +310,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void abortedTransactionsCannotBeReadOnSingleObject ()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
         getRuntime().getObjectsView().TXBegin();
@@ -395,12 +330,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void modificationDuringTransactionCausesAbort ()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView()
                 .open(CorfuRuntime.getStreamID("A"), SMRMap.class);
@@ -435,12 +365,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void smrMapCanContainCustomObjects()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,TestObject> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(),
                 SMRMap.class);
@@ -455,12 +380,7 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void smrMapCanContainCustomObjectsInsideTXes()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,TestObject> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(),
                 SMRMap.class);

--- a/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -51,12 +51,7 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void multipleWritesConsistencyTest()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(
                 CorfuRuntime.getStreamID("test"), TreeMap.class);
@@ -79,12 +74,7 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void multipleWritesConsistencyTestConcurrent()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().connect();
+        getDefaultRuntime().connect();
 
 
         Map<String,String> testMap = getRuntime().getObjectsView().open(
@@ -119,14 +109,8 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canWrapObjectWithPrimitiveTypes()
             throws Exception {
-        // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
         //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime().connect();
         TestClassWithPrimitives test = r.getObjectsView().open("test", TestClassWithPrimitives.class);
         test.setPrimitive("hello world".getBytes());
         assertThat(test.getPrimitive())
@@ -138,14 +122,8 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canUsePrimitiveSerializer()
             throws Exception {
-        // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
         //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime().connect();
         TestClassWithPrimitives test = r.getObjectsView().build()
                                                             .setType(TestClassWithPrimitives.class)
                                                             .setStreamName("test")

--- a/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -3,10 +3,7 @@ package org.corfudb.runtime.view;
 import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 import org.corfudb.AbstractCorfuTest;
-import org.corfudb.infrastructure.IServer;
-import org.corfudb.infrastructure.LayoutServer;
-import org.corfudb.infrastructure.LogUnitServer;
-import org.corfudb.infrastructure.SequencerServer;
+import org.corfudb.infrastructure.*;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.*;
 import org.corfudb.runtime.exceptions.OutrankedException;
@@ -50,8 +47,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
     {
         serverMap.keySet().stream()
                 .map(address -> {
-                    TestClientRouter r = new TestClientRouter();
-                    r.setAddress(address);
+                    TestClientRouter r = getTestRouterForEndpoint(address);
                     r.addClient(new LayoutClient())
                             .addClient(new SequencerClient())
                             .addClient(new LogUnitClient())
@@ -88,7 +84,9 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
 
     public CorfuRuntime getDefaultRuntime() {
         // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        routerMap.put(getDefaultEndpoint(), new TestClientRouter());
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap(),
+                routerMap.get(getDefaultEndpoint())));
         addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
         addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
         wireRouters();
@@ -102,6 +100,17 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
         routerMap = new HashMap<>();
         serverMap = new HashMap<>();
         runtime.setGetRouterFunction(routerMap::get);
+    }
+
+    public TestClientRouter getTestRouterForEndpoint(String endpoint) {
+        return routerMap.computeIfAbsent(endpoint, x -> {
+           TestClientRouter c = new TestClientRouter();
+           c.setAddress(x);
+            return c;
+        });
+    }
+    public IServerRouter getServerRouterForEndpoint(String endpoint) {
+        return routerMap.computeIfAbsent(endpoint, x -> new TestClientRouter());
     }
 
     public String getDefaultConfigurationString() {return getDefaultEndpoint();}

--- a/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -30,13 +30,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
 
     @Test
     public void cacheMissTimesOut() {
-        // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
-        getRuntime().setCacheDisabled(false).connect();
+        getDefaultRuntime().setCacheDisabled(false).connect();
 
         getRuntime().getAddressSpaceView().setEmptyDuration(Duration.ofNanos(100));
         assertThat(getRuntime().getAddressSpaceView().read(0).getResultType())
@@ -54,7 +48,8 @@ public class AddressSpaceViewTest extends AbstractViewTest {
             throws Exception
     {
         // default layout is chain replication.
-        addServerForTest(getEndpoint(9000), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getEndpoint(9000), new LayoutServer(defaultOptionsMap(),
+                getServerRouterForEndpoint(getEndpoint(9000))));
 
         LogUnitServer l9000 = new LogUnitServer(defaultOptionsMap());
         LogUnitServer l9001 = new LogUnitServer(defaultOptionsMap());
@@ -64,6 +59,9 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         addServerForTest(getEndpoint(9001), l9001);
         addServerForTest(getEndpoint(9002), l9002);
         wireRouters();
+
+        getServerRouterForEndpoint(getEndpoint(9001)).setServerEpoch(1L);
+        getServerRouterForEndpoint(getEndpoint(9002)).setServerEpoch(1L);
 
         //configure the layout accordingly
         CorfuRuntime r = getRuntime().connect();
@@ -120,7 +118,8 @@ public class AddressSpaceViewTest extends AbstractViewTest {
             throws Exception
     {
         // default layout is chain replication.
-        addServerForTest(getEndpoint(9000), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getEndpoint(9000), new LayoutServer(defaultOptionsMap(),
+                getServerRouterForEndpoint(getEndpoint(9000))));
 
         LogUnitServer l9000 = new LogUnitServer(defaultOptionsMap());
         LogUnitServer l9001 = new LogUnitServer(defaultOptionsMap());
@@ -130,6 +129,9 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         addServerForTest(getEndpoint(9001), l9001);
         addServerForTest(getEndpoint(9002), l9002);
         wireRouters();
+
+        getServerRouterForEndpoint(getEndpoint(9001)).setServerEpoch(1L);
+        getServerRouterForEndpoint(getEndpoint(9002)).setServerEpoch(1L);
 
         //configure the layout accordingly
         CorfuRuntime r = getRuntime().connect();
@@ -184,7 +186,8 @@ public class AddressSpaceViewTest extends AbstractViewTest {
             throws Exception
     {
         // default layout is chain replication.
-        addServerForTest(getEndpoint(9000), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getEndpoint(9000), new LayoutServer(defaultOptionsMap()
+                , getServerRouterForEndpoint(getEndpoint(9000))));
 
         LogUnitServer l9000 = new LogUnitServer(defaultOptionsMap());
         LogUnitServer l9001 = new LogUnitServer(defaultOptionsMap());
@@ -194,6 +197,9 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         addServerForTest(getEndpoint(9001), l9001);
         addServerForTest(getEndpoint(9002), l9002);
         wireRouters();
+
+        getServerRouterForEndpoint(getEndpoint(9001)).setServerEpoch(1L);
+        getServerRouterForEndpoint(getEndpoint(9002)).setServerEpoch(1L);
 
         //configure the layout accordingly
         CorfuRuntime r = getRuntime().connect();

--- a/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
@@ -29,7 +29,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
     public void canReadWriteToSingle()
     throws Exception {
         // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap(),
+                getServerRouterForEndpoint(getEndpoint(9000))));
         addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
         wireRouters();
 
@@ -54,7 +55,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
     public void canReadWriteToSingleConcurrent()
             throws Exception {
         // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap(),
+                getServerRouterForEndpoint(getEndpoint(9000))));
         addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
         wireRouters();
 
@@ -89,11 +91,15 @@ public class ChainReplicationViewTest extends AbstractViewTest {
     throws Exception
     {
         // default layout is chain replication.
-        addServerForTest(getEndpoint(9000), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getEndpoint(9000), new LayoutServer(defaultOptionsMap(),
+                getServerRouterForEndpoint(getEndpoint(9000))));
         addServerForTest(getEndpoint(9000), new LogUnitServer(defaultOptionsMap()));
         addServerForTest(getEndpoint(9001), new LogUnitServer(defaultOptionsMap()));
         addServerForTest(getEndpoint(9002), new LogUnitServer(defaultOptionsMap()));
         wireRouters();
+
+        getServerRouterForEndpoint(getEndpoint(9001)).setServerEpoch(1L);
+        getServerRouterForEndpoint(getEndpoint(9002)).setServerEpoch(1L);
 
         //configure the layout accordingly
         CorfuRuntime r = getRuntime().connect();
@@ -137,7 +143,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
             throws Exception
     {
         // default layout is chain replication.
-        addServerForTest(getEndpoint(9000), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getEndpoint(9000),
+                new LayoutServer(defaultOptionsMap(), getServerRouterForEndpoint(getEndpoint(9000))));
 
         LogUnitServer l9000 = new LogUnitServer(defaultOptionsMap());
         LogUnitServer l9001 = new LogUnitServer(defaultOptionsMap());
@@ -147,6 +154,9 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         addServerForTest(getEndpoint(9001), l9001);
         addServerForTest(getEndpoint(9002), l9002);
         wireRouters();
+
+        getServerRouterForEndpoint(getEndpoint(9001)).setServerEpoch(1L);
+        getServerRouterForEndpoint(getEndpoint(9002)).setServerEpoch(1L);
 
         //configure the layout accordingly
         CorfuRuntime r = getRuntime().connect();

--- a/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -20,7 +20,8 @@ public class LayoutViewTest extends AbstractViewTest {
 
     @Test
     public void canGetLayout() {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap(),
+                getServerRouterForEndpoint(getDefaultEndpoint())));
         wireRouters();
 
         CorfuRuntime r = getRuntime().connect();
@@ -32,7 +33,8 @@ public class LayoutViewTest extends AbstractViewTest {
     @Test
     public void canSetLayout()
             throws Exception {
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap(),
+                getServerRouterForEndpoint(getDefaultEndpoint())));
         wireRouters();
 
         CorfuRuntime r = getRuntime().connect();

--- a/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -30,14 +30,8 @@ public class StreamViewTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canReadWriteFromStream()
             throws Exception {
-        // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
         //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime().connect();
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
@@ -55,14 +49,8 @@ public class StreamViewTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canReadWriteFromStreamConcurrent()
             throws Exception {
-        // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
         //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime().connect();
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
@@ -81,14 +69,8 @@ public class StreamViewTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canReadWriteFromStreamWithoutBackpointers()
             throws Exception {
-        // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
         //begin tests
-        CorfuRuntime r = getRuntime()
+        CorfuRuntime r = getDefaultRuntime()
                 .setBackpointersDisabled(true)
                 .connect();
 
@@ -112,14 +94,8 @@ public class StreamViewTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canReadWriteFromCachedStream()
             throws Exception {
-        // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
         //begin tests
-        CorfuRuntime r = getRuntime().connect()
+        CorfuRuntime r = getDefaultRuntime().connect()
                 .setCacheDisabled(false);
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
@@ -138,14 +114,8 @@ public class StreamViewTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void streamCanSurviveOverwriteException()
             throws Exception {
-        // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
         //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime().connect();
         UUID streamA = CorfuRuntime.getStreamID("stream A");
         byte[] testPayload = "hello world".getBytes();
 
@@ -167,14 +137,8 @@ public class StreamViewTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void streamWillHoleFill()
             throws Exception {
-        // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
-
         //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime().connect();
         UUID streamA = CorfuRuntime.getStreamID("stream A");
         byte[] testPayload = "hello world".getBytes();
 

--- a/src/test/java/org/corfudb/runtime/view/StreamsViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/StreamsViewTest.java
@@ -22,14 +22,9 @@ public class StreamsViewTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canCopyStream()
             throws Exception {
-        // default layout is chain replication.
-        addServerForTest(getDefaultEndpoint(), new LayoutServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
-        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
-        wireRouters();
 
         //begin tests
-        CorfuRuntime r = getRuntime().connect();
+        CorfuRuntime r = getDefaultRuntime().connect();
         UUID streamA = CorfuRuntime.getStreamID("stream A");
         UUID streamACopy = CorfuRuntime.getStreamID("stream A copy");
         byte[] testPayload = "hello world".getBytes();

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <root level="DEBUG">
+    <root level="TRACE">
        <!--<appender-ref ref="STDOUT" />-->
     </root>
 </configuration>


### PR DESCRIPTION
Previously, the unit testing framework did not check for epochs in messages, which let a few bugs related to epoch checking slip through. This has been added now.

In addition, previously, after a layout change, the ACK message from a layout server in the wrong epoch would be dropped, causing communication issues with clients in the wrong epoch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/154)
<!-- Reviewable:end -->
