### PR TITLE
Failure handler testing

### DIFF
--- a/bin/corfu_handle_failures
+++ b/bin/corfu_handle_failures
@@ -1,0 +1,1 @@
+../scripts/cmdlet.sh

--- a/corfu_scripts/corfu_handle_failures.clj
+++ b/corfu_scripts/corfu_handle_failures.clj
@@ -1,0 +1,41 @@
+; Query endpoint status given the endpoint as the first arg
+(in-ns 'org.corfudb.shell) ; so our IDE knows what NS we are using
+
+(import org.docopt.Docopt) ; parse some cmdline opts
+(require 'clojure.pprint)
+(require 'clojure.java.shell)
+(def usage "corfu_handle_failures, initiates failure handler on all Management Servers.
+Usage:
+  corfu_handle_failures -c <config>
+Options:
+  -c <config>, --config <config>              Configuration string to use.
+  -h, --help     Show this screen.
+")
+
+; Parse the incoming docopt options.
+(def localcmd (.. (new Docopt usage) (parse *args)))
+;
+; Get the runtime.
+(get-runtime (.. localcmd (get "--config")))
+(connect-runtime)
+(def layout-view (get-layout-view))
+
+(defn start-fh [] (let [layout (.. (get-layout-view) (getLayout))]
+                       ; For each server send trigger to server initiating failure handling.
+                       (do
+                         (doseq [server (.getAllServers layout)]
+                                (do (get-router server)
+                                    (try
+                                      (.get (.initiateFailureHandler (get-management-client)))
+                                      (println "Failure handler on" server "started.")
+                                      (catch Exception e
+                                        (println "Exception :" server ":" (.getMessage e))))
+                                    ))
+                         (println "Initiation completed !")
+                       )
+                   ))
+
+; determine whether options passed correctly
+(cond (.. localcmd (get "--config")) (start-fh)
+      :else (println "Unknown arguments.")
+      )

--- a/corfu_scripts/corfu_management_bootstrap.clj
+++ b/corfu_scripts/corfu_management_bootstrap.clj
@@ -4,7 +4,7 @@
 (import org.docopt.Docopt)                                  ; parse some cmdline opts
 (import org.corfudb.runtime.view.Layout)
 
-(def usage "corfu_management_bootstrap, work with Corfu streams.
+(def usage "corfu_management_bootstrap, to bootstrap Corfu Management Server.
 Usage:
   corfu_management_bootstrap -c <config> -l <layout>
 Options:
@@ -20,7 +20,7 @@ Options:
                                             )
                                        ))
 
-; a function which reads a stream to stdout
+; a function which builds and bootstraps the layout
 (defn bootstrap-node [endpoint, layout] (do
                                           (build-layout endpoint (str (slurp layout)))
                                           ))

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -72,8 +72,7 @@ public class ManagementServer extends AbstractServer {
      * In milliseconds.
      */
     @Getter
-    @Setter
-    private volatile long policyExecuteInterval = 1000;
+    private final long policyExecuteInterval = 1000;
     /**
      * To schedule failure detection.
      */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.ChannelHandlerContext;
 
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
@@ -14,7 +15,6 @@ import org.corfudb.protocols.wireprotocol.FailureDetectorMsg;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.view.Layout;
-import org.corfudb.runtime.view.LayoutView;
 
 import java.lang.invoke.MethodHandles;
 
@@ -72,7 +72,8 @@ public class ManagementServer extends AbstractServer {
      * In milliseconds.
      */
     @Getter
-    private final long policyExecuteInterval = 1000;
+    @Setter
+    private volatile long policyExecuteInterval = 1000;
     /**
      * To schedule failure detection.
      */
@@ -319,15 +320,11 @@ public class ManagementServer extends AbstractServer {
      */
     private void failureDetectorTask() {
 
-        LayoutView layoutView;
-
-        CorfuRuntime corfuRuntime;
-        corfuRuntime = getCorfuRuntime();
+        CorfuRuntime corfuRuntime = getCorfuRuntime();
         corfuRuntime.invalidateLayout();
 
         // Fetch the latest layout view through the runtime.
-        layoutView = corfuRuntime.getLayoutView();
-        safeUpdateLayout(layoutView.getLayout());
+        safeUpdateLayout(corfuRuntime.getLayoutView().getLayout());
 
         // Execute the failure detection policy once.
         failureDetectorPolicy.executePolicy(latestLayout, corfuRuntime);

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -64,7 +64,7 @@ public class ManagementViewTest extends AbstractViewTest {
         // Reduce test execution time from 15+ seconds to about 8 seconds:
         // Set aggressive timeouts for surviving MS that polls the dead MS.
         ManagementServer ms = getManagementServer(SERVERS.PORT_1);
-        getManagementServer(SERVERS.PORT_1).setPolicyExecuteInterval(200);
+        getManagementServer(SERVERS.PORT_1).setPolicyExecuteInterval(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
@@ -137,7 +137,7 @@ public class ManagementViewTest extends AbstractViewTest {
         routerEndpoints.add(SERVERS.ENDPOINT_2);
         serverPorts.forEach(serverPort -> {
             routerEndpoints.forEach(routerEndpoint -> {
-                getManagementServer(serverPort).setPolicyExecuteInterval(200);
+                getManagementServer(serverPort).setPolicyExecuteInterval(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
                 getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
                 getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
                 getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
@@ -148,7 +148,7 @@ public class ManagementViewTest extends AbstractViewTest {
         addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
         getManagementServer(SERVERS.PORT_1).shutdown();
 
-        for (int i=0; i<PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++){
+        for (int i=0; i<PARAMETERS.NUM_ITERATIONS_LOW; i++){
             corfuRuntime.invalidateLayout();
             if (corfuRuntime.getLayoutView().getLayout().getEpoch() == 2L) {break;}
             Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -64,7 +64,6 @@ public class ManagementViewTest extends AbstractViewTest {
         // Reduce test execution time from 15+ seconds to about 8 seconds:
         // Set aggressive timeouts for surviving MS that polls the dead MS.
         ManagementServer ms = getManagementServer(SERVERS.PORT_1);
-        getManagementServer(SERVERS.PORT_1).setPolicyExecuteInterval(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
@@ -137,7 +136,6 @@ public class ManagementViewTest extends AbstractViewTest {
         routerEndpoints.add(SERVERS.ENDPOINT_2);
         serverPorts.forEach(serverPort -> {
             routerEndpoints.forEach(routerEndpoint -> {
-                getManagementServer(serverPort).setPolicyExecuteInterval(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
                 getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
                 getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
                 getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());


### PR DESCRIPTION
## Minor Update

### ManagementViewTest to handle single node failure
- In a cluster of 3 nodes, PORT_0, PORT_1 and PORT_2, we fail PORT_1 and wait until the new layout is proposed with epoch incremented and PORT_1 removed.
- This test takes an average of 10secs.

### Added cmdlet corfu_handle_failures
- Providing the user an interface to turn on failure handling capability.
- (Without executing. Failures are only detected and logged but **not** handled.