### PR TITLE
Add "multiping" cmdlet

### DIFF
--- a/bin/corfu_multiping
+++ b/bin/corfu_multiping
@@ -1,0 +1,1 @@
+../scripts/cmdlet.sh

--- a/src/main/java/org/corfudb/cmdlets/CmdletRouter.java
+++ b/src/main/java/org/corfudb/cmdlets/CmdletRouter.java
@@ -4,6 +4,8 @@ import java.io.File;
 import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 
+import static java.lang.System.exit;
+
 /** Routes symlink-files to the proper cmdlet.
  *  Symlinks are in the bin directory.
  *  They symlink to the script in scripts/cmdlet.sh
@@ -36,16 +38,19 @@ public class CmdletRouter {
                 try {
                     // Execute with the arguments other than the name of the cmdlet itself.
                     ((ICmdlet)cmdlet.getConstructor().newInstance()).main(Arrays.copyOfRange(args, 1, args.length));
+                    exit(0);
                 } catch (Exception e)
                 {
                     // Let the user know if an exception occurs.
                     System.out.println(e.getClass().getSimpleName() + " exception: " + e.getMessage());
+                    exit(1);
                 }
             }
         }
         catch (ClassNotFoundException cnfe)
         {
             System.out.println("No cmdlet named " + cmdletName + " available!");
+            exit(64);
         }
     }
 }

--- a/src/main/java/org/corfudb/cmdlets/corfu_multiping.java
+++ b/src/main/java/org/corfudb/cmdlets/corfu_multiping.java
@@ -113,12 +113,17 @@ public class corfu_multiping implements ICmdlet {
             if (routers[nth] == null) {
                 // System.out.println(hosts[nth] + " port " + ports[nth] + " new router.");
                 NettyClientRouter r = new NettyClientRouter(hosts[nth], ports[nth]);
-                r.start();
+                r.start(c);
                 routers[nth] = r;
                 routers[nth].setTimeoutConnect(50);
                 routers[nth].setTimeoutRetry(700);
                 routers[nth].setTimeoutResponse(4500);
             }
+            // sendMessageAndGetCompleteable(), which is just a couple layers down from
+            // the ping() here, appears be silent & do nothing if the router is not yet
+            // connected to the remote TCP server.  The only indication that we'll get
+            // that we aren't connected *now* is to wait for the entire TimeoutResponse
+            // interval and then get our timeout exception there.  Whee!
             CompletableFuture<Boolean> cf = routers[nth].getClient(BaseClient.class).ping();
             cf.exceptionally(e -> {
                 log.info(hosts[nth] + " port " + ports[nth] + " c " + c + " exception " + e);

--- a/src/main/java/org/corfudb/cmdlets/corfu_multiping.java
+++ b/src/main/java/org/corfudb/cmdlets/corfu_multiping.java
@@ -67,12 +67,16 @@ public class corfu_multiping implements ICmdlet {
         while (true) {
             ping_one_round();
             just_sleep_dammit(1000);
+            // just_sleep_dammit(2);
             // This kind of check may not see flapping that happens during
             // intervals of less than this loop's polling interval.
             for (int j = 0; j < num; j++) {
                 if (last_up[j] != up[j]) {
-                    System.out.println("Host " + hosts[j] + " port " + ports[j] + ": " +
-                                       last_up[j] + " -> " + up[j]);
+                    // System.out.println("Host " + hosts[j] + " port " + ports[j] + ": " +
+                    //                    last_up[j] + " -> " + up[j]);
+                    log.info("Host " + hosts[j] + " port " + ports[j] + ": " +
+                            last_up[j] + " -> " + up[j]);
+
                     last_up[j] = up[j];
                 }
             }
@@ -108,9 +112,9 @@ public class corfu_multiping implements ICmdlet {
                 NettyClientRouter r = new NettyClientRouter(hosts[nth], ports[nth]);
                 r.start();
                 routers[nth] = r;
-                routers[nth].setTimeoutConnect(1000);
+                routers[nth].setTimeoutConnect(500);
                 routers[nth].setTimeoutRetry(250);
-                routers[nth].setTimeoutResponse(3*1000);
+                routers[nth].setTimeoutResponse(2*1000);
             }
             CompletableFuture<Boolean> cf = routers[nth].getClient(BaseClient.class).ping();
             cf.exceptionally(e -> {

--- a/src/main/java/org/corfudb/cmdlets/corfu_multiping.java
+++ b/src/main/java/org/corfudb/cmdlets/corfu_multiping.java
@@ -1,0 +1,111 @@
+package org.corfudb.cmdlets;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.tools.ant.taskdefs.Sleep;
+import org.corfudb.runtime.clients.BaseClient;
+import org.corfudb.runtime.clients.NettyClientRouter;
+import org.corfudb.util.GitRepositoryState;
+import org.docopt.Docopt;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import static org.fusesource.jansi.Ansi.ansi;
+import static org.fusesource.jansi.Ansi.Color.*;
+/**
+ * Created by mwei on 12/10/15.
+ */
+@Slf4j
+public class corfu_multiping implements ICmdlet {
+
+    Boolean up[] = new Boolean[99];
+
+    private static final String USAGE =
+            "corfu_multiping, pings a Corfu Server to check for connectivity to multiple servers.\n"
+                    + "\n"
+                    + "Usage:\n"
+                    + "\tcorfu_ping [-d <level>] <address>:<port> [<address>:<port> ...]\n"
+                    + "\n"
+                    + "Options:\n"
+                    + " -d <level>, --log-level=<level>      Set the logging level, valid levels are: \n"
+                    + "                                      ERROR,WARN,INFO,DEBUG,TRACE [default: INFO].\n"
+                    + " -h, --help  Show this screen\n"
+                    + " --version  Show version\n";
+
+
+    @Override
+    public void main(String[] args) {
+        // Parse the options given, using docopt.
+        Map<String, Object> opts =
+                new Docopt(USAGE).withVersion(GitRepositoryState.getRepositoryState().describe).parse(args);
+
+        // Configure base options
+        configureBase(opts);
+
+        // Parse host address and port
+        ArrayList<String> aps = (ArrayList<String>) opts.get("<address>:<port>");
+        String hosts[] = new String[99];
+        Integer ports[] = new Integer[99];
+        NettyClientRouter routers[] = new NettyClientRouter[99];
+
+        for (int i = 0; i < aps.size(); i++) {
+            hosts[i] = aps.get(i).split(":")[0];
+            ports[i] = Integer.parseInt(aps.get(i).split(":")[1]);
+            System.out.println(ansi().a("PING ").fg(WHITE).a(hosts[i] + ":" + ports[i]).reset().a("\n"));
+            routers[i] = new NettyClientRouter(hosts[i], ports[i]);
+            System.out.println("Yo, eh?");
+            routers[i].start();
+            System.out.println("Yo, started.");
+            up[i] = false;
+        }
+
+        for (int i = 0; i < 5; i++) {
+            ping_one_round(hosts[0], ports[0], routers[0]);
+            just_sleep_dammit(1000);
+        }
+        java.lang.System.exit(8);
+
+    }
+
+    private void just_sleep_dammit(long i) {
+        try {
+            java.lang.Thread.sleep(i);
+        } catch (InterruptedException ie) {}
+    }
+
+    private void ping_one_round(String host, Integer port, NettyClientRouter router) {
+        CompletableFuture.runAsync(() -> {
+            CompletableFuture<Boolean> cf = router.getClient(BaseClient.class).ping();
+            // if an exception occurs, print it out.
+            cf.exceptionally(e -> {
+                if (e instanceof CompletionException) {
+                    System.out.println(ansi().fg(RED).a("ERROR ").reset().a("pinging ")
+                            .fg(WHITE).a(host + ":" + port).reset()
+                            .a(": seq=" + -1 + " error=" +
+                                    ((CompletionException) e).getCause().getClass().getSimpleName()));
+                } else {
+                    System.out.println(ansi().fg(RED).a("ERROR ").reset().a("pinging ")
+                            .fg(WHITE).a(host + ":" + port).reset()
+                            .a(": seq=" + -1 + " error=" +
+                                    (e).getClass().getSimpleName()));
+                }
+                return null;
+            });
+            // when the ping completes, print the time to screen.
+            cf.thenAccept((x) -> {
+                long end = System.nanoTime();
+                log.trace("Ping[{}] ended at {}", -1, end);
+                long duration = -2;
+                String ms = String.format("%.3f", (float) duration / 1000000L);
+                System.out.println(ansi().a("PONG from ").fg(WHITE).a(host + ":" + port).reset()
+                        .a(": seq=" + -1 + " time=" + ms + "ms"));
+            });
+        });
+
+    }
+}

--- a/src/main/java/org/corfudb/cmdlets/corfu_multiping.java
+++ b/src/main/java/org/corfudb/cmdlets/corfu_multiping.java
@@ -24,11 +24,11 @@ import static org.fusesource.jansi.Ansi.Color.*;
 public class corfu_multiping implements ICmdlet {
 
     int num;
-    String hosts[] = new String[99];
-    Integer ports[] = new Integer[99];
-    NettyClientRouter routers[] = new NettyClientRouter[99];
-    Boolean up[]      = new Boolean[99];
-    Boolean last_up[] = new Boolean[99];
+    String hosts[];
+    Integer ports[];
+    NettyClientRouter routers[];
+    Boolean up[];
+    Boolean last_up[];
 
     private static final String USAGE =
             "corfu_multiping, pings a Corfu Server to check for connectivity to multiple servers.\n"
@@ -55,6 +55,12 @@ public class corfu_multiping implements ICmdlet {
         // Parse host address and port
         ArrayList<String> aps = (ArrayList<String>) opts.get("<address>:<port>");
         num = aps.size();
+        hosts = new String[num];
+        ports = new Integer[num];
+        routers = new NettyClientRouter[num];
+        up = new Boolean[num];
+        last_up = new Boolean[num];
+
         for (int i = 0; i < aps.size(); i++) {
             hosts[i] = aps.get(i).split(":")[0];
             ports[i] = Integer.parseInt(aps.get(i).split(":")[1]);
@@ -99,11 +105,6 @@ public class corfu_multiping implements ICmdlet {
                 routers[nth].setTimeoutRetry(200);
                 routers[nth].setTimeoutResponse(1000);
             }
-            // sendMessageAndGetCompleteable(), which is just a couple layers down from
-            // the ping() here, appears be silent & do nothing if the router is not yet
-            // connected to the remote TCP server.  The only indication that we'll get
-            // that we aren't connected *now* is to wait for the entire TimeoutResponse
-            // interval and then get our timeout exception there.  Whee!
             CompletableFuture<Boolean> cf = routers[nth].getClient(BaseClient.class).ping();
             if (cf == null) {
                 // We are disconnected.  There is no point in registering async

--- a/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -263,16 +263,19 @@ implements IClientRouter {
         final CompletableFuture<T> cf = new CompletableFuture<>();
         outstandingRequests.put(thisRequest, cf);
         // Write the message out to the channel.
+        System.out.print("<");
         if (ctx == null) {
             channel.writeAndFlush(message);
         }
         else {
             ctx.writeAndFlush(message);
         }
+        System.out.print(">");
         log.trace("Sent message: {}", message);
         // Generate a timeout future, which will complete exceptionally if the main future is not completed.
         final CompletableFuture<T> cfTimeout = CFUtils.within(cf, Duration.ofMillis(timeoutResponse));
         cfTimeout.exceptionally(e -> {
+            System.out.print("t");
             outstandingRequests.remove(thisRequest);
             log.debug("Remove request {} due to timeout!", thisRequest);
             return null;

--- a/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -226,7 +226,7 @@ implements IClientRouter {
                         connectChannel(b);
                         return;
                     } catch (Exception ex) {
-                        log.warn("Exception while reconnecting, retry in 1s");
+                        log.warn("Exception while reconnecting, retry in {} ms", timeoutRetry);
                         Thread.sleep(timeoutRetry);
                     }
                 }

--- a/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -66,6 +66,8 @@ public class NettyCommTest extends AbstractCorfuTest {
             d.bootstrapServer();
             // First ping may fail due to connection loss.
             r.getClient(BaseClient.class).pingSync();
+            System.out.println("Sleeping...."); Thread.sleep(500); System.out.println("Sleeping...."); Thread.sleep(500); System.out.println("Sleeping...."); Thread.sleep(500);  System.out.println("Done Sleeping");
+            r.getClient(BaseClient.class).pingSync();
             assertThat(r.getClient(BaseClient.class).pingSync())
                     .isTrue();
         });

--- a/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -64,10 +64,17 @@ public class NettyCommTest extends AbstractCorfuTest {
                     .isTrue();
             d.shutdownServer();
             d.bootstrapServer();
-            // First ping may fail due to connection loss.
-            r.getClient(BaseClient.class).pingSync();
-            System.out.println("Sleeping...."); Thread.sleep(500); System.out.println("Sleeping...."); Thread.sleep(500); System.out.println("Sleeping...."); Thread.sleep(500);  System.out.println("Done Sleeping");
-            r.getClient(BaseClient.class).pingSync();
+            // We are now racing with the server's startup.  Immediate attempts
+            // to ping the server will fail immediately due to client-side
+            // rejection because the TCP session isn't yet connected.  Retry
+            // for up to 60 seconds before giving up: TravisCI can be truly
+            // unpredictably slow.
+            int sleep_incr = 10;
+            for (int i = 0; i < 60000; i += sleep_incr) {
+                if (r.getClient(BaseClient.class).pingSync() == true)
+                    break;
+                Thread.sleep(sleep_incr);
+            }
             assertThat(r.getClient(BaseClient.class).pingSync())
                     .isTrue();
         });


### PR DESCRIPTION
This branch does a few things.  First, it adds a new cmdlet called "multiping", which is useful for monitoring the PING protocol responses of multiple Corfu servers simultaneously.  Second, it moves hardcoded timeout constants to class member vars.  Third, it changes some behavior of NettyRouterClient.  (Fourth, some misc cleanup, including variable exit status of all cmdlets.)

NettyRouterClient had some behavior that was hiding server failure in an annoying way.  If the remote server is disconnected (i.e., TCP session closed), then the router goes into an infinite loop trying to reconnect.  If client code tries to send a new message to the server, that message will be queued up by netty ... and then wait wait wait until the request timeout exception happens @ 5 seconds.

Now, if the remote server is disconnected, the `sendMessageAndGetCompletable` method will return `null` immediately, as a signal to the caller/client that the server is disconnected and that we haven't bothered to queue that command.  (Who knows what century that message might be delivered?)

As noted in a comment:

            // SLF: Returning a null here may break a lot of callers' code: there's a
            //      frequent convention that our return value is immediately used to set
            //      callback behavior on success and/or exception.  Those callback calls
            //      almost always assume that null isn't an option.

The new cmdlet is checking the return value, but most other code doesn't.  From my short review, it looks like "most other code" is wrapped up in try/catch exception blocks to that nothing super-horrible happens.  However, smaller values of horrible probably exist.  Thoughts, @no2chem @Maithem @medhavidhawan @dahliamalkhi ?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/187)
<!-- Reviewable:end -->
