### PR TITLE
Simplify routing interface and add base server querying capabilities

### DIFF
--- a/src/main/java/org/corfudb/cmdlets/corfu_query.java
+++ b/src/main/java/org/corfudb/cmdlets/corfu_query.java
@@ -1,0 +1,70 @@
+package org.corfudb.cmdlets;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.VersionInfo;
+import org.corfudb.runtime.clients.BaseClient;
+import org.corfudb.runtime.clients.NettyClientRouter;
+import org.corfudb.util.GitRepositoryState;
+import org.docopt.Docopt;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static jdk.nashorn.internal.runtime.regexp.joni.Config.log;
+import static org.fusesource.jansi.Ansi.Color.RED;
+import static org.fusesource.jansi.Ansi.Color.WHITE;
+import static org.fusesource.jansi.Ansi.ansi;
+
+/**
+ * Created by mwei on 8/1/16.
+ */
+@Slf4j
+public class corfu_query implements ICmdlet {
+
+    private static final String USAGE =
+            "corfu_query, query a Corfu server to get runtime information.\n"
+                    + "\n"
+                    + "Usage:\n"
+                    + "\tcorfu_ping <address>:<port> [-d <level>]\n"
+                    + "\n"
+                    + "Options:\n"
+                    + " -d <level>, --log-level=<level>      Set the logging level, valid levels are: \n"
+                    + "                                      ERROR,WARN,INFO,DEBUG,TRACE [default: INFO].\n"
+                    + " -h, --help  Show this screen\n"
+                    + " --version  Show version\n";
+
+
+    @Override
+    public void main(String[] args) {
+        // Parse the options given, using docopt.
+        Map<String, Object> opts =
+                new Docopt(USAGE).withVersion(GitRepositoryState.getRepositoryState().describe).parse(args);
+
+        // Configure base options
+        configureBase(opts);
+
+        // Parse host address and port
+        String addressport = (String) opts.get("<address>:<port>");
+        String host = addressport.split(":")[0];
+        Integer port = Integer.parseInt(addressport.split(":")[1]);
+
+        // Create a client router and ping.
+        log.trace("Creating router for {}:{}", host, port);
+        NettyClientRouter router = new NettyClientRouter(host, port);
+        router.start();
+        System.out.println(ansi().a("QUERY ").fg(WHITE).a(host + ":" + port).reset().a(":"));
+        try {
+            VersionInfo vi = router.getClient(BaseClient.class).getVersionInfo().get();
+            Gson gs = new GsonBuilder().setPrettyPrinting().create();
+            System.out.println(ansi().a("RESPONSE").fg(WHITE).reset().a(":"));
+            System.out.println(gs.toJson(vi));
+        } catch (Exception ex) {
+            System.out.println(ansi().fg(RED).a("ERROR").reset().a(":"));
+            System.out.println(ex.toString());
+        }
+    }
+}

--- a/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -18,9 +18,9 @@ public class BaseServer extends AbstractServer {
     /** Handler for the base server */
     @Getter
     private CorfuMsgHandler handler = new CorfuMsgHandler()
-            .addHandler(CorfuMsg.CorfuMsgType.PING, CorfuMsg.class, BaseServer::ping)
-            .addHandler(CorfuMsg.CorfuMsgType.SET_EPOCH, CorfuSetEpochMsg.class, BaseServer::setEpoch)
-            .addHandler(CorfuMsg.CorfuMsgType.VERSION_REQUEST, CorfuMsg.class, BaseServer::getVersion);
+            .addHandler(CorfuMsg.CorfuMsgType.PING, BaseServer::ping)
+            .addHandler(CorfuMsg.CorfuMsgType.SET_EPOCH, BaseServer::setEpoch)
+            .addHandler(CorfuMsg.CorfuMsgType.VERSION_REQUEST, BaseServer::getVersion);
 
     /** Respond to a ping message.
      *

--- a/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure;
 
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuSetEpochMsg;
@@ -9,18 +10,26 @@ import org.corfudb.protocols.wireprotocol.JSONPayloadMsg;
 import org.corfudb.protocols.wireprotocol.VersionInfo;
 import org.corfudb.util.CorfuMsgHandler;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Created by mwei on 12/8/15.
  */
 @Slf4j
 public class BaseServer extends AbstractServer {
 
+    /** Options map, if available */
+    @Getter
+    @Setter
+    public Map<String, Object> optionsMap = new HashMap<>();
+
     /** Handler for the base server */
     @Getter
     private CorfuMsgHandler handler = new CorfuMsgHandler()
             .addHandler(CorfuMsg.CorfuMsgType.PING, BaseServer::ping)
             .addHandler(CorfuMsg.CorfuMsgType.SET_EPOCH, BaseServer::setEpoch)
-            .addHandler(CorfuMsg.CorfuMsgType.VERSION_REQUEST, BaseServer::getVersion);
+            .addHandler(CorfuMsg.CorfuMsgType.VERSION_REQUEST, this::getVersion);
 
     /** Respond to a ping message.
      *
@@ -57,11 +66,10 @@ public class BaseServer extends AbstractServer {
      * @param ctx   The channel context
      * @param r     The server router.
      */
-    private static void getVersion(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
-        VersionInfo vi = new VersionInfo();
+    private void getVersion(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+        VersionInfo vi = new VersionInfo(optionsMap);
         r.sendResponse(ctx, msg, new JSONPayloadMsg<>(vi, CorfuMsg.CorfuMsgType.VERSION_RESPONSE));
     }
-
 
     @Override
     public void reset() {

--- a/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -160,6 +160,7 @@ public class CorfuServer {
         router.addServer(new SequencerServer(opts));
         router.addServer(new LayoutServer(opts, router));
         router.addServer(new LogUnitServer(opts));
+        router.baseServer.setOptionsMap(opts);
 
         // Create the event loops responsible for servicing inbound messages.
         EventLoopGroup bossGroup;

--- a/src/main/java/org/corfudb/protocols/wireprotocol/JSONPayloadMsg.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/JSONPayloadMsg.java
@@ -1,0 +1,74 @@
+package org.corfudb.protocols.wireprotocol;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.netty.buffer.ByteBuf;
+import lombok.NoArgsConstructor;
+
+import java.lang.reflect.ParameterizedType;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Created by mwei on 7/27/16.
+ */
+@NoArgsConstructor
+public class JSONPayloadMsg<T> extends CorfuMsg {
+
+    static final Gson parser = new GsonBuilder().create();
+
+    /**
+     * The payload.
+     */
+    private T payload;
+
+    /**
+     * The data, before deserialization.
+     */
+    private String dataString;
+
+    public JSONPayloadMsg(T payload, CorfuMsg.CorfuMsgType type) {
+        this.msgType = type;
+        this.payload = payload;
+    }
+
+    /**
+     * Serialize the message into the given bytebuffer.
+     *
+     * @param buffer The buffer to serialize to.
+     */
+    @Override
+    public void serialize(ByteBuf buffer) {
+        super.serialize(buffer);
+        byte[] b = parser.toJson(payload).getBytes();
+        buffer.writeInt(b.length);
+        buffer.writeBytes(b);
+    }
+
+    /**
+     * Parse the rest of the message from the buffer. Classes that extend CorfuMsg
+     * should parse their fields in this method.
+     *
+     * @param buffer
+     */
+    @Override
+    public void fromBuffer(ByteBuf buffer) {
+        super.fromBuffer(buffer);
+        int length = buffer.readInt();
+        byte[] byteArray = new byte[length];
+        buffer.readBytes(byteArray, 0, length);
+        dataString = new String(byteArray, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Get the payload. Uses some type reflection voodoo in order to get the type to the JSON
+     * parser, so make sure to correctly parameterize this class, using with a raw type will
+     * most definitely fail.
+     *
+     * @return  The JSON payload.
+     */
+    @SuppressWarnings("unchecked")
+    public T getPayload() {
+        return parser.fromJson(dataString,
+                ((ParameterizedType)msgType.messageType.getType()).getActualTypeArguments()[0]);
+    }
+}

--- a/src/main/java/org/corfudb/protocols/wireprotocol/VersionInfo.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/VersionInfo.java
@@ -1,0 +1,11 @@
+package org.corfudb.protocols.wireprotocol;
+
+import lombok.Getter;
+
+/**
+ * Created by mwei on 7/27/16.
+ */
+public class VersionInfo {
+    @Getter
+    String oString = "abcd";
+}

--- a/src/main/java/org/corfudb/protocols/wireprotocol/VersionInfo.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/VersionInfo.java
@@ -1,11 +1,22 @@
 package org.corfudb.protocols.wireprotocol;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.lang.management.ManagementFactory;
+import java.util.Map;
 
 /**
  * Created by mwei on 7/27/16.
  */
 public class VersionInfo {
     @Getter
-    String oString = "abcd";
+    Map<String, Object> optionsMap;
+
+    @Getter
+    long upTime = ManagementFactory.getRuntimeMXBean().getUptime();
+
+    public VersionInfo(Map<String,Object> optionsMap) {
+        this.optionsMap = optionsMap;
+    }
 }

--- a/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -7,7 +7,11 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuSetEpochMsg;
+import org.corfudb.protocols.wireprotocol.JSONPayloadMsg;
+import org.corfudb.protocols.wireprotocol.VersionInfo;
 import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.util.ClientMsgHandler;
+import org.corfudb.util.CorfuMsgHandler;
 
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -34,6 +38,7 @@ public class BaseClient implements IClient {
                     .add(CorfuMsg.CorfuMsgType.NACK)
                     .add(CorfuMsg.CorfuMsgType.SET_EPOCH)
                     .add(CorfuMsg.CorfuMsgType.WRONG_EPOCH)
+                    .add(CorfuMsg.CorfuMsgType.VERSION_RESPONSE)
                     .build();
     /**
      * The router to use for the client.
@@ -42,48 +47,81 @@ public class BaseClient implements IClient {
     @Setter
     public IClientRouter router;
 
-    /**
-     * Handle a incoming message on the channel
+    @Getter
+    public ClientMsgHandler msgHandler = new ClientMsgHandler(this)
+            .addHandler(CorfuMsg.CorfuMsgType.PING, CorfuMsg.class, BaseClient::handlePing)
+            .addHandler(CorfuMsg.CorfuMsgType.PONG, CorfuMsg.class, BaseClient::handlePong)
+            .addHandler(CorfuMsg.CorfuMsgType.ACK, CorfuMsg.class, BaseClient::handleAck)
+            .addHandler(CorfuMsg.CorfuMsgType.NACK, CorfuMsg.class, BaseClient::handleNack)
+            .addHandler(CorfuMsg.CorfuMsgType.WRONG_EPOCH, CorfuSetEpochMsg.class, BaseClient::handleWrongEpoch)
+            .addHandler(CorfuMsg.CorfuMsgType.VERSION_RESPONSE, JSONPayloadMsg.class, BaseClient::handleVersionResponse);
+
+    /** Handle a ping request from the server.
      *
-     * @param msg    The incoming message
-     * @param ctx    The channel handler context
-     * @param router The router that routed the incoming message.
+     * @param msg   The ping request message
+     * @param ctx   The context the message was sent under
+     * @param r     A reference to the router
+     * @return      The return value, null since this is a message from the server.
      */
-    @Override
-    public void handleMessage(CorfuMsg msg, ChannelHandlerContext ctx) {
-        switch (msg.getMsgType()) {
-            case PONG:
-                router.completeRequest(msg.getRequestID(), true);
-                break;
-            case PING:
-                router.sendResponseToServer(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.PONG));
-                break;
-            case ACK:
-                router.completeRequest(msg.getRequestID(), true);
-                break;
-            case NACK:
-                router.completeRequest(msg.getRequestID(), false);
-                break;
-            case SET_EPOCH: {
-                CorfuSetEpochMsg csem = (CorfuSetEpochMsg) msg;
-                if (csem.getNewEpoch() >= router.getEpoch()) {
-                    log.info("Received SET_EPOCH, moving to new epoch {}", csem.getNewEpoch());
-                    router.setEpoch(csem.getNewEpoch());
-                    router.sendResponseToServer(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.ACK));
-                } else {
-                    log.debug("Rejected SET_EPOCH currrent={}, requested={}",
-                            router.getEpoch(), csem.getNewEpoch());
-                    router.sendResponseToServer(ctx, msg, new CorfuSetEpochMsg(CorfuMsg.CorfuMsgType.WRONG_EPOCH,
-                            router.getEpoch()));
-                }
-            }
-            break;
-            case WRONG_EPOCH: {
-                CorfuSetEpochMsg csem = (CorfuSetEpochMsg) msg;
-                router.completeExceptionally(msg.getRequestID(), new WrongEpochException(csem.getNewEpoch()));
-            }
-            break;
-        }
+    private static Object handlePing(CorfuMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
+        r.sendResponseToServer(ctx, msg, new CorfuMsg(CorfuMsg.CorfuMsgType.PONG));
+        return null;
+    }
+
+    /** Handle a pong response from the server.
+     *
+     * @param msg   The ping request message
+     * @param ctx   The context the message was sent under
+     * @param r     A reference to the router
+     * @return      Always True, since the ping message was successful.
+     */
+    private static Object handlePong(CorfuMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
+        return true;
+    }
+
+    /** Handle an ACK response from the server.
+     *
+     * @param msg   The ping request message
+     * @param ctx   The context the message was sent under
+     * @param r     A reference to the router
+     * @return      Always True, since the ACK message was successful.
+     */
+    private static Object handleAck(CorfuMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
+        return true;
+    }
+
+    /** Handle a NACK response from the server.
+     *
+     * @param msg   The ping request message
+     * @param ctx   The context the message was sent under
+     * @param r     A reference to the router
+     * @return      Always True, since the ACK message was successful.
+     */
+    private static Object handleNack(CorfuMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
+        return false;
+    }
+
+    /** Handle a WRONG_EPOCH response from the server.
+     *
+     * @param msg   The wrong epoch message
+     * @param ctx   The context the message was sent under
+     * @param r     A reference to the router
+     * @return      none, throw a wrong epoch exception instead.
+     */
+    private static Object handleWrongEpoch(CorfuSetEpochMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
+        throw new WrongEpochException(msg.getNewEpoch());
+    }
+
+    /** Handle a WRONG_EPOCH response from the server.
+     *
+     * @param msg   The wrong epoch message
+     * @param ctx   The context the message was sent under
+     * @param r     A reference to the router
+     * @return      none, throw a wrong epoch exception instead.
+     */
+    private static Object handleVersionResponse(JSONPayloadMsg<VersionInfo> msg,
+                                                ChannelHandlerContext ctx, IClientRouter r) {
+        return msg.getPayload();
     }
 
     /**
@@ -106,6 +144,12 @@ public class BaseClient implements IClient {
         return router.sendMessageAndGetCompletable(
                 new CorfuSetEpochMsg(CorfuMsg.CorfuMsgType.SET_EPOCH, newEpoch));
     }
+
+    public CompletableFuture<VersionInfo> getVersionInfo() {
+        return router.sendMessageAndGetCompletable(
+                new CorfuMsg(CorfuMsg.CorfuMsgType.VERSION_REQUEST));
+    }
+
 
     /**
      * Ping the endpoint, asynchronously.

--- a/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -49,12 +49,12 @@ public class BaseClient implements IClient {
 
     @Getter
     public ClientMsgHandler msgHandler = new ClientMsgHandler(this)
-            .addHandler(CorfuMsg.CorfuMsgType.PING, CorfuMsg.class, BaseClient::handlePing)
-            .addHandler(CorfuMsg.CorfuMsgType.PONG, CorfuMsg.class, BaseClient::handlePong)
-            .addHandler(CorfuMsg.CorfuMsgType.ACK, CorfuMsg.class, BaseClient::handleAck)
-            .addHandler(CorfuMsg.CorfuMsgType.NACK, CorfuMsg.class, BaseClient::handleNack)
-            .addHandler(CorfuMsg.CorfuMsgType.WRONG_EPOCH, CorfuSetEpochMsg.class, BaseClient::handleWrongEpoch)
-            .addHandler(CorfuMsg.CorfuMsgType.VERSION_RESPONSE, JSONPayloadMsg.class, BaseClient::handleVersionResponse);
+            .addHandler(CorfuMsg.CorfuMsgType.PING, BaseClient::handlePing)
+            .addHandler(CorfuMsg.CorfuMsgType.PONG, BaseClient::handlePong)
+            .addHandler(CorfuMsg.CorfuMsgType.ACK, BaseClient::handleAck)
+            .addHandler(CorfuMsg.CorfuMsgType.NACK, BaseClient::handleNack)
+            .addHandler(CorfuMsg.CorfuMsgType.WRONG_EPOCH, BaseClient::handleWrongEpoch)
+            .addHandler(CorfuMsg.CorfuMsgType.VERSION_RESPONSE, BaseClient::handleVersionResponse);
 
     /** Handle a ping request from the server.
      *
@@ -97,7 +97,7 @@ public class BaseClient implements IClient {
      * @param r     A reference to the router
      * @return      Always True, since the ACK message was successful.
      */
-    private static Object handleNack(CorfuMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
+    private static Object handleNack(CorfuSetEpochMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
         return false;
     }
 

--- a/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -27,26 +27,53 @@ import java.util.concurrent.CompletableFuture;
 public class BaseClient implements IClient {
 
     /**
-     * The messages this client should handle.
-     */
-    @Getter
-    public final Set<CorfuMsg.CorfuMsgType> HandledTypes =
-            new ImmutableSet.Builder<CorfuMsg.CorfuMsgType>()
-                    .add(CorfuMsg.CorfuMsgType.PING)
-                    .add(CorfuMsg.CorfuMsgType.PONG)
-                    .add(CorfuMsg.CorfuMsgType.ACK)
-                    .add(CorfuMsg.CorfuMsgType.NACK)
-                    .add(CorfuMsg.CorfuMsgType.SET_EPOCH)
-                    .add(CorfuMsg.CorfuMsgType.WRONG_EPOCH)
-                    .add(CorfuMsg.CorfuMsgType.VERSION_RESPONSE)
-                    .build();
-    /**
      * The router to use for the client.
      */
     @Getter
     @Setter
     public IClientRouter router;
 
+    /** Public functions which are exposed to clients. */
+
+    /**
+     * Ping the endpoint, synchronously.
+     *
+     * @return True, if the endpoint was reachable, false otherwise.
+     */
+    public boolean pingSync() {
+        try {
+            return ping().get();
+        } catch (Exception e) {
+            log.trace("Ping failed due to exception", e);
+            return false;
+        }
+    }
+
+    public CompletableFuture<Boolean> setRemoteEpoch(long newEpoch) {
+        // Set our own epoch to this epoch.
+        router.setEpoch(newEpoch);
+        return router.sendMessageAndGetCompletable(
+                new CorfuSetEpochMsg(CorfuMsg.CorfuMsgType.SET_EPOCH, newEpoch));
+    }
+
+    public CompletableFuture<VersionInfo> getVersionInfo() {
+        return router.sendMessageAndGetCompletable(
+                new CorfuMsg(CorfuMsg.CorfuMsgType.VERSION_REQUEST));
+    }
+
+
+    /**
+     * Ping the endpoint, asynchronously.
+     *
+     * @return A completable future which will be completed with True if
+     * the endpoint is reachable, otherwise False or exceptional completion.
+     */
+    public CompletableFuture<Boolean> ping() {
+        return router.sendMessageAndGetCompletable(
+                new CorfuMsg(CorfuMsg.CorfuMsgType.PING));
+    }
+
+    /** The handler and handlers which implement this client. */
     @Getter
     public ClientMsgHandler msgHandler = new ClientMsgHandler(this)
             .addHandler(CorfuMsg.CorfuMsgType.PING, BaseClient::handlePing)
@@ -124,41 +151,4 @@ public class BaseClient implements IClient {
         return msg.getPayload();
     }
 
-    /**
-     * Ping the endpoint, synchronously.
-     *
-     * @return True, if the endpoint was reachable, false otherwise.
-     */
-    public boolean pingSync() {
-        try {
-            return ping().get();
-        } catch (Exception e) {
-            log.trace("Ping failed due to exception", e);
-            return false;
-        }
-    }
-
-    public CompletableFuture<Boolean> setRemoteEpoch(long newEpoch) {
-        // Set our own epoch to this epoch.
-        router.setEpoch(newEpoch);
-        return router.sendMessageAndGetCompletable(
-                new CorfuSetEpochMsg(CorfuMsg.CorfuMsgType.SET_EPOCH, newEpoch));
-    }
-
-    public CompletableFuture<VersionInfo> getVersionInfo() {
-        return router.sendMessageAndGetCompletable(
-                new CorfuMsg(CorfuMsg.CorfuMsgType.VERSION_REQUEST));
-    }
-
-
-    /**
-     * Ping the endpoint, asynchronously.
-     *
-     * @return A completable future which will be completed with True if
-     * the endpoint is reachable, otherwise False or exceptional completion.
-     */
-    public CompletableFuture<Boolean> ping() {
-        return router.sendMessageAndGetCompletable(
-                new CorfuMsg(CorfuMsg.CorfuMsgType.PING));
-    }
 }

--- a/src/main/java/org/corfudb/runtime/clients/IClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/IClient.java
@@ -2,6 +2,8 @@ package org.corfudb.runtime.clients;
 
 import io.netty.channel.ChannelHandlerContext;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
+import org.corfudb.util.ClientMsgHandler;
+import org.corfudb.util.CorfuMsgHandler;
 
 import java.util.Set;
 
@@ -19,18 +21,31 @@ public interface IClient {
     void setRouter(IClientRouter router);
 
     /**
+     * Get the router used by the Netty client.
+     *
+     */
+    IClientRouter getRouter();
+
+    default ClientMsgHandler getMsgHandler() {
+        throw new UnsupportedOperationException("Message handler not provided, please override handleMessage!");
+    }
+
+    /**
      * Handle a incoming message on the channel
      *
      * @param msg The incoming message
      * @param ctx The channel handler context
-     * @param r   The router that routed the incoming message.
      */
-    void handleMessage(CorfuMsg msg, ChannelHandlerContext ctx);
+    default void handleMessage(CorfuMsg msg, ChannelHandlerContext ctx) {
+        getMsgHandler().handle(msg, ctx);
+    }
 
     /**
      * Returns a set of message types that the client handles.
      *
      * @return The set of message types this client handles.
      */
-    Set<CorfuMsg.CorfuMsgType> getHandledTypes();
+    default Set<CorfuMsg.CorfuMsgType> getHandledTypes() {
+        return getMsgHandler().getHandledTypes();
+    }
 }

--- a/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
@@ -43,6 +43,7 @@ public class LayoutClient implements IClient {
                     .build();
 
     @Setter
+    @Getter
     IClientRouter router;
 
     /**

--- a/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -56,6 +56,7 @@ public class LogUnitClient implements IClient {
                     .add(CorfuMsg.CorfuMsgType.ERROR_RANK)
                     .build();
     @Setter
+    @Getter
     IClientRouter router;
 
     /**

--- a/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -33,6 +33,7 @@ public class SequencerClient implements IClient {
                     .add(CorfuMsg.CorfuMsgType.TOKEN_RES)
                     .build();
     @Setter
+    @Getter
     IClientRouter router;
 
     /**

--- a/src/main/java/org/corfudb/util/ClientMsgHandler.java
+++ b/src/main/java/org/corfudb/util/ClientMsgHandler.java
@@ -35,15 +35,37 @@ public class ClientMsgHandler {
     /** Add a handler to this message handler.
      *
      * @param messageType       The type of CorfuMsg this handler will handle.
-     * @param messageClass      The class of messages this handler will receive.
      * @param handler           The handler itself.
      * @param <T>               A CorfuMsg type.
      * @return                  This handler, to support chaining.
      */
     public <T extends CorfuMsg> ClientMsgHandler
-    addHandler(CorfuMsg.CorfuMsgType messageType, Class<T> messageClass, ClientMsgHandler.Handler<T> handler) {
-        handlerMap.put(messageType, handler);
-        return this;
+    addHandler(CorfuMsg.CorfuMsgType messageType, ClientMsgHandler.Handler<T> handler) {
+        // We do type-checking at runtime.
+        // This should be okay as any incorrect handler will be registered
+        // at startup, and be caught during almost any unit test.
+
+        // Type-checking during compile time would be nice, but Java is just
+        // not friendly...
+
+        // TODO: Turn off this check when we aren't running tests.
+        try {
+            Class<?> c = handler.getClass().getMethod("handle",
+                    CorfuMsg.class, ChannelHandlerContext.class, IClientRouter.class)
+                    .getParameterTypes()[0];
+
+            if (!c.isAssignableFrom(messageType.messageType.getRawType())) {
+                throw new UnsupportedOperationException(
+                        "Handler for incorrect type registered, expected "
+                                + messageType.messageType.toString() + " but got " +
+                                c.toGenericString());
+            }
+
+            handlerMap.put(messageType, handler);
+            return this;
+        } catch (NoSuchMethodException nsme) {
+            throw new RuntimeException(nsme);
+        }
     }
 
     /** Handle an incoming CorfuMsg.

--- a/src/main/java/org/corfudb/util/ClientMsgHandler.java
+++ b/src/main/java/org/corfudb/util/ClientMsgHandler.java
@@ -1,0 +1,79 @@
+package org.corfudb.util;
+
+import io.netty.channel.ChannelHandlerContext;
+import org.corfudb.infrastructure.IServerRouter;
+import org.corfudb.protocols.wireprotocol.CorfuMsg;
+import org.corfudb.runtime.clients.IClient;
+import org.corfudb.runtime.clients.IClientRouter;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Created by mwei on 7/27/16.
+ */
+public class ClientMsgHandler {
+
+    @FunctionalInterface
+    public interface Handler<T extends CorfuMsg> {
+        Object handle(T CorfuMsg, ChannelHandlerContext ctx, IClientRouter r) throws Exception;
+    }
+
+    /** The handler map. */
+    private Map<CorfuMsg.CorfuMsgType, ClientMsgHandler.Handler> handlerMap;
+
+    /** The client. */
+    private IClient client;
+
+    /** Construct a new instance of ClientMsgHandler. */
+    public ClientMsgHandler(IClient client) {
+        this.client = client;
+        handlerMap = new ConcurrentHashMap<>();
+    }
+
+    /** Add a handler to this message handler.
+     *
+     * @param messageType       The type of CorfuMsg this handler will handle.
+     * @param messageClass      The class of messages this handler will receive.
+     * @param handler           The handler itself.
+     * @param <T>               A CorfuMsg type.
+     * @return                  This handler, to support chaining.
+     */
+    public <T extends CorfuMsg> ClientMsgHandler
+    addHandler(CorfuMsg.CorfuMsgType messageType, Class<T> messageClass, ClientMsgHandler.Handler<T> handler) {
+        handlerMap.put(messageType, handler);
+        return this;
+    }
+
+    /** Handle an incoming CorfuMsg.
+     *
+     * @param message   The message to handle.
+     * @param ctx       The channel handler context.
+     * @return          True, if the message was handled.
+     *                  False otherwise.
+     */
+    @SuppressWarnings("unchecked")
+    public boolean handle(CorfuMsg message, ChannelHandlerContext ctx) {
+        if (handlerMap.containsKey(message.getMsgType())) {
+            try {
+                Object ret = handlerMap.get(message.getMsgType()).handle(message, ctx, client.getRouter());
+                if (ret != null) {
+                    client.getRouter().completeRequest(message.getRequestID(), ret);
+                }
+            } catch (Exception ex) {
+                client.getRouter().completeExceptionally(message.getRequestID(), ex);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /** Get the types this handler will handle.
+     *
+     * @return  The types this handler will handle.
+     */
+    public Set<CorfuMsg.CorfuMsgType> getHandledTypes() {
+        return handlerMap.keySet();
+    }
+}

--- a/src/main/java/org/corfudb/util/CorfuMsgHandler.java
+++ b/src/main/java/org/corfudb/util/CorfuMsgHandler.java
@@ -4,6 +4,7 @@ import io.netty.channel.ChannelHandlerContext;
 import org.corfudb.infrastructure.IServerRouter;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 
+import java.lang.reflect.ParameterizedType;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
@@ -33,15 +34,38 @@ public class CorfuMsgHandler {
     /** Add a handler to this message handler.
      *
      * @param messageType       The type of CorfuMsg this handler will handle.
-     * @param messageClass      The class of messages this handler will receive.
      * @param handler           The handler itself.
      * @param <T>               A CorfuMsg type.
      * @return                  This handler, to support chaining.
      */
+    @SuppressWarnings("unchecked")
     public <T extends CorfuMsg> CorfuMsgHandler
-    addHandler(CorfuMsg.CorfuMsgType messageType, Class<T> messageClass, Handler<T> handler) {
-        handlerMap.put(messageType, handler);
-        return this;
+    addHandler(CorfuMsg.CorfuMsgType messageType, Handler<T> handler) {
+        // We do type-checking at runtime.
+        // This should be okay as any incorrect handler will be registered
+        // at startup, and be caught during almost any unit test.
+
+        // Type-checking during compile time would be nice, but Java is just
+        // not friendly...
+
+        // TODO: Turn off this check when we aren't running tests.
+        try {
+            Class<?> c = handler.getClass().getMethod("handle",
+                    CorfuMsg.class, ChannelHandlerContext.class, IServerRouter.class)
+                    .getParameterTypes()[0];
+
+            if (!c.isAssignableFrom(messageType.messageType.getRawType())) {
+                throw new UnsupportedOperationException(
+                        "Handler for incorrect type registered, expected "
+                                + messageType.messageType.toString() + " but got " +
+                                c.toGenericString());
+            }
+
+            handlerMap.put(messageType, handler);
+            return this;
+        } catch (NoSuchMethodException nsme) {
+            throw new RuntimeException(nsme);
+        }
     }
 
     /** Handle an incoming CorfuMsg.

--- a/src/main/java/org/corfudb/util/CorfuMsgHandler.java
+++ b/src/main/java/org/corfudb/util/CorfuMsgHandler.java
@@ -11,6 +11,8 @@ import java.util.function.Consumer;
 /**
  * This class simplifies writing switch(msg.getType()) statements.
  *
+ * For maximum performance, make the handlers static whenever possible.
+ *
  * Created by mwei on 7/26/16.
  */
 public class CorfuMsgHandler {

--- a/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -114,12 +114,15 @@ public class TestServerRouter implements IServerRouter {
     public CorfuMsg simulateSerialization(CorfuMsg message) {
         /* simulate serialization/deserialization */
         ByteBuf oBuf = ByteBufAllocator.DEFAULT.buffer();
-        Class<? extends CorfuMsg> type = message.getMsgType().messageType;
+        //Class<? extends CorfuMsg> type = message.getMsgType().messageType;
         //extra assert needed to simulate real Netty behavior
-        assertThat(message.getClass().getSimpleName()).isEqualTo(type.getSimpleName());
-        type.cast(message).serialize(oBuf);
+        //assertThat(message.getClass().getSimpleName()).isEqualTo(type.getSimpleName());
+        //type.cast(message).serialize(oBuf);
+        message.serialize(oBuf);
         oBuf.resetReaderIndex();
-        return CorfuMsg.deserialize(oBuf);
+        CorfuMsg msgOut = CorfuMsg.deserialize(oBuf);
+        oBuf.release();
+        return msgOut;
     }
 
 }

--- a/src/test/java/org/corfudb/runtime/clients/BaseClientTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/BaseClientTest.java
@@ -1,0 +1,38 @@
+package org.corfudb.runtime.clients;
+
+import com.google.common.collect.ImmutableSet;
+import org.corfudb.infrastructure.AbstractServer;
+import org.corfudb.infrastructure.BaseServer;
+import org.corfudb.infrastructure.LogUnitServer;
+import org.corfudb.util.CFUtils;
+import org.junit.Test;
+
+import java.util.Set;
+
+/**
+ * Created by mwei on 7/27/16.
+ */
+public class BaseClientTest extends AbstractClientTest {
+
+    BaseClient client;
+
+    @Override
+    Set<AbstractServer> getServersForTest() {
+        return new ImmutableSet.Builder<AbstractServer>()
+                .add(new BaseServer())
+                .build();
+    }
+
+    @Override
+    Set<IClient> getClientsForTest() {
+        client = new BaseClient();
+        return new ImmutableSet.Builder<IClient>()
+                .add(client)
+                .build();
+    }
+
+    @Test
+    public void canGetVersionInfo() {
+        CFUtils.getUninterruptibly(client.getVersionInfo());
+    }
+}

--- a/src/test/java/org/corfudb/runtime/clients/TestChannelContext.java
+++ b/src/test/java/org/corfudb/runtime/clients/TestChannelContext.java
@@ -6,6 +6,7 @@ import io.netty.channel.*;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.EventExecutor;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 
 import java.net.SocketAddress;
@@ -14,6 +15,7 @@ import java.util.concurrent.CompletableFuture;
 /**
  * Created by mwei on 7/6/16.
  */
+@Slf4j
 public class TestChannelContext implements ChannelHandlerContext {
 
     @FunctionalInterface
@@ -29,10 +31,14 @@ public class TestChannelContext implements ChannelHandlerContext {
 
     void sendMessageAsync(Object o) {
         CompletableFuture.runAsync(() -> {
-            if (o instanceof ByteBuf) {
-                CorfuMsg m = CorfuMsg.deserialize((ByteBuf) o);
-                hmf.handleMessage(m);
-                ((ByteBuf) o).release();
+            try {
+                if (o instanceof ByteBuf) {
+                    CorfuMsg m = CorfuMsg.deserialize((ByteBuf) o);
+                    hmf.handleMessage(m);
+                    ((ByteBuf) o).release();
+                }
+            } catch (Exception e) {
+                 log.warn("Error during deserialization", e);
             }
         });
     }


### PR DESCRIPTION
This patch simplifies the netty routing interface and enables the base
server to serve basic queries, which are currently limited to 
uptime and startup arguments. This patch also adds a new cmdlet 
called "corfu_query" for querying this information.