### PR TITLE
Paxos branch

### DIFF
--- a/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -2,19 +2,25 @@ package org.corfudb.infrastructure;
 
 import com.google.common.io.Files;
 import io.netty.channel.ChannelHandlerContext;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.LayoutMsg;
 import org.corfudb.protocols.wireprotocol.LayoutRankMsg;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.Layout.LayoutSegment;
+import org.corfudb.util.JSONUtils;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.file.StandardOpenOption;
 import java.util.Collections;
 import java.util.Map;
+
+import static com.google.common.io.Files.*;
 
 /**
  * The layout server serves layouts, which are used by clients to find the
@@ -46,6 +52,7 @@ import java.util.Map;
  *
  * Created by mwei on 12/8/15.
  */
+//TODO Finer grained synchronization needed for this class.
 @Slf4j
 public class LayoutServer implements IServer {
 
@@ -56,10 +63,13 @@ public class LayoutServer implements IServer {
     Layout currentLayout;
 
     /** The current phase 1 rank */
-    long phase1Rank;
+    Rank phase1Rank;
 
     /** The current phase 2 rank, which should be equal to the epoch. */
-    long phase2Rank;
+    Rank phase2Rank;
+
+    /** The layout proposed in phase 2. */
+    Layout proposedLayout;
 
     /** The server router. */
     @Getter
@@ -67,6 +77,12 @@ public class LayoutServer implements IServer {
 
     /** Th layout file, or null if in memory. */
     File layoutFile;
+
+    /** Persistent storage for phase1 data in paxos */
+    File phase1File;
+
+    /** Persistent storage for phase2 data in paxos */
+    File phase2File;
 
     public LayoutServer(Map<String, Object> opts, IServerRouter serverRouter)
     {
@@ -76,6 +92,8 @@ public class LayoutServer implements IServer {
         if (opts.get("--log-path") != null)
         {
             layoutFile = new File(opts.get("--log-path") + File.separator + "layout");
+            phase1File = new File(opts.get("--log-path") + File.separator + "phase1Data");
+            phase2File = new File(opts.get("--log-path") + File.separator + "phase2Data");
         }
 
         if ((Boolean)opts.get("--single"))
@@ -83,7 +101,7 @@ public class LayoutServer implements IServer {
             String localAddress =  opts.get("--address") + ":" + opts.get("<port>");
             log.info("Single-node mode requested, initializing layout with single log unit and sequencer at {}.",
                     localAddress);
-            currentLayout = new Layout(
+            saveCurrentLayout(new Layout(
                     Collections.singletonList(localAddress),
                     Collections.singletonList(localAddress),
                     Collections.singletonList(new LayoutSegment(
@@ -97,56 +115,190 @@ public class LayoutServer implements IServer {
                             )
                     )),
                     0L
-            );
+            ));
 
-            phase1Rank = phase2Rank = 0;
-            saveCurrentLayout();
+            phase1Rank = phase2Rank = null;
         }
         else
         {
-            try {
-                if (layoutFile == null) {
-                    log.info("Layout server started, but in-memory mode set without bootstrap. " +
-                            "Starting uninitialized layout server.");
-                    currentLayout = null;
-                }
-                else if (!layoutFile.exists())
-                {
-                    log.warn("Layout server started, but no layout log found. Starting uninitialized layout server.");
-                    currentLayout = null;
-                }
-                else {
-                    String l = Files.toString(layoutFile, Charset.defaultCharset());
-                    currentLayout = Layout.fromJSONString(l);
-                    phase1Rank = phase2Rank = currentLayout.getEpoch();
-                    getServerRouter().setServerEpoch(currentLayout.getEpoch());
-                    log.info("Layout server started with layout from disk: {}.", currentLayout);
-                }
+            loadCurrentLayout();
+            if(currentLayout != null) {
+                getServerRouter().setServerEpoch(currentLayout.getEpoch());
             }
-            catch (Exception e)
-            {
-                log.error("Error reading from layout server", e);
-                currentLayout = null;
-            }
+            log.info("Layout server started with layout from disk: {}.", currentLayout);
+            loadPhase1Data();
+            loadPhase2Data();
         }
     }
 
     /** Save the current layout to disk, if not in-memory mode.
      *
      */
-    public void saveCurrentLayout() {
-        if (layoutFile != null)
+    public synchronized void saveCurrentLayout(Layout layout) {
+        if(layoutFile == null) {
+            currentLayout = layout;
+            return;
+        }
+        try {
+            write(layout.asJSONString().getBytes(), layoutFile);
+            log.info("Layout epoch {} saved to disk.", layout.getEpoch());
+            currentLayout = layout;
+        } catch (Exception e)
         {
-            try {
-                Files.write(currentLayout.asJSONString().getBytes(), layoutFile);
-                log.info("Layout epoch {} saved to disk.", currentLayout.getEpoch());
-            } catch (Exception e)
-            {
-                log.error("Error saving layout to disk!", e);
+            log.error("Error saving layout to disk!", e);
+        }
+    }
+    /**
+     * Loads the latest committed layout
+     * TODO need to figure out the right behaviour when their is error from the persistence layer.
+     *
+     * @return
+     */
+    private void loadCurrentLayout() {
+        try {
+            if (layoutFile == null) {
+                log.info("Layout server started, but in-memory mode set without bootstrap. " +
+                        "Starting uninitialized layout server.");
+                this.currentLayout = null;
             }
+            else if (!layoutFile.exists())
+            {
+                log.warn("Layout server started, but no layout log found. Starting uninitialized layout server.");
+                this.currentLayout = null;
+            }
+            else {
+                String l = Files.toString(layoutFile, Charset.defaultCharset());
+                this.currentLayout = Layout.fromJSONString(l);
+            }
+        }
+        catch (Exception e)
+        {
+            log.error("Error reading from layout server", e);
         }
     }
 
+    /**
+     * TODO need to figure out what to do when the phase1Rank cannot be saved to disk.
+     */
+    /**
+     * Persists phase1 Rank and also caches it in memory.
+     * @param rank
+     */
+    private synchronized void savePhase1Data(Rank rank) {
+        if(phase1File == null) {
+            this.phase1Rank = rank;
+            return;
+        }
+        try {
+            write(rank.asJSONString().getBytes(), phase1File);
+            log.info("Phase1Rank {} saved to disk.", rank);
+            this.phase1Rank = rank;
+        } catch (Exception e)
+        {
+            log.error("Error saving phase1Rank to disk!", e);
+        }
+    }
+
+    /**
+     * Loads the last persisted phase1 data into memory.
+     * TODO need to figure out the right behaviour when their is error from the persistence layer.
+     *
+     * @return
+     */
+    private void loadPhase1Data() {
+             try {
+                if (phase1File == null) {
+                    log.info("No phase1 data persisted so far. ");
+                }
+                else if (!phase1File.exists())
+                {
+                    log.warn("Phase1 data file found but no phase1 data found!");
+                }
+                else {
+                    String r = Files.toString(phase1File, Charset.defaultCharset());
+                    phase1Rank = Rank.fromJSONString(r);
+                }
+            }
+            catch (Exception e)
+            {
+                log.error("Error reading phase1 rank from data file for phase1.", e);
+            }
+
+    }
+
+    /**
+     * Phase2 data consists of rank and the proposed layout.
+     * The container class provides a convenience to persist and retrieve
+     * these two pieces of data together.
+     *
+     */
+    @Data
+    @AllArgsConstructor
+    static class Phase2Data {
+        Rank rank;
+        Layout layout;
+        /** Get the layout as a JSON string. */
+        public String asJSONString()
+        {
+            return JSONUtils.parser.toJson(this);
+        }
+
+        /** Get a layout from a JSON string. */
+        public static Phase2Data fromJSONString(String json) {
+            return JSONUtils.parser.fromJson(json, Phase2Data.class);
+        }
+    }
+    /**
+     * Persists  phase2 Data [rank, layout] and caches it in memory
+     * TODO need to figure out what to do when the phase1Rank cannot be saved to disk.
+     */
+    private synchronized void savePhase2Data(Rank rank, Layout layout) {
+        if (phase2File == null) {
+            this.phase2Rank = rank;
+            this.proposedLayout = layout;
+            return;
+        }
+        Phase2Data phase2Data = new Phase2Data(rank, layout);
+        try {
+            write(phase2Data.asJSONString().getBytes(), phase2File);
+            log.info("Phase2Rank {} saved to disk.", phase2Rank);
+            this.phase2Rank = rank;
+            this.proposedLayout = layout;
+        } catch (Exception e)
+        {
+            log.error("Error saving phase2Rank to disk!", e);
+        }
+    }
+
+    /**
+     * Returns the last persisted phase2 rank and proposed layout.
+     * TODO need to figure out the right behaviour when their is error from the persistence layer.
+     *
+     * @return
+     */
+    private void loadPhase2Data() {
+             try {
+                if (phase2File == null) {
+                    log.info("No phase2 data witnessed so far. ");
+                }
+                else if (!phase2File.exists())
+                {
+                    log.warn("Phase2 data file found but no data found!");
+                }
+                else {
+                    String r = Files.toString(phase2File, Charset.defaultCharset());
+                    Phase2Data phase2Data = Phase2Data.fromJSONString(r);
+                    phase2Rank = phase2Data.getRank();
+                    proposedLayout = phase2Data.getLayout();
+                }
+            }
+            catch (Exception e)
+            {
+                log.error("Error reading phase2 rank from data file for phase2.", e);
+            }
+    }
+    //TODO need to figure out if we need to send the complete Rank object in the responses
+    //TODO need to figure out how to send back the last accepted value.
     @Override
     public void handleMessage(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         // This server has not been bootstrapped yet, ignore ALL requests except for LAYOUT_BOOTSTRAP
@@ -156,8 +308,9 @@ public class LayoutServer implements IServer {
             {
                 log.info("Bootstrap with new layout={}", ((LayoutMsg)msg).getLayout());
 
-                currentLayout = ((LayoutMsg)msg).getLayout();
-                saveCurrentLayout();
+                saveCurrentLayout(((LayoutMsg)msg).getLayout());
+                System.out.println(getServerRouter());
+                System.out.println(currentLayout);
                 getServerRouter().setServerEpoch(currentLayout.getEpoch());
                 //send a response that the bootstrap was successful.
                 r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.ACK));
@@ -182,41 +335,42 @@ public class LayoutServer implements IServer {
             case LAYOUT_PREPARE:
             {
                 LayoutRankMsg m = (LayoutRankMsg)msg;
+                Rank prepareRank = getRank(m);
                 // This is a prepare. If the rank is less than or equal to the phase 1 rank, reject.
-                if (m.getRank() <= phase1Rank) {
-                    log.debug("Rejected phase 1 prepare of rank={}, phase1Rank={}", m.getRank(), phase1Rank);
-                    r.sendResponse(ctx, msg, new LayoutRankMsg(null, phase1Rank, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_REJECT));
+                if (phase1Rank != null && prepareRank.compareTo(phase1Rank) <= 0) {
+                    log.debug("Rejected phase 1 prepare of rank={}, phase1Rank={}", prepareRank, phase1Rank);
+                    r.sendResponse(ctx, msg, new LayoutRankMsg(proposedLayout, phase1Rank.getRank(), CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_REJECT));
                 }
                 else
                 {
-                    phase1Rank = ((LayoutRankMsg) msg).getRank();
+                    savePhase1Data(prepareRank);
                     log.debug("New phase 1 rank={}", phase1Rank);
-                    r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.ACK));
+                    r.sendResponse(ctx, msg, new LayoutRankMsg(proposedLayout, phase1Rank.getRank(), CorfuMsg.CorfuMsgType.ACK));
                 }
             }
             break;
             case LAYOUT_PROPOSE:
             {
                 LayoutRankMsg m = (LayoutRankMsg)msg;
+                Rank proposeRank = getRank(m);
+                Layout proposeLayout = ((LayoutRankMsg) msg).getLayout();
                 // This is a propose. If the rank is less than or equal to the phase 1 rank, reject.
-                if (m.getRank() != phase1Rank) {
-                    log.debug("Rejected phase 2 propose of rank={}, phase1Rank={}", m.getRank(), phase1Rank);
-                    r.sendResponse(ctx, msg, new LayoutRankMsg(null, phase1Rank, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE_REJECT));
+                if (phase1Rank != null && proposeRank.compareTo(phase1Rank) != 0) {
+                    log.debug("Rejected phase 2 propose of rank={}, phase1Rank={}", proposeRank, phase1Rank);
+                    r.sendResponse(ctx, msg, new LayoutRankMsg(null, phase1Rank.getRank(), CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE_REJECT));
                 }
                 // In addition, if the rank is equal to the current phase 2 rank (already accepted message), reject.
-                else if (m.getRank() == phase2Rank)
+                else if (phase2Rank != null && proposeRank.compareTo(phase2Rank) == 0)
                 {
                     log.debug("Rejected phase 2 propose of rank={}, phase2Rank={}", m.getRank(), phase2Rank);
-                    r.sendResponse(ctx, msg, new LayoutRankMsg(null, phase2Rank, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE_REJECT));
+                    r.sendResponse(ctx, msg, new LayoutRankMsg(null, phase2Rank.getRank(), CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE_REJECT));
                 }
                 else
                 {
-                    log.debug("New phase 2 rank={}, old rank={}, layout={}", ((LayoutRankMsg) msg).getRank(), phase2Rank,
-                            ((LayoutRankMsg) msg).getLayout());
-                    phase2Rank = ((LayoutRankMsg) msg).getRank();
-                    currentLayout =  ((LayoutRankMsg) msg).getLayout();
-                    saveCurrentLayout();
-                    serverRouter.setServerEpoch(currentLayout.getEpoch());
+                    log.debug("New phase 2 rank={},  layout={}", proposeRank, proposeLayout);
+                    savePhase2Data(proposeRank, proposeLayout);
+                    //TODO this should be moved into commit message handling as this is for committed layouts.
+                    commitLayout(proposeLayout);
                     r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.ACK));
                 }
             }
@@ -232,6 +386,32 @@ public class LayoutServer implements IServer {
                 log.warn("Unknown message type {} passed to handler!", msg.getMsgType());
                 throw new RuntimeException("Unsupported message passed to handler!");
         }
+    }
+
+    private synchronized void commitLayout(Layout layout) {
+        saveCurrentLayout(layout);
+        serverRouter.setServerEpoch(currentLayout.getEpoch());
+        // this is needed so that we do not keep
+        // choosing the same value over each slot.
+        //TODO move this into commit message processing and then uncomment
+        //clearPhase2Data();
+    }
+
+    private void clearPhase2Data() {
+        phase2Rank = null;
+        proposedLayout = null;
+        if(phase2File != null) {
+            try {
+                Files.write(new byte[0], phase2File);
+            } catch (IOException e) {
+                log.error("Error clearing phase2 Data from disk!", e);
+            }
+        }
+    }
+
+
+    private Rank getRank(LayoutRankMsg msg) {
+        return new Rank(msg.getRank(), msg.getClientID());
     }
 
     @Override

--- a/src/main/java/org/corfudb/infrastructure/Rank.java
+++ b/src/main/java/org/corfudb/infrastructure/Rank.java
@@ -1,0 +1,49 @@
+package org.corfudb.infrastructure;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.util.JSONUtils;
+
+import java.util.UUID;
+
+/**
+ * Tuple to store the rank and clientId for each round in Paxos.
+ * Created by mdhawan on 6/28/16.
+ */
+@Slf4j
+@ToString(exclude="runtime")
+@AllArgsConstructor
+public class Rank implements Comparable<Rank>{
+    @Getter
+    Long rank;
+    @Getter
+    UUID clientId;
+
+    /**
+     * compares this.rank with other.rank
+     *      if equal 
+     * compares this.clientId with other.clientId
+     * @param other
+     * @return
+     */
+    @Override
+    public int compareTo(Rank other) {
+        if(rank.compareTo(other.getRank()) == 0) {
+            return clientId.compareTo(other.clientId);
+        }
+        return rank.compareTo(other.getRank());
+    }
+
+        /** Get the layout as a JSON string. */
+    public String asJSONString()
+    {
+        return JSONUtils.parser.toJson(this);
+    }
+
+    /** Get a layout from a JSON string. */
+    public static Rank fromJSONString(String json) {
+        return JSONUtils.parser.fromJson(json, Rank.class);
+    }
+}

--- a/src/main/java/org/corfudb/util/JSONUtils.java
+++ b/src/main/java/org/corfudb/util/JSONUtils.java
@@ -1,0 +1,11 @@
+package org.corfudb.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Created by mdhawan on 6/28/16.
+ */
+public class JSONUtils {
+    public static final Gson parser = new GsonBuilder().create();
+}

--- a/src/test/java/org/corfudb/infrastructure/AbstractServerTest.java
+++ b/src/test/java/org/corfudb/infrastructure/AbstractServerTest.java
@@ -8,12 +8,14 @@ import org.junit.Before;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Created by mwei on 12/12/15.
  */
 public abstract class AbstractServerTest extends AbstractCorfuTest {
 
+    public static final UUID testClientId = UUID.nameUUIDFromBytes("TEST_CLIENT".getBytes());
     @Getter
     TestServerRouter router;
 
@@ -53,6 +55,11 @@ public abstract class AbstractServerTest extends AbstractCorfuTest {
 
     public void sendMessage(CorfuMsg message)
     {
+        sendMessage(testClientId, message);
+    }
+
+    public void sendMessage(UUID clientId, CorfuMsg message) {
+        message.setClientID(clientId);
         router.sendServerMessage(message);
     }
 

--- a/src/test/java/org/corfudb/infrastructure/LayoutServerAssertions.java
+++ b/src/test/java/org/corfudb/infrastructure/LayoutServerAssertions.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.UnpooledByteBufAllocator;
 import org.assertj.core.api.AbstractAssert;
 import org.corfudb.protocols.wireprotocol.LogUnitPayloadMsg;
+import org.corfudb.runtime.view.Layout;
 
 /**
  * Created by mwei on 1/7/16.
@@ -44,10 +45,10 @@ public class LayoutServerAssertions extends AbstractAssert<LayoutServerAssertion
         return this;
     }
 
-    public LayoutServerAssertions isPhase1Rank(long phase1Rank) {
+    public LayoutServerAssertions isPhase1Rank(Rank phase1Rank) {
         isNotNull();
 
-        if (actual.currentLayout.getEpoch() != phase1Rank)
+        if (actual.phase1Rank.compareTo(phase1Rank) != 0)
         {
             failWithMessage("Expected server to be in phase1Rank <%d> but it was in phase1Rank <%d>", phase1Rank,
                     actual.phase1Rank);
@@ -56,15 +57,26 @@ public class LayoutServerAssertions extends AbstractAssert<LayoutServerAssertion
         return this;
     }
 
-    public LayoutServerAssertions isPhase2Rank(long phase2Rank) {
+    public LayoutServerAssertions isPhase2Rank(Rank phase2Rank) {
         isNotNull();
 
-        if (actual.currentLayout.getEpoch() != phase2Rank)
+        if (actual.phase2Rank.compareTo(phase2Rank) != 0)
         {
             failWithMessage("Expected server to be in phase2Rank <%d> but it was in phase2Rank <%d>", phase2Rank,
                     actual.phase2Rank);
         }
 
+        return this;
+    }
+
+    public LayoutServerAssertions isProposedLayout(Layout layout) {
+        isNotNull();
+        if(!actual.proposedLayout.asJSONString().equals(layout.asJSONString()))
+        {
+             failWithMessage("Expected server to have proposedLayout  <%s> but it is <%s>", layout,
+                    actual.proposedLayout);
+
+        }
         return this;
     }
 }

--- a/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Files;
+import com.google.common.util.concurrent.AbstractService;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.LayoutMsg;
 import org.corfudb.protocols.wireprotocol.LayoutRankMsg;
@@ -13,6 +14,7 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.corfudb.infrastructure.LayoutServerAssertions.assertThat;
@@ -137,6 +139,11 @@ public class LayoutServerTest extends AbstractServerTest {
     }
 
     @Test
+    public void prepareRejectsLowerRanksWithLastProposal() {
+
+    }
+
+    @Test
     public void proposeRejectsLowerRanks()
     {
         bootstrapServer(getTestLayout());
@@ -204,9 +211,9 @@ public class LayoutServerTest extends AbstractServerTest {
         assertThat(s1)
                 .isInEpoch(100);
         assertThat(s1)
-                .isPhase1Rank(100);
+                .isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
         assertThat(s1)
-                .isPhase2Rank(100);
+                .isPhase2Rank(new Rank(100L, AbstractServerTest.testClientId));
         s1.shutdown();
 
         LayoutServer s2 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
@@ -218,9 +225,9 @@ public class LayoutServerTest extends AbstractServerTest {
         assertThat(s2)
                 .isInEpoch(100);
         assertThat(s2)
-                .isPhase1Rank(100);
+                .isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
         assertThat(s2)
-                .isPhase2Rank(100);
+                .isPhase2Rank(new Rank(100L, AbstractServerTest.testClientId));
 
         sendMessage(new CorfuMsg(CorfuMsg.CorfuMsgType.LAYOUT_REQUEST));
         assertThat(getLastMessage().getMsgType())
@@ -228,5 +235,263 @@ public class LayoutServerTest extends AbstractServerTest {
         assertThat(((LayoutMsg)getLastMessage()).getLayout().getEpoch())
                 .isEqualTo(100);
     }
+
+    /**
+     * The test validates that the data in accepted phase1 and phase2 messages
+     * is persisted to disk and survives layout server restarts.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void checkPaxosPhasesPersisted() throws Exception
+    {
+       String serviceDir = getTempDir();
+
+        LayoutServer s1 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
+                .put("--log-path", serviceDir)
+                .put("--memory", false)
+                .put("--single", false)
+                .build(), getRouter());
+
+        setServer(s1);
+        bootstrapServer(getTestLayout());
+        Layout l100 = getTestLayout();
+
+        l100.setEpoch(100);
+
+        // validate phase 1
+        sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+
+        assertThat(s1).isInEpoch(0);
+        assertThat(s1).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
+        s1.shutdown();
+
+        LayoutServer s2 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
+                .put("--log-path", serviceDir)
+                .put("--single", false)
+                .put("--memory", false)
+                .build(), getRouter());
+        this.router.setServerUnderTest(s2);
+        assertThat(s2).isInEpoch(0);
+        assertThat(s2).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
+
+        // validate phase2 data persistence
+
+        sendMessage(new LayoutRankMsg(l100, 100, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+        s2.shutdown();
+
+        LayoutServer s3 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
+                .put("--log-path", serviceDir)
+                .put("--single", false)
+                .put("--memory", false)
+                .build(), getRouter());
+        this.router.setServerUnderTest(s3);
+        assertThat(s3).isInEpoch(100);
+        assertThat(s3).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
+        assertThat(s3).isPhase2Rank(new Rank(100L, AbstractServerTest.testClientId));
+        assertThat(s3).isProposedLayout(l100);
+
+    }
+
+    /**
+     * Validates that the layout server accept or rejects incoming phase1 messages based on
+     * the last persisted phase1 rank.
+     * @throws Exception
+     */
+    @Test
+    public void checkMessagesValidatedAgainstPhase1PersistedData() throws Exception
+    {
+        String serviceDir = getTempDir();
+
+        LayoutServer s1 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
+                .put("--log-path", serviceDir)
+                .put("--memory", false)
+                .put("--single", false)
+                .build(), getRouter());
+
+        setServer(s1);
+        bootstrapServer(getTestLayout());
+        Layout l100 = getTestLayout();
+
+        // validate phase 1
+        sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+
+        assertThat(s1).isInEpoch(0);
+        assertThat(s1).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
+        s1.shutdown();
+
+        LayoutServer s2 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
+                .put("--log-path", serviceDir)
+                .put("--single", false)
+                .put("--memory", false)
+                .build(), getRouter());
+        this.router.setServerUnderTest(s2);
+        assertThat(s2).isInEpoch(0);
+        assertThat(s2).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
+
+        //new LAYOUT_PREPARE message with a lower phase1 rank should be rejected
+        sendMessage(new LayoutRankMsg(null, 99, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_REJECT);
+
+
+        //new LAYOUT_PREPARE message with a higher phase1 rank should be accepted
+        sendMessage(new LayoutRankMsg(null, 101, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+    }
+
+    /**
+     * Validates that the layout server accept or rejects incoming phase2 messages based on
+     * the last persisted phase1 and phase2 data.
+     * If persisted phase1 rank does not match the LAYOUT_PROPOSE message then the server did not
+     * take part in the prepare phase. It should reject this message.
+     * If the persisted phase2 rank is the same as incoming message, it will be rejected as it is a
+     * duplicate message.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void checkMessagesValidatedAgainstPhase2PersistedData() throws Exception
+    {
+        String serviceDir = getTempDir();
+
+        LayoutServer s1 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
+                .put("--log-path", serviceDir)
+                .put("--memory", false)
+                .put("--single", false)
+                .build(), getRouter());
+
+        setServer(s1);
+        bootstrapServer(getTestLayout());
+
+        Layout l100 = getTestLayout();
+        l100.setEpoch(100);
+        // validate phase 1
+        sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+
+        // the epoch should not change yet.
+        assertThat(s1).isInEpoch(0);
+        assertThat(s1).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
+        s1.shutdown();
+
+        LayoutServer s2 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
+                .put("--log-path", serviceDir)
+                .put("--single", false)
+                .put("--memory", false)
+                .build(), getRouter());
+        this.router.setServerUnderTest(s2);
+        assertThat(s2).isInEpoch(0);
+        assertThat(s2).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
+
+        //new LAYOUT_PROPOSE message with a lower phase2 rank should be rejected
+        sendMessage(new LayoutRankMsg(l100, 99, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE_REJECT);
+
+
+        //new LAYOUT_PREPARE message with a higher phase2 rank should be rejected
+        sendMessage(new LayoutRankMsg(l100, 101, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE_REJECT);
+
+        //new LAYOUT_PREPARE message with same phase2 rank should be accepted
+        sendMessage(new LayoutRankMsg(l100, 100, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+        s2.shutdown();
+
+        LayoutServer s3 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
+                .put("--log-path", serviceDir)
+                .put("--single", false)
+                .put("--memory", false)
+                .build(), getRouter());
+        this.router.setServerUnderTest(s3);
+        // the epoch should have changed by now.
+        assertThat(s3).isInEpoch(100);
+        assertThat(s3).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
+        assertThat(s3).isProposedLayout(l100);
+    }
+
+    /**
+     * Validates that the layout server accept or rejects incoming phase1 and phase2 messages from multiple
+     * clients based on current state {Phease1Rank [rank, clientID], Phase2Rank [rank, clientID] }
+     * If LayoutServer has accepted a phase1 message from a client , it can only accept a higher ranked phase1 message
+     * from another client.
+     * A phase2 message can only be accepted if the last accepted phase1 message is from the same client and has the
+     * same rank.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void checkPhase1AndPhase2MessagesFromMultipleClients() throws Exception
+    {
+        String serviceDir = getTempDir();
+
+        LayoutServer s1 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
+                .put("--log-path", serviceDir)
+                .put("--memory", false)
+                .put("--single", false)
+                .build(), getRouter());
+
+        setServer(s1);
+        bootstrapServer(getTestLayout());
+
+        Layout l100 = getTestLayout();
+        l100.setEpoch(100);
+        /* validate phase 1 */
+        sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+
+        // the epoch should not change yet.
+        assertThat(s1).isInEpoch(0);
+        assertThat(s1).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
+
+        // message from a different client with same rank should be rejected or accepted based on
+        // whether the uuid is greater of smaller.
+        sendMessage(UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes()), new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_REJECT);
+
+        sendMessage(UUID.nameUUIDFromBytes("TEST_CLIENT_OTHER".getBytes()), new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+
+        // message from a different client but with a higher rank gets accepted
+        sendMessage(UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes()), new LayoutRankMsg(null, 101, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+        assertThat(s1).isPhase1Rank(new Rank(101L, UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes())));
+        assertThat(s1).isInEpoch(0);
+
+        // testing behaviour after server restart
+        s1.shutdown();
+        LayoutServer s2 = new LayoutServer(new ImmutableMap.Builder<String,Object>()
+                .put("--log-path", serviceDir)
+                .put("--single", false)
+                .put("--memory", false)
+                .build(), getRouter());
+        this.router.setServerUnderTest(s2);
+        assertThat(s2).isInEpoch(0);
+        assertThat(s2).isPhase1Rank(new Rank(101L, UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes())));
+        //duplicate message to be rejected
+        sendMessage(UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes()), new LayoutRankMsg(null, 101, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_REJECT);
+
+        /* validate phase 2 */
+
+        //phase2 message from a different client than the one whose phase1 was last accepted is rejected
+        sendMessage(new LayoutRankMsg(null, 101, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE_REJECT);
+
+        // phase2 from same client with same rank as in phase1 gets accepted
+        sendMessage(UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes()), new LayoutRankMsg(l100, 101, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+
+        //TODO fix this epoch needs to be fixed and should still be 0 till COMMIT
+        assertThat(s2).isInEpoch(100);
+        assertThat(s2).isPhase1Rank(new Rank(101L, UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes())));
+        assertThat(s2).isPhase2Rank(new Rank(101L, UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes())));
+        assertThat(s2).isProposedLayout(l100);
+
+        s2.shutdown();
+   }
+
 
 }


### PR DESCRIPTION
Fixes to Paxos protocol in Layout Server
    
    - Phase1 and Phase2 data is now persisted to disk.
    - ClientId now part of the Rank in the protocol.
    - Last known accepted value is part of phase1 response.
    - Class level synchronization for methods. Needs to be made finer
      grained.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/183)
<!-- Reviewable:end -->
