### PR TITLE
Find-bugs dependency to not be included in jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,8 @@
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>findbugs-maven-plugin</artifactId>
             <version>3.0.3</version>
+            <scope>provided</scope>
+            <type>maven-plugin</type>
         </dependency>
         <dependency>
             <groupId>de.javakaffee</groupId>


### PR DESCRIPTION
Find-bugs dependency to not be included in the final consumable jar. It uses struts jars that are not security compliant.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/231)
<!-- Reviewable:end -->
