### PR TITLE
Setup cluster cmdlet

### DIFF
--- a/bin/corfu_bootstrap_cluster
+++ b/bin/corfu_bootstrap_cluster
@@ -1,0 +1,1 @@
+../scripts/cmdlet.sh

--- a/corfu_scripts/corfu_bootstrap_cluster.clj
+++ b/corfu_scripts/corfu_bootstrap_cluster.clj
@@ -1,0 +1,36 @@
+; Setup a cluster with the layout passed as the argument.
+(in-ns 'org.corfudb.shell) ; so our IDE knows what NS we are using
+
+(import org.docopt.Docopt) ; parse some cmdline opts
+(require 'clojure.pprint)
+(require 'clojure.java.shell)
+(import org.corfudb.runtime.view.Layout)
+(def usage "corfu_bootstrap_cluster, setup the Corfu cluster where all nodes are NOT bootstrapped.
+Usage:
+  corfu_bootstrap_cluster -l <layout>
+Options:
+  -l <layout>, --layout <layout>              JSON layout file to be bootstrapped.
+  -h, --help     Show this screen.
+")
+
+; Parse the incoming docopt options.
+(def localcmd (.. (new Docopt usage) (parse *args)))
+
+(defn bootstrap-cluster [layout-file]
+               (do ; read in the new layout
+                 (let [new-layout (Layout/fromJSONString (str (slurp layout-file)))]
+
+                      (do
+                        (doseq [server (.getLayoutServers new-layout)]
+                           (do (get-router server)
+                               (.get (.bootstrapLayout (get-layout-client) new-layout))
+                               (.get (.bootstrapManagement (get-management-client) new-layout))
+                               (.get (.initiateFailureHandler (get-management-client)))
+                            ))
+                        (println "New layout installed!")
+                        )
+                  )))
+
+; determine whether to read or write
+(cond (.. localcmd (get "--layout")) (bootstrap-cluster (.. localcmd (get "--layout")))
+                                       :else (println "Unknown arguments."))

--- a/corfu_scripts/corfu_handle_failures.clj
+++ b/corfu_scripts/corfu_handle_failures.clj
@@ -4,38 +4,55 @@
 (import org.docopt.Docopt) ; parse some cmdline opts
 (require 'clojure.pprint)
 (require 'clojure.java.shell)
+(import org.corfudb.runtime.view.Layout)
 (def usage "corfu_handle_failures, initiates failure handler on all Management Servers.
 Usage:
   corfu_handle_failures -c <config>
+  corfu_handle_failures -l <layout>
 Options:
   -c <config>, --config <config>              Configuration string to use.
+  -l <layout>, --layout <layout>              Layout to use to send triggers.
   -h, --help     Show this screen.
 ")
 
 ; Parse the incoming docopt options.
 (def localcmd (.. (new Docopt usage) (parse *args)))
-;
-; Get the runtime.
-(get-runtime (.. localcmd (get "--config")))
-(connect-runtime)
-(def layout-view (get-layout-view))
 
-(defn start-fh [] (let [layout (.. (get-layout-view) (getLayout))]
-                       ; For each server send trigger to server initiating failure handling.
-                       (do
-                         (doseq [server (.getAllServers layout)]
-                                (do (get-router server)
-                                    (try
-                                      (.get (.initiateFailureHandler (get-management-client)))
-                                      (println "Failure handler on" server "started.")
-                                      (catch Exception e
-                                        (println "Exception :" server ":" (.getMessage e))))
-                                    ))
-                         (println "Initiation completed !")
-                       )
-                   ))
+(defn send-trigger [layout]
+      (do
+        ; For each server send trigger to server initiating failure handling.
+        (doseq [server (.getAllServers layout)]
+               (try
+                 (do (get-router server)
+                     (.get (.initiateFailureHandler (get-management-client)))
+                     (println "Failure handler on" server "started."))
+                 (catch Exception e
+                   (println "Exception :" server ":" (.getMessage e))))
+               )
+        (println "Initiation completed !")
+        )
+      )
+
+(defn start-fh-runtime []
+      ; Get the runtime.
+      (get-runtime (.. localcmd (get "--config")))
+      (connect-runtime)
+      (def layout-view (get-layout-view))
+
+      (let [layout (.. (get-layout-view) (getLayout))]
+           (send-trigger layout)
+       ))
+
+(defn start-fh-layout []
+      (do ; read in the new layout
+        (let [layout (Layout/fromJSONString (str (slurp (.. localcmd (get "--layout")))))]
+             (send-trigger layout)
+         )
+      ))
+
 
 ; determine whether options passed correctly
-(cond (.. localcmd (get "--config")) (start-fh)
+(cond (.. localcmd (get "--config")) (start-fh-runtime)
+      (.. localcmd (get "--layout")) (start-fh-layout)
       :else (println "Unknown arguments.")
       )


### PR DESCRIPTION
Simple cmdlet to setup a cluster required by the fault injection framework. 
Performs the following:
- bootstrap all nodes.
- bootstrap the management servers.
- initiate the failure handler of all these nodes.
NOTE: All nodes in the layout need to be non-bootstrapped.

Example:
```
./corfu_server -m 9000
./corfu_server -m 9001
./corfu_server -m 9002
./corfu_bootstrap_cluster -l <layout_file_path>
```

Example layout:
```
{
  "layoutServers": [
    "localhost:9000",
    "localhost:9001",
    "localhost:9002"
  ],
  "sequencers": [
    "localhost:9000"
  ],
  "segments": [
    {
      "replicationMode": "CHAIN_REPLICATION",
      "start": 0,
      "end": -1,
      "stripes": [
        {
          "logServers": [
            "localhost:9000"
          ]
        }
      ]
    }
  ],
  "epoch": 0
}
```