### PR TITLE
Removed Memory Mapped Buffers

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -143,7 +143,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         File logFile = new File(logFilePath);
         logFile.createNewFile();
         RandomAccessFile file = new RandomAccessFile(logFile, "rw");
-        StreamLogFiles.writeHeader(file.getChannel(), new AtomicLong(), version, noVerify);
+        StreamLogFiles.writeHeader(file.getChannel(), version, noVerify);
         file.close();
 
         return logFile.getAbsolutePath();


### PR DESCRIPTION
Since we are writing to an append only file, we are not benefiting
from memory mapped files. Also using many small memory mapped buffers
poses a problem when trying to unmap the buffers, because System.gc
needs to be called every time we need to unmap a buffer.

Addresses #294