### PR TITLE
Fix undo log rollback

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -40,17 +40,26 @@ public class SMREntry extends LogEntry implements ISMRConsumable {
      *
      */
     @Getter
-    @Setter
     public transient Object undoRecord;
 
-    /** Return whether or not this method can be undo.
-     *
-     * @return  True, if the entry has the record necessary
-     *          for undo, false otherwise.
+    /** A flag indicating whether an undo record is present. Necessary
+     * because undo records may be NULL.
      */
-    public boolean isUndoable() {
-        return  undoRecord != null;
+    @Getter
+    public boolean undoable;
+
+    /** Set the undo record for this entry. */
+    public void setUndoRecord(Object object) {
+        this.undoRecord = object;
+        undoable = true;
     }
+
+    /** Clear the undo record for this entry. */
+    public void clearUndoRecord() {
+        this.undoRecord = null;
+        undoable = false;
+    }
+
 
     public SMREntry(String SMRMethod, @NonNull Object[] SMRArguments, ISerializer serializer) {
         super(LogEntryType.SMR);

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -202,7 +202,7 @@ public class VersionLockedObject<T> {
             object = (T) record.getUndoRecord();
             // clear the undo record, since it is now
             // consumed (the object may change)
-            record.setUndoRecord(null);
+            record.clearUndoRecord();
             return;
         }
         // Otherwise we don't know how to undo,
@@ -271,7 +271,7 @@ public class VersionLockedObject<T> {
         }
 
         // Do we have an undo record now?
-        if (entry.getUndoRecord() != null) {
+        if (entry.isUndoable()) {
             // If this is a standard mutation record
             // and (1) we are not in optimistic mode
             // (2) the undoLog is not empty OR


### PR DESCRIPTION
This patch extracts a performance fix from #474 which
fixes a performance regression.

The regression was caused by the elimination of the undoable
flag, which was necessary because some undo records could
be null (for example, in a map the previous value of the map
could have been not set). This would cause many 
unneeded rollbacks based on the content of the 
undo record.