### PR TITLE
Fix for #292: add 'n' option to 1-line usage summary

### DIFF
--- a/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -72,7 +72,7 @@ public class CorfuServer {
             "Corfu Server, the server for the Corfu Infrastructure.\n"
                     + "\n"
                     + "Usage:\n"
-                    + "\tcorfu_server (-l <path>|-m) [-fsQ] [-a <address>] [-t <token>] [-c <size>] [-k seconds] [-d <level>] [-p <seconds>] [-P <seconds>] <port>\n"
+                    + "\tcorfu_server (-l <path>|-m) [-fnsQ] [-a <address>] [-t <token>] [-c <size>] [-k seconds] [-d <level>] [-p <seconds>] [-P <seconds>] <port>\n"
                     + "\n"
                     + "Options:\n"
                     + " -l <path>, --log-path=<path>            Set the path to the storage file for the log unit.\n"


### PR DESCRIPTION
In the "learn something new every day" department, it looks like the docopt parsing won't create a default value for a flag if that flag isn't mentioned in the 1-line summary.  Fixes #292.