### PR TITLE
Prevent multiple bootstrap Management Server

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -191,6 +191,15 @@ public class ManagementServer extends AbstractServer {
         return serverContext.getDataStore().get(Layout.class, PREFIX_LAYOUT, KEY_LAYOUT);
     }
 
+    boolean checkBootstrap(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+        if (latestLayout == null) {
+            log.warn("Received message but not bootstrapped! Message={}", msg);
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP));
+            return false;
+        }
+        return true;
+    }
+
     /**
      * Bootstraps the management server.
      * The msg contains the layout to be bootstrapped.
@@ -201,9 +210,16 @@ public class ManagementServer extends AbstractServer {
      */
     @ServerHandler(type = CorfuMsgType.MANAGEMENT_BOOTSTRAP)
     public synchronized void handleManagementBootstrap(CorfuPayloadMsg<Layout> msg, ChannelHandlerContext ctx, IServerRouter r) {
-        log.info("Received Bootstrap Layout : {}", msg.getPayload());
-        safeUpdateLayout(msg.getPayload());
-        r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
+        if (latestLayout != null) {
+            // We are already bootstrapped, bootstrap again is not allowed.
+            log.warn("Got a request to bootstrap a server which is already bootstrapped, rejecting!");
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_ALREADY_BOOTSTRAP));
+        }
+        else {
+            log.info("Received Bootstrap Layout : {}", msg.getPayload());
+            safeUpdateLayout(msg.getPayload());
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
+        }
     }
 
     /**
@@ -222,11 +238,8 @@ public class ManagementServer extends AbstractServer {
             return;
         }
         // This server has not been bootstrapped yet, ignore all requests.
-        if (latestLayout == null) {
-            log.warn("Received message but not bootstrapped! Message={}", msg);
-            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
-            return;
-        }
+        if (!checkBootstrap(msg, ctx, r)) { return; }
+
         log.info("Received Failures : {}", msg.getPayload().getNodes());
         r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
     }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -70,7 +70,9 @@ public enum CorfuMsgType {
 
     // Management Codes
     MANAGEMENT_BOOTSTRAP(62, new TypeToken<CorfuPayloadMsg<Layout>>(){}, true),
-    MANAGEMENT_FAILURE_DETECTED(63, new TypeToken<CorfuPayloadMsg<FailureDetectorMsg>>(){}, true);
+    MANAGEMENT_FAILURE_DETECTED(63, new TypeToken<CorfuPayloadMsg<FailureDetectorMsg>>(){}, true),
+    MANAGEMENT_NOBOOTSTRAP(64, TypeToken.of(CorfuMsg.class), true),
+    MANAGEMENT_ALREADY_BOOTSTRAP(65, TypeToken.of(CorfuMsg.class), true);
 
     public final int type;
     public final TypeToken<? extends CorfuMsg> messageType;

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -8,6 +8,8 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.FailureDetectorMsg;
+import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
+import org.corfudb.runtime.exceptions.NoBootstrapException;
 import org.corfudb.runtime.view.Layout;
 
 import java.util.Map;
@@ -31,6 +33,8 @@ public class ManagementClient implements IClient {
     public final Set<CorfuMsgType> HandledTypes =
             new ImmutableSet.Builder<CorfuMsgType>()
                     .add(CorfuMsgType.MANAGEMENT_BOOTSTRAP)
+                    .add(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP)
+                    .add(CorfuMsgType.MANAGEMENT_ALREADY_BOOTSTRAP)
                     .add(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)
                     .build();
 
@@ -50,8 +54,14 @@ public class ManagementClient implements IClient {
             case MANAGEMENT_BOOTSTRAP:
                 router.completeRequest(msg.getRequestID(), ((CorfuPayloadMsg<Layout>) msg).getPayload());
                 break;
+            case MANAGEMENT_NOBOOTSTRAP:
+                router.completeExceptionally(msg.getRequestID(), new NoBootstrapException());
+                break;
             case MANAGEMENT_FAILURE_DETECTED:
                 router.completeRequest(msg.getRequestID(), ((CorfuPayloadMsg<FailureDetectorMsg>) msg).getPayload());
+                break;
+            case MANAGEMENT_ALREADY_BOOTSTRAP:
+                router.completeExceptionally(msg.getRequestID(), new AlreadyBootstrappedException());
                 break;
         }
     }

--- a/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
@@ -1,6 +1,12 @@
 package org.corfudb.infrastructure;
 
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.FailureDetectorMsg;
+import org.corfudb.runtime.view.Layout;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,5 +37,33 @@ public class ManagementServerTest extends AbstractServerTest {
         assertThat(!managementServer.getFailureDetectorService().isShutdown());
         managementServer.shutdown();
         assertThat(managementServer.getFailureDetectorService().isShutdown());
+    }
+
+    /**
+     * Bootstrapping the management server multiple times.
+     */
+    @Test
+    public void bootstrapManagementServer() {
+        Layout layout = TestLayoutBuilder.single(9000);
+        sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP.payloadMsg(layout));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
+        sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP.payloadMsg(layout));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.MANAGEMENT_ALREADY_BOOTSTRAP);
+    }
+
+    /**
+     * Triggering the failure handler with and without bootstrapping the server.
+     */
+    @Test
+    public void triggerFailureHandler() {
+        Layout layout = TestLayoutBuilder.single(9000);
+        Map<String, Boolean> map = new HashMap<>();
+        map.put("key", true);
+        sendMessage(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(map)));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP);
+        sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP.payloadMsg(layout));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
+        sendMessage(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(map)));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
@@ -8,8 +8,10 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests the Management client.
@@ -62,8 +64,8 @@ public class ManagementClientTest extends AbstractClientTest {
     @Test
     public void handleBootstrap()
             throws Exception {
-
-        assertThat(client.bootstrapManagement(TestLayoutBuilder.single(9000)).get()).isEqualTo(true);
+        // Since the servers are started as single nodes thus already bootstrapped.
+        assertThatThrownBy(() -> client.bootstrapManagement(TestLayoutBuilder.single(9000)).get()).isInstanceOf(ExecutionException.class);
     }
 
     /**
@@ -75,7 +77,7 @@ public class ManagementClientTest extends AbstractClientTest {
     public void handleFailure()
             throws Exception {
 
-        client.bootstrapManagement(TestLayoutBuilder.single(9000)).get();
+        // Since the servers are started as single nodes thus already bootstrapped.
         Map map = new HashMap<String, Boolean>();
         map.put("Key", true);
         assertThat(client.handleFailure(map).get()).isEqualTo(true);


### PR DESCRIPTION
Preventing bootstrapping the management server multiple times.

Added 2 messages:
MANAGEMENT_ALREADY_BOOTSTRAP: Returned if the server is already bootstrapped.
MANAGEMENT_NOBOOTSTRAP: Returned if received any message before being bootstrapped.

Added test cases to support above cases.
Resolving #322 