### PR TITLE
remove unnecessary rollbacks

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -132,10 +132,12 @@ public class VersionLockedObject<T> {
         // TODO: merge the optimistic undo log into the undo log
         optimisticUndoLog.clear();
         optimisticVersion = 0;
+        optimisticallyModified = false;
         this.version = version;
         // TODO: fix the stream view pointer seek, for now
         // read will read the tx commit entry.
         sv.read();
+        modifyingContext = null;
     }
 
     /** Rollback any optimistic changes, if possible.
@@ -143,6 +145,11 @@ public class VersionLockedObject<T> {
      */
     public void optimisticRollbackUnsafe() {
         // TODO: validate the caller actually has a write lock.
+
+        if (!optimisticallyModified) {
+            log.debug("nothing to roll");
+            return;
+        }
         if (!optimisticallyUndoable) {
             throw new NoRollbackException();
         }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -55,6 +55,10 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
     private final Set<ICorfuSMRProxyInternal> modifiedProxies =
             new HashSet<>();
 
+    /** micro-transaction lock.
+     * used in order to allow tranasctions a certain uniterrupted period of
+     * time to commit
+     */
     @Getter
     private final Lock mTxLock = new ReentrantLock();
 
@@ -261,7 +265,9 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         // now unlock this transaction's contention lock
         try {
             getMTxLock().unlock();
-        } catch (IllegalMonitorStateException me) {}
+        } catch (IllegalMonitorStateException me) {
+            log.error("transaction fails to unlock its own contention lock");
+        }
 
         return ret;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -18,6 +18,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
@@ -52,6 +55,10 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
     private final Set<ICorfuSMRProxyInternal> modifiedProxies =
             new HashSet<>();
 
+    @Getter
+    private final Lock mTxLock = new ReentrantLock();
+
+
     OptimisticTransactionalContext(TransactionBuilder builder) {
         super(builder);
     }
@@ -71,10 +78,21 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         final UUID streamID = proxy.getStreamID();
 
         try {
+            OptimisticTransactionalContext oCtxt = (OptimisticTransactionalContext)
+                    object.getModifyingContextUnsafe();
+
             // If we don't own this object, roll it back
-            if (object.getModifyingContextUnsafe() != this) {
-                object.optimisticRollbackUnsafe();
+            // to avoid interrupting short-lived micro TX, grab the lock
+            if (oCtxt != null && oCtxt != this) {
+                try {
+                    oCtxt.getMTxLock().tryLock(
+                            TransactionalContext.mTxDuration.toMillis(), TimeUnit.MILLISECONDS);
+                } catch (InterruptedException ie) {
+                    // it's ok, just means that we move on without the lock
+                    log.debug("tx at {} proceeds without lock");
+                }
             }
+            object.optimisticRollbackUnsafe();
 
             // If the version of this object is ahead of what we expected,
             // we need to rollback...
@@ -238,6 +256,19 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
     @Override
     @SuppressWarnings("unchecked")
     public long commitTransaction() throws TransactionAbortedException {
+        long ret = commitTransactionNoReleaseLock();
+
+        // now unlock this transaction's contention lock
+        try {
+            getMTxLock().unlock();
+        } catch (IllegalMonitorStateException me) {}
+
+        return ret;
+    }
+
+    long commitTransactionNoReleaseLock() throws TransactionAbortedException {
+        log.debug("attempt to commit optimistic tx from snapshot {}", getSnapshotTimestamp());
+
 
         // If the transaction is nested, fold the transaction.
         if (TransactionalContext.isInNestedTransaction()) {
@@ -366,6 +397,18 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
      */
     @Override
     public synchronized long obtainSnapshotTimestamp() {
+        /** obtain micro-transaction lock */
+        /* */
+        try {
+            getMTxLock().tryLock(
+                    TransactionalContext.mTxDuration.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ie) {
+            // it's ok, just means that we move on without the lock
+            log.debug("tx at {} proceeds without lock");
+        }
+        /* */
+
+
         final AbstractTransactionalContext atc = getRootContext();
         if (atc != null && atc != this) {
             // If we're in a nested transaction, the first read timestamp

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.object.transactions;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.time.Duration;
 import java.util.Deque;
 import java.util.LinkedList;
 
@@ -14,6 +15,11 @@ import java.util.LinkedList;
  */
 @Slf4j
 public class TransactionalContext {
+    /** MicroTransaction support:
+     * allow short-lived transactions to run without contention for this
+     * duration
+     */
+    public static final Duration mTxDuration = Duration.ofMillis(10);
 
     /** A thread local stack containing all transaction contexts
      * for a given thread.

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -36,25 +36,7 @@ public class WriteAfterWriteTransactionalContext
         super(builder);
     }
 
-    /**
-     * Commit the transaction. If it is the last transaction in the stack,
-     * write it to the log, otherwise merge it into a nested transaction.
-     *
-     * @return The address of the committed transaction.
-     * @throws TransactionAbortedException If the transaction was aborted.
-     */
-    @Override
-    public long commitTransaction() throws TransactionAbortedException {
-        long ret = commitTransactionNoReleaseLock();
-
-        // now unlock this transaction's contention lock
-        try {
-            getMTxLock().unlock();
-        } catch (IllegalMonitorStateException me) {}
-
-        return ret;
-    }
-
+    @Override // from OptimisticTransactionalContext
     long commitTransactionNoReleaseLock() throws TransactionAbortedException {
 
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -45,6 +45,18 @@ public class WriteAfterWriteTransactionalContext
      */
     @Override
     public long commitTransaction() throws TransactionAbortedException {
+        long ret = commitTransactionNoReleaseLock();
+
+        // now unlock this transaction's contention lock
+        try {
+            getMTxLock().unlock();
+        } catch (IllegalMonitorStateException me) {}
+
+        return ret;
+    }
+
+    long commitTransactionNoReleaseLock() throws TransactionAbortedException {
+
 
         // If the transaction is nested, fold the transaction.
         if (TransactionalContext.isInNestedTransaction()) {


### PR DESCRIPTION
this patch removes unnecessary object rollbacks of transactions which already committed; and also reduces contention when one transaction needs to rollback a
running one.