### PR TITLE
Remove magic numbers in tests and enforce style checks

### DIFF
--- a/test/pom.xml
+++ b/test/pom.xml
@@ -32,4 +32,38 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <executions>
+                    <execution>
+                        <id>validate</id>
+                        <phase>validate</phase>
+                        <configuration>
+                            <skip>false</skip>
+                            <encoding>UTF-8</encoding>
+                            <consoleOutput>true</consoleOutput>
+                            <failsOnError>true</failsOnError>
+                            <configLocation>${session.executionRootDirectory}/test_checks.xml</configLocation>
+                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                        </configuration>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>7.3</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/test/src/test/java/org/corfudb/AbstractCorfuConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuConcurrencyTest.java
@@ -20,19 +20,20 @@ public class AbstractCorfuConcurrencyTest extends AbstractCorfuTest {
     public void concurrentTestsExecute()
             throws Exception {
         final AtomicLong l = new AtomicLong();
-        scheduleConcurrently(5, t -> l.getAndIncrement());
-        executeScheduled(5, PARAMETERS.TIMEOUT_SHORT);
+        scheduleConcurrently(PARAMETERS.CONCURRENCY_SOME, t ->
+                l.getAndIncrement());
+        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_SHORT);
         assertThat(l.get())
-                .isEqualTo(5);
+                .isEqualTo(PARAMETERS.CONCURRENCY_SOME);
     }
 
     @Test
     public void concurrentTestsThrowExceptions()
             throws Exception {
-        scheduleConcurrently(5, t -> {
+        scheduleConcurrently(PARAMETERS.CONCURRENCY_SOME, t -> {
             throw new IOException("hi");
         });
-        assertThatThrownBy(() -> executeScheduled(5,
+        assertThatThrownBy(() -> executeScheduled(PARAMETERS.CONCURRENCY_SOME,
                 PARAMETERS.TIMEOUT_SHORT))
                 .isInstanceOf(IOException.class);
     }
@@ -40,8 +41,9 @@ public class AbstractCorfuConcurrencyTest extends AbstractCorfuTest {
     @Test
     public void concurrentTestsTimeout()
             throws Exception {
-        scheduleConcurrently(5, t -> Thread.sleep(10000));
-        assertThatThrownBy(() -> executeScheduled(5,
+        scheduleConcurrently(PARAMETERS.CONCURRENCY_SOME,
+                t -> Thread.sleep(PARAMETERS.TIMEOUT_LONG.toMillis()));
+        assertThatThrownBy(() -> executeScheduled(PARAMETERS.CONCURRENCY_SOME,
                 PARAMETERS.TIMEOUT_VERY_SHORT))
                 .isInstanceOf(CancellationException.class);
     }

--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -38,6 +38,9 @@ public class AbstractCorfuTest {
     public static final CorfuTestParameters PARAMETERS =
             new CorfuTestParameters();
 
+    public static final CorfuTestServers SERVERS =
+            new CorfuTestServers();
+
     @Rule
     public TestRule watcher = new TestWatcher() {
         @Override
@@ -114,15 +117,19 @@ public class AbstractCorfuTest {
     }
 
     public void calculateAbortRate(int aborts, int transactions) {
+        final float FRACTION_TO_PERCENT = 100.0F;
         if (!testStatus.equals("")) {
             testStatus += ";";
         }
-        testStatus += "Aborts=" + String.format("%.2f", ((float) aborts / transactions) * 100.0f) + "%";
+        testStatus += "Aborts=" + String.format("%.2f",
+                ((float) aborts / transactions) * FRACTION_TO_PERCENT) + "%";
     }
 
     public void calculateRequestsPerSecond(String name, int totalRequests, long startTime) {
+        final float MILLISECONDS_TO_SECONDS = 1000.0F;
         long endTime = System.currentTimeMillis();
-        float timeInSeconds = ((float) (endTime - startTime)) / 1000.0F;
+        float timeInSeconds = ((float) (endTime - startTime))
+                / MILLISECONDS_TO_SECONDS;
         float rps = (float) totalRequests / timeInSeconds;
         if (!testStatus.equals("")) {
             testStatus += ";";

--- a/test/src/test/java/org/corfudb/CorfuTestParameters.java
+++ b/test/src/test/java/org/corfudb/CorfuTestParameters.java
@@ -35,6 +35,12 @@ public class CorfuTestParameters {
      */
     public final Duration TIMEOUT_LONG;
 
+    /** The number of iterations to run for a very small test.
+     * This number will be about 10 by default, and should be used for
+     * operations that need to be repeated just a few times.
+     */
+    public final int NUM_ITERATIONS_VERY_LOW;
+
     /** The number of iterations to run for a small test.
      * This will be about 100 by default, and should be used for operations
      * which perform I/O.
@@ -61,6 +67,8 @@ public class CorfuTestParameters {
      * cause the (un)expected behavior. */
     public final int CONCURRENCY_LOTS;
 
+    // Magic number check disabled to make this constants more readable.
+    @SuppressWarnings("checkstyle:magicnumber")
     public CorfuTestParameters(){
 
         if (isTravisBuild()) {
@@ -78,6 +86,7 @@ public class CorfuTestParameters {
                                         Duration.of(1, MINUTES);
 
         // Iterations
+        NUM_ITERATIONS_VERY_LOW = isTravisBuild() ? 1 : 10;
         NUM_ITERATIONS_LOW = isTravisBuild() ?  10 : 100;
         NUM_ITERATIONS_LARGE = isTravisBuild() ? 1_000 : 10_000;
 

--- a/test/src/test/java/org/corfudb/CorfuTestServers.java
+++ b/test/src/test/java/org/corfudb/CorfuTestServers.java
@@ -1,0 +1,67 @@
+package org.corfudb;
+
+/** This class provides constants to refer to test servers.
+ * Created by mwei on 12/9/16.
+ */
+public class CorfuTestServers {
+
+    /** The port for test server 0. */
+    public final int PORT_0 = 0;
+
+    /** The port for test server 1. */
+    public final int PORT_1 = 1;
+
+    /** The port for test server 2. */
+    public final int PORT_2 = 2;
+
+    /** The port for test server 3. */
+    public final int PORT_3 = 3;
+
+    /** The port for test server 4. */
+    public final int PORT_4 = 4;
+
+    /** The port for test server 5. */
+    public final int PORT_5 = 5;
+
+    /** The port for test server 6. */
+    public final int PORT_6 = 6;
+
+    /** The port for test server 7. */
+    public final int PORT_7 = 7;
+
+    /** The port for test server 8. */
+    public final int PORT_8 = 8;
+
+    /** The port for test server 9. */
+    public final int PORT_9 = 9;
+
+    /** The endpoint name for test server 0. */
+    public final String ENDPOINT_0 = "test:" + PORT_0;
+
+    /** The endpoint name for test server 1. */
+    public final String ENDPOINT_1 = "test:" + PORT_1;
+
+    /** The endpoint name for test server 2. */
+    public final String ENDPOINT_2 = "test:" + PORT_2;
+
+    /** The endpoint name for test server 3. */
+    public final String ENDPOINT_3 = "test:" + PORT_3;
+
+    /** The endpoint name for test server 4. */
+    public final String ENDPOINT_4 = "test:" + PORT_4;
+
+    /** The endpoint name for test server 5. */
+    public final String ENDPOINT_5 = "test:" + PORT_5;
+
+    /** The endpoint name for test server 6. */
+    public final String ENDPOINT_6 = "test:" + PORT_6;
+
+    /** The endpoint name for test server 7. */
+    public final String ENDPOINT_7 = "test:" + PORT_7;
+
+    /** The endpoint name for test server 8. */
+    public final String ENDPOINT_8 = "test:" + PORT_8;
+
+    /** The endpoint name for test server 9. */
+    public final String ENDPOINT_9 = "test:" + PORT_9;
+}

--- a/test/src/test/java/org/corfudb/infrastructure/FailureHandlerDispatcherTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/FailureHandlerDispatcherTest.java
@@ -23,36 +23,36 @@ public class FailureHandlerDispatcherTest extends AbstractViewTest {
     @Test
     public void updateLayoutOnFailure() {
 
-        addServer(9000);
-        addServer(9001);
-        addServer(9002);
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
+        addServer(SERVERS.PORT_2);
 
         Layout originalLayout = new TestLayoutBuilder()
                 .setEpoch(1L)
-                .addLayoutServer(9000)
-                .addLayoutServer(9001)
-                .addLayoutServer(9002)
-                .addSequencer(9000)
-                .addSequencer(9001)
-                .addSequencer(9002)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
                 .buildStripe()
-                .addLogUnit(9000)
-                .addLogUnit(9001)
-                .addLogUnit(9002)
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_1)
+                .addLogUnit(SERVERS.PORT_2)
                 .addToSegment()
                 .addToLayout()
                 .build();
         bootstrapAllServers(originalLayout);
 
         CorfuRuntime corfuRuntime = new CorfuRuntime();
-        corfuRuntime.addLayoutServer(getEndpoint(9000));
-        corfuRuntime.addLayoutServer(getEndpoint(9001));
-        corfuRuntime.addLayoutServer(getEndpoint(9002));
+        corfuRuntime.addLayoutServer(getEndpoint(SERVERS.PORT_0));
+        corfuRuntime.addLayoutServer(getEndpoint(SERVERS.PORT_1));
+        corfuRuntime.addLayoutServer(getEndpoint(SERVERS.PORT_2));
         corfuRuntime.connect();
 
         Set<String> failedServers = new HashSet<>();
-        failedServers.add(getEndpoint(9002));
+        failedServers.add(getEndpoint(SERVERS.PORT_2));
 
         FailureHandlerDispatcher failureHandlerDispatcher = new FailureHandlerDispatcher();
         IFailureHandlerPolicy failureHandlerPolicy = new PurgeFailurePolicy();
@@ -60,20 +60,20 @@ public class FailureHandlerDispatcherTest extends AbstractViewTest {
 
         Layout expectedLayout = new TestLayoutBuilder()
                 .setEpoch(2L)
-                .addLayoutServer(9000)
-                .addLayoutServer(9001)
-                .addSequencer(9000)
-                .addSequencer(9001)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_1)
                 .buildSegment()
                 .buildStripe()
-                .addLogUnit(9000)
-                .addLogUnit(9001)
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_1)
                 .addToSegment()
                 .addToLayout()
                 .build();
 
-        assertThat(getLayoutServer(9000).getCurrentLayout())
-                .isEqualTo(getLayoutServer(9001).getCurrentLayout())
+        assertThat(getLayoutServer(SERVERS.PORT_0).getCurrentLayout())
+                .isEqualTo(getLayoutServer(SERVERS.PORT_1).getCurrentLayout())
                 .isEqualTo(expectedLayout);
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutWorkflowManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutWorkflowManagerTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure;
 
 import org.assertj.core.api.Assertions;
+import org.corfudb.AbstractCorfuTest;
 import org.corfudb.runtime.exceptions.LayoutModificationException;
 import org.corfudb.runtime.view.Layout;
 import org.junit.Test;
@@ -16,7 +17,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Created by zlokhandwala on 10/26/16.
  */
-public class LayoutWorkflowManagerTest {
+public class LayoutWorkflowManagerTest extends AbstractCorfuTest {
+
+    final int SERVER_ENTRY_3 = 3;
+    final int SERVER_ENTRY_4 = 4;
 
     /**
      * Tests the Layout Workflow manager by removing nodes.
@@ -28,43 +32,39 @@ public class LayoutWorkflowManagerTest {
     public void checkRemovalOfNodes() throws LayoutModificationException, CloneNotSupportedException {
         Layout originalLayout = new TestLayoutBuilder()
                 .setEpoch(1L)
-                .addLayoutServer(9000)
-                .addLayoutServer(9001)
-                .addLayoutServer(9002)
-                .addLayoutServer(9003)
-                .addLayoutServer(9004)
-                .addSequencer(9000)
-                .addSequencer(9001)
-                .addSequencer(9002)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addLayoutServer(SERVERS.PORT_3)
+                .addLayoutServer(SERVERS.PORT_4)
+                .addSequencer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
                 .buildStripe()
-                .addLogUnit(9000)
-                .addLogUnit(9002)
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_2)
                 .addToSegment()
                 .buildStripe()
-                .addLogUnit(9001)
-                .addLogUnit(9003)
-                .addLogUnit(9004)
+                .addLogUnit(SERVERS.PORT_1)
+                .addLogUnit(SERVERS.PORT_3)
+                .addLogUnit(SERVERS.PORT_4)
                 .addToSegment()
                 .addToLayout()
                 .build();
 
         List<String> allNodes = new ArrayList<>();
-        allNodes.add(TestLayoutBuilder.getEndpoint(9000));
-        allNodes.add(TestLayoutBuilder.getEndpoint(9001));
-        allNodes.add(TestLayoutBuilder.getEndpoint(9002));
-        allNodes.add(TestLayoutBuilder.getEndpoint(9003));
-        allNodes.add(TestLayoutBuilder.getEndpoint(9004));
+        allNodes.add(TestLayoutBuilder.getEndpoint(SERVERS.PORT_0));
+        allNodes.add(TestLayoutBuilder.getEndpoint(SERVERS.PORT_1));
+        allNodes.add(TestLayoutBuilder.getEndpoint(SERVERS.PORT_2));
+        allNodes.add(TestLayoutBuilder.getEndpoint(SERVERS.PORT_3));
+        allNodes.add(TestLayoutBuilder.getEndpoint(SERVERS.PORT_4));
 
         Set<String> failedNodes = new HashSet<String>();
         LayoutWorkflowManager layoutWorkflowManager = new LayoutWorkflowManager(originalLayout);
 
         //Preparing failed nodes set.
-        failedNodes.add(allNodes.get(0));
-        failedNodes.add(allNodes.get(1));
-        failedNodes.add(allNodes.get(2));
-        failedNodes.add(allNodes.get(3));
-        failedNodes.add(allNodes.get(4));
+        failedNodes.addAll(allNodes);
 
 
         /*
@@ -99,29 +99,29 @@ public class LayoutWorkflowManagerTest {
          *  Valid Removal
          */
 
-        // Deleting 9000 and 9004
+        // Deleting SERVERS.PORT_0 and SERVERS.PORT_4
         // Preparing new layout
         Layout expectedLayout = new TestLayoutBuilder()
                 .setEpoch(1L)
-                .addLayoutServer(9001)
-                .addLayoutServer(9002)
-                .addLayoutServer(9003)
-                .addSequencer(9001)
-                .addSequencer(9002)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addLayoutServer(SERVERS.PORT_3)
+                .addSequencer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
                 .buildStripe()
-                .addLogUnit(9002)
+                .addLogUnit(SERVERS.PORT_2)
                 .addToSegment()
                 .buildStripe()
-                .addLogUnit(9001)
-                .addLogUnit(9003)
+                .addLogUnit(SERVERS.PORT_1)
+                .addLogUnit(SERVERS.PORT_3)
                 .addToSegment()
                 .addToLayout()
                 .build();
 
         failedNodes.clear();
         failedNodes.add(allNodes.get(0));
-        failedNodes.add(allNodes.get(4));
+        failedNodes.add(allNodes.get(SERVER_ENTRY_4));
 
         Layout actualLayout = layoutWorkflowManager.removeLayoutServers(failedNodes)
                 .removeLogunitServers(failedNodes)
@@ -136,39 +136,40 @@ public class LayoutWorkflowManagerTest {
 
         expectedLayout = new TestLayoutBuilder()
                 .setEpoch(1L)
-                .addLayoutServer(9003)
-                .addSequencer(9002)
+                .addLayoutServer(SERVERS.PORT_3)
+                .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
                 .buildStripe()
-                .addLogUnit(9002)
+                .addLogUnit(SERVERS.PORT_2)
                 .addToSegment()
                 .buildStripe()
-                .addLogUnit(9003)
+                .addLogUnit(SERVERS.PORT_3)
                 .addToSegment()
                 .addToLayout()
                 .build();
-        // Remove 9001 & 9002 from layout server
+
+        // Remove SERVERS.PORT_1 & SERVERS.PORT_2 from layout server
         layoutWorkflowManager.removeLayoutServer(allNodes.get(1));
         layoutWorkflowManager.removeLayoutServer(allNodes.get(2));
         // No effect on removing removed node
         layoutWorkflowManager.removeLayoutServer(allNodes.get(2));
-        // Remove 9003 from layout server should throw error.
+        // Remove SERVERS.PORT_3 from layout server should throw error.
         assertThatThrownBy(() ->
-                layoutWorkflowManager.removeLayoutServer(allNodes.get(3))
+                layoutWorkflowManager.removeLayoutServer(allNodes.get(SERVER_ENTRY_3))
         ).isInstanceOf(LayoutModificationException.class);
-        // Remove 9001 from sequencers
+        // Remove SERVERS.PORT_1 from sequencers
         layoutWorkflowManager.removeSequencerServer(allNodes.get(1));
         // No effect on removing removed node
         layoutWorkflowManager.removeSequencerServer(allNodes.get(1));
-        // Remove 9002 from sequencer server should throw error.
+        // Remove SERVERS.PORT_2 from sequencer server should throw error.
         assertThatThrownBy(() ->
                 layoutWorkflowManager.removeSequencerServer(allNodes.get(2))
         ).isInstanceOf(LayoutModificationException.class);
-        // Remove 9001 from logunits
+        // Remove SERVERS.PORT_1 from logunits
         layoutWorkflowManager.removeLogunitServer(allNodes.get(1));
         // No effect on removing removed node
         layoutWorkflowManager.removeLogunitServer(allNodes.get(1));
-        // Remove 9002 from logunit server should throw error.
+        // Remove SERVERS.PORT_2 from logunit server should throw error.
         assertThatThrownBy(() ->
                 layoutWorkflowManager.removeLogunitServer(allNodes.get(2))
         ).isInstanceOf(LayoutModificationException.class);

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -37,8 +37,9 @@ public class LogUnitServerTest extends AbstractServerTest {
         this.router.reset();
         this.router.addServer(s1);
         long address = 0L;
+        final byte TEST_BYTE = 42;
         ByteBuf b = ByteBufAllocator.DEFAULT.buffer(1);
-        b.writeByte(42);
+        b.writeByte(TEST_BYTE);
         WriteRequest wr = WriteRequest.builder()
                             .writeMode(WriteMode.NORMAL)
                             .data(new LogData(DataType.DATA, b))
@@ -68,6 +69,10 @@ public class LogUnitServerTest extends AbstractServerTest {
 
         this.router.reset();
         this.router.addServer(s1);
+
+        final long LOW_ADDRESS = 0L;
+        final long MID_ADDRESS = 100L;
+        final long HIGH_ADDRESS = 10000000L;
         //write at 0
         ByteBuf b = ByteBufAllocator.DEFAULT.buffer();
         Serializers.CORFU.serialize("0".getBytes(), b);
@@ -75,7 +80,7 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .writeMode(WriteMode.NORMAL)
                 .data(new LogData(DataType.DATA, b))
                 .build();
-        m.setGlobalAddress(0L);
+        m.setGlobalAddress(LOW_ADDRESS);
         m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
         m.setRank(0L);
         m.setBackpointerMap(Collections.emptyMap());
@@ -87,7 +92,7 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .writeMode(WriteMode.NORMAL)
                 .data(new LogData(DataType.DATA, b))
                 .build();
-        m.setGlobalAddress(100L);
+        m.setGlobalAddress(MID_ADDRESS);
         m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
         m.setRank(0L);
         m.setBackpointerMap(Collections.emptyMap());
@@ -99,20 +104,20 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .writeMode(WriteMode.NORMAL)
                 .data(new LogData(DataType.DATA, b))
                 .build();
-        m.setGlobalAddress(10000000L);
+        m.setGlobalAddress(HIGH_ADDRESS);
         m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
         m.setRank(0L);
         m.setBackpointerMap(Collections.emptyMap());
         sendMessage(CorfuMsgType.WRITE.payloadMsg(m));
 
         assertThat(s1)
-                .containsDataAtAddress(0)
-                .containsDataAtAddress(100)
-                .containsDataAtAddress(10000000);
+                .containsDataAtAddress(LOW_ADDRESS)
+                .containsDataAtAddress(MID_ADDRESS)
+                .containsDataAtAddress(HIGH_ADDRESS);
         assertThat(s1)
-                .matchesDataAtAddress(0, "0".getBytes())
-                .matchesDataAtAddress(100, "100".getBytes())
-                .matchesDataAtAddress(10000000, "10000000".getBytes());
+                .matchesDataAtAddress(LOW_ADDRESS, "0".getBytes())
+                .matchesDataAtAddress(MID_ADDRESS, "100".getBytes())
+                .matchesDataAtAddress(HIGH_ADDRESS, "10000000".getBytes());
 
         s1.shutdown();
 
@@ -124,13 +129,13 @@ public class LogUnitServerTest extends AbstractServerTest {
         this.router.addServer(s2);
 
         assertThat(s2)
-                .containsDataAtAddress(0)
-                .containsDataAtAddress(100)
-                .containsDataAtAddress(10000000);
+                .containsDataAtAddress(LOW_ADDRESS)
+                .containsDataAtAddress(MID_ADDRESS)
+                .containsDataAtAddress(HIGH_ADDRESS);
         assertThat(s2)
-                .matchesDataAtAddress(0, "0".getBytes())
-                .matchesDataAtAddress(100, "100".getBytes())
-                .matchesDataAtAddress(10000000, "10000000".getBytes());
+                .matchesDataAtAddress(LOW_ADDRESS, "0".getBytes())
+                .matchesDataAtAddress(MID_ADDRESS, "100".getBytes())
+                .matchesDataAtAddress(HIGH_ADDRESS, "10000000".getBytes());
     }
 
     private String createLogFile(String path, int version, boolean noVerify) throws IOException {

--- a/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
@@ -49,7 +49,7 @@ public class ManagementServerTest extends AbstractServerTest {
      */
     @Test
     public void bootstrapManagementServer() {
-        Layout layout = TestLayoutBuilder.single(9000);
+        Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP.payloadMsg(layout));
         assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
         sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP.payloadMsg(layout));
@@ -61,7 +61,7 @@ public class ManagementServerTest extends AbstractServerTest {
      */
     @Test
     public void triggerFailureHandler() {
-        Layout layout = TestLayoutBuilder.single(9000);
+        Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         Map<String, Boolean> map = new HashMap<>();
         map.put("key", true);
         sendMessage(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(map)));

--- a/test/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
@@ -112,7 +112,7 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
         expectedResult.put(getEndpoint(SERVERS.PORT_2), false);
 
         Map<String, Boolean> actualResult = new HashMap<>();
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             failureDetectorPolicy.getServerStatus().forEach(actualResult::putIfAbsent);
             Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
             if (actualResult.equals(expectedResult)) break;
@@ -136,7 +136,7 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
         expectedResult.remove(getEndpoint(SERVERS.PORT_0));
 
         actualResult = new HashMap<>();
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             failureDetectorPolicy.getServerStatus().forEach(actualResult::putIfAbsent);
             Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
             if (actualResult.equals(expectedResult)) break;

--- a/test/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
@@ -101,7 +101,7 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
         addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
         addServerRule(SERVERS.PORT_2, new TestRule().always().drop());
 
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             failureDetectorPolicy.executePolicy(layout, corfuRuntime);
             Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         }
@@ -112,7 +112,7 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
         expectedResult.put(getEndpoint(SERVERS.PORT_2), false);
 
         Map<String, Boolean> actualResult = new HashMap<>();
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LARGE; i++) {
             failureDetectorPolicy.getServerStatus().forEach(actualResult::putIfAbsent);
             Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
             if (actualResult.equals(expectedResult)) break;
@@ -128,7 +128,7 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
 
         clearServerRules(SERVERS.PORT_0);
 
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             failureDetectorPolicy.executePolicy(layout, corfuRuntime);
             Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         }
@@ -136,7 +136,7 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
         expectedResult.remove(getEndpoint(SERVERS.PORT_0));
 
         actualResult = new HashMap<>();
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LARGE; i++) {
             failureDetectorPolicy.getServerStatus().forEach(actualResult::putIfAbsent);
             Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
             if (actualResult.equals(expectedResult)) break;

--- a/test/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
@@ -28,23 +28,23 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
     @Before
     public void pollingEnvironmentSetup() {
 
-        addServer(9000);
-        addServer(9001);
-        addServer(9002);
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
+        addServer(SERVERS.PORT_2);
 
         layout = new TestLayoutBuilder()
                 .setEpoch(1L)
-                .addLayoutServer(9000)
-                .addLayoutServer(9001)
-                .addLayoutServer(9002)
-                .addSequencer(9000)
-                .addSequencer(9001)
-                .addSequencer(9002)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
                 .buildStripe()
-                .addLogUnit(9000)
-                .addLogUnit(9001)
-                .addLogUnit(9002)
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_1)
+                .addLogUnit(SERVERS.PORT_2)
                 .addToSegment()
                 .addToLayout()
                 .build();
@@ -52,12 +52,12 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
         // Bootstrapping only the layout servers.
         // Failure-correction/updateLayout will cause test to give a non-deterministic output.
 
-        getLayoutServer(9000).handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(layout)),
-                null, getServerRouter(9000));
-        getLayoutServer(9001).handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(layout)),
-                null, getServerRouter(9001));
-        getLayoutServer(9002).handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(layout)),
-                null, getServerRouter(9002));
+        getLayoutServer(SERVERS.PORT_0).handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(layout)),
+                null, getServerRouter(SERVERS.PORT_0));
+        getLayoutServer(SERVERS.PORT_1).handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(layout)),
+                null, getServerRouter(SERVERS.PORT_1));
+        getLayoutServer(SERVERS.PORT_2).handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(layout)),
+                null, getServerRouter(SERVERS.PORT_2));
 
         corfuRuntime = new CorfuRuntime();
         layout.getLayoutServers().forEach(corfuRuntime::addLayoutServer);
@@ -74,13 +74,13 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
     @Test
     public void successfulPolling() throws InterruptedException {
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < PARAMETERS.CONCURRENCY_SOME; i++) {
             failureDetectorPolicy.executePolicy(layout, corfuRuntime);
-            Thread.sleep(100);
+            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         }
 
         // A little more than responseTimeout for periodicPolling
-        Thread.sleep(1100);
+        Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
         Map<String, Boolean> result = failureDetectorPolicy.getServerStatus();
         assertThat(result.isEmpty()).isEqualTo(true);
 
@@ -89,60 +89,60 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
     /**
      * Polls 3 failed servers.
      * Returns failed status for the 3 servers.
-     * We then restart server 9000, run polls again.
-     * Assert only 2 failures. 9001 & 9002
+     * We then restart server SERVERS.PORT_0, run polls again.
+     * Assert only 2 failures. SERVERS.PORT_1 & SERVERS.PORT_2
      *
      * @throws InterruptedException
      */
     @Test
     public void failedPolling() throws InterruptedException {
 
-        addServerRule(9000, new TestRule().always().drop());
-        addServerRule(9001, new TestRule().always().drop());
-        addServerRule(9002, new TestRule().always().drop());
+        addServerRule(SERVERS.PORT_0, new TestRule().always().drop());
+        addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
+        addServerRule(SERVERS.PORT_2, new TestRule().always().drop());
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
             failureDetectorPolicy.executePolicy(layout, corfuRuntime);
-            Thread.sleep(100);
+            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         }
 
         Map<String, Boolean> expectedResult = new HashMap<>();
-        expectedResult.put(getEndpoint(9000), false);
-        expectedResult.put(getEndpoint(9001), false);
-        expectedResult.put(getEndpoint(9002), false);
+        expectedResult.put(getEndpoint(SERVERS.PORT_0), false);
+        expectedResult.put(getEndpoint(SERVERS.PORT_1), false);
+        expectedResult.put(getEndpoint(SERVERS.PORT_2), false);
 
         Map<String, Boolean> actualResult = new HashMap<>();
-        for (int i = 0; i < 20; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
             failureDetectorPolicy.getServerStatus().forEach(actualResult::putIfAbsent);
-            Thread.sleep(200);
+            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
             if (actualResult.equals(expectedResult)) break;
         }
 
         assertThat(actualResult).isEqualTo(expectedResult);
 
         /*
-         * Restarting the server 9000. Pings should work normally now.
+         * Restarting the server SERVERS.PORT_0. Pings should work normally now.
          * This is also to demonstrate that we no longer receive the failed
-         * nodes' status in the result map for 9000.
+         * nodes' status in the result map for SERVERS.PORT_0.
          */
 
-        clearServerRules(9000);
+        clearServerRules(SERVERS.PORT_0);
 
-        for (int i = 0; i < 5; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
             failureDetectorPolicy.executePolicy(layout, corfuRuntime);
-            Thread.sleep(100);
+            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         }
 
-        expectedResult.remove(getEndpoint(9000));
+        expectedResult.remove(getEndpoint(SERVERS.PORT_0));
 
         actualResult = new HashMap<>();
-        for (int i = 0; i < 20; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
             failureDetectorPolicy.getServerStatus().forEach(actualResult::putIfAbsent);
-            Thread.sleep(200);
+            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
             if (actualResult.equals(expectedResult)) break;
         }
 
-        // Has only 9001 & 9002
+        // Has only SERVERS.PORT_1 & SERVERS.PORT_2
         assertThat(actualResult).isEqualTo(expectedResult);
 
     }

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -27,7 +27,7 @@ public class SequencerServerTest extends AbstractServerTest {
 
     @Test
     public void responseForEachRequest() {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet(), false, false)));
             assertThat(getResponseMessages().size())
                     .isEqualTo(i + 1);
@@ -37,7 +37,7 @@ public class SequencerServerTest extends AbstractServerTest {
     @Test
     public void tokensAreIncreasing() {
         long lastToken = -1;
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet(), false, false)));
             long thisToken = getLastPayloadMessageAs(TokenResponse.class).getToken();
             assertThat(thisToken)
@@ -48,7 +48,7 @@ public class SequencerServerTest extends AbstractServerTest {
 
     @Test
     public void checkTokenPositionWorks() {
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet(), false, false)));
             long thisToken = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
@@ -66,7 +66,7 @@ public class SequencerServerTest extends AbstractServerTest {
         UUID streamA = UUID.nameUUIDFromBytes("streamA".getBytes());
         UUID streamB = UUID.nameUUIDFromBytes("streamB".getBytes());
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                     new TokenRequest(1L, Collections.singleton(streamA), false, false)));
             long thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
@@ -106,7 +106,7 @@ public class SequencerServerTest extends AbstractServerTest {
         UUID streamA = UUID.nameUUIDFromBytes("streamA".getBytes());
         UUID streamB = UUID.nameUUIDFromBytes("streamB".getBytes());
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                     new TokenRequest(1L, Collections.singleton(streamA), false, false)));
             long thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
@@ -129,15 +129,17 @@ public class SequencerServerTest extends AbstractServerTest {
             assertThat(thisTokenB)
                     .isEqualTo(checkTokenB);
 
+            final long MULTI_TOKEN = 5L;
+
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(5L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(MULTI_TOKEN, Collections.singleton(streamA), false, false)));
             thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                     new TokenRequest(1L, Collections.singleton(streamA), false, false)));
             checkTokenA = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
-            assertThat(thisTokenA + 4)
+            assertThat(thisTokenA + MULTI_TOKEN - 1)
                     .isEqualTo(checkTokenA);
 
             // check the requesting multiple tokens does not break the back-pointer for the multi-entry
@@ -146,7 +148,7 @@ public class SequencerServerTest extends AbstractServerTest {
             thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(5L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(MULTI_TOKEN, Collections.singleton(streamA), false, false)));
             checkTokenA = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
             assertThat(thisTokenA)
@@ -163,7 +165,7 @@ public class SequencerServerTest extends AbstractServerTest {
         long Alocal = -1L;
         long Blocal = -1L;
 
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                     new TokenRequest(1L, Collections.singleton(streamA), false, false)));
             long thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getStreamAddresses().get(streamA);
@@ -211,7 +213,7 @@ public class SequencerServerTest extends AbstractServerTest {
                 new TokenRequest(1L, Collections.singleton(CorfuRuntime.getStreamID("a")), false, false)));
         assertThat(s1)
                 .tokenIsAt(2);
-        Thread.sleep(1400);
+        Thread.sleep(PARAMETERS.TIMEOUT_NORMAL.toMillis());
         s1.shutdown();
 
         SequencerServer s2 = new SequencerServer(new ServerContextBuilder()

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -9,6 +9,8 @@ import lombok.experimental.Accessors;
  */
 @Accessors(chain = true)
 @Data
+// Disable magic number check to make defaults readable
+@SuppressWarnings("checkstyle:magicnumber")
 public class ServerContextBuilder {
 
     long initialToken = 0;

--- a/test/src/test/java/org/corfudb/integration/StreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamIT.java
@@ -48,7 +48,7 @@ public class StreamIT {
 
         // Generate and write random data
         int entrySize = Integer.valueOf(properties.getProperty("largeEntrySize"));
-        int numEntries = 100;
+        final int numEntries = 100;
         byte[][] data = new byte[numEntries][entrySize];
 
         for(int x = 0; x < numEntries; x++) {

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -21,25 +21,25 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         // Check that access to the CorfuRuntime layout is always valid. Specifically, access to the layout
         // while a new layout is being fetched/set concurrently.
 
-        scheduleConcurrently(10000, (v) -> {
+        scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LARGE, (v) -> {
             rt.invalidateLayout();
 
         });
 
-        scheduleConcurrently(10000, (v) -> {
+        scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LARGE, (v) -> {
             assertThat(rt.layout.get().getRuntime()).isEqualTo(rt);
         });
 
-        executeScheduled(2, 30, TimeUnit.SECONDS);
+        executeScheduled(PARAMETERS.CONCURRENCY_TWO, PARAMETERS.TIMEOUT_LONG);
 
     }
 
     @Test
     public void canInstantiateRuntimeWithoutTestRef() throws Exception {
 
-        addSingleServer(9000);
+        addSingleServer(SERVERS.PORT_0);
 
-        CorfuRuntime rt = new CorfuRuntime("test:9000");
+        CorfuRuntime rt = new CorfuRuntime(SERVERS.ENDPOINT_0);
         rt.connect();
 
     }

--- a/test/src/test/java/org/corfudb/runtime/clients/AbstractClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/AbstractClientTest.java
@@ -77,11 +77,12 @@ public abstract class AbstractClientTest extends AbstractCorfuTest {
     abstract Set<IClient> getClientsForTest();
 
     public ServerContext defaultServerContext() {
+        final int MAX_CACHE = 256_000_000;
         return new ServerContextBuilder()
                 .setInitialToken(0)
                 .setMemory(true)
                 .setSingle(false)
-                .setMaxCache(256000000)
+                .setMaxCache(MAX_CACHE)
                 .setServerRouter(serverRouter)
                 .build();
     }

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -38,13 +38,14 @@ public class LogUnitClientTest extends AbstractClientTest {
     @Override
     Set<AbstractServer> getServersForTest() {
         dirPath = getTempDir();
+        final int MAX_CACHE = 256_000_000;
         serverContext = new ServerContextBuilder()
                 .setInitialToken(0)
                 .setSingle(false)
                 .setNoVerify(false)
                 .setMemory(false)
                 .setLogPath(dirPath)
-                .setMaxCache(256000000)
+                .setMaxCache(MAX_CACHE)
                 .setServerRouter(serverRouter)
                 .build();
         server = new LogUnitServer(serverContext);
@@ -117,18 +118,21 @@ public class LogUnitClientTest extends AbstractClientTest {
     @Test
     public void backpointersCanBeWrittenAndRead()
             throws Exception {
+        final long ADDRESS_0 = 1337L;
+        final long ADDRESS_1 = 1338L;
+
         byte[] testString = "hello world".getBytes();
         client.write(0, Collections.<UUID>emptySet(), 0, testString,
                 ImmutableMap.<UUID, Long>builder()
-                        .put(CorfuRuntime.getStreamID("hello"), 1337L)
-                        .put(CorfuRuntime.getStreamID("hello2"), 1338L)
+                        .put(CorfuRuntime.getStreamID("hello"), ADDRESS_0)
+                        .put(CorfuRuntime.getStreamID("hello2"), ADDRESS_1)
                         .build()).get();
 
         LogData r = client.read(0).get().getReadSet().get(0L);
         assertThat(r.getBackpointerMap())
-                .containsEntry(CorfuRuntime.getStreamID("hello"), 1337L);
+                .containsEntry(CorfuRuntime.getStreamID("hello"), ADDRESS_0);
         assertThat(r.getBackpointerMap())
-                .containsEntry(CorfuRuntime.getStreamID("hello2"), 1338L);
+                .containsEntry(CorfuRuntime.getStreamID("hello2"), ADDRESS_1);
     }
 
     @Test
@@ -144,9 +148,10 @@ public class LogUnitClientTest extends AbstractClientTest {
                 .isEqualTo(testString);
         assertThat(r.getMetadataMap().get(IMetadata.LogUnitMetadataType.COMMIT));
 
+        final long OUTSIDE_ADDRESS = 10L;
         UUID streamA = CorfuRuntime.getStreamID("streamA");
         client.writeStream(1, Collections.singletonMap(streamA, 0L), testString).get();
-        client.writeCommit(Collections.singletonMap(streamA, 0L), 10L, true).get(); // 10L shouldn't matter
+        client.writeCommit(Collections.singletonMap(streamA, 0L), OUTSIDE_ADDRESS, true).get(); // 10L shouldn't matter
 
         r = client.read(streamA, Range.singleton(0L)).get().getReadSet().get(0L);
         assertThat(r.getType())
@@ -172,8 +177,10 @@ public class LogUnitClientTest extends AbstractClientTest {
         String logDir = (String) serverContext.getServerConfig().get("--log-path");
         String logFilePath = logDir + File.separator + "log/0.log";
         RandomAccessFile file = new RandomAccessFile(logFilePath, "rw");
-        file.seek(64 + 2); // File header + delimiter
-        file.writeInt(0xffff);
+        final long FILE_HEADER = 64;
+        final int CORRUPT_BYTES = 0xFFFF;
+        file.seek(FILE_HEADER + 2); // File header + delimiter
+        file.writeInt(CORRUPT_BYTES);
         file.close();
 
         // Try to read a corrupted log entry

--- a/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
@@ -25,11 +25,12 @@ public class ManagementClientTest extends AbstractClientTest {
 
     @Override
     Set<AbstractServer> getServersForTest() {
+        final int MAX_CACHE = 256_000_000;
         ServerContext serverContext = new ServerContextBuilder()
                 .setInitialToken(0)
                 .setMemory(true)
                 .setSingle(true)
-                .setMaxCache(256000000)
+                .setMaxCache(MAX_CACHE)
                 .setServerRouter(serverRouter)
                 .build();
         server = new ManagementServer(serverContext);
@@ -65,7 +66,7 @@ public class ManagementClientTest extends AbstractClientTest {
     public void handleBootstrap()
             throws Exception {
         // Since the servers are started as single nodes thus already bootstrapped.
-        assertThatThrownBy(() -> client.bootstrapManagement(TestLayoutBuilder.single(9000)).get()).isInstanceOf(ExecutionException.class);
+        assertThatThrownBy(() -> client.bootstrapManagement(TestLayoutBuilder.single(SERVERS.PORT_0)).get()).isInstanceOf(ExecutionException.class);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -27,6 +27,9 @@ import java.util.concurrent.atomic.AtomicLong;
  * Created by mwei on 12/13/15.
  */
 @Slf4j
+// this class does not have access to parameters and is
+// scheduled to be deprecated anyway.
+@SuppressWarnings("checkstyle:magicnumber")
 public class TestClientRouter implements IClientRouter {
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.clients;
 
+import org.apache.bcel.generic.NEW;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.infrastructure.BaseServer;
 import org.corfudb.infrastructure.TestServerRouter;
@@ -54,7 +55,8 @@ public class TestClientRouterTest extends AbstractCorfuTest {
         assertThat(bc.pingSync())
                 .isTrue();
 
-        assertThatThrownBy(() -> bc.setRemoteEpoch(9L).get())
+        final long NEW_EPOCH = 9L;
+        assertThatThrownBy(() -> bc.setRemoteEpoch(NEW_EPOCH).get())
                 .hasCauseInstanceOf(TimeoutException.class);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
@@ -241,8 +241,9 @@ public class FGMapTest extends AbstractViewTest {
             throws Exception {
         getDefaultRuntime();
 
+        final int NUM_BUCKETS = 20;
         Map<String, String> testMap = getRuntime().getObjectsView()
-                .open(UUID.randomUUID(), FGMap.class, 20);
+                .open(UUID.randomUUID(), FGMap.class, NUM_BUCKETS);
 
         final int num_threads = PARAMETERS.CONCURRENCY_SOME;
         final int num_records = PARAMETERS.NUM_ITERATIONS_LOW;

--- a/test/src/test/java/org/corfudb/runtime/collections/PutIfAbsentMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/PutIfAbsentMapTest.java
@@ -57,10 +57,10 @@ public class PutIfAbsentMapTest extends AbstractViewTest {
                 .open();
 
         ConcurrentLinkedQueue<Boolean> resultList = new ConcurrentLinkedQueue<>();
-        scheduleConcurrently(100, x -> {
+        scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW, x -> {
             resultList.add(stringMap.putIfAbsent("a", Integer.toString(x)));
         });
-        executeScheduled(4, 30, TimeUnit.SECONDS);
+        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_LONG);
 
         long trueCount = resultList.stream()
                 .filter(x -> x)

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -388,7 +388,9 @@ public class SMRMapTest extends AbstractViewTest {
                 .forEach(l -> {
                     try {
                         getRuntime().getObjectsView().TXBegin();
-                        testMap.put(Integer.toString(l), new TestObject(Integer.toString(l), l, ImmutableMap.of(
+                        testMap.put(Integer.toString(l),
+                                new TestObject(Integer.toString(l), l,
+                                        ImmutableMap.of(
                                 Integer.toString(l), l)));
                         if (l > 0) {
                             assertThat(testMap.get(Integer.toString(l - 1)).getTestInt())
@@ -403,7 +405,7 @@ public class SMRMapTest extends AbstractViewTest {
         assertThat(testMap.get("3").getTestString())
                 .isEqualTo("3");
         assertThat(testMap.get("3").getTestInt())
-                .isEqualTo(3);
+                .isEqualTo(Integer.parseInt("3"));
     }
 
     @Test
@@ -512,10 +514,13 @@ public class SMRMapTest extends AbstractViewTest {
                 .addOption(ObjectOpenOptions.NO_CACHE)
                 .open();
         // Do a get to prompt the sync
-        assertThat(testMap2.get(Integer.toString(0))).isEqualTo(Integer.toString(0));
+        assertThat(testMap2.get(Integer.toString(0)))
+                .isEqualTo(Integer.toString(0));
         long endTime = System.nanoTime();
 
-        testStatus += "Time to sync whole stream=" + String.format("%d us", (endTime - startTime) / 1000);
+        final int MILLISECONDS_TO_MICROSECONDS = 1000;
+        testStatus += "Time to sync whole stream=" + String.format("%d us",
+                (endTime - startTime) / MILLISECONDS_TO_MICROSECONDS);
     }
 
     @Data

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectConcurrencyTest.java
@@ -21,16 +21,17 @@ public class CorfuSMRObjectConcurrencyTest extends AbstractViewTest {
     public void testCorfuSharedCounterConcurrentReads() throws Exception {
         getDefaultRuntime();
 
+        final int COUNTER_INITIAL = 55;
         CorfuSharedCounter sharedCounter = getRuntime().getObjectsView().
                 build().
                 setStreamName("test")
                 .setType(CorfuSharedCounter.class)
                 .open();
-        sharedCounter.setValue(55);
+        sharedCounter.setValue(COUNTER_INITIAL);
 
-        int concurrency = 10;
-        int writeconcurrency = 5;
-        int writerwork = 50;
+        int concurrency = PARAMETERS.CONCURRENCY_SOME * 2;
+        int writeconcurrency = PARAMETERS.CONCURRENCY_SOME;
+        int writerwork = PARAMETERS.NUM_ITERATIONS_LOW;
 
         sharedCounter.setValue(-1);
         assertThat(sharedCounter.getValue())
@@ -43,7 +44,7 @@ public class CorfuSMRObjectConcurrencyTest extends AbstractViewTest {
         );
         scheduleConcurrently(concurrency-writeconcurrency, t -> {
                     int lastread = -1;
-                    for (int i = 0; i < 1000; i++) {
+                    for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
                         int res = sharedCounter.getValue();
                         boolean assertflag =
                                 (

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -50,15 +50,16 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
             throws Exception {
         getDefaultRuntime();
 
+        final int TEST_VALUE = 42;
         TestClass testClass = getRuntime().getObjectsView()
                 .build()
                 .setStreamName("test")
                 .setType(TestClass.class)
                 .open();
 
-        testClass.set(52);
+        testClass.set(TEST_VALUE);
         assertThat(testClass.get())
-                .isEqualTo(52);
+                .isEqualTo(TEST_VALUE);
 
         CorfuRuntime runtime2 = new CorfuRuntime(getDefaultEndpoint());
         runtime2.connect();
@@ -70,7 +71,7 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
                 .open();
 
         assertThat(testClass2.get())
-                .isEqualTo(52);
+                .isEqualTo(TEST_VALUE);
     }
 
     @Test
@@ -106,7 +107,7 @@ public class CorfuSMRObjectProxyTest extends AbstractViewTest {
         Map<String, String> testMap = getRuntime().getObjectsView().open(
                 CorfuRuntime.getStreamID("test"), TreeMap.class);
         testMap.clear();
-        int num_threads = 5;
+        int num_threads = PARAMETERS.CONCURRENCY_SOME;
         int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
 
         scheduleConcurrently(num_threads, threadNumber -> {

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/LockingTransactionalContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/LockingTransactionalContextTest.java
@@ -37,21 +37,26 @@ public class LockingTransactionalContextTest extends AbstractViewTest {
                 .setTypeToken(new TypeToken<SMRMap<Integer, Integer>>() {})
                 .open();
 
+        final int KEY_0 = 0;
+        final int KEY_1 = 100;
 
-        map1.put(0, 100);
-        map2.put(100, 0);
+        final int VAL_0 = 100;
+        final int VAL_1 = 0;
+
+        map1.put(KEY_0, VAL_0);
+        map2.put(KEY_1, VAL_1);
 
         getRuntime().getObjectsView().TXBegin(TransactionStrategy.LOCKING, map1, map2);
-        int temp = map2.get(100);
-        map2.put(100, map1.get(0));
-        map1.put(0, temp);
+        int temp = map2.get(KEY_1);
+        map2.put(KEY_1, map1.get(KEY_0));
+        map1.put(KEY_0, temp);
         getRuntime().getObjectsView().TXEnd();
 
         assertThat(map1)
-                .containsEntry(0, 0);
-        map2.get(100);
+                .containsEntry(KEY_0, VAL_1);
+        map2.get(KEY_1);
         assertThat(map2)
-                .containsEntry(100, 100);
+                .containsEntry(KEY_1, VAL_0);
     }
 
     // Note:: this is for TESTING only, abort rate will be high because of locks inside maps shared by threads.
@@ -75,8 +80,8 @@ public class LockingTransactionalContextTest extends AbstractViewTest {
                 .open();
 
 
-        final int num_threads = 10;
-        final int num_records = 10;
+        final int num_threads = PARAMETERS.CONCURRENCY_SOME;
+        final int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
 
         IntStream.range(0, num_threads * num_records)
                 .forEach(x -> {
@@ -117,7 +122,7 @@ public class LockingTransactionalContextTest extends AbstractViewTest {
         });
 
         long startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, 30, TimeUnit.SECONDS);
+        executeScheduled(num_threads, PARAMETERS.TIMEOUT_NORMAL);
         calculateRequestsPerSecond("TPS", num_records * num_threads, startTime);
         calculateAbortRate(aborts.get(), num_records * num_threads);
     }

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -239,8 +239,8 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
      * @return  A default CorfuRuntime
      */
     public CorfuRuntime getDefaultRuntime() {
-        if (!testServerMap.containsKey(getEndpoint(9000))) {
-            addSingleServer(9000);
+        if (!testServerMap.containsKey(getEndpoint(SERVERS.PORT_0))) {
+            addSingleServer(SERVERS.PORT_0);
         }
         return getRuntime().connect();
     }
@@ -316,7 +316,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
      * @return  Returns the default endpoint.
      */
     public String getDefaultEndpoint() {
-        return getEndpoint(9000);
+        return getEndpoint(SERVERS.PORT_0);
     }
 
     /** Get the endpoint string, given a port number.

--- a/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
@@ -54,7 +54,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
                         Integer.toString(i).getBytes(), Collections.emptyMap(), Collections.emptyMap());
             }
         });
-        executeScheduled(numberThreads, 50, TimeUnit.SECONDS);
+        executeScheduled(numberThreads, PARAMETERS.TIMEOUT_LONG);
 
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
@@ -63,7 +63,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
                         .isEqualTo(Integer.toString(i).getBytes());
             }
         });
-        executeScheduled(numberThreads, 50, TimeUnit.SECONDS);
+        executeScheduled(numberThreads, PARAMETERS.TIMEOUT_LONG);
     }
 
     @Test
@@ -71,19 +71,19 @@ public class ChainReplicationViewTest extends AbstractViewTest {
     public void canReadWriteToMultiple()
             throws Exception {
 
-        addServer(9000);
-        addServer(9001);
-        addServer(9002);
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
+        addServer(SERVERS.PORT_2);
 
         bootstrapAllServers(new TestLayoutBuilder()
-                .addLayoutServer(9000)
-                .addSequencer(9000)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_0)
                 .buildSegment()
                     .setReplicationMode(Layout.ReplicationMode.CHAIN_REPLICATION)
                     .buildStripe()
-                        .addLogUnit(9000)
-                        .addLogUnit(9001)
-                        .addLogUnit(9002)
+                        .addLogUnit(SERVERS.PORT_0)
+                        .addLogUnit(SERVERS.PORT_1)
+                        .addLogUnit(SERVERS.PORT_2)
                     .addToSegment()
                 .addToLayout()
                 .build());
@@ -112,19 +112,19 @@ public class ChainReplicationViewTest extends AbstractViewTest {
     public void ensureAllUnitsContainData()
             throws Exception {
 
-        addServer(9000);
-        addServer(9001);
-        addServer(9002);
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
+        addServer(SERVERS.PORT_2);
 
         bootstrapAllServers(new TestLayoutBuilder()
-                .addLayoutServer(9000)
-                .addSequencer(9000)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_0)
                 .buildSegment()
                     .setReplicationMode(Layout.ReplicationMode.CHAIN_REPLICATION)
                     .buildStripe()
-                        .addLogUnit(9000)
-                        .addLogUnit(9001)
-                        .addLogUnit(9002)
+                        .addLogUnit(SERVERS.PORT_0)
+                        .addLogUnit(SERVERS.PORT_1)
+                        .addLogUnit(SERVERS.PORT_2)
                     .addToSegment()
                 .addToLayout()
                 .build());
@@ -146,11 +146,11 @@ public class ChainReplicationViewTest extends AbstractViewTest {
                 .contains(streamA);
 
         // Ensure that the data was written to each logunit.
-        assertThat(getLogUnit(9000))
+        assertThat(getLogUnit(SERVERS.PORT_0))
                 .matchesDataAtAddress(0, testPayload);
-        assertThat(getLogUnit(9001))
+        assertThat(getLogUnit(SERVERS.PORT_1))
                 .matchesDataAtAddress(0, testPayload);
-        assertThat(getLogUnit(9002))
+        assertThat(getLogUnit(SERVERS.PORT_2))
                 .matchesDataAtAddress(0, testPayload);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -29,11 +29,11 @@ public class LayoutViewTest extends AbstractViewTest {
         CorfuRuntime r = getDefaultRuntime().connect();
         Layout l = new TestLayoutBuilder()
                 .setEpoch(1)
-                .addLayoutServer(9000)
-                .addSequencer(9000)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_0)
                 .buildSegment()
                 .buildStripe()
-                .addLogUnit(9000)
+                .addLogUnit(SERVERS.PORT_0)
                 .addToSegment()
                 .addToLayout()
                 .build();
@@ -48,17 +48,17 @@ public class LayoutViewTest extends AbstractViewTest {
     @Test
     public void canTolerateLayoutServerFailure()
             throws Exception {
-        addServer(9000);
-        addServer(9001);
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
 
         bootstrapAllServers(new TestLayoutBuilder()
                 .setEpoch(1L)
-                .addLayoutServer(9000)
-                .addLayoutServer(9001)
-                .addSequencer(9000)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_0)
                 .buildSegment()
                 .buildStripe()
-                .addLogUnit(9000)
+                .addLogUnit(SERVERS.PORT_0)
                 .addToSegment()
                 .addToLayout()
                 .build());
@@ -66,7 +66,7 @@ public class LayoutViewTest extends AbstractViewTest {
         CorfuRuntime r = getRuntime().connect();
 
         // Fail the network link between the client and test server
-        addServerRule(9001, new TestRule()
+        addServerRule(SERVERS.PORT_1, new TestRule()
                 .always()
                 .drop());
 
@@ -79,8 +79,8 @@ public class LayoutViewTest extends AbstractViewTest {
      * Fail a server and reconfigure
      * while data operations are going on.
      * Details:
-     * Start with a configuration of 3 servers 9000, 9001, 9002.
-     * Perform data operations. Fail 9001 and reconfigure to have only 9000 and 9002.
+     * Start with a configuration of 3 servers SERVERS.PORT_0, SERVERS.PORT_1, SERVERS.PORT_2.
+     * Perform data operations. Fail SERVERS.PORT_1 and reconfigure to have only SERVERS.PORT_0 and SERVERS.PORT_2.
      * Perform data operations while the reconfiguration is going on. The operations should
      * be stuck till the new configuration is chosen and then complete after that.
      * FIXME: We cannot failover the server with the primary sequencer yet.
@@ -90,22 +90,22 @@ public class LayoutViewTest extends AbstractViewTest {
     @Test
     public void reconfigurationDuringDataOperations()
             throws Exception {
-        addServer(9000);
-        addServer(9001);
-        addServer(9002);
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
+        addServer(SERVERS.PORT_2);
         Layout l = new TestLayoutBuilder()
                 .setEpoch(1L)
-                .addLayoutServer(9000)
-                .addLayoutServer(9001)
-                .addLayoutServer(9002)
-                .addSequencer(9000)
-                .addSequencer(9001)
-                .addSequencer(9002)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
                 .buildStripe()
-                .addLogUnit(9000)
-                .addLogUnit(9001)
-                .addLogUnit(9002)
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_1)
+                .addLogUnit(SERVERS.PORT_2)
                 .addToSegment()
                 .addToLayout()
                 .build();
@@ -122,18 +122,18 @@ public class LayoutViewTest extends AbstractViewTest {
                 corfuRuntime.invalidateLayout();
 
                 // Fail the network link between the client and test server
-                addServerRule(9001, new TestRule().always().drop());
-                // New layout removes the failed server 9000
+                addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
+                // New layout removes the failed server SERVERS.PORT_0
                 Layout newLayout = new TestLayoutBuilder()
                         .setEpoch(l.getEpoch() + 1)
-                        .addLayoutServer(9000)
-                        .addLayoutServer(9002)
-                        .addSequencer(9000)
-                        .addSequencer(9002)
+                        .addLayoutServer(SERVERS.PORT_0)
+                        .addLayoutServer(SERVERS.PORT_2)
+                        .addSequencer(SERVERS.PORT_0)
+                        .addSequencer(SERVERS.PORT_2)
                         .buildSegment()
                         .buildStripe()
-                        .addLogUnit(9000)
-                        .addLogUnit(9002)
+                        .addLogUnit(SERVERS.PORT_0)
+                        .addLogUnit(SERVERS.PORT_2)
                         .addToSegment()
                         .addToLayout()
                         .build();

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -21,7 +21,8 @@ public class ManagementViewTest extends AbstractViewTest {
      * Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
      * is sent by the Management client to its server.
      */
-    private static final Semaphore failureDetected = new Semaphore(1, true);
+    private static final Semaphore failureDetected = new Semaphore(1,
+            true);
 
     /**
      * Scenario with 2 nodes: SERVERS.PORT_0 and SERVERS.PORT_1.
@@ -57,14 +58,17 @@ public class ManagementViewTest extends AbstractViewTest {
 
         // Adding a rule on SERVERS.PORT_1 to toggle the flag when it sends the
         // MANAGEMENT_FAILURE_DETECTED message.
-        addClientRule(getManagementServer(SERVERS.PORT_1).getCorfuRuntime(), new TestRule().matches(corfuMsg -> {
-            if (corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)) {
+        addClientRule(getManagementServer(SERVERS.PORT_1).getCorfuRuntime(),
+                new TestRule().matches(corfuMsg -> {
+            if (corfuMsg.getMsgType().equals(CorfuMsgType
+                    .MANAGEMENT_FAILURE_DETECTED)) {
                 failureDetected.release();
             }
             return true;
         }));
 
-        assertThat(failureDetected.tryAcquire(PARAMETERS.TIMEOUT_NORMAL.toNanos(),
+        assertThat(failureDetected.tryAcquire(PARAMETERS.TIMEOUT_NORMAL
+                        .toNanos(),
                 TimeUnit.NANOSECONDS)).isEqualTo(true);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -24,26 +24,26 @@ public class ManagementViewTest extends AbstractViewTest {
     private static final Semaphore failureDetected = new Semaphore(1, true);
 
     /**
-     * Scenario with 2 nodes: 9000 and 9001.
-     * We fail 9000 and then listen to intercept the message
-     * sent by 9001's client to the server to handle the failure.
+     * Scenario with 2 nodes: SERVERS.PORT_0 and SERVERS.PORT_1.
+     * We fail SERVERS.PORT_0 and then listen to intercept the message
+     * sent by SERVERS.PORT_1's client to the server to handle the failure.
      *
      * @throws Exception
      */
     @Test
     public void invokeFailureHandler()
             throws Exception {
-        addServer(9000);
-        addServer(9001);
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
         Layout l = new TestLayoutBuilder()
                 .setEpoch(1L)
-                .addLayoutServer(9000)
-                .addLayoutServer(9001)
-                .addSequencer(9000)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_0)
                 .buildSegment()
                 .buildStripe()
-                .addLogUnit(9000)
-                .addLogUnit(9001)
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_1)
                 .addToSegment()
                 .addToLayout()
                 .build();
@@ -51,13 +51,13 @@ public class ManagementViewTest extends AbstractViewTest {
 
         failureDetected.acquire();
 
-        // Adding a rule on 9000 to drop all packets
-        addServerRule(9000, new TestRule().always().drop());
-        getManagementServer(9000).shutdown();
+        // Adding a rule on SERVERS.PORT_0 to drop all packets
+        addServerRule(SERVERS.PORT_0, new TestRule().always().drop());
+        getManagementServer(SERVERS.PORT_0).shutdown();
 
-        // Adding a rule on 9001 to toggle the flag when it sends the
+        // Adding a rule on SERVERS.PORT_1 to toggle the flag when it sends the
         // MANAGEMENT_FAILURE_DETECTED message.
-        addClientRule(getManagementServer(9001).getCorfuRuntime(), new TestRule().matches(corfuMsg -> {
+        addClientRule(getManagementServer(SERVERS.PORT_1).getCorfuRuntime(), new TestRule().matches(corfuMsg -> {
             if (corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)) {
                 failureDetected.release();
             }

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -54,12 +54,16 @@ public class StreamViewTest extends AbstractViewTest {
         byte[] testPayload = "hello world".getBytes();
 
         StreamView sv = r.getStreamsView().get(streamA);
-        scheduleConcurrently(100, i -> sv.write(testPayload));
-        executeScheduled(8, PARAMETERS.TIMEOUT_NORMAL);
+        scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW,
+                i -> sv.write(testPayload));
+        executeScheduled(PARAMETERS.CONCURRENCY_SOME,
+                PARAMETERS.TIMEOUT_NORMAL);
 
-        scheduleConcurrently(100, i -> assertThat(sv.read().getPayload(getRuntime()))
+        scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW,
+                i -> assertThat(sv.read().getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes()));
-        executeScheduled(8, PARAMETERS.TIMEOUT_NORMAL);
+        executeScheduled(PARAMETERS.CONCURRENCY_SOME,
+                PARAMETERS.TIMEOUT_NORMAL);
         assertThat(sv.read())
                 .isEqualTo(null);
     }
@@ -74,12 +78,14 @@ public class StreamViewTest extends AbstractViewTest {
         byte[] testPayload = "hello world".getBytes();
 
         StreamView sv = r.getStreamsView().get(streamA);
-        scheduleConcurrently(100, i -> sv.write(testPayload));
-        executeScheduled(8, PARAMETERS.TIMEOUT_NORMAL);
+        scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW, i ->
+                sv.write(testPayload));
+        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_NORMAL);
 
-        scheduleConcurrently(100, i -> assertThat(sv.read().getPayload(getRuntime()))
+        scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW, i ->
+                assertThat(sv.read().getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes()));
-        executeScheduled(8, PARAMETERS.TIMEOUT_NORMAL);
+        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_NORMAL);
         assertThat(sv.read())
                 .isEqualTo(null);
     }

--- a/test/src/test/java/org/corfudb/util/serializer/SerializersTest.java
+++ b/test/src/test/java/org/corfudb/util/serializer/SerializersTest.java
@@ -12,14 +12,15 @@ public class SerializersTest {
 
     @Test (expected = RuntimeException.class)
     public void registerSerializerWithInvalidTypeTest() {
-        ISerializer customSerializer = new CustomSerializer((byte) 10);
+        final byte SERIALIZER_TYPE0 = 10;
+        ISerializer customSerializer = new CustomSerializer(SERIALIZER_TYPE0);
         Serializers.registerSerializer(customSerializer);
     }
 
     @Test
     public void registerMultipleSerializersTest() {
-        byte type1 = (byte) 11;
-        byte type2 = (byte) 12;
+        final byte type1 = (byte) 11;
+        final byte type2 = (byte) 12;
 
         ISerializer customSerializer1 = new CustomSerializer(type1);
         ISerializer customSerializer2 = new CustomSerializer(type2);

--- a/test_checks.xml
+++ b/test_checks.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<!--
+
+  This is a modified Checkstyle configuration from the Sun coding conventions
+  for Corfu.
+
+  Important differences are:
+
+  1) Method names starting with TX... are allowed.
+  2) Inline conditionals are allowed.
+
+  Checkstyle configuration that checks the sun coding conventions from:
+
+    - the Java Language Specification at
+      http://java.sun.com/docs/books/jls/second_edition/html/index.html
+
+    - the Sun Code Conventions at http://java.sun.com/docs/codeconv/
+
+    - the Javadoc guidelines at
+      http://java.sun.com/j2se/javadoc/writingdoccomments/index.html
+
+    - the JDK Api documentation http://java.sun.com/j2se/docs/api/index.html
+
+    - some best practices
+
+  Checkstyle is very configurable. Be sure to read the documentation at
+  http://checkstyle.sf.net (or in your downloaded distribution).
+
+  Most Checks are configurable, be sure to consult the documentation.
+
+  To completely disable a check, just comment it out or delete it from the file.
+
+  Finally, it is worth reading the documentation.
+
+-->
+
+<module name="Checker">
+    <!--
+        If you set the basedir property below, then all reported file
+        names will be relative to the specified directory. See
+        http://checkstyle.sourceforge.net/5.x/config.html#Checker
+
+        <property name="basedir" value="${basedir}"/>
+    -->
+
+    <property name="fileExtensions" value="java, properties, xml"/>
+
+    <module name="TreeWalker">
+        <module name="MagicNumber"/>
+
+        <module name="SuppressWarningsHolder" />
+    </module>
+
+
+    <module name="SuppressWarningsFilter" />
+
+</module>


### PR DESCRIPTION
Patch #367 introduced constants, which can be controlled on a per-test-run basis.
This patch removes all magic numbers, and adds style checking to enforce that
magic numbers are not used.