### PR TITLE
Use testClientRouters in CorfuRuntime for client tests

### DIFF
--- a/src/test/java/org/corfudb/runtime/clients/AbstractClientTest.java
+++ b/src/test/java/org/corfudb/runtime/clients/AbstractClientTest.java
@@ -1,21 +1,30 @@
 package org.corfudb.runtime.clients;
 
-import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.infrastructure.AbstractServer;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.infrastructure.TestServerRouter;
+import org.corfudb.runtime.CorfuRuntime;
 import org.junit.Before;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Created by mwei on 12/13/15.
  */
 public abstract class AbstractClientTest extends AbstractCorfuTest {
+
+    /**
+     * Initialize the AbstractClientTest.
+     */
+    public AbstractClientTest() {
+        // Force all new CorfuRuntimes to override the getRouterFn
+        CorfuRuntime.overrideGetRouterFunction = this::getRouterFunction;
+    }
 
     @Getter
     TestClientRouter router;
@@ -29,6 +38,37 @@ public abstract class AbstractClientTest extends AbstractCorfuTest {
         router = new TestClientRouter(serverRouter);
         getServersForTest().stream().forEach(serverRouter::addServer);
         getClientsForTest().stream().forEach(router::addClient);
+    }
+
+    /**
+     * A map of maps to endpoint->routers, mapped for each runtime instance captured
+     */
+    final Map<CorfuRuntime, Map<String, TestClientRouter>>
+            runtimeRouterMap = new ConcurrentHashMap<>();
+
+    /**
+     * Function for obtaining a router, given a runtime and an endpoint.
+     *
+     * @param runtime  The CorfuRuntime to obtain a router for.
+     * @param endpoint An endpoint string for the router.
+     * @return
+     */
+    private IClientRouter getRouterFunction(CorfuRuntime runtime, String endpoint) {
+        runtimeRouterMap.putIfAbsent(runtime, new ConcurrentHashMap<>());
+        if (!endpoint.startsWith("test:")) {
+            throw new RuntimeException("Unsupported endpoint in test: " + endpoint);
+        }
+        return runtimeRouterMap.get(runtime).computeIfAbsent(endpoint,
+                x -> {
+                    TestClientRouter tcn =
+                            new TestClientRouter(serverRouter);
+                    tcn.addClient(new BaseClient())
+                            .addClient(new SequencerClient())
+                            .addClient(new LayoutClient())
+                            .addClient(new LogUnitClient());
+                    return tcn;
+                }
+        );
     }
 
     abstract Set<AbstractServer> getServersForTest();


### PR DESCRIPTION
In the AbstractClientTest, the client/server should not use NettyClientRouter in CorfuRuntime.

My specific use case:
Testing ManagementClient which tries to connect to the ManagementServer.
The management server uses the corfuRuntime to stay updated with the latest layout.
We need to use the testClientRouter instead of the NettyClientRouter to test this functionality.