### PR TITLE
copy runtime during mvn deploy.

### DIFF
--- a/.travis_scripts/mvnrepo.sh
+++ b/.travis_scripts/mvnrepo.sh
@@ -12,6 +12,7 @@ if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; th
         rm target/mvn-repo/org/corfudb/corfu/${PROJECT_VERSION}/*.deb.md5
         rm target/mvn-repo/org/corfudb/corfu/${PROJECT_VERSION}/*.deb.sha1
         cp -R target/mvn-repo $HOME/mvn-repo-current
+        cp -R runtime/target/mvn-repo $HOME/mvn-repo-current
         cd $HOME
         git config --global user.email "travis@travis-ci.org"
         git config --global user.name "travis-ci"


### PR DESCRIPTION
Splitting the project up into modules means that the runtime needs to be copied
as from its own module target directory. This patch fixes the Travis script to
do the copy.