### PR TITLE
dont save upcalls if they are not needed

### DIFF
--- a/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
+++ b/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
@@ -372,8 +372,12 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                     if (mutator != null || mutatorAccessor != null) {
                         ms.addStatement(
                                 (mutatorAccessor != null ? "long address" + CORFUSMR_FIELD + " = " : "") +
-                                "proxy" + CORFUSMR_FIELD + ".logUpdate($S,$L$L$L)",
+                                "proxy" + CORFUSMR_FIELD + ".logUpdate($S,$L,$L$L$L)",
                                 getSMRFunctionName(smrMethod),
+                                // Don't need upcall result for mutators
+                                mutator != null ? "false" :
+                                // or mutatorAccessors which return void.
+                                smrMethod.getReturnType().getKind().equals(TypeKind.VOID) ? "false" : "true",
                                 m.hasConflictAnnotations ? conflictField : "null",
                                 smrMethod.getParameters().size() > 0 ? "," : "",
                                 smrMethod.getParameters().stream()
@@ -384,7 +388,7 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
 
                     // If an accessor (or not annotated), return the object by doing the underlying call.
                     if (mutatorAccessor != null) {
-                        // If the return to the mutatorAcessor is void, we don't need
+                        // If the return to the mutatorAccessor is void, we don't need
                         // to do anything...
                         if (!smrMethod.getReturnType().getKind().equals(TypeKind.VOID)) {
                             ms.addStatement("return (" +

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
@@ -21,14 +21,17 @@ public interface ICorfuSMRProxy<T> {
     /**
      * Record an SMR function to the log before returning.
      * @param smrUpdateFunction     The name of the function to record.
+     * @param keepUpcallResult      Whether or not we need to keep the
+     *                              result to the upcall, for a subsequent
+     *                              call to getUpcallResult.
      * @param conflictObject        Fine-grained conflict information, if
      *                              available.
      * @param args                  The arguments to the function.
      *
      * @return  The address in the log the SMR function was recorded at.
      */
-    long logUpdate(String smrUpdateFunction, Object[] conflictObject,
-                   Object... args);
+    long logUpdate(String smrUpdateFunction, boolean keepUpcallResult,
+                   Object[] conflictObject, Object... args);
 
     /**
      * Return the result of an upcall at the given timestamp.


### PR DESCRIPTION
logUpdate currently saves upcalls whether they are needed or not,
which is unnecessary in the case of mutators or mutatorAccessors
which return void.

This causes a very small amount of memory to leak, since the
result of an upcall that is not needed is probably null.

This patch fixes logUpdate by adding a keepUpcallResult parameter,
which controls whether or not an upcall is added to the pendingUpcalls
list or not.