### PR TITLE
minor fix to optimistic rollback flag

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -127,6 +127,7 @@ public class VersionLockedObject<T> {
         optimisticUndoLog.clear();
         optimisticVersion = 0;
         optimisticallyModified = false;
+        optimisticallyUndoable = true;
         this.version = version;
         // TODO: fix the stream view pointer seek, for now
         // read will read the tx commit entry.


### PR DESCRIPTION
without this, tests like FGMap::loadsFollowedByGetsConcurrent fail intermittently.