### PR TITLE
adding undo tests and some fixes and cleanups to it

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -54,7 +54,7 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      */
     @Accessor
     @Override
-    boolean containsKey(Object key);
+    boolean containsKey(@ConflictParameter Object key);
 
     /**
      * Returns <tt>true</tt> if this map maps one or more keys to the
@@ -156,7 +156,7 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      *                                       or value prevents it from being stored in this map
      */
     @Mutator(name = "put", noUpcall = true)
-    default void blindPut(K key, V value) {
+    default void blindPut(@ConflictParameter K key, V value) {
         put(key, value);
     }
 
@@ -283,7 +283,7 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      * @throws UnsupportedOperationException if the <tt>clear</tt> operation
      *                                       is not supported by this map
      */
-    @Mutator(name="clear")
+    @Mutator(name="clear", reset=true)
     @Override
     void clear();
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -127,6 +127,7 @@ public class VersionLockedObject<T> {
         optimisticUndoLog.clear();
         optimisticVersion = 0;
         optimisticallyModified = false;
+        optimisticallyUndoable = true;
         this.version = version;
         // TODO: fix the stream view pointer seek, for now
         // read will read the tx commit entry.

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -13,9 +13,11 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 /**
- * A version locked object. The version locked object contains a
- * the state of an object as well as a history of modifications to
- * the object, which can be optimistic.
+ * The version locked object keeps track of where -- in the history of updates -- is the current state of the underying object.
+ *
+ * it maintains a shallow undo-log, back to the earliest open-transaction's snapshot.
+ * it also maintains an optimistic undo-log, for the current open-transaction, if any.
+ *
  * <p>
  * Created by mwei on 11/13/16.
  */
@@ -148,20 +150,37 @@ public class VersionLockedObject<T> {
         if (!optimisticallyUndoable) {
             throw new NoRollbackException();
         }
+
         // The undo log is a stack, where the last entry applied
         // is at the front, which is the same order stream() returns
         // entries.
-        optimisticUndoLog.stream()
-                .forEachOrdered(x -> {
-                    if (!x.isUndoable()) {
-                        throw new NoRollbackException(x);
-                    }
-                    undoFunctionMap.get(x.getSMRMethod())
-                            .doUndo(object, x.getUndoRecord(), x.getSMRArguments());
-                });
+        while (optimisticUndoLog.size() > 0) {
+
+            // first, check if the current entry is undo-able
+            SMREntry x = optimisticUndoLog.peekFirst();
+            if (!x.isUndoable()) {
+                optimisticallyUndoable = false;
+                throw new NoRollbackException(x);
+            }
+
+            // now, actually remove the undo entry and apply the undo
+            optimisticUndoLog.pollFirst();
+            undoFunctionMap.get(x.getSMRMethod())
+                    .doUndo(object, x.getUndoRecord(), x.getSMRArguments());
+
+            // update the version immediately, in case this while-loop gets aborted in the middle
+            optimisticVersion--;
+        };
+
+        // this should be zero already
+        if (optimisticVersion > 0 || optimisticUndoLog.size() > 0)
+            log.warn("rollback did not empty the optimistic undo sz={} version={}", optimisticUndoLog.size(), optimisticVersion);
+
+        // todo: the following two statements should not be necessary
         optimisticUndoLog.clear();
-        optimisticallyModified = false;
         optimisticVersion = 0;
+
+        optimisticallyModified = false;
         modifyingContext = null;
     }
 
@@ -252,62 +271,50 @@ public class VersionLockedObject<T> {
      */
     public Object applyUpdateUnsafe(SMREntry entry, boolean isOptimistic) {
         // TODO: validate the caller actually has a write lock.
-        try {
-            ICorfuSMRUpcallTarget<T> target =
-                    upcallTargetMap
-                            .get(entry.getSMRMethod());
-            if (target == null) {
-                throw new Exception("Unknown upcall " + entry.getSMRMethod());
+
+        ICorfuSMRUpcallTarget<T> target = upcallTargetMap.get(entry.getSMRMethod());
+        if (target == null) {
+            throw new RuntimeException("Unknown upcall " + entry.getSMRMethod());
+        }
+
+        // generate an undo record
+        IUndoRecordFunction<T> undoRecordTarget =
+                undoRecordFunctionMap
+                        .get(entry.getSMRMethod());
+        if (undoRecordTarget == null)
+            log.debug("undo not available {}", entry);
+        if (undoRecordTarget != null) {
+            // calculate the undo record if it doesn't exist.
+            if (!entry.isUndoable()) {
+                entry.setUndoRecord(undoRecordTarget
+                        .getUndoRecord(object, entry.getSMRArguments()));
+                entry.setUndoable(true);
             }
-            // Can we generate an undo record?
-            IUndoRecordFunction<T> undoRecordTarget =
-                    undoRecordFunctionMap
-                            .get(entry.getSMRMethod());
-            if (undoRecordTarget != null) {
-                // calculate the undo record if it doesn't exist.
-                if (!entry.isUndoable()) {
-                    entry.setUndoRecord(undoRecordTarget
-                            .getUndoRecord(object, entry.getSMRArguments()));
-                    entry.setUndoable(true);
-                }
-                // If this is a standard mutation record
-                // and (1) we are not in optimistic mode
-                // (2) the undoLog is not empty OR
-                // the undoLog is empty and we need to
-                // generate undo records add an undo
-                // record to the log.
-                if (!isOptimistic && (!undoLog.isEmpty() ||
-                        needUndoRecordUnsafe())) {
-                    undoLog.addFirst(entry);
-                }
-                // If we're in optimistic mode, add us to the
-                // optimistic undo log. (If there's a point. If
-                // the object isn't optimistically undoable anymore
-                // there's no point.)
-                else if (isOptimistic && optimisticallyUndoable) {
-                    optimisticUndoLog.addFirst(entry);
-                }
-            } else {
-                // We can't generate an undo record, so clear the
-                // optimistic undo log, and mark that the object is
-                // no longer optimistically undoable if we
-                // are in optimistic mode.
+        }
+
+        // Here we maintain the optimistic undo-log
+        if (isOptimistic) {
+            if (undoRecordTarget == null) {
                 optimisticUndoLog.clear();
-                if (isOptimistic) {
-                    optimisticallyUndoable = false;
-                }
-            }
-            // If we're in optimistic mode, mark that the object
-            // was optimistically modified.
-            if (isOptimistic) {
+                optimisticallyUndoable = false;
+            } else if (optimisticallyUndoable) {
+                optimisticUndoLog.addFirst(entry);
                 optimisticallyModified = true;
                 optimisticVersionIncrementUnsafe();
             }
-            return target.upcall(object, entry.getSMRArguments());
-        } catch (Exception e) {
-            log.error("Error: Couldn't execute upcall due to {}", e);
-            throw new RuntimeException(e);
         }
+
+        // Here we maintain the normal undo-log
+        else {
+            if (undoRecordTarget == null) {
+                undoLog.clear();
+            } else if (!undoLog.isEmpty() || needUndoRecordUnsafe()) {
+                undoLog.addFirst(entry);
+            }
+        }
+
+        // now invoke the upcall
+        return target.upcall(object, entry.getSMRArguments());
     }
 
     /** Execute the given function under a write lock, not returning

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -294,12 +294,12 @@ public class VersionLockedObject<T> {
 
         // Here we maintain the optimistic undo-log
         if (isOptimistic) {
+            optimisticallyModified = true;
             if (undoRecordTarget == null) {
                 optimisticUndoLog.clear();
                 optimisticallyUndoable = false;
             } else if (optimisticallyUndoable) {
                 optimisticUndoLog.addFirst(entry);
-                optimisticallyModified = true;
                 optimisticVersionIncrementUnsafe();
             }
         }

--- a/test/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
@@ -317,7 +317,6 @@ public class FGMapTest extends AbstractViewTest {
         scheduleConcurrently(num_threads, threadNumber -> {
             int base = threadNumber * num_records;
             for (int i = base; i < base + num_records; i++) {
-                System.out.println(threadNumber + ":" + i);
                 testMap.clear();
                 assertThat(testMap)
                         .isEmpty();

--- a/test/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/FGMapTest.java
@@ -317,6 +317,7 @@ public class FGMapTest extends AbstractViewTest {
         scheduleConcurrently(num_threads, threadNumber -> {
             int base = threadNumber * num_records;
             for (int i = base; i < base + num_records; i++) {
+                System.out.println(threadNumber + ":" + i);
                 testMap.clear();
                 assertThat(testMap)
                         .isEmpty();

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/UndoTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/UndoTest.java
@@ -15,12 +15,13 @@ public class UndoTest extends AbstractObjectTest {
 
     @Test
     public void ckCorrectUndo()
-        throws Exception {
+            throws Exception {
         Map<String, String> testMap = getRuntime()
                 .getObjectsView()
                 .build()
                 .setStreamName("test")
-                .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {
+                })
                 .open();
 
         // populate the map with an element
@@ -47,7 +48,6 @@ public class UndoTest extends AbstractObjectTest {
         // it should contain two elements, ("z", "z") and ("a", "a")
         // it should not contain ("y", "y")
         t(0, () -> {
-            System.out.println(testMap.entrySet());
             assertThat(testMap.get("z"))
                     .isEqualTo("z");
             assertThat(testMap.get("y"))
@@ -64,7 +64,8 @@ public class UndoTest extends AbstractObjectTest {
                 .getObjectsView()
                 .build()
                 .setStreamName("test")
-                .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {
+                })
                 .open();
 
         // populate the map with an element
@@ -86,10 +87,10 @@ public class UndoTest extends AbstractObjectTest {
                     .isEqualTo("z");
             testMap.put("y", "y");
             testMap.clear();
-                   assertThat(testMap.size())
-                           .isEqualTo(0);
-                   assertThat(testMap.get("z"))
-                           .isEqualTo(null);
+            assertThat(testMap.size())
+                    .isEqualTo(0);
+            assertThat(testMap.get("z"))
+                    .isEqualTo(null);
         });
 
         // now check the map inside the transaction
@@ -97,7 +98,6 @@ public class UndoTest extends AbstractObjectTest {
         // it should not contain ("y", "y")
         // it should not be clear
         t(0, () -> {
-            System.out.println(testMap.entrySet());
             assertThat(testMap.get("z"))
                     .isEqualTo("z");
             assertThat(testMap.get("y"))
@@ -105,5 +105,97 @@ public class UndoTest extends AbstractObjectTest {
             assertThat(testMap.size())
                     .isEqualTo(2);
         });
+    }
+
+    /**
+     * Check that optimisitcUndoable is properly reset.
+     *
+     * An irreversible modification causes a total object-rebuild.
+     * <p>
+     * This test verifies that after one transaction with undoable operation is rolled- back,
+     * the performance of further transactions is not hurt.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void canUndoAfterNoUndo()
+            throws Exception {
+        Map<Integer, String> testMap = getRuntime()
+                .getObjectsView()
+                .build()
+                .setStreamName("test")
+                .setTypeToken(new TypeToken<SMRMap<Integer, String>>() {
+                })
+                .open();
+        final int specialKey = 10;
+        final String normalValue = "z", specialValue = "y";
+        final int mapSize = 10 * PARAMETERS.NUM_ITERATIONS_LARGE;
+
+        // populate the map with many elements
+        for (int i = 0; i < mapSize; i++)
+            testMap.put(i, normalValue);
+
+        // start a transaction after the map was built
+        t(0, () -> {
+            getRuntime().getObjectsView().TXBegin();
+            assertThat(testMap.get(specialKey))
+                    .isEqualTo(normalValue);
+        });
+
+        // in another thread, optimistically do something to the map that cannot be undone
+        t(1, () -> {
+            getRuntime().getObjectsView().TXBegin();
+            testMap.clear();
+            assertThat(testMap.size())
+                    .isEqualTo(0);
+            assertThat(testMap.get(specialKey))
+                    .isEqualTo(null);
+        });
+
+
+        // check how long it takes to rebuild the map for the first thread
+        t(0, () -> {
+            long startTime, endTime;
+            startTime = System.currentTimeMillis();
+            testMap.get(specialKey);
+            endTime = System.currentTimeMillis();
+
+            if (!testStatus.equals("")) {
+                testStatus += ";";
+            }
+            testStatus += "reset rebuild time="
+                    + String.format("%.0f", (float)(endTime-startTime))
+                    + "ms";
+        });
+
+        // abort the bad transaction,
+        // and start a new one that is easily undone
+        t(1, () -> {
+            getRuntime().getObjectsView().TXAbort();
+            assertThat(testMap.size())
+                    .isEqualTo(mapSize);
+
+            getRuntime().getObjectsView().TXBegin();
+            testMap.put(specialKey, specialValue);
+            assertThat(testMap.get(specialKey))
+                    .isEqualTo(specialValue);
+        });
+
+        // now , re-take that measurement causing only the simple undo
+        t(0, () -> {
+            long startTime, endTime;
+            startTime = System.currentTimeMillis();
+            assertThat(testMap.get(specialKey))
+                    .isEqualTo(normalValue);
+            endTime = System.currentTimeMillis();
+
+            if (!testStatus.equals("")) {
+                testStatus += ";";
+            }
+            testStatus += "undo rebuild time=" +
+                    String.format("%.0f", (float)(endTime-startTime))
+                    + "ms";
+        });
+
     }
 }

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -8,7 +8,7 @@
 
     <logger name="org.corfudb.runtime.object" level="DEBUG"/>
 
-    <root level="ERROR">
+    <root level="TRACE">
         <!---appender-ref ref="STDOUT" /-->
     </root>
 </configuration>

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.corfudb.runtime.object" level="ERROR"/>
+    <logger name="org.corfudb.runtime.object" level="DEBUG"/>
 
     <root level="ERROR">
         <!---appender-ref ref="STDOUT" /-->

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -6,7 +6,9 @@
         </encoder>
     </appender>
 
-    <root level="TRACE">
+    <logger name="org.corfudb.runtime.object" level="ERROR"/>
+
+    <root level="ERROR">
         <!---appender-ref ref="STDOUT" /-->
     </root>
 </configuration>


### PR DESCRIPTION
This branch contains several tests that validate undo-correctness. 

One test -- UndoTest::canUndoAfterNoUndo -- is about performance, not correctness. It verifies that VersionLockedObject::optimisitcallyUndoable is properly reset (currently, it is not). 

This PR contains a fix to setting the optimistic flag properly, as well as some cleanups around the logic of optimistic undo/redo.
