### PR TITLE
stop travis from caching multi-module artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ after_success:
 - .travis_scripts/mvnrepo.sh
 - .travis_scripts/push_deb.sh
 before_cache:
-- rm -rf $HOME/.m2/repository/org/corfudb/corfu
+- rm -rf $HOME/.m2/repository/org/corfudb
 cache:
   directories:
   - $HOME/.m2


### PR DESCRIPTION
After the switch to multi-module artifacts, travis started caching
multi-module artifacts. This patch fixes that by deleting them before
running the cache step.