### PR TITLE
Add a function to reset the stream view

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -338,6 +338,6 @@ public class VersionLockedObject<T> {
     }
 
     public void resetStreamViewUnsafe() {
-        sv.setLogPointer(0L);
+        sv.reset();
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamView.java
@@ -47,6 +47,14 @@ public class StreamView implements AutoCloseable {
         return streamContexts.first();
     }
 
+    /** Reset the state of this streamview, causing the next read to return
+     * from the beginning of the stream.
+     */
+    public synchronized void reset() {
+        this.streamContexts.clear();
+        this.streamContexts.add(new StreamContext(streamID, Long.MAX_VALUE));
+    }
+
     /**
      * Write an object to this stream, returning the physical address it
      * was written at.

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamView.java
@@ -39,10 +39,6 @@ public class StreamView implements AutoCloseable {
         return getCurrentContext().logPointer.get();
     }
 
-    public void setLogPointer(long pos) {
-        getCurrentContext().logPointer.set(pos);
-    }
-
     public StreamContext getCurrentContext() {
         return streamContexts.first();
     }


### PR DESCRIPTION
This function adds a function to reset the stream view, and changes the compile
proxy to use it. It also eliminates the use of setLogPointer, which
was unsafe to use with concurrency.