### PR TITLE
Removing configMgr. Moved to Failure Detector

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -1,6 +1,5 @@
 package org.corfudb.infrastructure;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -8,15 +7,9 @@ import org.corfudb.protocols.wireprotocol.*;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.LayoutMsg;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.clients.BaseClient;
-import org.corfudb.runtime.clients.NettyClientRouter;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.Layout.LayoutSegment;
-import org.corfudb.runtime.view.LayoutView;
-import org.corfudb.util.Utils;
 
-import java.io.File;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.nio.file.DirectoryStream;
@@ -24,7 +17,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
-import java.util.concurrent.*;
 
 /**
  * The layout server serves layouts, which are used by clients to find the
@@ -84,72 +76,12 @@ public class LayoutServer extends AbstractServer {
 
     private int reboots = 0;
 
-    /**
-     * Configuration manager: disable polling loop
-     */
-    public static boolean disableConfigMgrPolling = false; // QQQ debugging only, put me back to false!!!!
-
-    /**
-     * Configuration manager: client runtime
-     */
-    private CorfuRuntime rt = null;
-
-    /**
-     * Configuration manager: layout view
-     */
-    private LayoutView lv = null;
-
-    /**
-     * Configuration manager: my endpoint name
-     */
-    private String my_endpoint;
-
-    /**
-     * Configuration manager: list of layout servers that we monitor for ping'ability.
-     */
-    private String[] history_servers = null;
-    private NettyClientRouter[] history_routers = null;
-
-    /**
-     * Configuration manager: polling history
-     */
-    private int[] history_poll_failures = null;
-    private int   history_poll_count = 0;
-    private HashMap<String,Boolean> history_status = null;
-
-    /**
-     * Configuration manager: future handle thingie to cancel periodic polling
-     */
-    public static ScheduledFuture<?> pollFuture = null;
-    private static Object pollFutureLock = new Object();
-
-    /**
-     * TODO DELETE ME.
-     */
-    Layout todo_layout_source_kludge = null;
-
-    /**
-     * A scheduler, which is used to schedule checkpoints and lease renewal
-     */
-    private final ScheduledExecutorService scheduler =
-            Executors.newScheduledThreadPool(
-                    1,
-                    new ThreadFactoryBuilder()
-                            .setDaemon(true)
-                            .setNameFormat("Config-Mgr-%d")
-                            .build());
-
     public LayoutServer(ServerContext serverContext) {
         this.opts = serverContext.getServerConfig();
         this.serverContext = serverContext;
 
         reboot();
         reset_part_2();
-
-        // schedule config manager polling.
-        if (! disableConfigMgrPolling) {
-            start_config_manager_polling();
-        }
 
         // QuickCheck: Create the distributed Erlang message handling threads
         Object test_mode = opts.get("--quickcheck-test-mode");
@@ -506,240 +438,5 @@ public class LayoutServer extends AbstractServer {
 
     protected void finalize() {
         //
-    }
-
-    private void start_config_manager_polling() {
-        synchronized (pollFutureLock) {
-            if (pollFuture == null) {
-                my_endpoint = opts.get("--address") + ":" + opts.get("<port>");
-                String cmpi = "--cm-poll-interval";
-                long poll_interval = (opts.get(cmpi) == null) ? 1 : Utils.parseLong(opts.get(cmpi));
-                pollFuture = scheduler.scheduleAtFixedRate(this::configMgrPoll,
-                        0, poll_interval, TimeUnit.SECONDS);
-            }
-        }
-    }
-
-    private void configMgrPoll() {
-        File f;
-        List<String> layout_servers;
-
-        f = new File("/tmp/shutdown-layout-server");
-        if (f.canRead()) {
-            System.out.println("SHUTDOWN FOUND");
-            shutdown();
-        }
-        f = new File("/tmp/abort-poll");
-        if (f.canRead()) {
-            System.out.println("disableConfigMgrPolling = true");
-            disableConfigMgrPolling = true;
-        } else {
-            disableConfigMgrPolling = false;
-        }
-
-        // NOTE: This polling action is associated with a particular LayoutServer
-        //       object.  If that object is shutdown, then polling will stop,
-        //       no matter how many other LayoutServer objects have been created
-        //       and are not shut down.
-        if (isShutdown() || disableConfigMgrPolling) {
-            log.warn("I am shutdown, skipping configMgrPoll");
-            return;
-        }
-        try {
-            if (lv == null) {    // Not bootstrapped yet?
-                Layout currentLayout = getCurrentLayout();
-                if (currentLayout == null) {
-                    // The local layout server is not bootstrapped, so we have
-                    // no hope of participating in Paxos decisions about layout.
-                    // We may receive a layout bootstrap sometime in the future,
-                    // so do not change the scheduling of this polling task.
-                    log.debug("No currentLayout, so skip ConfigMgr poll");
-                    return;
-                }
-                layout_servers = currentLayout.getLayoutServers();
-                rt = new CorfuRuntime();
-                layout_servers.stream().forEach(ls -> {
-                    rt.addLayoutServer(ls);
-                });
-                // TODO: Warning, rt.connect() will deadlock when run inside a JUnit test.
-                // Until I understand this deadlock, we avoid the problem by avoiding any
-                // polling at all during JUnit tests (see disableConfigMgrPolling var).
-                // SLF reminder: tag tmptag/config-manager-draft1-cf-deadlock, wireExistingRuntimeToTest()?
-                rt.connect();
-                lv = rt.getLayoutView();  // Can block for arbitrary time
-                log.info("Initial client layout for poller = {}", lv.getLayout());
-
-                // TODO: figure out what endpoint *I* am.
-                // Workaround: see my_endpoint.
-                //
-                // So, this is a cool problem.  How the hell do I figure out which
-                // endpoint in the layout is *my* server?
-                //
-                // * So, I know a TCP port number.  That doesn't help if we're
-                // deployed on multiple machines and some/all use the same TCP
-                // port.
-                // * I know the --address key in the 'opts' map.  But that
-                // defaults to 'localhost'.  And netty is binding to the "*"
-                // address, so other nodes in the cluster can use any IP address
-                // they wish on this machine.
-                //
-                // In the current implementation, I see only one choice:
-                // each 'corfu_server' invocation must include an --address=ADDR
-                // flag where ADDR is the canonical hostname (or IP address) for
-                // for this machine.  That means that the default for --address
-                // is only usable in toy localhost-only deployments.  Furthermore,
-                // when we get around to having init(8)/init.d(8)/systemd(8)
-                // daemon process management, the value of --address must be
-                // threaded through those daemon proc managers.
-                //
-                // HRM, there are uglier hacks available, I suppose.  The client
-                // could create a magic cookie and send it in a PING call.  The
-                // server side could stash away a history of cookies.  Then we
-                // could peek inside the local server, find the cookie history,
-                // and see if our cookie is in there.  Bwahahaha, that's icky.
-            }
-            // Get the current layout using the regular CorfuDB client.
-            // The client (in theory) will take care of discovering layout
-            // changes that may have taken place while we were stopped/crashed/
-            // sleeping/whatever ... AH!  Oops, bad assumption.  The client
-            // does *not* perform a discovery/update process.  It appears to
-            // accept the layout from the first layout server in the list that
-            // is available.  For example, if the list is:
-            //   [localhost:8010 @ epoch 0, localhost:8011 @ epoch 1],
-            // ... then if the 8010 server is up, the local client does
-            // not attempt to fetch 8011's copy and lv.getCurrentLayout()
-            // yields epoch 0.
-            // TODO: Cobble together a discovery/update function?  Or avoid
-            //       the problem by having the Paxos implementation always
-            //       fix any non-unanimous servers?
-
-            lv = rt.getLayoutView();  // Can block for arbitrary time
-            Layout l;
-
-            if (todo_layout_source_kludge == null) {
-                l = lv.getCurrentLayout();
-            } else {
-                l = todo_layout_source_kludge;
-            }
-            // log.warn("Hello, world! Client layout = {}", l);
-            // For now, assume that lv contains the latest & greatest layout
-            layout_servers = l.getLayoutServers();
-            if (! layout_servers.contains(my_endpoint)) {
-                log.debug("I am not a layout server in epoch " + l.getEpoch() + ", layout server list = " + layout_servers);
-                return;
-            }
-            // If we're here, then it's poll time.
-            configMgrPollOnce(l);
-        } catch (Exception e) {
-            log.warn("TODO Oops, " + e);
-            e.printStackTrace();
-        }
-    }
-
-    // TODO: Yank this into a separate class, refactor, de-C-ify, ...
-
-    private void configMgrPollOnce(Layout l) {
-        // Are we polling the same servers as last time?  If not, then reset polling state.
-        String[] all_servers = l.getAllServers().stream().toArray(String[]::new);
-        Arrays.sort(all_servers);
-
-        // log.warn("TODO FIXME: Poll all servers, not just the layout servers, and when the epoch changes!");
-        if (history_servers == null || ! Arrays.equals(history_servers, all_servers)) {
-            if (history_status == null) {
-                history_status = new HashMap<>();
-            }
-            log.debug("history_servers change, length = " + all_servers.length);
-            history_servers = all_servers;
-            history_routers = new NettyClientRouter[all_servers.length];
-            history_poll_failures = new int[all_servers.length];
-            for (int i = 0; i < all_servers.length; i++) {
-                if (! history_status.containsKey(all_servers[i])) {
-                    history_status.put(all_servers[i], true);  // Assume it's up until we think it isn't.
-                }
-                history_routers[i] = new NettyClientRouter(all_servers[i]);
-                history_routers[i].setTimeoutConnect(50);
-                history_routers[i].setTimeoutRetry(200);
-                history_routers[i].setTimeoutResponse(1000);
-                history_routers[i].start();
-                history_poll_failures[i] = 0;
-            }
-            history_poll_count = 0;
-        } else {
-            log.debug("No server list change since last poll.");
-        }
-
-        // Poll servers for health.  All ping activity will happen in the background.
-        // We probably won't notice changes in this iteration; a future iteration will
-        // eventually notice changes to history_poll_failures.
-        for (int i = 0; i < history_routers.length; i++) {
-            int ii = i;  // Intermediate var just for the sake of having a final for use inside the lambda below
-            CompletableFuture.runAsync(() -> {
-                // Any changes that we make to history_poll_failures here can possibly
-                // race with other async CFs that were launched in earlier/later CFs.
-                // We don't care if an increment gets clobbered by another increment:
-                //     being off by one isn't a big problem.
-                // We don't care if a reset to zero gets clobbered by an increment:
-                //     if the endpoint is really pingable, then a later reset to zero
-                //     will succeed, probably.
-                try {
-                    CompletableFuture<Boolean> cf = history_routers[ii].getClient(BaseClient.class).ping();
-                    cf.exceptionally(e -> {
-                        log.debug(history_servers[ii] + " exception " + e);
-                        history_poll_failures[ii]++;
-                        return false;
-                    });
-                    cf.thenAccept((x) -> {
-                        if (x == true) {
-                            history_poll_failures[ii] = 0;
-                        } else {
-                            history_poll_failures[ii]++;
-                        }
-                        return;
-                    });
-
-                } catch (Exception e) {
-                    log.debug("Ping failed for " + history_servers[ii] + " with " + e);
-                    history_poll_failures[ii]++;
-                }
-            });
-        }
-        history_poll_count++;
-
-        if (history_poll_count > 3) {
-            HashMap<String,Boolean> status_change = new HashMap<>();
-            Boolean is_up;
-
-            // Simple failure detector: Is there a change in health?
-            for (int i = 0; i < history_servers.length; i++) {
-                // TODO: Be a bit smarter than 'more than 2 failures in a row'
-                is_up = ! (history_poll_failures[i] > 2);
-                if (is_up != history_status.get(history_servers[i])) {
-                    log.debug("Change of status: " + history_servers[i] + " " +
-                            history_status.get(history_servers[i]) + " -> " + is_up);
-                    status_change.put(history_servers[i], is_up);
-                }
-            }
-
-            // TODO step: If change of health, then change layout.
-            if (status_change.size() > 0) {
-                log.warn("Status change: " + status_change);
-
-                HashMap<String,Boolean> tmph = new HashMap<String,Boolean>();
-                for (String s : history_status.keySet()) {
-                    tmph.put(s, history_status.get(s));
-                }
-                for (String s: status_change.keySet()) {
-                    tmph.put(s, status_change.get(s));
-                }
-                Layout nl = l; // l.newLayout_UpdateDownLists(tmph);
-                log.warn("New layout = " + nl);
-                // TODO: Replace the layout cluster-wide.
-                todo_layout_source_kludge = nl;
-
-                history_status = tmph;
-            } else {
-                log.debug("No status change");
-            }
-        }
     }
 }


### PR DESCRIPTION
**Removing configMgr code from the layout Server.**

This code functionality has been moved to the following as a part of the failure detector: 
PeriodicPollPolicy #255 
Management Server #261 
@slfritchie Please have a look at this to make sure this is no longer required and I am not breaking any QuickCheck tests.