### PR TITLE
Fixed a concurrency issue in LogUnitServer.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -161,7 +161,8 @@ public class LogUnitServer extends AbstractServer {
         try {
             for (Long l = msg.getPayload().getRange().lowerEndpoint();
                  l < msg.getPayload().getRange().upperEndpoint()+1L; l++) {
-                LogData e = dataCache.get(new LogAddress(l, msg.getPayload().getStreamID()));
+                LogAddress logAddress = new LogAddress(l, msg.getPayload().getStreamID());
+                LogData e = dataCache.get(logAddress);
                 if (e == null) {
                     rr.put(l, LogData.EMPTY);
                 } else if (e.getType() == DataType.HOLE) {
@@ -324,10 +325,8 @@ public class LogUnitServer extends AbstractServer {
 
     public synchronized void handleEviction(LogAddress address, LogData entry, RemovalCause cause) {
         log.trace("Eviction[{}]: {}", address, cause);
-        if (entry.getData() != null) {
-            // Free the internal buffer once the data has been evicted (in the case the server is not sync).
-            entry.getData().release();
-        }
+
+        streamLog.release(address, entry);
     }
 
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -72,4 +72,9 @@ public class InMemoryStreamLog implements StreamLog {
         logCache = new HashMap();
         streamCache = new HashMap();
     }
+
+    @Override
+    public void release(LogAddress logAddress, LogData entry) {
+        // in memory, do nothing
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -33,4 +33,11 @@ public interface StreamLog {
      * Close the stream log.
      */
     void close();
+
+    /**
+     * unmap/release the memory for entry
+     *
+     * @param address
+     */
+    void release(LogAddress address, LogData entry);
 }

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectConcurrencyTest.java
@@ -1,0 +1,70 @@
+package org.corfudb.runtime.object;
+
+import lombok.Getter;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.junit.Test;
+
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by dmalkhi on 12/4/16.
+ */
+public class CorfuSMRObjectConcurrencyTest extends AbstractViewTest {
+    @Getter
+    final String defaultConfigurationString = getDefaultEndpoint();
+
+    @Test
+    public void testCorfuSharedCounterConcurrentReads() throws Exception {
+        getDefaultRuntime();
+
+/*
+        TestClass sharedCounter = getRuntime().getObjectsView().
+                build().
+                setStreamName("test")
+                .setType(TestClass.class)
+                .open();
+        sharedCounter.set(55);
+*/
+
+        CorfuSharedCounter sharedCounter = getRuntime().getObjectsView().
+                build().
+                setStreamName("test")
+                .setType(CorfuSharedCounter.class)
+                .open();
+        sharedCounter.setValue(55);
+
+        int concurrency = 10;
+        int writeconcurrency = 5;
+        int writerwork = 50000;
+
+        sharedCounter.setValue(-1);
+        assertThat(sharedCounter.getValue())
+                .isEqualTo(-1);
+
+        scheduleConcurrently(writeconcurrency, t -> {
+                    for (int i = 0; i < writerwork; i++)
+                        sharedCounter.setValue(t*writerwork + i);
+                }
+        );
+        scheduleConcurrently(concurrency-writeconcurrency, t -> {
+                    int lastread = -1;
+                    for (int i = 0; i < 1000; i++) {
+                        int res = sharedCounter.getValue();
+                        boolean assertflag =
+                                (
+                                        ( ((lastread < writerwork && res < writerwork) || (lastread >= writerwork && res >= writerwork) ) && lastread <= res ) ||
+                                                ( (lastread < writerwork && res >= writerwork) || (lastread >= writerwork && res < writerwork) )
+                                );
+                        assertThat(assertflag)
+                                .isTrue();
+                    }
+                }
+        );
+        executeScheduled(concurrency, 50000, TimeUnit.MILLISECONDS);
+
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectConcurrencyTest.java
@@ -21,15 +21,6 @@ public class CorfuSMRObjectConcurrencyTest extends AbstractViewTest {
     public void testCorfuSharedCounterConcurrentReads() throws Exception {
         getDefaultRuntime();
 
-/*
-        TestClass sharedCounter = getRuntime().getObjectsView().
-                build().
-                setStreamName("test")
-                .setType(TestClass.class)
-                .open();
-        sharedCounter.set(55);
-*/
-
         CorfuSharedCounter sharedCounter = getRuntime().getObjectsView().
                 build().
                 setStreamName("test")
@@ -39,7 +30,7 @@ public class CorfuSMRObjectConcurrencyTest extends AbstractViewTest {
 
         int concurrency = 10;
         int writeconcurrency = 5;
-        int writerwork = 50000;
+        int writerwork = 5000;
 
         sharedCounter.setValue(-1);
         assertThat(sharedCounter.getValue())

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectConcurrencyTest.java
@@ -30,7 +30,7 @@ public class CorfuSMRObjectConcurrencyTest extends AbstractViewTest {
 
         int concurrency = 10;
         int writeconcurrency = 5;
-        int writerwork = 5000;
+        int writerwork = 50;
 
         sharedCounter.setValue(-1);
         assertThat(sharedCounter.getValue())

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSharedCounter.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSharedCounter.java
@@ -1,0 +1,21 @@
+package org.corfudb.runtime.object;
+
+/**
+ * Created by dmalkhi on 12/4/16.
+ */
+public class CorfuSharedCounter {
+    int value;
+
+    public int getValue() { return value; }
+
+    public void setValue(int newValue) { value = newValue; }
+
+    @MutatorAccessor
+    public int CAS(int testValue, int newValue) {
+        int curValue = value;
+        if (curValue == testValue)
+            value = newValue;
+        return curValue;
+    }
+
+}


### PR DESCRIPTION
For some reason, Caffeine may invoke handleEviction multiple times on the same
entry. Added check that refCnt() > 0 before calling release().