### PR TITLE
patch tx commit

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -40,6 +40,7 @@ public interface ILogData extends IMetadata {
      * Return the backpointer for a particular stream.
      */
     default Long getBackpointer(UUID streamID) {
+        if (getBackpointerMap() == null) return null;
         return getBackpointerMap().get(streamID);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -112,7 +112,7 @@ public class VersionLockedObject<T> {
     /** Clears all data about applied optimistic updates,
      * including the optimistic undo log.
      */
-    protected void clearOptimisticUpdatesUnsafe() {
+    public void clearOptimisticUpdatesUnsafe() {
         optimisticUndoLog.clear();
         optimisticVersion = 0;
         modifyingContext = null;

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -325,7 +325,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         updateAllProxies(x -> {
             // If some other client updated this object, sync
             // it forward to grab those updates
-            if (getSnapshotTimestamp() !=
+            if (getSnapshotTimestamp() <
                     committedEntry
                             .getBackpointer(x.getStreamID())) {
                 x.syncObjectUnsafe(x.getUnderlyingObject(),

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -2,7 +2,10 @@ package org.corfudb.runtime.object.transactions;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.ISMRConsumable;
 import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.exceptions.NoRollbackException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
@@ -301,11 +304,62 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         commitAddress = address;
 
         // Update all proxies, committing the new address.
-        updateAllProxies(x ->
-                x.getUnderlyingObject()
-                        .optimisticCommitUnsafe(commitAddress));
+        tryCommitAllProxies();
 
         return address;
+    }
+
+
+    /** Try to commit the optimistic updates to each proxy. */
+    protected void tryCommitAllProxies() {
+        // First, get the committed entry
+        // in order to get the backpointers
+        // and the underlying SMREntries.
+        final ILogData committedEntry = this.builder.getRuntime()
+                .getAddressSpaceView().read(commitAddress);
+
+        if (committedEntry.getType() == DataType.EMPTY) {
+            return;
+        }
+
+        updateAllProxies(x -> {
+            // If some other client updated this object, sync
+            // it forward to grab those updates
+            if (getSnapshotTimestamp() !=
+                    committedEntry
+                            .getBackpointer(x.getStreamID())) {
+                x.syncObjectUnsafe(x.getUnderlyingObject(),
+                        commitAddress-1);
+            }
+            // Clear tne optimistic update flag
+            x.getUnderlyingObject()
+                    .clearOptimisticUpdatesUnsafe();
+            // Also, be nice and transfer the undo
+            // log from the optimistic updates
+            // for this to work the write sets better
+            // be the same
+            List<WriteSetEntry> committedWrites =
+                    getWriteSetEntryList(x.getStreamID());
+            List<SMREntry> entryWrites =
+                    ((ISMRConsumable) committedEntry
+                            .getPayload(this.getBuilder().runtime))
+                            .getSMRUpdates(x.getStreamID());
+            if (committedWrites.size() ==
+                    entryWrites.size()) {
+                IntStream.range(0, committedWrites.size())
+                        .forEach(i -> {
+                            if (committedWrites.get(i)
+                                    .getEntry().isUndoable()) {
+                                entryWrites.get(i)
+                                        .setUndoRecord(committedWrites.get(i)
+                                                .getEntry().getUndoRecord());
+                            }
+                        });
+            }
+            x.getUnderlyingObject()
+                    .setVersionUnsafe(commitAddress);
+        });
+
     }
 
     @SuppressWarnings("unchecked")

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -92,9 +92,7 @@ public class WriteAfterWriteTransactionalContext
         commitAddress = address;
 
         // Update all proxies, committing the new address.
-        updateAllProxies(x ->
-                x.getUnderlyingObject()
-                        .optimisticCommitUnsafe(commitAddress));
+        tryCommitAllProxies();
 
         return address;
     }


### PR DESCRIPTION
Previously, tx commit skipped an entry in the stream view,
which may not have been correct in some cases. This patch
selects the tryCommitAllProxies change from #474 to fix
transaction commit