### PR TITLE
Fixed the fillHole and write handlers

### DIFF
--- a/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.runtime.exceptions.OverwriteException;
 
 /**
  * This class implements the StreamLog interface using a Java hash map. The stream log is only stored in-memory and not
@@ -21,7 +22,10 @@ public class InMemoryStreamLog implements StreamLog {
     }
 
     @Override
-    public void append(long address, LogData entry) {
+    public synchronized void append(long address, LogData entry) {
+        if(cache.containsKey(address)) {
+            throw new OverwriteException();
+        }
         cache.put(address, entry);
     }
 

--- a/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -28,6 +28,7 @@ import org.corfudb.protocols.wireprotocol.ICorfuPayload;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.infrastructure.LogUnitServer;
+import org.corfudb.runtime.exceptions.OverwriteException;
 
 /**
  * This class implements the StreamLog by persisting the stream log in multiple files.
@@ -204,7 +205,7 @@ public class StreamLogFiles implements StreamLog {
                     });
                 }
             } else {
-                throw new Exception("overwrite");
+                throw new OverwriteException();
             }
             log.info("Disk_write[{}]: Written to disk.", address);
         } catch (Exception e) {

--- a/src/main/java/org/corfudb/protocols/wireprotocol/FillHoleRequest.java
+++ b/src/main/java/org/corfudb/protocols/wireprotocol/FillHoleRequest.java
@@ -7,17 +7,17 @@ import lombok.RequiredArgsConstructor;
 import java.util.UUID;
 
 /**
- * Created by mwei on 8/8/16.
+ * Created by Maithem on 10/13/2016
  */
 @CorfuPayload
 @Data
 @RequiredArgsConstructor
-public class TrimRequest implements ICorfuPayload<TrimRequest> {
+public class FillHoleRequest implements ICorfuPayload<FillHoleRequest> {
 
     final UUID stream;
     final Long prefix;
 
-    public TrimRequest(ByteBuf buf) {
+    public FillHoleRequest(ByteBuf buf) {
         if (ICorfuPayload.fromBuffer(buf, Boolean.class))
             stream = ICorfuPayload.fromBuffer(buf, UUID.class);
         else stream = null;

--- a/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -245,12 +245,12 @@ public class LogUnitClient implements IClient {
      */
     public CompletableFuture<Boolean> fillHole(long address) {
         return router.sendMessageAndGetCompletable(
-                CorfuMsgType.FILL_HOLE.payloadMsg(new TrimRequest(null, address)));
+                CorfuMsgType.FILL_HOLE.payloadMsg(new FillHoleRequest(null, address)));
     }
 
     public CompletableFuture<Boolean> fillHole(UUID streamID, long address) {
         return router.sendMessageAndGetCompletable(
-                CorfuMsgType.FILL_HOLE.payloadMsg(new TrimRequest(streamID, address)));
+                CorfuMsgType.FILL_HOLE.payloadMsg(new FillHoleRequest(streamID, address)));
     }
 
 

--- a/src/main/java/org/corfudb/runtime/exceptions/LogUnitException.java
+++ b/src/main/java/org/corfudb/runtime/exceptions/LogUnitException.java
@@ -3,5 +3,5 @@ package org.corfudb.runtime.exceptions;
 /**
  * Created by mwei on 12/14/15.
  */
-public class LogUnitException extends Exception {
+public class LogUnitException extends RuntimeException {
 }

--- a/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -69,19 +69,6 @@ public class LogUnitClientTest extends AbstractClientTest {
     }
 
     @Test
-    public void holeFillDoesNotOverwrite()
-            throws Exception {
-        byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
-        client.fillHole(0).get();
-        LogData r = client.read(0).get().getReadSet().get(0L);
-        assertThat(r.getType())
-                .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
-                .isEqualTo(testString);
-    }
-
-    @Test
     public void holeFillCannotBeOverwritten()
             throws Exception {
         byte[] testString = "hello world".getBytes();
@@ -91,6 +78,21 @@ public class LogUnitClientTest extends AbstractClientTest {
                 .isEqualTo(DataType.HOLE);
 
         assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get())
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseInstanceOf(OverwriteException.class);
+    }
+
+    @Test
+    public void holeFillCannotOverwrite()
+            throws Exception {
+        byte[] testString = "hello world".getBytes();
+        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
+
+        LogData r = client.read(0).get().getReadSet().get(0L);
+        assertThat(r.getType())
+                .isEqualTo(DataType.DATA);
+
+        assertThatThrownBy(() -> client.fillHole(0).get())
                 .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(OverwriteException.class);
     }


### PR DESCRIPTION
The logunit was not properly detecting address overwrites for
hole filling requests. Also, fixed the write handler. It was conflating
runtime and overwrite exceptions. The server was returning an overwrite
error code on runtime exceptions that are not related to overwriting.