### PR TITLE
eliminate use of netty bytebuf in logdata

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -135,7 +135,7 @@ public class LogUnitServer extends AbstractServer {
         batchWriter = new BatchWriter(streamLog);
 
         dataCache = Caffeine.<LogAddress, LogData>newBuilder()
-                .<LogAddress, LogData>weigher((k, v) -> v.getData() == null ? 1 : v.getData().readableBytes())
+                .<LogAddress, LogData>weigher((k, v) -> v.getData() == null ? 1 : v.getData().length)
                 .maximumWeight(maxCacheSize)
                 .removalListener(this::handleEviction)
                 .writer(batchWriter)
@@ -336,10 +336,6 @@ public class LogUnitServer extends AbstractServer {
         // Invalidate this entry from the cache. This will cause the CacheLoader to free the entry from the disk
         // assuming the entry is back by disk
         dataCache.invalidate(address);
-        //and free any references the buffer might have
-        if (entry.getData() != null) {
-            entry.getData().release();
-        }
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -442,8 +442,6 @@ public class StreamLogFiles implements StreamLog {
 
     @Override
     public void release(LogAddress logAddress, LogData entry) {
-        if (entry != null && entry.getData() != null && entry.getData().refCnt() > 0)
-            entry.getData().release();
     }
 
     @VisibleForTesting

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.ICorfuSerializable;
@@ -44,7 +45,7 @@ public class LogEntry implements ICorfuSerializable {
      */
     @Getter
     @Setter
-    LogData entry;
+    ILogData entry;
 
     /**
      * Constructor for generating LogEntries.

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.Serializers;
@@ -78,7 +79,7 @@ public class MultiObjectSMREntry extends LogEntry implements IDivisibleEntry, IS
      * @param entry
      */
     @Override
-    public void setEntry(LogData entry) {
+    public void setEntry(ILogData entry) {
         super.setEntry(entry);
         this.getEntryMap().values().forEach(x -> {
             x.setEntry(entry);

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.Serializers;
@@ -56,7 +57,7 @@ public class MultiSMREntry extends LogEntry implements ISMRConsumable {
     }
 
     @Override
-    public void setEntry(LogData entry) {
+    public void setEntry(ILogData entry) {
         super.setEntry(entry);
         this.getUpdates().forEach(x -> x.setEntry(entry));
     }

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/TXEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/TXEntry.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import lombok.*;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
@@ -66,7 +67,7 @@ public class TXEntry extends LogEntry implements ISMRConsumable {
         }
 
         if (getEntry() != null && getEntry().hasBackpointer(stream)) {
-            LogData backpointedEntry = getEntry();
+            ILogData backpointedEntry = getEntry();
             if (backpointedEntry.isFirstEntry(stream)) {
                 return false;
             }
@@ -97,7 +98,7 @@ public class TXEntry extends LogEntry implements ISMRConsumable {
 
         for (long i = readTimestamp + 1; i < getEntry().getGlobalAddress(); i++) {
             // Backpointers not available, so we do a scan.
-            LogData rr = runtime.getAddressSpaceView().read(i);
+            ILogData rr = runtime.getAddressSpaceView().read(i);
             if (rr.getType() ==
                     DataType.DATA &&
                     ((Set<UUID>) rr.getMetadataMap().get(IMetadata.LogUnitMetadataType.STREAM))

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ICorfuPayload.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ICorfuPayload.java
@@ -46,6 +46,12 @@ public interface ICorfuPayload<T> {
                     return layout;
                 })
                 .put(UUID.class, x -> new UUID(x.readLong(), x.readLong()))
+                .put(byte[].class, x -> {
+                    int length = x.readInt();
+                    byte[] bytes = new byte[length];
+                    x.readBytes(bytes);
+                    return bytes;
+                })
                 .put(ByteBuf.class, x -> {
                     int bytes = x.readInt();
                     //ByteBuf b =
@@ -238,6 +244,9 @@ public interface ICorfuPayload<T> {
             buffer.writeDouble((Double) payload);
         } else if (payload instanceof Float) {
             buffer.writeFloat((Float) payload);
+        } else if (payload instanceof byte[]) {
+            buffer.writeInt(((byte[]) payload).length);
+            buffer.writeBytes((byte[]) payload);
         }
         // and some standard non prims as well
         else if (payload instanceof String) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/InMemoryLogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/InMemoryLogData.java
@@ -1,0 +1,59 @@
+package org.corfudb.protocols.wireprotocol;
+
+import org.corfudb.runtime.CorfuRuntime;
+
+import java.util.EnumMap;
+
+/** A class for in-memory log data, which is never serialized.
+ *
+ * Created by mwei on 1/5/17.
+ */
+public class InMemoryLogData implements ILogData {
+
+    /** The type of data held by this LogData. */
+    final DataType dataType;
+
+    /** The object, unserialized, held by this LogData. */
+    final Object data;
+
+    /** The metadata map for this entry. */
+    final EnumMap<LogUnitMetadataType, Object> metadataMap;
+
+    /** Create a LogData without a payload.
+     * @param dataType  The type this log data entry holds.
+     */
+    public InMemoryLogData(final DataType dataType) {
+        this.dataType = dataType;
+        this.data = null;
+        this.metadataMap = new EnumMap<>(IMetadata.LogUnitMetadataType.class);
+    }
+
+    /** Create a LogData with a payload.
+     * @param dataType  The type this log data entry holds.
+     * @param data      The underlying data.
+     */
+    public InMemoryLogData(final DataType dataType,
+                           final Object data) {
+        this.dataType = dataType;
+        this.data = data;
+        this.metadataMap = new EnumMap<>(IMetadata.LogUnitMetadataType.class);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Object getPayload(CorfuRuntime t) {
+        return data;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public DataType getType() {
+        return dataType;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public EnumMap<LogUnitMetadataType, Object> getMetadataMap() {
+        return metadataMap;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuProxyBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuProxyBuilder.java
@@ -10,6 +10,7 @@ import net.bytebuddy.implementation.MethodDelegation;
 import net.bytebuddy.matcher.ElementMatchers;
 import org.corfudb.annotations.*;
 import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.ObjectExistsException;
@@ -229,7 +230,7 @@ public class CorfuProxyBuilder {
                         log.debug("There appears to be an existing constructor for {}, reading it...", sv.getStreamID());
                         // The "default" entry should be the first entry in the stream.
                         // TODO: handle garbage collected streams.
-                        LogData entry = sv.read();
+                        ILogData entry = sv.read();
                         while (entry != null) {
                             if (entry.getPayload(runtime) instanceof SMREntry &&
                                     ((SMREntry) entry.getPayload(runtime)).getSMRMethod().equals("default")) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
@@ -12,6 +12,7 @@ import org.corfudb.annotations.Mutator;
 import org.corfudb.annotations.MutatorAccessor;
 import org.corfudb.protocols.logprotocol.*;
 import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.UnprocessedException;
@@ -371,7 +372,7 @@ public class CorfuSMRObjectProxy<P> extends CorfuObjectProxy<P> {
     @Override
     public synchronized void sync(P obj, long maxPos) {
         try (LockUtils.AutoCloseRWLock writeLock = new LockUtils.AutoCloseRWLock(rwLock).writeLock()) {
-            LogData[] entries = sv.readTo(maxPos);
+            ILogData[] entries = sv.readTo(maxPos);
             log.trace("Object[{}] sync to pos {}, read {} entries",
                     sv.getStreamID(), maxPos == Long.MAX_VALUE ? "MAX" : maxPos, entries.length);
             Arrays.stream(entries)

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamView.java
@@ -168,7 +168,7 @@ public class StreamView implements AutoCloseable {
         boolean hitBeforeRead = false;
         if (!runtime.backpointersDisabled) {
             resolvedBackpointers.add(latestToken);
-            LogData r = runtime.getAddressSpaceView().read(latestToken);
+            ILogData r = runtime.getAddressSpaceView().read(latestToken);
             long backPointer = latestToken;
             while (r.getType() != DataType.EMPTY
                     && r.getBackpointerMap().containsKey(streamID)) {
@@ -223,11 +223,11 @@ public class StreamView implements AutoCloseable {
      * @return The next item from the stream.
      */
     @SuppressWarnings("unchecked")
-    public synchronized LogData read() {
+    public synchronized ILogData read() {
         return read(Long.MAX_VALUE);
     }
 
-    public synchronized LogData read(long maxGlobal) {
+    public synchronized ILogData read(long maxGlobal) {
         while (true) {
             /*
             long thisRead = logPointer.getAndIncrement();
@@ -272,7 +272,7 @@ public class StreamView implements AutoCloseable {
                 getCurrentContext().logPointer.set(thisRead + 1);
 
                 log.trace("Read[{}]: reading at {}", streamID, thisRead);
-                LogData r = runtime.getAddressSpaceView().read(thisRead);
+                ILogData r = runtime.getAddressSpaceView().read(thisRead);
                 if (r.getType() == DataType.EMPTY) {
                     //determine whether or not this is a hole
                     long latestToken = runtime.getSequencerView().nextToken(Collections.singleton(streamID), 0).getToken();
@@ -356,7 +356,7 @@ public class StreamView implements AutoCloseable {
         }
     }
 
-    public synchronized LogData[] readTo(long pos) {
+    public synchronized ILogData[] readTo(long pos) {
         if (runtime.getLayoutView().getLayout().getSegments().get(
                 runtime.getLayoutView().getLayout().getSegments().size() - 1)
                 .getReplicationMode() == Layout.ReplicationMode.CHAIN_REPLICATION) {
@@ -367,17 +367,17 @@ public class StreamView implements AutoCloseable {
                 latestToken = runtime.getSequencerView().nextToken(Collections.singleton(streamID), 0).getToken();
                 log.trace("Linearization point set to {}", latestToken);
             }
-            ArrayList<LogData> al = new ArrayList<>();
+            ArrayList<ILogData> al = new ArrayList<>();
             log.debug("Stream[{}] pointer[{}], readTo {}", streamID, getCurrentContext().logPointer.get(), latestToken);
             while (getCurrentContext().logPointer.get() <= latestToken) {
-                LogData r = read(pos);
+                ILogData r = read(pos);
                 if (r != null && (max || r.getGlobalAddress() <= pos)) {
                     al.add(r);
                 } else {
                     break;
                 }
             }
-            return al.toArray(new LogData[al.size()]);
+            return al.toArray(new ILogData[al.size()]);
         } else if (runtime.getLayoutView().getLayout().getSegments().get(
                 runtime.getLayoutView().getLayout().getSegments().size() - 1)
                 .getReplicationMode() == Layout.ReplicationMode.REPLEX) {
@@ -389,7 +389,7 @@ public class StreamView implements AutoCloseable {
             log.trace("Linearization point set to {}", latestToken);
 
             if (latestToken < getCurrentContext().logPointer.get())
-                return (new ArrayList<LogData>()).toArray(new LogData[0]);
+                return (new ArrayList<LogData>()).toArray(new ILogData[0]);
 
             //if (getCurrentContext().logPointer.get() != 0 && latestToken == getCurrentContext().logPointer.get())
             //    return (new ArrayList<LogData>()).toArray(new LogData[0]);

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -83,34 +83,6 @@ public class LogUnitServerTest extends AbstractServerTest {
     }
 
     @Test
-    public void checkHeapLeak() throws Exception {
-
-        LogUnitServer s1 = new LogUnitServer(ServerContextBuilder.emptyContext());
-
-        this.router.reset();
-        this.router.addServer(s1);
-        long address = 0L;
-        final byte TEST_BYTE = 42;
-        ByteBuf b = ByteBufAllocator.DEFAULT.buffer(1);
-        b.writeByte(TEST_BYTE);
-        WriteRequest wr = WriteRequest.builder()
-                            .writeMode(WriteMode.NORMAL)
-                            .data(new LogData(DataType.DATA, b))
-                            .build();
-        //write at 0
-        wr.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
-        wr.setRank(0L);
-        wr.setBackpointerMap(Collections.emptyMap());
-        wr.setGlobalAddress(0L);
-
-        sendMessage(CorfuMsgType.WRITE.payloadMsg(wr));
-
-        LoadingCache<LogAddress, LogData> dataCache = s1.getDataCache();
-        // Make sure that extra bytes are truncated from the payload byte buf
-        Assertions.assertThat(dataCache.get(new LogAddress(address, null)).getData().capacity()).isEqualTo(1);
-    }
-
-    @Test
     public void checkThatWritesArePersisted()
             throws Exception {
         String serviceDir = PARAMETERS.TEST_TEMP_DIR;

--- a/test/src/test/java/org/corfudb/integration/StreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamIT.java
@@ -1,5 +1,6 @@
 package org.corfudb.integration;
 
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.StreamView;
@@ -58,7 +59,7 @@ public class StreamIT {
 
         // Read back the data and verify it is correct
         for(int x = 0; x < numEntries; x++) {
-            LogData entry = s1.read(x);
+            ILogData entry = s1.read(x);
             byte[] tmp = (byte[]) entry.getPayload(rt);
 
             assertThat(tmp).isEqualTo(data[x]);

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.object.transactions;
 
 import com.google.common.reflect.TypeToken;
 import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.collections.ISMRMap;
 import org.corfudb.runtime.collections.SMRMap;
@@ -107,7 +108,7 @@ public abstract class AbstractTransactionContextTest extends AbstractViewTest {
     public void ensureEmptyWriteSetIsNotWritten() {
         TXBegin();
         long result = TXEnd();
-        LogData ld =
+        ILogData ld =
                 getRuntime()
                         .getAddressSpaceView()
                         .read(0);

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
@@ -5,6 +5,7 @@ import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
 import org.corfudb.protocols.logprotocol.MultiSMREntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
@@ -50,7 +51,7 @@ public class WriteAfterWriteTransactionContextTest extends AbstractTransactionCo
 
         // Verify that the transaction that succeeded is written to the transaction stream
         StreamView txStream = getRuntime().getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID);
-        LogData[] txns = txStream.readTo(Long.MAX_VALUE);
+        ILogData[] txns = txStream.readTo(Long.MAX_VALUE);
         assertThat(txns.length).isEqualTo(1);
         assertThat(txns[0].getLogEntry(getRuntime()).getType()).isEqualTo(LogEntry.LogEntryType.MULTIOBJSMR);
 

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
 import org.corfudb.infrastructure.*;
 import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
@@ -155,7 +156,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
 
         RangeSet<Long> rs = TreeRangeSet.create();
         rs.add(Range.closed(0L, ADDRESS_2));
-        Map<Long, LogData> m = r.getAddressSpaceView().read(rs);
+        Map<Long, ILogData> m = r.getAddressSpaceView().read(rs);
 
         assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());

--- a/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.view;
 
 import com.google.common.reflect.TypeToken;
 import org.corfudb.protocols.logprotocol.*;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
@@ -135,7 +136,7 @@ public class ObjectsViewTest extends AbstractViewTest {
                 .containsEntry("k", "v2");
 
         StreamView txStream = r.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID);
-        LogData[] txns = txStream.readTo(Long.MAX_VALUE);
+        ILogData[] txns = txStream.readTo(Long.MAX_VALUE);
         assertThat(txns.length).isEqualTo(1);
         assertThat(txns[0].getLogEntry(getRuntime()).getType()).isEqualTo(LogEntry.LogEntryType.MULTIOBJSMR);
 


### PR DESCRIPTION
This patch replaces the Netty bytebuf in LogData with a standard byte array, reducing the dependency on 
Netty bytebufs throughout the code