### PR TITLE
Fixing failing invokeFailureHandler test

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -103,7 +103,7 @@ public class ManagementServer extends AbstractServer {
         } else {
             safeUpdateLayout(getCurrentLayout());
         }
-        
+
         this.failureDetectorPolicy = serverContext.getFailureDetectorPolicy();
         this.failureDetectorService = Executors.newScheduledThreadPool(
                 2,

--- a/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.FailureDetectorMsg;
 import org.corfudb.runtime.view.Layout;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.HashMap;
@@ -18,13 +19,21 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class ManagementServerTest extends AbstractServerTest {
 
+    private ManagementServer managementServer;
+
     @Override
     public ManagementServer getDefaultServer() {
         ServerContext serverContext = new ServerContextBuilder()
                 .setSingle(false)
                 .setServerRouter(getRouter())
                 .build();
-        return new ManagementServer(serverContext);
+        managementServer = new ManagementServer(serverContext);
+        return managementServer;
+    }
+
+    @After
+    public void cleanUp() {
+        managementServer.shutdown();
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -69,19 +69,19 @@ public class TestClientRouter implements IClientRouter {
      */
     @Getter
     @Setter
-    public long timeoutConnect = 5000L;
+    public long timeoutConnect = 50L;
     /**
      * Sync call response timeout (milliseconds)
      */
     @Getter
     @Setter
-    public long timeoutResponse = 5000L;
+    public long timeoutResponse = 50L;
     /**
      * Retry interval after timeout (milliseconds)
      */
     @Getter
     @Setter
-    public long timeoutRetry = 5000L;
+    public long timeoutRetry = 50L;
 
     public List<TestRule> rules;
 

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -24,7 +24,7 @@ public class ManagementViewTest extends AbstractViewTest {
     private static final Semaphore failureDetected = new Semaphore(1, true);
 
     /**
-     * Scenario with 3 nodes: 9000, 9001 and 9002.
+     * Scenario with 2 nodes: 9000 and 9001.
      * We fail 9000 and then listen to intercept the message
      * sent by 9001's client to the server to handle the failure.
      *
@@ -35,18 +35,15 @@ public class ManagementViewTest extends AbstractViewTest {
             throws Exception {
         addServer(9000);
         addServer(9001);
-        addServer(9002);
         Layout l = new TestLayoutBuilder()
                 .setEpoch(1L)
                 .addLayoutServer(9000)
                 .addLayoutServer(9001)
-                .addLayoutServer(9002)
                 .addSequencer(9000)
                 .buildSegment()
                 .buildStripe()
                 .addLogUnit(9000)
                 .addLogUnit(9001)
-                .addLogUnit(9002)
                 .addToSegment()
                 .addToLayout()
                 .build();
@@ -56,6 +53,7 @@ public class ManagementViewTest extends AbstractViewTest {
 
         // Adding a rule on 9000 to drop all packets
         addServerRule(9000, new TestRule().always().drop());
+        getManagementServer(9000).shutdown();
 
         // Adding a rule on 9001 to toggle the flag when it sends the
         // MANAGEMENT_FAILURE_DETECTED message.


### PR DESCRIPTION
Removing extra server from scenario to speed up test and prevent time out.
Attempting to recreate failure on travis env.