### PR TITLE
Removing a release that will cause bulk reads to break, because bulk …

### DIFF
--- a/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -48,7 +48,6 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
                             ((LogEntry) actualValue).setEntry(this);
                             ((LogEntry) actualValue).setRuntime(runtime);
                         }
-                        this.getData().release();
                         value = actualValue == null ? this.payload : actualValue;
                         this.payload.set(value);
                     }


### PR DESCRIPTION
…reads (i.e. when ReadResponse has a map of size() > 1) include LogData items that are all built wrt the same ByteBuffer. So if you release the first entry, all the subsequent entries are pointing to a freed ByteBuf


I would caution that Michael might have added this .release() at some point because of memory usage spikes.. A release should probably be called somewhere, but it is unclear where.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/corfudb/corfudb/250)
<!-- Reviewable:end -->
