### PR TITLE
when resetting the object, start from Address.NEVER_READ

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -9,6 +9,7 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.NoRollbackException;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
+import org.corfudb.runtime.view.Address;
 import org.corfudb.util.serializer.ISerializer;
 
 import java.lang.reflect.Constructor;
@@ -228,7 +229,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
             object.setObjectUnsafe(getNewInstance());
             object.clearOptimisticVersionUnsafe();
             object.resetStreamViewUnsafe();
-            object.version = 0L;
+            object.version = Address.NEVER_READ;
         } catch (InstantiationException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
During object reset, the version was being erroneously reset to 0
which caused the object to skip the first update. This patch
fixes that bug by setting the address to NEVER_READ instead.