### PR TITLE
Move test timeouts to constants.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ jdk:
 before_install:
 - .travis_scripts/generate_keys.sh $encrypted_026743b97986_key $encrypted_026743b97986_iv
 - .travis_scripts/setup_env.sh
+script:
+- ./mvnw test -Dmaven.javadoc.skip=true -Dtest.travisBuild=true
 after_success:
 - mvn jacoco:report coveralls:report
 - .travis_scripts/javadocs.sh

--- a/pom.xml
+++ b/pom.xml
@@ -302,9 +302,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.19.1</version>
-		<configuration>
-			<trimStackTrace>false</trimStackTrace>
-		</configuration>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                    <systemPropertyVariables>
+                        <propertyName>test.travisBuild</propertyName>
+                    </systemPropertyVariables>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/test/src/test/java/org/corfudb/AbstractCorfuConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuConcurrencyTest.java
@@ -21,7 +21,7 @@ public class AbstractCorfuConcurrencyTest extends AbstractCorfuTest {
             throws Exception {
         final AtomicLong l = new AtomicLong();
         scheduleConcurrently(5, t -> l.getAndIncrement());
-        executeScheduled(5, 1000, TimeUnit.MILLISECONDS);
+        executeScheduled(5, PARAMETERS.TIMEOUT_SHORT);
         assertThat(l.get())
                 .isEqualTo(5);
     }
@@ -32,7 +32,8 @@ public class AbstractCorfuConcurrencyTest extends AbstractCorfuTest {
         scheduleConcurrently(5, t -> {
             throw new IOException("hi");
         });
-        assertThatThrownBy(() -> executeScheduled(5, 1000, TimeUnit.MILLISECONDS))
+        assertThatThrownBy(() -> executeScheduled(5,
+                PARAMETERS.TIMEOUT_SHORT))
                 .isInstanceOf(IOException.class);
     }
 
@@ -40,7 +41,8 @@ public class AbstractCorfuConcurrencyTest extends AbstractCorfuTest {
     public void concurrentTestsTimeout()
             throws Exception {
         scheduleConcurrently(5, t -> Thread.sleep(10000));
-        assertThatThrownBy(() -> executeScheduled(5, 1, TimeUnit.MILLISECONDS))
+        assertThatThrownBy(() -> executeScheduled(5,
+                PARAMETERS.TIMEOUT_VERY_SHORT))
                 .isInstanceOf(CancellationException.class);
     }
 

--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.fusesource.jansi.Ansi.ansi;
 
@@ -166,8 +167,8 @@ public class AbstractCorfuTest {
      */
     public void executeScheduled(int maxConcurrency, Duration duration)
         throws Exception {
-        executeScheduled(maxConcurrency, duration.getNano(),
-                TimeUnit.NANOSECONDS);
+        executeScheduled(maxConcurrency, duration.toMillis(),
+                TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -9,6 +9,7 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 import java.io.File;
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -31,8 +32,10 @@ public class AbstractCorfuTest {
 
     public Set<Callable<Object>> scheduledThreads;
     public Set<String> temporaryDirectories;
-
     public String testStatus = "";
+
+    public static final CorfuTestParameters PARAMETERS =
+            new CorfuTestParameters();
 
     @Rule
     public TestRule watcher = new TestWatcher() {
@@ -41,16 +44,19 @@ public class AbstractCorfuTest {
             if (!testStatus.equals("")) {
                 testStatus = " [" + testStatus + "]";
             }
-            System.out.print(ansi().a("[").fg(Ansi.Color.GREEN).a("PASS").reset().a("]" + testStatus).newline());
+            System.out.print(ansi().a("[").fg(Ansi.Color.GREEN).a("PASS")
+                    .reset().a("]" + testStatus).newline());
         }
 
         @Override
         protected void failed(Throwable e, Description description) {
-            System.out.print(ansi().a("[").fg(Ansi.Color.RED).a("FAIL").reset().a("]").newline());
+            System.out.print(ansi().a("[").fg(Ansi.Color.RED)
+                    .a("FAIL").reset().a("]").newline());
         }
 
         protected void starting(Description description) {
-            System.out.print(String.format("%-60s", description.getMethodName()));
+            System.out.print(String.format("%-60s", description
+                    .getMethodName()));
             System.out.flush();
         }
     };
@@ -146,6 +152,22 @@ public class AbstractCorfuTest {
                 return null;
             });
         }
+    }
+
+    /**
+     * Execute any threads which were scheduled to run.
+     *
+     * @param maxConcurrency The maximum amount of concurrency to allow when
+     *                       running the threads
+     * @param duration       The maximum length to run the tests before timing
+     *                       out.
+     * @throws Exception     Any exception that was thrown by any thread while
+     *                       tests were run.
+     */
+    public void executeScheduled(int maxConcurrency, Duration duration)
+        throws Exception {
+        executeScheduled(maxConcurrency, duration.getNano(),
+                TimeUnit.NANOSECONDS);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/CorfuTestParameters.java
+++ b/test/src/test/java/org/corfudb/CorfuTestParameters.java
@@ -1,5 +1,7 @@
 package org.corfudb;
 
+import lombok.Getter;
+
 import java.time.Duration;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
@@ -15,21 +17,79 @@ public class CorfuTestParameters {
     /** A very short timeout, typically in the order of a 100ms.
      * You might expect a simple request to timeout in this timeframe.
      */
-    public final Duration TIMEOUT_VERY_SHORT = Duration.of(100, MILLIS);
+    public final Duration TIMEOUT_VERY_SHORT;
 
     /** A short timeout, typically in the order of 1s.
      * You might expect a typical request to timeout in this timeframe.
      */
-    public final Duration TIMEOUT_SHORT = Duration.of(1, SECONDS);
+    public final Duration TIMEOUT_SHORT;
 
     /** A normal timeout, typical in the order of 10s.
      * Your might expect a request like an IO flush to timeout in
      * this timeframe.
      */
-    public final Duration TIMEOUT_NORMAL = Duration.of(10, SECONDS);
+    public final Duration TIMEOUT_NORMAL;
 
     /** A long timeout, typically in the order of 1m.
      * You would expect an entire unit test to timeout in this timeframe.
      */
-    public final Duration TIMEOUT_LONG = Duration.of(1, MINUTES);
+    public final Duration TIMEOUT_LONG;
+
+    /** The number of iterations to run for a small test.
+     * This will be about 100 by default, and should be used for operations
+     * which perform I/O.
+     */
+    public final int NUM_ITERATIONS_LOW;
+
+    /** The number of iterations to run for a large test.
+     * This will be about 10,000 by default, and should be used for fast
+     * compute-only operations.
+     */
+    public final int NUM_ITERATIONS_LARGE;
+
+    /** Used when the concurrency factor should be only one thread. */
+    public final int CONCURRENCY_ONE;
+
+    /** Used when there should be only two threads for a concurency test. */
+    public final int CONCURRENCY_TWO;
+
+    /** Used when a few threads, on the order of 10 should be used to
+     * cause the (un)expected behavior */
+    public final int CONCURRENCY_SOME;
+
+    /** Used when many threads, on the order of 100s should be used to
+     * cause the (un)expected behavior. */
+    public final int CONCURRENCY_LOTS;
+
+    public CorfuTestParameters(){
+
+        if (isTravisBuild()) {
+            System.out.println("Building on travis, increased timeouts, "
+                   + "shorter tests and reduced concurrency will be used.");
+        }
+        // Timeouts
+        TIMEOUT_VERY_SHORT = isTravisBuild() ? Duration.of(1, SECONDS) :
+                                            Duration.of(100, MILLIS);
+        TIMEOUT_SHORT = isTravisBuild() ? Duration.of(5, SECONDS) :
+                                        Duration.of(1, SECONDS);
+        TIMEOUT_NORMAL = isTravisBuild() ? Duration.of(20, SECONDS) :
+                                        Duration.of(10, SECONDS);
+        TIMEOUT_LONG = isTravisBuild() ? Duration.of(2, MINUTES):
+                                        Duration.of(1, MINUTES);
+
+        // Iterations
+        NUM_ITERATIONS_LOW = isTravisBuild() ?  10 : 100;
+        NUM_ITERATIONS_LARGE = isTravisBuild() ? 1_000 : 10_000;
+
+        // Concurrency
+        CONCURRENCY_ONE = 1;
+        CONCURRENCY_TWO = 2;
+        CONCURRENCY_SOME = isTravisBuild() ? 3 : 5;
+        CONCURRENCY_LOTS = isTravisBuild() ? 25 : 100;
+    }
+
+    @Getter(lazy=true)
+    private final boolean travisBuild = System.getProperty("test.travisBuild")
+            != null && System.getProperty("test.travisBuild").toLowerCase()
+                                        .equals("true");
 }

--- a/test/src/test/java/org/corfudb/CorfuTestParameters.java
+++ b/test/src/test/java/org/corfudb/CorfuTestParameters.java
@@ -1,0 +1,35 @@
+package org.corfudb;
+
+import java.time.Duration;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.time.temporal.ChronoUnit.MINUTES;
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+
+/** This class contains automatically calculated parameters used for timeouts
+ * and concurrency throughout the infrastructure.
+ * Created by mwei on 12/8/16.
+ */
+public class CorfuTestParameters {
+    /** A very short timeout, typically in the order of a 100ms.
+     * You might expect a simple request to timeout in this timeframe.
+     */
+    public final Duration TIMEOUT_VERY_SHORT = Duration.of(100, MILLIS);
+
+    /** A short timeout, typically in the order of 1s.
+     * You might expect a typical request to timeout in this timeframe.
+     */
+    public final Duration TIMEOUT_SHORT = Duration.of(1, SECONDS);
+
+    /** A normal timeout, typical in the order of 10s.
+     * Your might expect a request like an IO flush to timeout in
+     * this timeframe.
+     */
+    public final Duration TIMEOUT_NORMAL = Duration.of(10, SECONDS);
+
+    /** A long timeout, typically in the order of 1m.
+     * You would expect an entire unit test to timeout in this timeframe.
+     */
+    public final Duration TIMEOUT_LONG = Duration.of(1, MINUTES);
+}

--- a/test/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
@@ -65,12 +65,12 @@ public class FGMapTest extends AbstractViewTest {
         assertThat(testMap)
                 .isEmpty();
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             testMap.put(Integer.toString(i), Integer.toString(i));
         }
 
         assertThat(testMap)
-                .hasSize(100);
+                .hasSize(PARAMETERS.NUM_ITERATIONS_LOW);
     }
 
     @Test
@@ -82,7 +82,7 @@ public class FGMapTest extends AbstractViewTest {
         assertThat(testMap)
                 .isEmpty();
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             testMap.put(Integer.toString(i), Integer.toString(i));
         }
 
@@ -92,9 +92,9 @@ public class FGMapTest extends AbstractViewTest {
         getRuntime().getObjectsView().TXEnd();
 
         assertThat(testMap.size())
-                .isEqualTo(101);
+                .isEqualTo(PARAMETERS.NUM_ITERATIONS_LOW + 1);
         assertThat(testMap.get("size"))
-                .isEqualTo("100");
+                .isEqualTo(Integer.toString(PARAMETERS.NUM_ITERATIONS_LOW));
     }
 
     @Test
@@ -106,12 +106,12 @@ public class FGMapTest extends AbstractViewTest {
         assertThat(testMap)
                 .isEmpty();
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             testMap.put(Integer.toString(i), Integer.toString(i));
         }
 
         assertThat(testMap)
-                .hasSize(100);
+                .hasSize(PARAMETERS.NUM_ITERATIONS_LOW);
 
         testMap.put("a", "b");
         testMap.clear();
@@ -129,7 +129,7 @@ public class FGMapTest extends AbstractViewTest {
                 .isEmpty();
 
         getRuntime().getObjectsView().TXBegin();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             testMap.put(Integer.toString(i), Integer.toString(i));
         }
         testMap.clear();
@@ -145,21 +145,22 @@ public class FGMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void canVaryBucketCount()
             throws Exception {
-        FGMap<String, String> testMap = getDefaultRuntime().getObjectsView().open("hello", FGMap.class, 101);
+        FGMap<String, String> testMap = getDefaultRuntime().getObjectsView().open("hello", FGMap.class,
+                PARAMETERS.NUM_ITERATIONS_LOW + 1);
         testMap.clear();
         assertThat(testMap)
                 .isEmpty();
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             testMap.put(Integer.toString(i), Integer.toString(i));
         }
 
         FGMap<String, String> testMap2 = getRuntime().getObjectsView().open("hello", FGMap.class,
                 EnumSet.of(ObjectOpenOptions.NO_CACHE));
         assertThat(testMap2)
-                .hasSize(100);
+                .hasSize(PARAMETERS.NUM_ITERATIONS_LOW);
         assertThat(testMap2.getNumBuckets())
-                .isEqualTo(101);
+                .isEqualTo(PARAMETERS.NUM_ITERATIONS_LOW + 1);
     }
 
 
@@ -171,8 +172,8 @@ public class FGMapTest extends AbstractViewTest {
 
         Map<String, String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), FGMap.class);
 
-        final int num_threads = 5;
-        final int num_records = 50;
+        final int num_threads = PARAMETERS.CONCURRENCY_SOME;
+        final int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
         testMap.clear();
 
         scheduleConcurrently(num_threads, threadNumber -> {
@@ -184,7 +185,7 @@ public class FGMapTest extends AbstractViewTest {
         });
 
         long startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, 30, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
         calculateRequestsPerSecond("WPS", num_records * num_threads, startTime);
 
         scheduleConcurrently(num_threads, threadNumber -> {
@@ -208,8 +209,8 @@ public class FGMapTest extends AbstractViewTest {
 
         Map<String, String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), FGMap.class);
 
-        final int num_threads = 5;
-        final int num_records = 100;
+        final int num_threads = PARAMETERS.CONCURRENCY_SOME;
+        final int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
         AtomicInteger aborts = new AtomicInteger();
         testMap.clear();
 
@@ -243,8 +244,8 @@ public class FGMapTest extends AbstractViewTest {
         Map<String, String> testMap = getRuntime().getObjectsView()
                 .open(UUID.randomUUID(), FGMap.class, 20);
 
-        final int num_threads = 5;
-        final int num_records = 100;
+        final int num_threads = PARAMETERS.CONCURRENCY_SOME;
+        final int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
 
         scheduleConcurrently(num_threads, threadNumber -> {
             int base = threadNumber * num_records;

--- a/test/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
@@ -196,7 +196,7 @@ public class FGMapTest extends AbstractViewTest {
         });
 
         startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, 30, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
         calculateRequestsPerSecond("RPS", num_records * num_threads, startTime);
     }
 
@@ -228,7 +228,7 @@ public class FGMapTest extends AbstractViewTest {
         });
 
         long startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, 30, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
         calculateRequestsPerSecond("TPS", num_records * num_threads, startTime);
 
         calculateAbortRate(aborts.get(), num_records * num_threads);
@@ -256,7 +256,7 @@ public class FGMapTest extends AbstractViewTest {
         });
 
         long startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, 30, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
         calculateRequestsPerSecond("OPS", num_records * num_threads, startTime);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -68,11 +69,11 @@ public class SMRMapTest extends AbstractViewTest {
             throws Exception {
         Map<String, String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
         testMap.clear();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             assertThat(testMap.put(Integer.toString(i), Integer.toString(i)))
                     .isNull();
         }
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             assertThat(testMap.get(Integer.toString(i)))
                     .isEqualTo(Integer.toString(i));
         }
@@ -125,8 +126,8 @@ public class SMRMapTest extends AbstractViewTest {
 
         Map<String, String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
 
-        final int num_threads = 5;
-        final int num_records = 100;
+        final int num_threads = PARAMETERS.CONCURRENCY_SOME;
+        final int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
         testMap.clear();
 
         scheduleConcurrently(num_threads, threadNumber -> {
@@ -181,19 +182,25 @@ public class SMRMapTest extends AbstractViewTest {
         testMap.put("a", "b");
         testMap2.put("a", "c");
 
+        Semaphore s1 = new Semaphore(0);
+        Semaphore s2 = new Semaphore(0);
         scheduleConcurrently(1, threadNumber -> {
-            Thread.sleep(1000);
+            s1.tryAcquire(PARAMETERS.TIMEOUT_NORMAL.toMillis(),
+                    TimeUnit.MILLISECONDS);
             testMap2.put("c", "d");
+            s2.release();
         });
 
         scheduleConcurrently(1, threadNumber -> {
             getRuntime().getObjectsView().TXBegin();
             testMap.compute("b", (k, v) -> testMap2.get("a"));
-            Thread.sleep(2000); // Wait for the other thread to finish;
+            s1.release();
+            s2.tryAcquire(PARAMETERS.TIMEOUT_NORMAL.toMillis(),
+                    TimeUnit.MILLISECONDS);
             assertThatThrownBy(() -> getRuntime().getObjectsView().TXEnd())
                     .isInstanceOf(TransactionAbortedException.class);
         });
-        executeScheduled(2, PARAMETERS.TIMEOUT_NORMAL);
+        executeScheduled(PARAMETERS.CONCURRENCY_TWO, PARAMETERS.TIMEOUT_NORMAL);
     }
 
    @Test
@@ -218,7 +225,7 @@ public class SMRMapTest extends AbstractViewTest {
     public void multipleTXesAreApplied()
             throws Exception {
         Map<String, String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
-        IntStream.range(0, 10).asLongStream()
+        IntStream.range(0, PARAMETERS.NUM_ITERATIONS_LOW).asLongStream()
                 .forEach(l -> {
                     try {
                         assertThat(testMap)
@@ -237,7 +244,7 @@ public class SMRMapTest extends AbstractViewTest {
                 });
 
         assertThat(testMap)
-                .hasSize(10);
+                .hasSize(PARAMETERS.NUM_ITERATIONS_LOW);
     }
 
     @Test
@@ -245,7 +252,7 @@ public class SMRMapTest extends AbstractViewTest {
     public void multipleTXesAreAppliedWOAccessors()
             throws Exception {
         Map<String, String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
-        IntStream.range(0, 10).asLongStream()
+        IntStream.range(0, PARAMETERS.NUM_ITERATIONS_LOW).asLongStream()
                 .forEach(l -> {
                     try {
                         getRuntime().getObjectsView().TXBegin();
@@ -258,7 +265,7 @@ public class SMRMapTest extends AbstractViewTest {
                 });
 
         assertThat(testMap)
-                .hasSize(10);
+                .hasSize(PARAMETERS.NUM_ITERATIONS_LOW);
     }
 
 
@@ -377,7 +384,7 @@ public class SMRMapTest extends AbstractViewTest {
         Map<String, TestObject> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(),
                 SMRMap.class);
 
-        IntStream.range(0, 10)
+        IntStream.range(0, PARAMETERS.NUM_ITERATIONS_LOW)
                 .forEach(l -> {
                     try {
                         getRuntime().getObjectsView().TXBegin();
@@ -416,7 +423,7 @@ public class SMRMapTest extends AbstractViewTest {
         Map<String, String> testMap = getRuntime().getObjectsView().open(UUID.randomUUID(), SMRMap.class);
 
         final int num_threads = 5;
-        final int num_records = 100;
+        final int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
         AtomicInteger aborts = new AtomicInteger();
         testMap.clear();
 
@@ -457,8 +464,8 @@ public class SMRMapTest extends AbstractViewTest {
                                                                 .open()
                                                     )
                                                     .collect(Collectors.toList());
-        final int num_threads = 5;
-        final int num_records = 100;
+        final int num_threads = PARAMETERS.CONCURRENCY_SOME;
+        final int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
         AtomicInteger aborts = new AtomicInteger();
 
         scheduleConcurrently(num_threads, threadNumber -> {
@@ -490,7 +497,7 @@ public class SMRMapTest extends AbstractViewTest {
         UUID stream = UUID.randomUUID();
         Map<String, String> testMap = getRuntime().getObjectsView().open(stream, SMRMap.class);
         testMap.clear();
-        for (int i = 0; i < 1_000; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             assertThat(testMap.put(Integer.toString(i), Integer.toString(i)))
                     .isNull();
         }

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -138,7 +138,7 @@ public class SMRMapTest extends AbstractViewTest {
         });
 
         long startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, 30, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
         calculateRequestsPerSecond("WPS", num_records * num_threads, startTime);
 
         scheduleConcurrently(num_threads, threadNumber -> {
@@ -150,7 +150,7 @@ public class SMRMapTest extends AbstractViewTest {
         });
 
         startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, 30, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
         calculateRequestsPerSecond("RPS", num_records * num_threads, startTime);
     }
 
@@ -193,7 +193,7 @@ public class SMRMapTest extends AbstractViewTest {
             assertThatThrownBy(() -> getRuntime().getObjectsView().TXEnd())
                     .isInstanceOf(TransactionAbortedException.class);
         });
-        executeScheduled(2, 10, TimeUnit.SECONDS);
+        executeScheduled(2, PARAMETERS.TIMEOUT_NORMAL);
     }
 
    @Test
@@ -435,7 +435,7 @@ public class SMRMapTest extends AbstractViewTest {
         });
 
         long startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, 30, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
         calculateRequestsPerSecond("TPS", num_records * num_threads, startTime);
 
         calculateAbortRate(aborts.get(), num_records * num_threads);
@@ -477,7 +477,7 @@ public class SMRMapTest extends AbstractViewTest {
         });
 
         long startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, 30, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
         calculateRequestsPerSecond("TPS", num_records * num_threads, startTime);
 
         calculateAbortRate(aborts.get(), num_records * num_threads);

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectConcurrencyTest.java
@@ -55,7 +55,7 @@ public class CorfuSMRObjectConcurrencyTest extends AbstractViewTest {
                     }
                 }
         );
-        executeScheduled(concurrency, 50000, TimeUnit.MILLISECONDS);
+        executeScheduled(concurrency, PARAMETERS.TIMEOUT_LONG);
 
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -83,14 +83,14 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
                 CorfuRuntime.getStreamID("test"), TreeMap.class);
         testMap.clear();
 
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             assertThat(testMap.put(Integer.toString(i), Integer.toString(i)))
                     .isNull();
         }
 
         Map<String, String> testMap2 = getRuntime().getObjectsView().open(
                 CorfuRuntime.getStreamID("test"), TreeMap.class);
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             assertThat(testMap2.get(Integer.toString(i)))
                     .isEqualTo(Integer.toString(i));
         }
@@ -107,7 +107,7 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
                 CorfuRuntime.getStreamID("test"), TreeMap.class);
         testMap.clear();
         int num_threads = 5;
-        int num_records = 100;
+        int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
 
         scheduleConcurrently(num_threads, threadNumber -> {
             int base = threadNumber * num_records;
@@ -187,7 +187,7 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
                         .setType(SMRMap.class)
                         .open();
 
-        for(int x = 0; x < 100; x++) {
+        for(int x = 0; x < PARAMETERS.NUM_ITERATIONS_LOW; x++) {
             // thread 1: update "a" and "b" atomically
             Thread t1 = new Thread(() -> {
                 runtime.getObjectsView().TXBegin();
@@ -205,9 +205,8 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
             });
             t2.start();
 
-            // Wait for 5 seconds
-            t1.join(5000);
-            t2.join(5000);
+            t1.join(PARAMETERS.TIMEOUT_NORMAL.toMillis());
+            t2.join(PARAMETERS.TIMEOUT_NORMAL.toMillis());
 
             assertThat(t1.isAlive()).isFalse();
             assertThat(t2.isAlive()).isFalse();

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -116,7 +116,7 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
                         .isEqualTo(null);
             }
         });
-        executeScheduled(num_threads, 50, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
 
         Map<String, String> testMap2 = getRuntime().getObjectsView().open(
                 CorfuRuntime.getStreamID("test"), TreeMap.class);
@@ -128,7 +128,7 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
                         .isEqualTo(Integer.toString(i));
             }
         });
-        executeScheduled(num_threads, 50, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -64,6 +64,7 @@ public class ManagementViewTest extends AbstractViewTest {
             return true;
         }));
 
-        assertThat(failureDetected.tryAcquire(15, TimeUnit.SECONDS)).isEqualTo(true);
+        assertThat(failureDetected.tryAcquire(PARAMETERS.TIMEOUT_NORMAL.getNano(),
+                TimeUnit.NANOSECONDS)).isEqualTo(true);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -64,7 +64,7 @@ public class ManagementViewTest extends AbstractViewTest {
             return true;
         }));
 
-        assertThat(failureDetected.tryAcquire(PARAMETERS.TIMEOUT_NORMAL.getNano(),
+        assertThat(failureDetected.tryAcquire(PARAMETERS.TIMEOUT_NORMAL.toNanos(),
                 TimeUnit.NANOSECONDS)).isEqualTo(true);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -55,11 +55,11 @@ public class StreamViewTest extends AbstractViewTest {
 
         StreamView sv = r.getStreamsView().get(streamA);
         scheduleConcurrently(100, i -> sv.write(testPayload));
-        executeScheduled(8, 10, TimeUnit.SECONDS);
+        executeScheduled(8, PARAMETERS.TIMEOUT_NORMAL);
 
         scheduleConcurrently(100, i -> assertThat(sv.read().getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes()));
-        executeScheduled(8, 10, TimeUnit.SECONDS);
+        executeScheduled(8, PARAMETERS.TIMEOUT_NORMAL);
         assertThat(sv.read())
                 .isEqualTo(null);
     }
@@ -75,11 +75,11 @@ public class StreamViewTest extends AbstractViewTest {
 
         StreamView sv = r.getStreamsView().get(streamA);
         scheduleConcurrently(100, i -> sv.write(testPayload));
-        executeScheduled(8, 10, TimeUnit.SECONDS);
+        executeScheduled(8, PARAMETERS.TIMEOUT_NORMAL);
 
         scheduleConcurrently(100, i -> assertThat(sv.read().getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes()));
-        executeScheduled(8, 10, TimeUnit.SECONDS);
+        executeScheduled(8, PARAMETERS.TIMEOUT_NORMAL);
         assertThat(sv.read())
                 .isEqualTo(null);
     }


### PR DESCRIPTION
This PR moves timeouts to constants, so that in the future different timeouts can be
set in Travis. It also forces the user to select from a set of four timeout lengths.