### PR TITLE
Finegrainedconflictresolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,6 +180,7 @@ $RECYCLE.BIN/
 
 # Mac crap
 .DS_Store
+Icon*
 
 
 #############

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -6,11 +6,17 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
 /**
  * Created by mwei on 12/4/15.
  */
 @Slf4j
 public abstract class AbstractServer {
+    public static final long NO_LOG_ADDR_MAGIC = -1L;
+    public static final Duration SMALL_INTERVAL = Duration.ofMillis(60_000);
+
 
     @Getter
     @Setter
@@ -38,16 +44,6 @@ public abstract class AbstractServer {
             log.warn("Received unhandled message type {}" , msg.getMsgType());
         }
     }
-
-    /**
-     * Reboot the server, using persistent state on disk to restart.
-     */
-    public abstract void reboot();
-
-    /**
-     * Reset the server, deleting persistent state on disk prior to rebooting.
-     */
-    public abstract void reset();
 
     /**
      * Shutdown the server.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -14,9 +14,6 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 public abstract class AbstractServer {
-    public static final long NON_LOG_ADDR_MAGIC = -1L;
-    public static final Duration SMALL_INTERVAL = Duration.ofMillis(60_000);
-
 
     @Getter
     @Setter

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -14,7 +14,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 public abstract class AbstractServer {
-    public static final long NO_LOG_ADDR_MAGIC = -1L;
+    public static final long NON_LOG_ADDR_MAGIC = -1L;
     public static final Duration SMALL_INTERVAL = Duration.ofMillis(60_000);
 
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -65,10 +65,4 @@ public class BaseServer extends AbstractServer {
         Utils.sleepUninterruptibly(500); // Sleep, to make sure that all channels are flushed...
         System.exit(100);
     }
-
-    @Override
-    public void reset() { }
-
-    @Override
-    public void reboot() { }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -12,11 +12,7 @@ import org.corfudb.runtime.exceptions.OverwriteException;
 import javax.annotation.Nonnull;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.*;
 
 /**
  * BatchWriter is a class that will intercept write-through calls to batch and

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -180,7 +180,7 @@ public class CorfuServer {
         addSequencer();
         addLayoutServer();
         addLogUnit();
-        addManagmentServer();
+        addManagementServer();
         router.baseServer.setOptionsMap(opts);
 
         // Create the event loops responsible for servicing inbound messages.
@@ -276,7 +276,7 @@ public class CorfuServer {
         router.addServer(logUnitServer);
     }
 
-    public static void addManagmentServer() {
+    public static void addManagementServer() {
         managementServer = new ManagementServer(serverContext);
         router.addServer(managementServer);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -55,6 +55,10 @@ public class CorfuServer {
     @Getter
     private static ManagementServer managementServer;
 
+    private static NettyServerRouter router;
+
+    private static ServerContext serverContext;
+
     public static boolean serverRunning = false;
 
     /**
@@ -169,20 +173,16 @@ public class CorfuServer {
         }
 
         // Now, we start the Netty router, and have it route to the correct port.
-        NettyServerRouter router = new NettyServerRouter(opts);
+        router = new NettyServerRouter(opts);
 
         // Create a common Server Context for all servers to access.
-        ServerContext serverContext = new ServerContext(opts, router);
+        serverContext = new ServerContext(opts, router);
 
         // Add each role to the router.
-        sequencerServer = new SequencerServer(serverContext);
-        router.addServer(sequencerServer);
-        layoutServer = new LayoutServer(serverContext);
-        router.addServer(layoutServer);
-        logUnitServer = new LogUnitServer(serverContext);
-        router.addServer(logUnitServer);
-        managementServer = new ManagementServer(serverContext);
-        router.addServer(managementServer);
+        addSequencer();
+        addLayoutServer();
+        addLogUnit();
+        addManagmentServer();
         router.baseServer.setOptionsMap(opts);
 
         // Create the event loops responsible for servicing inbound messages.
@@ -261,5 +261,25 @@ public class CorfuServer {
             workerGroup.shutdownGracefully();
         }
 
+    }
+
+    public static void addSequencer() {
+        sequencerServer = new SequencerServer(serverContext);
+        router.addServer(sequencerServer);
+    }
+
+    public static void addLayoutServer() {
+        layoutServer = new LayoutServer(serverContext);
+        router.addServer(layoutServer);
+    }
+
+    public static void addLogUnit() {
+        logUnitServer = new LogUnitServer(serverContext);
+        router.addServer(logUnitServer);
+    }
+
+    public static void addManagmentServer() {
+        managementServer = new ManagementServer(serverContext);
+        router.addServer(managementServer);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -90,8 +90,6 @@ public class CorfuServer {
                     + "                                         evicted entries will be auto-trimmed. [default: 1000000000].\n"
                     + " -t <token>, --initial-token=<token>     The first token the sequencer will issue, or -1 to recover\n"
                     + "                                         from the log. [default: -1].\n"
-                    + " -k <seconds>, --checkpoint=<seconds>    The rate the sequencer should checkpoint its state to disk,\n"
-                    + "                                         in seconds [default: 60].\n"
                     + " -p <seconds>, --compact=<seconds>       The rate the log unit should compact entries (find the,\n"
                     + "                                         contiguous tail) in seconds [default: 60].\n"
                     + " -d <level>, --log-level=<level>         Set the logging level, valid levels are: \n"

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
@@ -1,9 +1,7 @@
 package org.corfudb.infrastructure;
 
-import com.github.benmanes.caffeine.cache.CacheWriter;
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.*;
+import com.google.common.cache.CacheBuilder;
 import lombok.Getter;
 import org.corfudb.util.JSONUtils;
 
@@ -19,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Stores data as JSON.
@@ -32,72 +31,89 @@ import java.util.concurrent.Callable;
  */
 
 public class DataStore implements IDataStore {
+
+    private final Map<String, Object> opts;
+    private final boolean isPersistent;
+    private final Cache<String, String> cache;
+    private final String logDir;
+
     @Getter
-    public String logDir;
-
-    private LoadingCache<String, String> cache;
-
     private final long maxDataStoreSize = 1_000;
 
 
     public DataStore(Map<String, Object> opts) {
-        this.logDir = (String) opts.get("--log-path");
-        this.cache = Caffeine.newBuilder().writer(new CacheWriter<String, String>(
-        ) {
-            @Override
-            public synchronized void write(@Nonnull String key, @Nonnull String value) {
-                System.out.println("  *caffeine write " + key);
-                if (logDir == null) {
-                    return;
-                }
-                try {
-                    Path path = Paths.get(logDir + File.separator + key);
-                    Files.write(path, value.getBytes());
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
+        this.opts = opts;
 
-            @Override
-            public synchronized void delete(@Nonnull String key, @Nullable String value, @Nonnull RemovalCause cause) {
-                System.out.println("  *caffeine evict " + key);
-                if (logDir == null) {
-                    return;
-                }
-                try {
-                    Path path = Paths.get(logDir + File.separator + key);
-                    Files.deleteIfExists(path);
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-          })
-                .maximumSize(maxDataStoreSize)
-                .removalListener(this::handleEviction)
-                .build(key -> {
-                    System.out.println("  *caffeine build " + key);
-                    if (logDir != null) {
+        if ((opts.get("--memory") != null && (Boolean) opts.get("--memory"))
+                || opts.get("--log-path") == null) {
+            isPersistent = false;
+            this.logDir = null;
+            cache = buildMemoryDS();
+        } else {
+            isPersistent = true;
+            this.logDir = (String) opts.get("--log-path");
+            cache = buildPersistentDS();
+        }
+    }
+
+    private Cache<String, String> buildMemoryDS() {
+        Cache<String, String> cache = Caffeine
+                .newBuilder()
+                .build();
+        return cache;
+    }
+
+    private Cache<String, String> buildPersistentDS() {
+        LoadingCache<String, String> cache = Caffeine.newBuilder()
+                .writer(new CacheWriter<String, String>() {
+                    @Override
+                    public synchronized void write(@Nonnull String key, @Nonnull String value) {
+                        System.out.println("  *caffeine write " + key);
                         try {
                             Path path = Paths.get(logDir + File.separator + key);
-                            if (Files.notExists(path)) {
-                                return null;
-                            }
-                            return new String(Files.readAllBytes(path));
+                            Files.write(path, value.getBytes());
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }
                     }
-                    return null;
+
+                    @Override
+                    public synchronized void delete(@Nonnull String key, @Nullable String value, @Nonnull RemovalCause cause) {
+                        System.out.println("  *caffeine evict " + key);
+                        try {
+                            Path path = Paths.get(logDir + File.separator + key);
+                            Files.deleteIfExists(path);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
                 })
-               ;
+            .maximumSize(maxDataStoreSize)
+            .removalListener(this::handleEviction)
+            .build(key -> {
+                    System.out.println("  *caffeine build " + key);
+                    try {
+                        Path path = Paths.get(logDir + File.separator + key);
+                        if (Files.notExists(path)) {
+                            return null;
+                        }
+                        return new String(Files.readAllBytes(path));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+
+        return cache;
     }
 
     public synchronized void handleEviction(String key, String  entry, RemovalCause cause) {
         System.out.println("  *caffeine eviction " + key + ", " + entry);
+        if (! isPersistent)
+            throw new RuntimeException(); // panic, we'll lose state!
     }
 
 
-        @Override
+    @Override
     public synchronized  <T> void put(Class<T> tClass, String prefix, String key, T value) {
         System.out.println("dataStore put " + getKey(prefix, key) + ", " + value);
         cache.put(getKey(prefix, key), JSONUtils.parser.toJson(value, tClass));
@@ -106,8 +122,9 @@ public class DataStore implements IDataStore {
     @Override
     public synchronized  <T> T get(Class<T> tClass, String prefix, String key) {
         System.out.println("dataStore get of " + getKey(prefix, key));
-        String json = cache.get(getKey(prefix, key));
-        System.out.println("dataStore get retrieves value " + getKey(prefix, key) + ", " + json);
+        String json = cache.get(getKey(prefix, key), k -> null);
+        if (json == null)
+            System.out.println("dataStore get retrieves null value " + getKey(prefix, key));
         return getObject(json, tClass);
     }
 
@@ -131,11 +148,6 @@ public class DataStore implements IDataStore {
     @Override
     public synchronized <T> void delete(Class<T> tClass, String prefix, String key) {
         cache.invalidate(getKey(prefix, key));
-    }
-
-    @Override
-    public synchronized void deleteAll() {
-        cache.invalidateAll();
     }
 
     // Helper methods

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
@@ -35,6 +35,8 @@ public class DataStore implements IDataStore {
 
     private LoadingCache<String, String> cache;
 
+    private final long maxDataStoreSize = 10_00;
+
 
     public DataStore(Map<String, Object> opts) {
         this.logDir = (String) opts.get("--log-path");
@@ -65,7 +67,7 @@ public class DataStore implements IDataStore {
                     throw new RuntimeException(e);
                 }
             }
-        }).maximumSize(10_00)
+        }).maximumSize(maxDataStoreSize)
                 .build(key -> {
                     if (logDir != null) {
                         try {
@@ -107,6 +109,11 @@ public class DataStore implements IDataStore {
     @Override
     public synchronized <T> void delete(Class<T> tClass, String prefix, String key) {
         cache.invalidate(getKey(prefix, key));
+    }
+
+    @Override
+    public synchronized void deleteAll() {
+        cache.invalidateAll();
     }
 
     // Helper methods

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
@@ -40,7 +40,7 @@ public class DataStore implements IDataStore {
     private final String logDir;
 
     @Getter
-    private final long maxDataStoreCacheSize = 1_000; // size bound for in-memory cache for dataStore
+    private final long DS_CACHE_SZ = 1_000; // size bound for in-memory cache for dataStore
 
 
     public DataStore(Map<String, Object> opts) {
@@ -74,7 +74,7 @@ public class DataStore implements IDataStore {
     /**
      * obtain a {@link LoadingCache}.
      * The cache is backed up by file-per-key uner {@link DataStore::logDir}.
-     * The cache size is bounded by {@link DataStore::maxDataStoreCacheSize}.
+     * The cache size is bounded by {@link DataStore::DS_CACHE_SZ}.
      *
      * @return the cache object
      */
@@ -101,7 +101,7 @@ public class DataStore implements IDataStore {
                         }
                     }
                 })
-            .maximumSize(maxDataStoreCacheSize)
+            .maximumSize(DS_CACHE_SZ)
             .build(key -> {
                     try {
                         Path path = Paths.get(logDir + File.separator + key);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IDataStore.java
@@ -46,6 +46,11 @@ public interface IDataStore {
     public <T> void delete(Class<T> tClass, String prefix, String key);
 
     /**
+     * Delete all entries
+     */
+    public void deleteAll();
+
+    /**
      * Retrieves all the values under a prefix.
      * <p>
      * NOTE there is no ordered retrieval provided.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IDataStore.java
@@ -46,11 +46,6 @@ public interface IDataStore {
     public <T> void delete(Class<T> tClass, String prefix, String key);
 
     /**
-     * Delete all entries
-     */
-    public void deleteAll();
-
-    /**
      * Retrieves all the values under a prefix.
      * <p>
      * NOTE there is no ordered retrieval provided.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -64,84 +64,41 @@ public class LayoutServer extends AbstractServer {
     /**
      * The options map.
      */
-    private Map<String, Object> opts;
+    private final Map<String, Object> opts;
 
     @Getter
-    private ServerContext serverContext;
+    private final ServerContext serverContext;
 
     /** Handler for this server */
     @Getter
     private CorfuMsgHandler handler = new CorfuMsgHandler()
             .generateHandlers(MethodHandles.lookup(), this);
 
-    private int reboots = 0;
-
     public LayoutServer(ServerContext serverContext) {
         this.opts = serverContext.getServerConfig();
         this.serverContext = serverContext;
 
-        reboot();
-        reset_part_2();
-
-        // QuickCheck: Create the distributed Erlang message handling threads
-        Object test_mode = opts.get("--quickcheck-test-mode");
-        if (test_mode != null && (Boolean) test_mode) {
-            // Disabled due to cyclic dependency...
-         //   QuickCheckMode qm = new QuickCheckMode(opts);
-        }
+        if ((Boolean) opts.get("--single"))
+            getSingleNodeLayout();
     }
 
-    /**
-     * Reset the server, deleting persistent state on disk prior to rebooting.
-     */
-
-    @Override
-    public synchronized void reset() {
-        serverContext.getDataStore().deleteAll();
-
-        reset_part_2();
-        reboot();
-    }
-
-    private void reset_part_2() {
-        if ((Boolean) opts.get("--single")) {
-            String localAddress = opts.get("--address") + ":" + opts.get("<port>");
-            String boot_msg = "Single-node mode requested, initializing layout with single log unit and sequencer at {}.";
-            if (reboots++ == 0 ) {
-                log.info(boot_msg, localAddress);
-            } else {
-                log.debug(boot_msg, localAddress);
-
-            }
-            setCurrentLayout(new Layout(
-                    Collections.singletonList(localAddress),
-                    Collections.singletonList(localAddress),
-                    Collections.singletonList(new LayoutSegment(
-                            Layout.ReplicationMode.CHAIN_REPLICATION,
-                            0L,
-                            -1L,
-                            Collections.singletonList(
-                                    new Layout.LayoutStripe(
-                                            Collections.singletonList(localAddress)
-                                    )
-                            )
-                    )),
-                    0L
-            ));
-        }
-    }
-
-    /**
-     * Reboot the server, using persistent state on disk to restart.
-     */
-    @Override
-    public synchronized void reboot() {
-        serverContext.resetDataStore();
-
-        if (serverContext.getServerRouter().getClass().toString().equals("class org.corfudb.infrastructure.TestServerRouter") &&
-                (Boolean) opts.get("--single") && (Boolean) opts.get("--memory")) {
-            reset_part_2();
-        }
+    private void getSingleNodeLayout() {
+        String localAddress = opts.get("--address") + ":" + opts.get("<port>");
+        setCurrentLayout(new Layout(
+                Collections.singletonList(localAddress),
+                Collections.singletonList(localAddress),
+                Collections.singletonList(new LayoutSegment(
+                        Layout.ReplicationMode.CHAIN_REPLICATION,
+                        0L,
+                        -1L,
+                        Collections.singletonList(
+                                new Layout.LayoutStripe(
+                                        Collections.singletonList(localAddress)
+                                )
+                        )
+                )),
+                0L
+        ));
     }
 
     boolean checkBootstrap(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -97,34 +97,8 @@ public class LayoutServer extends AbstractServer {
 
     @Override
     public synchronized void reset() {
-        String d = serverContext.getDataStore().getLogDir();
-        if (d != null) {
-            Path dir = FileSystems.getDefault().getPath(d);
-            String prefixes[] = new String[] {PREFIX_LAYOUT, KEY_LAYOUT, PREFIX_PHASE_1, PREFIX_PHASE_2,
-                    PREFIX_LAYOUTS, "SERVER_EPOCH"};
+        serverContext.getDataStore().deleteAll();
 
-            for (String pfx : prefixes) {
-                try (DirectoryStream<Path> stream =
-                             Files.newDirectoryStream(dir, pfx + "_*")) {
-                    for (Path entry : stream) {
-                        // System.out.println("Deleting " + entry);
-                        Files.delete(entry);
-                    }
-                } catch (IOException e) {
-                    log.error("reset: error deleting prefix " + pfx + ": " + e.toString());
-                }
-            }
-            /*
-            try (DirectoryStream<Path> stream =
-                         Files.newDirectoryStream(dir, "*")) {
-                for (Path entry : stream) {
-                    System.out.println("Remaining file " + entry);
-                }
-            } catch (IOException e) {
-                log.error("reset: error deleting prefix: " + e.toString());
-            }
-            */
-        }
         reset_part_2();
         reboot();
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -86,6 +86,7 @@ public class LogUnitServer extends AbstractServer {
 
     /**
      * GC parameters
+     * TODO: entire GC handling needs updating, currently not being activated
      */
     private final Thread gcThread = null;
     private IntervalAndSentinelRetry gcRetry;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -71,7 +71,7 @@ import org.corfudb.util.retry.IntervalAndSentinelRetry;
 @Slf4j
 public class LogUnitServer extends AbstractServer {
 
-    private ServerContext serverContext;
+    private final ServerContext serverContext;
 
     /**
      * A scheduler, which is used to schedule periodic tasks like garbage collection.
@@ -83,10 +83,18 @@ public class LogUnitServer extends AbstractServer {
                             .setDaemon(true)
                             .setNameFormat("LogUnit-Maintenance-%d")
                             .build());
+
+    /**
+     * GC parameters
+     */
+    private final Thread gcThread = null;
+    private IntervalAndSentinelRetry gcRetry;
+    private AtomicBoolean running = new AtomicBoolean(true);
+
     /**
      * The options map.
      */
-    Map<String, Object> opts;
+    private final Map<String, Object> opts;
 
     /**
      * Handler for the base server
@@ -94,6 +102,53 @@ public class LogUnitServer extends AbstractServer {
     @Getter
     private CorfuMsgHandler handler = new CorfuMsgHandler()
             .generateHandlers(MethodHandles.lookup(), this);
+
+    private final ConcurrentHashMap<UUID, Long> trimMap;
+
+    /**
+     * This cache services requests for data at various addresses. In a memory implementation,
+     * it is not backed by anything, but in a disk implementation it is backed by persistent storage.
+     */
+    private final LoadingCache<LogAddress, LogData> dataCache;
+    private final long maxCacheSize;
+
+    private final StreamLog streamLog;
+
+    private final BatchWriter<LogAddress, LogData> batchWriter;
+
+    public LogUnitServer(ServerContext serverContext) {
+        this.opts = serverContext.getServerConfig();
+        this.serverContext = serverContext;
+        maxCacheSize = Utils.parseLong(opts.get("--max-cache"));
+
+        if ((Boolean) opts.get("--memory")) {
+            log.warn("Log unit opened in-memory mode (Maximum size={}). " +
+                    "This should be run for testing purposes only. " +
+                    "If you exceed the maximum size of the unit, old entries will be AUTOMATICALLY trimmed. " +
+                    "The unit WILL LOSE ALL DATA if it exits.", Utils.convertToByteStringRepresentation(maxCacheSize));
+            streamLog = new InMemoryStreamLog();
+        } else {
+            String logdir = opts.get("--log-path") + File.separator + "log";
+            File dir = new File(logdir);
+            if (!dir.exists()) {
+                dir.mkdir();
+            }
+            streamLog = new StreamLogFiles(logdir, (Boolean) opts.get("--no-verify"));
+        }
+
+        batchWriter = new BatchWriter(streamLog);
+
+        dataCache = Caffeine.<LogAddress, LogData>newBuilder()
+                .<LogAddress, LogData>weigher((k, v) -> v.getData() == null ? 1 : v.getData().readableBytes())
+                .maximumWeight(maxCacheSize)
+                .removalListener(this::handleEviction)
+                .writer(batchWriter)
+                .build(this::handleRetrieval);
+
+        // Trim map is set to empty on start
+        // TODO: persist trim map - this is optional since trim is just a hint.
+        trimMap = new ConcurrentHashMap<>();
+    }
 
     /**
      * Service an incoming write request.
@@ -207,106 +262,6 @@ public class LogUnitServer extends AbstractServer {
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
     }
 
-
-    /**
-     * The garbage collection thread.
-     */
-    Thread gcThread;
-
-    ConcurrentHashMap<UUID, Long> trimMap;
-    IntervalAndSentinelRetry gcRetry;
-    AtomicBoolean running = new AtomicBoolean(true);
-    /**
-     * This cache services requests for data at various addresses. In a memory implementation,
-     * it is not backed by anything, but in a disk implementation it is backed by persistent storage.
-     */
-    LoadingCache<LogAddress, LogData> dataCache;
-    long maxCacheSize;
-
-    private StreamLog streamLog;
-
-    private BatchWriter<LogAddress, LogData> batchWriter;
-
-    public LogUnitServer(ServerContext serverContext) {
-        this.opts = serverContext.getServerConfig();
-        this.serverContext = serverContext;
-        maxCacheSize = Utils.parseLong(opts.get("--max-cache"));
-
-        reboot();
-
-/*       compactTail seems to be broken, disabling it for now
-         scheduler.scheduleAtFixedRate(this::compactTail,
-                Utils.getOption(opts, "--compact", Long.class, 60L),
-                Utils.getOption(opts, "--compact", Long.class, 60L),
-                TimeUnit.SECONDS);*/
-
-        //gcThread = new Thread(this::runGC);
-        //gcThread.start();
-    }
-
-    @Override
-    public void reset() {
-        String d = serverContext.getDataStore().getLogDir();
-        streamLog.close();
-        if (d != null) {
-            Path dir = FileSystems.getDefault().getPath(d + File.separator + "log");
-            try (DirectoryStream<Path> stream =
-                         Files.newDirectoryStream(dir, "*")) {
-                for (Path entry : stream) {
-                    try {
-                        Files.delete(entry);
-                    } catch (IOException ie) {
-                        log.error("reset: error deleting " + entry.toString() + ": " + entry.toString());
-                    }
-                }
-            } catch (IOException e) {
-                log.error("reset: error for dir " + dir + ": " + e.toString());
-            }
-        }
-        reboot();
-    }
-
-    @Override
-    public void reboot() {
-        if ((Boolean) opts.get("--memory")) {
-            log.warn("Log unit opened in-memory mode (Maximum size={}). " +
-                    "This should be run for testing purposes only. " +
-                    "If you exceed the maximum size of the unit, old entries will be AUTOMATICALLY trimmed. " +
-                    "The unit WILL LOSE ALL DATA if it exits.", Utils.convertToByteStringRepresentation(maxCacheSize));
-            streamLog = new InMemoryStreamLog();
-        } else {
-            String logdir = opts.get("--log-path") + File.separator + "log";
-            File dir = new File(logdir);
-            if (!dir.exists()) {
-                dir.mkdir();
-            }
-            streamLog = new StreamLogFiles(logdir, (Boolean) opts.get("--no-verify"));
-        }
-
-        if (dataCache != null) {
-            /** Free all references */
-            dataCache.asMap().values().parallelStream()
-                    .map(m -> m.getData().release());
-        }
-
-        if (batchWriter != null) {
-            batchWriter.close();
-        }
-
-        batchWriter = new BatchWriter(streamLog);
-
-        dataCache = Caffeine.<LogAddress, LogData>newBuilder()
-                .<LogAddress, LogData>weigher((k, v) -> v.getData() == null ? 1 : v.getData().readableBytes())
-                .maximumWeight(maxCacheSize)
-                .removalListener(this::handleEviction)
-                .writer(batchWriter)
-                .build(this::handleRetrieval);
-
-        // Trim map is set to empty on start
-        // TODO: persist trim map - this is optional since trim is just a hint.
-        trimMap = new ConcurrentHashMap<>();
-    }
-
     /**
      * Retrieve the LogUnitEntry from disk, given an address.
      *
@@ -333,7 +288,7 @@ public class LogUnitServer extends AbstractServer {
         Thread.currentThread().setName("LogUnit-GC");
         val retry = IRetry.build(IntervalAndSentinelRetry.class, this::handleGC)
                 .setOptions(x -> x.setSentinelReference(running))
-                .setOptions(x -> x.setRetryInterval(60_000));
+                .setOptions(x -> x.setRetryInterval(SMALL_INTERVAL.toMillis()));
 
         gcRetry = (IntervalAndSentinelRetry) retry;
 
@@ -397,7 +352,6 @@ public class LogUnitServer extends AbstractServer {
     @Override
     public void shutdown() {
         scheduler.shutdownNow();
-        dataCache.invalidateAll(); //should evict all entries
         batchWriter.close();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -55,6 +55,8 @@ import org.corfudb.util.Utils;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.IntervalAndSentinelRetry;
 
+import static org.corfudb.infrastructure.ServerContext.SMALL_INTERVAL;
+
 /**
  * Created by mwei on 12/10/15.
  * <p>

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -49,7 +49,6 @@ public class ManagementServer extends AbstractServer {
 
     private static final String PREFIX_LAYOUT = "M_LAYOUT";
     private static final String KEY_LAYOUT = "M_CURRENT";
-    private static final long SHUTDOWN_TIMER = 5; // seconds
 
     private CorfuRuntime corfuRuntime;
     /**
@@ -319,7 +318,7 @@ public class ManagementServer extends AbstractServer {
         }
 
         try {
-            failureDetectorService.awaitTermination(SHUTDOWN_TIMER, TimeUnit.SECONDS);
+            failureDetectorService.awaitTermination(serverContext.SHUTDOWN_TIMER.getSeconds(), TimeUnit.SECONDS);
         } catch (InterruptedException ie) {
             log.debug("failureDetectorService awaitTermination interrupted : {}", ie);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -66,6 +66,15 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
                 });
     }
 
+    public void removeServer(AbstractServer server) {
+        // Iterate through all types of CorfuMsgType, un-registering the handler
+        server.getHandler().getHandledTypes()
+                .forEach(x -> {
+                    handlerMap.remove(x, server);
+                    log.trace("Un-Registered {} to handle messages of type {}", server, x);
+                });
+    }
+
     /**
      * Send a netty message through this router, setting the fields in the outgoing message.
      *
@@ -74,11 +83,11 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
      * @param outMsg Outgoing message.
      */
     public void sendResponse(ChannelHandlerContext ctx, CorfuMsg inMsg, CorfuMsg outMsg) {
-        long badEpoch = -667788;
+        // long badEpoch = -667788;
 
-        outMsg.setEpoch(badEpoch);
+        // outMsg.setEpoch(badEpoch);
         outMsg.copyBaseFields(inMsg);
-        if (outMsg.getEpoch() == badEpoch) { log.warn("copyBaseFields didn't clobber epoch"); System.exit(66); }
+        // if (outMsg.getEpoch() == badEpoch) { log.warn("copyBaseFields didn't clobber epoch"); System.exit(66); }
 
         ctx.writeAndFlush(outMsg);
         log.trace("Sent response: {}", outMsg);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -83,12 +83,7 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
      * @param outMsg Outgoing message.
      */
     public void sendResponse(ChannelHandlerContext ctx, CorfuMsg inMsg, CorfuMsg outMsg) {
-        // long badEpoch = -667788;
-
-        // outMsg.setEpoch(badEpoch);
         outMsg.copyBaseFields(inMsg);
-        // if (outMsg.getEpoch() == badEpoch) { log.warn("copyBaseFields didn't clobber epoch"); System.exit(66); }
-
         ctx.writeAndFlush(outMsg);
         log.trace("Sent response: {}", outMsg);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -1,5 +1,8 @@
 package org.corfudb.infrastructure;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.ChannelHandlerContext;
@@ -16,12 +19,10 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -37,108 +38,66 @@ import java.util.concurrent.atomic.AtomicLong;
 @Slf4j
 public class SequencerServer extends AbstractServer {
 
-    /**
-     * A scheduler, which is used to schedule checkpoints and lease renewal
-     */
-    private final ScheduledExecutorService scheduler =
-            Executors.newScheduledThreadPool(
-                    1,
-                    new ThreadFactoryBuilder()
-                            .setDaemon(true)
-                            .setNameFormat("Seq-Checkpoint-%d")
-                            .build());
-    @Getter
-    long epoch;
-    AtomicLong globalLogTail;
+    private static final String PREFIX_SEQUENCER = "SEQUENCER";
+    private static final String KEY_SEQUENCER = "CURRENT";
 
     /**
-     * The file channel.
+     * Inherit from CorfuServer a server context
      */
-    private FileChannel fc;
-    private Object fcLock = new Object();
+    private final ServerContext serverContext;
 
     /**
      * Our options
      */
-    private Map<String, Object> opts;
+    private final Map<String, Object> opts;
+
+    /**
+     * The sequencer maintains information about log and streams.
+     * Every append to the log updates the information in these maps.
+     *
+     * The following informaion and maps reflect the state of the logs and streams:
+     *
+     *  - globalLogTail: global log tail
+     *  - streamTailMap: a map of per-stream tail
+     *  - map from stream-tails to global-log tails. used for backpointers.
+     *  - cache of maxConflictCacheSize conflict keys and their latest commit (global-log) index
+     */
+    @Getter
+    private final AtomicLong globalLogTail = new AtomicLong(0L);
+    private final ConcurrentHashMap<UUID, Long> streamTailMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<UUID, Long> streamTailToGlobalTailMap = new ConcurrentHashMap<>();
+    private final long maxConflictCacheSize = 10000;
+    private final Cache<Object, Long> conflictToGlobalTailCache = Caffeine.newBuilder()
+            .maximumSize(maxConflictCacheSize)
+                .build();
+
+    /**
+     * A sequencer needs a lease to serve a certain number of tokens.
+     * The lease starting index is persisted.
+     * A lease is good for (@Link #SequencerServer::leaseLength) number of tokens.
+     *
+     * A lease is renewed when we reach leaseRenew tokens away from the limit.
+     */
+    @Getter
+    private final long leaseLength = 10000;
+    private final long leaseRenew = 1000;
 
     /** Handler for this server */
     @Getter
     private CorfuMsgHandler handler = new CorfuMsgHandler()
             .generateHandlers(MethodHandles.lookup(), this);
 
-    /**
-     * map from stream-trails to global-log tails. used for backpointers.
-     */
-    ConcurrentHashMap<UUID, Long> streamTailToGlobalTailMap;
-
-    /**
-     * map of stream tails.
-     */
-    ConcurrentHashMap<UUID, Long> streamTailMap;
-
     public SequencerServer(ServerContext serverContext) {
-        Map<String, Object> opts = serverContext.getServerConfig();
-        streamTailToGlobalTailMap = new ConcurrentHashMap<>();
-        streamTailMap = new ConcurrentHashMap<>();
-        globalLogTail = new AtomicLong();
-        this.opts = opts;
+        this.serverContext = serverContext;
+        this.opts = serverContext.getServerConfig();
 
-        try {
-            if (!(Boolean) opts.get("--memory")) {
-                synchronized (fcLock) {
-                    open_fc();
-                }
-                // schedule checkpointing.
-                scheduler.scheduleAtFixedRate(this::checkpointState,
-                        Utils.parseLong(opts.get("--checkpoint")),
-                        Utils.parseLong(opts.get("--checkpoint")),
-                        TimeUnit.SECONDS);
-            }
-            reboot();
-
-            log.info("Sequencer initial token set to {}", globalLogTail.get());
-        } catch (Exception ex) {
-            log.warn("Exception parsing initial token, default to 0.", ex);
-            ex.printStackTrace();
+        long initialToken = Utils.parseLong(opts.get("--initial-token"));
+        if (initialToken != -1) {
+            renewLease(initialToken);
+            globalLogTail.set(initialToken);
         }
-    }
-
-    private void open_fc() {
-        try {
-            fc = FileChannel.open(make_checkpoint_path(),
-                    EnumSet.of(StandardOpenOption.READ, StandardOpenOption.WRITE,
-                            StandardOpenOption.CREATE, StandardOpenOption.SPARSE));
-        } catch (IOException e) {
-            log.warn("Error opening " + make_checkpoint_path() + ": " + e);
-            fc = null;
-        }
-    }
-
-    private java.nio.file.Path make_checkpoint_path() {
-        return FileSystems.getDefault().getPath(opts.get("--log-path")
-                + File.separator + "sequencer_checkpoint");
-    }
-
-    /**
-     * Checkpoints the state of the sequencer.
-     */
-    public void checkpointState() {
-        ByteBuffer b = ByteBuffer.allocate(8);
-        long checkpointAddress = globalLogTail.get();
-        b.putLong(checkpointAddress);
-        b.flip();
-        synchronized (fcLock) {
-            if (fc != null) {
-                try {
-                    fc.write(b, 0L);
-                    fc.force(true);
-                    log.debug("Sequencer state successfully checkpointed at {}", checkpointAddress);
-                } catch (IOException ie) {
-                    log.warn("Sequencer checkpoint failed due to exception", ie);
-                }
-            }
-        }
+        else
+            getInitalLease();
     }
 
     /**
@@ -218,6 +177,10 @@ public class SequencerServer extends AbstractServer {
             return;
         }
 
+        // check if need to renew sequencer lease
+        if (globalLogTail.get() - getCurrentLease() < leaseRenew)
+            renewLease(getCurrentLease() + leaseLength);
+
         // if no streams, simply allocate a position at the tail of the global log
         if (req.getStreams() == null) {
             r.sendResponse(ctx, msg, CorfuMsgType.TOKEN_RES.payloadMsg(
@@ -288,60 +251,64 @@ public class SequencerServer extends AbstractServer {
 
     @Override
     public void reset() {
-        if (fc != null) {
-            synchronized (fcLock) {
-                try { fc.close(); } catch (IOException e) { /* Not a fatal problem, right? */ }
-                try {
-                    Files.delete(make_checkpoint_path());
-                } catch (IOException e) {
-                    log.warn("Error deleting " + make_checkpoint_path() + ":" + e);
-                }
-                open_fc();
-            }
-        }
+        serverContext.getDataStore().deleteAll();
         reboot();
     }
 
     @Override
     public synchronized void reboot() {
-            streamTailToGlobalTailMap = new ConcurrentHashMap<>();
-            streamTailMap = new ConcurrentHashMap<>();
-            globalLogTail = new AtomicLong(0L);
-            long newIndex = Utils.parseLong(opts.get("--initial-token"));
-            if (newIndex == -1) {
-                if (!(Boolean) opts.get("--memory")) {
-                    try {
-                        ByteBuffer b = ByteBuffer.allocate((int) fc.size());
-                        fc.read(b);
-                        if (fc.size() >= 8) {
-                            globalLogTail.set(b.getLong(0));
-                        } else {
-                            log.warn("Sequencer recovery requested but checkpoint not set, defaulting to 0");
-                        }
-                    } catch (IOException e) {
-                        log.warn("Reboot to zero.  Sequencer checkpoint read & parse: " + e);
-                    }
-                } else {
-                    log.warn("Sequencer recovery requested but has no meaning for a in-memory server, defaulting to 0");
-                }
-            } else {
-                globalLogTail.set(newIndex);
-            }
+
+        streamTailToGlobalTailMap.clear();
+        streamTailMap.clear();
+        conflictToGlobalTailCache.invalidateAll();
+        serverContext.resetDataStore();
+
+        // get a new lease.
+        // note: do not conflict with the previous sequencer incarnation!
+        getInitalLease();
+        log.info("Sequencer initial token set to {}", globalLogTail.get());
+    }
+
+    /**
+     * obtain the initial lease (a log tail).
+     * for now, this works only with a local file.
+     * TODO in the future, a sequencer needs to obtain the lease from the layout service
+     */
+    private void getInitalLease() {
+        Long leaseTail = serverContext.getDataStore()
+                .get(Long.class, PREFIX_SEQUENCER, KEY_SEQUENCER);
+        if (leaseTail != null) {
+            renewLease(leaseTail + leaseLength);
+            globalLogTail.set(leaseTail + leaseLength);
+        } else {
+            renewLease(0L);
+            globalLogTail.set(0L);
+        }
+    }
+
+    /**
+     * extend the current lease to a new tail
+     * @param leaseStart the new lease starting point
+     */
+    private void renewLease(long leaseStart) {
+        serverContext.getDataStore()
+                .put(Long.class, PREFIX_SEQUENCER, KEY_SEQUENCER, leaseStart);
+    }
+
+    /**
+     * query the current lease
+     * @return the lease's starting point
+     */
+    private long getCurrentLease() {
+        return serverContext.getDataStore()
+                .get(Long.class, PREFIX_SEQUENCER, KEY_SEQUENCER);
     }
 
     /**
      * Shutdown the server.
-     */
     @Override
     public void shutdown() {
-        try {
-            scheduler.shutdownNow();
-            checkpointState();
-            synchronized (fcLock) {
-                if (fc != null) fc.close();
-            }
-        } catch (IOException ie) {
-            log.warn("Error checkpointing server during shutdown!", ie);
-        }
+        // nothing to do
     }
+     */
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -16,6 +16,8 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static org.corfudb.infrastructure.ServerContext.NON_LOG_ADDR_MAGIC;
+
 /**
  * This server implements the sequencer functionality of Corfu.
  * <p>

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.corfudb.runtime.view.Layout;
 
+import java.time.Duration;
 import java.util.Map;
 
 /**
@@ -23,6 +24,18 @@ import java.util.Map;
 public class ServerContext {
     private static final String PREFIX_EPOCH = "SERVER_EPOCH";
     private static final String KEY_EPOCH = "CURRENT";
+
+    /**
+     * magic non-address value, used in parameters to indicate no valid log address is provided
+     */
+    public static final long NON_LOG_ADDR_MAGIC = -1L;
+
+    /**
+     * various duration constants
+     */
+    public static final Duration SMALL_INTERVAL = Duration.ofMillis(60_000);
+    public static final Duration SHUTDOWN_TIMER = Duration.ofSeconds(5);
+
 
     @Getter
     private final Map<String, Object> serverConfig;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -25,10 +25,10 @@ public class ServerContext {
     private static final String KEY_EPOCH = "CURRENT";
 
     @Getter
-    private Map<String, Object> serverConfig;
+    private final Map<String, Object> serverConfig;
 
     @Getter
-    private DataStore dataStore;
+    private final DataStore dataStore;
 
     @Getter
     private IServerRouter serverRouter;
@@ -39,13 +39,9 @@ public class ServerContext {
 
     public ServerContext(Map<String, Object> serverConfig, IServerRouter serverRouter) {
         this.serverConfig = serverConfig;
-        resetDataStore();
+        this.dataStore = new DataStore(serverConfig);
         this.serverRouter = serverRouter;
         this.failureDetectorPolicy = new PeriodicPollPolicy();
-    }
-
-    public void resetDataStore() {
-        this.dataStore = new DataStore(serverConfig);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
@@ -35,12 +35,67 @@ public class DataStoreTest extends AbstractCorfuTest {
                 .build());
         String value = UUID.randomUUID().toString();
         dataStore.put(String.class, "test", "key", value);
+
         //Simulate a restart of data store
         dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
                 .put("--log-path", serviceDir)
                 .build());
         assertThat(dataStore.get(String.class, "test", "key")).isEqualTo(value);
+
         dataStore.put(String.class, "test", "key", "NEW_VALUE");
         assertThat(dataStore.get(String.class, "test", "key")).isEqualTo("NEW_VALUE");
+    }
+
+    @Test
+    public void testDatastoreEviction() {
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+        DataStore dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
+                .put("--log-path", serviceDir)
+                .build());
+
+        for (int i = 0; i < dataStore.getMaxDataStoreSize() * 2; i++) {
+            String value = UUID.randomUUID().toString();
+            dataStore.put(String.class, "test", "key", value);
+
+            //Simulate a restart of data store
+            dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
+                    .put("--log-path", serviceDir)
+                    .build());
+            assertThat(dataStore.get(String.class, "test", "key")).isEqualTo(value);
+            dataStore.put(String.class, "test", "key", "NEW_VALUE");
+            assertThat(dataStore.get(String.class, "test", "key")).isEqualTo("NEW_VALUE");
+        }
+    }
+
+    @Test
+    public void testInmemoryPutGet() {
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+        DataStore dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
+                .put("--memory", true)
+                .build());
+        String value = UUID.randomUUID().toString();
+        dataStore.put(String.class, "test", "key", value);
+        assertThat(dataStore.get(String.class, "test", "key")).isEqualTo(value);
+
+        dataStore.put(String.class, "test", "key", "NEW_VALUE");
+        assertThat(dataStore.get(String.class, "test", "key")).isEqualTo("NEW_VALUE");
+
+    }
+
+    @Test
+    public void testInmemoryEviction() {
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+        DataStore dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
+                .put("--memory", true)
+                .build());
+
+        for (int i = 0; i < dataStore.getMaxDataStoreSize() * 2; i++) {
+            String value = UUID.randomUUID().toString();
+            dataStore.put(String.class, "test", "key", value);
+            assertThat(dataStore.get(String.class, "test", "key")).isEqualTo(value);
+
+            dataStore.put(String.class, "test", "key", "NEW_VALUE");
+            assertThat(dataStore.get(String.class, "test", "key")).isEqualTo("NEW_VALUE");
+        }
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
@@ -53,7 +53,7 @@ public class DataStoreTest extends AbstractCorfuTest {
                 .put("--log-path", serviceDir)
                 .build());
 
-        for (int i = 0; i < dataStore.getMaxDataStoreCacheSize() * 2; i++) {
+        for (int i = 0; i < dataStore.getDS_CACHE_SZ() * 2; i++) {
             String value = UUID.randomUUID().toString();
             dataStore.put(String.class, "test", "key", value);
 
@@ -89,7 +89,7 @@ public class DataStoreTest extends AbstractCorfuTest {
                 .put("--memory", true)
                 .build());
 
-        for (int i = 0; i < dataStore.getMaxDataStoreCacheSize() * 2; i++) {
+        for (int i = 0; i < dataStore.getDS_CACHE_SZ() * 2; i++) {
             String value = UUID.randomUUID().toString();
             dataStore.put(String.class, "test", "key", value);
             assertThat(dataStore.get(String.class, "test", "key")).isEqualTo(value);

--- a/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
@@ -53,7 +53,7 @@ public class DataStoreTest extends AbstractCorfuTest {
                 .put("--log-path", serviceDir)
                 .build());
 
-        for (int i = 0; i < dataStore.getMaxDataStoreSize() * 2; i++) {
+        for (int i = 0; i < dataStore.getMaxDataStoreCacheSize() * 2; i++) {
             String value = UUID.randomUUID().toString();
             dataStore.put(String.class, "test", "key", value);
 
@@ -89,7 +89,7 @@ public class DataStoreTest extends AbstractCorfuTest {
                 .put("--memory", true)
                 .build());
 
-        for (int i = 0; i < dataStore.getMaxDataStoreSize() * 2; i++) {
+        for (int i = 0; i < dataStore.getMaxDataStoreCacheSize() * 2; i++) {
             String value = UUID.randomUUID().toString();
             dataStore.put(String.class, "test", "key", value);
             assertThat(dataStore.get(String.class, "test", "key")).isEqualTo(value);

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
+//import static org.assertj.core.api.Assertions.assertThat;
 import static org.corfudb.infrastructure.LayoutServerAssertions.assertThat;
 
 /**
@@ -450,7 +450,7 @@ public class LayoutServerTest extends AbstractServerTest {
         bootstrapServer(layout);
 
         // Reboot, then check that our epoch 100 layout is still there.
-        s1.reboot();
+        //s1.reboot();
 
         requestLayout(NEW_EPOCH);
         Assertions.assertThat(getLastMessage().getMsgType())
@@ -466,16 +466,8 @@ public class LayoutServerTest extends AbstractServerTest {
         }
     }
 
-    // Same as commitReturnsAck() test, but we perhaps make a .reboot() call
-    // between each step.
-
-    // note: unclear what "reboot" does, so disabling this style check.
-    @SuppressWarnings("checkstyle:magicnumber")
     private void commitReturnsAck(LayoutServer s1, Integer reboot, long baseEpoch) {
 
-        if ((reboot & 1) > 0) {
-            s1.reboot();
-        }
         long newEpoch = baseEpoch + reboot;
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.SET_EPOCH, newEpoch));
 
@@ -485,24 +477,11 @@ public class LayoutServerTest extends AbstractServerTest {
         sendPrepare(newEpoch, HIGH_RANK);
         Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.LAYOUT_PREPARE_ACK);
 
-        if ((reboot & 2) > 0) {
-            log.debug("Rebooted server because reboot & 2 {}", reboot & 2);
-            s1.reboot();
-        }
-
         sendPropose(newEpoch, HIGH_RANK, layout);
         Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
 
-        if ((reboot & 4) > 0) {
-            s1.reboot();
-        }
-
         sendCommitted(newEpoch, layout);
         Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
-
-        if ((reboot & 8) > 0) {
-            s1.reboot();
-        }
 
         sendCommitted(newEpoch, layout);
         Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerAssertions.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerAssertions.java
@@ -24,7 +24,7 @@ public class LogUnitServerAssertions extends AbstractAssert<LogUnitServerAsserti
     public LogUnitServerAssertions isEmptyAtAddress(long address) {
         isNotNull();
 
-        if (actual.dataCache.get(new LogAddress(address, null)) != null) {
+        if (actual.getDataCache().get(new LogAddress(address, null)) != null) {
             failWithMessage("Expected address <%d> to be empty but contained data!", address);
         }
 
@@ -34,9 +34,9 @@ public class LogUnitServerAssertions extends AbstractAssert<LogUnitServerAsserti
     public LogUnitServerAssertions containsDataAtAddress(long address) {
         isNotNull();
 
-        if (actual.dataCache.get(new LogAddress(address, null)) == null) {
+        if (actual.getDataCache().get(new LogAddress(address, null)) == null) {
             failWithMessage("Expected address <%d> to contain data but was empty!", address);
-        } else if (actual.dataCache.get(new LogAddress(address, null)).isHole()) {
+        } else if (actual.getDataCache().get(new LogAddress(address, null)).isHole()) {
             failWithMessage("Expected address <%d> to contain data but was filled hole!", address);
         }
 
@@ -46,9 +46,9 @@ public class LogUnitServerAssertions extends AbstractAssert<LogUnitServerAsserti
     public LogUnitServerAssertions containsFilledHoleAtAddress(long address) {
         isNotNull();
 
-        if (actual.dataCache.get(new LogAddress(address, null)) == null) {
+        if (actual.getDataCache().get(new LogAddress(address, null)) == null) {
             failWithMessage("Expected address <%d> to contain filled hole but was empty!", address);
-        } else if (!actual.dataCache.get(new LogAddress(address, null)).isHole()) {
+        } else if (!actual.getDataCache().get(new LogAddress(address, null)).isHole()) {
             failWithMessage("Expected address <%d> to contain filled hole but was data!", address);
         }
 
@@ -58,18 +58,18 @@ public class LogUnitServerAssertions extends AbstractAssert<LogUnitServerAsserti
     public LogUnitServerAssertions matchesDataAtAddress(long address, Object data) {
         isNotNull();
 
-        if (actual.dataCache.get(new LogAddress(address, null)) == null) {
+        if (actual.getDataCache().get(new LogAddress(address, null)) == null) {
             failWithMessage("Expected address <%d> to contain data but was empty!", address);
         } else {
-            actual.dataCache.get(new LogAddress(address, null)).getData().resetReaderIndex();
+            actual.getDataCache().get(new LogAddress(address, null)).getData().resetReaderIndex();
             ByteBuf b = UnpooledByteBufAllocator.DEFAULT.buffer();
             Serializers.CORFU.serialize(data, b);
             byte[] expected = new byte[b.readableBytes()];
             b.getBytes(0, expected);
-            int actualbytes = actual.dataCache.get(new LogAddress(address, null)).getData().readableBytes();
+            int actualbytes = actual.getDataCache().get(new LogAddress(address, null)).getData().readableBytes();
             byte[] actualb = new byte[actualbytes];
-            actual.dataCache.get(new LogAddress(address, null)).getData().getBytes(0, actualb);
-            actual.dataCache.get(new LogAddress(address, null)).getData().resetReaderIndex();
+            actual.getDataCache().get(new LogAddress(address, null)).getData().getBytes(0, actualb);
+            actual.getDataCache().get(new LogAddress(address, null)).getData().resetReaderIndex();
 
             org.assertj.core.api.Assertions.assertThat(actualb)
                     .isEqualTo(expected);

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerAssertions.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerAssertions.java
@@ -18,8 +18,9 @@ public class SequencerServerAssertions extends AbstractAssert<SequencerServerAss
     public SequencerServerAssertions tokenIsAt(long address) {
         isNotNull();
 
-        if (actual.globalLogTail.get() != address) {
-            failWithMessage("Expected token to be at <%d> but got <%d>!", address, actual.globalLogTail.get());
+        if (actual.getGlobalLogTail().get() != address) {
+            failWithMessage("Expected token to be at <%d> but got <%d>!", address,
+                    actual.getGlobalLogTail().get());
         }
 
         return this;

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.corfudb.infrastructure.SequencerServerAssertions.assertThat;
+import static org.corfudb.infrastructure.ServerContext.NON_LOG_ADDR_MAGIC;
 
 /**
  * Created by mwei on 12/13/15.
@@ -217,7 +218,7 @@ public class SequencerServerTest extends AbstractServerTest {
         SequencerServer s2 = new SequencerServer(new ServerContextBuilder()
                 .setLogPath(serviceDir)
                 .setMemory(false)
-                .setInitialToken(SequencerServer.NON_LOG_ADDR_MAGIC)
+                .setInitialToken(NON_LOG_ADDR_MAGIC)
                 .build());
         this.router.reset();
         this.router.addServer(s2);

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -194,7 +194,7 @@ public class SequencerServerTest extends AbstractServerTest {
     }
 
     @Test
-    public void checkSequencerCheckpointingWorks()
+    public void checkSequencerLeaseWorks()
             throws Exception {
         String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
@@ -202,7 +202,7 @@ public class SequencerServerTest extends AbstractServerTest {
                 .setLogPath(serviceDir)
                 .setMemory(false)
                 .setInitialToken(0)
-                .setCheckpoint(1)
+                // .setCheckpoint(1)
                 .build());
 
         this.router.reset();
@@ -219,13 +219,13 @@ public class SequencerServerTest extends AbstractServerTest {
         SequencerServer s2 = new SequencerServer(new ServerContextBuilder()
                 .setLogPath(serviceDir)
                 .setMemory(false)
-                .setInitialToken(-1)
-                .setCheckpoint(1)
+                //.setInitialToken(ServerContextBuilder.NO_INITIAL_TOKEN)
+                //.setCheckpoint(1)
                 .build());
         this.router.reset();
         this.router.addServer(s2);
         assertThat(s2)
-                .tokenIsAt(2);
+                .tokenIsAt(s2.getLeaseLength());
     }
 
 }

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -219,7 +219,7 @@ public class SequencerServerTest extends AbstractServerTest {
         SequencerServer s2 = new SequencerServer(new ServerContextBuilder()
                 .setLogPath(serviceDir)
                 .setMemory(false)
-                .setInitialToken(SequencerServer.NO_INITIAL_TOKEN)
+                .setInitialToken(SequencerServer.NO_LOG_ADDR_MAGIC)
                 //.setCheckpoint(1)
                 .build());
         this.router.reset();

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -201,8 +201,6 @@ public class SequencerServerTest extends AbstractServerTest {
         SequencerServer s1 = new SequencerServer(new ServerContextBuilder()
                 .setLogPath(serviceDir)
                 .setMemory(false)
-                // .setInitialToken(0)
-                // .setCheckpoint(1)
                 .build());
 
         this.router.reset();
@@ -219,8 +217,7 @@ public class SequencerServerTest extends AbstractServerTest {
         SequencerServer s2 = new SequencerServer(new ServerContextBuilder()
                 .setLogPath(serviceDir)
                 .setMemory(false)
-                .setInitialToken(SequencerServer.NO_LOG_ADDR_MAGIC)
-                //.setCheckpoint(1)
+                .setInitialToken(SequencerServer.NON_LOG_ADDR_MAGIC)
                 .build());
         this.router.reset();
         this.router.addServer(s2);

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -201,7 +201,7 @@ public class SequencerServerTest extends AbstractServerTest {
         SequencerServer s1 = new SequencerServer(new ServerContextBuilder()
                 .setLogPath(serviceDir)
                 .setMemory(false)
-                .setInitialToken(0)
+                // .setInitialToken(0)
                 // .setCheckpoint(1)
                 .build());
 
@@ -219,7 +219,7 @@ public class SequencerServerTest extends AbstractServerTest {
         SequencerServer s2 = new SequencerServer(new ServerContextBuilder()
                 .setLogPath(serviceDir)
                 .setMemory(false)
-                //.setInitialToken(ServerContextBuilder.NO_INITIAL_TOKEN)
+                .setInitialToken(SequencerServer.NO_INITIAL_TOKEN)
                 //.setCheckpoint(1)
                 .build());
         this.router.reset();

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -13,8 +13,7 @@ import lombok.experimental.Accessors;
 @SuppressWarnings("checkstyle:magicnumber")
 public class ServerContextBuilder {
 
-    static final long NO_INITIAL_TOKEN = -1;
-    long initialToken = NO_INITIAL_TOKEN;
+    long initialToken = 0L; // for testing, we want to reset the sequencer on each test
 
     boolean single = true;
     boolean memory = true;

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -13,7 +13,9 @@ import lombok.experimental.Accessors;
 @SuppressWarnings("checkstyle:magicnumber")
 public class ServerContextBuilder {
 
-    long initialToken = 0;
+    static final long NO_INITIAL_TOKEN = -1;
+    long initialToken = NO_INITIAL_TOKEN;
+
     boolean single = true;
     boolean memory = true;
     String logPath = null;

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -41,7 +41,7 @@ public class ServerContextBuilder {
          builder
                 .put("--no-verify", noVerify)
                 .put("--max-cache", maxCache)
-                .put("--checkpoint", checkpoint)
+//                .put("--checkpoint", checkpoint)
                 .put("--address", address)
                 .put("<port>", port);
         return new ServerContext(builder.build(), serverRouter);

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -20,7 +20,6 @@ public class ServerContextBuilder {
     String logPath = null;
     boolean noVerify = false;
     int maxCache = 1000000;
-    int checkpoint = 100;
     String address = "test";
     int port = 9000;
     IServerRouter serverRouter;
@@ -41,7 +40,6 @@ public class ServerContextBuilder {
          builder
                 .put("--no-verify", noVerify)
                 .put("--max-cache", maxCache)
-//                .put("--checkpoint", checkpoint)
                 .put("--address", address)
                 .put("<port>", port);
         return new ServerContext(builder.build(), serverRouter);

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -169,9 +169,8 @@ public class LogUnitClientTest extends AbstractClientTest {
         // Verify that the data has been written correctly
         assertThat(r.getPayload(null)).isEqualTo(testString);
 
-        // In order to clear the logunit's cache, the server is restarted so that
-        // the next read is forced to be retrieved from file and not the cache
-        server.reboot();
+        LogUnitServer server2 = new LogUnitServer(serverContext);
+        serverRouter.addServer(server2);
 
         // Corrupt the written log entry
         String logDir = (String) serverContext.getServerConfig().get("--log-path");

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -224,7 +224,6 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
     {
         testServerMap.entrySet().parallelStream()
                 .forEach(e -> {
-                    e.getValue().layoutServer.reset();
                     e.getValue().layoutServer
                             .handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(l)),
                                     null, e.getValue().serverRouter);

--- a/test/src/test/java/org/corfudb/util/quickcheck/QCLayout.java
+++ b/test/src/test/java/org/corfudb/util/quickcheck/QCLayout.java
@@ -63,19 +63,11 @@ public class QCLayout {
                     + " --version  Show version\n";
 
     public static String[] main(String[] args) {
-        if (args != null && args.length > 0 && args[0].contentEquals("reset")) {
-            LayoutServer ls = CorfuServer.getLayoutServer();
-            if (ls != null) {
-                ls.reset();
-                return replyOk();
-            } else {
-                return replyErr("No active layout server");
-            }
-        }
         if (args != null && args.length > 0 && args[0].contentEquals("reboot")) {
             LayoutServer ls = CorfuServer.getLayoutServer();
             if (ls != null) {
-                ls.reboot();
+                ls.shutdown();
+                CorfuServer.addLayoutServer();
                 return replyOk();
             } else {
                 return replyErr("No active layout server");

--- a/test/src/test/java/org/corfudb/util/quickcheck/QCSMRobject.java
+++ b/test/src/test/java/org/corfudb/util/quickcheck/QCSMRobject.java
@@ -42,45 +42,15 @@ public class QCSMRobject {
                     + " --version                                      Show version\n";
 
     public static String[] main(String[] args) {
-        if (args != null && args.length > 0 && args[0].contentEquals("reset")) {
-            LogUnitServer ls = CorfuServer.getLogUnitServer();
-            SequencerServer ss = CorfuServer.getSequencerServer();
-            if (ls != null && ss != null) {
-
-                // Reset the local management server.
-                ManagementServer ms = CorfuServer.getManagementServer();
-                ms.reset();
-
-                // Reset the local log server.
-                ls.reset();
-
-                // Reset the local sequencer server
-                ss.reset();
-
-                // Reset all local CorfuRuntime instances
-                Iterator<String> it = rtMap.keySet().iterator();
-                while (it.hasNext()) {
-                    String key = it.next();
-                    CorfuRuntime rt = (CorfuRuntime) rtMap.get(key);
-                    // State needs resetting in rt's ObjectsView
-                    rt.getObjectsView().getObjectCache().clear();
-                    // State needs resetting in rt's AddressSpaceView
-                    rt.getAddressSpaceView().resetCaches();
-                    // Stop the router: false means don't really shutdown,
-                    // but disconnect any existing connection.
-                    rt.stop(false);
-                }
-                return replyOk();
-            } else {
-                return replyErr("No active log server or sequencer server");
-            }
-        }
         if (args != null && args.length > 0 && args[0].contentEquals("reboot")) {
             ManagementServer ms = CorfuServer.getManagementServer();
-            ms.reboot();
+            ms.shutdown();
+            CorfuServer.addManagmentServer();
+
             LogUnitServer ls = CorfuServer.getLogUnitServer();
             if (ls != null) {
-                ls.reboot();
+                ls.shutdown();
+                CorfuServer.addLogUnit();
                 return replyOk();
             } else {
                 return replyErr("No active log server");

--- a/test/src/test/java/org/corfudb/util/quickcheck/QCSMRobject.java
+++ b/test/src/test/java/org/corfudb/util/quickcheck/QCSMRobject.java
@@ -4,7 +4,6 @@ import org.codehaus.plexus.util.ExceptionUtils;
 import org.corfudb.infrastructure.CorfuServer;
 import org.corfudb.infrastructure.LogUnitServer;
 import org.corfudb.infrastructure.ManagementServer;
-import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.GitRepositoryState;
 import org.docopt.Docopt;
@@ -12,7 +11,6 @@ import org.docopt.Docopt;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -45,7 +43,7 @@ public class QCSMRobject {
         if (args != null && args.length > 0 && args[0].contentEquals("reboot")) {
             ManagementServer ms = CorfuServer.getManagementServer();
             ms.shutdown();
-            CorfuServer.addManagmentServer();
+            CorfuServer.addManagementServer();
 
             LogUnitServer ls = CorfuServer.getLogUnitServer();
             if (ls != null) {


### PR DESCRIPTION
This branch introduces several important cleanups to the sequencer and to the caching-layer supporting serverContext.

* Previously, the in-memory version of the dataStore cache would lose data if the cache was ever evicted. Now, the in-memory version grows without a bound, and panics if putting more data into it fails.

* Previously, the reboot/reset mechanism removed persistent store from under the dataStore cache, which is a really bad idea. I replaced reboot with a mechanism to re-attach newly constructed services to the main CorfuServer router. Reset is no longer supported from internally, and should be discussed if we want it in the future.

* Previously, there was no way to recover the sequencer. Now, the sequencer works by a lease. This allows a recovered sequencer to start at the position following the previous lease. 

TODO: We will need to persist the lease somewhere, not just to the local serverContext, so a new sequencer can find it. The new sequencer will also need to triger quick hole-filling of all previously leased positions.