### PR TITLE
CorfuSMRObjectProxy Deadlock

### DIFF
--- a/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
+++ b/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
@@ -401,7 +401,7 @@ public class CorfuSMRObjectProxy<P> extends CorfuObjectProxy<P> {
     }
 
     @Override
-    public void sync(P obj, long maxPos) {
+    public synchronized void sync(P obj, long maxPos) {
         try (LockUtils.AutoCloseRWLock writeLock = new LockUtils.AutoCloseRWLock(rwLock).writeLock()) {
             LogData[] entries = sv.readTo(maxPos);
             log.trace("Object[{}] sync to pos {}, read {} entries",


### PR DESCRIPTION
CorfuSMRObjectProxy uses reentrant locks and synchronized methods. As a
consequence, code paths can aquire the locks in reverse order can
cause a deadlock. For example, thead1(t1) acquires a synchronized method
lock, thread2(t2) acquire a reentrant lock, then t1 tries to acquire the
same method's lock while t2 is trying to acquire the reentrant lock.