### PR TITLE
Added failure handling policies

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IFailureHandlerPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IFailureHandlerPolicy.java
@@ -1,0 +1,28 @@
+package org.corfudb.infrastructure;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.LayoutModificationException;
+import org.corfudb.runtime.view.Layout;
+
+import java.util.Set;
+
+/**
+ * Failure Handler Policy modifies the current layout based on the
+ * set of failures passed.
+ * <p>
+ * Created by zlokhandwala on 11/21/16.
+ */
+public interface IFailureHandlerPolicy {
+
+    /**
+     * Generates a new layout based on the set of failures.
+     *
+     * @param currentLayout Latest instance of the layout.
+     * @param corfuRuntime  A connected instance of the Corfu Runtime.
+     * @param failedNodes   Set of failed nodes.
+     * @return generated layout
+     * @throws LayoutModificationException
+     * @throws CloneNotSupportedException
+     */
+    Layout generateLayout(Layout currentLayout, CorfuRuntime corfuRuntime, Set<String> failedNodes) throws LayoutModificationException, CloneNotSupportedException;
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/PurgeFailurePolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/PurgeFailurePolicy.java
@@ -1,0 +1,38 @@
+package org.corfudb.infrastructure;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.LayoutModificationException;
+import org.corfudb.runtime.view.Layout;
+
+import java.util.Set;
+
+/**
+ * Handles the failures.
+ * <p>
+ * Created by zlokhandwala on 11/21/16.
+ */
+public class PurgeFailurePolicy implements IFailureHandlerPolicy {
+
+    /**
+     * Modifies the layout by removing/purging the set failed nodes.
+     *
+     * @param originalLayout Original Layout which needs to be modified.
+     * @param corfuRuntime   Connected runtime to attach to the new layout.
+     * @param failedNodes    Set of all failed/defected servers.
+     * @return The new and modified layout.
+     * @throws LayoutModificationException Thrown if attempt to create an invalid layout.
+     * @throws CloneNotSupportedException  Clone not supported for layout.
+     */
+    @Override
+    public Layout generateLayout(Layout originalLayout, CorfuRuntime corfuRuntime, Set<String> failedNodes)
+            throws LayoutModificationException, CloneNotSupportedException {
+        LayoutWorkflowManager layoutManager = new LayoutWorkflowManager(originalLayout);
+        Layout newLayout = layoutManager
+                .removeLayoutServers(failedNodes)
+                .removeSequencerServers(failedNodes)
+                .removeLogunitServers(failedNodes)
+                .build();
+        newLayout.setRuntime(corfuRuntime);
+        return newLayout;
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/FailureHandlerDispatcherTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/FailureHandlerDispatcherTest.java
@@ -55,7 +55,8 @@ public class FailureHandlerDispatcherTest extends AbstractViewTest {
         failedServers.add(getEndpoint(9002));
 
         FailureHandlerDispatcher failureHandlerDispatcher = new FailureHandlerDispatcher();
-        failureHandlerDispatcher.dispatchHandler(originalLayout, corfuRuntime, failedServers);
+        IFailureHandlerPolicy failureHandlerPolicy = new PurgeFailurePolicy();
+        failureHandlerDispatcher.dispatchHandler(failureHandlerPolicy, originalLayout, corfuRuntime, failedServers);
 
         Layout expectedLayout = new TestLayoutBuilder()
                 .setEpoch(2L)


### PR DESCRIPTION
Moving generateLayout to PurgeFailurePolicy.

PurgeFailurePolicy
Simple policy to remove all failures from the layout.