### PR TITLE
Implement richer stream interface

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -70,7 +70,9 @@ public class MultiObjectSMREntry extends LogEntry implements IDivisibleEntry, IS
 
     @Override
     public List<SMREntry> getSMRUpdates(UUID id) {
-        return entryMap.get(id).getUpdates();
+        MultiSMREntry entry = entryMap.get(id);
+        return entryMap.get(id) == null ? Collections.emptyList() :
+                entry.getUpdates();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -48,6 +48,20 @@ public class SMREntry extends LogEntry implements ISMRConsumable {
     @Getter
     public boolean undoable;
 
+    /** The upcall result, if present. */
+    @Getter
+    public transient Object upcallResult;
+
+    /** If there is an upcall result for this modification. */
+    @Getter
+    public transient boolean haveUpcallResult = false;
+
+    /** Set the upcall result for this entry. */
+    public void setUpcallResult(Object result) {
+        upcallResult = result;
+        haveUpcallResult = true;
+    }
+
     /** Set the undo record for this entry. */
     public void setUndoRecord(Object object) {
         this.undoRecord = object;

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/NoRollbackException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/NoRollbackException.java
@@ -12,6 +12,6 @@ public class NoRollbackException extends RuntimeException {
     }
 
     public NoRollbackException (SMREntry entry) {
-        super("Can't roll back due to method" + entry.getSMRMethod());
+        super("Can't roll back due to " + entry.getSMRMethod() + "@" + entry.getEntry().getGlobalAddress());
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
@@ -1,5 +1,7 @@
 package org.corfudb.runtime.object;
 
+import org.corfudb.runtime.exceptions.NoRollbackException;
+
 import java.util.Map;
 
 /** An internal interface to the SMR Proxy.
@@ -15,16 +17,6 @@ public interface ICorfuSMRProxyInternal<T> extends ICorfuSMRProxy<T> {
     /** Directly get the state of the object the proxy is managing,
      * without causing a sync. */
     VersionLockedObject<T> getUnderlyingObject();
-
-    /** Sync the object forward. At the end of the call, the version
-     * locked object will be at the version given in the timestamp.
-     *
-     * Unsafe, so ensure the append lock has been taken on the object
-     * before calling.
-     * @param object        The object to sync forward.
-     * @param timestamp     The timestamp to sync it to.
-     */
-    void syncObjectUnsafe(VersionLockedObject<T> object, long timestamp);
 
     /** Get a map of SMR upcall targets from method strings.
      * @return              The SMR upcall map for this proxy. */

--- a/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
@@ -1,0 +1,52 @@
+package org.corfudb.runtime.object;
+
+import org.corfudb.protocols.logprotocol.ISMRConsumable;
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.runtime.view.Address;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Created by mwei on 3/13/17.
+ */
+public interface ISMRStream {
+
+
+    List<SMREntry> remainingUpTo(long maxGlobal);
+
+    List<SMREntry> current();
+
+    List<SMREntry> previous();
+
+    long pos();
+
+    void reset();
+
+    void seek(long globalAddress);
+
+    /** Append a SMREntry to the stream, returning the global address
+     * it was written at.
+     * <p>
+     * Optionally, provide a method to be called when an address is acquired,
+     * and also a method to be called when an address is released (due to
+     * an unsuccessful append).
+     * </p>
+     * @param   entry               The SMR entry to append.
+     * @param   acquisitionCallback A function to call when an address is
+     *                              acquired.
+     *                              It should return true to continue with the
+     *                              append.
+     * @param   deacquisitionCallback A function to call when an address is
+     *                                released. It should return true to retry
+     *                                writing.
+     * @return  The (global) address the object was written at.
+     */
+    long append(SMREntry entry,
+                Function<TokenResponse, Boolean> acquisitionCallback,
+                Function<TokenResponse, Boolean> deacquisitionCallback);
+}

--- a/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
@@ -8,6 +8,7 @@ import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.view.Address;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -49,4 +50,11 @@ public interface ISMRStream {
     long append(SMREntry entry,
                 Function<TokenResponse, Boolean> acquisitionCallback,
                 Function<TokenResponse, Boolean> deacquisitionCallback);
+
+    /** Get the UUID for this stream (optional operation).
+     * @return  The UUID for this stream.
+     */
+    default UUID getID() {
+        return new UUID(0L, 0L);
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
@@ -1,0 +1,105 @@
+package org.corfudb.runtime.object;
+
+import org.corfudb.protocols.logprotocol.ISMRConsumable;
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.IStreamView;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Created by mwei on 3/10/17.
+ */
+public class StreamViewSMRAdapter implements ISMRStream {
+
+    /** The stream view backing this adapter. */
+    final IStreamView streamView;
+
+    /** Necessary until the runtime is no longer necessary for deserialization. */
+    final CorfuRuntime runtime;
+
+    public StreamViewSMRAdapter(CorfuRuntime runtime,
+                                IStreamView streamView) {
+        this.runtime = runtime;
+        this.streamView = streamView;
+    }
+
+    public List<SMREntry> remainingUpTo(long maxGlobal) {
+        return streamView.remainingUpTo(maxGlobal).stream()
+                .filter(m -> m.getType() == DataType.DATA)
+                .filter(m -> m.getPayload(runtime) instanceof ISMRConsumable)
+                .map(logData -> ((ISMRConsumable)logData.getPayload(runtime)).getSMRUpdates(streamView.getID()))
+                .flatMap(List::stream)
+                .collect(Collectors.toList());
+    }
+
+    public List<SMREntry> current() {
+        ILogData data = streamView.current();
+        if (data != null) {
+            if (data.getType() == DataType.DATA &&
+                    data.getPayload(runtime)
+                            instanceof ISMRConsumable) {
+                return ((ISMRConsumable)data.getPayload(runtime))
+                        .getSMRUpdates(streamView.getID());
+            }
+        }
+        return null;
+    }
+
+    public List<SMREntry> previous() {
+        ILogData data = streamView.previous();
+        while (streamView.getCurrentGlobalPosition() >
+                Address.NEVER_READ && data != null) {
+            if (data.getType() == DataType.DATA &&
+                    data.getPayload(runtime)
+                            instanceof ISMRConsumable) {
+                return ((ISMRConsumable)data.getPayload(runtime))
+                        .getSMRUpdates(streamView.getID());
+            }
+            data = streamView.previous();
+        }
+        return null;
+    }
+
+    public long pos() {
+        return streamView.getCurrentGlobalPosition();
+    }
+
+    public void reset() {
+        streamView.reset();
+    }
+
+    public void seek(long globalAddress) {
+        streamView.seek(globalAddress);
+    }
+
+    /** Append a SMREntry to the stream, returning the global address
+     * it was written at.
+     * <p>
+     * Optionally, provide a method to be called when an address is acquired,
+     * and also a method to be called when an address is released (due to
+     * an unsuccessful append).
+     * </p>
+     * @param   entry               The SMR entry to append.
+     * @param   acquisitionCallback A function to call when an address is
+     *                              acquired.
+     *                              It should return true to continue with the
+     *                              append.
+     * @param   deacquisitionCallback A function to call when an address is
+     *                                released. It should return true to retry
+     *                                writing.
+     * @return  The (global) address the object was written at.
+     */
+    public long append(SMREntry entry,
+                Function<TokenResponse, Boolean> acquisitionCallback,
+                Function<TokenResponse, Boolean> deacquisitionCallback) {
+        return streamView.append(entry, acquisitionCallback, deacquisitionCallback);
+    }
+
+}

--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
@@ -10,6 +10,7 @@ import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.IStreamView;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -100,6 +101,12 @@ public class StreamViewSMRAdapter implements ISMRStream {
                 Function<TokenResponse, Boolean> acquisitionCallback,
                 Function<TokenResponse, Boolean> deacquisitionCallback) {
         return streamView.append(entry, acquisitionCallback, deacquisitionCallback);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public UUID getID() {
+        return streamView.getID();
     }
 
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -342,7 +342,7 @@ public class VersionLockedObject<T> {
         return optimisticStream;
     }
 
-    public void clearOptimisticStreamUnsafe() {
+    public void optimisticCommitUnsafe() {
         optimisticStream = null;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -1,14 +1,15 @@
 package org.corfudb.runtime.object;
 
+import io.netty.util.internal.ConcurrentSet;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.exceptions.NoRollbackException;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
+import org.corfudb.runtime.object.transactions.WriteSetSMRStream;
 import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.stream.IStreamView;
-import org.corfudb.runtime.object.transactions.TransactionalContext;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -31,41 +32,48 @@ public class VersionLockedObject<T> {
      */
     T object;
 
-    /** The version of the underlying object.
-     *
+    /** Whether or not the object was optimistically
+     * modified or not.
      */
-    long version;
+    boolean optimisticallyModified;
+
+    /** A list of upcalls pending in the system. The proxy keeps this
+     * set so it can remember to save the upcalls for pending requests.
+     */
+    final Set<Long> pendingUpcalls;
+
+    // This enum is necessary because null cannot be inserted
+    // into a ConcurrentHashMap.
+    enum NullValue {
+        NULL_VALUE
+    }
+
+    /** A list of upcall results, keyed by the address they were
+     * requested.
+     */
+    final Map<Long, Object> upcallResults;
+
 
     /** A lock, which controls access to modifications to
      * the object. Any access to unsafe methods should
      * obtain the lock.
      */
-    private StampedLock lock;
+    private final StampedLock lock;
 
     /** The stream view this object is backed by.
      *
      */
-    private IStreamView sv;
+    private final ISMRStream smrStream;
+
+    /** The optimistic SMR stream on this object, if any
+     *
+     */
+    private WriteSetSMRStream optimisticStream;
 
     /** If the object reflects optimistic updates, the
      * context which made those updates.
      */
     private AbstractTransactionalContext modifyingContext;
-
-    /** An undo log, which records undo entries for the object.
-     *
-     */
-    private final Deque<SMREntry> undoLog;
-
-    /** An optimistic undo log, which records undo entries for
-     * optimistic changes to the object.
-     */
-    private final Deque<SMREntry> optimisticUndoLog;
-
-    /** The number of optimistic changes made to this object.
-     *
-     */
-    private int optimisticVersion;
 
     /** The upcall map for this object. */
     private final Map<String, ICorfuSMRUpcallTarget<T>> upcallTargetMap;
@@ -82,17 +90,14 @@ public class VersionLockedObject<T> {
     /** A function that generates a new instance of this object. */
     private final Supplier<T> newObjectFn;
 
-    public VersionLockedObject(Supplier<T> newObjectFn, long version, IStreamView sv,
+    public VersionLockedObject(Supplier<T> newObjectFn,
+                               StreamViewSMRAdapter smrStream,
                   Map<String, ICorfuSMRUpcallTarget<T>> upcallTargets,
                   Map<String, IUndoRecordFunction<T>> undoRecordTargets,
                   Map<String, IUndoFunction<T>> undoTargets,
                   Set<String> resetSet)
     {
-        this.version = version;
-        this.sv = sv;
-
-        this.undoLog = new LinkedList<>();
-        this.optimisticUndoLog = new LinkedList<>();
+        this.smrStream = smrStream;
 
         this.upcallTargetMap = upcallTargets;
         this.undoRecordFunctionMap = undoRecordTargets;
@@ -102,92 +107,17 @@ public class VersionLockedObject<T> {
         this.newObjectFn = newObjectFn;
         this.object = newObjectFn.get();
 
+        this.pendingUpcalls = new ConcurrentSet<>();
+        this.upcallResults = new ConcurrentHashMap<>();
+
         lock = new StampedLock();
-    }
-
-    public int getOptimisticVersionUnsafe() {
-        return this.optimisticVersion;
-    }
-
-    /** Clears all data about applied optimistic updates,
-     * including the optimistic undo log.
-     */
-    public void clearOptimisticUpdatesUnsafe() {
-        optimisticUndoLog.clear();
-        optimisticVersion = 0;
-        modifyingContext = null;
-    }
-
-    /** Commits all optimistic changes as a new version.
-     *
-     */
-    public void optimisticCommitUnsafe(long version) {
-        // TODO: merge the optimistic undo log into the undo log
-        clearOptimisticUpdatesUnsafe();
-
-        this.version = version;
-        // TODO: fix the stream view pointer seek, for now
-        // read will read the tx commit entry.
-        sv.next();
-    }
-
-    /** Rollback any optimistic changes, if possible.
-     *  Unsafe, requires that the caller has acquired a write lock.
-     */
-    public void optimisticRollbackUnsafe() {
-        if (!isOptimisticallyUndoableUnsafe()) {
-            throw new NoRollbackException();
-        }
-
-        optimisticUndoLog.stream()
-                .forEachOrdered(this::applyUndoRecord);
-
-        clearOptimisticUpdatesUnsafe();
-    }
-
-    /** Roll the object back to the supplied version if possible.
-     * This function may roll back to a point prior to the requested version.
-     * Otherwise, throws a NoRollbackException.
-     *
-     * Unsafe, requires that the caller has acquired a write lock.
-     *
-     * @param  version              The version to rollback to.
-     * @throws NoRollbackException  If the object cannot be rolled back to
-     *                              the supplied version.
-     */
-    public void rollbackUnsafe(long version) {
-        // If we're already at or before the given version, there's
-        // nothing to do
-        if (this.version <= version) {
-            return;
-        }
-
-        // If we don't have an undo log, we can't roll back.
-        if (undoLog.size() == 0) {
-            throw new NoRollbackException();
-        }
-
-        while (undoLog.size() > 0) {
-            SMREntry undoRecord = undoLog.pollFirst();
-
-            applyUndoRecord(undoRecord);
-            this.version = undoRecord.getEntry().getGlobalAddress();
-
-
-            // check if we rolled back to the requested version
-            if (this.version <= version) {
-                return;
-            }
-        }
-
-        throw new NoRollbackException();
     }
 
     /** Given a SMR entry with an undo record, undo the update.
      *
       * @param record   The record to undo.
      */
-    protected void applyUndoRecord(SMREntry record) {
+    public void applyUndoRecordUnsafe(SMREntry record) {
         IUndoFunction<T> undoFunction =
                 undoFunctionMap.get(record.getSMRMethod());
         // If the undo function exists, apply it.
@@ -212,40 +142,14 @@ public class VersionLockedObject<T> {
         throw new RuntimeException("Unknown undo record in undo log");
     }
 
-    /** Calculate the number of undo records we need to keep,
-     * possibly cleaning up the undo log, and return whether
-     * we need to keep this undo record.
-     *
-     * @return  True, if an undo record is needed in the undo log,
-     *          False otherwise.
-     */
-    public boolean needUndoRecordUnsafe() {
-        // Now get the oldest transaction in the context set.
-        long oldestVersion = TransactionalContext.getOldestSnapshot();
 
-        // If there are no active transactions, or all active transactions
-        // are after this object's version, we can just drop everything.
-        if (oldestVersion == -1L || oldestVersion > version) {
-            undoLog.clear();
-            return false;
-        }
-
-        // remove anything older than the oldest version we need
-        while (undoLog.size() > 0 &&
-                undoLog.getLast().getEntry().getGlobalAddress() < oldestVersion) {
-            undoLog.pollLast();
-        }
-
-        return true;
-    }
-
-    /** Apply an SMR update to the object, possibly optimistically,
-     * if set.
+    /** Apply an SMR update to the object, possibly optimistically.
      * @param entry         The entry to apply.
-     * @param isOptimistic  Whether the update is optimistic or not.
+     * @param timestamp     The timestamp the update should be applied at,
+     *                      or Address.OPTIMISTIC if the update is optimistic.
      * @return              The upcall result, if available.
      */
-    public Object applyUpdateUnsafe(SMREntry entry, boolean isOptimistic) {
+    public Object applyUpdateUnsafe(SMREntry entry, long timestamp) {
         ICorfuSMRUpcallTarget<T> target = upcallTargetMap.get(entry.getSMRMethod());
         if (target == null) {
             throw new RuntimeException("Unknown upcall " + entry.getSMRMethod());
@@ -270,45 +174,113 @@ public class VersionLockedObject<T> {
             }
         }
 
-        // Do we have an undo record now?
-        if (entry.isUndoable()) {
-            // If this is a standard mutation record
-            // and (1) we are not in optimistic mode
-            // (2) the undoLog is not empty OR
-            // the undoLog is empty and we need to
-            // generate undo records add an undo
-            // record to the log.
-            if (!isOptimistic && (!undoLog.isEmpty() ||
-                    needUndoRecordUnsafe())) {
-                undoLog.addFirst(entry);
-            }
-            // If we're in optimistic mode, add us to the
-            // optimistic undo log. (If there's a point. If
-            // the object isn't optimistically undoable anymore
-            // there's no point.)
-            else if (isOptimistic && isOptimisticallyUndoableUnsafe()) {
-                optimisticUndoLog.addFirst(entry);
-            }
-        }
-        else {
-            // We can't generate an undo record, so clear the
-            // optimistic undo log, and mark that the object is
-            // no longer optimistically undoable if we
-            // are in optimistic mode.
-            if (isOptimistic) {
-                optimisticUndoLog.clear();
-            } else {
-                undoLog.clear();
-            }
-        }
-
-        // if optimistic, update the optimistic version.
-        if (isOptimistic) {
-            optimisticVersion++;
-        }
-
         // now invoke the upcall
-        return target.upcall(object, entry.getSMRArguments());
+        Object ret = target.upcall(object, entry.getSMRArguments());
+        if (timestamp != Address.OPTIMISTIC) {
+        } else {
+            optimisticallyModified = true;
+        }
+        return ret;
+    }
+
+    /** Roll the object back to the supplied version if possible.
+     * This function may roll back to a point prior to the requested version.
+     * Otherwise, throws a NoRollbackException.
+     *
+     * Unsafe, requires that the caller has acquired a write lock.
+     *
+     * @param  rollbackVersion      The version to rollback to.
+     * @throws NoRollbackException  If the object cannot be rolled back to
+     *                              the supplied version.
+     */
+    public void rollbackObjectUnsafe(long rollbackVersion) {
+        // If we're already at or before the given version, there's
+        // nothing to do
+        if (getVersionUnsafe() <= rollbackVersion) {
+            return;
+        }
+
+        List<SMREntry> entries =  smrStream.current();
+
+        while(entries != null) {
+            if (entries.stream().allMatch(x -> x.isUndoable())) {
+                // start from the end, process one at a time
+                ListIterator<SMREntry> it =
+                        entries.listIterator(entries.size());
+                while (it.hasPrevious()) {
+                    applyUndoRecordUnsafe(it.previous());
+                }
+            }
+            else {
+                throw new NoRollbackException();
+            }
+
+            entries = smrStream.previous();
+
+            if (getVersionUnsafe() <= rollbackVersion) {
+                return;
+            }
+        }
+
+        throw new NoRollbackException();
+    }
+
+    /** Move the pointer for this object (effectively, forcefuly
+     * change the version of this object without playing
+     * any updates).
+     * @param globalAddress     The global address to set the pointer to
+     */
+    public void seek(long globalAddress) {
+        smrStream.seek(globalAddress);
+    }
+
+    /** Update the object. Ensure that you have the write lock before calling
+     * this function...
+     * @param timestamp         The timestamp to update the object to.
+     */
+    public void syncObjectUnsafe(long timestamp) {
+        smrStream.remainingUpTo(timestamp)
+            .stream()
+            .forEachOrdered(entry -> {
+                try {
+                    Object res = applyUpdateUnsafe(entry, entry.getEntry().getGlobalAddress());
+                    if (pendingUpcalls.contains(entry.getEntry().getGlobalAddress())) {
+                        log.debug("upcall result for {}", entry.getEntry().getGlobalAddress());
+                        upcallResults.put(entry.getEntry().getGlobalAddress(), res == null ?
+                                NullValue.NULL_VALUE : res);
+                        pendingUpcalls.remove(entry.getEntry().getGlobalAddress());
+                    }
+                } catch (Exception e) {
+                    log.error("Error: Couldn't execute upcall due to {}", e);
+                    throw new RuntimeException(e);
+                }
+            });
+    }
+
+    public long logUpdate(SMREntry entry, boolean saveUpcall) {
+        return smrStream.append(entry, t -> {
+            if (saveUpcall) {
+                pendingUpcalls.add(t.getToken());
+            }
+            return true;
+        }, t -> {
+            if (saveUpcall) {
+                pendingUpcalls.remove(t.getToken());
+            }
+            return true;
+        });
+    }
+
+    public WriteSetSMRStream getOptimisticStreamUnsafe() {
+        return optimisticStream;
+    }
+
+    public void clearOptimisticStreamUnsafe() {
+        optimisticStream = null;
+    }
+
+    public void setOptimisticStreamUnsafe(WriteSetSMRStream optimisticStream) {
+        this.optimisticStream = optimisticStream;
     }
 
     /** Execute the given function under a write lock, not returning
@@ -345,7 +317,7 @@ public class VersionLockedObject<T> {
     public <R> R optimisticallyReadAndRetry(BiFunction<Long, T, R> readFunction) {
         long ts = lock.tryOptimisticRead();
         if (ts != 0) {
-            R ret = readFunction.apply(version, object);
+            R ret = readFunction.apply(getVersionUnsafe(), object);
             if (lock.validate(ts)) {
                 return ret;
             }
@@ -354,7 +326,7 @@ public class VersionLockedObject<T> {
         // Optimistic reading failed, retry with a full lock
         ts = lock.readLock();
         try {
-            return readFunction.apply(version, object);
+            return readFunction.apply(getVersionUnsafe(), object);
         } finally {
             lock.unlockRead(ts);
         }
@@ -367,7 +339,7 @@ public class VersionLockedObject<T> {
         long ts = lock.tryOptimisticRead();
         if (ts != 0) {
             try {
-                R ret = readFunction.apply(version, object);
+                R ret = readFunction.apply(getVersionUnsafe(), object);
                 if (lock.validate(ts)) {
                     return ret;
                 }
@@ -379,7 +351,7 @@ public class VersionLockedObject<T> {
         ts = lock.readLock();
         try {
             try {
-                return readFunction.apply(version, object);
+                return readFunction.apply(getVersionUnsafe(), object);
             } finally {
                 lock.unlock(ts);
             }
@@ -389,7 +361,7 @@ public class VersionLockedObject<T> {
         // reading failed, retry with a full lock
         ts = lock.writeLock();
         try {
-            return retryWriteFunction.apply(version, object);
+            return retryWriteFunction.apply(getVersionUnsafe(), object);
         } finally {
             lock.unlock(ts);
         }
@@ -404,16 +376,8 @@ public class VersionLockedObject<T> {
         return object;
     }
 
-    public void setObjectUnsafe(T object) {
-        this.object = object;
-    }
-
     public long getVersionUnsafe() {
-        return version;
-    }
-
-    public void setVersionUnsafe(long version) {
-        this.version = version;
+        return smrStream.pos();
     }
 
     public AbstractTransactionalContext getModifyingContextUnsafe() {
@@ -425,32 +389,33 @@ public class VersionLockedObject<T> {
         this.modifyingContext = context;
     }
 
-    public IStreamView getStreamViewUnsafe() {
-        return sv;
-    }
-
-    public boolean isOptimisticallyUndoableUnsafe() {
-        return optimisticUndoLog.size() == optimisticVersion;
-    }
-
     public boolean isOptimisticallyModifiedUnsafe() {
-        return optimisticVersion != 0;
+        return optimisticallyModified;
     }
 
-    /** Reset the stream view backing this object.
-     * This function also resets the undo log, since it's based
-     * on the current position in the stream view.
-     */
-    public void resetStreamViewUnsafe() {
-        sv.reset();
-        undoLog.clear();
+    public void clearOptimisticallyModifiedUnsafe() {
+        optimisticallyModified = false;
     }
 
     /** Reset this object to the uninitialized state. */
     public void resetUnsafe() {
         object = newObjectFn.get();
-        clearOptimisticUpdatesUnsafe();
-        resetStreamViewUnsafe();
-        version = Address.NEVER_READ;
+        optimisticallyModified = false;
+        modifyingContext = null;
+        smrStream.reset();
+    }
+
+    /** Generate the summary string for this version locked object.
+     *
+     * The format of this string is [type]@[version][+]
+     * (where + is the optimistic flag)
+     *
+     * @return  The summary string for this version locked object
+     */
+    @Override
+    public String toString() {
+        return object.getClass().getSimpleName() + "@"
+                + (getVersionUnsafe() == Address.NEVER_READ ? "NR" : getVersionUnsafe())
+                + (optimisticallyModified ? "+" : "");
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -3,11 +3,13 @@ package org.corfudb.runtime.object.transactions;
 import com.google.common.collect.ImmutableMap;
 import lombok.Getter;
 
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
 import org.corfudb.protocols.logprotocol.MultiSMREntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.*;
+import org.corfudb.util.Utils;
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -21,6 +23,7 @@ import java.util.stream.Collectors;
  *
  * Created by mwei on 4/4/16.
  */
+@Slf4j
 public abstract class AbstractTransactionalContext implements
         Comparable<AbstractTransactionalContext> {
 
@@ -119,6 +122,7 @@ public abstract class AbstractTransactionalContext implements
         this.builder = builder;
         this.startTime = System.currentTimeMillis();
         this.parentContext = TransactionalContext.getCurrentContext();
+        log.debug("TXBegin[{}]", this);
     }
 
     /** Access the state of the object.
@@ -184,6 +188,7 @@ public abstract class AbstractTransactionalContext implements
     /** Forcefully abort the transaction.
      */
     public void abortTransaction() {
+        log.debug("TXAbort[{}]", this);
         commitAddress = ABORTED_ADDRESS;
         completionFuture
                 .completeExceptionally(new TransactionAbortedException());
@@ -318,5 +323,10 @@ public abstract class AbstractTransactionalContext implements
     public int compareTo(AbstractTransactionalContext o) {
         return Long.compare(this.getSnapshotTimestamp(), o
                 .getSnapshotTimestamp());
+    }
+
+    @Override
+    public String toString() {
+        return "TX[" + Utils.toReadableID(transactionID) + "]";
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -141,6 +141,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                                         TransactionalContext.getTransactionStackAsList(),
                                         proxy.getStreamID()));
             }
+            log.trace("Upcall[{}] {} requires sync", this, timestamp);
             proxy.getUnderlyingObject().syncObjectUnsafe(getSnapshotTimestamp());
             WriteSetEntry wrapper2 = getWriteSetEntryList(proxy.getStreamID()).get((int)timestamp);
             if (wrapper2 != null && wrapper2.getEntry().isHaveUpcallResult()){

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -63,7 +63,8 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
                     // First undo any optimistic changes.
                     if (proxy.getUnderlyingObject().isOptimisticallyModifiedUnsafe()) {
                         try {
-                            proxy.getUnderlyingObject().optimisticRollbackUnsafe();
+                            proxy.getUnderlyingObject().getModifyingContextUnsafe()
+                                    .optimisticRollback(proxy);
                         } catch (NoRollbackException nre) {
                             // guess our only option is to start from scratch.
                             proxy.getUnderlyingObject().resetUnsafe();
@@ -77,8 +78,8 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
 
                     // Now we sync forward if we are behind
                     if (proxy.getVersion() < getSnapshotTimestamp()) {
-                        proxy.syncObjectUnsafe(proxy.getUnderlyingObject(),
-                                getSnapshotTimestamp());
+                        proxy.getUnderlyingObject()
+                                .syncObjectUnsafe(getSnapshotTimestamp());
                     }
 
                     // Now we do the access

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -3,11 +3,9 @@ package org.corfudb.runtime.object.transactions;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
-import java.util.Deque;
-import java.util.LinkedList;
-import java.util.NavigableSet;
-import java.util.NoSuchElementException;
+import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.stream.Collectors;
 
 /** A class which allows access to transactional contexts, which manage
  * transactions. The static methods of this class provide access to the
@@ -39,6 +37,17 @@ public class TransactionalContext {
      */
     public static Deque<AbstractTransactionalContext> getTransactionStack() {
         return threadTransactionStack.get();
+    }
+
+    /**
+     * Get the transaction stack as a list.
+     * @return  The transaction stack as a list.
+     */
+    public static List<AbstractTransactionalContext> getTransactionStackAsList() {
+        List<AbstractTransactionalContext> listReverse =
+                getTransactionStack().stream().collect(Collectors.toList());
+        Collections.reverse(listReverse);
+        return listReverse;
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -26,25 +26,6 @@ public class TransactionalContext {
             threadTransactionStack = ThreadLocal.withInitial(
             LinkedList<AbstractTransactionalContext>::new);
 
-    /** A navigable set (priority queue) of contexts. The minimum context
-     * indicates how far we should try to keep the undo log up to.
-     */
-    private static final NavigableSet<AbstractTransactionalContext> contextSet =
-            new ConcurrentSkipListSet<>();
-
-    /** Return the oldest snapshot active in the system, or -1L if
-     * there are no active snapshots. */
-    public static long getOldestSnapshot() {
-        if (contextSet.isEmpty()) {
-            return -1L;
-        }
-        try {
-            return contextSet.first().getSnapshotTimestamp();
-        } catch (NoSuchElementException nse) {
-            return -1L;
-        }
-    }
-
     /** Whether or not the current thread is in a nested transaction.
      *
      * @return  True, if the current thread is in a nested transaction.
@@ -95,7 +76,6 @@ public class TransactionalContext {
      */
     public static AbstractTransactionalContext newContext(AbstractTransactionalContext context) {
         getTransactionStack().addFirst(context);
-        contextSet.add(context);
         return context;
     }
 
@@ -105,7 +85,6 @@ public class TransactionalContext {
      */
     public static AbstractTransactionalContext removeContext() {
         AbstractTransactionalContext r = getTransactionStack().pollFirst();
-        contextSet.remove(r);
         if (getTransactionStack().isEmpty()) {
             synchronized (getTransactionStack())
             {

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -91,7 +91,6 @@ public class WriteAfterWriteTransactionalContext
         completionFuture.complete(true);
         commitAddress = address;
 
-        // Update all proxies, committing the new address.
         tryCommitAllProxies();
 
         return address;

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -92,7 +92,7 @@ public class WriteAfterWriteTransactionalContext
         completionFuture.complete(true);
         commitAddress = address;
 
-        tryCommitAllProxies();
+        //tryCommitAllProxies();
 
         return address;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -92,7 +92,7 @@ public class WriteAfterWriteTransactionalContext
         completionFuture.complete(true);
         commitAddress = address;
 
-        //tryCommitAllProxies();
+        tryCommitAllProxies();
 
         return address;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -34,6 +34,7 @@ public class WriteAfterWriteTransactionalContext
 
     WriteAfterWriteTransactionalContext(TransactionBuilder builder) {
         super(builder);
+        getSnapshotTimestamp();
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -1,0 +1,70 @@
+package org.corfudb.runtime.object.transactions;
+
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.runtime.object.ISMRStream;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Created by mwei on 3/13/17.
+ */
+public class WriteSetSMRStream implements ISMRStream {
+
+    List<AbstractTransactionalContext> contexts;
+
+    long writePos;
+
+    public WriteSetSMRStream(List<AbstractTransactionalContext> contexts) {
+
+    }
+
+    /** Return whether we are the stream for this thread's transactions.
+     *
+     * This is checked by checking whether the root context
+     * for this stream is the same as for this thread.
+     *
+     * @return  True, if we are the stream for this transaction.
+     *          False otherwise.
+     */
+    public boolean isStreamForThisTransaction() {
+            return contexts.get(0)
+                    .equals(TransactionalContext.getRootContext());
+    }
+
+    @Override
+    public List<SMREntry> remainingUpTo(long maxGlobal) {
+        return null;
+    }
+
+    @Override
+    public List<SMREntry> current() {
+        return null;
+    }
+
+    @Override
+    public List<SMREntry> previous() {
+        return null;
+    }
+
+    @Override
+    public long pos() {
+        return 0;
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public void seek(long globalAddress) {
+
+    }
+
+    @Override
+    public long append(SMREntry entry, Function<TokenResponse, Boolean> acquisitionCallback, Function<TokenResponse, Boolean> deacquisitionCallback) {
+        return 0;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -3,8 +3,11 @@ package org.corfudb.runtime.object.transactions;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.object.ISMRStream;
+import org.corfudb.runtime.view.Address;
 
+import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Function;
 
 /**
@@ -14,10 +17,19 @@ public class WriteSetSMRStream implements ISMRStream {
 
     List<AbstractTransactionalContext> contexts;
 
+    int currentContext = 0;
+
+    long currentContextPos;
+
     long writePos;
 
-    public WriteSetSMRStream(List<AbstractTransactionalContext> contexts) {
+    final UUID id;
 
+    public WriteSetSMRStream(List<AbstractTransactionalContext> contexts,
+                             UUID id) {
+        this.contexts = contexts;
+        this.id = id;
+        reset();
     }
 
     /** Return whether we are the stream for this thread's transactions.
@@ -35,36 +47,70 @@ public class WriteSetSMRStream implements ISMRStream {
 
     @Override
     public List<SMREntry> remainingUpTo(long maxGlobal) {
+
         return null;
     }
 
     @Override
     public List<SMREntry> current() {
-        return null;
+        if (writePos == Address.NEVER_READ) {
+            return null;
+        }
+        return Collections.singletonList(contexts.get(currentContext)
+                .getWriteSet().get(id)
+                .getValue().get((int)(writePos - currentContextPos))
+                            .getEntry());
     }
 
     @Override
     public List<SMREntry> previous() {
-        return null;
+        if (writePos == Address.NEVER_READ) {
+            return null;
+        }
+
+        writePos--;
+
+        // Pop the context if we're at the beginning of it
+        if (currentContextPos == 0) {
+            if (currentContext == 0) {
+                throw new RuntimeException("Attempted to pop first context");
+            }
+            else {
+                currentContext--;
+            }
+
+            currentContextPos = contexts.get(currentContext)
+                    .getWriteSet().get(id).getValue().size();
+        }
+        return current();
     }
 
     @Override
     public long pos() {
-        return 0;
+        return writePos;
     }
 
     @Override
     public void reset() {
-
+        writePos = Address.NEVER_READ;
+        currentContext = 0;
+        currentContextPos = 0;
     }
 
     @Override
     public void seek(long globalAddress) {
-
+        writePos = globalAddress;
     }
 
     @Override
-    public long append(SMREntry entry, Function<TokenResponse, Boolean> acquisitionCallback, Function<TokenResponse, Boolean> deacquisitionCallback) {
-        return 0;
+    public long append(SMREntry entry,
+                       Function<TokenResponse, Boolean> acquisitionCallback,
+                       Function<TokenResponse, Boolean> deacquisitionCallback) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public UUID getID() {
+        return id;
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/Address.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Address.java
@@ -19,4 +19,14 @@ public class Address {
      * was rejected at the request of the client.
      */
     public static final long ABORTED = -2L;
+
+    /** Not found constant. Used to indicate that a search for an entry
+     * did not result in a entry.
+     */
+    public static final long NOT_FOUND = -3L;
+
+    /** Optimistic constant. Used to indicate that an update is
+     * optimistic.
+     */
+    public static final long OPTIMISTIC = -4L;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -182,7 +182,6 @@ public class ObjectsView extends AbstractView {
         if (context == null) {
             log.warn("Attempted to abort a transaction, but no transaction active!");
         } else {
-            log.trace("Aborting transactional context {}.", context.getTransactionID());
             context.abortTransaction();
             TransactionalContext.removeContext();
         }
@@ -213,9 +212,8 @@ public class ObjectsView extends AbstractView {
             return AbstractTransactionalContext.UNCOMMITTED_ADDRESS;
         } else {
             long totalTime = System.currentTimeMillis() - context.getStartTime();
-            log.trace("Exiting (committing) transactional context {} (time={} ms).",
-                    context.getTransactionID(), totalTime);
-
+            log.trace("TXCommit[{}] time={} ms",
+                    context, totalTime);
                 try {
                     return TransactionalContext.getCurrentContext().commitTransaction();
                 } finally {

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
@@ -87,6 +87,25 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
      * {@inheritDoc}
      */
     @Override
+    public synchronized void seek(long globalAddress) {
+        // pop any stream context which has a max address
+        // less than the global address
+        while (this.streamContexts.size() > 1) {
+            if (this.streamContexts.first().maxGlobalAddress <
+                    globalAddress)
+            {
+                this.streamContexts.pollFirst();
+            }
+        }
+
+        // now request a seek on the context
+        this.streamContexts.first().seek(globalAddress);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void close() {}
 
     /**
@@ -147,6 +166,10 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
 
         // Nothing read, nothing to process.
         if (entries.size() == 0) {
+            // We've resolved up to maxGlobal, so remember it. (if it wasn't max)
+            if (maxGlobal != Address.MAX) {
+                getCurrentContext().globalPointer = maxGlobal;
+            }
             return entries;
         }
 
@@ -168,8 +191,12 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
             entries.addAll(remainingUpTo(maxGlobal));
         }
 
-        // Otherwise update the pointer with the last entry
-        updatePointer(entries.get(entries.size() - 1));
+        // Otherwise update the pointer
+        if (maxGlobal != Address.MAX) {
+            getCurrentContext().globalPointer = maxGlobal;
+        } else {
+            updatePointer(entries.get(entries.size() - 1));
+        }
 
         // And return the entries.
         return entries;
@@ -274,18 +301,33 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
             // If this is a COW entry, we update the context as well.
             if (payload instanceof StreamCOWEntry) {
                 StreamCOWEntry ce = (StreamCOWEntry) payload;
-                streamContexts
-                        .add(contextFactory.apply(ce.getOriginalStream(),
-                                ce.getFollowUntil()));
+                pushNewContext(ce.getOriginalStream(),
+                                ce.getFollowUntil());
                 return true;
             }
         }
         return false;
     }
 
-    /** Get the current context. */
+    /** Get the current context.
+     *
+     * Should never throw a NoSuchElement exception because streamContexts should
+     * always at least have one element.
+     *
+     * */
     protected T getCurrentContext() {
         return streamContexts.first();
     }
 
+    /** Add a new context. */
+    protected void pushNewContext(UUID id, long maxGlobal) {
+        streamContexts.add(contextFactory.apply(id, maxGlobal));
+    }
+
+    protected void popContext() {
+        if (streamContexts.size() <= 1) {
+            throw new RuntimeException("Attempted to pop context with less than 1 context remaining!");
+        }
+        streamContexts.pollFirst();
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
@@ -7,6 +7,7 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.util.Utils;
 
 import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -329,5 +330,10 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
             throw new RuntimeException("Attempted to pop context with less than 1 context remaining!");
         }
         streamContexts.pollFirst();
+    }
+
+    @Override
+    public String toString() {
+        return Utils.toReadableID(baseContext.id) + "@" + getCurrentContext().globalPointer;
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -47,6 +47,20 @@ public abstract class AbstractQueuedStreamView extends
         super(runtime, streamID, QueuedStreamContext::new);
     }
 
+    /** Add the given address to the resolved queue of the
+     * given context.
+     * @param context           The context to add the address to
+     * @param globalAddress     The resolved global address.
+     */
+    protected void addToResolvedQueue(QueuedStreamContext context,
+                                      long globalAddress) {
+        if (context.maxResolution < globalAddress)
+        {
+            context.resolvedQueue.add(globalAddress);
+            context.maxResolution = globalAddress;
+        }
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -73,11 +87,7 @@ public abstract class AbstractQueuedStreamView extends
             final long thisRead = context.readQueue.pollFirst();
             ILogData ld = read(thisRead);
             if (ld.containsStream(context.id)) {
-                if (context.maxResolution < thisRead)
-                {
-                    context.resolvedQueue.add(thisRead);
-                    context.maxResolution = thisRead;
-                }
+                addToResolvedQueue(context, thisRead);
                 return ld;
             }
         }
@@ -119,17 +129,12 @@ public abstract class AbstractQueuedStreamView extends
             long readAddress = context.readQueue.pollFirst();
             ILogData data = read(readAddress);
 
+
             // Add to the read list if the entry is part of this
             // stream and contains data
             if (data.getType() == DataType.DATA &&
                     data.containsStream(context.id)) {
-
-                if (context.maxResolution < readAddress)
-                {
-                    context.resolvedQueue.add(readAddress);
-                    context.maxResolution = readAddress;
-                }
-
+                addToResolvedQueue(context, readAddress);
                 read.add(data);
             }
 
@@ -171,6 +176,85 @@ public abstract class AbstractQueuedStreamView extends
     abstract protected boolean fillReadQueue(final long maxGlobal,
                                           final QueuedStreamContext context);
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized long find(long globalAddress, SearchDirection direction) {
+        // First, check if we have resolved up to the given address
+        if (getCurrentContext().maxResolution < globalAddress) {
+            // If not we need to read to that position
+            // to resolve all the addresses.
+            remainingUpTo(globalAddress + 1);
+        }
+
+        // Now we can do the search.
+        // First, check for inclusive searches.
+        if (direction.isInclusive() &&
+                getCurrentContext().resolvedQueue.contains(globalAddress)) {
+            return globalAddress;
+        }
+        // Next, check all elements excluding
+        // in the correct direction.
+        Long result;
+        if (direction.isForward()) {
+            result = getCurrentContext().resolvedQueue.higher(globalAddress);
+        }  else {
+            result = getCurrentContext().resolvedQueue.lower(globalAddress);
+        }
+
+        // Convert the address to never read if there was no result.
+        return result == null ? Address.NEVER_READ : result;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public synchronized ILogData previous() {
+        // If never read, there would be no pointer to the previous entry.
+        if (getCurrentContext().globalPointer == Address.NEVER_READ) {
+            return null;
+        }
+        // If the pointer is before our min resolution, we need to resolve
+        // to get the previous entry.
+        if (getCurrentContext().globalPointer <
+                getCurrentContext().minResolution) {
+            long oldPointer = getCurrentContext().globalPointer;
+            getCurrentContext().globalPointer = Address.NEVER_READ;
+            remainingUpTo(getCurrentContext().minResolution);
+            getCurrentContext().minResolution = Address.NEVER_READ;
+            getCurrentContext().globalPointer = oldPointer;
+
+        }
+        // Otherwise, the previous entry should be resolved, so get
+        // one less than the current.
+        Long prevAddress = getCurrentContext()
+                .resolvedQueue.lower(getCurrentContext().globalPointer);
+        // Could be null, if we only read one entry
+        if (prevAddress == null) {
+            return null;
+        }
+        // Add the current pointer back into the read queue
+        getCurrentContext().readQueue.add(getCurrentContext().globalPointer);
+        // Update the global pointer
+        getCurrentContext().globalPointer = prevAddress;
+        return read(prevAddress);
+    }
+
+   /** {@inheritDoc} */
+    @Override
+    public synchronized ILogData current() {
+        if (getCurrentContext().globalPointer == Address.NEVER_READ) {
+            return null;
+        }
+        return read(getCurrentContext().globalPointer);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public long getCurrentGlobalPosition() {
+        return getCurrentContext().globalPointer;
+    }
+
 
     /** {@inheritDoc}
      *
@@ -184,6 +268,11 @@ public abstract class AbstractQueuedStreamView extends
         /** A queue of addresses which have already been resolved. */
         final NavigableSet<Long> resolvedQueue
                 = new TreeSet<>();
+
+        /** The minimum global address which we have resolved this
+         * stream to.
+         */
+        long minResolution = Address.NEVER_READ;
 
         /** The maximum global address which we have resolved this
          * stream to.
@@ -211,6 +300,23 @@ public abstract class AbstractQueuedStreamView extends
         void reset() {
             super.reset();
             readQueue.clear();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        void seek(long globalAddress) {
+            // Update minResolution if necessary
+            if (globalAddress > maxResolution) {
+                minResolution = globalAddress;
+            }
+            // remove anything in the read queue LESS
+            // than global address.
+            readQueue.headSet(globalAddress).clear();
+            // transfer from the resolved queue into
+            // the read queue anything equal to or
+            // greater than the global address
+            readQueue.addAll(resolvedQueue.tailSet(globalAddress, true));
+            super.seek(globalAddress);
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractStreamContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractStreamContext.java
@@ -34,7 +34,7 @@ public abstract class AbstractStreamContext implements
     /**
      * Generate a new stream context given the id of the stream and the
      * maximum address to read to.
-     * @param id            The id of the stream.
+     * @param id                  The id of the stream.
      * @param maxGlobalAddress    The maximum address to read up to.
      */
     public AbstractStreamContext(final UUID id,
@@ -47,6 +47,17 @@ public abstract class AbstractStreamContext implements
     /** Reset the stream context. */
     void reset() {
         globalPointer = Address.NEVER_READ;
+    }
+
+    /** Move the pointer for the context to the given global address,
+     * updating any structures if necessary.
+     * @param globalAddress     The address to seek to.
+     */
+    void seek(long globalAddress) {
+        // by default we just need to update the pointer.
+        // we subtract by one, since the NEXT read will
+        // have to include globalAddress.
+        globalPointer = globalAddress - 1;
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -167,7 +167,8 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
 
         // If everything is available in the resolved
         // queue, use it
-        if (context.maxResolution > maxAddress) {
+        if (context.maxResolution > maxAddress &&
+                context.minResolution < context.globalPointer) {
             return fillFromResolved(maxGlobal, context);
         }
 
@@ -183,7 +184,8 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
 
         // If everything is available in the resolved
         // queue, use it
-        if (context.maxResolution > latestToken) {
+        if (context.maxResolution > latestToken &&
+                context.minResolution < context.globalPointer) {
             return fillFromResolved(latestToken, context);
         }
 
@@ -264,7 +266,8 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
 
             // If everything left is available in the resolved
             // queue, use it
-            if (context.maxResolution > currentRead) {
+            if (context.maxResolution > currentRead &&
+                    context.minResolution < context.globalPointer) {
                 return fillFromResolved(latestToken, context);
             }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -300,9 +300,4 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
         log.debug("Read_Fill_Queue[{}] Filled queue with {}", this, context.readQueue);
         return !context.readQueue.isEmpty();
     }
-
-    @Override
-    public String toString() {
-        return Utils.toReadableID(baseContext.id) + "@" + getCurrentContext().globalPointer;
-    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/ReplexStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/ReplexStreamView.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.view.stream;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
@@ -45,6 +46,46 @@ public class ReplexStreamView extends
     public ReplexStreamView(final CorfuRuntime runtime,
                                  final UUID streamID) {
         super(runtime, streamID, ReplexStreamContext::new);
+    }
+
+    /** {@inheritDoc}
+     *
+     * This is problematic in Replex since we need to translate
+     * from stream addresses to global addresses. We create
+     * a temporary context to do the search.
+     * */
+    @Override
+    public synchronized long find(long globalAddress, SearchDirection direction) {
+        pushNewContext(getCurrentContext().id,
+                getCurrentContext().maxGlobalAddress-1);
+
+        Long foundAddress = null;
+        // See if we can find the element.
+        ILogData data;
+        ILogData prev = null;
+        while ((data = nextUpTo(globalAddress + 1)) != null) {
+            if (data.getGlobalAddress() >= globalAddress)
+            {
+                if (direction.isInclusive() &&
+                        data.getGlobalAddress() == globalAddress) {
+                    foundAddress = globalAddress;
+                }
+                else if (!direction.isForward()) {
+                    if (prev == null) {
+                        foundAddress = globalAddress;
+                    } else {
+                        foundAddress = prev.getGlobalAddress();
+                    }
+                }
+                else {
+                    foundAddress = data.getGlobalAddress();
+                }
+                break;
+            }
+            prev = data;
+        }
+        popContext();
+        return foundAddress == null ? Address.NOT_FOUND : foundAddress;
     }
 
     /** {@inheritDoc}
@@ -109,6 +150,39 @@ public class ReplexStreamView extends
         }
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public ILogData previous() {
+        // Deal with any requested seek
+        doPendingSeek(getCurrentContext(), Address.MAX);
+
+        // If never read or only one entry, return null
+        if (getCurrentContext().streamPointer == Address.NEVER_READ ||
+                getCurrentContext().streamPointer == 0)
+        return null;
+
+        // Move the stream pointer backwards and return the "next"
+        // entry, which is actually the previous.
+        getCurrentContext().streamPointer -= 2;
+        ILogData data = next();
+        getCurrentContext().globalPointer = data.getGlobalAddress();
+        return data;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ILogData current() {
+        if (getCurrentContext().streamPointer > Address.NEVER_READ) {
+            getCurrentContext().streamPointer--;
+        }
+        return next();
+    }
+
+    @Override
+    public long getCurrentGlobalPosition() {
+        return 0;
+    }
+
     /** Update the known maximum stream address, given the context.
      *
      * @param context   The context to use.
@@ -117,6 +191,34 @@ public class ReplexStreamView extends
         context.knownStreamMax = runtime.getSequencerView()
                 .nextToken(Collections.singleton(context.id), 0)
                 .getStreamAddresses().get(context.id);
+    }
+
+    /** Resolve any pending seek that was queued.
+     *
+     * @param context       The context to seek in
+     * @param maxGlobal     The maxGlobal to process to
+     */
+    private void doPendingSeek(final ReplexStreamContext context,
+                               long maxGlobal) {
+        // If there's a pending seek, resolve the correct global address
+        if (context.pendingSeek != Address.NEVER_READ) {
+            long pendingSeek = context.pendingSeek;
+            context.pendingSeek = Address.NEVER_READ;
+            // This is a low performance implementation that
+            // will seek from the beginning.
+            context.streamPointer = Address.NEVER_READ;
+            while (true) {
+                ILogData data = getNextEntry(context, maxGlobal);
+                if (data == null || data.getType() != DataType.DATA) {
+                    break;
+                }
+                if (data.getGlobalAddress() >= pendingSeek) {
+                    context.globalPointer = data.getGlobalAddress();
+                    break;
+                }
+            }
+            context.streamPointer = Math.max(Address.NEVER_READ, context.streamPointer-1);
+        }
     }
 
     /** {@inheritDoc}
@@ -128,6 +230,9 @@ public class ReplexStreamView extends
     @Override
     protected LogData getNextEntry(final ReplexStreamContext context,
                                    long maxGlobal) {
+        // Deal with any requested seek
+        doPendingSeek(context, maxGlobal);
+
         // If we are at (or greater than, which shouldn't occur...) the known
         // stream maximum, we need to check if theres a new stream maximum.
         if (context.streamPointer >= context.knownStreamMax) {
@@ -181,6 +286,7 @@ public class ReplexStreamView extends
                     return null;
                 }
                 context.streamPointer++;
+                context.globalPointer = ld.getGlobalAddress();
                 return ld;
             }
 
@@ -224,8 +330,18 @@ public class ReplexStreamView extends
          */
         long streamPointer;
 
+        /** A pointer to the current position in the stream which
+         * uses the global address.
+         */
+        long globalPointer;
+
         /** The largest known stream address we know was issued. */
         long knownStreamMax;
+
+        /** A pending seek, if requested, or Address.NEVER_READ
+         * if there is no pending seek.
+         */
+        long pendingSeek;
 
         /** Create a new stream context with the given ID and maximum address
          * to read to.
@@ -236,6 +352,37 @@ public class ReplexStreamView extends
             super(id, maxGlobalAddress);
             streamPointer = Address.NEVER_READ;
             knownStreamMax = Address.NEVER_READ;
+            pendingSeek = Address.NEVER_READ;
+            globalPointer = Address.NEVER_READ;
         }
+
+        @Override
+        void reset() {
+            super.reset();
+            streamPointer = Address.NEVER_READ;
+            knownStreamMax = Address.NEVER_READ;
+            pendingSeek = Address.NEVER_READ;
+            globalPointer = Address.NEVER_READ;
+        }
+
+        /**
+         * {@inheritDoc}
+         * In replex, seek is problematic because the interface takes
+         * global addresses, but the implementation only knows
+         * about stream addresses.
+         *
+         * So we take the current stream pointer and seek until
+         * we hit the global address. In the future, this could
+         * be optimized using a cache, potentially.
+         *
+         * In this function, we just mark pendingSeek so it can be
+         * resolved on the next read.
+         */
+        @Override
+        void seek(long globalAddress) {
+            pendingSeek = globalAddress;
+            super.seek(globalAddress);
+        }
+
     }
 }

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -344,6 +344,6 @@ public class Utils {
      * @return      A human readable UUID string
      */
     public static String toReadableID(UUID id) {
-        return Long.toHexString((id.getMostSignificantBits() >> 16) & 0xFFFF);
+        return Long.toHexString((id.getLeastSignificantBits()) & 0xFFFF);
     }
 }

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -337,4 +337,13 @@ public class Utils {
             }
         }
     }
+
+    /** Generates a human readable UUID string (4 hex chars)
+     * using time_mid
+     * @param id    The UUID to parse
+     * @return      A human readable UUID string
+     */
+    public static String toReadableID(UUID id) {
+        return Long.toHexString((id.getMostSignificantBits() >> 16) & 0xFFFF);
+    }
 }

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -90,7 +90,7 @@ public class CompileProxyTest extends AbstractViewTest {
         // track the raw stream updates caused by the execution so far
         ICorfuSMR<CorfuSharedCounter> compiledSharedCounter = (ICorfuSMR<CorfuSharedCounter>) sharedCounter;
         ICorfuSMRProxyInternal<CorfuSharedCounter> proxy_CORFUSMR = (ICorfuSMRProxyInternal<CorfuSharedCounter>) compiledSharedCounter.getCorfuSMRProxy();
-        IStreamView objStream = proxy_CORFUSMR.getUnderlyingObject().getStreamViewUnsafe();
+        //IStreamView objStream = proxy_CORFUSMR.getUnderlyingObject().getStreamViewUnsafe();
 
         int beforeSync, afterSync;
 
@@ -100,7 +100,8 @@ public class CompileProxyTest extends AbstractViewTest {
 
         // sync with the stream entry by entry
         for (int timestamp = 1; timestamp <= concurrency; timestamp++) {
-            proxy_CORFUSMR.syncObjectUnsafe(proxy_CORFUSMR.getUnderlyingObject(), timestamp);
+            proxy_CORFUSMR.getUnderlyingObject()
+                    .syncObjectUnsafe(timestamp);
             assertThat((afterSync = proxy_CORFUSMR.getUnderlyingObject().object.getValue()))
                     .isBetween(0, concurrency);
             assertThat(beforeSync)
@@ -214,7 +215,7 @@ public class CompileProxyTest extends AbstractViewTest {
 
         ICorfuSMR<CorfuSharedCounter> compiledSharedCounter = (ICorfuSMR<CorfuSharedCounter>)  sharedCounter;
         ICorfuSMRProxyInternal<CorfuSharedCounter> proxy_CORFUSMR = (ICorfuSMRProxyInternal<CorfuSharedCounter>) compiledSharedCounter.getCorfuSMRProxy();
-        IStreamView objStream = proxy_CORFUSMR.getUnderlyingObject().getStreamViewUnsafe();
+      //  IStreamView objStream = proxy_CORFUSMR.getUnderlyingObject().getStreamViewUnsafe();
 
         int numTasks = PARAMETERS.NUM_ITERATIONS_LOW;
         Random r = new Random(PARAMETERS.SEED);
@@ -392,7 +393,7 @@ public class CompileProxyTest extends AbstractViewTest {
         // for tracking raw stream status
         ICorfuSMR<CorfuCompoundObj> compiledCorfuCompound = (ICorfuSMR<CorfuCompoundObj>) sharedCorfuCompound;
         ICorfuSMRProxyInternal<CorfuCompoundObj> proxy_CORFUSMR = (ICorfuSMRProxyInternal<CorfuCompoundObj>) compiledCorfuCompound.getCorfuSMRProxy();
-        IStreamView objStream = proxy_CORFUSMR.getUnderlyingObject().getStreamViewUnsafe();
+       // IStreamView objStream = proxy_CORFUSMR.getUnderlyingObject().getStreamViewUnsafe();
 
         // initialization
         sharedCorfuCompound.set(sharedCorfuCompound.new Inner("E" + 0, "F" + 0), 0);

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -108,8 +108,8 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
     @Before
     public void resetTests() {
         testServerMap.clear();
-        runtime.parseConfigurationString(getDefaultConfigurationString())
-                .setCacheDisabled(true); // Disable cache during unit tests to fully stress the system.
+        runtime.parseConfigurationString(getDefaultConfigurationString());
+       //         .setCacheDisabled(true); // Disable cache during unit tests to fully stress the system.
         runtime.getAddressSpaceView().resetCaches();
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -109,6 +109,119 @@ public class StreamViewTest extends AbstractViewTest {
     }
 
     @Test
+    public void canSeekOnStream()
+        throws Exception
+    {
+        CorfuRuntime r = getDefaultRuntime().connect();
+        IStreamView sv = r.getStreamsView().get(
+                CorfuRuntime.getStreamID("stream  A"));
+
+        // Append some entries
+        sv.append("a".getBytes());
+        sv.append("b".getBytes());
+        sv.append("c".getBytes());
+
+        // Try reading two entries
+        assertThat(sv.next().getPayload(r))
+                .isEqualTo("a".getBytes());
+        assertThat(sv.next().getPayload(r))
+                .isEqualTo("b".getBytes());
+
+        // Seeking to the beginning
+        sv.seek(0);
+        assertThat(sv.next().getPayload(r))
+                .isEqualTo("a".getBytes());
+
+        // Seeking to the end
+        sv.seek(2);
+        assertThat(sv.next().getPayload(r))
+                .isEqualTo("c".getBytes());
+
+        // Seeking to the middle
+        sv.seek(1);
+        assertThat(sv.next().getPayload(r))
+                .isEqualTo("b".getBytes());
+    }
+
+    @Test
+    public void canFindInStream()
+            throws Exception
+    {
+        CorfuRuntime r = getDefaultRuntime().connect();
+        IStreamView svA = r.getStreamsView().get(
+                CorfuRuntime.getStreamID("stream  A"));
+        IStreamView svB = r.getStreamsView().get(
+                CorfuRuntime.getStreamID("stream  B"));
+
+        // Append some entries
+        final long A_GLOBAL = 0;
+        svA.append("a".getBytes());
+        final long B_GLOBAL = 1;
+        svB.append("b".getBytes());
+        final long C_GLOBAL = 2;
+        svA.append("c".getBytes());
+        final long D_GLOBAL = 3;
+        svB.append("d".getBytes());
+        final long E_GLOBAL = 4;
+        svA.append("e".getBytes());
+
+        // See if we can find entries:
+        // Should find entry "c"
+        assertThat(svA.find(B_GLOBAL,
+                IStreamView.SearchDirection.FORWARD))
+                .isEqualTo(C_GLOBAL);
+        // Should find entry "a"
+        assertThat(svA.find(B_GLOBAL,
+                IStreamView.SearchDirection.REVERSE))
+                .isEqualTo(A_GLOBAL);
+        // Should find entry "e"
+        assertThat(svA.find(E_GLOBAL,
+                IStreamView.SearchDirection.FORWARD_INCLUSIVE))
+                .isEqualTo(E_GLOBAL);
+        // Should find entry "c"
+        assertThat(svA.find(C_GLOBAL,
+                IStreamView.SearchDirection.REVERSE_INCLUSIVE))
+                .isEqualTo(C_GLOBAL);
+    }
+
+    @Test
+    public void canDoPreviousOnStream()
+            throws Exception
+    {
+        CorfuRuntime r = getDefaultRuntime().connect();
+        IStreamView sv = r.getStreamsView().get(
+                CorfuRuntime.getStreamID("stream  A"));
+
+        // Append some entries
+        sv.append("a".getBytes());
+        sv.append("b".getBytes());
+        sv.append("c".getBytes());
+
+        // Move backward should return null
+        assertThat(sv.previous())
+                .isNull();
+
+        // Move forward
+        sv.next(); // "a"
+        sv.next(); // "b"
+
+        // Should be now "a"
+        assertThat(sv.previous().getPayload(r))
+                .isEqualTo("a".getBytes());
+
+        // Move forward, should be now "b"
+        assertThat(sv.next().getPayload(r))
+                .isEqualTo("b".getBytes());
+
+        sv.next(); // "c"
+        sv.next(); // null
+
+        // Should be now "b"
+        assertThat(sv.previous().getPayload(r))
+                .isEqualTo("b".getBytes());
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void streamCanSurviveOverwriteException()
             throws Exception {

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -9,7 +9,10 @@
     <!-- Control logging levels for individual components here. -->
     <logger name="org.corfudb.runtime.object" level="TRACE"/>
     <logger name="org.corfudb.runtime.clients" level="INFO"/>
-    <logger name="org.corfudb.runtime.infrastructure" level="INFO"/>
+    <logger name="org.corfudb.infrastructure" level="INFO"/>
+    <logger name="io.netty.util" level="INFO"/>
+    <logger name="io.netty.util.internal" level="INFO"/>
+    <logger name="io.netty.buffer" level="INFO"/>
 
     <root level="TRACE">
         <!--<appender-ref ref="STDOUT" />-->

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -6,9 +6,12 @@
         </encoder>
     </appender>
 
-    <logger name="org.corfudb.runtime.object" level="DEBUG"/>
+    <!-- Control logging levels for individual components here. -->
+    <logger name="org.corfudb.runtime.object" level="TRACE"/>
+    <logger name="org.corfudb.runtime.clients" level="INFO"/>
+    <logger name="org.corfudb.runtime.infrastructure" level="INFO"/>
 
     <root level="TRACE">
-        <!---appender-ref ref="STDOUT" /-->
+        <!--<appender-ref ref="STDOUT" />-->
     </root>
 </configuration>


### PR DESCRIPTION
This patch adds several interfaces to IStreamView:
seek() - moves the stream pointer
find() - given a global address, get the global address for next/prev entries
previous() - return the previous entry
current() - return the previously returned entry

It also patches versionLockedObject to use these interfaces and
eliminates the undoLog and associated tracking mechanisms.