### PR TITLE
save stream on reset

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractStreamContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractStreamContext.java
@@ -44,6 +44,11 @@ public abstract class AbstractStreamContext implements
         this.globalPointer = Address.NEVER_READ;
     }
 
+    /** Reset the stream context. */
+    void reset() {
+        globalPointer = Address.NEVER_READ;
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -133,6 +133,22 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
     public void close() {}
 
 
+    protected boolean fillFromResolved(final long maxGlobal,
+                                       final QueuedStreamContext context) {
+        // There's nothing to read if we're already past maxGlobal.
+        if (maxGlobal < context.globalPointer) {
+            return false;
+        }
+        // Get the subset of the resolved queue, which starts at
+        // globalPointer and ends at maxAddress inclusive.
+        NavigableSet<Long> resolvedSet =
+                context.resolvedQueue.subSet(context.globalPointer,
+                        false, maxGlobal, true);
+        // Put those elements in the read queue
+        context.readQueue.addAll(resolvedSet);
+        return !context.readQueue.isEmpty();
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -149,6 +165,12 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             return false;
         }
 
+        // If everything is available in the resolved
+        // queue, use it
+        if (context.maxResolution > maxAddress) {
+            return fillFromResolved(maxGlobal, context);
+        }
+
         // First, we fetch the current token (backpointer) from the sequencer.
         final long latestToken = runtime.getSequencerView()
                 .nextToken(Collections.singleton(context.id), 0)
@@ -157,6 +179,12 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
         // If the backpointer was unwritten, return, there is nothing to do
         if (latestToken == Address.NEVER_READ) {
             return false;
+        }
+
+        // If everything is available in the resolved
+        // queue, use it
+        if (context.maxResolution > latestToken) {
+            return fillFromResolved(latestToken, context);
         }
 
         // Now we start traversing backpointers, if they are available. We
@@ -232,6 +260,12 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             // we add it to the read queue.
             if (currentEntry.containsStream(context.id)) {
                 context.readQueue.add(currentRead);
+            }
+
+            // If everything left is available in the resolved
+            // queue, use it
+            if (context.maxResolution > currentRead) {
+                return fillFromResolved(latestToken, context);
             }
 
             // Now we calculate the next entry to read.

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
@@ -143,13 +143,9 @@ public class StreamTest extends AbstractObjectTest {
                     int r2 = rand.nextInt(numTasks);
                     int r3 = rand.nextInt(numTasks);
                     int accumulator = 0;
-                    try {
-                        accumulator += map1.get("m1" + r1);
-                        accumulator += map2.get("m2" + r2);
-                        accumulator += map3.get("m3" + r3);
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
+                    accumulator += map1.get("m1" + r1);
+                    accumulator += map2.get("m2" + r2);
+                    accumulator += map3.get("m3" + r3);
 
                     // perform random put()'s with probability '1 - readPercent/100'
                     if (rand.nextInt(MAX_PERCENT) >= readPrecent) {


### PR DESCRIPTION
Previously, whenever a stream is reset, all backpointer information was lost.
This patch enables the queued stream to save the "resolved" stream, improving
performance when reset is called.

A future update should enable seeking within a previously resolved stream.