### PR TITLE
Revert "Flush log unit servers"

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -6,6 +6,9 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
 /**
  * Created by mwei on 12/4/15.
  */
@@ -37,12 +40,6 @@ public abstract class AbstractServer {
         if (!getHandler().handle(msg, ctx, r)) {
             log.warn("Received unhandled message type {}" , msg.getMsgType());
         }
-    }
-
-    /**
-     * Flushes the current state of the server when an epoch is sealed.
-     */
-    public void flush() {
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -6,9 +6,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
-
 /**
  * Created by mwei on 12/4/15.
  */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -76,7 +76,7 @@ public class BatchWriter <K, V> implements CacheWriter<K, V>, AutoCloseable {
                 } else {
                     currOp = writeQueue.poll();
 
-                    if (currOp == null || processed == BATCH_SIZE || currOp.getFlush() || currOp == WriteOperation.SHUTDOWN) {
+                    if (currOp == null || processed == BATCH_SIZE || currOp == WriteOperation.SHUTDOWN) {
                         streamLog.sync();
                         log.trace("Sync'd {} writes", processed);
 
@@ -103,22 +103,6 @@ public class BatchWriter <K, V> implements CacheWriter<K, V>, AutoCloseable {
                     continue;
                 }
 
-                if (currOp.getFlush()) {
-                    log.trace("Flushing all pending writes");
-                    if (currOp.getLogAddress() == null && currOp.getLogData() == null) {
-                        currOp.getFuture().complete(null);
-                    } else {
-                        try {
-                            streamLog.append(currOp.getLogAddress(), currOp.getLogData());
-                            currOp.getFuture().complete(null);
-                        } catch (OverwriteException e) {
-                            currOp.getFuture().completeExceptionally(new OverwriteException());
-                        }
-                    }
-                    lastOp = currOp;
-                    continue;
-                }
-
                 try {
                     streamLog.append(currOp.getLogAddress(), currOp.getLogData());
                     ack.add(currOp.getFuture());
@@ -131,30 +115,6 @@ public class BatchWriter <K, V> implements CacheWriter<K, V>, AutoCloseable {
             }
         } catch (Exception e) {
             log.error("Caught exception in the write processor {}", e);
-        }
-    }
-
-    /**
-     * Issues a flush message to the writeQueue and waits for it to be processed.
-     */
-    void flushPendingWrites() {
-        CompletableFuture cf = new CompletableFuture();
-        WriteOperation flushOperation = new WriteOperation(null, null, cf, true);
-        writeQueue.add(flushOperation);
-        // Wait for flush to complete.
-        // Periodically check if a shutdown trigger is invoked to avoid deadlock.
-        while (true) {
-            try {
-                cf.get(1000, TimeUnit.MILLISECONDS);
-                break;
-            } catch (ExecutionException e) {
-                log.error("Exception while flushing queue: {}", e.getMessage());
-                break;
-            } catch (TimeoutException | InterruptedException e) {
-                if (writerService.isShutdown()) {
-                    break;
-                }
-            }
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -147,15 +147,6 @@ public class LogUnitServer extends AbstractServer {
     }
 
     /**
-     * Flush the pending writes of the log unit server.
-     * Blocks until the batchWriter is flushed.
-     */
-    public void flush() {
-        log.info("Flushing Log Unit Server BatchWriter.");
-        batchWriter.flushPendingWrites();
-    }
-
-    /**
      * Service an incoming write request.
      */
     @ServerHandler(type = CorfuMsgType.WRITE)
@@ -267,12 +258,6 @@ public class LogUnitServer extends AbstractServer {
     private void trim(CorfuPayloadMsg<TrimRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
         trimMap.compute(msg.getPayload().getStream(), (key, prev) ->
                 prev == null ? msg.getPayload().getPrefix() : Math.max(prev, msg.getPayload().getPrefix()));
-        r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
-    }
-
-    @ServerHandler(type = CorfuMsgType.FLUSH_LOGUNIT)
-    private void flushRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
-        flush();
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/WriteOperation.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/WriteOperation.java
@@ -15,18 +15,6 @@ public class WriteOperation {
     private final LogAddress logAddress;
     private final LogData logData;
     private final CompletableFuture future;
-    private final Boolean flush;
-
-    public WriteOperation(LogAddress logAddress, LogData logData, CompletableFuture future, Boolean flush) {
-        this.logAddress = logAddress;
-        this.logData = logData;
-        this.future = future;
-        this.flush = flush;
-    }
-
-    public WriteOperation(LogAddress logAddress, LogData logData, CompletableFuture future) {
-        this(logAddress, logData, future, false);
-    }
 
     public static WriteOperation SHUTDOWN = new WriteOperation(null, null, null);
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -54,7 +54,6 @@ public enum CorfuMsgType {
     GC_INTERVAL(36, new TypeToken<CorfuPayloadMsg<Long>>() {}),
     FORCE_COMPACT(37, TypeToken.of(CorfuMsg.class)),
     COMMIT(40, new TypeToken<CorfuPayloadMsg<CommitRequest>>() {}),
-    FLUSH_LOGUNIT(41, TypeToken.of(CorfuMsg.class)),
 
     WRITE_OK(50, TypeToken.of(CorfuMsg.class)),
     ERROR_TRIMMED(51, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -267,14 +267,6 @@ public class LogUnitClient implements IClient {
                 CorfuMsgType.FILL_HOLE.payloadMsg(new FillHoleRequest(streamID, address)));
     }
 
-    /**
-     * Flush the log unit server's current pending writes.
-     * @return A Completable future which will complete once the flush is successful.
-     */
-    public CompletableFuture<Boolean> flush() {
-        return router.sendMessageAndGetCompletable(CorfuMsgType.FLUSH_LOGUNIT.msg());
-    }
-
 
     /**
      * Force the garbage collector to begin garbage collection.

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -77,7 +77,6 @@ public class Layout implements Cloneable {
 
     /**
      * Move each server in the system to the epoch of this layout.
-     * Flushes the current state of each server.
      *
      * @throws WrongEpochException If any server is in a higher epoch.
      */
@@ -89,22 +88,6 @@ public class Layout implements Cloneable {
                 .map(runtime::getRouter)
                 .map(x -> x.getClient(BaseClient.class))
                 .forEach(x -> CFUtils.getUninterruptibly(x.setRemoteEpoch(epoch)));
-        flushServers();
-    }
-
-    /**
-     *  Flushes all the servers.
-     */
-    public void flushServers() {
-        // TODO: Flush Sequencer servers
-        getSegments().forEach(
-                layoutSegment -> layoutSegment.getStripes().forEach(
-                        layoutStripe -> layoutStripe.getLogServers().stream()
-                                .map(runtime::getRouter)
-                                .map(x -> x.getClient(LogUnitClient.class))
-                                .forEach(x -> CFUtils.getUninterruptibly(x.flush()))
-                )
-        );
     }
 
     /**


### PR DESCRIPTION
Reverts CorfuDB/CorfuDB#448

It seems the flush is not required for the normal operation of the layout update.
Since its not a current requirement and adds to the code complexity it is best we revert this for now.