### PR TITLE
Do not update maxConflictWildcard for mere overwrites

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -106,7 +106,11 @@ public class SequencerServer extends AbstractServer {
             conflictToGlobalTailCache = Caffeine.newBuilder()
             .maximumSize(maxConflictCacheSize)
             .removalListener((Integer K, Long V, RemovalCause cause) -> {
-                maxConflictWildcard = Math.max(V, maxConflictWildcard);
+                if (!RemovalCause.REPLACED.equals(cause)) {
+                    log.trace("Updating maxConflictWildcard. Old value = '{}', new value = '{}', conflictParam = '{}'. Removal cause = '{}'",
+                            maxConflictWildcard, V, K, cause);
+                    maxConflictWildcard = Math.max(V, maxConflictWildcard);
+                }
             })
             .build();
 

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -333,6 +333,7 @@ public class TestClientRouter implements IClientRouter {
         message.serialize(oBuf);
         oBuf.resetReaderIndex();
         CorfuMsg msg = CorfuMsg.deserialize(oBuf);
+        oBuf.release();
         return msg;
     }
 


### PR DESCRIPTION
Intent is to update maxConflictWildcard when an
eviction event occurs. Earlier, we would update
even when a put was performed for a key that already
existed in the cache.