### PR TITLE
increase cache miss test wait time, addresses #268

### DIFF
--- a/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -24,6 +24,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class AddressSpaceViewTest extends AbstractViewTest {
 
+    /** This test checks to see if stale cache misses time out,
+     *  That is, if a cache read returns EMPTY, after the timeout period
+     *  the cache should retry the read, and get the correct result.
+     *
+     *  In this case, the cache miss initially misses, but we fill a hole.
+     *  After the timeout, the client should see the hole, rather than
+     *  empty again.
+     */
     @Test
     public void cacheMissTimesOut() {
         getDefaultRuntime().setCacheDisabled(false).connect();
@@ -33,7 +41,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
                 .isEqualTo(DataType.EMPTY);
         getRuntime().getLayoutView().getLayout().getLogUnitClient(0, 0).fillHole(0);
         try {
-            Thread.sleep(100);
+            Thread.sleep(1000);
         } catch (InterruptedException e) {// don't do anything
         }
         assertThat(getRuntime().getAddressSpaceView().read(0).getType())


### PR DESCRIPTION
This patch increases the cache miss time in the cacheMissTimesOut test to 1s,
which reduces the chance that the test will fail in Travis due to a slow container.

In the future, we will need to have a variable timeout, since increasing the 
timeout time increases local execution time as well.