### PR TITLE
Provide conflict parameters in access, logUpdate and getUpcallResult calls

### DIFF
--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
@@ -29,9 +29,6 @@ public interface ICorfuSMR<T> {
     /** Get a map from strings (function names) to undoRecord methods.
      * @return The undo record map. */
     Map<String, IUndoRecordFunction<T>> getCorfuUndoRecordMap();
-    /** Get a map from strings (function names) to conflict methods.
-     * @return The conflict map. */
-    Map<String, IConflictFunction> getCorfuConflictMap();
 
     /** Return the stream ID that this object belongs to.
      * @return The stream ID this object belongs to. */

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
@@ -12,27 +12,33 @@ public interface ICorfuSMRProxy<T> {
 
     /** Access the state of the object.
      * @param accessMethod      The method to execute when accessing an object.
+     * @param conflictObject    Fine-grained conflict information, if available.
      * @param <R>               The type to return.
      * @return                  The result of the accessMethod
      */
-    <R> R access(ICorfuSMRAccess<R, T> accessMethod);
+    <R> R access(ICorfuSMRAccess<R, T> accessMethod, Object[] conflictObject);
 
     /**
      * Record an SMR function to the log before returning.
      * @param smrUpdateFunction     The name of the function to record.
+     * @param conflictObject        Fine-grained conflict information, if
+     *                              available.
      * @param args                  The arguments to the function.
      *
      * @return  The address in the log the SMR function was recorded at.
      */
-    long logUpdate(String smrUpdateFunction, Object... args);
+    long logUpdate(String smrUpdateFunction, Object[] conflictObject,
+                   Object... args);
 
     /**
      * Return the result of an upcall at the given timestamp.
      * @param timestamp             The timestamp to request the upcall for.
+     * @param conflictObject        Fine-grained conflict information, if
+     *                              available.
      * @param <R>                   The type of the upcall to return.
      * @return                      The result of the upcall.
      */
-    <R> R getUpcallResult(long timestamp);
+    <R> R getUpcallResult(long timestamp, Object[] conflictObject);
 
     /** Get the ID of the stream this proxy is subscribed to.
      *

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -47,8 +47,7 @@ public class CorfuCompileWrapperBuilder {
                 type, args, serializer,
                 wrapperObject.getCorfuSMRUpcallMap(),
                 wrapperObject.getCorfuUndoMap(),
-                wrapperObject.getCorfuUndoRecordMap(),
-                wrapperObject.getCorfuConflictMap()));
+                wrapperObject.getCorfuUndoRecordMap()));
 
         if (wrapperObject instanceof ICorfuSMRProxyWrapper) {
             ((ICorfuSMRProxyWrapper) wrapperObject)

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/ReadSetEntry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/ReadSetEntry.java
@@ -1,0 +1,21 @@
+package org.corfudb.runtime.object.transactions;
+
+import lombok.Getter;
+
+/** An entry in a transaction read set.
+ * Created by mwei on 12/19/16.
+ */
+public class ReadSetEntry {
+
+    /** The fine-grained conflict information for this read, if present.*/
+    @Getter
+    final Object[] conflictObjects;
+
+    /** Create a new read set entry.
+     * @param conflictObjects       Fine-grained conflict information,
+     *                              if available.
+     */
+    public ReadSetEntry(Object[] conflictObjects) {
+        this.conflictObjects = conflictObjects;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -62,7 +62,7 @@ public class WriteAfterWriteTransactionalContext
         getWriteSet().entrySet()
                 .forEach(x -> builder.put(x.getKey(),
                         new MultiSMREntry(x.getValue().stream()
-                                .map(UpcallWrapper::getEntry)
+                                .map(WriteSetEntry::getEntry)
                                 .collect(Collectors.toList()))));
         Map<UUID, MultiSMREntry> entryMap = builder.build();
         MultiObjectSMREntry entry = new MultiObjectSMREntry(entryMap);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetEntry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetEntry.java
@@ -1,0 +1,45 @@
+package org.corfudb.runtime.object.transactions;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.corfudb.protocols.logprotocol.SMREntry;
+
+/** A entry which is in a transaction's write set.
+ *
+ * Created by mwei on 12/19/16.
+ */
+public class WriteSetEntry {
+
+    /** The modification represented by this write set entry. */
+    @Getter
+    final SMREntry entry;
+
+    /** The upcall result, if present. */
+    @Getter
+    Object upcallResult;
+
+    /** If there is an upcall result for this modification. */
+    @Getter
+    boolean haveUpcallResult = false;
+
+    /** The fine-grained conflict information for this object,
+     * or NULL, if there is no fine-grained conflict information.
+     */
+    @Getter
+    final Object[] conflictObjects;
+
+    /** Set the upcall result for this entry. */
+    public void setUpcallResult(Object result) {
+        upcallResult = result;
+        haveUpcallResult = true;
+    }
+
+    /** Create a new write set entry.
+     * @param entry             An entry, representing the modifcation made
+     * @param conflictObjects   Fine grained conflict information, if present.
+     */
+    public WriteSetEntry(@NonNull SMREntry entry, Object[] conflictObjects) {
+        this.entry = entry;
+        this.conflictObjects = conflictObjects;
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -2,14 +2,17 @@ package org.corfudb.runtime.object;
 
 import com.google.common.reflect.TypeToken;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.StreamView;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -439,10 +442,6 @@ public class CompileProxyTest extends AbstractViewTest {
 
     /** Checks that the fine-grained conflict set is correctly produced
      * by the annotation framework.
-     *
-     * Each method in ConflictParameterClass is executed, and the result
-     * of invoking the method from the conflict function map should be
-     * the objects annotated by conflict parameter.
      */
     @Test
     public void checkConflictParameters() {
@@ -453,26 +452,38 @@ public class CompileProxyTest extends AbstractViewTest {
                 .setType(ConflictParameterClass.class)
                 .open();
 
-        ICorfuSMR<ConflictParameterClass> testObjectSMR =
-                (ICorfuSMR<ConflictParameterClass>) testObject;
-        CorfuCompileProxy<ConflictParameterClass> proxy =
-                (CorfuCompileProxy<ConflictParameterClass>) testObjectSMR
-                        .getCorfuSMRProxy();
+        final String TEST_0 = "0";
+        final String TEST_1 = "1";
+        final int TEST_2 = 2;
+        final int TEST_3 = 3;
+        final String TEST_4 = "4";
+        final String TEST_5 = "5";
 
-        // mutator test -> second option should be conflict
-        assertThat(proxy.getConflictFunctionMap().get("mutatorTest")
-                .getConflictSet(0, 1))
-                .contains(1);
+        getRuntime().getObjectsView().TXBegin();
+        // RS=TEST_0
+        testObject.accessorTest(TEST_0, TEST_1);
+        // WS=TEST_3
+        testObject.mutatorTest(TEST_2, TEST_3);
+        // WS,RS=TEST_4
+        testObject.mutatorAccessorTest(TEST_4, TEST_5);
 
-        // accessor test -> first option should be conflict.
-        assertThat(proxy.getConflictFunctionMap().get("accessorTest")
-                .getConflictSet("a", "b"))
-                .contains("a");
+        // Assert that the read set contains TEST_1, TEST_4
+        assertThat(TransactionalContext.getCurrentContext()
+                .getReadSet().values().stream()
+                .flatMap(x -> x.stream())
+                .flatMap(x -> Arrays.stream(x.getConflictObjects()))
+                        .collect(Collectors.toList()))
+                .contains(TEST_0, TEST_4);
 
-        // mutatorAccessor test -> first option should be conflict.
-        assertThat(proxy.getConflictFunctionMap().get("mutatorAccessorTest")
-                .getConflictSet("a", "b"))
-                .contains("a");
+        // Assert that the write set contains TEST_2, TEST_4
+        assertThat(TransactionalContext.getCurrentContext()
+                .getWriteSet().values().stream()
+                .flatMap(x -> x.stream())
+                .flatMap(x -> Arrays.stream(x.getConflictObjects()))
+                .collect(Collectors.toList()))
+                .contains(TEST_3, TEST_4);
+
+        getRuntime().getObjectsView().TXAbort();
     }
 
 }

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -119,6 +119,10 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
             x.getLogUnitServer().shutdown();
             x.getManagementServer().shutdown();
         });
+        // Abort any active transactions...
+        while (runtime.getObjectsView().TXActive()) {
+            runtime.getObjectsView().TXAbort();
+        }
     }
 
     /** Add a server at a specific port, using the given configuration options.


### PR DESCRIPTION
Modify the interface in ISMRProxy to take conflict parameters, and save the
conflict parameters in both transactional read sets and write sets.

This patch provides most of the client-side code needed to do fine-grained
conflict resolution. What is left is for the sequencer to perform 
fine-grained conflict resolution - which means the client will 
have to send the fine-grained read and write sets.

Without this information, the sequencer will fall back to using
versions to do conflict resolution.