### PR TITLE
A thread safe future that will complete only when n/2+1 futures complete

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/QuorumFutureFactory.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/QuorumFutureFactory.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.view;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Ordering;
+import com.google.common.collect.TreeMultimap;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.exceptions.QuorumUnreachableException;
+
+import java.util.Comparator;
+import java.util.Set;
+import java.util.concurrent.*;
+
+/**
+ * Factory for custom futures used by the quorum replication.
+ * Created by Konstantin Spirov on 2/3/2017.
+ */
+@Slf4j
+class QuorumFutureFactory {
+
+    /**
+     * Get a thread safe future that will complete only when n/2+1 futures complete or if there is no hope
+     * (if n/2+1 futures are canceled or have conflicting value).
+     *
+     * The future returned does not block explicitly, it aggregates the futures and delegates the blocking.
+     *
+     * In case of normal execution, any of the compete futures can be used to return the result.
+     * In case of termination, the cancel flag will be updated and if any of the futures threw an exception,
+     * ExecutionException will be thrown,  otherwise the future will return null
+     *
+     * @param comparator Any comparator consistent with equals that is able to distinguish the results
+     * @param futures The N futures
+     * @return The composite future
+     */
+    static <R> CompositeFuture<R> getQuorumFuture(Comparator<R> comparator, CompletableFuture<R>... futures) {
+        return new CompositeFuture<R>(comparator, futures.length/2+1, futures);
+    }
+
+    /**
+     * Get a thread safe future that will complete only when a single futures complete.
+     *
+     * The future returned does not block explicitly, it aggregates the futures and delegates the blocking.
+     *
+     * In case if some future completes successfully its value will be returned.
+     * In case of termination, the cancel flag will be updated and if any of the futures threw an exception,
+     * ExecutionException will be thrown,  otherwise the future will return null
+     *
+     * @param comparator Any comparator consistent with equals that is able to distinguish the results
+     * @param futures The N futures
+     * @return The composite future
+     */
+    static <R> CompositeFuture<R> getFirstWinsFuture(Comparator<R> comparator, CompletableFuture<R>... futures) {
+        return new CompositeFuture<R>(comparator, 1, futures);
+    }
+
+
+    public static class CompositeFuture<R> implements Future<R> {
+        private final Comparator<R> comparator;
+        private final int quorum;
+        private final CompletableFuture<R>[] futures;
+        private volatile boolean done = false;
+        private volatile boolean canceled = false;
+        private volatile boolean conflict = false;
+        private volatile Throwable throwable;
+
+        private CompositeFuture(Comparator<R> comparator, int quorum, CompletableFuture<R>... futures) {
+            this.comparator = comparator;
+            this.quorum = quorum;
+            this.futures = futures;
+        }
+
+        @Override
+        public R get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+            Comparator<Integer> ic = Integer::compareTo;
+            TreeMultimap<Integer, R> valuesSortedByCount = TreeMultimap.create(ic.reversed(), comparator);
+            HashMultimap<R, Integer> indexesByValue = HashMultimap.create();
+
+            long until = 0;
+            boolean infinite = (timeout==Long.MAX_VALUE);
+            if (!infinite) {
+                until = System.nanoTime() + unit.toNanos(timeout);
+            }
+
+            while (infinite || System.nanoTime() < until) {
+                Integer lastExceptionIndex = null;
+                int numIncompleteFutures = 0;
+                CompletableFuture aggregatedFuture = null; // block until some future completes
+                for (int i = 0; i < futures.length; i++) {
+                    CompletableFuture<R> c = futures[i];
+                    if (!c.isDone()) {
+                        numIncompleteFutures++;
+                        if (aggregatedFuture == null) {
+                            aggregatedFuture = c;
+                        } else {
+                            aggregatedFuture = CompletableFuture.anyOf(aggregatedFuture, c);
+                        }
+                    } else {
+                        if (c.isCancelled()) {
+                        } else if (c.isCompletedExceptionally()) {
+                            lastExceptionIndex = i;
+                        } else {
+                            R value = c.get();
+                            Set<Integer> indexes = indexesByValue.get(value);
+                            if (!indexes.contains(i)) {
+                                valuesSortedByCount.remove(indexes.size(), value);
+                                indexes.add(i);
+                                valuesSortedByCount.put(indexes.size(), value);
+                            }
+                            if (indexesByValue.keySet().size()>1) {
+                                conflict = true;
+                            }
+                        }
+                    }
+                }
+
+                int greatestNumCompleteFutures = valuesSortedByCount.size()==0? 0:
+                        valuesSortedByCount.keySet().iterator().next();
+                if (greatestNumCompleteFutures>=quorum) { // normal exit, quorum
+                    done = true;
+                    return valuesSortedByCount.entries().iterator().next().getValue();
+                }
+                boolean noMoreHope = numIncompleteFutures+greatestNumCompleteFutures < quorum;
+                if (noMoreHope) {
+                    done = canceled = true;
+                    if (lastExceptionIndex != null) {
+                        try {
+                            futures[lastExceptionIndex].get(); // this will throw the ExecutionException
+                        } catch (ExecutionException e) {
+                            throwable = e.getCause();
+                            throw e;
+                        }
+                    }
+                    throw new ExecutionException(
+                            new QuorumUnreachableException(greatestNumCompleteFutures, quorum));
+                }
+                if (infinite) {
+                    aggregatedFuture.get();
+                } else {
+                    aggregatedFuture.get(timeout, unit);
+                }
+            }
+            throw new TimeoutException();
+        }
+
+
+        @Override
+        public R get() throws InterruptedException, ExecutionException {
+            try {
+                return get(Long.MAX_VALUE, null);
+            } catch (TimeoutException e) {
+                log.error(e.getMessage(), e); // not likely to happen in near future
+                return null;
+            }
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            for (CompletableFuture f : futures) {
+                f.cancel(mayInterruptIfRunning);
+            }
+            done = canceled = true;
+            return canceled;
+        }
+
+        /**
+         * @return true the future was canceled explicitly, or if the future was unable to reach quorum due to
+         * conflicts, cancaled futures or futures that have thrown exception.
+         */
+        @Override
+        public boolean isCancelled() {
+            return canceled;
+        }
+
+        @Override
+        public boolean isDone() {
+            return done;
+        }
+
+        /**
+         * @return true if there were two successful results with different values, otherwise false
+         */
+        public boolean isConflict() {
+            return conflict;
+        }
+
+        public Throwable getThrowable() {return throwable;}
+    }
+
+
+}

--- a/runtime/src/main/java/org/corfudb/util/CFUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/CFUtils.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -30,7 +31,7 @@ public class CFUtils {
             B extends Throwable,
             C extends Throwable,
             D extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
+    T getUninterruptibly(Future<T> future,
                          Class<A> throwableA,
                          Class<B> throwableB,
                          Class<C> throwableC,
@@ -63,7 +64,7 @@ public class CFUtils {
             A extends Throwable,
             B extends Throwable,
             C extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
+    T getUninterruptibly(Future<T> future,
                          Class<A> throwableA,
                          Class<B> throwableB,
                          Class<C> throwableC)
@@ -74,7 +75,7 @@ public class CFUtils {
     public static <T,
             A extends Throwable,
             B extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
+    T getUninterruptibly(Future<T> future,
                          Class<A> throwableA,
                          Class<B> throwableB)
             throws A, B {
@@ -83,14 +84,14 @@ public class CFUtils {
 
     public static <T,
             A extends Throwable>
-    T getUninterruptibly(CompletableFuture<T> future,
+    T getUninterruptibly(Future<T> future,
                          Class<A> throwableA)
             throws A {
         return getUninterruptibly(future, throwableA, RuntimeException.class, RuntimeException.class, RuntimeException.class);
     }
 
     public static <T>
-    T getUninterruptibly(CompletableFuture<T> future) {
+    T getUninterruptibly(Future<T> future) {
         return getUninterruptibly(future, RuntimeException.class, RuntimeException.class, RuntimeException.class, RuntimeException.class);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumFutureFactoryTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumFutureFactoryTest.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.view;
+
+import org.corfudb.AbstractCorfuTest;
+import org.corfudb.runtime.exceptions.QuorumUnreachableException;
+import org.junit.Test;
+
+import java.util.concurrent.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests the futures used in the quorum replication
+ * Created by Konstantin Spirov on 2/6/2017.
+ */
+public class QuorumFutureFactoryTest extends AbstractCorfuTest {
+
+    @Test
+    public void testSingleFutureIncompleteComplete() throws Exception {
+        CompletableFuture<String> f1 = new CompletableFuture<>();
+        Future<String> result = QuorumFutureFactory.getQuorumFuture(String::compareTo, f1);
+        try {
+            result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        assertFalse(result.isDone());
+        f1.complete("ok");
+        Object value = result.get(PARAMETERS.TIMEOUT_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+        assertTrue(result.isDone());
+    }
+
+    @Test
+    public void testInfiniteGet() throws Exception {
+        CompletableFuture<String> f1 = new CompletableFuture<>();
+        Future<String> result = QuorumFutureFactory.getQuorumFuture(String::compareTo, f1);
+        f1.complete("ok");
+        Object value = result.get();
+        assertEquals("ok", value);
+        assertTrue(result.isDone());
+    }
+
+
+    @Test
+    public void test2FuturesIncompleteComplete() throws Exception {
+        CompletableFuture<String> f1 = new CompletableFuture<>();
+        CompletableFuture<String> f2 = new CompletableFuture<>();
+        Future<String> result = QuorumFutureFactory.getQuorumFuture(String::compareTo, f1, f2);
+        try {
+            result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f2.complete("ok");
+        try {
+            result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f1.complete("ok");
+        Object value = result.get(PARAMETERS.TIMEOUT_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+    }
+
+    @Test
+    public void test3FuturesIncompleteComplete() throws Exception {
+        CompletableFuture<String> f1 = new CompletableFuture<>();
+        CompletableFuture<String> f2 = new CompletableFuture<>();
+        CompletableFuture<String> f3 = new CompletableFuture<>();
+        QuorumFutureFactory.CompositeFuture<String> result = QuorumFutureFactory.getQuorumFuture(String::compareTo, f1, f2, f3);
+        try {
+            result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f2.complete("ok");
+        try {
+            result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f3.complete("ok");
+        Object value = result.get(PARAMETERS.TIMEOUT_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+        f1.complete("ok");
+        value = result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+        assertFalse(result.isConflict());
+    }
+
+
+    @Test
+    public void test3FuturesWithFirstWinnerIncompleteComplete() throws Exception {
+        CompletableFuture<String> f1 = new CompletableFuture<>();
+        CompletableFuture<String> f2 = new CompletableFuture<>();
+        CompletableFuture<String> f3 = new CompletableFuture<>();
+        Future<String> result = QuorumFutureFactory.getFirstWinsFuture(String::compareTo, f1, f2, f3);
+        try {
+            result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f2.complete("ok");
+        Object value = result.get(PARAMETERS.TIMEOUT_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+    }
+
+
+    @Test
+    public void testException() throws Exception {
+        CompletableFuture<String> f1 = new CompletableFuture<>();
+        Future<String> result = QuorumFutureFactory.getQuorumFuture(String::compareTo, f1);
+        f1.completeExceptionally(new NullPointerException());
+        try {
+            Object value = result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (ExecutionException e) {
+            // expected behaviour
+        }
+        assertTrue(result.isDone());
+    }
+
+    @Test
+    public void testCanceledFromInside() throws Exception {
+        CompletableFuture<String> f1 = new CompletableFuture<>();
+        QuorumFutureFactory.CompositeFuture<String> result = QuorumFutureFactory.getQuorumFuture(String::compareTo, f1);
+        f1.cancel(true);
+        try {
+            Object value = result.get(PARAMETERS.TIMEOUT_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof QuorumUnreachableException);
+            assertEquals(0, ((QuorumUnreachableException)e.getCause()).getReachable());
+            assertEquals(1, ((QuorumUnreachableException)e.getCause()).getRequired());
+        }
+        assertTrue(result.isCancelled());
+        assertTrue(result.isDone());
+        assertFalse(result.isConflict());
+        assertNull(result.getThrowable());
+    }
+
+
+    @Test
+    public void testCanceledPlusException() throws Exception {
+        CompletableFuture<String> f1 = new CompletableFuture<>();
+        CompletableFuture<String> f2 = new CompletableFuture<>();
+        QuorumFutureFactory.CompositeFuture<String> result = QuorumFutureFactory.getQuorumFuture(String::compareTo, f1, f2);
+        f1.cancel(true);
+        f2.completeExceptionally(new NullPointerException());
+        try {
+            Object value = result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (ExecutionException e) {
+            // expected behaviour
+        }
+        assertTrue(result.isCancelled());
+        assertTrue(result.isDone());
+        assertEquals(result.getThrowable().getClass(), NullPointerException.class);
+    }
+
+
+    @Test
+    public void test3FuturesCompleteWithResolvedConflict() throws Exception {
+        CompletableFuture<String> f1 = new CompletableFuture<>();
+        CompletableFuture<String> f2 = new CompletableFuture<>();
+        CompletableFuture<String> f3 = new CompletableFuture<>();
+        QuorumFutureFactory.CompositeFuture<String> result = QuorumFutureFactory.getQuorumFuture(String::compareTo, f1, f2, f3);
+        f2.complete("ok");
+        try {
+            result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f3.complete("not-ok");
+        try {
+            Object value = result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            // expected
+        }
+        f1.complete("ok");
+        Object value = result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+        assertEquals("ok", value);
+        assertTrue(result.isConflict());
+    }
+
+
+    @Test
+    public void test3FuturesCompleteWithUnresolvedConflict() throws Exception {
+        CompletableFuture<String> f1 = new CompletableFuture<>();
+        CompletableFuture<String> f2 = new CompletableFuture<>();
+        CompletableFuture<String> f3 = new CompletableFuture<>();
+        QuorumFutureFactory.CompositeFuture<String> result = QuorumFutureFactory.getQuorumFuture(String::compareTo, f1, f2, f3);
+        f2.complete("ok");
+        f3.complete("not-ok");
+        f1.complete("1/3 split brain");
+        try {
+            Object value = result.get(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis(), TimeUnit.MILLISECONDS);
+            fail();
+        } catch (ExecutionException e) {
+            assertTrue(e.getCause() instanceof QuorumUnreachableException);
+            assertEquals(1, ((QuorumUnreachableException) e.getCause()).getReachable());
+            assertEquals(2, ((QuorumUnreachableException) e.getCause()).getRequired());
+        }
+        assertTrue(result.isConflict());
+    }
+
+}


### PR DESCRIPTION
Started to split https://github.com/CorfuDB/CorfuDB/pull/449 into incremental builds