### PR TITLE
Performance improvement in transactional context

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -192,6 +192,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
      * this function...
      * @param underlyingObject  The object to update.
      * @param timestamp         The timestamp to update the object to.
+     * @return The version number of the object after sync.
      */
     public long syncObjectUnsafe(VersionLockedObject<T> underlyingObject,
                                       long timestamp) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -193,7 +193,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
      * @param underlyingObject  The object to update.
      * @param timestamp         The timestamp to update the object to.
      */
-    public void syncObjectUnsafe(VersionLockedObject<T> underlyingObject,
+    public long syncObjectUnsafe(VersionLockedObject<T> underlyingObject,
                                       long timestamp) {
         underlyingObject.getStreamViewUnsafe().remainingUpTo(timestamp).stream()
             // Turn this into a flat stream of SMR entries
@@ -227,6 +227,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                         }
                     });
             });
+        return underlyingObject.getVersionUnsafe();
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
@@ -24,7 +24,7 @@ public interface ICorfuSMRProxyInternal<T> extends ICorfuSMRProxy<T> {
      * @param object        The object to sync forward.
      * @param timestamp     The timestamp to sync it to.
      */
-    void syncObjectUnsafe(VersionLockedObject<T> object, long timestamp);
+    long syncObjectUnsafe(VersionLockedObject<T> object, long timestamp);
 
     /** Reset the object to it's original initialized state.
      *

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -10,14 +10,7 @@ import org.corfudb.runtime.object.ICorfuSMRAccess;
 import org.corfudb.runtime.object.ICorfuSMRProxyInternal;
 import org.corfudb.runtime.object.VersionLockedObject;
 
-import java.util.Collections;
-import java.util.ConcurrentModificationException;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -55,6 +48,13 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
     @Getter
     private final Set<ICorfuSMRProxyInternal> modifiedProxies =
             new HashSet<>();
+
+    /** Keep the version (at global snapshot time)
+     *  of each accessed object.
+     */
+    private final Map<ICorfuSMRProxyInternal, Long> streamSnapshots =
+            new HashMap<>();
+
 
     OptimisticTransactionalContext(TransactionBuilder builder) {
         super(builder);
@@ -97,11 +97,17 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
             proxy.resetObjectUnsafe(object);
         }
 
-        // next, if the version is older than what we need
-        // sync.
-        if (object.getVersionUnsafe() < getSnapshotTimestamp()) {
-            proxy.syncObjectUnsafe(proxy.getUnderlyingObject(), getSnapshotTimestamp());
+        // Sync only if we never read the object in this transaction
+        // or if the version is older than what we need
+        OptimisticTransactionalContext oCtxt = (OptimisticTransactionalContext)
+                object.getModifyingContextUnsafe();
+        long snapshotOfThisStream =  streamSnapshots.computeIfAbsent(proxy,
+                k -> k.syncObjectUnsafe(k.getUnderlyingObject(), getSnapshotTimestamp()));
+        if (oCtxt == null || oCtxt != this &&
+                proxy.getUnderlyingObject().getVersionUnsafe() < snapshotOfThisStream) {
+            proxy.syncObjectUnsafe(object, snapshotOfThisStream);
         }
+
 
         // Take ownership of the object.
         object.setTXContextUnsafe(this);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -101,11 +101,17 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         // or if the version is older than what we need
         OptimisticTransactionalContext oCtxt = (OptimisticTransactionalContext)
                 object.getModifyingContextUnsafe();
-        long snapshotOfThisStream =  streamSnapshots.computeIfAbsent(proxy,
-                k -> k.syncObjectUnsafe(k.getUnderlyingObject(), getSnapshotTimestamp()));
+
         if (oCtxt == null || oCtxt != this &&
-                proxy.getUnderlyingObject().getVersionUnsafe() < snapshotOfThisStream) {
-            proxy.syncObjectUnsafe(object, snapshotOfThisStream);
+                proxy.getUnderlyingObject().getVersionUnsafe() < getSnapshotTimestamp()) {
+
+            // Cache version number of the object at global snapshot
+            long snapshotOfThisStream =  streamSnapshots.computeIfAbsent(proxy,
+                    k -> k.syncObjectUnsafe(k.getUnderlyingObject(), getSnapshotTimestamp()));
+
+            if (proxy.getUnderlyingObject().getVersionUnsafe() < snapshotOfThisStream) {
+                proxy.syncObjectUnsafe(object, snapshotOfThisStream);
+            }
         }
 
 


### PR DESCRIPTION
This addresses chattiness issue during transactional context. Upon access of an object, the version would be validated against the global snapshot in order to make a decision of syncing it or not. If the version was not at the global snapshot, it would sync. The problem is the object would almost never be at the global snapshot, because the global snapshot is the tail of the entire log, not the tail for the object. 

On each access, we would sync and ask the tail of the object to the sequencer. Even without context switch.

This changes also introduces a cache, that will keep the version of the objects at the global snapshot. It gets populated upon first access to each object during the transaction. It means that, after a context switch, if both threads had the same version of the object at their global snapshot (each global snapshot might be different), we would not have to resync the object. We would only unroll for optimistic changes.

