### PR TITLE
Improvements to reconfig protocol implementation

### DIFF
--- a/src/main/java/org/corfudb/cmdlets/corfu_layout.java
+++ b/src/main/java/org/corfudb/cmdlets/corfu_layout.java
@@ -141,9 +141,10 @@ public class corfu_layout implements ICmdlet {
             }
         } else if ((Boolean) opts.get("committed")) {
             long rank = Long.parseLong((String) opts.get("--rank"));
+            Layout l = getLayout(opts);
             log.debug("Propose with new rank={}", rank);
             try {
-                if (router.getClient(LayoutClient.class).committed(rank).get()) {
+                if (router.getClient(LayoutClient.class).committed(rank, l).get()) {
                     System.out.println(ansi().a("RESPONSE from ").fg(WHITE).a(host + ":" + port)
                             .reset().fg(GREEN).a(": ACK"));
                 } else {

--- a/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -154,7 +154,7 @@ public class CorfuServer {
         }
 
         // Now, we start the Netty router, and have it route to the correct port.
-        NettyServerRouter router = new NettyServerRouter();
+        NettyServerRouter router = new NettyServerRouter(opts);
 
         // Add each role to the router.
         router.addServer(new SequencerServer(opts));

--- a/src/main/java/org/corfudb/infrastructure/DataStore.java
+++ b/src/main/java/org/corfudb/infrastructure/DataStore.java
@@ -1,0 +1,122 @@
+package org.corfudb.infrastructure;
+
+import com.github.benmanes.caffeine.cache.CacheWriter;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import org.corfudb.util.JSONUtils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Stores data as JSON.
+ * Employs a {@link LoadingCache} to front a file per value storage scheme.
+ * In this scheme, the key for each value is also the name of the file where the value is stored.
+ * The key is determined as (prefix + "_" + key).
+ * <p>
+ * If a log-path for storing files is not provided, the store is just an in memory cache.
+ * <p>
+ * Created by mdhawan on 7/27/16.
+ */
+
+public class DataStore implements IDataStore {
+    private String logDir;
+
+    private LoadingCache<String, String> cache;
+
+
+    public DataStore(Map<String, Object> opts) {
+        this.logDir = (String) opts.get("--log-path");
+        this.cache = Caffeine.newBuilder().writer(new CacheWriter<String, String>(
+        ) {
+            @Override
+            public void write(@Nonnull String key, @Nonnull String value) {
+                if (logDir == null) {
+                    return;
+                }
+                try {
+                    Path path = Paths.get(logDir + File.separator + key);
+                    Files.write(path, value.getBytes());
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void delete(@Nonnull String key, @Nullable String value, @Nonnull RemovalCause cause) {
+                if (logDir == null) {
+                    return;
+                }
+                try {
+                    Path path = Paths.get(logDir + File.separator + key);
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }).maximumSize(10_00)
+                .build(key -> {
+                    if (logDir != null) {
+                        try {
+                            Path path = Paths.get(logDir + File.separator + key);
+                            if (Files.notExists(path))
+                                return null;
+                            return new String(Files.readAllBytes(path));
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                    return null;
+                });
+    }
+
+    @Override
+    public <T> void put(Class<T> tClass, String prefix, String key, T value) {
+        cache.put(getKey(prefix, key), JSONUtils.parser.toJson(value, tClass));
+    }
+
+    @Override
+    public <T> T get(Class<T> tClass, String prefix, String key) {
+        String json = cache.get(getKey(prefix, key));
+        return getObject(json, tClass);
+    }
+
+    @Override
+    public <T> List<T> getAll(Class<T> tClass, String prefix) {
+        List<T> list = new ArrayList<T>();
+        for (Map.Entry<String, String> entry : cache.asMap().entrySet()) {
+            if (entry.getKey().startsWith(prefix)) {
+                list.add(getObject(entry.getValue(), tClass));
+            }
+        }
+        return list;
+    }
+
+    @Override
+    public <T> void delete(Class<T> tClass, String prefix, String key) {
+        cache.invalidate(getKey(prefix, key));
+    }
+
+    // Helper methods
+
+    private <T> T getObject(String json, Class<T> tClass) {
+        return isNotNull(json) ? JSONUtils.parser.fromJson(json, tClass) : null;
+    }
+
+    private String getKey(String prefix, String key) {
+        return prefix + "_" + key;
+    }
+
+    private boolean isNotNull(String value) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/src/main/java/org/corfudb/infrastructure/IDataStore.java
+++ b/src/main/java/org/corfudb/infrastructure/IDataStore.java
@@ -1,0 +1,60 @@
+package org.corfudb.infrastructure;
+
+import java.util.List;
+
+/**
+ * Key Value data store abstraction that provides persistence for variables that need
+ * retain values across node restarts or need to be accessed by multiple modules/threads.
+ * <p>
+ * The key value store is partitioned by prefix (namespace/table). All values being stored
+ * under a prefix should be of a single Type or Class<T>.
+ * <p>
+ * <p>
+ * Created by mdhawan on 7/27/16.
+ */
+public interface IDataStore {
+    /**
+     * Stores a value for a key under a prefix (namespace).
+     *
+     * @param tClass the class of the object being stored
+     * @param prefix
+     * @param key
+     * @param value
+     * @param <T>
+     */
+    public <T> void put(Class<T> tClass, String prefix, String key, T value);
+
+    /**
+     * Retrieves the value for a key under a prefix.
+     *
+     * @param tClass the class of the object being retrieved
+     * @param prefix
+     * @param key
+     * @param <T>
+     * @return
+     */
+    public <T> T get(Class<T> tClass, String prefix, String key);
+
+    /**
+     * Deletes the value for a key under a prefix.
+     *
+     * @param tClass the class of the object being retrieved
+     * @param prefix
+     * @param key
+     * @param <T>
+     */
+    public <T> void delete(Class<T> tClass, String prefix, String key);
+
+    /**
+     * Retrieves all the values under a prefix.
+     * <p>
+     * NOTE there is no ordered retrieval provided.
+     *
+     * @param tClass the class of the objects being retrieved.
+     * @param prefix
+     * @param <T>
+     * @return
+     */
+    public <T> List<T> getAll(Class<T> tClass, String prefix);
+
+}

--- a/src/main/java/org/corfudb/infrastructure/Phase2Data.java
+++ b/src/main/java/org/corfudb/infrastructure/Phase2Data.java
@@ -1,0 +1,19 @@
+package org.corfudb.infrastructure;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.ToString;
+import org.corfudb.runtime.view.Layout;
+
+/**
+ * Phase2 data consists of rank and the proposed layout.
+ * The container class provides a convenience to persist and retrieve
+ * these two pieces of data together.
+ */
+@Data
+@ToString
+@AllArgsConstructor
+class Phase2Data {
+    Rank rank;
+    Layout layout;
+}

--- a/src/main/java/org/corfudb/infrastructure/Rank.java
+++ b/src/main/java/org/corfudb/infrastructure/Rank.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.util.JSONUtils;
 
 import java.util.UUID;
 
@@ -13,20 +12,13 @@ import java.util.UUID;
  * Created by mdhawan on 6/28/16.
  */
 @Slf4j
-@ToString(exclude = "runtime")
+@ToString
 @AllArgsConstructor
 public class Rank implements Comparable<Rank> {
     @Getter
     Long rank;
     @Getter
     UUID clientId;
-
-    /**
-     * Get a layout from a JSON string.
-     */
-    public static Rank fromJSONString(String json) {
-        return JSONUtils.parser.fromJson(json, Rank.class);
-    }
 
     /**
      * compares this.rank with other.rank
@@ -42,12 +34,5 @@ public class Rank implements Comparable<Rank> {
             return clientId.compareTo(other.clientId);
         }
         return rank.compareTo(other.getRank());
-    }
-
-    /**
-     * Get the layout as a JSON string.
-     */
-    public String asJSONString() {
-        return JSONUtils.parser.toJson(this);
     }
 }

--- a/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
@@ -140,10 +140,10 @@ public class LayoutClient implements IClient {
      *              Otherwise, the completablefuture completes exceptionally
      *              with OutrankedException.
      */
-    public CompletableFuture<Boolean> committed(long rank)
+    public CompletableFuture<Boolean> committed(long rank, Layout layout)
     {
         return router.sendMessageAndGetCompletable(
-                new LayoutRankMsg(null, rank, CorfuMsg.CorfuMsgType.LAYOUT_COMMITTED)
+                new LayoutRankMsg(layout, rank, CorfuMsg.CorfuMsgType.LAYOUT_COMMITTED)
         );
     }
 

--- a/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
+++ b/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
@@ -1,0 +1,46 @@
+package org.corfudb.infrastructure;
+
+import com.google.common.collect.ImmutableMap;
+import org.corfudb.AbstractCorfuTest;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by mdhawan on 7/29/16.
+ */
+public class DataStoreTest extends AbstractCorfuTest {
+
+    @Test
+    public void testPutGet() {
+        String serviceDir = getTempDir();
+        DataStore dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
+                .put("--log-path", serviceDir)
+                .build());
+        String value = UUID.randomUUID().toString();
+        dataStore.put(String.class, "test", "key", value);
+        assertThat(dataStore.get(String.class, "test", "key")).isEqualTo(value);
+
+        dataStore.put(String.class, "test", "key", "NEW_VALUE");
+        assertThat(dataStore.get(String.class, "test", "key")).isEqualTo("NEW_VALUE");
+    }
+
+    @Test
+    public void testPutGetWithRestart() {
+        String serviceDir = getTempDir();
+        DataStore dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
+                .put("--log-path", serviceDir)
+                .build());
+        String value = UUID.randomUUID().toString();
+        dataStore.put(String.class, "test", "key", value);
+        //Simulate a restart of data store
+        dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
+                .put("--log-path", serviceDir)
+                .build());
+        assertThat(dataStore.get(String.class, "test", "key")).isEqualTo(value);
+        dataStore.put(String.class, "test", "key", "NEW_VALUE");
+        assertThat(dataStore.get(String.class, "test", "key")).isEqualTo("NEW_VALUE");
+    }
+}

--- a/src/test/java/org/corfudb/infrastructure/LayoutServerAssertions.java
+++ b/src/test/java/org/corfudb/infrastructure/LayoutServerAssertions.java
@@ -18,55 +18,47 @@ public class LayoutServerAssertions extends AbstractAssert<LayoutServerAssertion
 
     public LayoutServerAssertions layoutHasSequencerCount(int count) {
         isNotNull();
-
-        if (actual.currentLayout.getSequencers().size() != count) {
+        if (actual.getCurrentLayout().getSequencers().size() != count) {
             failWithMessage("Expected server to be have <%d> sequencers but it had <%d>", count,
-                    actual.currentLayout.getSequencers().size());
+                    actual.getCurrentLayout().getSequencers().size());
         }
-
         return this;
     }
 
     public LayoutServerAssertions isInEpoch(long epoch) {
         isNotNull();
-
-        if (actual.currentLayout.getEpoch() != epoch) {
+        if (actual.getCurrentLayout().getEpoch() != epoch) {
             failWithMessage("Expected server to be in epoch <%d> but it was in epoch <%d>", epoch,
-                    actual.currentLayout.getEpoch());
+                    actual.getCurrentLayout().getEpoch());
         }
-
         return this;
     }
 
     public LayoutServerAssertions isPhase1Rank(Rank phase1Rank) {
         isNotNull();
-
-        if (actual.phase1Rank.compareTo(phase1Rank) != 0) {
+        if (actual.getPhase1Rank().compareTo(phase1Rank) != 0) {
             failWithMessage("Expected server to be in phase1Rank <%d> but it was in phase1Rank <%d>", phase1Rank,
-                    actual.phase1Rank);
+                    actual.getPhase1Rank());
         }
-
         return this;
     }
 
     public LayoutServerAssertions isPhase2Rank(Rank phase2Rank) {
         isNotNull();
-
-        if (actual.phase2Rank.compareTo(phase2Rank) != 0) {
+        if (actual.getPhase2Rank().compareTo(phase2Rank) != 0) {
             failWithMessage("Expected server to be in phase2Rank <%d> but it was in phase2Rank <%d>", phase2Rank,
-                    actual.phase2Rank);
+                    actual.getPhase2Rank());
         }
-
         return this;
     }
 
     public LayoutServerAssertions isProposedLayout(Layout layout) {
         isNotNull();
-        if (!actual.proposedLayout.asJSONString().equals(layout.asJSONString())) {
+        if (!actual.getProposedLayout().asJSONString().equals(layout.asJSONString())) {
             failWithMessage("Expected server to have proposedLayout  <%s> but it is <%s>", layout,
-                    actual.proposedLayout);
+                    actual.getProposedLayout());
 
         }
         return this;
     }
-}
+ }

--- a/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -135,7 +135,7 @@ public class LayoutServerTest extends AbstractServerTest {
         sendMessage(new LayoutRankMsg(TestLayoutBuilder.single(9000), 100, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
         assertThat(getLastMessage().getMsgType())
                 .isEqualTo(CorfuMsg.CorfuMsgType.ACK);
-        sendMessage(new LayoutRankMsg(null, 1000, CorfuMsg.CorfuMsgType.LAYOUT_COMMITTED));
+        sendMessage(new LayoutRankMsg(TestLayoutBuilder.single(9000), 1000, CorfuMsg.CorfuMsgType.LAYOUT_COMMITTED));
         assertThat(getLastMessage().getMsgType())
                 .isEqualTo(CorfuMsg.CorfuMsgType.ACK);
     }
@@ -163,7 +163,7 @@ public class LayoutServerTest extends AbstractServerTest {
         assertThat(getLastMessage().getMsgType())
                 .isEqualTo(CorfuMsg.CorfuMsgType.ACK);
         assertThat(s1)
-                .isInEpoch(100);
+                .isInEpoch(0);
         assertThat(s1)
                 .isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
         assertThat(s1)
@@ -178,7 +178,7 @@ public class LayoutServerTest extends AbstractServerTest {
         this.router.reset();
         this.router.addServer(s2);
         assertThat(s2)
-                .isInEpoch(100);
+                .isInEpoch(0);
         assertThat(s2)
                 .isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
         assertThat(s2)
@@ -188,7 +188,7 @@ public class LayoutServerTest extends AbstractServerTest {
         assertThat(getLastMessage().getMsgType())
                 .isEqualTo(CorfuMsg.CorfuMsgType.LAYOUT_RESPONSE);
         assertThat(((LayoutMsg) getLastMessage()).getLayout().getEpoch())
-                .isEqualTo(100);
+                .isEqualTo(0);
     }
 
     /**
@@ -244,7 +244,7 @@ public class LayoutServerTest extends AbstractServerTest {
                 .build(), getRouter());
         this.router.reset();
         this.router.addServer(s3);
-        assertThat(s3).isInEpoch(100);
+        assertThat(s3).isInEpoch(0);
         assertThat(s3).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
         assertThat(s3).isPhase2Rank(new Rank(100L, AbstractServerTest.testClientId));
         assertThat(s3).isProposedLayout(l100);
@@ -364,7 +364,7 @@ public class LayoutServerTest extends AbstractServerTest {
         this.router.reset();
         this.router.addServer(s3);
         // the epoch should have changed by now.
-        assertThat(s3).isInEpoch(100);
+        assertThat(s3).isInEpoch(0);
         assertThat(s3).isPhase1Rank(new Rank(100L, AbstractServerTest.testClientId));
         assertThat(s3).isProposedLayout(l100);
     }
@@ -440,8 +440,7 @@ public class LayoutServerTest extends AbstractServerTest {
         sendMessage(UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes()), new LayoutRankMsg(l100, 101, CorfuMsg.CorfuMsgType.LAYOUT_PROPOSE));
         assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsg.CorfuMsgType.ACK);
 
-        //TODO fix this epoch needs to be fixed and should still be 0 till COMMIT
-        assertThat(s2).isInEpoch(100);
+        assertThat(s2).isInEpoch(0);
         assertThat(s2).isPhase1Rank(new Rank(101L, UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes())));
         assertThat(s2).isPhase2Rank(new Rank(101L, UUID.nameUUIDFromBytes("OTHER_CLIENT".getBytes())));
         assertThat(s2).isProposedLayout(l100);

--- a/src/test/java/org/corfudb/runtime/clients/LayoutClientTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/LayoutClientTest.java
@@ -140,7 +140,7 @@ public class LayoutClientTest extends AbstractClientTest {
         assertThat(client.prepare(10L).get().isAccepted())
                 .isEqualTo(true);
 
-        assertThat(client.committed(10L).get())
+        assertThat(client.committed(10L, TestLayoutBuilder.single(9000)).get())
                 .isEqualTo(true);
     }
 

--- a/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.clients;
 
+import com.google.common.collect.ImmutableMap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
@@ -80,7 +81,7 @@ public class NettyCommTest extends AbstractCorfuTest {
     void runWithBaseServer(NettyCommFunction actionFn)
             throws Exception {
 
-        NettyServerRouter nsr = new NettyServerRouter();
+        NettyServerRouter nsr = new NettyServerRouter(new ImmutableMap.Builder<String, Object>().build());
         nsr.addServer(new BaseServer());
         int port = findRandomOpenPort();
 
@@ -123,7 +124,7 @@ public class NettyCommTest extends AbstractCorfuTest {
         }
 
         void bootstrapServer() throws Exception {
-            NettyServerRouter nsr = new NettyServerRouter();
+            NettyServerRouter nsr = new NettyServerRouter(new ImmutableMap.Builder<String, Object>().build());
             bossGroup = new NioEventLoopGroup(1, new ThreadFactory() {
                 final AtomicInteger threadNum = new AtomicInteger(0);
 

--- a/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -34,7 +34,7 @@ public class LayoutViewTest extends AbstractViewTest {
                     .addToSegment()
                 .addToLayout()
                 .build();
-
+        l.setRuntime(r);
         r.getLayoutView().updateLayout(l, 1L);
         r.invalidateLayout();
         assertThat(r.getLayoutView().getLayout().epoch)


### PR DESCRIPTION
- Implemented node level datastore to persist Layouts and data related to Paxos phases.
- Refactored Layout server code
- Implemented committed phase of the paxos protocol
- Added persistence so that Server Epoch does not reset on node restart
- Added basic tests for datastore implementation
- Fixed existing tests to work with reconfiguration changes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/208)
<!-- Reviewable:end -->
