### PR TITLE
minor fix - rollback unnecessarily performed because placed outside 'if' statement

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -88,7 +88,10 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
             // If we don't own this object, roll it back
             // to avoid interrupting short-lived micro TX, grab the lock
             if (oCtxt != null && oCtxt != this) {
-                /* */
+                /**
+                 *  comment this block out to increase concurrency, but also,
+                 *  potential contention
+                 *  */
                 try {
                     oCtxt.getMTxLock().tryLock(
                             TransactionalContext.mTxDuration.toMillis(), TimeUnit.MILLISECONDS);
@@ -96,7 +99,8 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                     // it's ok, just means that we move on without the lock
                     log.debug("tx at {} proceeds without lock");
                 }
-                /* */
+                /**
+                 *  to here */
                 object.optimisticRollbackUnsafe();
             }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -88,6 +88,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
             // If we don't own this object, roll it back
             // to avoid interrupting short-lived micro TX, grab the lock
             if (oCtxt != null && oCtxt != this) {
+                /* */
                 try {
                     oCtxt.getMTxLock().tryLock(
                             TransactionalContext.mTxDuration.toMillis(), TimeUnit.MILLISECONDS);
@@ -95,8 +96,9 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                     // it's ok, just means that we move on without the lock
                     log.debug("tx at {} proceeds without lock");
                 }
+                /* */
+                object.optimisticRollbackUnsafe();
             }
-            object.optimisticRollbackUnsafe();
 
             // If the version of this object is ahead of what we expected,
             // we need to rollback...

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -19,7 +19,7 @@ public class TransactionalContext {
      * allow short-lived transactions to run without contention for this
      * duration
      */
-    public static final Duration mTxDuration = Duration.ofMillis(10);
+    public static final Duration mTxDuration = Duration.ofMillis(1);
 
     /** A thread local stack containing all transaction contexts
      * for a given thread.


### PR DESCRIPTION
rollback wrongly placed outside 'if' statement