### PR TITLE
Test deadlock fix

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
@@ -1,10 +1,7 @@
 package org.corfudb.runtime.clients;
 
 import com.google.common.collect.ImmutableSet;
-import org.corfudb.infrastructure.AbstractServer;
-import org.corfudb.infrastructure.ManagementServer;
-import org.corfudb.infrastructure.ServerContext;
-import org.corfudb.infrastructure.TestLayoutBuilder;
+import org.corfudb.infrastructure.*;
 import org.junit.After;
 import org.junit.Test;
 
@@ -26,10 +23,17 @@ public class ManagementClientTest extends AbstractClientTest {
 
     @Override
     Set<AbstractServer> getServersForTest() {
-        ServerContext serverContext = defaultServerContext();
+        ServerContext serverContext = new ServerContextBuilder()
+                .setInitialToken(0)
+                .setMemory(true)
+                .setSingle(true)
+                .setMaxCache(256000000)
+                .setServerRouter(serverRouter)
+                .build();
         server = new ManagementServer(serverContext);
         return new ImmutableSet.Builder<AbstractServer>()
                 .add(server)
+                .add(new LayoutServer(serverContext))
                 .build();
     }
 


### PR DESCRIPTION
This fixes the deadlock created by the "handleFailures" test in ManagementClientTest.

The CorfuRuntime in the managementServer is stuck endlessly trying to connect to the layout server mentioned in the layout with which it is bootstrapped.
This causes a weird bug by blocking the main thread of the ManagementServer and disallowing it to accept any new messages even the FailureDetected message.
Thus by now giving this runtime a new bootstrapped layout server it connects to and returns and the rest of the messages are then accepted just fine.

I am not using defaultServerContext as I need to start the servers in single mode. (avoid having to bootstrap layout server separately).