### PR TITLE
Readme update for replica bootstrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ $ corfu_server -m 9001
 
 Bootstraping the newly added server using previous layout
 ```
-$corfu_layouts -c localhost:9000 query 2>&1 | grep -v parsley.fold/cat | sed 1d  > /tmp/master_layout
-$corfu_management_bootstrap -c localhost:9001 -l /tmp/master_layout
+$ corfu_layouts -c localhost:9000 query 2>&1 | grep -v parsley.fold/cat | sed 1d  > /tmp/master_layout
+$ corfu_management_bootstrap -c localhost:9001 -l /tmp/master_layout
 ```
 
 Now lets add that layout server to the previous deployment:

--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ Let's start by adding a layout server. To do that, start a non-provisioned Corfu
 $ corfu_server -m 9001
 ```
 
+Bootstraping the newly added server using previous layout
+```
+$corfu_layouts -c localhost:9000 query 2>&1 | grep -v parsley.fold/cat | sed 1d  > /tmp/master_layout
+$corfu_management_bootstrap -c localhost:9001 -l /tmp/master_layout
+```
+
 Now lets add that layout server to the previous deployment:
 ```
 $ corfu_layouts -c localhost:9000 edit

--- a/README.md
+++ b/README.md
@@ -148,13 +148,7 @@ Now that you have a working Corfu deployment, you'll probably want to make it di
 
 Let's start by adding a layout server. To do that, start a non-provisioned Corfu server instance in addition to the previous one. We'll start it on port 9001.
 ```
-$ corfu_server -m 9001
-```
-
-Bootstraping the newly added server using previous layout
-```
-$ corfu_layouts -c localhost:9000 query 2>&1 | grep -v parsley.fold/cat | sed 1d  > /tmp/master_layout
-$ corfu_management_bootstrap -c localhost:9001 -l /tmp/master_layout
+$ corfu_server -m -M localhost:9000 9001
 ```
 
 Now lets add that layout server to the previous deployment:


### PR DESCRIPTION
While adding the second layout server, the Readme doesn't mention that we need to bootstrap it before changing layout on the master server. 

Changing layout on the master server without bootstrapping the replica, kept replica waiting for bootstrap. Also, the master layout could not be changed back as it violated quorum requirement (as replica is not responding)