### PR TITLE
Logging changes (after batch writer & annotation processor merges)

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -82,7 +82,7 @@ public class BatchWriter <K, V> implements CacheWriter<K, V>, AutoCloseable {
 
                     if (currOp == null || processed == BATCH_SIZE || currOp == WriteOperation.SHUTDOWN) {
                         streamLog.sync();
-                        log.info("Sync'd {} writes", processed);
+                        log.trace("Sync'd {} writes", processed);
 
                         for(CompletableFuture cf : ack) {
                             cf.complete(null);
@@ -99,7 +99,7 @@ public class BatchWriter <K, V> implements CacheWriter<K, V>, AutoCloseable {
                 }
 
                 if (currOp == WriteOperation.SHUTDOWN) {
-                    log.info("Shutting down the write processor");
+                    log.trace("Shutting down the write processor");
                     break;
                 }
                 if (currOp == null) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -44,7 +44,7 @@ public class BatchWriter <K, V> implements CacheWriter<K, V>, AutoCloseable {
         try {
             submitWrite((LogAddress) key, (LogData) value).get();
         } catch (Exception e) {
-            log.error("Write Exception {}", e);
+            log.trace("Write Exception {}", e);
 
             if(e.getCause() instanceof OverwriteException) {
                 throw new OverwriteException();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -266,7 +266,7 @@ public class StreamLogFiles implements StreamLog {
                 }
 
                 writeHeader(fc, VERSION, verify);
-                log.info("Opened new log file at {}", a);
+                log.trace("Opened new log file at {}", a);
                 FileHandle fh = new FileHandle(fc, a);
                 // The first time we open a file we should read to the end, to load the
                 // map of entries we already have.
@@ -349,7 +349,7 @@ public class StreamLogFiles implements StreamLog {
             } else {
                 throw new OverwriteException();
             }
-            log.info("Disk_write[{}]: Written to disk.", logAddress);
+            log.trace("Disk_write[{}]: Written to disk.", logAddress);
         } catch (IOException e) {
             log.error("Disk_write[{}]: Exception", logAddress, e);
             throw new RuntimeException(e);

--- a/runtime/src/main/resources/logback.xml
+++ b/runtime/src/main/resources/logback.xml
@@ -7,6 +7,6 @@
     </appender>
 
     <root level="ERROR">
-        <!--<appender-ref ref="STDOUT"/>-->
+        <appender-ref ref="STDOUT"/>
     </root>
 </configuration>


### PR DESCRIPTION
Three commits, to make logging changes after merges of batch writer & annotation processor branches.

1. Severity change from error -> trace for `OverwriteException` case, e.g. in an honest race with hole fill.  (There isn't a safety violation in this case, so error severity is too strong.)
2. Reset the <append-ref> entity in `runtime`'s `logback.xml` file
3. Move BatchWriter and StreamLogFiles priorities info -> trace to match priority for other write-related events.
