### PR TITLE
Utility class - Multi read write lock

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/MultiReadWriteLock.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/MultiReadWriteLock.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.infrastructure.log;
+import java.util.HashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/**
+ * Allows acquiring different read/write locks for different addresses
+ *
+ * Created by Konstantin Spirov on 1/22/2015
+ */
+public class MultiReadWriteLock {
+
+    private HashMap<Long, ReentrantReadWriteLock> locks = new HashMap<>();
+
+    /**
+     * Acquire a read lock. The recommended use of this method is in try-with-resources statement.
+     * @param address id of the lock to acquire.
+     * @return A closable that will free the allocations for this lock if necessary
+     */
+    public AutoCloseableLock acquireReadLock(final Long address) {
+        ReentrantReadWriteLock lock = constructLockFor(address);
+        final ReentrantReadWriteLock.ReadLock readLock = lock.readLock();
+        readLock.lock();
+        return () -> {
+            readLock.unlock();
+            clearEventuallyLockFor(address);
+        };
+    }
+
+
+    /**
+     * Acquire a write lock. The recommended use of this method is in try-with-resources statement.
+     * @param address id of the lock to acquire.
+     * @return A closable that will free the allocations for this lock if necessary
+     */
+    public AutoCloseableLock acquireWriteLock(final Long address) {
+        ReentrantReadWriteLock lock = constructLockFor(address);
+        final ReentrantReadWriteLock.WriteLock writeLock = lock.writeLock();
+        writeLock.lock();
+        return () -> {
+            writeLock.unlock();
+            clearEventuallyLockFor(address);
+        };
+    }
+
+    private ReentrantReadWriteLock constructLockFor(Long name) {
+        synchronized (locks) {
+            ReentrantReadWriteLock lock = locks.get(name);
+            if (lock == null) {
+                lock = new ReentrantReadWriteLock();
+                locks.put(name, lock);
+            }
+            return lock;
+        }
+    }
+
+    private void clearEventuallyLockFor(Long name) {
+        synchronized (locks) {
+            ReentrantReadWriteLock lock = locks.get(name);
+            if (lock == null)
+                throw new IllegalStateException("Lock is wrongly used " + lock);
+            if (!lock.isWriteLocked() && lock.getReadLockCount() == 0) {
+                locks.remove(lock);
+            }
+        }
+    }
+
+    public interface AutoCloseableLock extends AutoCloseable {
+        @Override
+        void close();
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/log/MultiReadWriteLockTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/MultiReadWriteLockTest.java
@@ -1,0 +1,95 @@
+package org.corfudb.infrastructure.log;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.AbstractCorfuTest;
+import org.junit.Test;
+
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Created by kspirov on 3/8/17.
+ */
+@Slf4j
+public class MultiReadWriteLockTest extends AbstractCorfuTest {
+
+    @Test
+    public void testWriteAndReadLocksAreReentrant() throws Exception {
+        CallableConsumer c = (r) -> {
+            MultiReadWriteLock locks = new MultiReadWriteLock();
+            try (MultiReadWriteLock.AutoCloseableLock ignored1 = locks.acquireWriteLock(1l)) {
+                try (MultiReadWriteLock.AutoCloseableLock ignored2 = locks.acquireWriteLock(1l)) {
+                    try (MultiReadWriteLock.AutoCloseableLock ignored3 = locks.acquireReadLock(1l)) {
+                        try (MultiReadWriteLock.AutoCloseableLock ignored4 = locks.acquireReadLock(1l)) {
+                        }
+                    }
+                }
+            }
+        };
+        scheduleConcurrently(PARAMETERS.CONCURRENCY_ONE, c);
+        executeScheduled(PARAMETERS.CONCURRENCY_ONE, PARAMETERS.TIMEOUT_NORMAL);
+        // victory - we were not canceled
+    }
+
+    @Test
+    public void testIndependentWriteLocksDoNotSynchronize() throws Exception {
+        MultiReadWriteLock locks = new MultiReadWriteLock();
+        CyclicBarrier entry = new CyclicBarrier(PARAMETERS.CONCURRENCY_SOME);
+        // Here  test that the lock does not synchronize when the value is different.
+        // Otherwise one of the locks would halt on await, and the others - when acquiring the write log.
+        CallableConsumer c = (r) -> {
+            try(MultiReadWriteLock.AutoCloseableLock ignored = locks.acquireWriteLock((long)r)){
+                entry.await();
+            }
+        };
+        scheduleConcurrently(PARAMETERS.CONCURRENCY_SOME, c);
+        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_NORMAL);
+        // victory - we were not canceled
+    }
+
+
+
+    @Test
+    public void testWriteLockSynchronizes() throws Exception {
+        MultiReadWriteLock locks = new MultiReadWriteLock();
+        CyclicBarrier entry = new CyclicBarrier(PARAMETERS.CONCURRENCY_SOME);
+        // All threads should block, nobody should exit
+        AtomicBoolean noProblems = new AtomicBoolean(true);
+        CallableConsumer c = (r) -> {
+            try(MultiReadWriteLock.AutoCloseableLock ignored = locks.acquireWriteLock(1l)) {
+                entry.await();
+                noProblems.set(false);
+            }
+        };
+        scheduleConcurrently(PARAMETERS.CONCURRENCY_SOME, c);
+        try {
+            executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_VERY_SHORT);
+            fail();
+        } catch (CancellationException e) {
+            assertTrue(noProblems.get());
+        }
+    }
+
+
+
+    @Test
+    public void testReadLock() throws Exception {
+        MultiReadWriteLock locks = new MultiReadWriteLock();
+        CyclicBarrier entry = new CyclicBarrier(PARAMETERS.CONCURRENCY_SOME);
+        CallableConsumer c = (r) -> {
+            try(MultiReadWriteLock.AutoCloseableLock ignored = locks.acquireReadLock(1l)){
+                entry.await();
+            }
+        };
+        scheduleConcurrently(PARAMETERS.CONCURRENCY_SOME, c);
+        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_NORMAL);
+    }
+
+
+
+
+}


### PR DESCRIPTION
Next independent/incremental submission for the quorum replication, based on  https://github.com/CorfuDB/CorfuDB/pull/449 

This is a small request, while waiting decision how to proceed with the overwrite on the server.

This utility class is self explanatory, it allows multiple R/W locks identified by a long value.

One example when we will need it:  in quorum replication we need to read the result from phase 1 from the disk and then to take decision on writing based on the data,  we need this operation to be done only by a single thread, per log position. We don't want a global lock, this is very ineffective.