### PR TITLE
Don't automatically commit when TX read timestamp is -1L

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -151,15 +151,14 @@ public class SequencerServer extends AbstractServer {
      * @param streams   Read set of the txn.
      */
     public boolean txnResolution(long timestamp, Set<UUID> streams) {
-        // If the timestamp is -1L, then the transaction automatically commits.
         log.trace("txn resolution, timestamp: {}, streams: {}", timestamp, streams);
-        if (timestamp == -1L)
-            return true;
 
         AtomicBoolean commit = new AtomicBoolean(true);
         for (UUID id : streams) {
             if (!commit.get())
                 break;
+
+
             streamTailToGlobalTailMap.compute(id, (k, v) -> {
                 if (v == null) {
                     return null;


### PR DESCRIPTION
Previously, the sequencer would automatically decide on commit if the
transaction timestamp was -1L, which is incorrect because the read timestamp
could be -1L for two transactions on a stream that has never been read.

@amytai, could you check if this is correct?