### PR TITLE
force mvnw use

### DIFF
--- a/.travis_scripts/mvnrepo.sh
+++ b/.travis_scripts/mvnrepo.sh
@@ -6,7 +6,7 @@ if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; th
 
         PROJECT_VERSION=$(cat ${HOME}/.project_version)
         mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
-        mvn deploy -DskipTests=true
+        ./mvnw deploy -DskipTests=true
         #delete debian artifacts before deploy
         rm target/mvn-repo/org/corfudb/corfu/${PROJECT_VERSION}/*.deb
         rm target/mvn-repo/org/corfudb/corfu/${PROJECT_VERSION}/*.deb.md5

--- a/.travis_scripts/push_deb.sh
+++ b/.travis_scripts/push_deb.sh
@@ -4,7 +4,7 @@ if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; th
     if [ "$TRAVIS_JDK_VERSION" == "oraclejdk8" ]; then
         echo -e "Shipping deb package..."
         mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
-        mvn deploy -DskipTests=true
+        ./mvnw deploy -DskipTests=true
         gpg --import public.key private.key
 #this is fragile and needs to account for changes in the filename
         DEBNAME="corfu_0.1+${TRAVIS_BUILD_NUMBER}_all.deb"


### PR DESCRIPTION
This pull request fixes an issue with deb and mvn builds
not using the maven wrapper, and thus getting the wrong mvn revision.