### PR TITLE
Flush log unit servers

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -6,9 +6,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-
 /**
  * Created by mwei on 12/4/15.
  */
@@ -40,6 +37,12 @@ public abstract class AbstractServer {
         if (!getHandler().handle(msg, ctx, r)) {
             log.warn("Received unhandled message type {}" , msg.getMsgType());
         }
+    }
+
+    /**
+     * Flushes the current state of the server when an epoch is sealed.
+     */
+    public void flush() {
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -147,6 +147,15 @@ public class LogUnitServer extends AbstractServer {
     }
 
     /**
+     * Flush the pending writes of the log unit server.
+     * Blocks until the batchWriter is flushed.
+     */
+    public void flush() {
+        log.info("Flushing Log Unit Server BatchWriter.");
+        batchWriter.flushPendingWrites();
+    }
+
+    /**
      * Service an incoming write request.
      */
     @ServerHandler(type = CorfuMsgType.WRITE)
@@ -258,6 +267,12 @@ public class LogUnitServer extends AbstractServer {
     private void trim(CorfuPayloadMsg<TrimRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
         trimMap.compute(msg.getPayload().getStream(), (key, prev) ->
                 prev == null ? msg.getPayload().getPrefix() : Math.max(prev, msg.getPayload().getPrefix()));
+        r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
+    }
+
+    @ServerHandler(type = CorfuMsgType.FLUSH_LOGUNIT)
+    private void flushRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+        flush();
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/WriteOperation.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/WriteOperation.java
@@ -15,6 +15,18 @@ public class WriteOperation {
     private final LogAddress logAddress;
     private final LogData logData;
     private final CompletableFuture future;
+    private final Boolean flush;
+
+    public WriteOperation(LogAddress logAddress, LogData logData, CompletableFuture future, Boolean flush) {
+        this.logAddress = logAddress;
+        this.logData = logData;
+        this.future = future;
+        this.flush = flush;
+    }
+
+    public WriteOperation(LogAddress logAddress, LogData logData, CompletableFuture future) {
+        this(logAddress, logData, future, false);
+    }
 
     public static WriteOperation SHUTDOWN = new WriteOperation(null, null, null);
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -54,6 +54,7 @@ public enum CorfuMsgType {
     GC_INTERVAL(36, new TypeToken<CorfuPayloadMsg<Long>>() {}),
     FORCE_COMPACT(37, TypeToken.of(CorfuMsg.class)),
     COMMIT(40, new TypeToken<CorfuPayloadMsg<CommitRequest>>() {}),
+    FLUSH_LOGUNIT(41, TypeToken.of(CorfuMsg.class)),
 
     WRITE_OK(50, TypeToken.of(CorfuMsg.class)),
     ERROR_TRIMMED(51, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -267,6 +267,14 @@ public class LogUnitClient implements IClient {
                 CorfuMsgType.FILL_HOLE.payloadMsg(new FillHoleRequest(streamID, address)));
     }
 
+    /**
+     * Flush the log unit server's current pending writes.
+     * @return A Completable future which will complete once the flush is successful.
+     */
+    public CompletableFuture<Boolean> flush() {
+        return router.sendMessageAndGetCompletable(CorfuMsgType.FLUSH_LOGUNIT.msg());
+    }
+
 
     /**
      * Force the garbage collector to begin garbage collection.


### PR DESCRIPTION
### Flushes the write queue of the log unit server.

This call would block until the server has successfully flushed its current state to disk.
Every time we need to seal the epoch, we need to flush the queues of all log unit servers.
