### PR TITLE
StreamLogFiles: Move throw of OverwriteException outside of catch-all

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -348,7 +348,7 @@ public class StreamLogFiles implements StreamLog {
                 throw new OverwriteException();
             }
             log.info("Disk_write[{}]: Written to disk.", logAddress);
-        } catch (Exception e) {
+        } catch (IOException e) {
             log.error("Disk_write[{}]: Exception", logAddress, e);
             throw new RuntimeException(e);
         }

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -55,8 +55,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         log.append(address0, new LogData(DataType.DATA, b));
 
         assertThatThrownBy(() -> log.append(address0, new LogData(DataType.DATA, b)))
-                .isInstanceOf(RuntimeException.class)
-                .hasCauseInstanceOf(OverwriteException.class);
+                .isInstanceOf(OverwriteException.class);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -20,6 +20,7 @@ import java.io.RandomAccessFile;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -80,7 +81,7 @@ public class LogUnitClientTest extends AbstractClientTest {
         client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
         assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), 0,
                 testString, Collections.emptyMap()).get())
-                .isInstanceOf(RuntimeException.class)
+                .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(OverwriteException.class);
     }
 
@@ -94,7 +95,7 @@ public class LogUnitClientTest extends AbstractClientTest {
                 .isEqualTo(DataType.HOLE);
 
         assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get())
-                .isInstanceOf(RuntimeException.class)
+                .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(OverwriteException.class);
     }
 
@@ -109,7 +110,7 @@ public class LogUnitClientTest extends AbstractClientTest {
                 .isEqualTo(DataType.DATA);
 
         assertThatThrownBy(() -> client.fillHole(0).get())
-                .isInstanceOf(RuntimeException.class)
+                .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(OverwriteException.class);
     }
 


### PR DESCRIPTION
StreamLogFiles.append() was throwing an `OverwriteException` inside of a catch-all try block.  Move the throw outside of the catch-all to match original caller's expectation.

I've also patched up the unit tests to expect the shape of the `OverwriteException`.  Reviewer: please double-check.  The execution passes, but a sanity check from someone else would be good, thanks.

Fixes #273.