### PR TITLE
Add SO_REUSEADDR to avoid socket binding reuse problems during rapid process restarts

### DIFF
--- a/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -207,6 +207,7 @@ public class CorfuServer {
                     .channel(NioServerSocketChannel.class)
                     .option(ChannelOption.SO_BACKLOG, 100)
                     .childOption(ChannelOption.SO_KEEPALIVE, true)
+                    .childOption(ChannelOption.SO_REUSEADDR, true)
                     .childOption(ChannelOption.TCP_NODELAY, true)
                     .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
                     .handler(new LoggingHandler(LogLevel.INFO))

--- a/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -196,6 +196,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         b.group(workerGroup);
         b.channel(NioSocketChannel.class);
         b.option(ChannelOption.SO_KEEPALIVE, true);
+        b.option(ChannelOption.SO_REUSEADDR, true);
         b.option(ChannelOption.TCP_NODELAY, true);
         NettyClientRouter router = this;
         b.handler(new ChannelInitializer<SocketChannel>() {

--- a/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -154,6 +154,7 @@ public class NettyCommTest extends AbstractCorfuTest {
                     .channel(NioServerSocketChannel.class)
                     .option(ChannelOption.SO_BACKLOG, 100)
                     .childOption(ChannelOption.SO_KEEPALIVE, true)
+                    .childOption(ChannelOption.SO_REUSEADDR, true)
                     .childOption(ChannelOption.TCP_NODELAY, true)
                     .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
                     .handler(new LoggingHandler(LogLevel.INFO))


### PR DESCRIPTION
I've only been bitten by port reuse problems during manual testing and not during automated tests ... but it'll eventually happen.  Let's avoid the easy stuff now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/192)
<!-- Reviewable:end -->
