### PR TITLE
New temp dir parameter and print of parameters during test

### DIFF
--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -32,7 +32,6 @@ import static org.fusesource.jansi.Ansi.ansi;
 public class AbstractCorfuTest {
 
     public Set<Callable<Object>> scheduledThreads;
-    public Set<String> temporaryDirectories;
     public String testStatus = "";
 
     public static final CorfuTestParameters PARAMETERS =
@@ -116,35 +115,6 @@ public class AbstractCorfuTest {
                 false);
     }
 
-    /** Get a new temporary directory. This temporary directory will be
-     * deleted at the conclusion of this test.
-     * @return  The path to the new temporary directory
-     */
-    public String getNewTempDir() {
-        String tempdir = com.google.common.io.Files.createTempDir()
-                                                    .getAbsolutePath();
-        temporaryDirectories.add(tempdir);
-        return tempdir;
-    }
-
-    /** Setup the temporary directory list by creating a new directory set.
-     *
-     */
-    @Before
-    public void setupTempDirs() {
-        temporaryDirectories = new HashSet<>();
-    }
-
-    /** Cleanup the temporary directories by going through the directory
-     * set and deleting each one.
-     */
-    @After
-    public void deleteTempDirs() {
-        for (String s : temporaryDirectories) {
-            File folder = new File(s);
-            deleteFolder(folder, true);
-        }
-    }
 
     public void calculateAbortRate(int aborts, int transactions) {
         final float FRACTION_TO_PERCENT = 100.0F;

--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -65,18 +65,20 @@ public class AbstractCorfuTest {
         }
     };
 
-    public static void deleteFolder(File folder) {
+    public static void deleteFolder(File folder, boolean deleteSelf) {
         File[] files = folder.listFiles();
         if (files != null) { //some JVMs return null for empty dirs
             for (File f : files) {
                 if (f.isDirectory()) {
-                    deleteFolder(f);
+                    deleteFolder(f, true);
                 } else {
                     f.delete();
                 }
             }
         }
-        folder.delete();
+        if (deleteSelf) {
+            folder.delete();
+        }
     }
 
     @Before
@@ -102,6 +104,12 @@ public class AbstractCorfuTest {
         scheduledThreads.clear();
     }
 
+    @After
+    public void cleanPerTestTempDir() {
+        deleteFolder(new File(PARAMETERS.TEST_TEMP_DIR),
+                false);
+    }
+
     public String getTempDir() {
         String tempdir = com.google.common.io.Files.createTempDir().getAbsolutePath();
         temporaryDirectories.add(tempdir);
@@ -112,7 +120,7 @@ public class AbstractCorfuTest {
     public void deleteTempDirs() {
         for (String s : temporaryDirectories) {
             File folder = new File(s);
-            deleteFolder(folder);
+            deleteFolder(folder, true);
         }
     }
 

--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -65,6 +65,12 @@ public class AbstractCorfuTest {
         }
     };
 
+    /** Delete a folder.
+     *
+     * @param folder        The folder, as a File.
+     * @param deleteSelf    True to delete the folder itself,
+     *                      False to delete just the folder contents.
+     */
     public static void deleteFolder(File folder, boolean deleteSelf) {
         File[] files = folder.listFiles();
         if (files != null) { //some JVMs return null for empty dirs
@@ -91,10 +97,6 @@ public class AbstractCorfuTest {
         scheduledThreads = new HashSet<>();
     }
 
-    @Before
-    public void setupTempDirs() {
-        temporaryDirectories = new HashSet<>();
-    }
 
     @After
     public void cleanupScheduledThreads() {
@@ -104,18 +106,38 @@ public class AbstractCorfuTest {
         scheduledThreads.clear();
     }
 
+    /** Clean the per test temporary directory (PARAMETERS.TEST_TEMP_DIR)
+     * This is different than deleteTempDirs because it does not remove
+     * the directory itself.
+     */
     @After
     public void cleanPerTestTempDir() {
         deleteFolder(new File(PARAMETERS.TEST_TEMP_DIR),
                 false);
     }
 
-    public String getTempDir() {
-        String tempdir = com.google.common.io.Files.createTempDir().getAbsolutePath();
+    /** Get a new temporary directory. This temporary directory will be
+     * deleted at the conclusion of this test.
+     * @return  The path to the new temporary directory
+     */
+    public String getNewTempDir() {
+        String tempdir = com.google.common.io.Files.createTempDir()
+                                                    .getAbsolutePath();
         temporaryDirectories.add(tempdir);
         return tempdir;
     }
 
+    /** Setup the temporary directory list by creating a new directory set.
+     *
+     */
+    @Before
+    public void setupTempDirs() {
+        temporaryDirectories = new HashSet<>();
+    }
+
+    /** Cleanup the temporary directories by going through the directory
+     * set and deleting each one.
+     */
     @After
     public void deleteTempDirs() {
         for (String s : temporaryDirectories) {

--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -106,8 +106,6 @@ public class AbstractCorfuTest {
     }
 
     /** Clean the per test temporary directory (PARAMETERS.TEST_TEMP_DIR)
-     * This is different than deleteTempDirs because it does not remove
-     * the directory itself.
      */
     @After
     public void cleanPerTestTempDir() {

--- a/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
@@ -15,7 +15,7 @@ public class DataStoreTest extends AbstractCorfuTest {
 
     @Test
     public void testPutGet() {
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
         DataStore dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
                 .put("--log-path", serviceDir)
                 .build());
@@ -29,7 +29,7 @@ public class DataStoreTest extends AbstractCorfuTest {
 
     @Test
     public void testPutGetWithRestart() {
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
         DataStore dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
                 .put("--log-path", serviceDir)
                 .build());

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -28,7 +28,7 @@ public class LayoutServerTest extends AbstractServerTest {
 
     @Override
     public LayoutServer getDefaultServer() {
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
         return getDefaultServer(serviceDir);
     }
 
@@ -178,7 +178,7 @@ public class LayoutServerTest extends AbstractServerTest {
     @Test
     public void checkLayoutPersisted() throws Exception {
         //serviceDirectory from which all instances of corfu server are to be booted.
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
         LayoutServer s1 = getDefaultServer(serviceDir);
 
@@ -232,7 +232,7 @@ public class LayoutServerTest extends AbstractServerTest {
      */
     @Test
     public void checkPaxosPhasesPersisted() throws Exception {
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
         LayoutServer s1 = getDefaultServer(serviceDir);
 
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
@@ -280,7 +280,7 @@ public class LayoutServerTest extends AbstractServerTest {
      */
     @Test
     public void checkMessagesValidatedAgainstPhase1PersistedData() throws Exception {
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
         LayoutServer s1 = getDefaultServer(serviceDir);
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         bootstrapServer(layout);
@@ -324,7 +324,7 @@ public class LayoutServerTest extends AbstractServerTest {
      */
     @Test
     public void checkMessagesValidatedAgainstPhase2PersistedData() throws Exception {
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
         LayoutServer s1 = getDefaultServer(serviceDir);
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         bootstrapServer(layout);
@@ -381,7 +381,7 @@ public class LayoutServerTest extends AbstractServerTest {
      */
     @Test
     public void checkPhase1AndPhase2MessagesFromMultipleClients() throws Exception {
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
         LayoutServer s1 = getDefaultServer(serviceDir);
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
@@ -440,7 +440,7 @@ public class LayoutServerTest extends AbstractServerTest {
 
     @Test
     public void testReboot() throws Exception {
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
         LayoutServer s1 = getDefaultServer(serviceDir);
         setServer(s1);
 

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -60,7 +60,7 @@ public class LogUnitServerTest extends AbstractServerTest {
     @Test
     public void checkThatWritesArePersisted()
             throws Exception {
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
         LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
                 .setLogPath(serviceDir)
@@ -157,7 +157,7 @@ public class LogUnitServerTest extends AbstractServerTest {
     @Test (expected = RuntimeException.class)
     public void testInvalidLogVersion() throws Exception {
         // Create a log file with an invalid version
-        String tempDir = getTempDir();
+        String tempDir = PARAMETERS.TEST_TEMP_DIR;
         createLogFile(tempDir, StreamLogFiles.VERSION + 1, false);
 
         // Start a new logging version
@@ -173,7 +173,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         boolean noVerify = true;
 
         // Generate a log file without computing the checksum for log entries
-        String tempDir = getTempDir();
+        String tempDir = PARAMETERS.TEST_TEMP_DIR;
         createLogFile(tempDir, StreamLogFiles.VERSION + 1, noVerify);
 
         // Start a new logging version

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -196,7 +196,7 @@ public class SequencerServerTest extends AbstractServerTest {
     @Test
     public void checkSequencerCheckpointingWorks()
             throws Exception {
-        String serviceDir = getTempDir();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
         SequencerServer s1 = new SequencerServer(new ServerContextBuilder()
                 .setLogPath(serviceDir)

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class StreamLogFilesTest extends AbstractCorfuTest {
 
     private String getDirPath() {
-        return getTempDir() + File.separator;
+        return PARAMETERS.TEST_TEMP_DIR + File.separator;
     }
 
     @Test
@@ -40,8 +40,12 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
 
         // Disable checksum, then write and read then same entry
-        log = new StreamLogFiles(getDirPath(), true);
-        log.append(address0, new LogData(DataType.DATA, b));
+        // An overwrite exception should occur, since we are writing the
+        // same entry.
+        final StreamLog newLog = new StreamLogFiles(getDirPath(), true);
+        assertThatThrownBy(() -> { newLog
+                .append(address0, new LogData(DataType.DATA, b)); })
+                .isInstanceOf(OverwriteException.class);
         assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -37,7 +37,7 @@ public class LogUnitClientTest extends AbstractClientTest {
 
     @Override
     Set<AbstractServer> getServersForTest() {
-        dirPath = getTempDir();
+        dirPath = PARAMETERS.TEST_TEMP_DIR;
         final int MAX_CACHE = 256_000_000;
         serverContext = new ServerContextBuilder()
                 .setInitialToken(0)


### PR DESCRIPTION
This patch introduces a new temporary directory parameter
which ensures the same temporary directory is used 
throughout the entire test.