### PR TITLE
Added bulk reads to ReplexReplicationView (really, just a wrapper aro…

### DIFF
--- a/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -234,9 +234,9 @@ public class LogUnitClient implements IClient {
                 CorfuMsgType.READ_REQUEST.payloadMsg(new ReadRequest(address)));
     }
 
-    public CompletableFuture<ReadResponse> read(UUID stream, long offset) {
+    public CompletableFuture<ReadResponse> read(UUID stream, Range<Long> offsetRange) {
         return router.sendMessageAndGetCompletable(
-                CorfuMsgType.READ_REQUEST.payloadMsg(new ReadRequest(Range.singleton(offset), stream)));
+                CorfuMsgType.READ_REQUEST.payloadMsg(new ReadRequest(offsetRange, stream)));
     }
 
     /**

--- a/src/main/java/org/corfudb/runtime/view/AbstractReplicationView.java
+++ b/src/main/java/org/corfudb/runtime/view/AbstractReplicationView.java
@@ -112,6 +112,10 @@ public abstract class AbstractReplicationView {
      */
     public abstract Map<Long, LogData> read(UUID stream, long offset, long size);
 
+    public Map<Long, LogData> readPrefix(UUID stream) {
+        throw new UnsupportedOperationException("unsupported");
+    }
+
     /**
      * Fill a hole at an address, using the replication method given.
      *

--- a/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -177,14 +177,17 @@ public class AddressSpaceView extends AbstractView {
     }
 
     /**
-     * Read the given object from a range of addresses.
+     * Do a bulk read of the stream.
      *
-     * @param stream An address range to read from.
-     * @return A result, which be cached.
+     * @param stream The stream to download.
+     * @return A result.
      */
     public Map<Long, LogData> readPrefix(UUID stream) {
-        /* TODO : implement in both backpointer and Replex cases */
-        throw new UnsupportedOperationException("unsupported");
+        return layoutHelper(l -> AbstractReplicationView
+                        .getReplicationView(l, l.getSegments().get(l.getSegments().size() - 1).getReplicationMode(),
+                                l.getSegments().get(l.getSegments().size() - 1))
+                        .readPrefix(stream)
+        );
     }
 
 

--- a/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.clients;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import org.corfudb.infrastructure.AbstractServer;
@@ -128,7 +129,7 @@ public class LogUnitClientTest extends AbstractClientTest {
         client.writeStream(1, Collections.singletonMap(streamA, 0L), testString).get();
         client.writeCommit(Collections.singletonMap(streamA, 0L), 10L, true).get(); // 10L shouldn't matter
 
-        r = client.read(streamA, 0L).get().getReadSet().get(0L);
+        r = client.read(streamA, Range.singleton(0L)).get().getReadSet().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
         assertThat(r.getPayload(new CorfuRuntime()))


### PR DESCRIPTION
…und the read function) and added bulk reads in the StreamView.readTo function. This is useful because readTo with Replex should be implemented as a bulk readgit status

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/223)
<!-- Reviewable:end -->
