### PR TITLE
Bug369 management server timeouts

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -23,6 +23,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.corfudb.AbstractCorfuTest.PARAMETERS;
+
 /**
  * Created by mwei on 12/13/15.
  */
@@ -69,19 +71,19 @@ public class TestClientRouter implements IClientRouter {
      */
     @Getter
     @Setter
-    public long timeoutConnect = 50L;
+    public long timeoutConnect = PARAMETERS.TIMEOUT_NORMAL.toMillis();
     /**
      * Sync call response timeout (milliseconds)
      */
     @Getter
     @Setter
-    public long timeoutResponse = 50L;
+    public long timeoutResponse = PARAMETERS.TIMEOUT_NORMAL.toMillis();
     /**
      * Retry interval after timeout (milliseconds)
      */
     @Getter
     @Setter
-    public long timeoutRetry = 50L;
+    public long timeoutRetry = PARAMETERS.TIMEOUT_SHORT.toMillis();
 
     public List<TestRule> rules;
 

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.view;
 
+import org.corfudb.infrastructure.ManagementServer;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.runtime.clients.TestRule;
@@ -49,6 +50,13 @@ public class ManagementViewTest extends AbstractViewTest {
                 .build();
         bootstrapAllServers(l);
 
+        // Reduce test execution time from 15+ seconds to about 8 seconds:
+        // Set aggressive timeouts for surviving MS that polls the dead MS.
+        ManagementServer ms = getManagementServer(9001);
+        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutConnect(50L);
+        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutResponse(50L);
+        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutRetry(50L);
+
         failureDetected.acquire();
 
         // Adding a rule on 9000 to drop all packets
@@ -64,7 +72,7 @@ public class ManagementViewTest extends AbstractViewTest {
             return true;
         }));
 
-        assertThat(failureDetected.tryAcquire(PARAMETERS.TIMEOUT_NORMAL.toNanos(),
+        assertThat(failureDetected.tryAcquire(PARAMETERS.TIMEOUT_LONG.toNanos(),
                 TimeUnit.NANOSECONDS)).isEqualTo(true);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -53,9 +53,9 @@ public class ManagementViewTest extends AbstractViewTest {
         // Reduce test execution time from 15+ seconds to about 8 seconds:
         // Set aggressive timeouts for surviving MS that polls the dead MS.
         ManagementServer ms = getManagementServer(9001);
-        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutConnect(50L);
-        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutResponse(50L);
-        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutRetry(50L);
+        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
 
         failureDetected.acquire();
 

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -53,10 +53,10 @@ public class ManagementViewTest extends AbstractViewTest {
 
         // Reduce test execution time from 15+ seconds to about 8 seconds:
         // Set aggressive timeouts for surviving MS that polls the dead MS.
-        ManagementServer ms = getManagementServer(9001);
-        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-        ms.getCorfuRuntime().getRouter("test:9000").setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        ManagementServer ms = getManagementServer(SERVERS.PORT_1);
+        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
 
         failureDetected.acquire();
 


### PR DESCRIPTION
* Add `TestClientRouter` timeouts to the test parameter scheme created by #367.
* Add aggressive polling timeouts to `ManagementViewTest.invokeFailureHandler` to reduce test execution time.

Prior to this PR, I've observed on my local machine that the `invokeFailureHandler` test could take anywhere from 6-27 seconds to run, with 15-18 seconds being typical.  This PR cuts that time to about 8 seconds max.

    % sh -c 'for i in `seq 1 10`; do mvn -Dtest="ManagementViewTest" test -pl test ; if [ $? -ne 0 ]; then echo FAILED; exit 1; fi done' | & egrep 'Time el'
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.598 sec - in org.corfudb.runtime.view.ManagementViewTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.372 sec - in org.corfudb.runtime.view.ManagementViewTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.129 sec - in org.corfudb.runtime.view.ManagementViewTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.156 sec - in org.corfudb.runtime.view.ManagementViewTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.185 sec - in org.corfudb.runtime.view.ManagementViewTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.286 sec - in org.corfudb.runtime.view.ManagementViewTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.255 sec - in org.corfudb.runtime.view.ManagementViewTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 7.119 sec - in org.corfudb.runtime.view.ManagementViewTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 6.186 sec - in org.corfudb.runtime.view.ManagementViewTest
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 8.524 sec - in org.corfudb.runtime.view.ManagementViewTest
