### PR TITLE
skip tests on javadoc generation, set maven version to 3.3.9 on debian/mvn build

### DIFF
--- a/.travis_scripts/javadocs.sh
+++ b/.travis_scripts/javadocs.sh
@@ -4,7 +4,8 @@ if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; th
     if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
         echo -e "Publishing javadocs..."
 
-        mvn javadoc:javadoc
+        mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
+        mvn javadoc:javadoc -DskipTests=true
         cp -R target/site/apidocs $HOME/javadoc
         cd $HOME
         git config --global user.email "travis@travis-ci.org"

--- a/.travis_scripts/mvnrepo.sh
+++ b/.travis_scripts/mvnrepo.sh
@@ -5,6 +5,7 @@ if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; th
         echo -e "Publishing maven repository..."
 
         PROJECT_VERSION=$(cat ${HOME}/.project_version)
+        mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
         mvn deploy -DskipTests=true
         #delete debian artifacts before deploy
         rm target/mvn-repo/org/corfudb/corfu/${PROJECT_VERSION}/*.deb

--- a/.travis_scripts/push_deb.sh
+++ b/.travis_scripts/push_deb.sh
@@ -3,6 +3,7 @@
 if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
     if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
         echo -e "Shipping deb package..."
+        mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
         mvn deploy -DskipTests=true
         gpg --import public.key private.key
 #this is fragile and needs to account for changes in the filename


### PR DESCRIPTION
This pull request fixes an issue with deb and mvn build generation, due to incorrect maven
version and eliminates a redundant test run when javadocs are generated.