### PR TITLE
Bootstrap Management Server

### DIFF
--- a/corfu_scripts/corfu_layouts.clj
+++ b/corfu_scripts/corfu_layouts.clj
@@ -60,26 +60,29 @@ Options:
                              (if (.equals layout new-layout) (println "Layout not modified, exiting")
                                  ; If changes were made, check if the layout servers were modified
                                  ; if it was, we'll have to add them to the service
-                                 (if (.equals (.getLayoutServers layout) (.getLayoutServers new-layout))
-                                     ; Equal, just install the new layout
-                                     (do
-                                      (install-layout new-layout)
-                                      (println "New layout installed!"))
-                                     ; Not equal, need to:
-                                     ; (1) make sure all layout servers are bootstrapped
-                                     ; (2) install layout on all servers
-                                     (do
-                                       (doseq [server (.getLayoutServers new-layout)]
-                                       (do (get-router server)
-                                           (try
-                                             (.get (.bootstrapLayout (get-layout-client) new-layout))
-                                             (catch Exception e
-                                             (println server":" (.getMessage e))))
-                                           ))
-                                       (install-layout new-layout)
-                                       (println "New layout installed!")
-                                     )
-                                 )
+                                 ; Do not allow the user to modify the epoch directly.
+                                 (if-not (.equals (.getEpoch layout) (.getEpoch new-layout)) (println "Epoch modification not allowed, exiting")
+                                   (if (.equals (.getLayoutServers layout) (.getLayoutServers new-layout))
+                                       ; Equal, just install the new layout
+                                       (do
+                                        (install-layout new-layout)
+                                        (println "New layout installed!"))
+                                       ; Not equal, need to:
+                                       ; (1) make sure all layout servers are bootstrapped
+                                       ; (2) install layout on all servers
+                                       (do
+                                         (doseq [server (.getLayoutServers new-layout)]
+                                         (do (get-router server)
+                                             (try
+                                               (.get (.bootstrapLayout (get-layout-client) new-layout))
+                                               (catch Exception e
+                                               (println server":" (.getMessage e))))
+                                             ))
+                                         (install-layout new-layout)
+                                         (println "New layout installed!")
+                                       )
+                                   )
+                                )
                             )
                        ))))
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -76,7 +76,7 @@ public class CorfuServer {
             "Corfu Server, the server for the Corfu Infrastructure.\n"
                     + "\n"
                     + "Usage:\n"
-                    + "\tcorfu_server (-l <path>|-m) [-nsQ] [-a <address>] [-t <token>] [-c <size>] [-k seconds] [-d <level>] [-p <seconds>] [-P <seconds>] <port>\n"
+                    + "\tcorfu_server (-l <path>|-m) [-nsQ] [-a <address>] [-t <token>] [-c <size>] [-k seconds] [-d <level>] [-p <seconds>] [-M <address>:<port>] <port>\n"
                     + "\n"
                     + "Options:\n"
                     + " -l <path>, --log-path=<path>            Set the path to the storage file for the log unit.\n"
@@ -95,7 +95,7 @@ public class CorfuServer {
                     + " -d <level>, --log-level=<level>         Set the logging level, valid levels are: \n"
                     + "                                         ERROR,WARN,INFO,DEBUG,TRACE [default: INFO].\n"
                     + " -Q, --quickcheck-test-mode              Run in QuickCheck test mode\n"
-                    + " -P <seconds>, --cm-poll-interval        Configuration manager poll interval [default: 1]\n"
+                    + " -M <address>:<port>, --mgmt=<address>:<port>     Layout endpoint to seed Management Server\n"
                     + " -n, --no-verify                         Disable checksum computation and verification.\n"
                     + " -h, --help  Show this screen\n"
                     + " --version  Show version\n";

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -95,7 +95,7 @@ public class CorfuServer {
                     + " -d <level>, --log-level=<level>         Set the logging level, valid levels are: \n"
                     + "                                         ERROR,WARN,INFO,DEBUG,TRACE [default: INFO].\n"
                     + " -Q, --quickcheck-test-mode              Run in QuickCheck test mode\n"
-                    + " -M <address>:<port>, --mgmt=<address>:<port>     Layout endpoint to seed Management Server\n"
+                    + " -M <address>:<port>, --management-server=<address>:<port>     Layout endpoint to seed Management Server\n"
                     + " -n, --no-verify                         Disable checksum computation and verification.\n"
                     + " -h, --help  Show this screen\n"
                     + " --version  Show version\n";

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -88,7 +88,7 @@ public class ManagementServer extends AbstractServer {
         this.opts = serverContext.getServerConfig();
         this.serverContext = serverContext;
 
-        bootstrapEndpoint = (opts.get("--mgmt")!=null) ? opts.get("--mgmt").toString() : null;
+        bootstrapEndpoint = (opts.get("--management-server")!=null) ? opts.get("--management-server").toString() : null;
 
         if((Boolean) opts.get("--single")) {
             String localAddress = opts.get("--address") + ":" + opts.get("<port>");

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -16,12 +16,7 @@ import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.LayoutView;
 
-import java.io.IOException;
 import java.lang.invoke.MethodHandles;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 import java.util.Collections;
 import java.util.Map;
@@ -56,9 +51,22 @@ public class ManagementServer extends AbstractServer {
      */
     private IFailureDetectorPolicy failureDetectorPolicy;
     /**
+     * Policy to be used to handle failures.
+     */
+    private IFailureHandlerPolicy failureHandlerPolicy;
+    /**
      * Latest layout received from bootstrap or the runtime.
      */
     private volatile Layout latestLayout;
+    /**
+     * Bootstrap endpoint to seed the Management Server
+     */
+    private String bootstrapEndpoint;
+    /**
+     * To determine whether the cluster is setup and the server is ready to
+     * start handling the detected failures.
+     */
+    private boolean startFailureHandler = false;
     /**
      * Interval in executing the failure detection policy.
      * In milliseconds.
@@ -79,6 +87,8 @@ public class ManagementServer extends AbstractServer {
 
         this.opts = serverContext.getServerConfig();
         this.serverContext = serverContext;
+
+        bootstrapEndpoint = (opts.get("--mgmt")!=null) ? opts.get("--mgmt").toString() : null;
 
         if((Boolean) opts.get("--single")) {
             String localAddress = opts.get("--address") + ":" + opts.get("<port>");
@@ -105,6 +115,7 @@ public class ManagementServer extends AbstractServer {
         }
 
         this.failureDetectorPolicy = serverContext.getFailureDetectorPolicy();
+        this.failureHandlerPolicy = serverContext.getFailureHandlerPolicy();
         this.failureDetectorService = Executors.newScheduledThreadPool(
                 2,
                 new ThreadFactoryBuilder()
@@ -166,9 +177,9 @@ public class ManagementServer extends AbstractServer {
     }
 
     boolean checkBootstrap(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
-        if (latestLayout == null) {
+        if (latestLayout == null && bootstrapEndpoint == null) {
             log.warn("Received message but not bootstrapped! Message={}", msg);
-            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP));
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP_ERROR));
             return false;
         }
         return true;
@@ -182,18 +193,44 @@ public class ManagementServer extends AbstractServer {
      * @param ctx
      * @param r
      */
-    @ServerHandler(type = CorfuMsgType.MANAGEMENT_BOOTSTRAP)
+    @ServerHandler(type = CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST)
     public synchronized void handleManagementBootstrap(CorfuPayloadMsg<Layout> msg, ChannelHandlerContext ctx, IServerRouter r) {
         if (latestLayout != null) {
             // We are already bootstrapped, bootstrap again is not allowed.
             log.warn("Got a request to bootstrap a server which is already bootstrapped, rejecting!");
-            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_ALREADY_BOOTSTRAP));
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_ALREADY_BOOTSTRAP_ERROR));
         }
         else {
             log.info("Received Bootstrap Layout : {}", msg.getPayload());
             safeUpdateLayout(msg.getPayload());
             r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
         }
+    }
+
+    /**
+     * Trigger to start the failure handler.
+     *
+     * @param msg
+     * @param ctx
+     * @param r
+     */
+    @ServerHandler(type = CorfuMsgType.MANAGEMENT_START_FAILURE_HANDLER)
+    public synchronized void initiateFailureHandler(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+        if (isShutdown()) {
+            log.warn("Management Server received {} but is shutdown.", msg.getMsgType().toString());
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
+            return;
+        }
+        // This server has not been bootstrapped yet, ignore all requests.
+        if (!checkBootstrap(msg, ctx, r)) { return; }
+
+        if (!startFailureHandler) {
+            startFailureHandler = true;
+            log.info("Initiated Failure Handler.");
+        } else {
+            log.info("Failure Handler already initiated.");
+        }
+        r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
     }
 
     /**
@@ -216,6 +253,8 @@ public class ManagementServer extends AbstractServer {
 
         log.info("Received Failures : {}", msg.getPayload().getNodes());
         r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
+        FailureHandlerDispatcher failureHandlerDispatcher = new FailureHandlerDispatcher();
+        failureHandlerDispatcher.dispatchHandler(failureHandlerPolicy, latestLayout, getCorfuRuntime(), msg.getPayload().getNodes().keySet());
     }
 
     /**
@@ -227,7 +266,11 @@ public class ManagementServer extends AbstractServer {
 
         if (corfuRuntime == null) {
             corfuRuntime = new CorfuRuntime();
-            latestLayout.getLayoutServers().forEach(ls -> corfuRuntime.addLayoutServer(ls));
+            // Runtime can be set up either using the layout or the bootstrapEndpoint address.
+            if (latestLayout != null)
+                latestLayout.getLayoutServers().forEach(ls -> corfuRuntime.addLayoutServer(ls));
+            else
+                corfuRuntime.addLayoutServer(bootstrapEndpoint);
             corfuRuntime.connect();
             log.info("Corfu Runtime connected successfully");
         }
@@ -247,7 +290,7 @@ public class ManagementServer extends AbstractServer {
      * Schedules the failure detector task only if the previous task is completed.
      */
     private void failureDetectorScheduler() {
-        if (latestLayout == null) {
+        if (latestLayout == null && bootstrapEndpoint == null) {
             log.warn("Management Server waiting to be bootstrapped");
             return;
         }
@@ -294,6 +337,11 @@ public class ManagementServer extends AbstractServer {
         if (!map.isEmpty()) {
             log.info("Failures detected. Failed nodes : {}", map.toString());
             // If map not empty, failures present. Trigger handler.
+            // Check if handler has been initiated.
+            if (!startFailureHandler) {
+                log.warn("Failure Handler not yet initiated .");
+                return;
+            }
             try {
                 corfuRuntime.getRouter(getLocalEndpoint()).getClient(ManagementClient.class).handleFailure(map);
             } catch (Exception e) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -50,11 +50,16 @@ public class ServerContext {
     @Setter
     private IFailureDetectorPolicy failureDetectorPolicy;
 
+    @Getter
+    @Setter
+    private IFailureHandlerPolicy failureHandlerPolicy;
+
     public ServerContext(Map<String, Object> serverConfig, IServerRouter serverRouter) {
         this.serverConfig = serverConfig;
         this.dataStore = new DataStore(serverConfig);
         this.serverRouter = serverRouter;
         this.failureDetectorPolicy = new PeriodicPollPolicy();
+        this.failureHandlerPolicy = new PurgeFailurePolicy();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -68,11 +68,13 @@ public enum CorfuMsgType {
     LAYOUT_ALREADY_BOOTSTRAP(60, TypeToken.of(CorfuMsg.class), true),
     LAYOUT_PREPARE_ACK(61, new TypeToken<CorfuPayloadMsg<LayoutPrepareResponse>>(){}, true),
 
-    // Management Codes
-    MANAGEMENT_BOOTSTRAP(62, new TypeToken<CorfuPayloadMsg<Layout>>(){}, true),
-    MANAGEMENT_FAILURE_DETECTED(63, new TypeToken<CorfuPayloadMsg<FailureDetectorMsg>>(){}, true),
-    MANAGEMENT_NOBOOTSTRAP(64, TypeToken.of(CorfuMsg.class), true),
-    MANAGEMENT_ALREADY_BOOTSTRAP(65, TypeToken.of(CorfuMsg.class), true);
+    // Management Messages
+    MANAGEMENT_BOOTSTRAP_REQUEST(70, new TypeToken<CorfuPayloadMsg<Layout>>(){}, true),
+    MANAGEMENT_NOBOOTSTRAP_ERROR(71, TypeToken.of(CorfuMsg.class), true),
+    MANAGEMENT_ALREADY_BOOTSTRAP_ERROR(72, TypeToken.of(CorfuMsg.class), true),
+    MANAGEMENT_START_FAILURE_HANDLER(73, TypeToken.of(CorfuMsg.class), true),
+    MANAGEMENT_FAILURE_DETECTED(74, new TypeToken<CorfuPayloadMsg<FailureDetectorMsg>>(){}, true);
+
 
     public final int type;
     public final TypeToken<? extends CorfuMsg> messageType;

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.Setter;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
-import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.FailureDetectorMsg;
 import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.NoBootstrapException;
@@ -32,10 +31,11 @@ public class ManagementClient implements IClient {
     @Getter
     public final Set<CorfuMsgType> HandledTypes =
             new ImmutableSet.Builder<CorfuMsgType>()
-                    .add(CorfuMsgType.MANAGEMENT_BOOTSTRAP)
-                    .add(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP)
-                    .add(CorfuMsgType.MANAGEMENT_ALREADY_BOOTSTRAP)
+                    .add(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST)
+                    .add(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP_ERROR)
+                    .add(CorfuMsgType.MANAGEMENT_ALREADY_BOOTSTRAP_ERROR)
                     .add(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)
+                    .add(CorfuMsgType.MANAGEMENT_START_FAILURE_HANDLER)
                     .build();
 
     @Setter
@@ -51,16 +51,10 @@ public class ManagementClient implements IClient {
     @Override
     public void handleMessage(CorfuMsg msg, ChannelHandlerContext ctx) {
         switch (msg.getMsgType()) {
-            case MANAGEMENT_BOOTSTRAP:
-                router.completeRequest(msg.getRequestID(), ((CorfuPayloadMsg<Layout>) msg).getPayload());
-                break;
-            case MANAGEMENT_NOBOOTSTRAP:
+            case MANAGEMENT_NOBOOTSTRAP_ERROR:
                 router.completeExceptionally(msg.getRequestID(), new NoBootstrapException());
                 break;
-            case MANAGEMENT_FAILURE_DETECTED:
-                router.completeRequest(msg.getRequestID(), ((CorfuPayloadMsg<FailureDetectorMsg>) msg).getPayload());
-                break;
-            case MANAGEMENT_ALREADY_BOOTSTRAP:
+            case MANAGEMENT_ALREADY_BOOTSTRAP_ERROR:
                 router.completeExceptionally(msg.getRequestID(), new AlreadyBootstrappedException());
                 break;
         }
@@ -74,7 +68,7 @@ public class ManagementClient implements IClient {
      * bootstrap was successful, false otherwise.
      */
     public CompletableFuture<Boolean> bootstrapManagement(Layout l) {
-        return router.sendMessageAndGetCompletable(CorfuMsgType.MANAGEMENT_BOOTSTRAP.payloadMsg(l));
+        return router.sendMessageAndGetCompletable(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST.payloadMsg(l));
     }
 
     /**
@@ -85,5 +79,14 @@ public class ManagementClient implements IClient {
      */
     public CompletableFuture<Boolean> handleFailure(Map nodes) {
         return router.sendMessageAndGetCompletable(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(nodes)));
+    }
+
+    /**
+     * Initiates failure handling in the Management Server.
+     *
+     * @return A future which returns TRUE if failure handler triggered successfully.
+     */
+    public CompletableFuture<Boolean> initiateFailureHandler() {
+        return router.sendMessageAndGetCompletable(CorfuMsgType.MANAGEMENT_START_FAILURE_HANDLER.msg());
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
@@ -50,10 +50,10 @@ public class ManagementServerTest extends AbstractServerTest {
     @Test
     public void bootstrapManagementServer() {
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
-        sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP.payloadMsg(layout));
+        sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST.payloadMsg(layout));
         assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
-        sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP.payloadMsg(layout));
-        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.MANAGEMENT_ALREADY_BOOTSTRAP);
+        sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST.payloadMsg(layout));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.MANAGEMENT_ALREADY_BOOTSTRAP_ERROR);
     }
 
     /**
@@ -65,8 +65,8 @@ public class ManagementServerTest extends AbstractServerTest {
         Map<String, Boolean> map = new HashMap<>();
         map.put("key", true);
         sendMessage(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(map)));
-        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP);
-        sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP.payloadMsg(layout));
+        assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP_ERROR);
+        sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST.payloadMsg(layout));
         assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
         sendMessage(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(map)));
         assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -22,6 +22,7 @@ public class ServerContextBuilder {
     int maxCache = 1000000;
     String address = "test";
     int port = 9000;
+    String managementBootstrapEndpoint = null;
     IServerRouter serverRouter;
 
     public ServerContextBuilder() {
@@ -36,6 +37,9 @@ public class ServerContextBuilder {
                 .put("--memory", memory);
         if (logPath != null) {
          builder.put("--log-path", logPath);
+        }
+        if (managementBootstrapEndpoint != null) {
+            builder.put("--mgmt", managementBootstrapEndpoint);
         }
          builder
                 .put("--no-verify", noVerify)

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -39,7 +39,7 @@ public class ServerContextBuilder {
          builder.put("--log-path", logPath);
         }
         if (managementBootstrapEndpoint != null) {
-            builder.put("--mgmt", managementBootstrapEndpoint);
+            builder.put("--management-server", managementBootstrapEndpoint);
         }
          builder
                 .put("--no-verify", noVerify)

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -232,7 +232,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
                             .handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(l)),
                                     null, e.getValue().serverRouter);
                     e.getValue().managementServer
-                            .handleMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP.payloadMsg(l),
+                            .handleMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST.payloadMsg(l),
                                     null, e.getValue().serverRouter);
                 });
     }

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -3,6 +3,8 @@ package org.corfudb.runtime.view;
 import org.corfudb.infrastructure.ManagementServer;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.clients.TestRule;
 import org.junit.Test;
 
@@ -50,6 +52,12 @@ public class ManagementViewTest extends AbstractViewTest {
                 .addToLayout()
                 .build();
         bootstrapAllServers(l);
+
+        CorfuRuntime corfuRuntime = new CorfuRuntime();
+        l.getLayoutServers().forEach(corfuRuntime::addLayoutServer);
+        corfuRuntime.connect();
+        corfuRuntime.getRouter(SERVERS.ENDPOINT_1).getClient(ManagementClient.class).initiateFailureHandler();
+
 
         // Reduce test execution time from 15+ seconds to about 8 seconds:
         // Set aggressive timeouts for surviving MS that polls the dead MS.


### PR DESCRIPTION
## Updates
Failure Handling ( #237 Failure Detector )

### Minor update in cmdlet.
- Prevent user from modifying epoch field.

### Corfu Server
- Added a new flag -M or --mgmt taking <address>:<port> which would be an endpoint for the Management server to connect to. Thus another explicit bootstrap message is not required.
(We still keep the bootstrap message for now. In case the user forgets to pass this flag and still needs to spawn the Management Server.)
- Removed the config mngr poll interval flag as the config manager has been removed.

### Management Server
- Bootstraps now using the flag --mgmt passed by the corfu server.
- Failure Handler now in place. The failure handler currently is defaulted to using the PurgeFailurePolicy.
( #360 This policy removes any failure detected from the layout.)
- Failure handler not activated unless an explicit trigger message (MANAGEMENT_START_FAILURE_HANDLER) is received by the server.
- Without the above trigger the Management server will not handle any failures.

### Server Context
- Added the Failure handler policy in the server context.

### Management Client
- Added the trigger method to send the MANAGEMENT_START_FAILURE_HANDLER message and start failure handling.

### Management View Test
- Modified the test a bit to trigger the failure handling to assert the required result.