### PR TITLE
fix a bug in the annotation framework where unannotated methods were not instrumented

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,12 +154,12 @@
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
-            <version>1.3.6</version>
+            <version>1.4.4</version>
         </dependency>
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>
-            <version>1.3.6</version>
+            <version>1.4.4</version>
         </dependency>
         <dependency>
             <groupId>com.esotericsoftware</groupId>

--- a/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
@@ -301,7 +301,7 @@ public class CorfuSMRObjectProxy<P> extends CorfuObjectProxy<P> {
 
     private synchronized Object doUnderlyingCall(Callable superMethod, Method method, Object[] arguments)
             throws Exception {
-            if (isCorfuObject) {
+            if (isCorfuObject || selfState) {
                 return superMethod.call();
             } else {
                 return method.invoke(interceptGetSMRObject(null), arguments);

--- a/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -162,8 +162,24 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
 
         assertThat(test.testIncrement())
                 .isTrue();
-    }
 
+        assertThat(test.getValue())
+                .isNotZero();
+
+        // clear the cache, forcing a new object to be built.
+        r.getObjectsView().getObjectCache().clear();
+
+        TestClassUsingAnnotation test2 = r.getObjectsView().build()
+                .setStreamName("test")
+                .setType(TestClassUsingAnnotation.class)
+                .open();
+
+        assertThat(test)
+                .isNotSameAs(test2);
+
+        assertThat(test2.getValue())
+                .isNotZero();
+    }
 
     @Test
     @SuppressWarnings("unchecked")

--- a/src/test/java/org/corfudb/runtime/object/TestClassUsingAnnotation.java
+++ b/src/test/java/org/corfudb/runtime/object/TestClassUsingAnnotation.java
@@ -6,7 +6,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * Created by mwei on 6/22/16.
  */
 @CorfuObject(objectType= ObjectType.SMR,
-        constructorType= ConstructorType.PERSISTED,
+        constructorType= ConstructorType.RUNTIME,
         stateSource = StateSource.SELF
 )
 public class TestClassUsingAnnotation {
@@ -17,15 +17,19 @@ public class TestClassUsingAnnotation {
         a1 = new AtomicInteger();
     }
 
-    boolean testFn1() {
+    public boolean testFn1() {
         return true;
     }
 
-    boolean testIncrement() {
+    public boolean testIncrement() {
         return a1.incrementAndGet() != 0;
     }
 
-    void reset() {
+    public int getValue() {
+        return a1.get();
+    }
+
+    public void reset() {
         a1.set(0);
     }
 }


### PR DESCRIPTION
In the annotation framework, methods which were not annotated were not being instrumented by default. This patch fixes this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/159)
<!-- Reviewable:end -->
