### PR TITLE
Stream Read NullPointerException Fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/serializer/CorfuSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/CorfuSerializer.java
@@ -31,9 +31,7 @@ public class CorfuSerializer implements ISerializer {
      */
     @Override
     public Object deserialize(ByteBuf b, CorfuRuntime rt) {
-        byte magic;
-        if ((magic = b.readByte()) != CorfuPayloadMagic) {
-            b.resetReaderIndex();
+        if (b.readByte() != CorfuPayloadMagic) {
             byte[] bytes = new byte[b.readableBytes()];
             b.readBytes(bytes);
             return bytes;
@@ -54,6 +52,8 @@ public class CorfuSerializer implements ISerializer {
             ICorfuSerializable c = (ICorfuSerializable) o;
             c.serialize(b);
         } else if (o instanceof byte[]) {
+            // Reserve byte for an empty magic byte
+            b.writeByte(0);
             byte[] bytes = (byte[]) o;
             b.writeBytes(bytes);
         } else {

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -8,6 +8,7 @@ import org.corfudb.infrastructure.log.LogAddress;
 import org.corfudb.infrastructure.log.StreamLogFiles;
 import org.corfudb.protocols.wireprotocol.*;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
 import java.io.File;
@@ -69,7 +70,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         this.router.addServer(s1);
         //write at 0
         ByteBuf b = ByteBufAllocator.DEFAULT.buffer();
-        b.writeBytes("0".getBytes());
+        Serializers.CORFU.serialize("0".getBytes(), b);
         WriteRequest m = WriteRequest.builder()
                 .writeMode(WriteMode.NORMAL)
                 .data(new LogData(DataType.DATA, b))
@@ -81,7 +82,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         sendMessage(CorfuMsgType.WRITE.payloadMsg(m));
         //100
         b = ByteBufAllocator.DEFAULT.buffer();
-        b.writeBytes("100".getBytes());
+        Serializers.CORFU.serialize("100".getBytes(), b);
         m = WriteRequest.builder()
                 .writeMode(WriteMode.NORMAL)
                 .data(new LogData(DataType.DATA, b))
@@ -93,7 +94,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         sendMessage(CorfuMsgType.WRITE.payloadMsg(m));
         //and 10000000
         b = ByteBufAllocator.DEFAULT.buffer();
-        b.writeBytes("10000000".getBytes());
+        Serializers.CORFU.serialize("10000000".getBytes(), b);
         m = WriteRequest.builder()
                 .writeMode(WriteMode.NORMAL)
                 .data(new LogData(DataType.DATA, b))

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -13,6 +13,7 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
 
@@ -31,7 +32,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         StreamLog log = new StreamLogFiles(getDirPath(), false);
         ByteBuf b = ByteBufAllocator.DEFAULT.buffer();
         byte[] streamEntry = "Payload".getBytes();
-        b.writeBytes(streamEntry);
+        Serializers.CORFU.serialize(streamEntry, b);
         log.append(0, new LogData(DataType.DATA, b));
         assertThat(log.read(0).getPayload(null)).isEqualTo(streamEntry);
 
@@ -46,7 +47,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         StreamLog log = new StreamLogFiles(getDirPath(), false);
         ByteBuf b = ByteBufAllocator.DEFAULT.buffer();
         byte[] streamEntry = "Payload".getBytes();
-        b.writeBytes(streamEntry);
+        Serializers.CORFU.serialize(streamEntry, b);
         log.append(0, new LogData(DataType.DATA, b));
 
         assertThatThrownBy(() -> log.append(0, new LogData(DataType.DATA, b)))
@@ -59,7 +60,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         StreamLog log = new StreamLogFiles(getDirPath(), false);
         ByteBuf b = ByteBufAllocator.DEFAULT.buffer();
         byte[] streamEntry = "Payload".getBytes();
-        b.writeBytes(streamEntry);
+        Serializers.CORFU.serialize(streamEntry, b);
         log.append(0, new LogData(DataType.DATA, b));
         log.append(2, new LogData(DataType.DATA, b));
         assertThat(log.read(1)).isNull();
@@ -75,7 +76,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         StreamLog log = new StreamLogFiles(logDir, true);
         ByteBuf b = ByteBufAllocator.DEFAULT.buffer();
         byte[] streamEntry = "Payload".getBytes();
-        b.writeBytes(streamEntry);
+        Serializers.CORFU.serialize(streamEntry, b);
         log.append(0, new LogData(DataType.DATA, b));
 
         assertThat(log.read(0).getPayload(null)).isEqualTo(streamEntry);
@@ -96,7 +97,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         StreamLog log = new StreamLogFiles(logDir, false);
         ByteBuf b = ByteBufAllocator.DEFAULT.buffer();
         byte[] streamEntry = "Payload".getBytes();
-        b.writeBytes(streamEntry);
+        Serializers.CORFU.serialize(streamEntry, b);
         log.append(0, new LogData(DataType.DATA, b));
 
         assertThat(log.read(0).getPayload(null)).isEqualTo(streamEntry);


### PR DESCRIPTION
This patch fixes bug #305. This bug is caused by a classic encoding
typo, where a control byte(i.e. CorfuPayloadMagic) can be part of the
data segment. Writing a byte array where the first byte is equal to
CorfuPayloadMagic would cause a NullPointerException.