### PR TITLE
Add exponential backoff to CorfuCompileProxy.TXExecute()

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -357,7 +357,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 rt.getObjectsView().TXEnd();
                 return ret;
             } catch (Exception e) {
-                log.trace("Transactional function aborted due to {}, retrying", e);
+                log.debug("Transactional function aborted due to {}, retrying after {} msec", e, sleepTime);
                 try {Thread.sleep(sleepTime); }
                 catch (Exception ex) {}
                 sleepTime = min(sleepTime * 2L, 1000L);

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -16,6 +16,8 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
+import static java.lang.Long.min;
+
 /**
  * Created by mwei on 11/11/16.
  */
@@ -347,6 +349,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
      */
     @Override
     public <R> R TXExecute(Supplier<R> txFunction) {
+        long sleepTime = 1L;
         while (true) {
             try {
                 rt.getObjectsView().TXBegin();
@@ -354,9 +357,10 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 rt.getObjectsView().TXEnd();
                 return ret;
             } catch (Exception e) {
-                log.warn("Transactional function aborted due to {}, retrying", e);
-                try {Thread.sleep(1000); }
+                log.trace("Transactional function aborted due to {}, retrying", e);
+                try {Thread.sleep(sleepTime); }
                 catch (Exception ex) {}
+                sleepTime = min(sleepTime * 2L, 1000L);
             }
         }
     }


### PR DESCRIPTION
I've noticed that with transactionless client code (i.e. optimistic transactions), I could quite frequently run into the 1 second sleep & retry on a txn abort.  This patch switches to exponential backoff, up to a maximum of one second.  In light concurrency tests, I rarely see a 2nd retry.

Also, change the severity of the log message in this method to `trace`, to match some use for txn abort events in `ObjectsView.java`.