### PR TITLE
Opacity

### DIFF
--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -46,7 +46,7 @@ public class AbstractCorfuTest {
     public Set<Callable<Object>> scheduledThreads;
     public String testStatus = "";
 
-    public Map<Integer, TestThread> threadsMap;
+    public Map<Integer, TestThread> threadsMap = new ConcurrentHashMap<>();
 
     public ArrayList<IntConsumer> testSM = null;
 
@@ -727,9 +727,8 @@ public class AbstractCorfuTest {
     /** utilities for building a test state-machine
      *
      */
-    // @Before
+    @Before
     public void InitSM() {
-        System.out.println("initSM");
         if (testSM != null)
             testSM.clear();
         else
@@ -738,7 +737,6 @@ public class AbstractCorfuTest {
 
     public void addTestStep(IntConsumer stepFunction) {
         if (testSM == null) {
-            System.out.println("SM was null");
             InitSM();
         }
         testSM.add(stepFunction);

--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -266,9 +266,12 @@ public class AbstractCorfuTest {
      */
     public void scheduleConcurrently(int repetitions, CallableConsumer function) {
         for (int i = 0; i < repetitions; i++) {
-            final int threadNumber = i;
+            final int taskNumber = i;
+
             scheduledThreads.add(() -> {
-                function.accept(threadNumber);
+                // executorService uses Callable functions
+                // here, wrap a Corfu test CallableConsumer task (input task #, no output) as a Callable.
+                function.accept(taskNumber);
                 return null;
             });
         }
@@ -334,21 +337,6 @@ public class AbstractCorfuTest {
             throw new RuntimeException(ie);
         }
 
-    }
-
-    /**
-     * An interface that defines threads run through the unit testing interface.
-     */
-    @FunctionalInterface
-    public interface CallableConsumer {
-        /**
-         * The function contains the code to be run when the thread is scheduled.
-         * The thread number is passed as the first argument.
-         *
-         * @param threadNumber The thread number of this thread.
-         * @throws Exception The exception to be called.
-         */
-        void accept(Integer threadNumber) throws Exception;
     }
 
     @FunctionalInterface
@@ -736,4 +724,18 @@ public class AbstractCorfuTest {
         executeScheduled(numThreads, PARAMETERS.TIMEOUT_NORMAL);
     }
 
+    /**
+     * An interface that defines threads run through the unit testing interface.
+     */
+    @FunctionalInterface
+    public interface CallableConsumer {
+        /**
+         * The function contains the code to be run when the thread is scheduled.
+         * The thread number is passed as the first argument.
+         *
+         * @param threadNumber The thread number of this thread.
+         * @throws Exception The exception to be called.
+         */
+        void accept(Integer threadNumber) throws Exception;
+    }
 }

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -580,7 +580,6 @@ public class SMRMapTest extends AbstractViewTest {
 
         testMap.put("a", "z");
     }
-
     AtomicInteger aborts;
 
     ArrayList<IntConsumer> getAbortTestSM() {
@@ -720,6 +719,26 @@ public class SMRMapTest extends AbstractViewTest {
         final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
         AtomicInteger aborts = new AtomicInteger();
 
+
+        long startTime = System.currentTimeMillis();
+
+        // invoke the interleaving engine
+        scheduleInterleaved(numThreads, numThreads*numRecords,
+                getMultiViewSM(numThreads)
+        );
+
+        // print stats..
+        calculateRequestsPerSecond("TPS", numRecords * numThreads, startTime);
+        calculateAbortRate(aborts.get(), numRecords * numThreads);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void concurrentAbortMultiViewThreaded()
+            throws Exception {
+        final int numThreads = PARAMETERS.CONCURRENCY_SOME;
+        final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
+        AtomicInteger aborts = new AtomicInteger();
 
         long startTime = System.currentTimeMillis();
 

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -580,6 +580,7 @@ public class SMRMapTest extends AbstractViewTest {
 
         testMap.put("a", "z");
     }
+
     AtomicInteger aborts;
 
     ArrayList<IntConsumer> getAbortTestSM() {
@@ -673,7 +674,6 @@ public class SMRMapTest extends AbstractViewTest {
                                     .open();
                         })
                         .toArray(Map[]::new);
-        AtomicInteger aborts = new AtomicInteger();
 
         // # keys indicate how much contention there will be
         final int numKeys = numThreads * 5;
@@ -717,10 +717,10 @@ public class SMRMapTest extends AbstractViewTest {
             throws Exception {
         final int numThreads = PARAMETERS.CONCURRENCY_SOME;
         final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
-        AtomicInteger aborts = new AtomicInteger();
 
 
         long startTime = System.currentTimeMillis();
+        aborts = new AtomicInteger();
 
         // invoke the interleaving engine
         scheduleInterleaved(numThreads, numThreads*numRecords,
@@ -738,9 +738,9 @@ public class SMRMapTest extends AbstractViewTest {
             throws Exception {
         final int numThreads = PARAMETERS.CONCURRENCY_SOME;
         final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
-        AtomicInteger aborts = new AtomicInteger();
 
         long startTime = System.currentTimeMillis();
+        aborts = new AtomicInteger();
 
         // invoke the interleaving engine
         scheduleInterleaved(numThreads, numThreads*numRecords,
@@ -752,25 +752,6 @@ public class SMRMapTest extends AbstractViewTest {
         calculateAbortRate(aborts.get(), numRecords * numThreads);
     }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void concurrentAbortMultiViewThreaded()
-            throws Exception {
-        final int numThreads = PARAMETERS.CONCURRENCY_SOME;
-        final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
-        AtomicInteger aborts = new AtomicInteger();
-
-        long startTime = System.currentTimeMillis();
-
-        // invoke the interleaving engine
-        scheduleThreaded(numThreads, numThreads*numRecords,
-                getMultiViewSM(numThreads)
-        );
-
-        // print stats..
-        calculateRequestsPerSecond("TPS", numRecords * numThreads, startTime);
-        calculateAbortRate(aborts.get(), numRecords * numThreads);
-    }
     @Test
     @SuppressWarnings("unchecked")
     public void bulkReads()

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -581,90 +581,58 @@ public class SMRMapTest extends AbstractViewTest {
         testMap.put("a", "z");
     }
 
-    @Test
-    public void concurrentAbortTest()
-            throws Exception {
+    AtomicInteger aborts;
 
+    ArrayList<IntConsumer> getAbortTestSM() {
         Map<String, String> testMap = getRuntime().getObjectsView().build()
                 .setStreamID(UUID.randomUUID())
                 .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
                 .addOption(ObjectOpenOptions.NO_CACHE)
                 .open();
-
-        final int num_threads = 5;
-        final int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
         AtomicInteger aborts = new AtomicInteger();
         testMap.clear();
 
-        scheduleConcurrently(num_threads, threadNumber -> {
-            int base = threadNumber * num_records;
-            for (int i = base; i < base + num_records; i++) {
-                try {
+        ArrayList<IntConsumer> stateMachine = new ArrayList<IntConsumer>(){
+
+            {
+                // state 0: start a transaction
+                add ((ignored_task_num) -> {
                     getRuntime().getObjectsView().TXBegin();
-                    assertThat(testMap.put(Integer.toString(i),
-                            Integer.toString(i)))
+                });
+
+                // state 1: do a put
+                add( (task_num) -> {
+                    assertThat(testMap.put(Integer.toString(task_num),
+                            Integer.toString(task_num)))
                             .isEqualTo(null);
-                    getRuntime().getObjectsView().TXEnd();
-                } catch (TransactionAbortedException tae) {
-                    aborts.incrementAndGet();
-                }
+                });
+
+                // state 2 (final): ask to commit the transaction
+                add ( (ignored_task_num) -> {
+                    try {
+                        getRuntime().getObjectsView().TXEnd();
+                    } catch (TransactionAbortedException tae) {
+                        aborts.incrementAndGet();
+                    }
+                });
+
             }
-        });
-
-        long startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
-        calculateRequestsPerSecond("TPS", num_records * num_threads, startTime);
-
-        calculateAbortRate(aborts.get(), num_records * num_threads);
+        } ;
+        return stateMachine;
     }
 
-
     @Test
-    public void concurrentAbortTestInterleaved()
-        throws Exception
+    public void concurrentAbortTestThreaded()
+            throws Exception
     {
         final int numThreads =  PARAMETERS.CONCURRENCY_SOME;
         final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
 
-        Map<String, String> testMap = getRuntime().getObjectsView().build()
-                .setStreamID(UUID.randomUUID())
-                .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
-                .addOption(ObjectOpenOptions.NO_CACHE)
-                .open();
-        AtomicInteger aborts = new AtomicInteger();
-        testMap.clear();
-
-        ArrayList<BiConsumer<Integer, Integer>> stateMachine = new ArrayList<BiConsumer<Integer, Integer>>(){
-
-            {
-                // state 0: start a transaction
-                add ((Integer ignored_thread_num, Integer ignored_task_num) -> {
-                    getRuntime().getObjectsView().TXBegin();
-                         });
-
-                // state 1: do a put
-                add( (Integer ignored_thread_num, Integer task_num) -> {
-                            assertThat(testMap.put(Integer.toString(task_num),
-                                    Integer.toString(task_num)))
-                                    .isEqualTo(null);
-                        });
-
-                // state 2 (final): ask to commit the transaction
-                add ( (Integer ignored_thread_num, Integer ignored_task_num) -> {
-                            try {
-                                getRuntime().getObjectsView().TXEnd();
-                            } catch (TransactionAbortedException tae) {
-                                aborts.incrementAndGet();
-                            }
-                        });
-
-            }
-        } ;
-
         long startTime = System.currentTimeMillis();
 
-        // invoke the interleaving engine
-        scheduleInterleaved(numThreads, numThreads*numRecords, stateMachine);
+        aborts = new AtomicInteger();
+        // invoke the threaded engine
+        scheduleThreaded(numThreads, numThreads*numRecords, getAbortTestSM());
 
         // print stats..
         calculateRequestsPerSecond("TPS", numRecords * numThreads, startTime);
@@ -673,17 +641,27 @@ public class SMRMapTest extends AbstractViewTest {
     }
 
     @Test
-    @SuppressWarnings("unchecked")
-    public void concurrentAbortMultiViewInterleaved()
-            throws Exception {
-        final int numThreads = PARAMETERS.CONCURRENCY_SOME;
-        final int numKeys = PARAMETERS.CONCURRENCY_SOME * 5; // When fine-grained map conflicts will be implemented, this number of keys SHOULD allow some concurrency, but create conflicts
+    public void concurrentAbortTestInterleaved()
+            throws Exception
+    {
+        final int numThreads =  PARAMETERS.CONCURRENCY_SOME;
         final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
-        AtomicInteger aborts = new AtomicInteger();
+
+        long startTime = System.currentTimeMillis();
+
+        aborts = new AtomicInteger();
+        // invoke the interleaving engine
+        scheduleInterleaved(numThreads, numThreads*numRecords, getAbortTestSM());
+
+        // print stats..
+        calculateRequestsPerSecond("TPS", numRecords * numThreads, startTime);
+        calculateAbortRate(aborts.get(), numRecords * numThreads);
+
+    }
+
+    ArrayList<IntConsumer> getMultiViewSM(int numThreads) {
 
         UUID mapStream = UUID.randomUUID();
-
-
         Map<String, String>[] testMap =
                 IntStream.range(0, numThreads)
                         .mapToObj(i -> {
@@ -696,27 +674,31 @@ public class SMRMapTest extends AbstractViewTest {
                                     .open();
                         })
                         .toArray(Map[]::new);
+        AtomicInteger aborts = new AtomicInteger();
+
+        // # keys indicate how much contention there will be
+        final int numKeys = numThreads * 5;
 
         Random r = new Random();
 
-        ArrayList<BiConsumer<Integer, Integer>> stateMachine = new ArrayList<BiConsumer<Integer, Integer>>(){
+        ArrayList<IntConsumer> stateMachine = new ArrayList<IntConsumer>(){
 
             {
                 // state 0: start a transaction
-                add ((Integer ignored_thread_num, Integer ignored_task_num) -> {
+                add ((ignored_task_num) -> {
                     getRuntime().getObjectsView().TXBegin();
                 });
 
                 // state 1: do a put and a get
-                add( (Integer thread_num, Integer task_num) -> {
+                add( (task_num) -> {
                     final int putKey = r.nextInt(numKeys);
                     final int getKey = r.nextInt(numKeys);
-                    testMap[thread_num].put(Integer.toString(putKey),
-                            testMap[thread_num].get(Integer.toString(getKey)));
+                    testMap[task_num%numThreads].put(Integer.toString(putKey),
+                            testMap[task_num%numThreads].get(Integer.toString(getKey)));
                 });
 
                 // state 2 (final): ask to commit the transaction
-                add ( (Integer ignored_thread_num, Integer ignored_task_num) -> {
+                add ( (ignored_task_num) -> {
                     try {
                         getRuntime().getObjectsView().TXEnd();
                     } catch (TransactionAbortedException tae) {
@@ -727,107 +709,49 @@ public class SMRMapTest extends AbstractViewTest {
             }
         } ;
 
+        return stateMachine;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void concurrentAbortMultiViewInterleaved()
+            throws Exception {
+        final int numThreads = PARAMETERS.CONCURRENCY_SOME;
+        final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
+        AtomicInteger aborts = new AtomicInteger();
+
+
         long startTime = System.currentTimeMillis();
 
         // invoke the interleaving engine
-        scheduleInterleaved(numThreads, numThreads*numRecords, stateMachine);
+        scheduleInterleaved(numThreads, numThreads*numRecords,
+                getMultiViewSM(numThreads)
+        );
 
         // print stats..
         calculateRequestsPerSecond("TPS", numRecords * numThreads, startTime);
         calculateAbortRate(aborts.get(), numRecords * numThreads);
-
-
-
-    }
-
-
-    @Test
-    @SuppressWarnings("unchecked")
-    public void concurrentAbortMultiViewTest()
-            throws Exception {
-        final int num_threads = 5;
-        final int num_keys = 100;
-        final int num_records = 1_000;
-        AtomicInteger aborts = new AtomicInteger();
-
-        UUID mapStream = UUID.randomUUID();
-
-        Map<String, String>[] testMap =
-            IntStream.range(0, num_threads)
-                    .mapToObj(i -> {
-                        return getRuntime().getObjectsView()
-                                .build()
-                                .setStreamID(mapStream)
-                                .setTypeToken(new TypeToken<SMRMap<String, String>>() {
-                                })
-                                .addOption(ObjectOpenOptions.NO_CACHE)
-                                .open();
-                    })
-                    .toArray(Map[]::new);
-
-        Random r = new Random();
-        scheduleConcurrently(num_threads, threadNumber -> {
-            int base = threadNumber * num_records;
-            for (int i = base; i < base + num_records; i++) {
-                try {
-                    getRuntime().getObjectsView().TXBegin();
-                    testMap[threadNumber].put(Integer.toString(r.nextInt(num_keys)),
-                            testMap[threadNumber].get(Integer.toString(r.nextInt(num_keys))));
-                    getRuntime().getObjectsView().TXEnd();
-                } catch (TransactionAbortedException tae) {
-                    aborts.incrementAndGet();
-                }
-            }
-        });
-
-        long startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
-        calculateRequestsPerSecond("TPS", num_records * num_threads, startTime);
-
-        calculateAbortRate(aborts.get(), num_records * num_threads);
     }
 
     @Test
     @SuppressWarnings("unchecked")
-    public void concurrentAbortTestMulti()
+    public void concurrentAbortMultiViewThreaded()
             throws Exception {
-
-        final int num_maps = 100;
-        List<Map<Integer,Integer>> mapList = IntStream.range(0, num_maps)
-                                                    .mapToObj(x ->
-                                                        getRuntime()
-                                                                .getObjectsView().build()
-                                                                .setStreamName("map-" + x)
-                                                                .setTypeToken(new TypeToken<SMRMap<Integer, Integer>>() {})
-                                                                .open()
-                                                    )
-                                                    .collect(Collectors.toList());
-        final int num_threads = PARAMETERS.CONCURRENCY_SOME;
-        final int num_records = PARAMETERS.NUM_ITERATIONS_LOW;
+        final int numThreads = PARAMETERS.CONCURRENCY_SOME;
+        final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
         AtomicInteger aborts = new AtomicInteger();
 
-        scheduleConcurrently(num_threads, threadNumber -> {
-            int base = threadNumber * num_records;
-            Random r = new Random(threadNumber);
-            for (int i = base; i < base + num_records; i++) {
-                try {
-                    getRuntime().getObjectsView().TXBegin();
-                    //pick a map at "random" to insert to
-                    mapList.get(r.nextInt(num_maps)).put(0, 1);
-                    getRuntime().getObjectsView().TXEnd();
-                } catch (TransactionAbortedException tae) {
-                    aborts.incrementAndGet();
-                }
-            }
-        });
-
         long startTime = System.currentTimeMillis();
-        executeScheduled(num_threads, PARAMETERS.TIMEOUT_LONG);
-        calculateRequestsPerSecond("TPS", num_records * num_threads, startTime);
 
-        calculateAbortRate(aborts.get(), num_records * num_threads);
+        // invoke the interleaving engine
+        scheduleThreaded(numThreads, numThreads*numRecords,
+                getMultiViewSM(numThreads)
+        );
+
+        // print stats..
+        calculateRequestsPerSecond("TPS", numRecords * numThreads, startTime);
+        calculateAbortRate(aborts.get(), numRecords * numThreads);
     }
-
     @Test
     @SuppressWarnings("unchecked")
     public void bulkReads()

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -636,6 +636,8 @@ public class SMRMapTest extends AbstractViewTest {
         long startTime = System.currentTimeMillis();
 
         aborts = new AtomicInteger();
+
+        getAbortTestSM();
         // invoke the interleaving engine
         scheduleInterleaved(numThreads, numThreads*numRecords);
 
@@ -701,6 +703,7 @@ public class SMRMapTest extends AbstractViewTest {
         long startTime = System.currentTimeMillis();
         aborts = new AtomicInteger();
 
+        getMultiViewSM(numThreads);
         // invoke the interleaving engine
         scheduleInterleaved(numThreads, numThreads*numRecords);
 
@@ -719,8 +722,9 @@ public class SMRMapTest extends AbstractViewTest {
         long startTime = System.currentTimeMillis();
         aborts = new AtomicInteger();
 
+        getMultiViewSM(numThreads);
         // invoke the interleaving engine
-        scheduleInterleaved(numThreads, numThreads*numRecords);
+        scheduleThreaded(numThreads, numThreads*numRecords);
 
         // print stats..
         calculateRequestsPerSecond("TPS", numRecords * numThreads, startTime);

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -188,7 +188,7 @@ public class CompileProxyTest extends AbstractViewTest {
                 .open();
 
         int numTasks = PARAMETERS.NUM_ITERATIONS_LOW;
-        Random r = new Random(PARAMETERS.isRandomSeed() ? System.currentTimeMillis() : 0);
+        Random r = new Random(PARAMETERS.SEED);
 
         sharedCounter.setValue(-1);
         AtomicInteger lastUpdate = new AtomicInteger(-1);
@@ -242,7 +242,7 @@ public class CompileProxyTest extends AbstractViewTest {
         StreamView objStream = proxy_CORFUSMR.getUnderlyingObject().getStreamViewUnsafe();
 
         int numTasks = PARAMETERS.NUM_ITERATIONS_LOW;
-        Random r = new Random(PARAMETERS.isRandomSeed() ? System.currentTimeMillis() : 0);
+        Random r = new Random(PARAMETERS.SEED);
 
         final int INITIAL = -1;
 

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -6,12 +6,10 @@ import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.StreamView;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.IntConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -181,21 +179,15 @@ public class CompileProxyTest extends AbstractViewTest {
         assertThat(sharedCounter.getValue())
                 .isEqualTo(lastUpdate.get());
 
-        // build a state-machine:
-        ArrayList<IntConsumer> stateMachine = new ArrayList<IntConsumer>(){
-
-            {
-                // only one step: randomly choose between read/write of the shared counter
-                add ((task_num) -> {
-                    if (r.nextBoolean()) {
-                        sharedCounter.setValue(task_num);
-                        lastUpdate.set(task_num); // remember the last written value
-                    } else {
-                        assertThat(sharedCounter.getValue()).isEqualTo(lastUpdate.get()); // expect to read the value in lastUpdate
-                    }
-                } );
+        // only one step: randomly choose between read/write of the shared counter
+        addTestStep ((task_num) -> {
+            if (r.nextBoolean()) {
+                sharedCounter.setValue(task_num);
+                lastUpdate.set(task_num); // remember the last written value
+            } else {
+                assertThat(sharedCounter.getValue()).isEqualTo(lastUpdate.get()); // expect to read the value in lastUpdate
             }
-        };
+        } );
 
         // invoke the interleaving engine
         scheduleInterleaved(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.CONCURRENCY_SOME*numTasks);

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTXConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTXConcurrencyTest.java
@@ -1,17 +1,13 @@
 package org.corfudb.runtime.object.transactions;
 
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.CorfuSharedCounter;
 import org.corfudb.runtime.view.AbstractViewTest;
-import org.corfudb.runtime.view.StreamView;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicIntegerArray;
-import java.util.function.BiConsumer;
-import java.util.function.IntConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -67,7 +63,7 @@ public class OptimisticTXConcurrencyTest extends AbstractViewTest {
 
     }
 
-    ArrayList<IntConsumer> getOpacityTestSM() {
+    void getOpacityTestSM() {
         // populate numTasks and sharedCounters array
         setupCounters();
 
@@ -75,51 +71,48 @@ public class OptimisticTXConcurrencyTest extends AbstractViewTest {
         AtomicIntegerArray commitStatus = new AtomicIntegerArray(numTasks);
         final int COMMITVALUE = 1;
 
-        // a state-machine:
-        ArrayList<IntConsumer> stateMachine = new ArrayList<IntConsumer>();
-
         // SM step 1: start an optimistic transaction
-        stateMachine.add((ignored_task_num) -> {
+        addTestStep((ignored_task_num) -> {
             TXBegin();
         });
 
         // SM step 2: modify shared counter per task
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             sharedCounters.get(task_num).setValue(OVERWRITE_ONCE);
         });
 
         // SM step 3: each task reads a shared counter modified by another task and records it
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             snapStatus.set(task_num, sharedCounters.get((task_num + 1) % numTasks).getValue());
         });
 
         // SM step 4: each task verifies opacity, checking that it can read its own modified value
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             assertThat(sharedCounters.get(task_num).getValue())
                     .isEqualTo(OVERWRITE_ONCE);
         });
 
         // SM step 5: next, each task overwrites its own value again
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             sharedCounters.get(task_num).setValue(OVERWRITE_TWICE);
         } );
 
         // SM step 6: each task again reads a counter modified by another task.
         // it should read the same snapshot value as the beginning of the transaction
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             assertThat(sharedCounters.get((task_num + 1) % numTasks).getValue())
                     .isEqualTo(snapStatus.get(task_num));
         });
 
         // SM step 7: each task  again verifies opacity, checking that it can read its own modified value
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             assertThat(sharedCounters.get(task_num).getValue())
                     .isEqualTo(OVERWRITE_TWICE);
         });
 
         // SM step 8: all tasks try to commit their transacstion.
         // Task k aborts if, and only if, counter k+1 was modified after it read it and transaction k+1 already committed.
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             try {
                 TXEnd();
                 commitStatus.set(task_num, COMMITVALUE);
@@ -130,8 +123,6 @@ public class OptimisticTXConcurrencyTest extends AbstractViewTest {
                         .isEqualTo(COMMITVALUE);
             }
         } );
-
-        return stateMachine;
     }
 
 
@@ -163,13 +154,13 @@ public class OptimisticTXConcurrencyTest extends AbstractViewTest {
     @Test
     public void testOpacityInterleaved() throws Exception {
         // invoke the interleaving engine
-        scheduleInterleaved(PARAMETERS.CONCURRENCY_SOME, numTasks, getOpacityTestSM());
+        scheduleInterleaved(PARAMETERS.CONCURRENCY_SOME, numTasks);
     }
 
     @Test
     public void testOpacityThreaded() throws Exception {
         // invoke the threaded engine
-        scheduleThreaded(PARAMETERS.CONCURRENCY_SOME, numTasks, getOpacityTestSM());
+        scheduleThreaded(PARAMETERS.CONCURRENCY_SOME, numTasks);
     }
 
     /**
@@ -197,8 +188,7 @@ public class OptimisticTXConcurrencyTest extends AbstractViewTest {
      *  If task k aborts, then either task (k-1), or (k+1), or both, must have committed
      *  (wrapping around for tasks n-1 and 0, respectively).
      */
-    @Test
-    public void testOptimism() throws Exception {
+    void getOptimismSM() {
         // populate numTasks and sharedCounters array
         setupCounters();
 
@@ -207,63 +197,71 @@ public class OptimisticTXConcurrencyTest extends AbstractViewTest {
 
         assertThat(numTasks).isGreaterThan(1); // don't change concurrency to less than 2, test will break
 
-        // a state-machine:
-        ArrayList<IntConsumer> stateMachine = new ArrayList<IntConsumer>();
-
         // SM step 1: start an optimistic transaction
-        stateMachine.add((ignored_task_num) -> {
+        addTestStep((ignored_task_num) -> {
             TXBegin();
         });
 
         // SM step 2: task k modify counter k
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             sharedCounters.get(task_num).setValue(OVERWRITE_ONCE);
         });
 
         // SM step 3: task k reads counter k+1
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             assertThat(sharedCounters.get((task_num + 1) % numTasks).getValue())
                     .isBetween(INITIAL, OVERWRITE_ONCE);
         });
 
         // SM step 4: task k verifies opacity, checking that it can read its own modified value of counter k
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             assertThat(sharedCounters.get(task_num).getValue())
                     .isEqualTo(OVERWRITE_ONCE);
         });
 
         // SM step 5: task k overwrites counter k+1
-        stateMachine.add((task_num) -> {
-            sharedCounters.get((task_num+1)%numTasks).setValue(OVERWRITE_TWICE);
-        } );
+        addTestStep((task_num) -> {
+            sharedCounters.get((task_num + 1) % numTasks).setValue(OVERWRITE_TWICE);
+        });
 
         // SM step 6: task k again check opacity, reading its own modified value, this time of counter k+1
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             assertThat(sharedCounters.get((task_num + 1) % numTasks).getValue())
                     .isEqualTo(OVERWRITE_TWICE);
         });
 
         // SM step 7: each thread again verifies opacity, checking that it can re-read counter k
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             assertThat(sharedCounters.get(task_num).getValue())
                     .isEqualTo(OVERWRITE_ONCE);
         });
 
         // SM step 8: try to commit all transactions;
         // task k aborts only if one or both of (k-1), (k+1) committed before it
-        stateMachine.add((task_num) -> {
+        addTestStep((task_num) -> {
             try {
                 TXEnd();
                 commitStatus.set(task_num, COMMITVALUE);
             } catch (TransactionAbortedException tae) {
                 assertThat(commitStatus.get((task_num + 1) % numTasks) == COMMITVALUE ||
-                                commitStatus.get((task_num - 1) % numTasks) == COMMITVALUE)
+                        commitStatus.get((task_num - 1) % numTasks) == COMMITVALUE)
                         .isTrue();
             }
-        } );
+        });
+    }
 
+    @Test
+    public void testOptimismInterleaved() throws Exception {
+        getOptimismSM();
         // invoke the interleaving engine
-        scheduleInterleaved(PARAMETERS.CONCURRENCY_SOME, numTasks, stateMachine);
+        scheduleInterleaved(PARAMETERS.CONCURRENCY_SOME, numTasks);
+    }
+
+    @Test
+    public void testOptimismThreaded() throws Exception {
+        getOptimismSM();
+        // invoke the interleaving engine
+        scheduleThreaded(PARAMETERS.CONCURRENCY_SOME, numTasks);
     }
 
     void TXEnd() {

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTXConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTXConcurrencyTest.java
@@ -1,14 +1,17 @@
 package org.corfudb.runtime.object.transactions;
 
+import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.CorfuSharedCounter;
 import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.StreamView;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 import java.util.function.BiConsumer;
+import java.util.function.IntConsumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,6 +26,22 @@ public class OptimisticTXConcurrencyTest extends AbstractViewTest {
     static final int INITIAL = 32;
     static final int OVERWRITE_ONCE = 33;
     static final int OVERWRITE_TWICE = 34;
+
+    @Test
+    public void OptimisticTXSimpleTest() {
+        CorfuSharedCounter sharedCounter1 = getRuntime().getObjectsView()
+                .build()
+                .setStreamName("test"+1)
+                .setType(CorfuSharedCounter.class)
+                .open() ;
+        sharedCounter1.setValue(INITIAL);
+
+        t(1, this::TXBegin);
+        t(1, () -> sharedCounter1.setValue(OVERWRITE_ONCE));
+        t(2, () -> sharedCounter1.setValue(OVERWRITE_TWICE));
+        t(1, () -> sharedCounter1.getValue());
+
+    }
 
     int numTasks;
     ArrayList<CorfuSharedCounter> sharedCounters;
@@ -47,6 +66,74 @@ public class OptimisticTXConcurrencyTest extends AbstractViewTest {
             sharedCounters.get(i).setValue(INITIAL);
 
     }
+
+    ArrayList<IntConsumer> getOpacityTestSM() {
+        // populate numTasks and sharedCounters array
+        setupCounters();
+
+        AtomicIntegerArray snapStatus = new AtomicIntegerArray(numTasks);
+        AtomicIntegerArray commitStatus = new AtomicIntegerArray(numTasks);
+        final int COMMITVALUE = 1;
+
+        // a state-machine:
+        ArrayList<IntConsumer> stateMachine = new ArrayList<IntConsumer>();
+
+        // SM step 1: start an optimistic transaction
+        stateMachine.add((ignored_task_num) -> {
+            TXBegin();
+        });
+
+        // SM step 2: modify shared counter per task
+        stateMachine.add((task_num) -> {
+            sharedCounters.get(task_num).setValue(OVERWRITE_ONCE);
+        });
+
+        // SM step 3: each task reads a shared counter modified by another task and records it
+        stateMachine.add((task_num) -> {
+            snapStatus.set(task_num, sharedCounters.get((task_num + 1) % numTasks).getValue());
+        });
+
+        // SM step 4: each task verifies opacity, checking that it can read its own modified value
+        stateMachine.add((task_num) -> {
+            assertThat(sharedCounters.get(task_num).getValue())
+                    .isEqualTo(OVERWRITE_ONCE);
+        });
+
+        // SM step 5: next, each task overwrites its own value again
+        stateMachine.add((task_num) -> {
+            sharedCounters.get(task_num).setValue(OVERWRITE_TWICE);
+        } );
+
+        // SM step 6: each task again reads a counter modified by another task.
+        // it should read the same snapshot value as the beginning of the transaction
+        stateMachine.add((task_num) -> {
+            assertThat(sharedCounters.get((task_num + 1) % numTasks).getValue())
+                    .isEqualTo(snapStatus.get(task_num));
+        });
+
+        // SM step 7: each task  again verifies opacity, checking that it can read its own modified value
+        stateMachine.add((task_num) -> {
+            assertThat(sharedCounters.get(task_num).getValue())
+                    .isEqualTo(OVERWRITE_TWICE);
+        });
+
+        // SM step 8: all tasks try to commit their transacstion.
+        // Task k aborts if, and only if, counter k+1 was modified after it read it and transaction k+1 already committed.
+        stateMachine.add((task_num) -> {
+            try {
+                TXEnd();
+                commitStatus.set(task_num, COMMITVALUE);
+            } catch (TransactionAbortedException tae) {
+                assertThat(sharedCounters.get((task_num + 1) % numTasks).getValue())
+                        .isNotEqualTo(snapStatus.get(task_num));
+                assertThat(commitStatus.get((task_num + 1) % numTasks))
+                        .isEqualTo(COMMITVALUE);
+            }
+        } );
+
+        return stateMachine;
+    }
+
 
     /**
      * test concurrent transactions for opacity. This works as follows:
@@ -74,72 +161,15 @@ public class OptimisticTXConcurrencyTest extends AbstractViewTest {
      * @throws Exception
      */
     @Test
-    public void testOpacity() throws Exception {
-        // populate numTasks and sharedCounters array
-        setupCounters();
-
-        AtomicIntegerArray snapStatus = new AtomicIntegerArray(numTasks);
-        AtomicIntegerArray commitStatus = new AtomicIntegerArray(numTasks);
-        final int COMMITVALUE = 1;
-
-        // a state-machine:
-        ArrayList<BiConsumer<Integer, Integer>> stateMachine = new ArrayList<BiConsumer<Integer, Integer>>();
-
-        // SM step 1: start an optimistic transaction
-        stateMachine.add((Integer ignored_thread_num, Integer ignored_task_num) -> {
-            TXBegin();
-        });
-
-        // SM step 2: modify shared counter per task
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
-            sharedCounters.get(task_num).setValue(OVERWRITE_ONCE);
-        });
-
-        // SM step 3: each task reads a shared counter modified by another task and records it
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
-            snapStatus.set(task_num, sharedCounters.get((task_num + 1) % numTasks).getValue());
-        });
-
-        // SM step 4: each task verifies opacity, checking that it can read its own modified value
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
-            assertThat(sharedCounters.get(task_num).getValue())
-                    .isEqualTo(OVERWRITE_ONCE);
-        });
-
-        // SM step 5: next, each task overwrites its own value again
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
-            sharedCounters.get(task_num).setValue(OVERWRITE_TWICE);
-        } );
-
-        // SM step 6: each task again reads a counter modified by another task.
-        // it should read the same snapshot value as the beginning of the transaction
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
-            assertThat(sharedCounters.get((task_num + 1) % numTasks).getValue())
-                    .isEqualTo(snapStatus.get(task_num));
-        });
-
-        // SM step 7: each task  again verifies opacity, checking that it can read its own modified value
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
-            assertThat(sharedCounters.get(task_num).getValue())
-                    .isEqualTo(OVERWRITE_TWICE);
-        });
-
-        // SM step 8: all tasks try to commit their transacstion.
-        // Task k aborts if, and only if, counter k+1 was modified after it read it and transaction k+1 already committed.
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
-            try {
-                TXEnd();
-                commitStatus.set(task_num, COMMITVALUE);
-            } catch (TransactionAbortedException tae) {
-                assertThat(sharedCounters.get((task_num + 1) % numTasks).getValue())
-                    .isNotEqualTo(snapStatus.get(task_num));
-                assertThat(commitStatus.get((task_num + 1) % numTasks))
-                        .isEqualTo(COMMITVALUE);
-            }
-        } );
-
+    public void testOpacityInterleaved() throws Exception {
         // invoke the interleaving engine
-        scheduleInterleaved(PARAMETERS.CONCURRENCY_SOME, numTasks, stateMachine);
+        scheduleInterleaved(PARAMETERS.CONCURRENCY_SOME, numTasks, getOpacityTestSM());
+    }
+
+    @Test
+    public void testOpacityThreaded() throws Exception {
+        // invoke the threaded engine
+        scheduleThreaded(PARAMETERS.CONCURRENCY_SOME, numTasks, getOpacityTestSM());
     }
 
     /**
@@ -178,50 +208,50 @@ public class OptimisticTXConcurrencyTest extends AbstractViewTest {
         assertThat(numTasks).isGreaterThan(1); // don't change concurrency to less than 2, test will break
 
         // a state-machine:
-        ArrayList<BiConsumer<Integer, Integer>> stateMachine = new ArrayList<BiConsumer<Integer, Integer>>();
+        ArrayList<IntConsumer> stateMachine = new ArrayList<IntConsumer>();
 
         // SM step 1: start an optimistic transaction
-        stateMachine.add((Integer ignored_thread_num, Integer ignored_task_num) -> {
+        stateMachine.add((ignored_task_num) -> {
             TXBegin();
         });
 
         // SM step 2: task k modify counter k
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
+        stateMachine.add((task_num) -> {
             sharedCounters.get(task_num).setValue(OVERWRITE_ONCE);
         });
 
         // SM step 3: task k reads counter k+1
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
+        stateMachine.add((task_num) -> {
             assertThat(sharedCounters.get((task_num + 1) % numTasks).getValue())
                     .isBetween(INITIAL, OVERWRITE_ONCE);
         });
 
         // SM step 4: task k verifies opacity, checking that it can read its own modified value of counter k
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
+        stateMachine.add((task_num) -> {
             assertThat(sharedCounters.get(task_num).getValue())
                     .isEqualTo(OVERWRITE_ONCE);
         });
 
         // SM step 5: task k overwrites counter k+1
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
+        stateMachine.add((task_num) -> {
             sharedCounters.get((task_num+1)%numTasks).setValue(OVERWRITE_TWICE);
         } );
 
         // SM step 6: task k again check opacity, reading its own modified value, this time of counter k+1
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
+        stateMachine.add((task_num) -> {
             assertThat(sharedCounters.get((task_num + 1) % numTasks).getValue())
                     .isEqualTo(OVERWRITE_TWICE);
         });
 
         // SM step 7: each thread again verifies opacity, checking that it can re-read counter k
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
+        stateMachine.add((task_num) -> {
             assertThat(sharedCounters.get(task_num).getValue())
                     .isEqualTo(OVERWRITE_ONCE);
         });
 
         // SM step 8: try to commit all transactions;
         // task k aborts only if one or both of (k-1), (k+1) committed before it
-        stateMachine.add((Integer ignored_thread_num, Integer task_num) -> {
+        stateMachine.add((task_num) -> {
             try {
                 TXEnd();
                 commitStatus.set(task_num, COMMITVALUE);


### PR DESCRIPTION
state-machine tests can now be in two modes: 
  - threaded: each state-machine task is run in a thread. the number of concurrent threads is (as usual) a parameter. interleaving is controlled by the OS.
  - interleaved: each state-machine tasks is controlled by the interleaving engine. Scheduling is completely under the control of the interleaving engine. 

Gradually, we can turn concurrency tests into state-machines, allowing to run them in either manner.