### PR TITLE
fixed failing managementServerTest

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
@@ -23,11 +23,9 @@ public class ManagementServerTest extends AbstractServerTest {
 
     @Override
     public ManagementServer getDefaultServer() {
-        ServerContext serverContext = new ServerContextBuilder()
-                .setSingle(false)
-                .setServerRouter(getRouter())
-                .build();
-        managementServer = new ManagementServer(serverContext);
+        // Adding layout server for management server runtime to connect to.
+        router.addServer(new LayoutServer(new ServerContextBuilder().setSingle(true).setServerRouter(getRouter()).build()));
+        managementServer = new ManagementServer(new ServerContextBuilder().setSingle(false).setServerRouter(getRouter()).build());
         return managementServer;
     }
 
@@ -41,8 +39,6 @@ public class ManagementServerTest extends AbstractServerTest {
      */
     @Test
     public void checkFailureDetectorStatus() {
-        ManagementServer managementServer = getDefaultServer();
-
         assertThat(!managementServer.getFailureDetectorService().isShutdown());
         managementServer.shutdown();
         assertThat(managementServer.getFailureDetectorService().isShutdown());


### PR DESCRIPTION
Resolving #352 

Forcing CorfuRuntime to use testRouters in AbstractServerTest.
Runtime is used by Management Server.

Added Layout Server in ManagementServerTest for the management server runtime to connect to.