### PR TITLE
Re-organization and clean up

### DIFF
--- a/src/main/java/org/corfudb/protocols/wireprotocol/LogUnitReadResponseMsg.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/LogUnitReadResponseMsg.java
@@ -3,6 +3,7 @@ package org.corfudb.protocols.wireprotocol;
 import io.netty.buffer.ByteBuf;
 import lombok.*;
 import lombok.experimental.Accessors;
+import org.corfudb.infrastructure.LogUnitServer;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.runtime.CorfuRuntime;
 
@@ -39,25 +40,6 @@ public class LogUnitReadResponseMsg extends LogUnitPayloadMsg {
     public static Map<Byte, ReadResultType> readResultTypeMap =
             Arrays.<ReadResultType>stream(ReadResultType.values())
                     .collect(Collectors.toMap(ReadResultType::asByte, Function.identity()));
-
-    @Data
-    @RequiredArgsConstructor
-    @AllArgsConstructor
-    public static class LogUnitEntry implements IMetadata {
-        public final ByteBuf buffer;
-        public final EnumMap<IMetadata.LogUnitMetadataType, Object> metadataMap;
-        public final boolean isHole;
-        public boolean isPersisted;
-
-        /** Generate a new log unit entry which is a hole */
-        public LogUnitEntry()
-        {
-            buffer = null;
-            metadataMap = new EnumMap<>(IMetadata.LogUnitMetadataType.class);
-            isHole = true;
-            isPersisted = false;
-        }
-    }
 
     @ToString(exclude="runtime")
     @Accessors(chain=true)
@@ -119,7 +101,7 @@ public class LogUnitReadResponseMsg extends LogUnitPayloadMsg {
         this.result = result;
     }
 
-    public LogUnitReadResponseMsg(LogUnitEntry entry)
+    public LogUnitReadResponseMsg(LogUnitServer.LogUnitEntry entry)
     {
         this.msgType = CorfuMsgType.READ_RESPONSE;
         this.result = ReadResultType.DATA;

--- a/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -54,7 +54,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         m.setPayload(payload);
         sendMessage(m);
 
-        LoadingCache<Long, LogUnitReadResponseMsg.LogUnitEntry> dataCache = s1.getDataCache();
+        LoadingCache<Long, LogUnitServer.LogUnitEntry> dataCache = s1.getDataCache();
         // Make sure that extra bytes are truncated from the payload byte buf
         assertThat(dataCache.get(address).getBuffer().capacity()).isEqualTo(payload.length);
 


### PR DESCRIPTION
Since the LogUnitEntry is part of the LogUnitServer internal
representation, I grouped them together. Also, I added a address
field in LogUnitEntry because that information was only retained
in the datacache map.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/181)
<!-- Reviewable:end -->
