### PR TITLE
fix javadocs for multi-module build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,7 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.1</version>
                 <configuration>
+                    <aggregate>true</aggregate>
                     <additionalparam>-Xdoclint:none</additionalparam>
                 </configuration>
             </plugin>


### PR DESCRIPTION
After moving to a multi-module build, javadoc production in travis stopped working. This patch turns on javadoc aggregation, which should make the script work again.