### PR TITLE
Support Multiple Streams in StreamLog

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure.log;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.corfudb.protocols.wireprotocol.LogData;
@@ -15,23 +16,50 @@ import org.corfudb.runtime.exceptions.OverwriteException;
  */
 public class InMemoryStreamLog implements StreamLog {
 
-    private Map<Long, LogData> cache;
+    private Map<Long, LogData> logCache;
+    private Map<UUID, Map<Long, LogData>> streamCache;
 
     public InMemoryStreamLog() {
-        cache = new ConcurrentHashMap();
+        logCache = new ConcurrentHashMap();
+        streamCache = new HashMap();
     }
 
     @Override
-    public synchronized void append(long address, LogData entry) {
-        if(cache.containsKey(address)) {
-            throw new OverwriteException();
+    public synchronized void append(LogAddress logAddress, LogData entry) {
+        if (logAddress.getStream() == null) {
+            if(logCache.containsKey(logAddress.address)) {
+                throw new OverwriteException();
+            }
+            logCache.put(logAddress.address, entry);
+        } else {
+
+            Map<Long, LogData> stream = streamCache.get(logAddress.getStream());
+            if(stream == null) {
+                stream = new HashMap();
+                streamCache.put(logAddress.getStream(), stream);
+            }
+
+            if(stream.containsKey(logAddress.address)) {
+                throw new OverwriteException();
+            } else {
+                stream.put(logAddress.address, entry);
+            }
         }
-        cache.put(address, entry);
     }
 
     @Override
-    public LogData read(long address) {
-        return cache.get(address);
+    public LogData read(LogAddress logAddress) {
+        if (logAddress.getStream() == null) {
+            return logCache.get(logAddress.address);
+        } else {
+
+            Map<Long, LogData> stream = streamCache.get(logAddress.getStream());
+            if (stream == null) {
+                return null;
+            } else {
+                return stream.get(logAddress.address);
+            }
+        }
     }
 
     @Override
@@ -41,6 +69,7 @@ public class InMemoryStreamLog implements StreamLog {
 
     @Override
     public void close() {
-        cache = new HashMap();
+        logCache = new HashMap();
+        streamCache = new HashMap();
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -15,14 +15,14 @@ public interface StreamLog {
      * @param address
      * @param entry
      */
-    void append(long address, LogData entry);
+    void append(LogAddress address, LogData entry);
 
     /**
      * Given an address, read the corresponding stream entry.
      * @param address
      * @return Stream entry if it exists, otherwise return null
      */
-    LogData read(long address);
+    LogData read(LogAddress address);
 
     /**
      * Sync the stream log file to secondary storage.

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -144,13 +144,6 @@ public class LogUnitClientTest extends AbstractClientTest {
         assertThat(r.getMetadataMap().get(IMetadata.LogUnitMetadataType.COMMIT));
 
         UUID streamA = CorfuRuntime.getStreamID("streamA");
-        // Create log directories for streams
-        String streamLogDir = (String) serverContext.getServerConfig().get("--log-path");
-        streamLogDir = streamLogDir + File.separator + "log";
-        File streamDir = new File(streamLogDir);
-
-        assertThat(streamDir.mkdir()).isTrue();
-
         client.writeStream(1, Collections.singletonMap(streamA, 0L), testString).get();
         client.writeCommit(Collections.singletonMap(streamA, 0L), 10L, true).get(); // 10L shouldn't matter
 
@@ -176,7 +169,7 @@ public class LogUnitClientTest extends AbstractClientTest {
 
         // Corrupt the written log entry
         String logDir = (String) serverContext.getServerConfig().get("--log-path");
-        String logFilePath = logDir + File.separator + "log0.log";
+        String logFilePath = logDir + File.separator + "log/0.log";
         RandomAccessFile file = new RandomAccessFile(logFilePath, "rw");
         file.seek(64 + 2); // File header + delimiter
         file.writeInt(0xffff);


### PR DESCRIPTION
Added support for multiple streams in StreamLog, so that we don't
have to create a StreamLog per stream.


This pull request has a dependency on https://github.com/CorfuDB/CorfuDB/pull/317, that patch needs to be committed before we can commit this one.