### PR TITLE
remove maven-dependency from build

### DIFF
--- a/cmdlets/pom.xml
+++ b/cmdlets/pom.xml
@@ -29,11 +29,28 @@
             <groupId>org.clojure</groupId>
             <artifactId>clojure</artifactId>
             <version>1.8.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
+            <version>3.1.2</version>
         </dependency>
         <dependency>
             <groupId>reply</groupId>
             <artifactId>reply</artifactId>
             <version>0.3.7</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>jline</groupId>
+                    <artifactId>jline</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.offbytwo</groupId>
@@ -43,7 +60,7 @@
         <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
-            <version>1.11</version>
+            <version>1.14</version>
         </dependency>
     </dependencies>
 

--- a/cmdlets/pom.xml
+++ b/cmdlets/pom.xml
@@ -37,9 +37,15 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.jline</groupId>
+            <groupId>jline</groupId>
             <artifactId>jline</artifactId>
-            <version>3.1.2</version>
+            <version>2.14.2</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.fusesource.jansi</groupId>
+                    <artifactId>jansi</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>reply</groupId>

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.fusesource.jansi</groupId>
             <artifactId>jansi</artifactId>
-            <version>1.11</version>
+            <version>1.14</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -177,23 +177,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.8</version>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/libs/</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.5.1</version> <!-- version < 3.5.1 has issue with annotation incremental compile-->
                 <configuration>


### PR DESCRIPTION
The maven dependency plugin appears to be doing something on top of
what maven-shade was doing. This patch removes the dependency plugin
and cleans up some dependencies to provide smaller JARs.