### PR TITLE
Fix the version after undo operation in rollbackUnsafe

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -220,7 +220,11 @@ public class VersionLockedObject<T> {
                     .doUndo(object, undoRecord.getUndoRecord(),
                                     undoRecord.getSMRArguments());
 
-            this.version = undoRecord.getEntry().getGlobalAddress();
+            // After undoing the record, we should get back to the previous version
+            // We use the backpointerMap to get the previous entry version
+            // If none found, throw NoRollbackException.
+            this.version = undoRecord.getEntry().getBackpointerMap().values().stream().
+                    findFirst().orElseThrow(NoRollbackException::new);
 
 
             // check if we rolled back to the requested version

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -223,8 +223,8 @@ public class VersionLockedObject<T> {
             // After undoing the record, we should get back to the previous version
             // We use the backpointerMap to get the previous entry version
             // If none found, throw NoRollbackException.
-            this.version = undoRecord.getEntry().getBackpointerMap().values().stream().
-                    findFirst().orElseThrow(NoRollbackException::new);
+            this.version = Optional.ofNullable(undoRecord.getEntry().getBackpointer(sv.getID()))
+                    .orElseThrow(NoRollbackException::new);
 
 
             // check if we rolled back to the requested version


### PR DESCRIPTION
Previously, once we were undoing a record, we would leave the object at the version of the
record we undid.
This would trigger a resetObjectUnsafe, because once we undo the latest record, we will check that
the current version of the object is <= version we wanted to unroll to. This would not be the case
and would iterate again through the while loop, generating a NoRollBackException (undoLog is empty).

In this commit, we use the backpointermap to get the previous version of the object and update the
version to its predecessor.