### PR TITLE
Avoid Scanning When Reading A Record

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/AddressMetaData.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/AddressMetaData.java
@@ -1,0 +1,16 @@
+package org.corfudb.infrastructure.log;
+
+/**
+ * Created by maithem on 3/14/17.
+ */
+public class AddressMetaData {
+    public final int checksum;
+    public final int length;
+    public final long offset;
+
+    public AddressMetaData(int checksum, int length, long offset) {
+        this.checksum = checksum;
+        this.length = length;
+        this.offset = offset;
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -60,7 +60,7 @@ import org.corfudb.runtime.exceptions.TrimmedException;
  * This class implements the StreamLog by persisting the stream log as records in multiple files.
  * This StreamLog implementation can detect log file corruption, if checksum is enabled, otherwise
  * the checksum field will be ignored.
- *
+ * <p>
  * Created by maithem on 10/28/16.
  */
 
@@ -163,7 +163,7 @@ public class StreamLogFiles implements StreamLog {
     @Override
     public void trim(LogAddress logAddress) {
         SegmentHandle handle = getSegmentHandleForAddress(logAddress);
-        if (!handle.getKnownAddresses().contains(logAddress.getAddress()) ||
+        if (!handle.getKnownAddresses().containsKey(logAddress.getAddress()) ||
                 handle.getPendingTrims().contains(logAddress.getAddress())) {
             return;
         }
@@ -345,11 +345,23 @@ public class StreamLogFiles implements StreamLog {
         fc.force(true);
     }
 
-    static private ByteBuffer getByteBufferWithMetaData(AbstractMessage message) {
-        Metadata metadata = Metadata.newBuilder()
+    static private Metadata getMetadata(AbstractMessage message) {
+        return Metadata.newBuilder()
                 .setChecksum(getChecksum(message.toByteArray()))
                 .setLength(message.getSerializedSize())
                 .build();
+    }
+
+    static private ByteBuffer getByteBuffer(Metadata metadata, AbstractMessage message) {
+        ByteBuffer buf = ByteBuffer.allocate(metadata.getSerializedSize() + message.getSerializedSize());
+        buf.put(metadata.toByteArray());
+        buf.put(message.toByteArray());
+        buf.flip();
+        return buf;
+    }
+
+    static private ByteBuffer getByteBufferWithMetaData(AbstractMessage message) {
+        Metadata metadata = getMetadata(message);
 
         ByteBuffer buf = ByteBuffer.allocate(metadata.getSerializedSize() + message.getSerializedSize());
         buf.put(metadata.toByteArray());
@@ -389,28 +401,22 @@ public class StreamLogFiles implements StreamLog {
     }
 
     /**
-     * Find a log entry in a file.
+     * Reads an address space from a log file into a SegmentHandle
      *
-     * @param fh      The file handle to use.
-     * @param address The address of the entry.
-     * @return The log unit entry at that address, or NULL if there was no entry.
+     * @param sh
      */
-    private LogData readRecord(SegmentHandle fh, long address)
-            throws IOException {
-
-        // A channel lock is required to read the file size because the channel size can change
-        // when it is written to, so when we read the size we need to guarantee that the size only
-        // includes fully written records.
+    private void readAddressSpace(SegmentHandle sh) throws IOException {
         long logFileSize;
 
-        synchronized (fh.lock) {
-            logFileSize = fh.logChannel.size();
+        synchronized (sh.lock) {
+            logFileSize = sh.logChannel.size();
         }
 
-        FileChannel fc = getChannel(fh.fileName, true);
+        FileChannel fc = getChannel(sh.fileName, true);
 
         if (fc == null) {
-            return null;
+            log.trace("Can't read address space, {} doesn't exist", sh.fileName);
+            return;
         }
 
         // Skip the header
@@ -421,6 +427,7 @@ public class StreamLogFiles implements StreamLog {
         Metadata headerMetadata = Metadata.parseFrom(headerMetadataBuf.array());
 
         fc.position(fc.position() + headerMetadata.getLength());
+        long channelOffset = fc.position();
         ByteBuffer o = ByteBuffer.allocate((int) logFileSize - (int) fc.position());
         fc.read(o);
         fc.close();
@@ -429,13 +436,15 @@ public class StreamLogFiles implements StreamLog {
         while (o.hasRemaining()) {
 
             short magic = o.getShort();
+            channelOffset += Short.BYTES;
 
             if (magic != RECORD_DELIMITER) {
-                return null;
+                return;
             }
 
             byte[] metadataBuf = new byte[METADATA_SIZE];
             o.get(metadataBuf);
+            channelOffset += METADATA_SIZE;
 
             try {
                 Metadata metadata = Metadata.parseFrom(metadataBuf);
@@ -448,26 +457,47 @@ public class StreamLogFiles implements StreamLog {
 
                 if (!noVerify) {
                     if (metadata.getChecksum() != getChecksum(entry.toByteArray())) {
-                        log.error("Checksum mismatch detected while trying to read address {}", address);
+                        log.error("Checksum mismatch detected while trying to read file {}", sh.fileName);
                         throw new DataCorruptionException();
                     }
                 }
 
-                if (address == -1) {
-                    //Todo(Maithem) : maybe we can move this to getChannelForAddress
-                    fh.knownAddresses.add(entry.getGlobalAddress());
-                } else if (entry.getGlobalAddress() != address) {
-                    log.trace("Read address {}, not match {}, skipping. (remain={})", entry.getGlobalAddress(), address);
-                } else {
-                    log.debug("Entry at {} hit, reading (size={}).", address, metadata.getLength());
+                sh.knownAddresses.put(entry.getGlobalAddress(),
+                        new AddressMetaData(metadata.getChecksum(), metadata.getLength(), channelOffset));
 
-                    return getLogData(entry);
-                }
+                channelOffset += metadata.getLength();
+
             } catch (InvalidProtocolBufferException e) {
                 throw new DataCorruptionException();
             }
         }
-        return null;
+    }
+
+    /**
+     * Read a log entry in a file.
+     *
+     * @param sh      The file handle to use.
+     * @param address The address of the entry.
+     * @return The log unit entry at that address, or NULL if there was no entry.
+     */
+    private LogData  readRecord(SegmentHandle sh, long address)
+            throws IOException {
+
+        FileChannel fc = getChannel(sh.fileName, true);
+        AddressMetaData metaData = sh.getKnownAddresses().get(address);
+        if (metaData == null) {
+            return null;
+        }
+
+        fc.position(metaData.offset);
+
+        try {
+            ByteBuffer entryBuf = ByteBuffer.allocate(metaData.length);
+            fc.read(entryBuf);
+            return getLogData(LogEntry.parseFrom(entryBuf.array()));
+        } catch (InvalidProtocolBufferException e) {
+            throw new DataCorruptionException();
+        }
     }
 
     private FileChannel getChannel(String filePath, boolean readOnly) throws IOException {
@@ -500,7 +530,7 @@ public class StreamLogFiles implements StreamLog {
      * @return The FileChannel for that address.
      */
     @VisibleForTesting
-     synchronized SegmentHandle getSegmentHandleForAddress(LogAddress logAddress) {
+    synchronized SegmentHandle getSegmentHandleForAddress(LogAddress logAddress) {
         String filePath = logDir + File.separator;
         long segment = logAddress.address / RECORDS_PER_LOG_FILE;
 
@@ -516,7 +546,7 @@ public class StreamLogFiles implements StreamLog {
 
             try {
                 FileChannel fc1 = getChannel(a, false);
-                FileChannel fc2 = getChannel(getTrimmedFilePath(a) , false);
+                FileChannel fc2 = getChannel(getTrimmedFilePath(a), false);
                 FileChannel fc3 = getChannel(getPendingTrimsFilePath(a), false);
 
                 boolean verify = true;
@@ -530,7 +560,7 @@ public class StreamLogFiles implements StreamLog {
                 SegmentHandle sh = new SegmentHandle(fc1, fc2, fc3, a);
                 // The first time we open a file we should read to the end, to load the
                 // map of entries we already have.
-                readRecord(sh, -1);
+                readAddressSpace(sh);
                 loadTrimAddresses(sh);
                 return sh;
             } catch (IOException e) {
@@ -550,7 +580,7 @@ public class StreamLogFiles implements StreamLog {
             pendingTrimSize = sh.getPendingTrimChannel().size();
         }
 
-        FileChannel fcTrimmed = getChannel(getTrimmedFilePath(sh.getFileName() ), true);
+        FileChannel fcTrimmed = getChannel(getTrimmedFilePath(sh.getFileName()), true);
         FileChannel fcPending = getChannel(getPendingTrimsFilePath(sh.getFileName()), true);
 
         if (fcTrimmed == null) {
@@ -660,11 +690,13 @@ public class StreamLogFiles implements StreamLog {
      * @param fh      The file handle to use.
      * @param address The address of the entry.
      * @param entry   The LogUnitEntry to append.
+     * @return Returns metadata for the written record
      */
-    private void writeRecord(SegmentHandle fh, long address, LogData entry) throws IOException {
+    private AddressMetaData writeRecord(SegmentHandle fh, long address, LogData entry) throws IOException {
         LogEntry logEntry = getLogEntry(address, entry);
+        Metadata metadata = getMetadata(logEntry);
 
-        ByteBuffer record = getByteBufferWithMetaData(logEntry);
+        ByteBuffer record = getByteBuffer(metadata, logEntry);
 
         ByteBuffer recordBuf = ByteBuffer.allocate(Short.BYTES // Delimiter
                 + record.capacity());
@@ -673,10 +705,15 @@ public class StreamLogFiles implements StreamLog {
         recordBuf.put(record.array());
         recordBuf.flip();
 
+        long channelOffset;
+
         synchronized (fh.lock) {
+            channelOffset = fh.logChannel.position() + Short.BYTES + METADATA_SIZE;
             fh.logChannel.write(recordBuf);
             channelsToSync.add(fh.logChannel);
         }
+
+        return new AddressMetaData(metadata.getChecksum(), metadata.getLength(), channelOffset);
     }
 
     @Override
@@ -686,12 +723,12 @@ public class StreamLogFiles implements StreamLog {
             // make sure the entry doesn't currently exist...
             // (probably need a faster way to do this - high watermark?)
             SegmentHandle fh = getSegmentHandleForAddress(logAddress);
-            if (fh.getKnownAddresses().contains(logAddress.address) ||
+            if (fh.getKnownAddresses().containsKey(logAddress.address) ||
                     fh.getTrimmedAddresses().contains(logAddress.address)) {
                 throw new OverwriteException();
             } else {
-                writeRecord(fh, logAddress.address, entry);
-                fh.getKnownAddresses().add(logAddress.address);
+                AddressMetaData addressMetaData = writeRecord(fh, logAddress.address, entry);
+                fh.getKnownAddresses().put(logAddress.address, addressMetaData);
             }
             log.trace("Disk_write[{}]: Written to disk.", logAddress);
         } catch (IOException e) {
@@ -704,18 +741,18 @@ public class StreamLogFiles implements StreamLog {
     public LogData read(LogAddress logAddress) {
         try {
             SegmentHandle sh = getSegmentHandleForAddress(logAddress);
-            if(sh.getPendingTrims().contains(logAddress.getAddress())){
+            if (sh.getPendingTrims().contains(logAddress.getAddress())) {
                 throw new TrimmedException();
             }
-            return readRecord(sh,logAddress.address);
+            return readRecord(sh, logAddress.address);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
     /**
-     *  A SegmentHandle is a range view of consecutive addresses in the log. It contains
-     *  the address space along with metadata like addresses that are trimmed and pending trims.
+     * A SegmentHandle is a range view of consecutive addresses in the log. It contains
+     * the address space along with metadata like addresses that are trimmed and pending trims.
      */
     @Data
     class SegmentHandle {
@@ -727,7 +764,7 @@ public class StreamLogFiles implements StreamLog {
         private FileChannel pendingTrimChannel;
         @NonNull
         private String fileName;
-        private Set<Long> knownAddresses = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        private Map<Long, AddressMetaData> knownAddresses = new ConcurrentHashMap();
         private Set<Long> trimmedAddresses = Collections.newSetFromMap(new ConcurrentHashMap<>());
         private Set<Long> pendingTrims = Collections.newSetFromMap(new ConcurrentHashMap<>());
         private final Lock lock = new ReentrantLock();

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -289,7 +289,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         assertThat(sh.getKnownAddresses().size()).isEqualTo(logChunk);
 
         for (long x = logChunk; x < logChunk * 2; x++) {
-            assertThat(sh.getKnownAddresses().contains(x)).isTrue();
+            assertThat(sh.getKnownAddresses().get(x)).isNotNull();
         }
 
         // Verify that the trimmed addresses cannot be written to or read from after compaction


### PR DESCRIPTION
When a segment is opened its address space is read into memory
along with the file offsets that correspond to log entries.
As a consequence, record reads do not linearly scan the log
file anymore, instead the record is directly read from
the log file using its offset.