### PR TITLE
Sync interface - update objects without an access

### DIFF
--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
@@ -40,6 +40,11 @@ public interface ICorfuSMRProxy<T> {
      */
     <R> R getUpcallResult(long timestamp, Object[] conflictObject);
 
+    /**
+     * Update the proxy to the latest committed version.
+     */
+    void sync();
+
     /** Get the ID of the stream this proxy is subscribed to.
      *
      * @return  The UUID of the stream this proxy is subscribed to.

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -312,6 +312,66 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void sync() {
+        // Linearize this read against a timestamp
+        final long timestamp =
+                rt.getSequencerView()
+                        .nextToken(Collections.singleton(streamID), 0).getToken();
+
+        // Acquire locks and perform read.
+        underlyingObject.optimisticallyReadThenReadLockThenWriteOnFail(
+                (ver,o) -> {
+                    // If not in a transaction, check if the version is
+                    // at least that of the linearized read requested.
+                    if (ver >= timestamp
+                            && !underlyingObject.isOptimisticallyModifiedUnsafe()) {
+                        return null;
+                    }
+                    // We don't have the right version, so we need to write
+                    // throwing this exception causes us to take a write lock.
+                    throw new ConcurrentModificationException();
+                },
+                //  The read did not acquire the right version, so we
+                //  have now acquired a write lock.
+                (ver, o) -> {
+                    // In the off chance that someone updated the version
+                    // for us.
+                    if (ver >= timestamp
+                            && !underlyingObject.isOptimisticallyModifiedUnsafe()) {
+                        return null;
+                    }
+
+                    // Now we sync forward while we have the lock, if the object
+                    // was not optimistically modified
+                    if (!underlyingObject.isOptimisticallyModifiedUnsafe()) {
+                        syncObjectUnsafe(underlyingObject, timestamp);
+                        return null;
+                    }
+                    // Otherwise, we rollback any optimistic changes, if they
+                    // are undoable, and then sync the object before accessing
+                    // the object.
+                    else if (underlyingObject.isOptimisticallyUndoableUnsafe()){
+                        try {
+                            underlyingObject.optimisticRollbackUnsafe();
+                            syncObjectUnsafe(underlyingObject, timestamp);
+                            return null;
+                        } catch (NoRollbackException nre) {
+                            // We couldn't roll back, so we'll have to
+                            // resort to generating a new object.
+                        }
+                    }
+
+                    // As a last resort, we'll reset...
+                    underlyingObject.resetUnsafe();
+                    syncObjectUnsafe(underlyingObject, timestamp);
+                    return null;
+                });
+    }
+
     private <R> R getUpcallResultInner(long timestamp, Object[] conflictObject) {
         // If we aren't coming from a transactional context,
         // redirect us to a transactional context first.

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -15,6 +15,7 @@ import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.serializer.Serializers;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
@@ -221,6 +222,29 @@ public class ObjectsView extends AbstractView {
                     TransactionalContext.removeContext();
                 }
         }
+    }
+
+    /** Given a Corfu object, syncs the object to the most up to date version.
+     * If the object is not a Corfu object, this function won't do anything.
+     * @param object    The Corfu object to sync.
+     */
+    public void syncObject(Object object) {
+        if (object instanceof ICorfuSMR<?>) {
+            ICorfuSMR<?> corfuObject = (ICorfuSMR<?>) object;
+            corfuObject.getCorfuSMRProxy().sync();
+        }
+    }
+
+    /** Given a list of Corfu objects, syncs the objects to the most up to date
+     * version, possibly in parallel.
+     * @param objects   A list of Corfu objects to sync.
+     */
+    public void syncObject(Object... objects) {
+        Arrays.stream(objects)
+                .parallel()
+                .filter(x -> x instanceof ICorfuSMR<?>)
+                .map(x -> (ICorfuSMR<?>) x)
+                .forEach(x -> x.getCorfuSMRProxy().sync());
     }
 
     @Data


### PR DESCRIPTION
This patch adds a sync interface to objects view, which 
enables objects to be sync'd without calling an
accessor. Note that sync can also be called from
within a transaction, which will actually force a
sync (undoing optimistic updates if necessary).