### PR TITLE
Fix issue with optimistic rollback

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -143,7 +143,7 @@ public class VersionLockedObject<T> {
      */
     public void optimisticRollbackUnsafe() {
         // TODO: validate the caller actually has a write lock.
-        if (optimisticUndoLog.size() > 0 || !optimisticallyUndoable) {
+        if (!optimisticallyUndoable) {
             throw new NoRollbackException();
         }
         // The undo log is a stack, where the last entry applied


### PR DESCRIPTION
Due to a small bug, optimistic rollback was always aborting,
even if undo information was available. This patch fixes that
bug.