### PR TITLE
Add conflict parameter annotation and a map for accessing the conflict objects

### DIFF
--- a/annotations/src/main/java/org/corfudb/annotations/ConflictParameter.java
+++ b/annotations/src/main/java/org/corfudb/annotations/ConflictParameter.java
@@ -1,0 +1,18 @@
+package org.corfudb.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** This annotation marks that a parameter should be considered
+ * to generate the hash for fine-grained conflict resolution.
+ *
+ * Created by mwei on 12/15/16.
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface ConflictParameter {
+}

--- a/annotations/src/main/java/org/corfudb/runtime/object/IConflictFunction.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/IConflictFunction.java
@@ -1,0 +1,12 @@
+package org.corfudb.runtime.object;
+
+/** A function which is used to calculate the fine-grained conflict set.
+ * Created by mwei on 12/15/16.
+ */
+public interface IConflictFunction {
+    /** Given the parameters to a function, calculate the conflict set.
+     * @param args  The arguments to the function.
+     * @return      The fine-grained conflict set.
+     */
+    Object[] calculate(Object... args);
+}

--- a/annotations/src/main/java/org/corfudb/runtime/object/IConflictFunction.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/IConflictFunction.java
@@ -1,12 +1,12 @@
 package org.corfudb.runtime.object;
 
-/** A function which is used to calculate the fine-grained conflict set.
+/** A function which is used to getConflictSet the fine-grained conflict set.
  * Created by mwei on 12/15/16.
  */
 public interface IConflictFunction {
-    /** Given the parameters to a function, calculate the conflict set.
+    /** Given the parameters to a function, getConflictSet the conflict set.
      * @param args  The arguments to the function.
      * @return      The fine-grained conflict set.
      */
-    Object[] calculate(Object... args);
+    Object[] getConflictSet(Object... args);
 }

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
@@ -29,7 +29,9 @@ public interface ICorfuSMR<T> {
     /** Get a map from strings (function names) to undoRecord methods.
      * @return The undo record map. */
     Map<String, IUndoRecordFunction<T>> getCorfuUndoRecordMap();
-
+    /** Get a map from strings (function names) to conflict methods.
+     * @return The undo record map. */
+    Map<String, IConflictFunction> getCorfuConflictMap();
 
     /** Return the stream ID that this object belongs to.
      * @return The stream ID this object belongs to. */

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
@@ -30,7 +30,7 @@ public interface ICorfuSMR<T> {
      * @return The undo record map. */
     Map<String, IUndoRecordFunction<T>> getCorfuUndoRecordMap();
     /** Get a map from strings (function names) to conflict methods.
-     * @return The undo record map. */
+     * @return The conflict map. */
     Map<String, IConflictFunction> getCorfuConflictMap();
 
     /** Return the stream ID that this object belongs to.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -156,7 +156,7 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      *                                       or value prevents it from being stored in this map
      */
     @Mutator(name = "put", noUpcall = true)
-    default void blindPut(@ConflictParameter K key, V value) {
+    default void blindPut(K key, V value) {
         put(key, value);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -105,7 +105,7 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      */
     @Accessor
     @Override
-    V get(Object key);
+    V get(@ConflictParameter Object key);
 
     /**
      * Associates the specified value with the specified key in this map
@@ -133,10 +133,30 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      */
     @MutatorAccessor(name = "put", undoFunction = "undoPut", undoRecordFunction = "undoPutRecord")
     @Override
-    V put(K key, V value);
+    V put(@ConflictParameter K key, V value);
 
+
+    /**
+     * Associates the specified value with the specified key in this map
+     * without return the previous value.  If the map previously contained a
+     * mapping for the key, the old value is replaced by the specified value.
+     * (A map <tt>m</tt> is said to contain a mapping for a key <tt>k</tt> if
+     * and only if {@link #containsKey(Object) m.containsKey(k)} would return
+     * <tt>true</tt>.)
+     *
+     * @param key   key with which the specified value is to be associated
+     * @param value value to be associated with the specified key
+     * @throws UnsupportedOperationException if the <tt>put</tt> operation
+     *                                       is not supported by this map
+     * @throws ClassCastException            if the class of the specified key or value
+     *                                       prevents it from being stored in this map
+     * @throws NullPointerException          if the specified key or value is null
+     *                                       and this map does not permit null keys or values
+     * @throws IllegalArgumentException      if some property of the specified key
+     *                                       or value prevents it from being stored in this map
+     */
     @Mutator(name = "put", noUpcall = true)
-    default void blindPut(K key, V value) {
+    default void blindPut(@ConflictParameter K key, V value) {
         put(key, value);
     }
 
@@ -204,7 +224,7 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      */
     @MutatorAccessor(name="remove", undoFunction = "undoRemove", undoRecordFunction = "undoRemoveRecord")
     @Override
-    V remove(Object key);
+    V remove(@ConflictParameter Object key);
 
     /** Generate an undo record for a remove, given the previous state of the map
      * and the parameters to the remove call.

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -69,6 +69,13 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
     @Getter
     final Map<String, IUndoRecordFunction<T>> undoRecordTargetMap;
 
+    /** A conflict function map. This map contains functions which given
+     * the name of the function and its parameters, calculates the
+     * fine-grained conflict set.
+     */
+    @Getter
+    final Map<String, IConflictFunction> conflictFunctionMap;
+
     /** The arguments this proxy was created with.
      *
      */
@@ -94,7 +101,8 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                              ISerializer serializer,
                              Map<String, ICorfuSMRUpcallTarget<T>> upcallTargetMap,
                              Map<String, IUndoFunction<T>> undoTargetMap,
-                             Map<String, IUndoRecordFunction<T>> undoRecordTargetMap
+                             Map<String, IUndoRecordFunction<T>> undoRecordTargetMap,
+                             Map<String, IConflictFunction> conflictFunctionMap
                              ) {
         this.rt = rt;
         this.streamID = streamID;
@@ -105,6 +113,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         this.upcallTargetMap = upcallTargetMap;
         this.undoTargetMap = undoTargetMap;
         this.undoRecordTargetMap = undoRecordTargetMap;
+        this.conflictFunctionMap = conflictFunctionMap;
 
         this.pendingUpcalls = new ConcurrentSet<>();
         this.upcallResults = new ConcurrentHashMap<>();

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -47,7 +47,8 @@ public class CorfuCompileWrapperBuilder {
                 type, args, serializer,
                 wrapperObject.getCorfuSMRUpcallMap(),
                 wrapperObject.getCorfuUndoMap(),
-                wrapperObject.getCorfuUndoRecordMap()));
+                wrapperObject.getCorfuUndoRecordMap(),
+                wrapperObject.getCorfuConflictMap()));
 
         if (wrapperObject instanceof ICorfuSMRProxyWrapper) {
             ((ICorfuSMRProxyWrapper) wrapperObject)

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -467,4 +467,42 @@ public class CompileProxyTest extends AbstractViewTest {
 
     }
 
+    /** Checks that the fine-grained conflict set is correctly produced
+     * by the annotation framework.
+     *
+     * Each method in ConflictParameterClass is executed, and the result
+     * of invoking the method from the conflict function map should be
+     * the objects annotated by conflict parameter.
+     */
+    @Test
+    public void checkConflictParameters() {
+        ConflictParameterClass testObject = getDefaultRuntime()
+                .getObjectsView().build()
+                .setStreamName("my stream")
+                .setUseCompiledClass(true)
+                .setType(ConflictParameterClass.class)
+                .open();
+
+        ICorfuSMR<ConflictParameterClass> testObjectSMR =
+                (ICorfuSMR<ConflictParameterClass>) testObject;
+        CorfuCompileProxy<ConflictParameterClass> proxy =
+                (CorfuCompileProxy<ConflictParameterClass>) testObjectSMR
+                        .getCorfuSMRProxy();
+
+        // mutator test -> second option should be conflict
+        assertThat(proxy.getConflictFunctionMap().get("mutatorTest")
+                .calculate(0, 1))
+                .contains(1);
+
+        // accessor test -> first option should be conflict.
+        assertThat(proxy.getConflictFunctionMap().get("accessorTest")
+                .calculate("a", "b"))
+                .contains("a");
+
+        // mutatorAccessor test -> first option should be conflict.
+        assertThat(proxy.getConflictFunctionMap().get("mutatorAccessorTest")
+                .calculate("a", "b"))
+                .contains("a");
+    }
+
 }

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -1,28 +1,14 @@
 package org.corfudb.runtime.object;
 
 import com.google.common.reflect.TypeToken;
-import lombok.Getter;
-import lombok.Setter;
-import org.corfudb.annotations.Accessor;
-import org.corfudb.annotations.CorfuObject;
-import org.corfudb.annotations.Mutator;
-import org.corfudb.annotations.MutatorAccessor;
-import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.runtime.collections.SMRMap;
-import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.StreamView;
-import org.corfudb.runtime.view.StreamsView;
 import org.junit.Test;
-import org.omg.CORBA.INITIALIZE;
-import org.omg.CORBA.TIMEOUT;
 
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
@@ -491,17 +477,17 @@ public class CompileProxyTest extends AbstractViewTest {
 
         // mutator test -> second option should be conflict
         assertThat(proxy.getConflictFunctionMap().get("mutatorTest")
-                .calculate(0, 1))
+                .getConflictSet(0, 1))
                 .contains(1);
 
         // accessor test -> first option should be conflict.
         assertThat(proxy.getConflictFunctionMap().get("accessorTest")
-                .calculate("a", "b"))
+                .getConflictSet("a", "b"))
                 .contains("a");
 
         // mutatorAccessor test -> first option should be conflict.
         assertThat(proxy.getConflictFunctionMap().get("mutatorAccessorTest")
-                .calculate("a", "b"))
+                .getConflictSet("a", "b"))
                 .contains("a");
     }
 

--- a/test/src/test/java/org/corfudb/runtime/object/ConflictParameterClass.java
+++ b/test/src/test/java/org/corfudb/runtime/object/ConflictParameterClass.java
@@ -1,0 +1,29 @@
+package org.corfudb.runtime.object;
+
+import org.corfudb.annotations.Accessor;
+import org.corfudb.annotations.ConflictParameter;
+import org.corfudb.annotations.CorfuObject;
+import org.corfudb.annotations.Mutator;
+import org.corfudb.annotations.MutatorAccessor;
+
+/**
+ * Created by mwei on 12/15/16.
+ */
+@CorfuObject
+public class ConflictParameterClass {
+
+    @Mutator
+    void mutatorTest(int test1, @ConflictParameter int test2) {
+
+    }
+
+    @Accessor
+    int accessorTest(@ConflictParameter String test1, String test2) {
+        return 0;
+    }
+
+    @MutatorAccessor
+    Object mutatorAccessorTest(@ConflictParameter String test1, String test2) {
+        return 0;
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -41,7 +41,8 @@ public class ObjectsViewTest extends AbstractViewTest {
 
         Map<String, String> smrMap = r.getObjectsView().open("map a", SMRMap.class);
         smrMap.put("a", "a");
-        Map<String, String> smrMapCopy = r.getObjectsView().copy(smrMap, "map a copy");
+        Map<String, String> smrMapCopy = r.getObjectsView()
+                .copy(smrMap, "map a copy");
         smrMapCopy.put("b", "b");
 
         assertThat(smrMapCopy)

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="TRACE">
         <!--<appender-ref ref="STDOUT" />-->
     </root>
 </configuration>


### PR DESCRIPTION
This patch adds the @ConflictParameter annotation, which indicates to the runtime
that a parameter should be used to generate objects for fine-grained conflict
resolution. 

This patch does not implement fine-grained conflict resolution, which will have to
be implemented in both the transactional context and the sequencer.