### PR TITLE
Synchronize invalidateLayout

### DIFF
--- a/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -271,7 +271,7 @@ public class CorfuRuntime {
      * If the layout has been previously invalidated and a new layout has not yet been retrieved,
      * this function does nothing.
      */
-    public void invalidateLayout() {
+    public synchronized void invalidateLayout() {
         // Is there a pending request to retrieve the layout?
         if (!layout.isDone()) {
             // Don't create a new request for a layout if there is one pending.


### PR DESCRIPTION
Invalidating a layout can result in multiple background layout fetch
tasks, this can cause race conditions when setting the layout because
the fetchLayout method is not thread safe. This is a quick fix until
the fetch layout mechanism is redone.