### PR TITLE
Don't commit empty write sets

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -1,7 +1,6 @@
 package org.corfudb.runtime.object.transactions;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import lombok.Getter;
 
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
@@ -36,6 +35,11 @@ public abstract class AbstractTransactionalContext {
      *
      */
     public static final long ABORTED_ADDRESS = -3L;
+
+    /** Constant for committing a transaction which did not
+     * modify the log at all.
+     */
+    public static final long NOWRITE_ADDRESS = -4L;
 
     /** The ID of the transaction. This is used for tracking only, it is
      * NOT recorded in the log.
@@ -103,7 +107,8 @@ public abstract class AbstractTransactionalContext {
      * It is completed exceptionally when the transaction aborts.
      */
     @Getter
-    public CompletableFuture<Boolean> completionFuture = new CompletableFuture<>();
+    public CompletableFuture<Boolean> completionFuture =
+            new CompletableFuture<>();
 
     AbstractTransactionalContext(TransactionBuilder builder) {
         transactionID = UUID.randomUUID();
@@ -162,7 +167,7 @@ public abstract class AbstractTransactionalContext {
      */
     public long commitTransaction() throws TransactionAbortedException {
         completionFuture.complete(true);
-        return 0L;
+        return NOWRITE_ADDRESS;
     }
 
     /** Forcefully abort the transaction.
@@ -186,7 +191,7 @@ public abstract class AbstractTransactionalContext {
         if (conflictObjects != null) {
             Set<Integer> conflictParamSet = readSet.get(proxy.getStreamID());
             Arrays.asList(conflictObjects).stream()
-                .forEach(V -> conflictParamSet.add(Integer.valueOf(V.hashCode())) ) ;
+                .forEach(V -> conflictParamSet.add(Integer.valueOf(V.hashCode()))) ;
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -236,6 +236,13 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
             return commitAddress;
         }
 
+        // If the write set is empty, we're done and just return
+        // NOWRITE_ADDRESS.
+        if (writeSet.isEmpty())
+        {
+            return NOWRITE_ADDRESS;
+        }
+
         // Now we obtain a conditional address from the sequencer.
         // This step currently happens all at once, and we get an
         // address of -1L if it is rejected.

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -50,6 +50,14 @@ public class WriteAfterWriteTransactionalContext
             return commitAddress;
         }
 
+
+        // If the write set is empty, we're done and just return
+        // NOWRITE_ADDRESS.
+        if (writeSet.keySet().isEmpty())
+        {
+            return NOWRITE_ADDRESS;
+        }
+
         // Now we obtain a conditional address from the sequencer.
         // This step currently happens all at once, and we get an
         // address of -1L if it is rejected.
@@ -73,7 +81,6 @@ public class WriteAfterWriteTransactionalContext
                                 collectWriteConflictParams(),
                                 collectWriteConflictParams())
                 );
-
 
         if (address == -1L) {
             log.debug("Transaction aborted due to sequencer rejecting request");

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
@@ -1,6 +1,8 @@
 package org.corfudb.runtime.object.transactions;
 
 import com.google.common.reflect.TypeToken;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.collections.ISMRMap;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
@@ -14,6 +16,8 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import static org.assertj.core.api.Assertions.fail;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by mwei on 11/21/16.
@@ -94,4 +98,23 @@ public abstract class AbstractTransactionContextTest extends AbstractViewTest {
         commitStatus = new AtomicIntegerArray(numTasks);
         snapStatus = new AtomicIntegerArray(numTasks);
     }
+
+    /** Ensure that empty write sets are not written to the log.
+     * This test applies to all contexts which is why it is in
+     * the abstract test.
+     */
+    @Test
+    public void ensureEmptyWriteSetIsNotWritten() {
+        TXBegin();
+        long result = TXEnd();
+        LogData ld =
+                getRuntime()
+                        .getAddressSpaceView()
+                        .read(0);
+        assertThat(ld.getType())
+                .isEqualTo(DataType.EMPTY);
+        assertThat(result)
+                .isEqualTo(AbstractTransactionalContext.NOWRITE_ADDRESS);
+    }
+
 }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -1,15 +1,7 @@
 package org.corfudb.runtime.object.transactions;
 
-import com.google.common.reflect.TypeToken;
-import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.view.AbstractViewTest;
-import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Map;
-import java.util.UUID;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**


### PR DESCRIPTION
Previously, if a write set was empty, the transaction context would
commit an empty write set to the log. This patch fixes that behavior,
adding a new return value (ADDRESS_NOWRITE) to indicate that
the transaction completed successfully but nothing was
committed into the log.