### PR TITLE
Abort bootstrap layout when node already bootstrapped

### DIFF
--- a/corfu_scripts/corfu_layouts.clj
+++ b/corfu_scripts/corfu_layouts.clj
@@ -76,17 +76,17 @@ Options:
                                        ; (1) make sure all layout servers are bootstrapped
                                        ; (2) install layout on all servers
                                        (do
-                                         (doseq [server (.getLayoutServers new-layout)]
-                                         (do (get-router server localcmd)
-                                             (try
-                                               (.get (.bootstrapLayout (get-layout-client) new-layout))
-                                               (catch Exception e
-                                                 (println server":" (.getMessage e))
-                                                 (throw e)))
-                                             ))
+                                         (doseq [server (into [] (remove (set (.getLayoutServers layout)) (.getLayoutServers new-layout)))]
+                                                (do (get-router server localcmd)
+                                                    (try
+                                                      (.get (.bootstrapLayout (get-layout-client) new-layout))
+                                                      (catch Exception e
+                                                        (println server ":" (.getMessage e))
+                                                        (throw e)))
+                                                    ))
                                          (install-layout new-layout)
                                          (println "New layout installed!")
-                                       )
+                                         )
                                    )
                                 )
                             )

--- a/corfu_scripts/corfu_layouts.clj
+++ b/corfu_scripts/corfu_layouts.clj
@@ -81,7 +81,8 @@ Options:
                                              (try
                                                (.get (.bootstrapLayout (get-layout-client) new-layout))
                                                (catch Exception e
-                                               (println server":" (.getMessage e))))
+                                                 (println server":" (.getMessage e))
+                                                 (throw e)))
                                              ))
                                          (install-layout new-layout)
                                          (println "New layout installed!")


### PR DESCRIPTION
Issue #240

Basic abortion of the bootstrap process of a node if the node is already bootstrapped.