### PR TITLE
support undoing resets

### DIFF
--- a/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
+++ b/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
@@ -1,6 +1,7 @@
 package org.corfudb.annotations;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.squareup.javapoet.*;
 import org.corfudb.runtime.object.*;
 
@@ -15,6 +16,7 @@ import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.ParameterizedType;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -460,6 +462,7 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
         addUpcallMap(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
         addUndoRecordMap(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
         addUndoMap(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
+        addResetSet(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
 
         typeSpecBuilder
                 .addSuperinterfaces(interfacesToAdd);
@@ -473,6 +476,41 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                 .build();
 
         javaFile.writeTo(filer);
+    }
+
+    /** Add the reset set and the getter for the set.
+     *
+     * @param typeSpecBuilder   The typespec builder to add the reset set to
+     * @param originalName      The name of the original base type (without $CORFUSMR)
+     * @param interfacesToAdd   A list of interfaces to add for instrumentation.
+     * @param methodSet         The set of methods to add for instrumentation.
+     */
+    private void addResetSet(TypeSpec.Builder typeSpecBuilder, TypeName originalName,
+                             Set<TypeName> interfacesToAdd, Set<SMRMethodInfo> methodSet) {
+        // Generate the initializer for the reset set.
+        String resetString = methodSet.stream()
+                .filter(x -> x.method.getAnnotation(Mutator.class) != null
+                        && x.method.getAnnotation(Mutator.class).reset()||
+                        x.method.getAnnotation(MutatorAccessor.class) != null
+                                && x.method.getAnnotation(MutatorAccessor.class).reset())
+                .map(x -> "\n.add(\"" + getSMRFunctionName(x.method) + "\")")
+                .collect(Collectors.joining());
+
+        FieldSpec resetSet = FieldSpec.builder(ParameterizedTypeName.get(ClassName.get(Set.class),
+                ClassName.get(String.class)), "resetSet" + CORFUSMR_FIELD, Modifier.FINAL, Modifier.PUBLIC)
+                .initializer("new $T()$L.build()",
+                        ParameterizedTypeName.get(ClassName.get(ImmutableSet.Builder.class),
+                                ClassName.get(String.class)), resetString)
+                .build();
+
+        typeSpecBuilder.addField(resetSet);
+        typeSpecBuilder.addMethod(MethodSpec.methodBuilder("getCorfuResetSet")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get(Set.class),
+                        ClassName.get(String.class)))
+                .addStatement("return $L", "resetSet" + CORFUSMR_FIELD)
+                .build());
+
     }
 
     private void addUpcallMap(TypeSpec.Builder typeSpecBuilder, TypeName originalName,

--- a/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
+++ b/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
@@ -30,4 +30,10 @@ public @interface MutatorAccessor {
      * @return The name of the undoRecord function.
      */
     String undoRecordFunction() default "";
+
+    /** Whether this mutator resets the state of this object. Typically used
+     * for methods like clear().
+     * @return True, if the mutator resets the object.
+     */
+    boolean reset() default false;
 }

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.object;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /** The interface for an object interfaced with SMR.
@@ -23,12 +24,20 @@ public interface ICorfuSMR<T> {
     /** Get a map from strings (function names) to SMR upcalls.
      * @return The SMR upcall map. */
     Map<String, ICorfuSMRUpcallTarget<T>> getCorfuSMRUpcallMap();
+
     /** Get a map from strings (function names) to undo methods.
      * @return The undo map. */
     Map<String, IUndoFunction<T>> getCorfuUndoMap();
+
     /** Get a map from strings (function names) to undoRecord methods.
      * @return The undo record map. */
     Map<String, IUndoRecordFunction<T>> getCorfuUndoRecordMap();
+
+    /** Get a set of strings (function names) which result in a reset
+     * of the objhect.
+     * @return  The set of strings that cause a reset on the object.
+     */
+    Set<String> getCorfuResetSet();
 
     /** Return the stream ID that this object belongs to.
      * @return The stream ID this object belongs to. */

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
@@ -34,7 +34,7 @@ public interface ICorfuSMR<T> {
     Map<String, IUndoRecordFunction<T>> getCorfuUndoRecordMap();
 
     /** Get a set of strings (function names) which result in a reset
-     * of the objhect.
+     * of the object.
      * @return  The set of strings that cause a reset on the object.
      */
     Set<String> getCorfuResetSet();

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -43,12 +43,14 @@ public class SMREntry extends LogEntry implements ISMRConsumable {
     @Setter
     public transient Object undoRecord;
 
-    /** A boolean - true if this record can be undone.
+    /** Return whether or not this method can be undo.
      *
+     * @return  True, if the entry has the record necessary
+     *          for undo, false otherwise.
      */
-    @Getter
-    @Setter
-    public transient boolean undoable = false;
+    public boolean isUndoable() {
+        return  undoRecord != null;
+    }
 
     public SMREntry(String SMRMethod, @NonNull Object[] SMRArguments, ISerializer serializer) {
         super(LogEntryType.SMR);

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -236,15 +236,6 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
             });
     }
 
-    // TODO: move to version locked object.
-    @Override
-    public void resetObjectUnsafe(VersionLockedObject<T> object) {
-        object.setObjectUnsafe(getNewInstance());
-        object.clearOptimisticVersionUnsafe();
-        object.resetStreamViewUnsafe();
-        object.version = Address.NEVER_READ;
-    }
-
     /**
      * {@inheritDoc}
      */

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -47,7 +47,8 @@ public class CorfuCompileWrapperBuilder {
                 type, args, serializer,
                 wrapperObject.getCorfuSMRUpcallMap(),
                 wrapperObject.getCorfuUndoMap(),
-                wrapperObject.getCorfuUndoRecordMap()));
+                wrapperObject.getCorfuUndoRecordMap(),
+                wrapperObject.getCorfuResetSet()));
 
         if (wrapperObject instanceof ICorfuSMRProxyWrapper) {
             ((ICorfuSMRProxyWrapper) wrapperObject)

--- a/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
@@ -26,14 +26,6 @@ public interface ICorfuSMRProxyInternal<T> extends ICorfuSMRProxy<T> {
      */
     void syncObjectUnsafe(VersionLockedObject<T> object, long timestamp);
 
-    /** Reset the object to it's original initialized state.
-     *
-     * Unsafe, so ensure the append lock has been taken on the object
-     * before calling.
-     * @param object        The object to sync forward.
-     */
-    void resetObjectUnsafe(VersionLockedObject<T> object);
-
     /** Get a map of SMR upcall targets from method strings.
      * @return              The SMR upcall map for this proxy. */
     Map<String, ICorfuSMRUpcallTarget<T>> getUpcallTargetMap();

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -79,7 +79,8 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                     object.getModifyingContextUnsafe();
 
             // If we don't own this object, roll it back
-            if (modifyingContext != null && modifyingContext != this) {
+            if (object.isOptimisticallyModifiedUnsafe() &&
+                    modifyingContext != null && modifyingContext != this) {
                 object.optimisticRollbackUnsafe();
             }
 
@@ -92,7 +93,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
             // Couldn't roll back the object, so we'll have
             // to start from scratch.
             // TODO: create a copy instead
-            proxy.resetObjectUnsafe(object);
+            object.resetUnsafe();
         }
 
         // next, if the version is older than what we need

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -66,13 +66,13 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
                             proxy.getUnderlyingObject().optimisticRollbackUnsafe();
                         } catch (NoRollbackException nre) {
                             // guess our only option is to start from scratch.
-                            proxy.resetObjectUnsafe(proxy.getUnderlyingObject());
+                            proxy.getUnderlyingObject().resetUnsafe();
                         }
                     }
                     // Next check the version, if it is ahead, try undo
                     // We don't support this yet, so we just reset
                     if (proxy.getVersion() > getSnapshotTimestamp()) {
-                        proxy.resetObjectUnsafe(proxy.getUnderlyingObject());
+                        proxy.getUnderlyingObject().resetUnsafe();
                     }
 
                     // Now we sync forward if we are behind


### PR DESCRIPTION
This patch enables undo of mutators (and mutatorAccessors) which
contain the reset=true parameter. When this parameter is encountered,
the runtime saves the version itself as the undo information, and 
creates a new empty object for further modifications to be made.

Eventually, when the undo record is no longer needed, garbage
collection will free the undo record from memory, as it will
be removed from the undo log.