### PR TITLE
Return on Interrupt

### DIFF
--- a/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -88,7 +88,7 @@ public class Layout implements Cloneable {
         getAllServers().stream()
                 .map(runtime::getRouter)
                 .map(x -> x.getClient(BaseClient.class))
-                .forEach(x -> CFUtils.getUninterruptibly(x.setRemoteEpoch(epoch)));
+                .forEach(x -> CFUtils.getInterruptible(x.setRemoteEpoch(epoch)));
     }
 
     /**

--- a/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -93,7 +93,7 @@ public class LayoutView extends AbstractView {
 
                                 // wait for someone to complete.
                                 try {
-                                    CFUtils.getUninterruptibly(CompletableFuture.anyOf(prepareList),
+                                    CFUtils.getInterruptible(CompletableFuture.anyOf(prepareList),
                                             OutrankedException.class, TimeoutException.class);
                                 } catch (TimeoutException te) {
                                     timeouts++;
@@ -154,7 +154,7 @@ public class LayoutView extends AbstractView {
 
                                 // wait for someone to complete.
                                 try {
-                                    CFUtils.getUninterruptibly(CompletableFuture.anyOf(proposeList),
+                                    CFUtils.getInterruptible(CompletableFuture.anyOf(proposeList),
                                             OutrankedException.class, TimeoutException.class);
                                 } catch (TimeoutException te) {
                                     timeouts++;
@@ -205,7 +205,7 @@ public class LayoutView extends AbstractView {
                             while (responses < commitList.length) {
                                 // wait for someone to complete.
                                 try {
-                                    CFUtils.getUninterruptibly(CompletableFuture.anyOf(commitList),
+                                    CFUtils.getInterruptible(CompletableFuture.anyOf(commitList),
                                             WrongEpochException.class, TimeoutException.class);
                                 } catch (TimeoutException te) {
                                     timeouts++;

--- a/src/main/java/org/corfudb/runtime/view/SequencerView.java
+++ b/src/main/java/org/corfudb/runtime/view/SequencerView.java
@@ -24,6 +24,6 @@ public class SequencerView extends AbstractView {
      * @return The first token retrieved.
      */
     public SequencerClient.TokenResponse nextToken(Set<UUID> streamIDs, int numTokens) {
-        return layoutHelper(l -> CFUtils.getUninterruptibly(l.getSequencer(0).nextToken(streamIDs, numTokens)));
+        return layoutHelper(l -> CFUtils.getInterruptible(l.getSequencer(0).nextToken(streamIDs, numTokens)));
     }
 }

--- a/src/main/java/org/corfudb/util/CFUtils.java
+++ b/src/main/java/org/corfudb/util/CFUtils.java
@@ -30,17 +30,18 @@ public class CFUtils {
             B extends Throwable,
             C extends Throwable,
             D extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
-                         Class<A> throwableA,
-                         Class<B> throwableB,
-                         Class<C> throwableC,
-                         Class<D> throwableD)
+    T getInterruptible(CompletableFuture<T> future,
+                       Class<A> throwableA,
+                       Class<B> throwableB,
+                       Class<C> throwableC,
+                       Class<D> throwableD)
             throws A, B, C, D {
         while (true) {
             try {
                 return future.get();
             } catch (InterruptedException e) {
-                //retry
+                future.cancel(true);
+                return null;
             } catch (ExecutionException ee) {
                 if (throwableA.isInstance(ee.getCause())) {
                     throw (A) ee.getCause();
@@ -63,35 +64,35 @@ public class CFUtils {
             A extends Throwable,
             B extends Throwable,
             C extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
-                         Class<A> throwableA,
-                         Class<B> throwableB,
-                         Class<C> throwableC)
+    T getInterruptible(CompletableFuture<T> future,
+                       Class<A> throwableA,
+                       Class<B> throwableB,
+                       Class<C> throwableC)
             throws A, B, C {
-        return getUninterruptibly(future, throwableA, throwableB, throwableC, RuntimeException.class);
+        return getInterruptible(future, throwableA, throwableB, throwableC, RuntimeException.class);
     }
 
     public static <T,
             A extends Throwable,
             B extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
-                         Class<A> throwableA,
-                         Class<B> throwableB)
+    T getInterruptible(CompletableFuture<T> future,
+                       Class<A> throwableA,
+                       Class<B> throwableB)
             throws A, B {
-        return getUninterruptibly(future, throwableA, throwableB, RuntimeException.class, RuntimeException.class);
+        return getInterruptible(future, throwableA, throwableB, RuntimeException.class, RuntimeException.class);
     }
 
     public static <T,
             A extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
-                         Class<A> throwableA)
+    T getInterruptible(CompletableFuture<T> future,
+                       Class<A> throwableA)
             throws A {
-        return getUninterruptibly(future, throwableA, RuntimeException.class, RuntimeException.class, RuntimeException.class);
+        return getInterruptible(future, throwableA, RuntimeException.class, RuntimeException.class, RuntimeException.class);
     }
 
     public static <T>
-    T getUninterruptibly(CompletableFuture<T> future) {
-        return getUninterruptibly(future, RuntimeException.class, RuntimeException.class, RuntimeException.class, RuntimeException.class);
+    T getInterruptible(CompletableFuture<T> future) {
+        return getInterruptible(future, RuntimeException.class, RuntimeException.class, RuntimeException.class, RuntimeException.class);
     }
 
     /**

--- a/src/test/java/org/corfudb/runtime/clients/BaseClientTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/BaseClientTest.java
@@ -3,7 +3,6 @@ package org.corfudb.runtime.clients;
 import com.google.common.collect.ImmutableSet;
 import org.corfudb.infrastructure.AbstractServer;
 import org.corfudb.infrastructure.BaseServer;
-import org.corfudb.infrastructure.LogUnitServer;
 import org.corfudb.util.CFUtils;
 import org.junit.Test;
 
@@ -33,6 +32,6 @@ public class BaseClientTest extends AbstractClientTest {
 
     @Test
     public void canGetVersionInfo() {
-        CFUtils.getUninterruptibly(client.getVersionInfo());
+        CFUtils.getInterruptible(client.getVersionInfo());
     }
 }

--- a/src/test/java/org/corfudb/util/CFUtilsTest.java
+++ b/src/test/java/org/corfudb/util/CFUtilsTest.java
@@ -1,0 +1,67 @@
+package org.corfudb.util;
+
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+import org.corfudb.protocols.wireprotocol.LogUnitReadResponseMsg.ReadResult;
+import org.junit.Test;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by maithem on 9/23/16.
+ */
+
+public class CFUtilsTest {
+
+    @Test
+    public void testGetInterruptible() throws Exception {
+        NonEndingTask<ReadResult> future = new NonEndingTask();
+        CountDownLatch interrupted = new CountDownLatch(1);
+
+        Thread thread = new Thread() {
+            public void run() {
+                // Wait on a future that is never completed
+                assertNull(CFUtils.getInterruptible(future));
+                interrupted.countDown();
+            }
+        };
+
+        thread.start();
+
+        // Wait for the thread till it calls future.get
+        for(int x = 0; x < 5; x++){
+            if(future.isCalled()){
+                break;
+            }
+
+            Thread.sleep(2000);
+        }
+
+        // Interrupt and verify that the thread called future.get
+        // and returned on interruption
+        assertTrue(future.isCalled());
+        thread.interrupt();
+        interrupted.await(4, TimeUnit.SECONDS);
+        assertEquals(0, interrupted.getCount());
+    }
+
+    class NonEndingTask<T> extends CompletableFuture {
+        private boolean called = false;
+        @Override
+        public T get() throws InterruptedException, ExecutionException {
+            called = true;
+            Thread.sleep(Long.MAX_VALUE);
+            return null;
+        }
+
+        boolean isCalled(){
+            return called;
+        }
+    }
+
+}


### PR DESCRIPTION
CFUtils.getUnInterruptible doesn't honor a InterruptedException, this
can hinder the jvm's shutdown process by making the thread UnInterruptible.
This change addresses the problem by returning on a InterruptedException.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/230)
<!-- Reviewable:end -->
