### PR TITLE
Add Address After Writing

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -296,9 +296,8 @@ public class StreamLogFiles implements StreamLog {
             // (probably need a faster way to do this - high watermark?)
             FileHandle fh = getChannelForAddress(address);
             if (!fh.getKnownAddresses().contains(address)) {
-                fh.getKnownAddresses().add(address);
                 writeRecord(fh, address, entry);
-
+                fh.getKnownAddresses().add(address);
             } else {
                 throw new OverwriteException();
             }


### PR DESCRIPTION
On a write operation, the set of known addresses is updated before
the write operate completes. The problem is, if the write fails
then the logunit will rejected writes to that address because it
thinks that address has already been written.