### PR TITLE
Disable Replex unit tests

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/collections/ReplexSMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/ReplexSMRMapTest.java
@@ -1,6 +1,8 @@
 package org.corfudb.runtime.collections;
 
 import com.google.common.reflect.TypeToken;
+import groovy.lang.DelegatesTo;
+import org.corfudb.AbstractCorfuTest;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.Layout;
 import org.junit.Before;
@@ -17,19 +19,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by mwei on 1/8/16.
  */
-public class ReplexSMRMapTest extends SMRMapTest {
+public class ReplexSMRMapTest extends AbstractCorfuTest {
 
-    @Before
-    @Override
-    public void setRuntime() throws Exception {
-        r = getDefaultRuntime().connect();
-        // First commit a layout that uses Replex
-        Layout newLayout = r.layout.get();
-        newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.REPLEX);
-        newLayout.getSegment(0L).setReplexes(Collections.singletonList(
-                new Layout.LayoutStripe(Collections.singletonList(defaultConfigurationString))));
-        newLayout.setEpoch(1);
-        r.getLayoutView().committed(1, newLayout);
-        r.invalidateLayout();
+    /** Replex tests are disabled until unit tests stabilize
+     * TODO: Restore & fix up test as of commit 3567e2ee6b
+     */
+
+    @Test
+    public void replexTestsAreDisabled() {
+        testStatus = "TODO";
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/collections/ReplexSMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/ReplexSMRMapTest.java
@@ -27,6 +27,5 @@ public class ReplexSMRMapTest extends AbstractCorfuTest {
 
     @Test
     public void replexTestsAreDisabled() {
-        testStatus = "TODO";
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ReplexStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ReplexStreamViewTest.java
@@ -26,6 +26,5 @@ public class ReplexStreamViewTest extends AbstractCorfuTest {
 
     @Test
     public void replexTestsAreDisabled() {
-        testStatus = "TODO";
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ReplexStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ReplexStreamViewTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.view;
 
 import lombok.Getter;
+import org.corfudb.AbstractCorfuTest;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
@@ -17,20 +18,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by mwei on 1/8/16.
  */
-public class ReplexStreamViewTest extends StreamViewTest {
+public class ReplexStreamViewTest extends AbstractCorfuTest {
 
-    @Before
-    @Override
-    public void setRuntime() throws Exception {
-        r = getDefaultRuntime().connect();
-        // First commit a layout that uses Replex
-        Layout newLayout = r.layout.get();
-        newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.REPLEX);
-        newLayout.getSegment(0L).setReplexes(Collections.singletonList(
-                new Layout.LayoutStripe(Collections.singletonList(defaultConfigurationString))));
-        newLayout.setEpoch(1);
-        r.getLayoutView().committed(1L, newLayout);
-        r.invalidateLayout();
+    /** Replex tests are disabled until unit tests stabilize
+     * TODO: Restore & fix up test as of commit 3567e2ee6b
+     */
+
+    @Test
+    public void replexTestsAreDisabled() {
+        testStatus = "TODO";
     }
-
 }


### PR DESCRIPTION
As discussed in followup to #359, I propose replacing the existing Replex unit tests with TODO placeholders.  If review suggests removing the unit test classes altogether (or some other change), I'm fine with that.

Placeholder output looks like this (`egrep -i "todo|replex"`):

    Running org.corfudb.runtime.collections.ReplexSMRMapTest
    replexTestsAreDisabled                                      [PASS] [TODO]
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.corfudb.runtime.collections.ReplexSMRMapTest
    Running org.corfudb.runtime.view.ReplexStreamViewTest
    replexTestsAreDisabled                                      [PASS] [TODO]
    Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 sec - in org.corfudb.runtime.view.ReplexStreamViewTest
