### PR TITLE
Fix: Client can deserialize LAYOUT_PREPARE_ACK

### DIFF
--- a/src/main/java/org/corfudb/cmdlets/corfu_layout.java
+++ b/src/main/java/org/corfudb/cmdlets/corfu_layout.java
@@ -106,7 +106,7 @@ public class corfu_layout implements ICmdlet {
             long rank = Long.parseLong((String) opts.get("--rank"));
             log.debug("Prepare with new rank={}", rank);
             try {
-                if (router.getClient(LayoutClient.class).prepare(rank).get()) {
+                if (router.getClient(LayoutClient.class).prepare(rank).get().isAccepted()) {
                     System.out.println(ansi().a("RESPONSE from ").fg(WHITE).a(host + ":" + port)
                             .reset().fg(GREEN).a(": ACK"));
                 } else {

--- a/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -313,7 +313,7 @@ public class LayoutServer extends AbstractServer {
                 } else {
                     savePhase1Data(prepareRank);
                     log.debug("New phase 1 rank={}", phase1Rank);
-                    r.sendResponse(ctx, msg, new LayoutRankMsg(proposedLayout, phase1Rank.getRank(), CorfuMsg.CorfuMsgType.ACK));
+                    r.sendResponse(ctx, msg, new LayoutRankMsg(proposedLayout, phase1Rank.getRank(), CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK));
                 }
             }
             break;

--- a/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
@@ -201,7 +201,9 @@ public class CorfuMsg {
         ERROR_RANK(54, CorfuMsg.class, LogUnitServer.class),
 
         // EXTRA CODES
-        LAYOUT_ALREADY_BOOTSTRAP(60, CorfuMsg.class, LayoutServer.class);
+        LAYOUT_ALREADY_BOOTSTRAP(60, CorfuMsg.class, LayoutServer.class),
+        LAYOUT_PREPARE_ACK(61, LayoutRankMsg.class, LayoutServer.class);
+
 
         public final int type;
         public final Class<? extends CorfuMsg> messageType;

--- a/src/main/java/org/corfudb/runtime/clients/LayoutPrepareResponse.java
+++ b/src/main/java/org/corfudb/runtime/clients/LayoutPrepareResponse.java
@@ -1,0 +1,23 @@
+package org.corfudb.runtime.clients;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+import org.corfudb.runtime.view.Layout;
+
+/**
+ * {@link org.corfudb.infrastructure.LayoutServer} response in phase1 of paxos can be an accept or reject.
+ * If a {@link org.corfudb.infrastructure.LayoutServer} accepts (the proposal rank is higher than
+ * any seen by the server so far), it will send back a previously agreed {@link Layout}.
+ * {@link org.corfudb.infrastructure.LayoutServer} will reject any proposal with a rank less than or equal to
+ * any already seen by the server.
+ * <p>
+ * Created by mdhawan on 7/21/16.
+ */
+@ToString(callSuper = true)
+@Data
+@AllArgsConstructor
+public class LayoutPrepareResponse {
+    boolean accepted;
+    Layout layout;
+}

--- a/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -2,11 +2,7 @@ package org.corfudb.runtime.view;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.ToString;
+import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.BaseClient;
@@ -26,7 +22,8 @@ import java.util.stream.Stream;
  * Created by mwei on 12/8/15.
  */
 @Slf4j
-@ToString(exclude = "runtime")
+@ToString(exclude = {"runtime", "valid"})
+@EqualsAndHashCode(exclude = {"runtime","valid"})
 public class Layout implements Cloneable {
     /**
      * A Gson parser.

--- a/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.view;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.LayoutPrepareResponse;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.util.CFUtils;
@@ -51,7 +52,7 @@ public class LayoutView extends AbstractView {
         layoutHelper(
                 (LayoutFunction<Layout, Void, QuorumUnreachableException, OutrankedException, RuntimeException, RuntimeException>)
                         l -> {
-                            CompletableFuture<Boolean>[] prepareList = l.getLayoutClientStream()
+                            CompletableFuture<LayoutPrepareResponse>[] prepareList = l.getLayoutClientStream()
                                     .map(x -> x.prepare(rank))
                                     .toArray(CompletableFuture[]::new);
 
@@ -78,8 +79,8 @@ public class LayoutView extends AbstractView {
 
                                 // count successes.
                                 long count = Arrays.stream(prepareList)
-                                        .map(x -> x.getNow(false))
-                                        .filter(x -> true)
+                                        .map(x -> x.getNow(new LayoutPrepareResponse(false, null)))
+                                        .filter( x -> x.isAccepted())
                                         .count();
 
                                 log.debug("Successful responses={}, needed={}, timeouts={}", count, getQuorumNumber(), timeouts);

--- a/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -89,7 +89,7 @@ public class LayoutServerTest extends AbstractServerTest {
         bootstrapServer(TestLayoutBuilder.single(9000));
         sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
         assertThat(getLastMessage().getMsgType())
-                .isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+                .isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
         sendMessage(new LayoutRankMsg(null, 10, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
         assertThat(getLastMessage().getMsgType())
                 .isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_REJECT);
@@ -105,7 +105,7 @@ public class LayoutServerTest extends AbstractServerTest {
         bootstrapServer(TestLayoutBuilder.single(9000));
         sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
         assertThat(getLastMessage().getMsgType())
-                .isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+                .isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
         sendMessage(new LayoutRankMsg(TestLayoutBuilder.single(9000), 10, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
         assertThat(getLastMessage().getMsgType())
                 .isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE_REJECT);
@@ -116,7 +116,7 @@ public class LayoutServerTest extends AbstractServerTest {
         bootstrapServer(TestLayoutBuilder.single(9000));
         sendMessage(new LayoutRankMsg(null, 10, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
         assertThat(getLastMessage().getMsgType())
-                .isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+                .isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
         sendMessage(new LayoutRankMsg(TestLayoutBuilder.single(9000), 10, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
         assertThat(getLastMessage().getMsgType())
                 .isEqualTo(CorfuMsg.CorfuMsgType.ACK);
@@ -130,7 +130,7 @@ public class LayoutServerTest extends AbstractServerTest {
         bootstrapServer(TestLayoutBuilder.single(9000));
         sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
         assertThat(getLastMessage().getMsgType())
-                .isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+                .isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
         sendMessage(new LayoutRankMsg(TestLayoutBuilder.single(9000), 100, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
         assertThat(getLastMessage().getMsgType())
                 .isEqualTo(CorfuMsg.CorfuMsgType.ACK);
@@ -156,7 +156,7 @@ public class LayoutServerTest extends AbstractServerTest {
         l100.setEpoch(100);
         sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
         assertThat(getLastMessage().getMsgType())
-                .isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+                .isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
         sendMessage(new LayoutRankMsg(l100, 100, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
 
         assertThat(getLastMessage().getMsgType())
@@ -213,7 +213,7 @@ public class LayoutServerTest extends AbstractServerTest {
 
         // validate phase 1
         sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
-        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
 
 //        assertThat(s1).isInEpoch(0);
         assertThat(s1).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
@@ -269,7 +269,7 @@ public class LayoutServerTest extends AbstractServerTest {
 
         // validate phase 1
         sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
-        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
 
         assertThat(s1).isInEpoch(0);
         assertThat(s1).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
@@ -291,7 +291,7 @@ public class LayoutServerTest extends AbstractServerTest {
 
         //new LAYOUT_PREPARE message with a higher phase1 rank should be accepted
         sendMessage(new LayoutRankMsg(null, 101, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
-        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
     }
 
     /**
@@ -320,7 +320,7 @@ public class LayoutServerTest extends AbstractServerTest {
         l100.setEpoch(100);
         // validate phase 1
         sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
-        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
 
         // the epoch should not change yet.
 //        assertThat(s1).isInEpoch(0);
@@ -388,7 +388,7 @@ public class LayoutServerTest extends AbstractServerTest {
         l100.setEpoch(100);
         /* validate phase 1 */
         sendMessage(new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
-        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
 
         // the epoch should not change yet.
 //        assertThat(s1).isInEpoch(0);
@@ -400,11 +400,11 @@ public class LayoutServerTest extends AbstractServerTest {
         assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_REJECT);
 
         sendMessage(UUID.nameUUIDFromBytes("TEST_CLIENT_OTHER".getBytes()), new LayoutRankMsg(null, 100, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
-        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
 
         // message from a different client but with a higher rank gets accepted
         sendMessage(UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes()), new LayoutRankMsg(null, 101, CorfuMsg.CorfuMsgType.LAYOUT_PREPARE));
-        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_PREPARE_ACK);
         assertThat(s1).isPhase1Rank(new Rank(101L, UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes())));
 //        assertThat(s1).isInEpoch(0);
 

--- a/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -1,5 +1,7 @@
 package org.corfudb.infrastructure;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
 import lombok.Setter;
@@ -8,6 +10,8 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by mwei on 12/13/15.
@@ -39,7 +43,8 @@ public class TestServerRouter implements IServerRouter {
     @Override
     public void sendResponse(ChannelHandlerContext ctx, CorfuMsg inMsg, CorfuMsg outMsg) {
         outMsg.setEpoch(serverEpoch);
-        this.responseMessages.add(outMsg);
+        CorfuMsg response = simulateSerialization(outMsg);
+        this.responseMessages.add(response);
     }
 
     public void sendServerMessage(CorfuMsg msg) {
@@ -47,4 +52,24 @@ public class TestServerRouter implements IServerRouter {
         msg.setRequestID(requestCounter.getAndIncrement());
         serverUnderTest.handleMessage(msg, null, this);
     }
+
+    /**
+     * This simulates the serialization and deserialization that happens in the Netty pipeline for all messages
+     * from server to client.
+     *
+     * @param message
+     * @return
+     */
+
+    public CorfuMsg simulateSerialization(CorfuMsg message) {
+        /* simulate serialization/deserialization */
+        ByteBuf oBuf = ByteBufAllocator.DEFAULT.buffer();
+        Class<? extends CorfuMsg> type = message.getMsgType().messageType;
+        //extra assert needed to simulate real Netty behavior
+        assertThat(message.getClass().getSimpleName()).isEqualTo(type.getSimpleName());
+        type.cast(message).serialize(oBuf);
+        oBuf.resetReaderIndex();
+        return CorfuMsg.deserialize(oBuf);
+    }
+
 }

--- a/src/test/java/org/corfudb/runtime/clients/LayoutClientTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/LayoutClientTest.java
@@ -82,7 +82,7 @@ public class LayoutClientTest extends AbstractClientTest {
         assertThat(client.bootstrapLayout(TestLayoutBuilder.single(9000)).get())
                 .isEqualTo(true);
 
-        assertThat(client.prepare(10L).get())
+        assertThat(client.prepare(10L).get().isAccepted())
                 .isEqualTo(true);
 
         assertThatThrownBy(() -> {
@@ -100,7 +100,7 @@ public class LayoutClientTest extends AbstractClientTest {
         assertThat(client.bootstrapLayout(TestLayoutBuilder.single(9000)).get())
                 .isEqualTo(true);
 
-        assertThat(client.prepare(10L).get())
+        assertThat(client.prepare(10L).get().isAccepted())
                 .isEqualTo(true);
 
         assertThatThrownBy(() -> {
@@ -117,7 +117,7 @@ public class LayoutClientTest extends AbstractClientTest {
         assertThat(client.bootstrapLayout(TestLayoutBuilder.single(9000)).get())
                 .isEqualTo(true);
 
-        assertThat(client.prepare(10L).get())
+        assertThat(client.prepare(10L).get().isAccepted())
                 .isEqualTo(true);
 
         client.propose(10L, TestLayoutBuilder.single(9000)).get();
@@ -137,7 +137,7 @@ public class LayoutClientTest extends AbstractClientTest {
         assertThat(client.bootstrapLayout(TestLayoutBuilder.single(9000)).get())
                 .isEqualTo(true);
 
-        assertThat(client.prepare(10L).get())
+        assertThat(client.prepare(10L).get().isAccepted())
                 .isEqualTo(true);
 
         assertThat(client.committed(10L).get())


### PR DESCRIPTION
LAYOUT_PREPARE_ACK message was being incorrectly instantiated by
layoutServer. Fixed the issue and also added Message
Serialization/Deserialization to Server Tests to catch this problem
in automated testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/200)
<!-- Reviewable:end -->
