### PR TITLE
fix stream bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -214,10 +214,13 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                     try {
                         runtime.getAddressSpaceView().fillHole(currentRead);
                         // If we reached here, our hole fill was successful.
+                        currentEntry = LogData.HOLE;
                     } catch (OverwriteException oe) {
                         // If we reached here, this means the remote client
                         // must have successfully completed the write and
                         // we can continue.
+                        currentEntry =
+                                runtime.getAddressSpaceView().read(currentRead);
                     }
                 }
 
@@ -226,9 +229,8 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             }
 
             // If the entry contains this context's stream,
-            // and it is less than max read, we add it to the read queue.
-            if (currentEntry.containsStream(context.id) &&
-                    currentRead <= maxAddress) {
+            // we add it to the read queue.
+            if (currentEntry.containsStream(context.id)) {
                 context.readQueue.add(currentRead);
             }
 


### PR DESCRIPTION
Fix a bug which would occur during hole fill where unsuccessful
hole fill attempts would fail to read the correctly written
entry. 

This patch forces the client to re-read on the overwrite exception
of a hole fill, correctly reading failed hole-fills.

In addition, it also cleans up AbstractQueuedStreamView::getNextEntries
so that it is more readable.