### PR TITLE
Move artifacts to Corfu-Repo repo

### DIFF
--- a/.travis_scripts/mvnrepo.sh
+++ b/.travis_scripts/mvnrepo.sh
@@ -14,7 +14,7 @@ if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; th
         cd $HOME
         git config --global user.email "travis@travis-ci.org"
         git config --global user.name "travis-ci"
-        git clone --quiet --branch=mvn-repo https://${GH_TOKEN}@github.com/CorfuDB/CorfuDB mvn-repo > /dev/null
+        git clone --quiet --branch=mvn-repo https://${GH_TOKEN}@github.com/CorfuDB/Corfu-Repos mvn-repo > /dev/null
 
         cd mvn-repo
         cp -Rf $HOME/mvn-repo-current/* .

--- a/.travis_scripts/push_deb.sh
+++ b/.travis_scripts/push_deb.sh
@@ -12,7 +12,7 @@ if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; th
         cd $HOME
         git config --global user.email "travis@travis-ci.org"
         git config --global user.name "travis-ci"
-        git clone --quiet --branch=debian https://${GH_TOKEN}@github.com/CorfuDB/CorfuDB debian > /dev/null
+        git clone --quiet --branch=debian https://${GH_TOKEN}@github.com/CorfuDB/Corfu-Repos debian > /dev/null
 
         cd debian
         reprepro -b . includedeb trusty $HOME/$DEBNAME


### PR DESCRIPTION
Currently artifacts are being stored in this repo, causing checkouts to take
a long time. This modifies the scripts to store the artifacts in another repo.