### PR TITLE
Undo log for objects

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -207,17 +207,10 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                     .forEachOrdered(l -> {
                         try {
                             Object res = underlyingObject.applyUpdateUnsafe(l, false);
-
-                            Long streamAddress = logData.getStreamAddress(streamID);
-                            if (streamAddress != null) {
-                                underlyingObject.setVersionUnsafe(streamAddress);
-                            } else {
-                                underlyingObject.setVersionUnsafe(logData.getGlobalAddress());
-                            }
-                            underlyingObject.setGlobalVersionUnsafe(logData.getGlobalAddress());
+                            underlyingObject.setVersionUnsafe(logData.getGlobalAddress());
 
                             if (pendingUpcalls.contains(logData.getGlobalAddress())) {
-                                upcallResults.put(underlyingObject.getGlobalVersionUnsafe(), res == null ?
+                                upcallResults.put(underlyingObject.getVersionUnsafe(), res == null ?
                                         NullValue.NULL_VALUE : res);
                                 pendingUpcalls.remove(logData.getGlobalAddress());
                             }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -19,7 +19,8 @@ import java.util.stream.Collectors;
  *
  * Created by mwei on 4/4/16.
  */
-public abstract class AbstractTransactionalContext {
+public abstract class AbstractTransactionalContext implements
+        Comparable<AbstractTransactionalContext> {
 
     /** Constant for the address of an uncommitted log entry.
      *
@@ -301,4 +302,10 @@ public abstract class AbstractTransactionalContext {
     }
 
 
+    /** Transactions are ordered by their snapshot timestamp. */
+    @Override
+    public int compareTo(AbstractTransactionalContext o) {
+        return Long.compare(this.getSnapshotTimestamp(), o
+                .getSnapshotTimestamp());
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -108,9 +108,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
             // If the version of this object is ahead of what we expected,
             // we need to rollback...
             if (object.getVersionUnsafe() > getSnapshotTimestamp()) {
-                // We don't yet support version rollback, but we would
-                // perform that here when we do.
-                throw new NoRollbackException();
+                object.rollbackUnsafe(getSnapshotTimestamp());
             }
         } catch (NoRollbackException nre) {
             // Couldn't roll back the object, so we'll have
@@ -400,7 +398,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
      */
     private OptimisticTransactionalContext getRootContext() {
         AbstractTransactionalContext atc = TransactionalContext.getRootContext();
-        if (!(atc instanceof OptimisticTransactionalContext)) {
+        if (atc != null && !(atc instanceof OptimisticTransactionalContext)) {
             throw new RuntimeException("Attempted to nest two different transactional context types");
         }
         return (OptimisticTransactionalContext)atc;

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -5,6 +5,9 @@ import lombok.extern.slf4j.Slf4j;
 import java.time.Duration;
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.NavigableSet;
+import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 /** A class which allows access to transactional contexts, which manage
  * transactions. The static methods of this class provide access to the
@@ -24,14 +27,34 @@ public class TransactionalContext {
     /** A thread local stack containing all transaction contexts
      * for a given thread.
      */
-    private static final ThreadLocal<Deque<AbstractTransactionalContext>> threadStack = ThreadLocal.withInitial(
+    private static final ThreadLocal<Deque<AbstractTransactionalContext>>
+            threadTransactionStack = ThreadLocal.withInitial(
             LinkedList<AbstractTransactionalContext>::new);
+
+    /** A navigable set (priority queue) of contexts. The minimum context
+     * indicates how far we should try to keep the undo log up to.
+     */
+    private static final NavigableSet<AbstractTransactionalContext> contextSet =
+            new ConcurrentSkipListSet<>();
+
+    /** Return the oldest snapshot active in the system, or -1L if
+     * there are no active snapshots. */
+    public static long getOldestSnapshot() {
+        if (contextSet.isEmpty()) {
+            return -1L;
+        }
+        try {
+            return contextSet.first().getSnapshotTimestamp();
+        } catch (NoSuchElementException nse) {
+            return -1L;
+        }
+    }
 
     /** Whether or not the current thread is in a nested transaction.
      *
      * @return  True, if the current thread is in a nested transaction.
      */
-    public static boolean isInNestedTransaction() {return threadStack.get().size() > 1;}
+    public static boolean isInNestedTransaction() {return threadTransactionStack.get().size() > 1;}
 
     /**
      * Returns the transaction stack for the calling thread.
@@ -39,7 +62,7 @@ public class TransactionalContext {
      * @return The transaction stack for the calling thread.
      */
     public static Deque<AbstractTransactionalContext> getTransactionStack() {
-        return threadStack.get();
+        return threadTransactionStack.get();
     }
 
     /**
@@ -77,6 +100,7 @@ public class TransactionalContext {
      */
     public static AbstractTransactionalContext newContext(AbstractTransactionalContext context) {
         getTransactionStack().addFirst(context);
+        contextSet.add(context);
         return context;
     }
 
@@ -86,6 +110,7 @@ public class TransactionalContext {
      */
     public static AbstractTransactionalContext removeContext() {
         AbstractTransactionalContext r = getTransactionStack().pollFirst();
+        contextSet.remove(r);
         if (getTransactionStack().isEmpty()) {
             synchronized (getTransactionStack())
             {

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -176,6 +176,24 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
                 .doesNotContainEntry("k", "v4");
     }
 
+    /** This test makes sure that a write-only transaction properly
+     * commits its updates, even if there are no accesses
+     * during the transaction.
+     */
+    @Test
+    public void writeOnlyTransactionCommitsInMemory() {
+        // Write twice to the transaction without a read
+        TXBegin();
+        write("k", "v1");
+        write("k", "v2");
+        TXEnd();
+
+        // Make sure the object correctly reflects the value
+        // of the most recent write.
+        assertThat(getMap())
+                .containsEntry("k", "v2");
+    }
+
     @Override
     protected void TXBegin() {
         getRuntime().getObjectsView().TXBuild()


### PR DESCRIPTION
This PR reopens #416, which adds per-object undo log support as well as rollback support.