### PR TITLE
fix address space typo

### DIFF
--- a/cmdlets/src/main/clojure/org/corfudb/shell.clj
+++ b/cmdlets/src/main/clojure/org/corfudb/shell.clj
@@ -112,7 +112,7 @@ The variable *r holds the last runtime obtrained, and *o holds the last router o
 ; Functions to interact with a runtime.
 (defn get-objects-view ([] (.. *r (getObjectsView)))
   ([runtime] (.. runtime (getObjectsView))))
-(defn get-address-view ([] (.. *r (getAddressSpaceView)))
+(defn get-address-space-view ([] (.. *r (getAddressSpaceView)))
   ([runtime] (.. runtime (getAddressSpaceView))))
 (defn get-sequencer-view ([] (.. *r (getSequencerView)))
   ([runtime] (.. runtime (getSequencerView))))


### PR DESCRIPTION
The (get-address-space-view) function was mis-named (get-address-space), this patch
fixes it.