### PR TITLE
Failure Detection Policy

### DIFF
--- a/src/main/java/org/corfudb/infrastructure/IFailureDetectorPolicy.java
+++ b/src/main/java/org/corfudb/infrastructure/IFailureDetectorPolicy.java
@@ -1,0 +1,27 @@
+package org.corfudb.infrastructure;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.Layout;
+
+import java.util.HashMap;
+
+/**
+ * Failure Detection Policies.
+ * Created by zlokhandwala on 9/29/16.
+ */
+public interface IFailureDetectorPolicy {
+
+    /**
+     * Executes the policy which runs the failure detecting algorithm.
+     *
+     * @param layout latest layout
+     */
+    void executePolicy(Layout layout, CorfuRuntime corfuRuntime);
+
+    /**
+     * Gets the server status from the last execution of the policy.
+     *
+     * @return A hash map containing servers mapped to their failure status.
+     */
+    HashMap<String, Boolean> getServerStatus();
+}

--- a/src/main/java/org/corfudb/infrastructure/PeriodicPollPolicy.java
+++ b/src/main/java/org/corfudb/infrastructure/PeriodicPollPolicy.java
@@ -23,7 +23,6 @@ import java.util.concurrent.CompletableFuture;
 @Slf4j
 public class PeriodicPollPolicy implements IFailureDetectorPolicy {
 
-    private CorfuRuntime corfuRuntime;
     /**
      * list of layout servers that we monitor.
      */
@@ -60,10 +59,9 @@ public class PeriodicPollPolicy implements IFailureDetectorPolicy {
     @Override
     public void executePolicy(Layout layout, CorfuRuntime corfuRuntime) {
 
-        this.corfuRuntime = corfuRuntime;
         String[] allServers = layout.getAllServers().stream().toArray(String[]::new);
         // Performs setup and checks for changes in the layout to update failure count
-        checkForChanges(allServers);
+        checkForChanges(allServers, corfuRuntime);
         // Perform polling of all servers in historyServers
         pollOnce();
 
@@ -73,9 +71,10 @@ public class PeriodicPollPolicy implements IFailureDetectorPolicy {
      * Checks for changes in the layout.
      * Fetches corfu runtime router to be able to ping a node.
      *
-     * @param allServers List of all servers in teh layout
+     * @param allServers   List of all servers in teh layout
+     * @param corfuRuntime A connected corfu runtime
      */
-    private void checkForChanges(String[] allServers) {
+    private void checkForChanges(String[] allServers, CorfuRuntime corfuRuntime) {
 
         Arrays.sort(allServers);
 

--- a/src/main/java/org/corfudb/infrastructure/PeriodicPollPolicy.java
+++ b/src/main/java/org/corfudb/infrastructure/PeriodicPollPolicy.java
@@ -1,0 +1,182 @@
+package org.corfudb.infrastructure;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.BaseClient;
+import org.corfudb.runtime.clients.IClientRouter;
+import org.corfudb.runtime.view.Layout;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Simple Polling policy.
+ * Every node polls every other node.
+ * <p>
+ * Failure Condition:
+ * Considers failure if server a node does not respond to the ping
+ * more than 2 times in a row.
+ * <p>
+ * Created by zlokhandwala on 9/29/16.
+ */
+@Slf4j
+public class PeriodicPollPolicy implements IFailureDetectorPolicy {
+
+    private CorfuRuntime corfuRuntime;
+    /**
+     * list of layout servers that we monitor.
+     */
+    private String[] historyServers = null;
+    private IClientRouter[] historyRouters = null;
+
+    /**
+     * polling history
+     */
+    private int[] historyPollFailures = null;
+    private int historyPollCount = 0;
+    private HashMap<String, Boolean> historyStatus = null;
+
+    /**
+     * Retry timeouts
+     */
+    long timeoutConnect = 50;
+    long timeoutRetry = 200;
+    long timeoutResponse = 1000;
+
+    /**
+     * Failed Poll Limit.
+     * Failed pings after which a node is considered dead.
+     */
+    long failedPollLimit = 3;
+
+    /**
+     * Executes the policy once.
+     * Checks for changes in the layout.
+     * Then polls all the servers and updates the status.
+     *
+     * @param layout Current Layout
+     */
+    @Override
+    public void executePolicy(Layout layout, CorfuRuntime corfuRuntime) {
+
+        this.corfuRuntime = corfuRuntime;
+        String[] allServers = layout.getAllServers().stream().toArray(String[]::new);
+        // Performs setup and checks for changes in the layout to update failure count
+        checkForChanges(allServers);
+        // Perform polling of all servers in historyServers
+        pollOnce();
+
+    }
+
+    /**
+     * Checks for changes in the layout.
+     * Fetches corfu runtime router to be able to ping a node.
+     *
+     * @param allServers List of all servers in teh layout
+     */
+    private void checkForChanges(String[] allServers) {
+
+        Arrays.sort(allServers);
+
+        if (historyServers == null || !Arrays.equals(historyServers, allServers)) {
+            // Initialize the status map for the first time or if there is a change.
+            if (historyStatus == null) {
+                historyStatus = new HashMap<>();
+            }
+
+            log.debug("historyServers change, length = {}", allServers.length);
+            historyServers = allServers;
+            historyRouters = new IClientRouter[allServers.length];
+            historyPollFailures = new int[allServers.length];
+            for (int i = 0; i < allServers.length; i++) {
+                if (!historyStatus.containsKey(allServers[i])) {
+                    historyStatus.put(allServers[i], true);  // Assume it's up until we think it isn't.
+                }
+                historyRouters[i] = corfuRuntime.getRouterFunction.apply(allServers[i]);
+                historyRouters[i].setTimeoutConnect(timeoutConnect);
+                historyRouters[i].setTimeoutRetry(timeoutRetry);
+                historyRouters[i].setTimeoutResponse(timeoutResponse);
+                historyRouters[i].start();
+                historyPollFailures[i] = 0;
+            }
+            historyPollCount = 0;
+        } else {
+            log.debug("No server list change since last poll.");
+        }
+    }
+
+    /**
+     * Polls all the server nodes from historyServers once.
+     * If failure is detected it updates in the historyPollFailures.
+     */
+    private void pollOnce() {
+
+        // Poll servers for health.  All ping activity will happen in the background.
+        // We probably won't notice changes in this iteration; a future iteration will
+        // eventually notice changes to historyPollFailures.
+        for (int i = 0; i < historyRouters.length; i++) {
+            int ii = i;  // Intermediate var just for the sake of having a final for use inside the lambda below
+            CompletableFuture.runAsync(() -> {
+                // Any changes that we make to historyPollFailures here can possibly
+                // race with other async CFs that were launched in earlier/later CFs.
+                // We don't care if an increment gets clobbered by another increment:
+                //     being off by one isn't a big problem.
+                // We don't care if a reset to zero gets clobbered by an increment:
+                //     if the endpoint is really pingable, then a later reset to zero
+                //     will succeed, probably.
+                try {
+                    CompletableFuture<Boolean> cf = historyRouters[ii].getClient(BaseClient.class).ping();
+                    cf.exceptionally(e -> {
+                        log.debug(historyServers[ii] + " exception " + e);
+                        historyPollFailures[ii]++;
+                        return false;
+                    });
+                    cf.thenAccept((pingResult) -> {
+                        if (pingResult) {
+                            historyPollFailures[ii] = 0;
+                        } else {
+                            historyPollFailures[ii]++;
+                        }
+                    });
+
+                } catch (Exception e) {
+                    log.debug("Ping failed for " + historyServers[ii] + " with " + e);
+                    historyPollFailures[ii]++;
+                }
+            });
+        }
+        historyPollCount++;
+    }
+
+    /**
+     * Gets the server status from the last poll.
+     * A failure is detected after at least 2 polls.
+     *
+     * @return A map of failed server nodes and their status.
+     */
+    @Override
+    public HashMap<String, Boolean> getServerStatus() {
+
+        HashMap<String, Boolean> status_change = new HashMap<>();
+        if (historyPollCount > 3) {
+            Boolean is_up;
+
+            // Simple failure detector: Is there a change in health?
+            for (int i = 0; i < historyServers.length; i++) {
+                // TODO: Be a bit smarter than 'more than 2 failures in a row'
+                is_up = !(historyPollFailures[i] >= failedPollLimit);
+                if (is_up != historyStatus.get(historyServers[i])) {
+                    log.debug("Change of status: " + historyServers[i] + " " +
+                            historyStatus.get(historyServers[i]) + " -> " + is_up);
+                    status_change.put(historyServers[i], is_up);
+
+                    // Resetting the failure counter.
+                    historyPollFailures[i] = 0;
+                }
+            }
+
+        }
+        return status_change;
+    }
+}

--- a/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
+++ b/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
@@ -121,4 +121,25 @@ public interface IClientRouter {
      * Set the current epoch.
      */
     void setEpoch(long newEpoch);
+
+    /**
+     * Set the Connect timeout
+     *
+     * @param timeoutConnect timeout for connection in milliseconds.
+     */
+    void setTimeoutConnect(long timeoutConnect);
+
+    /**
+     * Set the retry timeout
+     *
+     * @param timeoutRetry timeout to make a retry in milliseconds.
+     */
+    void setTimeoutRetry(long timeoutRetry);
+
+    /**
+     * Set the Response timeout
+     *
+     * @param timeoutResponse Response timeout in milliseconds.
+     */
+    void setTimeoutResponse(long timeoutResponse);
 }

--- a/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -338,7 +338,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
             }
             log.trace("Sent message: {}", message);
             // Generate a timeout future, which will complete exceptionally if the main future is not completed.
-            final CompletableFuture<T> cfTimeout = CFUtils.within(cf, Duration.ofSeconds(timeoutResponse));
+            final CompletableFuture<T> cfTimeout = CFUtils.within(cf, Duration.ofMillis(timeoutResponse));
             cfTimeout.exceptionally(e -> {
                 outstandingRequests.remove(thisRequest);
                 log.debug("Remove request {} due to timeout!", thisRequest);

--- a/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
+++ b/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
@@ -1,0 +1,131 @@
+package org.corfudb.infrastructure;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.Layout;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests the Periodic Polling Policy.
+ * <p>
+ * Created by zlokhandwala on 10/26/16.
+ */
+public class PeriodicPollPolicyTest extends AbstractViewTest {
+
+    private IFailureDetectorPolicy failureDetectorPolicy = null;
+    private Layout layout = null;
+    private CorfuRuntime corfuRuntime = null;
+
+    @Before
+    public void pollingEnvironmentSetup() {
+
+        addServer(9000);
+        addServer(9001);
+        addServer(9002);
+
+        layout = new TestLayoutBuilder()
+                .setEpoch(1L)
+                .addLayoutServer(9000)
+                .addLayoutServer(9001)
+                .addLayoutServer(9002)
+                .addSequencer(9000)
+                .addSequencer(9001)
+                .addSequencer(9002)
+                .buildSegment()
+                .buildStripe()
+                .addLogUnit(9000)
+                .addLogUnit(9001)
+                .addLogUnit(9002)
+                .addToSegment()
+                .addToLayout()
+                .build();
+        bootstrapAllServers(layout);
+
+        corfuRuntime = new CorfuRuntime();
+        layout.getLayoutServers().forEach(corfuRuntime::addLayoutServer);
+        corfuRuntime.connect();
+
+        failureDetectorPolicy = new PeriodicPollPolicy();
+    }
+
+    /**
+     * Polls 3 running servers. Poll returns no failures.
+     *
+     * @throws InterruptedException Sleep interrupted
+     */
+    @Test
+    public void successfulPolling() throws InterruptedException {
+
+        for (int i = 0; i < 5; i++) {
+            failureDetectorPolicy.executePolicy(layout, corfuRuntime);
+            Thread.sleep(100);
+        }
+
+        // A little more than responseTimeout for periodicPolling
+        Thread.sleep(1100);
+        Map<String, Boolean> result = failureDetectorPolicy.getServerStatus();
+        assertThat(result.isEmpty()).isEqualTo(true);
+
+    }
+
+    /**
+     * Polls 3 failed servers.
+     * Returns failed status for the 3 servers.
+     * We then restart server 9000, run polls again.
+     * Assert only 2 failures. 9001 & 9002
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void failedPolling() throws InterruptedException {
+
+        addServerRule(9000, new TestRule().always().drop());
+        addServerRule(9001, new TestRule().always().drop());
+        addServerRule(9002, new TestRule().always().drop());
+
+        for (int i = 0; i < 5; i++) {
+            failureDetectorPolicy.executePolicy(layout, corfuRuntime);
+            Thread.sleep(100);
+        }
+
+        // A little more than responseTimeout for periodicPolling
+        Thread.sleep(1100);
+
+        Map<String, Boolean> actualResult = failureDetectorPolicy.getServerStatus();
+
+        Map<String, Boolean> expectedResult = new HashMap<>();
+        expectedResult.put(getEndpoint(9000), false);
+        expectedResult.put(getEndpoint(9001), false);
+        expectedResult.put(getEndpoint(9002), false);
+
+        assertThat(actualResult).isEqualTo(expectedResult);
+
+        /*
+         * Restarting the server 9000. Pings should work normally now.
+         * This is also to demonstrate that we no longer receive the failed
+         * nodes' status in the result map for 9000.
+         */
+
+        clearServerRules(9000);
+
+        for (int i = 0; i < 5; i++) {
+            failureDetectorPolicy.executePolicy(layout, corfuRuntime);
+            Thread.sleep(100);
+        }
+
+        Thread.sleep(1100);
+
+        actualResult = failureDetectorPolicy.getServerStatus();
+        expectedResult.remove(getEndpoint(9000));
+        // Has only 9001 & 9002
+        assertThat(actualResult).isEqualTo(expectedResult);
+
+    }
+}

--- a/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -58,6 +58,25 @@ public class TestClientRouter implements IClientRouter {
     @Setter
     public UUID clientID;
 
+    /**
+     * New connection timeout (milliseconds)
+     */
+    @Getter
+    @Setter
+    public long timeoutConnect = 5000L;
+    /**
+     * Sync call response timeout (milliseconds)
+     */
+    @Getter
+    @Setter
+    public long timeoutResponse = 5000L;
+    /**
+     * Retry interval after timeout (milliseconds)
+     */
+    @Getter
+    @Setter
+    public long timeoutRetry = 5000L;
+
     public List<TestRule> rules;
 
     /**
@@ -164,7 +183,7 @@ public class TestClientRouter implements IClientRouter {
                 routeMessage(message);
         }
         // Generate a timeout future, which will complete exceptionally if the main future is not completed.
-        final CompletableFuture<T> cfTimeout = CFUtils.within(cf, Duration.ofMillis(5000));
+        final CompletableFuture<T> cfTimeout = CFUtils.within(cf, Duration.ofMillis(timeoutResponse));
         cfTimeout.exceptionally(e -> {
             outstandingRequests.remove(thisRequest);
             log.debug("Remove request {} due to timeout!", thisRequest);


### PR DESCRIPTION
PeriodicPollingPolicy added.
executePolicy : Pings all the servers in the layout once and updates their status.
Marks them failed if pings fail more than 2 times in a row.

get ServerStatus : Fetches the latest server status.
This resets the status of the failed servers so that they are not shown in the next result. Thus a failed node will only appear once in the result after failedPollLimit which is 3 polls by default.