### PR TITLE
Add an annotation to disable tests on Travis.

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/collections/ReplexSMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/ReplexSMRMapTest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.collections;
 import com.google.common.reflect.TypeToken;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.Layout;
+import org.corfudb.test.DisabledOnTravis;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -17,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by mwei on 1/8/16.
  */
+@DisabledOnTravis
 public class ReplexSMRMapTest extends SMRMapTest {
 
     @Before

--- a/test/src/test/java/org/corfudb/test/DisabledOnTravis.java
+++ b/test/src/test/java/org/corfudb/test/DisabledOnTravis.java
@@ -1,0 +1,15 @@
+package org.corfudb.test;
+
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/** Marks that a test should not run on Travis-CI, typically because
+ * the results are always random, the test is extremely long running,
+ * or the test is not mature.
+ * Created by mwei on 12/13/16.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface DisabledOnTravis {
+}


### PR DESCRIPTION
This patch introduces the `@DisabledOnTravis` annotation, which allows us to temporarily disable tests
on Travis. This should be used when a test has transient issues which may be due to timeouts, allow
development of the test to continue without breaking the build.