### PR TITLE
Retry if netty router connection fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
-            <version>4.0.35.Final</version>
+            <version>4.0.37.Final</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -102,11 +102,15 @@ public class CorfuRuntime {
         // Generate a new router, start it and add it to the table.
         NettyClientRouter router = new NettyClientRouter(host, port);
         log.debug("Connecting to new router {}:{}", host, port);
-        router.addClient(new LayoutClient())
-                .addClient(new SequencerClient())
-                .addClient(new LogUnitClient())
-                .start();
-        nodeRouters.put(address, router);
+        try {
+            router.addClient(new LayoutClient())
+                    .addClient(new SequencerClient())
+                    .addClient(new LogUnitClient())
+                    .start();
+            nodeRouters.put(address, router);
+        } catch (Exception e) {
+            log.warn("Error connecting to router", e);
+        }
         return router;
     };
 

--- a/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -136,70 +136,60 @@ implements IClientRouter {
 
     public void start()
     {
-        while (true) {
-            try {
-                workerGroup = new NioEventLoopGroup(Runtime.getRuntime().availableProcessors() * 2, new ThreadFactory() {
-                    final AtomicInteger threadNum = new AtomicInteger(0);
+        workerGroup = new NioEventLoopGroup(Runtime.getRuntime().availableProcessors() * 2, new ThreadFactory() {
+            final AtomicInteger threadNum = new AtomicInteger(0);
 
-                    @Override
-                    public Thread newThread(Runnable r) {
-                        Thread t = new Thread(r);
-                        t.setName("worker-" + threadNum.getAndIncrement());
-                        t.setDaemon(true);
-                        return t;
-                    }
-                });
-
-                ee = new DefaultEventExecutorGroup(Runtime.getRuntime().availableProcessors() * 2, new ThreadFactory() {
-
-                    final AtomicInteger threadNum = new AtomicInteger(0);
-
-                    @Override
-                    public Thread newThread(Runnable r) {
-                        Thread t = new Thread(r);
-                        t.setName(this.getClass().getName() + "event-" + threadNum.getAndIncrement());
-                        t.setDaemon(true);
-                        return t;
-                    }
-                });
-
-
-                Bootstrap b = new Bootstrap();
-                b.group(workerGroup);
-                b.channel(NioSocketChannel.class);
-                b.option(ChannelOption.SO_KEEPALIVE, true);
-                b.option(ChannelOption.TCP_NODELAY, true);
-                NettyClientRouter router = this;
-                b.handler(new ChannelInitializer<SocketChannel>() {
-                    @Override
-                    public void initChannel(SocketChannel ch) throws Exception {
-                        ch.pipeline().addLast(new LengthFieldPrepender(4));
-                        ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
-                        ch.pipeline().addLast(ee, new NettyCorfuMessageDecoder());
-                        ch.pipeline().addLast(ee, new NettyCorfuMessageEncoder());
-                        ch.pipeline().addLast(ee, router);
-                    }
-                });
-
-                try {
-                    ChannelFuture cf = b.connect(host, port);
-                    cf.syncUninterruptibly();
-                    if (!cf.awaitUninterruptibly(5000)) {
-                        throw new NetworkException("Timeout connecting to endpoint", host + ":" + port);
-                    }
-                    channel = cf.channel();
-                } catch (Exception e) {
-                    throw new NetworkException(e.getClass().getSimpleName() +
-                            " connecting to endpoint", host + ":" + port, e);
-                }
-                return;
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r);
+                t.setName("worker-" + threadNum.getAndIncrement());
+                t.setDaemon(true);
+                return t;
             }
-            catch (Exception ex) {
-                log.warn("Exception occurred during connection to endpoint, retrying in 5s", ex);
-                try {
-                    Thread.sleep(5000);
-                } catch (InterruptedException ie) {}
+        });
+
+        ee = new DefaultEventExecutorGroup(Runtime.getRuntime().availableProcessors() * 2, new ThreadFactory() {
+
+            final AtomicInteger threadNum = new AtomicInteger(0);
+
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread t = new Thread(r);
+                t.setName(this.getClass().getName() + "event-" + threadNum.getAndIncrement());
+                t.setDaemon(true);
+                return t;
             }
+        });
+
+
+        Bootstrap b = new Bootstrap();
+        b.group(workerGroup);
+        b.channel(NioSocketChannel.class);
+        b.option(ChannelOption.SO_KEEPALIVE, true);
+        b.option(ChannelOption.TCP_NODELAY, true);
+        NettyClientRouter router = this;
+        b.handler(new ChannelInitializer<SocketChannel>() {
+            @Override
+            public void initChannel(SocketChannel ch) throws Exception {
+                ch.pipeline().addLast(new LengthFieldPrepender(4));
+                ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
+                ch.pipeline().addLast(ee, new NettyCorfuMessageDecoder());
+                ch.pipeline().addLast(ee, new NettyCorfuMessageEncoder());
+                ch.pipeline().addLast(ee, router);
+            }
+        });
+
+        try {
+            ChannelFuture cf = b.connect(host, port);
+            cf.syncUninterruptibly();
+            if (!cf.awaitUninterruptibly(5000)) {
+                throw new NetworkException("Timeout connecting to endpoint", host + ":" + port);
+            }
+            channel = cf.channel();
+        } catch (Exception e)
+        {
+            throw new NetworkException(e.getClass().getSimpleName() +
+                    " connecting to endpoint", host + ":" + port, e);
         }
     }
 

--- a/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -15,6 +15,8 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.infrastructure.BaseServer;
@@ -27,6 +29,8 @@ import java.io.IOException;
 import java.net.ServerSocket;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @Slf4j
 public class NettyCommTest extends AbstractCorfuTest {
+
 
     private Integer findRandomOpenPort() throws IOException {
         try (
@@ -46,95 +51,137 @@ public class NettyCommTest extends AbstractCorfuTest {
 
     @Test
     public void nettyServerClientPingable() throws Exception {
-        NettyServerRouter nsr = new NettyServerRouter();
-        nsr.addServer(new BaseServer(nsr));
-        int port = findRandomOpenPort();
+        runWithBaseServer((r, d) -> {
+            assertThat(r.getClient(BaseClient.class).pingSync())
+                    .isTrue();
+        });
+    }
 
-        // Create the event loops responsible for servicing inbound messages.
+    @Test
+    public void nettyServerClientPingableAfterFailure() throws Exception {
+        runWithBaseServer((r, d) -> {
+            assertThat(r.getClient(BaseClient.class).pingSync())
+                    .isTrue();
+            d.shutdownServer();
+            d.bootstrapServer();
+            // First ping may fail due to connection loss.
+            r.getClient(BaseClient.class).pingSync();
+            assertThat(r.getClient(BaseClient.class).pingSync())
+                    .isTrue();
+        });
+    }
+
+    @Data
+    public class NettyServerData {
+        ServerBootstrap b;
+        ChannelFuture f;
+        int port;
+
+        public NettyServerData(int port) {
+            this.port = port;
+        }
+
         EventLoopGroup bossGroup;
         EventLoopGroup workerGroup;
         EventExecutorGroup ee;
 
-        bossGroup = new NioEventLoopGroup(1, new ThreadFactory() {
-            final AtomicInteger threadNum = new AtomicInteger(0);
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setName("accept-" +threadNum.getAndIncrement());
-                return t;
-            }
-        });
+        void bootstrapServer() throws Exception {
+            NettyServerRouter nsr = new NettyServerRouter();
+            bossGroup = new NioEventLoopGroup(1, new ThreadFactory() {
+                final AtomicInteger threadNum = new AtomicInteger(0);
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread t = new Thread(r);
+                    t.setName("accept-" +threadNum.getAndIncrement());
+                    return t;
+                }
+            });
 
-        workerGroup = new NioEventLoopGroup(Runtime.getRuntime().availableProcessors() * 2, new ThreadFactory() {
-            final AtomicInteger threadNum = new AtomicInteger(0);
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setName("io-" + threadNum.getAndIncrement());
-                return t;
-            }
-        });
+            workerGroup = new NioEventLoopGroup(Runtime.getRuntime().availableProcessors() * 2, new ThreadFactory() {
+                final AtomicInteger threadNum = new AtomicInteger(0);
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread t = new Thread(r);
+                    t.setName("io-" + threadNum.getAndIncrement());
+                    return t;
+                }
+            });
 
-        ee = new DefaultEventExecutorGroup(Runtime.getRuntime().availableProcessors() * 2, new ThreadFactory() {
+            ee = new DefaultEventExecutorGroup(Runtime.getRuntime().availableProcessors() * 2, new ThreadFactory() {
 
-            final AtomicInteger threadNum = new AtomicInteger(0);
+                final AtomicInteger threadNum = new AtomicInteger(0);
 
-            @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setName("event-" + threadNum.getAndIncrement());
-                return t;
-            }
-        });
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread t = new Thread(r);
+                    t.setName("event-" + threadNum.getAndIncrement());
+                    return t;
+                }
+            });
 
-
-        try {
-            ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
-                    .channel(NioServerSocketChannel.class)
-                    .option(ChannelOption.SO_BACKLOG, 100)
-                    .childOption(ChannelOption.SO_KEEPALIVE, true)
-                    .childOption(ChannelOption.TCP_NODELAY, true)
-                    .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
-                    .handler(new LoggingHandler(LogLevel.INFO))
-                    .childHandler(new ChannelInitializer<SocketChannel>() {
-                        @Override
-                        public void initChannel(io.netty.channel.socket.SocketChannel ch) throws Exception {
-                            ch.pipeline().addLast(new LengthFieldPrepender(4));
-                            ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
-                            ch.pipeline().addLast(ee, new NettyCorfuMessageDecoder());
-                            ch.pipeline().addLast(ee, new NettyCorfuMessageEncoder());
-                            ch.pipeline().addLast(ee, nsr);
-                        }
-                    });
-            ChannelFuture f = b.bind(port).sync();
-
-            NettyClientRouter ncr = new NettyClientRouter("localhost", port);
-            try {
-
-                ncr.addClient(new BaseClient());
-                ncr.start();
-                assertThat(ncr.getClient(BaseClient.class).pingSync())
-                        .isTrue();
-            }
-            finally {
-                ncr.stop();
-            }
-            f.channel().close();
-
+            b = new ServerBootstrap();
+                b.group(bossGroup, workerGroup)
+                        .channel(NioServerSocketChannel.class)
+                        .option(ChannelOption.SO_BACKLOG, 100)
+                        .childOption(ChannelOption.SO_KEEPALIVE, true)
+                        .childOption(ChannelOption.TCP_NODELAY, true)
+                        .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
+                        .handler(new LoggingHandler(LogLevel.INFO))
+                        .childHandler(new ChannelInitializer<SocketChannel>() {
+                            @Override
+                            public void initChannel(io.netty.channel.socket.SocketChannel ch) throws Exception {
+                                ch.pipeline().addLast(new LengthFieldPrepender(4));
+                                ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
+                                ch.pipeline().addLast(ee, new NettyCorfuMessageDecoder());
+                                ch.pipeline().addLast(ee, new NettyCorfuMessageEncoder());
+                                ch.pipeline().addLast(ee, nsr);
+                            }
+                        });
+            f = b.bind(port).sync();
         }
-        catch (InterruptedException ie)
+
+        public void shutdownServer()
         {
-
-        }
-        catch (Exception ex)
-        {
-            log.error("Corfu server shut down unexpectedly due to exception", ex);
-        }
-        finally {
+            f.channel().close().awaitUninterruptibly();
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();
         }
+
+    }
+
+    @FunctionalInterface
+    public interface NettyCommFunction {
+        void runTest(NettyClientRouter r, NettyServerData d) throws Exception;
+    }
+
+    void runWithBaseServer(NettyCommFunction actionFn)
+    throws Exception {
+
+        NettyServerRouter nsr = new NettyServerRouter();
+        nsr.addServer(new BaseServer(nsr));
+        int port = findRandomOpenPort();
+
+            NettyServerData d = new NettyServerData(port);
+            NettyClientRouter ncr = new NettyClientRouter("localhost", port);
+            try {
+                d.bootstrapServer();
+                ncr.addClient(new BaseClient());
+                ncr.start();
+                actionFn.runTest(ncr, d);
+            }
+            catch (Exception ex)
+            {
+                log.error("Exception ", ex);
+                throw ex;
+            }
+            finally {
+                try {
+                    ncr.stop();
+                } catch (Exception ex) {
+                    log.warn("Error shutting down client...", ex);
+                }
+                d.shutdownServer();
+            }
 
     }
 }

--- a/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -1,12 +1,19 @@
 package org.corfudb.runtime.view;
 
+import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 import org.corfudb.infrastructure.LayoutServer;
+import org.corfudb.infrastructure.LogUnitServer;
 import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.LayoutClient;
+import org.corfudb.runtime.clients.TestClientRouter;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,5 +66,69 @@ public class LayoutViewTest extends AbstractViewTest {
         r.invalidateLayout();
         assertThat(r.getLayoutView().getLayout().epoch)
                 .isEqualTo(1L);
+    }
+
+    @Test
+    public void canTolerateLayoutServerFailure()
+            throws Exception {
+        // No Bootstrap Option Map
+        Map<String, Object> noBootstrap = new ImmutableMap.Builder<String,Object>()
+                .put("--initial-token", "0")
+                .put("--memory", true)
+                .put("--single", false)
+                .put("--max-cache", "256M")
+                .put("--sync", false)
+                .build();
+
+        // Server @ 9000 : Layout, Sequencer, LogUnit
+        addServerForTest(getDefaultEndpoint(), new LayoutServer(noBootstrap,
+                getServerRouterForEndpoint(getDefaultEndpoint())));
+        addServerForTest(getDefaultEndpoint(), new SequencerServer(defaultOptionsMap()));
+        addServerForTest(getDefaultEndpoint(), new LogUnitServer(defaultOptionsMap()));
+
+        // Server @ 9001 : Layout
+        LayoutServer failingServer = new LayoutServer(noBootstrap,
+                getServerRouterForEndpoint(getEndpoint(9001)));
+
+        addServerForTest(getEndpoint(9001), failingServer);
+        wireRouters();
+
+        String localAddress = "localhost:9000";
+        String failingAddress = "localhost:9001";
+        List<String> layoutServers = new ArrayList<>();
+        layoutServers.add(localAddress);
+        layoutServers.add(failingAddress);
+
+        Layout l = new Layout(
+                layoutServers,
+                Collections.singletonList(localAddress),
+                Collections.singletonList(new Layout.LayoutSegment(
+                        Layout.ReplicationMode.CHAIN_REPLICATION,
+                        0L,
+                        -1L,
+                        Collections.singletonList(
+                                new Layout.LayoutStripe(
+                                        Collections.singletonList(localAddress)
+                                )
+                        )
+                )),
+                1L
+        );
+
+        // Bootstrap with this layout.
+        getTestRouterForEndpoint(getEndpoint(9000L)).getClient(LayoutClient.class)
+                .bootstrapLayout(l);
+        getTestRouterForEndpoint(getEndpoint(9001L)).getClient(LayoutClient.class)
+                .bootstrapLayout(l);
+
+        CorfuRuntime r = getRuntime().connect();
+
+        // Fail the network link between the client and test server
+        TestClientRouter tcr = getTestRouterForEndpoint(getEndpoint(9001));
+        tcr.setDropAllMessagesClientToServer(true);
+
+        r.invalidateLayout();
+
+        r.getStreamsView().get(CorfuRuntime.getStreamID("hi")).check();
     }
 }


### PR DESCRIPTION
Previously, if the router fails on start(), it throws an exception which causes the generation of a client layout view to fail. This patch makes the router retry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/156)
<!-- Reviewable:end -->
