### PR TITLE
Small (careful) refactoring and cleanup in org.corfudb.runtime.view.

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenRequest.java
@@ -40,19 +40,10 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
     /** The streams which are written to by this token request. */
     final Set<UUID> streams;
 
-    /* True if the Replex protocol encountered an overwrite at the global log layer. */
-    @Deprecated
-    final Boolean overwrite = false; // todo : deprecate
-
-    /* True if the Replex protocol encountered an overwrite at the local stream layer. */
-    @Deprecated
-    final Boolean replexOverwrite = false; // todo: deprecate
-
     /* used for transaction resolution. */
     final TxResolutionInfo txnResolution;
 
     public TokenRequest(Long numTokens, Set<UUID> streams,
-                        Boolean overwrite, Boolean replexOverwrite,
                         TxResolutionInfo conflictInfo) {
         reqType = TK_TX;
         this.numTokens = numTokens;
@@ -60,7 +51,7 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
         txnResolution = conflictInfo;
     }
 
-    public TokenRequest(Long numTokens, Set<UUID> streams, Boolean overwrite, Boolean replexOverwrite) {
+    public TokenRequest(Long numTokens, Set<UUID> streams) {
         if (numTokens == 0)
             this.reqType = TK_QUERY;
         else if (streams == null || streams.size() == 0)

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -41,23 +41,12 @@ public class SequencerClient implements IClient {
 
     public CompletableFuture<TokenResponse> nextToken(Set<UUID> streamIDs, long numTokens) {
         return router.sendMessageAndGetCompletable(
-                CorfuMsgType.TOKEN_REQ.payloadMsg(new TokenRequest(numTokens, streamIDs, false, false)));
+                CorfuMsgType.TOKEN_REQ.payloadMsg(new TokenRequest(numTokens, streamIDs)));
     }
 
-    public CompletableFuture<TokenResponse> nextToken(Set<UUID> streamIDs, long numTokens,
-                                                      boolean overwrite,
-                                                      boolean replexOverwrite) {
+    public CompletableFuture<TokenResponse> nextToken(Set<UUID> streamIDs, long numTokens, TxResolutionInfo conflictInfo) {
         return router.sendMessageAndGetCompletable(
-                CorfuMsgType.TOKEN_REQ.payloadMsg(new TokenRequest(numTokens, streamIDs, overwrite, replexOverwrite)));
+                CorfuMsgType.TOKEN_REQ.payloadMsg(new TokenRequest(numTokens, streamIDs, conflictInfo)));
     }
 
-    public CompletableFuture<TokenResponse> nextToken(Set<UUID> streamIDs, long numTokens,
-                                                      boolean overwrite,
-                                                      boolean replexOverwrite,
-                                                      TxResolutionInfo conflictInfo) {
-        return router.sendMessageAndGetCompletable(
-                CorfuMsgType.TOKEN_REQ.payloadMsg(new TokenRequest(numTokens, streamIDs,
-                        overwrite, replexOverwrite,
-                        conflictInfo)));
-    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractReplicationView.java
@@ -39,20 +39,7 @@ public abstract class AbstractReplicationView {
     public static AbstractReplicationView getReplicationView(Layout l, Layout.ReplicationMode mode, Layout.LayoutSegment ls) {
         if (l.replicationViewCache == null) { l.replicationViewCache = new ConcurrentHashMap<>(); } //super hacky
         return l.replicationViewCache.computeIfAbsent(ls, x -> {
-            // TODO: really broken software engineering here... refactor!
-            switch (ls.getReplicationMode()) {
-                case CHAIN_REPLICATION:
-                    return new ChainReplicationView(l, ls);
-                case QUORUM_REPLICATION:
-                    log.warn("Quorum replication is not yet supported!");
-                    break;
-                case REPLEX:
-                    return new ReplexReplicationView(l, ls);
-                default:
-                    log.error("Unknown replication mode {} selected.", mode);
-                    break;
-            }
-            return null;
+            return mode.getReplicationView(l, ls);
         });
     }
 
@@ -134,5 +121,7 @@ public abstract class AbstractReplicationView {
     public void fillStreamHole(UUID stream, long address) throws OverwriteException {
         throw new UnsupportedOperationException("This replication view doesn't support filling stream holes");
     }
+
+
 
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ChainReplicationStreamViewDelegate.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ChainReplicationStreamViewDelegate.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.view;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.StreamCOWEntry;
+import org.corfudb.protocols.wireprotocol.*;
+import org.corfudb.runtime.exceptions.OverwriteException;
+
+import java.util.*;
+
+/**
+ * Helper object for StreamView with the methods specific for chain replication.
+ * Created by Konstantin Spirov on 1/30/2017.
+ */
+@Slf4j
+class ChainReplicationStreamViewDelegate implements IStreamViewDelegate {
+
+    private ChainReplicationStreamViewDelegate() {
+    }
+
+    @Override
+    public ILogData read(StreamView v, long maxGlobal) {
+        while (true) {
+            if (v.getCurrentContext().logPointer.get() > v.getCurrentContext().maxAddress) {
+                StreamView.StreamContext last = v.streamContexts.pollFirst();
+                log.trace("Completed context {}@{}, removing.", last.contextID, last.maxAddress);
+            }
+            Long thisRead = v.getCurrentContext().currentBackpointerList.pollFirst();
+            if (thisRead == null) {
+                v.getCurrentContext().currentBackpointerList =
+                        v.resolveBackpointersToRead(v.getCurrentContext().contextID, v.getCurrentContext().logPointer.get());
+                log.trace("Backpointer list was empty, it has been filled with {} entries.",
+                        v.getCurrentContext().currentBackpointerList.size());
+                if (v.getCurrentContext().currentBackpointerList.size() == 0) {
+                    log.trace("No backpointers resolved, nothing to read.");
+                    return null;
+                }
+                thisRead = v.getCurrentContext().currentBackpointerList.pollFirst();
+            }
+            if (thisRead > maxGlobal) {
+                v.getCurrentContext().currentBackpointerList.add(thisRead);
+                return null;
+            }
+            v.getCurrentContext().logPointer.set(thisRead + 1);
+            log.trace("Read[{}]: reading at {}", v.streamID, thisRead);
+            ILogData r = v.runtime.getAddressSpaceView().read(thisRead);
+            if (r.getType() == DataType.EMPTY) {
+                //determine whether or not this is a hole
+                long latestToken = v.runtime.getSequencerView().nextToken(Collections.singleton(v.streamID), 0).getToken();
+                log.trace("Read[{}]: latest token at {}", v.streamID, latestToken);
+                if (latestToken < thisRead) {
+                    v.getCurrentContext().logPointer.decrementAndGet();
+                    return null;
+                }
+                log.debug("Read[{}]: hole detected at {} (token at {}), attempting fill.", v.streamID, thisRead, latestToken);
+                try {
+                    v.runtime.getAddressSpaceView().fillHole(thisRead);
+                } catch (OverwriteException oe) {
+                    //ignore overwrite.
+                }
+                r = v.runtime.getAddressSpaceView().read(thisRead);
+                log.debug("Read[{}]: holeFill {} result: {}", v.streamID, thisRead, r.getType());
+            }
+            Set<UUID> streams = (Set<UUID>) r.getMetadataMap().get(IMetadata.LogUnitMetadataType.STREAM);
+            if (streams != null && streams.contains(v.getCurrentContext().contextID)) {
+                log.trace("Read[{}]: valid entry at {}", v.streamID, thisRead);
+                Object res = r.getPayload(v.runtime);
+                if (res instanceof StreamCOWEntry) {
+                    StreamCOWEntry ce = (StreamCOWEntry) res;
+                    log.trace("Read[{}]: encountered COW entry for {}@{}", v.streamID, ce.getOriginalStream(),
+                            ce.getFollowUntil());
+                    v.streamContexts.add(v.new StreamContext(ce.getOriginalStream(), ce.getFollowUntil()));
+                } else {
+                    return r;
+                }
+            }
+        }
+    }
+
+    @Override
+    public ILogData[] readTo(StreamView v, long pos) {
+        long latestToken = pos;
+        boolean max = false;
+        if (pos == Long.MAX_VALUE) {
+            max = true;
+            latestToken = v.runtime.getSequencerView().nextToken(Collections.singleton(v.streamID), 0).getToken();
+            log.trace("Linearization point set to {}", latestToken);
+        }
+        ArrayList<ILogData> al = new ArrayList<>();
+        log.debug("Stream[{}] pointer[{}], readTo {}", v.streamID, v.getCurrentContext().logPointer.get(), latestToken);
+        while (v.getCurrentContext().logPointer.get() <= latestToken) {
+            ILogData r = read(v, pos);
+            if (r != null && (max || r.getGlobalAddress() <= pos)) {
+                al.add(r);
+            } else {
+                break;
+            }
+        }
+        return al.toArray(new ILogData[al.size()]);
+    }
+
+    static class DelegateHolder {
+        public static final ChainReplicationStreamViewDelegate delegate = new ChainReplicationStreamViewDelegate();
+    }
+
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/ChainReplicationStreamViewDelegate.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ChainReplicationStreamViewDelegate.java
@@ -18,7 +18,7 @@ import java.util.*;
 @Slf4j
 class ChainReplicationStreamViewDelegate implements IStreamViewDelegate {
 
-    private ChainReplicationStreamViewDelegate() {
+    ChainReplicationStreamViewDelegate() {
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/view/IStreamViewDelegate.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/IStreamViewDelegate.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.view;
+
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+
+import java.util.function.Function;
+
+/**
+ * Defines the methods in StreamView specific for given replication mode.
+ * Created by Konstantin Spirov on 1/30/2017.
+ */
+public interface IStreamViewDelegate {
+
+    /**
+     * Read the next item from the stream.
+     * @param receiver  The StreamView that delegates to this object
+     * @param maxGlobal Constraint for the max stream address, usable for integration tests
+     * @return The next item from the stream.
+     */
+     ILogData read(StreamView receiver, long maxGlobal);
+
+
+    /**
+     * Read the items from the stream until a given position is reached
+     * @param receiver  The StreamView that delegates to this object
+     * @param pos  The highest position to read from (inclusive)
+     * @return The next item from the stream.
+     */
+     ILogData[] readTo(StreamView receiver, long pos);
+
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/IStreamViewDelegate.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/IStreamViewDelegate.java
@@ -27,7 +27,7 @@ public interface IStreamViewDelegate {
     /**
      * Read the items from the stream until a given position is reached
      * @param receiver  The StreamView that delegates to this object
-     * @param pos  The highest position to read from (inclusive)
+     * @param pos  The highest position to read from (inclusive).
      * @return The next item from the stream.
      */
      ILogData[] readTo(StreamView receiver, long pos);

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 import java.util.stream.Stream;
 
 /**
@@ -319,16 +318,59 @@ public class Layout implements Cloneable {
     }
 
     public enum ReplicationMode {
-        CHAIN_REPLICATION,
-        QUORUM_REPLICATION,
-        REPLEX,
-        NO_REPLICATION
+        CHAIN_REPLICATION {
+            @Override
+            public AbstractReplicationView getReplicationView(Layout l, LayoutSegment ls) {
+                return new ChainReplicationView(l, ls);
+            }
+
+            @Override
+            public IStreamViewDelegate getStreamViewDelegate() {
+                return ChainReplicationStreamViewDelegate.DelegateHolder.delegate;
+            }
+        },
+        QUORUM_REPLICATION {
+            @Override
+            public AbstractReplicationView getReplicationView(Layout l, LayoutSegment ls) {
+                return new QuorumReplicationView(l, ls);
+            }
+
+            @Override
+            public IStreamViewDelegate getStreamViewDelegate() {
+                return QuorumReplicationStreamViewDelegate.DelegateHolder.delegate;
+            }
+        },
+        REPLEX {
+            @Override
+            public AbstractReplicationView getReplicationView(Layout l, LayoutSegment ls) {
+                return new ReplexReplicationView(l, ls);
+            }
+
+            @Override
+            public IStreamViewDelegate getStreamViewDelegate() {
+                return ReplexReplicationStreamViewDelegate.DelegateHolder.delegate;
+            }
+        },
+        NO_REPLICATION {
+            @Override
+            public AbstractReplicationView getReplicationView(Layout l, LayoutSegment ls) {
+                throw new UnsupportedOperationException("Replication view used without a replication mode");
+            }
+
+            @Override
+            public IStreamViewDelegate getStreamViewDelegate() {
+                throw new UnsupportedOperationException("Stream view used without a replication mode");
+            }
+        };
+
+        public abstract AbstractReplicationView  getReplicationView(Layout l, Layout.LayoutSegment ls);
+        public abstract IStreamViewDelegate getStreamViewDelegate();
     }
 
     @Data
     @Getter
     @Setter
-    public static class LayoutSegment {
+    public static class  LayoutSegment {
         /**
          * The replication mode of the segment.
          */

--- a/runtime/src/main/java/org/corfudb/runtime/view/QuorumFutureFactory.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/QuorumFutureFactory.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.view;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.*;
+
+/**
+ * Factory for custom futures used by the quorum replication.
+ * Created by Konstantin Spirov on 2/3/2017.
+ */
+@Slf4j
+class QuorumFutureFactory {
+
+    /**
+     * Get a future that will complete only when n/2+1 futures complete or n/2+1 futures are canceled.
+     *
+     * The future returned does not block explicitly, it aggregates the futures and delegates the blocking.
+     *
+     * In case of normal execution, any of the compete futures can be used to return the result.
+     * In case of termination, the cancel flag will be updated and if any of the futures threw an exception,
+     * ExecutionException will be thrown,  otherwise the future will return null
+     *
+     * @param futures The N futures
+     * @return The composite future
+     */
+    static <R> Future<R> getQuorumFuture(CompletableFuture<R>... futures) {
+        return getCompositeFuture(futures.length/2+1, futures);
+    }
+
+    /**
+     * Get a future that will complete only when a single futures complete or n/2+1 futures are canceled.
+     *
+     * The future returned does not block explicitly, it aggregates the futures and delegates the blocking.
+     *
+     * In case if some future completes successfully its value will be returned.
+     * In case of termination, the cancel flag will be updated and if any of the futures threw an exception,
+     * ExecutionException will be thrown,  otherwise the future will return null
+     *
+     * @param futures The N futures
+     * @return The composite future
+     */
+    static <R> Future<R> getFirstWinsFuture(CompletableFuture<R>... futures) {
+        return getCompositeFuture(1, futures);
+    }
+
+    private static <R> Future<R> getCompositeFuture(int futuresToWait, CompletableFuture<R>... futures) {
+        return new Future<R>() {
+            private boolean done = false;
+            private boolean canceled = false;
+
+            @Override
+            public R get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+                long until = 0;
+                boolean infinite = (timeout==Long.MAX_VALUE);
+                if (!infinite) {
+                    until = System.nanoTime() + unit.toNanos(timeout);
+                }
+                while (infinite || System.nanoTime() < until) {
+                    Integer lastCompleteFutureIndex = null;
+                    Integer lastExceptionIndex = null;
+                    int numAbnormalExists = 0;
+                    int numCompleteFutures = 0;
+                    CompletableFuture aggregatedFuture = null; // block until some future completes
+                    for (int i = 0; i < futures.length; i++) {
+                        CompletableFuture<R> c = futures[i];
+                        if (!c.isDone()) {
+                            if (aggregatedFuture == null) {
+                                aggregatedFuture = c;
+                            } else {
+                                aggregatedFuture = CompletableFuture.anyOf(aggregatedFuture, c);
+                            }
+                        } else {
+                            if (c.isCancelled() ) {
+                                numAbnormalExists++;
+                            } else if (c.isCompletedExceptionally()) {
+                                numAbnormalExists++;
+                                lastExceptionIndex = i;
+                            } else {
+                                lastCompleteFutureIndex = i;
+                                numCompleteFutures++;
+                            }
+                        }
+                    }
+                    int quorum = futures.length/2+1;
+                    if (numCompleteFutures>=futuresToWait) { // normal exit, quorum
+                        done = true;
+                        return futures[lastCompleteFutureIndex].get();
+                    }
+                    if (numAbnormalExists>=quorum) { // abnormal exit, canceled or failed futures
+                        done = canceled = true;
+                        if (lastExceptionIndex != null) {
+                            futures[lastExceptionIndex].get(); // this will throw the ExecutionException
+                        }
+                        return null;
+                    }
+                    if (infinite) {
+                        aggregatedFuture.get();
+                    } else {
+                        aggregatedFuture.get(timeout, unit);
+                    }
+                }
+                throw new TimeoutException();
+            }
+
+            @Override
+            public R get() throws InterruptedException, ExecutionException {
+                try {
+                    return get(Long.MAX_VALUE, null);
+                } catch (TimeoutException e) {
+                    log.error(e.getMessage(), e); // not likely to happen in near future
+                    return null;
+                }
+            }
+
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                for (CompletableFuture f : futures) {
+                    f.cancel(mayInterruptIfRunning);
+                }
+                done = canceled = true;
+                return canceled;
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return canceled;
+            }
+
+            @Override
+            public boolean isDone() {
+                return done;
+            }
+        };
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationStreamViewDelegate.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationStreamViewDelegate.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.view;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.StreamCOWEntry;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.IMetadata;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.runtime.exceptions.OverwriteException;
+
+import java.util.*;
+
+/**
+ * Helper object for StreamView with the methods specific for quorum replication mode.
+ * Created by Konstantin Spirov on 1/30/2017.
+ */
+@Slf4j
+class QuorumReplicationStreamViewDelegate implements IStreamViewDelegate {
+    private QuorumReplicationStreamViewDelegate() {
+    }
+
+    @Override
+    public ILogData read(StreamView v, long max) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public ILogData[] readTo(StreamView v, long pos) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    static class DelegateHolder {
+        static final QuorumReplicationStreamViewDelegate delegate = new QuorumReplicationStreamViewDelegate();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationStreamViewDelegate.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationStreamViewDelegate.java
@@ -19,18 +19,8 @@ import java.util.*;
  * Created by Konstantin Spirov on 1/30/2017.
  */
 @Slf4j
-class QuorumReplicationStreamViewDelegate implements IStreamViewDelegate {
+class QuorumReplicationStreamViewDelegate extends ChainReplicationStreamViewDelegate implements IStreamViewDelegate {
     private QuorumReplicationStreamViewDelegate() {
-    }
-
-    @Override
-    public ILogData read(StreamView v, long max) {
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
-
-    @Override
-    public ILogData[] readTo(StreamView v, long pos) {
-        throw new UnsupportedOperationException("Not implemented yet");
     }
 
     static class DelegateHolder {

--- a/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationView.java
@@ -5,31 +5,21 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.util.AutoCloseableByteBuf;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.serializer.Serializers;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
+import java.util.concurrent.*;
 import java.util.function.Function;
 
 /**
- * A view of an address implemented by chain replication.
- * <p>
- * Chain replication is a protocol defined by Renesse and Schneider (OSDI'04),
- * which is an alternative to quorum based replication protocols. It requires
- * that writes be written to a chain of replicas in order, and that reads are
- * always performed at the end of the chain.
- * <p>
- * The primary advantage of chain replication is that unlike quorum replication,
- * where reads must contact a quorum of replicas, chain replication only requires
- * contacting the last replica in the chain. However, writes require contacting
- * every replica in sequence. In general, chain replication is best suited for
- * small chains.
- * <p>
- * Created by mwei on 12/11/15.
+ * In quorum-based replication, there are 2F+1 replicas, and the read and write protocols can operate over
+ * any subset of F+1. The advantage of quorum-based replication is that the write protocol can commit a
+ * value using the fastest majority of replicas, and not have to wait for a slow (or failed) replica.
+ * Quorums can replace majorities wherever they are used below, we use these terms interchangeably.
  */
 @Slf4j
 public class QuorumReplicationView extends AbstractReplicationView {
@@ -38,17 +28,40 @@ public class QuorumReplicationView extends AbstractReplicationView {
         super(l, ls);
     }
 
-    /**
-     * Write the given object to an address and streams, using the replication method given.
-     *
-     * @param address An address to write to.
-     * @param stream  The streams which will belong on this entry.
-     * @param data    The data to write.
-     */
-    @Override
+
     public int write(long address, Set<UUID> stream, Object data, Map<UUID, Long> backpointerMap,
-                     Map<UUID, Long> streamAddresses, Function<UUID, Object> partialEntryFunction) {
-        throw new UnsupportedOperationException("Not implemented yet");
+                     Map<UUID, Long> streamAddresses, Function<UUID, Object> partialEntryFunction)
+            throws OverwriteException {
+        int numUnits = getLayout().getSegmentLength(address);
+        int payloadBytes = 0;
+        // To reduce the overhead of serialization, we serialize only the first time we write, saving
+        // when we go down the chain.
+        try (AutoCloseableByteBuf b =
+                     new AutoCloseableByteBuf(ByteBufAllocator.DEFAULT.directBuffer())) {
+            Serializers.CORFU.serialize(data, b);
+
+            LogData ld = new LogData(DataType.DATA, b);
+            ld.setBackpointerMap(backpointerMap);
+            ld.setStreams(stream);
+            ld.setGlobalAddress(address);
+
+            // FIXME
+            if (data instanceof LogEntry) {
+                ((LogEntry) data).setRuntime(getLayout().getRuntime());
+                ((LogEntry) data).setEntry(ld);
+            }
+
+            payloadBytes = b.readableBytes();
+            CompletableFuture<Boolean>[] futures = new CompletableFuture[numUnits];
+            for (int i = 0; i < numUnits; i++) {
+                log.trace("Write[{}]: quorum {}/{}", address, i + 1, numUnits);
+                // sending the message to all logging units and ignoring the exception.
+                futures[i] = getLayout().getLogUnitClient(address, i).write(address, stream, 0L, data, backpointerMap);
+            }
+            Boolean result = CFUtils.getUninterruptibly(QuorumFutureFactory.getQuorumFuture(futures));
+            log.trace("Write[{}]: {}", address, result);
+        }
+        return payloadBytes;
     }
 
     /**
@@ -59,7 +72,15 @@ public class QuorumReplicationView extends AbstractReplicationView {
      */
     @Override
     public LogData read(long address) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        int numUnits = getLayout().getSegmentLength(address);
+        log.trace("Read[{}]: chain {}/{}", address, numUnits, numUnits);
+        CompletableFuture<ReadResponse>[] futures = new CompletableFuture[numUnits];
+            for (int i=0; i<numUnits; i++) {
+                futures[i]=getLayout().getLogUnitClient(address, i).read(address);
+        }
+        ReadResponse readResponse = CFUtils.getUninterruptibly(QuorumFutureFactory.getFirstWinsFuture(futures));
+        Map<Long, LogData> rs = readResponse.getReadSet();
+        return rs.get(address);
     }
 
     /**
@@ -70,7 +91,8 @@ public class QuorumReplicationView extends AbstractReplicationView {
      */
     @Override
     public Map<Long, LogData> read(UUID stream, long offset, long size) {
-        throw new UnsupportedOperationException("Not implemented yet");
+        // TODO: when quorum replication is used, scan
+        throw new UnsupportedOperationException("not supported in quorum replication");
     }
 
     /**
@@ -80,6 +102,18 @@ public class QuorumReplicationView extends AbstractReplicationView {
      */
     @Override
     public void fillHole(long address) throws OverwriteException {
-        throw new UnsupportedOperationException("Not implemented yet");
+        int numUnits = getLayout().getSegmentLength(address);
+        CompletableFuture<Boolean>[] futures = new CompletableFuture[numUnits];
+        for (int i=0; i<numUnits; i++) {
+            log.trace("fillHole[{}]: quorum {}/{}", address, i + 1, numUnits);
+            futures[i]=getLayout().getLogUnitClient(address, i).fillHole(address);
+        }
+        // In quorum, we write asynchronously to every unit in the chain and wait n/2+1 to complete
+        Boolean result = CFUtils.getUninterruptibly(QuorumFutureFactory.getQuorumFuture(futures));
+        log.trace("fillHole[{}]: {}", address, result);
     }
+
+
+
+
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationView.java
@@ -1,0 +1,85 @@
+package org.corfudb.runtime.view;
+
+import io.netty.buffer.ByteBufAllocator;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.LogEntry;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.util.AutoCloseableByteBuf;
+import org.corfudb.util.CFUtils;
+import org.corfudb.util.serializer.Serializers;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ * A view of an address implemented by chain replication.
+ * <p>
+ * Chain replication is a protocol defined by Renesse and Schneider (OSDI'04),
+ * which is an alternative to quorum based replication protocols. It requires
+ * that writes be written to a chain of replicas in order, and that reads are
+ * always performed at the end of the chain.
+ * <p>
+ * The primary advantage of chain replication is that unlike quorum replication,
+ * where reads must contact a quorum of replicas, chain replication only requires
+ * contacting the last replica in the chain. However, writes require contacting
+ * every replica in sequence. In general, chain replication is best suited for
+ * small chains.
+ * <p>
+ * Created by mwei on 12/11/15.
+ */
+@Slf4j
+public class QuorumReplicationView extends AbstractReplicationView {
+
+    public QuorumReplicationView(Layout l, Layout.LayoutSegment ls) {
+        super(l, ls);
+    }
+
+    /**
+     * Write the given object to an address and streams, using the replication method given.
+     *
+     * @param address An address to write to.
+     * @param stream  The streams which will belong on this entry.
+     * @param data    The data to write.
+     */
+    @Override
+    public int write(long address, Set<UUID> stream, Object data, Map<UUID, Long> backpointerMap,
+                     Map<UUID, Long> streamAddresses, Function<UUID, Object> partialEntryFunction) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * Read the given object from an address, using the replication method given.
+     *
+     * @param address The address to read from.
+     * @return The result of the read.
+     */
+    @Override
+    public LogData read(long address) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * Read a stream prefix, using the replication method given.
+     *
+     * @param stream the stream to read from.
+     * @return A map containing the results of the read.
+     */
+    @Override
+    public Map<Long, LogData> read(UUID stream, long offset, long size) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    /**
+     * Fill a hole at an address, using the replication method given.
+     *
+     * @param address The address to hole fill at.
+     */
+    @Override
+    public void fillHole(long address) throws OverwriteException {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/ReplexReplicationStreamViewDelegate.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ReplexReplicationStreamViewDelegate.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.view;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.StreamCOWEntry;
+import org.corfudb.protocols.wireprotocol.*;
+import org.corfudb.runtime.exceptions.OverwriteException;
+
+import java.util.*;
+
+/**
+ * Helper object for StreamView with the methods specific for replex replication mode.
+ * Created by Konstantin Spirov on 1/30/2017.
+ */
+@Slf4j
+class ReplexReplicationStreamViewDelegate implements IStreamViewDelegate {
+
+    private ReplexReplicationStreamViewDelegate() {
+    }
+
+    @Override
+    public ILogData read(StreamView v, long maxGlobal) {
+        while (true) {
+            long thisRead = v.getCurrentContext().logPointer.get();
+            if (thisRead > maxGlobal) {
+                return null;
+            }
+            log.trace("Doing a stream read, stream: {}, address: {}", v.streamID, thisRead);
+            LogData result = v.runtime.getAddressSpaceView().read(v.streamID, thisRead, 1L).get(thisRead);
+            v.getCurrentContext().logPointer.incrementAndGet();
+
+            if (result.getType() == DataType.EMPTY) {
+                //determine whether or not this is a hole
+                long latestToken = v.runtime.getSequencerView().nextToken(Collections.singleton(v.streamID), 0)
+                        .getStreamAddresses().get(v.streamID);
+                log.trace("Read[{}]: latest token at {}", v.streamID, latestToken);
+                if (latestToken < thisRead) {
+                    v.getCurrentContext().logPointer.decrementAndGet();
+                    return null;
+                }
+                log.debug("Read[{}]: hole detected at {} (token at {}), attempting fill.", v.streamID, thisRead, latestToken);
+                try {
+                    v.runtime.getAddressSpaceView().fillStreamHole(v.streamID, thisRead);
+                } catch (OverwriteException oe) {
+                    //ignore overwrite.
+                }
+                result = v.runtime.getAddressSpaceView().read(v.streamID, thisRead, 1L).get(thisRead);
+                log.debug("Read[{}]: holeFill {} result: {}", v.streamID, thisRead, result.getType());
+            }
+            if (result.getMetadataMap().get(IMetadata.LogUnitMetadataType.STREAM_ADDRESSES) == null)
+                continue;
+
+            Set<UUID> streams = ((Map<UUID, Long>) result.getMetadataMap().get(IMetadata.LogUnitMetadataType.STREAM_ADDRESSES)).keySet();
+            if (streams != null && streams.contains(v.getCurrentContext().contextID)) {
+                log.trace("Read[{}]: valid entry at {}", v.streamID, thisRead);
+                Object res = result.getPayload(v.runtime);
+                if (res instanceof StreamCOWEntry) {
+                    StreamCOWEntry ce = (StreamCOWEntry) res;
+                    log.trace("Read[{}]: encountered COW entry for {}@{}", v.streamID, ce.getOriginalStream(),
+                            ce.getFollowUntil());
+                    v.streamContexts.add(v.new StreamContext(ce.getOriginalStream(), ce.getFollowUntil()));
+                } else {
+                    return result;
+                }
+            }
+        }
+    }
+
+    public ILogData[] readTo(StreamView v, long pos) {
+        long latestToken = pos;
+
+        latestToken = v.runtime.getSequencerView().nextToken(Collections.singleton(v.streamID), 0)
+                .getStreamAddresses().get(v.streamID);
+        log.trace("Linearization point set to {}", latestToken);
+
+        if (latestToken < v.getCurrentContext().logPointer.get())
+            return (new ArrayList<LogData>()).toArray(new ILogData[0]);
+
+        //if (getCurrentContext().logPointer.get() != 0 && latestToken == getCurrentContext().logPointer.get())
+        //    return (new ArrayList<LogData>()).toArray(new LogData[0]);
+        // We can do a bulk read
+        Map<Long, LogData> readResult = v.runtime.getAddressSpaceView().read(v.streamID, v.getCurrentContext().logPointer.get(),
+                latestToken - v.getCurrentContext().logPointer.get() + 1);
+        v.getCurrentContext().logPointer.addAndGet(latestToken - v.getCurrentContext().logPointer.get() + 1);
+        ArrayList<LogData> al = new ArrayList<>();
+        for (Long addr : readResult.keySet()) {
+            // Now we effectively copy the logic from the read() function above.
+            if (readResult.get(addr) == null) {
+                continue;
+            }
+
+            if (readResult.get(addr).getType() == DataType.EMPTY) {
+                if (addr <= latestToken) {
+                    // If it's a hole, fill it and don't return it
+                    LogData retry;
+                    while (true) {
+                        log.debug("Replex readTO[{}]: hole detected at {} (token at {}), attempting fill.", v.streamID, addr, latestToken);
+                        try {
+                            v.runtime.getAddressSpaceView().fillStreamHole(v.streamID, addr);
+                        } catch (OverwriteException oe) {
+                            //ignore overwrite.
+                        }
+                        retry = v.runtime.getAddressSpaceView().read(v.streamID, addr, 1L).get(addr);
+                        if (retry.getType() != DataType.EMPTY)
+                            break;
+                    }
+                    if (retry.getMetadataMap().get(IMetadata.LogUnitMetadataType.STREAM_ADDRESSES) == null)
+                        continue;
+                    Set<UUID> streams = ((Map<UUID, Long>) retry.getMetadataMap().get(IMetadata.LogUnitMetadataType.STREAM_ADDRESSES)).keySet();
+                    if (streams != null && streams.contains(v.getCurrentContext().contextID)) {
+                        log.trace("Read[{}]: valid entry at {}", v.streamID, retry);
+                        Object res = retry.getPayload(v.runtime);
+                        if (res instanceof StreamCOWEntry) {
+                            StreamCOWEntry ce = (StreamCOWEntry) res;
+                            log.trace("Read[{}]: encountered COW entry for {}@{}", v.streamID, ce.getOriginalStream(),
+                                    ce.getFollowUntil());
+                            v.streamContexts.add(v.new StreamContext(ce.getOriginalStream(), ce.getFollowUntil()));
+                        } else {
+                            al.add(retry);
+                        }
+                    }
+                } else {
+                    v.getCurrentContext().logPointer.decrementAndGet();
+                }
+                continue;
+            }
+            al.add(readResult.get(addr));
+        }
+        return al.toArray(new LogData[al.size()]);
+    }
+
+    static class DelegateHolder {
+        static final ReplexReplicationStreamViewDelegate delegate = new ReplexReplicationStreamViewDelegate();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
@@ -34,14 +34,9 @@ public class SequencerView extends AbstractView {
         return layoutHelper(l -> CFUtils.getUninterruptibly(l.getSequencer(0).nextToken(streamIDs, numTokens)));
     }
 
-    public TokenResponse nextToken(Set<UUID> streamIDs, int numTokens, boolean overwrite, boolean replexOverwrite) {
-        return layoutHelper(l -> CFUtils.getUninterruptibly(l.getSequencer(0).nextToken(
-                streamIDs, numTokens, overwrite, replexOverwrite)));
-    }
 
-    public TokenResponse nextToken(Set<UUID> streamIDs, int numTokens, boolean overwrite, boolean replexOverwrite,
-                                   TxResolutionInfo conflictInfo) {
+    public TokenResponse nextToken(Set<UUID> streamIDs, int numTokens, TxResolutionInfo conflictInfo) {
         return layoutHelper(l -> CFUtils.getUninterruptibly(l.getSequencer(0).nextToken(
-                streamIDs, numTokens, overwrite, replexOverwrite, conflictInfo)));
+                streamIDs, numTokens, conflictInfo)));
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -126,17 +126,9 @@ public class StreamsView {
         TokenResponse tokenResponse = null;
         while (true) {
             if (conflictInfo != null) {
-                long token;
-                if (overwrite) {
-                    TokenResponse temp =
-                            runtime.getSequencerView().nextToken(streamIDs, 1, true, false, conflictInfo);
-                    token = temp.getToken();
-                    tokenResponse = new TokenResponse(token, temp.getBackpointerMap(), tokenResponse.getStreamAddresses());
-                } else {
-                    tokenResponse =
-                            runtime.getSequencerView().nextToken(streamIDs, 1, false, false, conflictInfo);
-                    token = tokenResponse.getToken();
-                }
+                tokenResponse =
+                        runtime.getSequencerView().nextToken(streamIDs, 1, conflictInfo);
+                long token = tokenResponse.getToken();
                 log.trace("Write[{}]: acquired token = {}, global addr: {}", streamIDs, tokenResponse, token);
                 if (acquisitionCallback != null) {
                     if (!acquisitionCallback.apply(tokenResponse)) {
@@ -176,21 +168,9 @@ public class StreamsView {
                     log.debug("Overwrite occurred at {}, retrying.", token);
                 }
             } else {
-                long token;
-                if (replexOverwrite) {
-                    tokenResponse =
-                            runtime.getSequencerView().nextToken(streamIDs, 1, false, true);
-                    token = tokenResponse.getToken();
-                } else if (overwrite) {
-                    TokenResponse temp =
-                            runtime.getSequencerView().nextToken(streamIDs, 1, true, false);
-                    token = temp.getToken();
-                    tokenResponse = new TokenResponse(token, temp.getBackpointerMap(), tokenResponse.getStreamAddresses());
-                } else {
-                    tokenResponse =
-                            runtime.getSequencerView().nextToken(streamIDs, 1);
-                    token = tokenResponse.getToken();
-                }
+                tokenResponse =
+                        runtime.getSequencerView().nextToken(streamIDs, 1);
+                long token = tokenResponse.getToken();
                 log.trace("Write[{}]: acquired token = {}, global addr: {}", streamIDs, tokenResponse, token);
                 if (acquisitionCallback != null) {
                     if (!acquisitionCallback.apply(tokenResponse)) {

--- a/runtime/src/main/java/org/corfudb/util/CFUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/CFUtils.java
@@ -3,12 +3,7 @@ package org.corfudb.util;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
+import java.util.concurrent.*;
 import java.util.function.Function;
 
 /**
@@ -30,7 +25,7 @@ public class CFUtils {
             B extends Throwable,
             C extends Throwable,
             D extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
+    T getUninterruptibly(Future<T> future,
                          Class<A> throwableA,
                          Class<B> throwableB,
                          Class<C> throwableC,
@@ -63,7 +58,7 @@ public class CFUtils {
             A extends Throwable,
             B extends Throwable,
             C extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
+    T getUninterruptibly(Future<T> future,
                          Class<A> throwableA,
                          Class<B> throwableB,
                          Class<C> throwableC)
@@ -74,7 +69,7 @@ public class CFUtils {
     public static <T,
             A extends Throwable,
             B extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
+    T getUninterruptibly(Future<T> future,
                          Class<A> throwableA,
                          Class<B> throwableB)
             throws A, B {
@@ -83,14 +78,14 @@ public class CFUtils {
 
     public static <T,
             A extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
+    T getUninterruptibly(Future<T> future,
                          Class<A> throwableA)
             throws A {
         return getUninterruptibly(future, throwableA, RuntimeException.class, RuntimeException.class, RuntimeException.class);
     }
 
     public static <T>
-    T getUninterruptibly(CompletableFuture<T> future) {
+    T getUninterruptibly(Future<T> future) {
         return getUninterruptibly(future, RuntimeException.class, RuntimeException.class, RuntimeException.class, RuntimeException.class);
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -29,7 +29,7 @@ public class SequencerServerTest extends AbstractServerTest {
     @Test
     public void responseForEachRequest() {
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
-            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet(), false, false)));
+            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet())));
             assertThat(getResponseMessages().size())
                     .isEqualTo(i + 1);
         }
@@ -39,7 +39,7 @@ public class SequencerServerTest extends AbstractServerTest {
     public void tokensAreIncreasing() {
         long lastToken = -1;
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
-            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet(), false, false)));
+            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet())));
             long thisToken = getLastPayloadMessageAs(TokenResponse.class).getToken();
             assertThat(thisToken)
                     .isGreaterThan(lastToken);
@@ -50,11 +50,11 @@ public class SequencerServerTest extends AbstractServerTest {
     @Test
     public void checkTokenPositionWorks() {
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
-            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet(), false, false)));
+            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet())));
             long thisToken = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(0L, Collections.<UUID>emptySet(), false, false)));
+                    new TokenRequest(0L, Collections.<UUID>emptySet())));
             long checkToken = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             assertThat(thisToken)
@@ -69,29 +69,29 @@ public class SequencerServerTest extends AbstractServerTest {
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(1L, Collections.singleton(streamA))));
             long thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(0L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(0L, Collections.singleton(streamA))));
             long checkTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             assertThat(thisTokenA)
                     .isEqualTo(checkTokenA);
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamB), false, false)));
+                    new TokenRequest(1L, Collections.singleton(streamB))));
             long thisTokenB = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(0L, Collections.singleton(streamB), false, false)));
+                    new TokenRequest(0L, Collections.singleton(streamB))));
             long checkTokenB = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             assertThat(thisTokenB)
                     .isEqualTo(checkTokenB);
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(0L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(0L, Collections.singleton(streamA))));
             long checkTokenA2 = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             assertThat(checkTokenA2)
@@ -109,22 +109,22 @@ public class SequencerServerTest extends AbstractServerTest {
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(1L, Collections.singleton(streamA))));
             long thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(1L, Collections.singleton(streamA))));
             long checkTokenA = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
             assertThat(thisTokenA)
                     .isEqualTo(checkTokenA);
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamB), false, false)));
+                    new TokenRequest(1L, Collections.singleton(streamB))));
             long thisTokenB = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamB), false, false)));
+                    new TokenRequest(1L, Collections.singleton(streamB))));
             long checkTokenB = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamB);
 
             assertThat(thisTokenB)
@@ -133,11 +133,11 @@ public class SequencerServerTest extends AbstractServerTest {
             final long MULTI_TOKEN = 5L;
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(MULTI_TOKEN, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(MULTI_TOKEN, Collections.singleton(streamA))));
             thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(1L, Collections.singleton(streamA))));
             checkTokenA = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
             assertThat(thisTokenA + MULTI_TOKEN - 1)
@@ -145,11 +145,11 @@ public class SequencerServerTest extends AbstractServerTest {
 
             // check the requesting multiple tokens does not break the back-pointer for the multi-entry
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(1L, Collections.singleton(streamA))));
             thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(MULTI_TOKEN, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(MULTI_TOKEN, Collections.singleton(streamA))));
             checkTokenA = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
             assertThat(thisTokenA)
@@ -168,7 +168,7 @@ public class SequencerServerTest extends AbstractServerTest {
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(1L, Collections.singleton(streamA))));
             long thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getStreamAddresses().get(streamA);
 
             Alocal++;
@@ -176,7 +176,7 @@ public class SequencerServerTest extends AbstractServerTest {
                     .isEqualTo(Alocal);
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamB), false, false)));
+                    new TokenRequest(1L, Collections.singleton(streamB))));
             long thisTokenB = getLastPayloadMessageAs(TokenResponse.class).getStreamAddresses().get(streamB);
 
             Blocal++;
@@ -185,7 +185,7 @@ public class SequencerServerTest extends AbstractServerTest {
 
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(2L, Collections.singleton(streamA), false, false)));
+                    new TokenRequest(2L, Collections.singleton(streamA))));
             thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getStreamAddresses().get(streamA);
 
             Alocal+=2;

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumFutureFactoryTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumFutureFactoryTest.java
@@ -1,0 +1,167 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.view;
+
+import org.junit.Test;
+
+import java.util.concurrent.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by Konstantin Spirov on 2/6/2017.
+ */
+public class QuorumFutureFactoryTest {
+
+    @Test
+    public void testSingleFutureIncompleteComplete() throws Exception {
+        CompletableFuture<Object> f1 = new CompletableFuture<>();
+        Future<Object> result = QuorumFutureFactory.getQuorumFuture(f1);
+        try {
+            result.get(10, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        assertFalse(result.isDone());
+        f1.complete("ok");
+        Object value = result.get(100, TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+        assertTrue(result.isDone());
+    }
+
+    @Test
+    public void testInfiniteGet() throws Exception {
+        CompletableFuture<Object> f1 = new CompletableFuture<>();
+        Future<Object> result = QuorumFutureFactory.getQuorumFuture(f1);
+        f1.complete("ok");
+        Object value = result.get();
+        assertEquals("ok", value);
+        assertTrue(result.isDone());
+    }
+
+
+    @Test
+    public void test2FuturesIncompleteComplete() throws Exception {
+        CompletableFuture<Object> f1 = new CompletableFuture<>();
+        CompletableFuture<Object> f2 = new CompletableFuture<>();
+        Future<Object> result = QuorumFutureFactory.getQuorumFuture(f1, f2);
+        try {
+            result.get(100, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f2.complete("ok");
+        try {
+            result.get(100, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f1.complete("ok");
+        Object value = result.get(100, TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+    }
+
+    @Test
+    public void test3FuturesIncompleteComplete() throws Exception {
+        CompletableFuture<Object> f1 = new CompletableFuture<>();
+        CompletableFuture<Object> f2 = new CompletableFuture<>();
+        CompletableFuture<Object> f3 = new CompletableFuture<>();
+        Future<Object> result = QuorumFutureFactory.getQuorumFuture(f1, f2, f3);
+        try {
+            result.get(100, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f2.complete("ok");
+        try {
+            result.get(100, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f3.complete("ok");
+        Object value = result.get(100, TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+        f1.complete("ok");
+        value = result.get(10, TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+    }
+
+
+    @Test
+    public void test3FuturesWithFirstWinnerIncompleteComplete() throws Exception {
+        CompletableFuture<Object> f1 = new CompletableFuture<>();
+        CompletableFuture<Object> f2 = new CompletableFuture<>();
+        CompletableFuture<Object> f3 = new CompletableFuture<>();
+        Future<Object> result = QuorumFutureFactory.getFirstWinsFuture(f1, f2, f3);
+        try {
+            result.get(100, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f2.complete("ok");
+        Object value = result.get(100, TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+    }
+
+
+    @Test
+    public void testException() throws Exception {
+        CompletableFuture<Object> f1 = new CompletableFuture<>();
+        Future<Object> result = QuorumFutureFactory.getQuorumFuture(f1);
+        f1.completeExceptionally(new NullPointerException());
+        try {
+            Object value = result.get(100, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (ExecutionException e) {
+            // expected behaviour
+        }
+        assertTrue(result.isDone());
+    }
+
+    @Test
+    public void testCanceledFromInside() throws Exception {
+        CompletableFuture<Object> f1 = new CompletableFuture<>();
+        Future<Object> result = QuorumFutureFactory.getQuorumFuture(f1);
+        f1.cancel(true);
+        Object value = result.get(100, TimeUnit.MILLISECONDS);
+        assertTrue(result.isCancelled());
+        assertTrue(result.isDone());
+        assertNull(value);
+    }
+
+
+    @Test
+    public void testCanceledPlusException() throws Exception {
+        CompletableFuture<Object> f1 = new CompletableFuture<>();
+        CompletableFuture<Object> f2 = new CompletableFuture<>();
+        Future<Object> result = QuorumFutureFactory.getQuorumFuture(f1, f2);
+        f1.cancel(true);
+        try {
+            result.get(10, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f2.completeExceptionally(new NullPointerException());
+        try {
+            Object value = result.get(10, TimeUnit.MILLISECONDS);
+            fail();
+        } catch (ExecutionException e) {
+            // expected behaviour
+        }
+        assertTrue(result.isCancelled());
+        assertTrue(result.isDone());
+    }
+
+
+
+
+}

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
@@ -8,18 +8,14 @@ import java.util.Collections;
 /**
  * Created by kspirov
  */
-@Ignore
 public class QuorumReplicationStreamViewTest extends StreamViewTest {
-
     @Before
     @Override
     public void setRuntime() throws Exception {
         r = getDefaultRuntime().connect();
         // First commit a layout that uses Replex
         Layout newLayout = r.layout.get();
-        newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.CHAIN_REPLICATION);
-        newLayout.getSegment(0L).setReplexes(Collections.singletonList(
-                new Layout.LayoutStripe(Collections.singletonList(defaultConfigurationString))));
+        newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.QUORUM_REPLICATION);
         newLayout.setEpoch(1);
         r.getLayoutView().committed(1L, newLayout);
         r.invalidateLayout();

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
@@ -1,0 +1,28 @@
+package org.corfudb.runtime.view;
+
+import org.junit.Before;
+import org.junit.Ignore;
+
+import java.util.Collections;
+
+/**
+ * Created by kspirov
+ */
+@Ignore
+public class QuorumReplicationStreamViewTest extends StreamViewTest {
+
+    @Before
+    @Override
+    public void setRuntime() throws Exception {
+        r = getDefaultRuntime().connect();
+        // First commit a layout that uses Replex
+        Layout newLayout = r.layout.get();
+        newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.CHAIN_REPLICATION);
+        newLayout.getSegment(0L).setReplexes(Collections.singletonList(
+                new Layout.LayoutStripe(Collections.singletonList(defaultConfigurationString))));
+        newLayout.setEpoch(1);
+        r.getLayoutView().committed(1L, newLayout);
+        r.invalidateLayout();
+    }
+
+}

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationViewTest.java
@@ -22,8 +22,6 @@ public class QuorumReplicationViewTest extends ChainReplicationViewTest {
         try {
             Layout newLayout = r.layout.get();
             newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.CHAIN_REPLICATION);
-            newLayout.getSegment(0L).setReplexes(Collections.singletonList(
-                    new Layout.LayoutStripe(Collections.singletonList(defaultConfigurationString))));
             newLayout.setEpoch(1);
             r.getLayoutView().committed(1L, newLayout);
             r.invalidateLayout();
@@ -32,5 +30,6 @@ public class QuorumReplicationViewTest extends ChainReplicationViewTest {
         }
         return r;
     }
+
 
 }

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationViewTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.view;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.junit.Ignore;
+
+import java.util.Collections;
+
+/**
+ * Created by Konstantin Spirov on 1/30/2017.
+ */
+@Ignore
+public class QuorumReplicationViewTest extends ChainReplicationViewTest {
+
+    final String defaultConfigurationString = getDefaultEndpoint();
+
+    public CorfuRuntime getDefaultRuntime() {
+        CorfuRuntime r = super.getDefaultRuntime().connect();
+        try {
+            Layout newLayout = r.layout.get();
+            newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.CHAIN_REPLICATION);
+            newLayout.getSegment(0L).setReplexes(Collections.singletonList(
+                    new Layout.LayoutStripe(Collections.singletonList(defaultConfigurationString))));
+            newLayout.setEpoch(1);
+            r.getLayoutView().committed(1L, newLayout);
+            r.invalidateLayout();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return r;
+    }
+
+}


### PR DESCRIPTION
* StreamView is not aware any longer about the REPLEX and CHAIN
replication, used delegation to decouple a bit. These delegates are
available trough the ReplicationMode enum.  This will allow us to
 implement additional replication schemes without bloating the common
 views. As these classes are very sensitive, we don't want to worry any
 longer that we will destabilize something. Also the delegates are more
 readable now.

* In the same manner I refactored the switch for hardcoded
 ReplicationModes in AbstractReplicationView (see
 your comment   // TODO: really broken software engineering here...
 refactor!). Only enum is aware about the clases, specific for the
 replication view.

* I also eliminated the flags 'override' and 'replexOverride' in TokenRequest and their reference in many place. Removed some related code in StreamView. Actually these flags were deprecated by you and you don't use them any longer.

* Fixed some obvious bugs in AbstractCorfuTest (2 minor thread safety isssues and wrong position of one as() from assertJs)

* Inherited some tests for the quorum replication. Ignored them as they would fail (test driven approach).