### PR TITLE
Sequencer Failover

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -3,7 +3,6 @@ package org.corfudb.infrastructure;
 import com.github.benmanes.caffeine.cache.CacheWriter;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.log.LogAddress;
 import org.corfudb.infrastructure.log.StreamLog;
@@ -34,12 +33,6 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
             .setDaemon(false)
             .setNameFormat("LogUnit-Write-Processor-%d")
             .build());
-
-    /**
-     * Maintain the max globalAddress we have written.
-     */
-    @Getter
-    private long maxAddressGlobalTail = 0L;
 
     public BatchWriter(StreamLog streamLog) {
         this.streamLog = streamLog;
@@ -130,8 +123,6 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                         streamLog.append(currOp.getLogAddress(), currOp.getLogData());
                         currOp.setException(null);
                         res.add(currOp);
-                        long globalAddress = currOp.getLogAddress().getAddress();
-                        maxAddressGlobalTail = maxAddressGlobalTail < globalAddress ? globalAddress : maxAddressGlobalTail;
                     } catch (OverwriteException e) {
                         currOp.setException(new OverwriteException());
                         res.add(currOp);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -123,8 +123,8 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                         streamLog.append(currOp.getLogAddress(), currOp.getLogData());
                         currOp.setException(null);
                         res.add(currOp);
-                    } catch (OverwriteException e) {
-                        currOp.setException(new OverwriteException());
+                    } catch (OverwriteException | DataOutrankedException e) {
+                        currOp.setException(e);
                         res.add(currOp);
                     } catch (Exception e) {
                         currOp.setException(e);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure;
 import com.github.benmanes.caffeine.cache.CacheWriter;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.log.LogAddress;
 import org.corfudb.infrastructure.log.StreamLog;
@@ -33,6 +34,12 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
             .setDaemon(false)
             .setNameFormat("LogUnit-Write-Processor-%d")
             .build());
+
+    /**
+     * Maintain the max globalAddress we have written.
+     */
+    @Getter
+    private long maxAddressGlobalTail = 0L;
 
     public BatchWriter(StreamLog streamLog) {
         this.streamLog = streamLog;
@@ -123,8 +130,10 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                         streamLog.append(currOp.getLogAddress(), currOp.getLogData());
                         currOp.setException(null);
                         res.add(currOp);
-                    } catch (OverwriteException | DataOutrankedException e) {
-                        currOp.setException(e);
+                        long globalAddress = currOp.getLogAddress().getAddress();
+                        maxAddressGlobalTail = maxAddressGlobalTail < globalAddress ? globalAddress : maxAddressGlobalTail;
+                    } catch (OverwriteException e) {
+                        currOp.setException(new OverwriteException());
                         res.add(currOp);
                     } catch (Exception e) {
                         currOp.setException(e);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ConservativeFailureHandlerPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ConservativeFailureHandlerPolicy.java
@@ -1,0 +1,39 @@
+package org.corfudb.infrastructure;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.LayoutModificationException;
+import org.corfudb.runtime.view.Layout;
+
+import java.util.Set;
+
+/**
+ * Conserves the failures.
+ * <p>
+ * Created by zlokhandwala on 11/21/16.
+ */
+public class ConservativeFailureHandlerPolicy implements IFailureHandlerPolicy {
+
+    /**
+     * Modifies the layout by marking the failed nodes as unresponsive but still keeping them in
+     * the layout.
+     *
+     * @param originalLayout Original Layout which needs to be modified.
+     * @param corfuRuntime   Connected runtime to attach to the new layout.
+     * @param failedNodes    Set of all failed/defected servers.
+     * @return The new and modified layout.
+     * @throws LayoutModificationException Thrown if attempt to create an invalid layout.
+     * @throws CloneNotSupportedException  Clone not supported for layout.
+     */
+    @Override
+    public Layout generateLayout(Layout originalLayout, CorfuRuntime corfuRuntime, Set<String> failedNodes)
+            throws LayoutModificationException, CloneNotSupportedException {
+        LayoutWorkflowManager layoutManager = new LayoutWorkflowManager(originalLayout);
+        Layout newLayout = layoutManager
+                .moveResponsiveSequencerToTop(failedNodes)
+                .addUnresponsiveServers(failedNodes)
+                .build();
+        newLayout.setRuntime(corfuRuntime);
+        newLayout.setEpoch(newLayout.getEpoch() + 1);
+        return newLayout;
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/FailureHandlerDispatcher.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/FailureHandlerDispatcher.java
@@ -87,7 +87,8 @@ public class FailureHandlerDispatcher {
      * @param originalLayout Current layout to get the latest state of servers.
      * @param newLayout      New Layout to be reconfigured.
      */
-    private void reconfigureServers(CorfuRuntime runtime, Layout originalLayout, Layout newLayout) {
+    private void reconfigureServers(CorfuRuntime runtime, Layout originalLayout, Layout newLayout)
+            throws ExecutionException {
 
         // Reconfigure the primary Sequencer Server if changed.
         reconfigureSequencerServers(runtime, originalLayout, newLayout);
@@ -105,7 +106,8 @@ public class FailureHandlerDispatcher {
      * @param originalLayout    Current layout to get the latest state of servers.
      * @param newLayout         New Layout to be reconfigured.
      */
-    private void reconfigureSequencerServers(CorfuRuntime runtime, Layout originalLayout, Layout newLayout) {
+    private void reconfigureSequencerServers(CorfuRuntime runtime, Layout originalLayout, Layout newLayout)
+            throws ExecutionException {
 
         // Reconfigure Primary Sequencer if required
         if (!originalLayout.getSequencers().get(0).equals(newLayout.getSequencers().get(0))) {
@@ -128,8 +130,8 @@ public class FailureHandlerDispatcher {
             try {
                 // Configuring the new sequencer.
                 newLayout.getSequencer(0).reset(maxTokenRequested + 1).get();
-            } catch (InterruptedException | ExecutionException e) {
-                e.printStackTrace();
+            } catch (InterruptedException e) {
+                log.error("Sequencer Reset interrupted : {}", e);
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/FailureHandlerDispatcher.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/FailureHandlerDispatcher.java
@@ -2,11 +2,13 @@ package org.corfudb.infrastructure;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.view.Layout;
 
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 
 /**
  * The FailureHandlerDispatcher handles the trigger provided by any source
@@ -43,6 +45,9 @@ public class FailureHandlerDispatcher {
             currentLayout.setRuntime(corfuRuntime);
             sealEpoch(currentLayout);
 
+            // Reconfigure servers if required
+            reconfigureServers(corfuRuntime, currentLayout, newLayout);
+
             // Attempts to update all the layout servers with the modified layout.
             try {
                 corfuRuntime.getLayoutView().updateLayout(newLayout, prepareRank);
@@ -73,5 +78,59 @@ public class FailureHandlerDispatcher {
     private void sealEpoch(Layout layout) throws QuorumUnreachableException {
         layout.setEpoch(layout.getEpoch() + 1);
         layout.moveServersToEpoch();
+    }
+
+    /**
+     * Reconfigures the servers in the new layout if reconfiguration required.
+     *
+     * @param runtime        Runtime to reconfigure new servers.
+     * @param originalLayout Current layout to get the latest state of servers.
+     * @param newLayout      New Layout to be reconfigured.
+     */
+    private void reconfigureServers(CorfuRuntime runtime, Layout originalLayout, Layout newLayout) {
+
+        // Reconfigure the primary Sequencer Server if changed.
+        reconfigureSequencerServers(runtime, originalLayout, newLayout);
+
+        // TODO: Reconfigure log units if new log unit added.
+    }
+
+    /**
+     * Reconfigures the sequencer.
+     * If the primary sequencer has changed in the new layout,
+     * the global tail of the log units are queried and used to set
+     * the initial token of the new primary sequencer.
+     *
+     * @param runtime           Runtime to reconfigure new servers.
+     * @param originalLayout    Current layout to get the latest state of servers.
+     * @param newLayout         New Layout to be reconfigured.
+     */
+    private void reconfigureSequencerServers(CorfuRuntime runtime, Layout originalLayout, Layout newLayout) {
+
+        // Reconfigure Primary Sequencer if required
+        if (!originalLayout.getSequencers().get(0).equals(newLayout.getSequencers().get(0))) {
+            long maxTokenRequested = 0;
+            for (Layout.LayoutSegment segment : originalLayout.getSegments()) {
+                // Query the tail of every log unit in every stripe.
+                for (Layout.LayoutStripe stripe : segment.getStripes()) {
+                    for (String logServer : stripe.getLogServers()) {
+                        try {
+                            long tail = runtime.getRouter(logServer).getClient(LogUnitClient.class).getTail().get();
+                            if (tail != 0) {
+                                maxTokenRequested = maxTokenRequested > tail ? maxTokenRequested : tail;
+                            }
+                        } catch (Exception e) {
+                            log.error("Exception while fetching log unit tail : {}", e);
+                        }
+                    }
+                }
+            }
+            try {
+                // Configuring the new sequencer.
+                newLayout.getSequencer(0).reset(maxTokenRequested + 1).get();
+            } catch (InterruptedException | ExecutionException e) {
+                e.printStackTrace();
+            }
+        }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -188,7 +188,7 @@ public class LayoutServer extends AbstractServer {
         long serverEpoch = getServerEpoch();
         if (msg.getPayload().getEpoch() != serverEpoch) {
             r.sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
-            log.trace("Incoming message with wrong epoch, got {}, expected {}, message was: {}", msg.getEpoch(), serverEpoch, msg);
+            log.trace("Incoming message with wrong epoch, got {}, expected {}, message was: {}", msg.getPayload().getEpoch(), serverEpoch, msg);
             return;
         }
 
@@ -225,7 +225,7 @@ public class LayoutServer extends AbstractServer {
 
         if (msg.getPayload().getEpoch() != serverEpoch) {
             r.sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
-            log.trace("Incoming message with wrong epoch, got {}, expected {}, message was: {}", proposeLayout.getEpoch(), serverEpoch, msg);
+            log.trace("Incoming message with wrong epoch, got {}, expected {}, message was: {}", msg.getPayload().getEpoch(), serverEpoch, msg);
             return;
         }
         // This is a propose. If no prepare, reject.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutWorkflowManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutWorkflowManager.java
@@ -36,6 +36,19 @@ public class LayoutWorkflowManager {
     }
 
     /**
+     * Adds unresponsive servers in the list.
+     *
+     * @param endpoints Endpoints to be added.
+     * @return
+     */
+    public LayoutWorkflowManager addUnresponsiveServers(Set<String> endpoints) {
+        List<String> unresponsiveServers = layout.getUnresponsiveServers();
+        unresponsiveServers.clear();
+        endpoints.forEach(unresponsiveServers::add);
+        return this;
+    }
+
+    /**
      * Removes the Layout Server passed
      *
      * @param endpoint Endpoint to be removed
@@ -83,6 +96,30 @@ public class LayoutWorkflowManager {
         }
         layout.getLayoutServers().retainAll(modifiedLayoutServers);
         return this;
+    }
+
+    /**
+     * Moves a responsive server to the top of the sequencer server list.
+     * If all have failed, throws exception.
+     *
+     * @param endpoints Failed endpoints.
+     * @return LayoutWorkflowManager
+     * @throws LayoutModificationException throws if no working sequencer left.
+     */
+    public LayoutWorkflowManager moveResponsiveSequencerToTop(Set<String> endpoints)
+            throws LayoutModificationException {
+
+        List<String> modifiedSequencerServers = new ArrayList<>(layout.getSequencers());
+        for (int i = 0; i < modifiedSequencerServers.size(); i++) {
+            String sequencerServer = modifiedSequencerServers.get(i);
+            if (!endpoints.contains(sequencerServer)) {
+                modifiedSequencerServers.remove(sequencerServer);
+                modifiedSequencerServers.add(0, sequencerServer);
+                layout.setSequencers(modifiedSequencerServers);
+                return this;
+            }
+        }
+        throw new LayoutModificationException("All sequencers failed.");
     }
 
     /**
@@ -216,6 +253,7 @@ public class LayoutWorkflowManager {
                 layout.getLayoutServers(),
                 layout.getSequencers(),
                 layout.getSegments(),
+                layout.getUnresponsiveServers(),
                 this.epoch);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 import com.codahale.metrics.MetricRegistry;
@@ -73,6 +74,11 @@ public class LogUnitServer extends AbstractServer {
     private AtomicBoolean running = new AtomicBoolean(true);
 
     /**
+     * Maintain the max globalAddress we have written.
+     */
+    private AtomicLong maxAddressGlobalTail = new AtomicLong(0L);
+
+    /**
      * The options map.
      */
     private final Map<String, Object> opts;
@@ -137,7 +143,7 @@ public class LogUnitServer extends AbstractServer {
      */
     @ServerHandler(type = CorfuMsgType.TAIL_REQUEST, opTimer = metricsPrefix + "tailReq")
     public void handleTailRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r, boolean isMetricsEnabled) {
-        r.sendResponse(ctx, msg, CorfuMsgType.TAIL_RESPONSE.payloadMsg(batchWriter.getMaxAddressGlobalTail()));
+        r.sendResponse(ctx, msg, CorfuMsgType.TAIL_RESPONSE.payloadMsg(maxAddressGlobalTail.get()));
     }
 
     /**
@@ -155,7 +161,6 @@ public class LogUnitServer extends AbstractServer {
             if (msg.getPayload().getWriteMode() != WriteMode.REPLEX_STREAM) {
                 dataCache.put(new LogAddress(msg.getPayload().getGlobalAddress(), null), msg.getPayload().getData());
                 r.sendResponse(ctx, msg, CorfuMsgType.WRITE_OK.msg());
-                return;
             } else {
                 for (UUID streamID : msg.getPayload().getStreamAddresses().keySet()) {
                     dataCache.put(new LogAddress(msg.getPayload().getStreamAddresses().get(streamID), streamID),
@@ -163,6 +168,8 @@ public class LogUnitServer extends AbstractServer {
                 }
                 r.sendResponse(ctx, msg, CorfuMsgType.WRITE_OK.msg());
             }
+            long globalTail = msg.getPayload().getGlobalAddress();
+            maxAddressGlobalTail.getAndUpdate(maxTail -> globalTail > maxTail ? globalTail : maxTail);
         } catch (OverwriteException ex) {
             if (msg.getPayload().getWriteMode() != WriteMode.REPLEX_STREAM) {
                 r.sendResponse(ctx, msg, CorfuMsgType.ERROR_OVERWRITE.msg());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -132,6 +132,15 @@ public class LogUnitServer extends AbstractServer {
     }
 
     /**
+     * Service an incoming request for maximum global address the log unit server has written.
+     * This value is not persisted and only maintained in memory.
+     */
+    @ServerHandler(type = CorfuMsgType.TAIL_REQUEST, opTimer = metricsPrefix + "tailReq")
+    public void handleTailRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r, boolean isMetricsEnabled) {
+        r.sendResponse(ctx, msg, CorfuMsgType.TAIL_RESPONSE.payloadMsg(batchWriter.getMaxAddressGlobalTail()));
+    }
+
+    /**
      * Service an incoming write request.
      */
     @ServerHandler(type = CorfuMsgType.WRITE, opTimer = metricsPrefix + "write")

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -415,6 +415,7 @@ public class ManagementServer extends AbstractServer {
                 // unresponsive in the layout. If yes take no action. Else trigger handler.
                 log.info("Failures detected. Failed nodes : {}", pollReport.toString());
                 // Check if this failure has already been recognized.
+                //TODO: Does not handle the un-marking case where markedSet is a superset of pollFailures.
                 for (String failedServer : pollReport.getFailingNodes()) {
                     if (!latestLayout.getUnresponsiveServers().contains(failedServer)) {
                         localManagementClient.handleFailure(pollReport.getFailingNodes()).get();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -15,8 +15,12 @@ import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Utils;
 
 import java.lang.invoke.MethodHandles;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -256,7 +260,7 @@ public class SequencerServer extends AbstractServer {
         long responseGlobalTail = (req.getStreams().size() == 0) ? globalLogTail.get() - 1 : maxStreamGlobalTails;
         r.sendResponse(ctx, msg, CorfuMsgType.TOKEN_RES.payloadMsg(
                 new TokenResponse(TokenType.NORMAL,
-                        responseGlobalTail, Collections.emptyMap(), responseStreamTails.build())));
+                        responseGlobalTail, Collections.emptyMap(), responseStreamTails.build(), -1L)));
     }
 
     /**
@@ -312,7 +316,8 @@ public class SequencerServer extends AbstractServer {
         if (req.getReqType() == TokenRequest.TK_RAW) {
             r.sendResponse(ctx, msg, CorfuMsgType.TOKEN_RES.payloadMsg(
                     new TokenResponse(TokenType.NORMAL,
-                            globalLogTail.getAndAdd(req.getNumTokens()), Collections.emptyMap(), Collections.emptyMap())));
+                            globalLogTail.getAndAdd(req.getNumTokens()), Collections.emptyMap(), Collections.emptyMap(),
+                            -1L)));
             return;
         }
 
@@ -326,7 +331,7 @@ public class SequencerServer extends AbstractServer {
                 // If the txn aborts, then DO NOT hand out a token.
                 r.sendResponse(ctx, msg, CorfuMsgType.TOKEN_RES.payloadMsg(
                         new TokenResponse(tokenType,
-                                -1L, Collections.emptyMap(), Collections.emptyMap())));
+                                -1L, Collections.emptyMap(), Collections.emptyMap(), -1L)));
                 return;
             }
         }
@@ -395,6 +400,7 @@ public class SequencerServer extends AbstractServer {
                 new TokenResponse(TokenType.NORMAL,
                         currentTail,
                         backPointerMap.build(),
-                        requestStreamTokens.build())));
+                        requestStreamTokens.build(),
+                        -1L)));
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -251,6 +251,18 @@ public class SequencerServer extends AbstractServer {
     }
 
     /**
+     * Service an incoming request to reset the sequencer.
+     */
+    @ServerHandler(type=CorfuMsgType.RESET_SEQUENCER, opTimer=metricsPrefix + "reset")
+    public synchronized void resetServer(CorfuPayloadMsg<Long> msg, ChannelHandlerContext ctx, IServerRouter r,
+                                         boolean isMetricsEnabled) {
+        long initialToken = msg.getPayload();
+        globalLogTail.set(initialToken);
+        log.info("Sequencer reset with token = {}", initialToken);
+        r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
+    }
+
+    /**
      * Service an incoming token request.
      */
     @ServerHandler(type=CorfuMsgType.TOKEN_REQ, opTimer=metricsPrefix + "token-req")

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -66,7 +66,7 @@ public class ServerContext {
         this.dataStore = new DataStore(serverConfig);
         this.serverRouter = serverRouter;
         this.failureDetectorPolicy = new PeriodicPollPolicy();
-        this.failureHandlerPolicy = new PurgeFailurePolicy();
+        this.failureHandlerPolicy = new ConservativeFailureHandlerPolicy();
 
         // Metrics setup & reporting configuration
         String mp = "corfu.server.";

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -43,6 +43,7 @@ public enum CorfuMsgType {
     // Sequencer Messages
     TOKEN_REQ(20, new TypeToken<CorfuPayloadMsg<TokenRequest>>(){}),
     TOKEN_RES(21, new TypeToken<CorfuPayloadMsg<TokenResponse>>(){}),
+    RESET_SEQUENCER(22, new TypeToken<CorfuPayloadMsg<Long>>(){}),
 
     // Logging Unit Messages
     WRITE(30, new TypeToken<CorfuPayloadMsg<WriteRequest>>() {}),
@@ -54,6 +55,8 @@ public enum CorfuMsgType {
     GC_INTERVAL(36, new TypeToken<CorfuPayloadMsg<Long>>() {}),
     FORCE_COMPACT(37, TypeToken.of(CorfuMsg.class)),
     COMMIT(40, new TypeToken<CorfuPayloadMsg<CommitRequest>>() {}),
+    TAIL_REQUEST(41, TypeToken.of(CorfuMsg.class), true),
+    TAIL_RESPONSE(42, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
 
     WRITE_OK(50, TypeToken.of(CorfuMsg.class)),
     ERROR_TRIMMED(51, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/Token.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/Token.java
@@ -1,0 +1,19 @@
+package org.corfudb.protocols.wireprotocol;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Token returned by the sequencer is a combination of the
+ * sequence number and the epoch at which it was acquired.
+ * <p>
+ * Created by zlokhandwala on 4/7/17.
+ */
+@Data
+@AllArgsConstructor
+public class Token {
+
+    private final Long tokenValue;
+    private final Long epoch;
+
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -19,7 +19,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse> {
 
     /** The current token,
      * or overload with "cause address" in case token request is denied. */
-    final Long token;
+    final Token token;
 
     /** The backpointer map, if available. */
     final Map<UUID, Long> backpointerMap;
@@ -27,12 +27,11 @@ public class TokenResponse implements ICorfuPayload<TokenResponse> {
     /** The map of local stream addresses. */
     final Map<UUID, Long> streamAddresses;
 
-    /** The epoch while receiving this token response. */
-    long epoch;
-
     public TokenResponse(ByteBuf buf) {
         respType = TokenType.values()[ICorfuPayload.fromBuffer(buf, Byte.class)];
-        token = ICorfuPayload.fromBuffer(buf, Long.class);
+        Long tokenValue = ICorfuPayload.fromBuffer(buf, Long.class);
+        Long epoch = ICorfuPayload.fromBuffer(buf, Long.class);
+        token = new Token(tokenValue, epoch);
         backpointerMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
         streamAddresses = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
     }
@@ -40,7 +39,8 @@ public class TokenResponse implements ICorfuPayload<TokenResponse> {
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, respType);
-        ICorfuPayload.serialize(buf, token);
+        ICorfuPayload.serialize(buf, token.getTokenValue());
+        ICorfuPayload.serialize(buf, token.getEpoch());
         ICorfuPayload.serialize(buf, backpointerMap);
         ICorfuPayload.serialize(buf, streamAddresses);
     }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -27,6 +27,9 @@ public class TokenResponse implements ICorfuPayload<TokenResponse> {
     /** The map of local stream addresses. */
     final Map<UUID, Long> streamAddresses;
 
+    /** The epoch while receiving this token response. */
+    long epoch;
+
     public TokenResponse(ByteBuf buf) {
         respType = TokenType.values()[ICorfuPayload.fromBuffer(buf, Byte.class)];
         token = ICorfuPayload.fromBuffer(buf, Long.class);

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -186,6 +186,18 @@ public class LogUnitClient implements IClient {
     }
 
     /**
+     * Handle a TAIL_RESPONSE message
+     * @param msg   Incoming Message
+     * @param ctx   Context
+     * @param r     Router
+     */
+    @ClientHandler(type=CorfuMsgType.TAIL_RESPONSE)
+    private static Object handleTailResponse(CorfuPayloadMsg<Long> msg,
+                                             ChannelHandlerContext ctx, IClientRouter r) {
+        return msg.getPayload();
+    }
+
+    /**
      * Asynchronously write to the logging unit.
      *
      * @param address        The address to write to.
@@ -314,6 +326,15 @@ public class LogUnitClient implements IClient {
         CompletableFuture<ReadResponse> cf = router.sendMessageAndGetCompletable(
                 CorfuMsgType.READ_REQUEST.payloadMsg(new ReadRequest(offsetRange, stream)));
         return cf.thenApply(x -> { context.stop(); return x; });
+    }
+
+    /**
+     * Get the global tail maximum address the log unit has written.
+     * @return A CompletableFuture which will complete with the globalTail once
+     * received.
+     */
+    public CompletableFuture<Long> getTail() {
+        return router.sendMessageAndGetCompletable(CorfuMsgType.TAIL_REQUEST.msg());
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -36,7 +36,6 @@ public class SequencerClient implements IClient {
     @ClientHandler(type=CorfuMsgType.TOKEN_RES)
     private static Object handleTokenResponse(CorfuPayloadMsg<TokenResponse> msg,
                                                 ChannelHandlerContext ctx, IClientRouter r) {
-        msg.getPayload().setEpoch(msg.getEpoch());
         return msg.getPayload();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -1,15 +1,11 @@
 package org.corfudb.runtime.clients;
 
-import com.google.common.collect.ImmutableSet;
 import io.netty.channel.ChannelHandlerContext;
-import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import org.corfudb.protocols.wireprotocol.*;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -49,4 +45,12 @@ public class SequencerClient implements IClient {
                 CorfuMsgType.TOKEN_REQ.payloadMsg(new TokenRequest(numTokens, streamIDs, conflictInfo)));
     }
 
+    /**
+     * Resets the sequencer with the specified initialToken
+     * @param initialToken  Token Number which the sequencer starts distributing.
+     * @return A CompletableFuture which completes once the sequencer is reset.
+     */
+    public CompletableFuture<Boolean> reset(Long initialToken) {
+        return router.sendMessageAndGetCompletable(CorfuMsgType.RESET_SEQUENCER.payloadMsg(initialToken));
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -3,7 +3,11 @@ package org.corfudb.runtime.clients;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
 import lombok.Setter;
-import org.corfudb.protocols.wireprotocol.*;
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
+import org.corfudb.protocols.wireprotocol.TokenRequest;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Set;
@@ -32,6 +36,7 @@ public class SequencerClient implements IClient {
     @ClientHandler(type=CorfuMsgType.TOKEN_RES)
     private static Object handleTokenResponse(CorfuPayloadMsg<TokenResponse> msg,
                                                 ChannelHandlerContext ctx, IClientRouter r) {
+        msg.getPayload().setEpoch(msg.getEpoch());
         return msg.getPayload();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -137,7 +137,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         // Linearize this read against a timestamp
         final long timestamp =
                 rt.getSequencerView()
-                .nextToken(Collections.singleton(streamID), 0).getToken();
+                .nextToken(Collections.singleton(streamID), 0).getToken().getTokenValue();
         log.debug("Access[{}] conflictObj={} version={}", this, conflictObject, timestamp);
 
         // Perform underlying access
@@ -197,7 +197,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         // Linearize this read against a timestamp
         final long timestamp =
                 rt.getSequencerView()
-                        .nextToken(Collections.singleton(streamID), 0).getToken();
+                        .nextToken(Collections.singleton(streamID), 0).getToken().getTokenValue();
 
         log.debug("Sync[{}] {}", this, timestamp);
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuObjectProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuObjectProxy.java
@@ -122,7 +122,7 @@ public class CorfuObjectProxy<P> {
             if (!method.getReturnType().getName().equals("void")) {
                 CompletableFuture cf = new CompletableFuture();
                 long txAddr = runtime.getStreamsView().acquireAndWrite(affectedStreams, tlre, t -> {
-                    runtime.getObjectsView().getTxFuturesMap().put(t.getToken(), cf);
+                    runtime.getObjectsView().getTxFuturesMap().put(t.getToken().getTokenValue(), cf);
                     return true;
                 }, t -> {
                     runtime.getObjectsView().getTxFuturesMap().remove(t.getToken());

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuSMRObjectProxy.java
@@ -297,7 +297,7 @@ public class CorfuSMRObjectProxy<P> extends CorfuObjectProxy<P> {
         log.trace("Write update and map future: {} with arguments {}", method, arguments);
         return sv.append(new SMREntry(method, arguments, serializer),
                 t -> {
-                    completableFutureMap.put(t.getToken(), new CompletableFuture<>());
+                    completableFutureMap.put(t.getToken().getTokenValue(), new CompletableFuture<>());
                     return true;
                 },
                 t -> {

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -295,7 +295,7 @@ public class VersionLockedObject<T> {
     public long logUpdate(SMREntry entry, boolean saveUpcall) {
         return smrStream.append(entry, t -> {
             if (saveUpcall) {
-                pendingUpcalls.add(t.getToken());
+                pendingUpcalls.add(t.getToken().getTokenValue());
             }
             return true;
         }, t -> {

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -385,7 +385,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
             // Otherwise, fetch a read token from the sequencer the linearize
             // ourselves against.
             long currentTail = builder.runtime
-                    .getSequencerView().nextToken(Collections.emptySet(), 0).getToken();
+                    .getSequencerView().nextToken(Collections.emptySet(), 0).getToken().getTokenValue();
             log.trace("SnapshotTimestamp[{}] {}", this, currentTail);
             return currentTail;
         }

--- a/runtime/src/main/java/org/corfudb/runtime/view/MultiStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/MultiStreamView.java
@@ -63,7 +63,8 @@ public class MultiStreamView {
         while (!written) {
             TokenResponse tokenResponse =
                     runtime.getSequencerView().nextToken(Collections.singleton(destination), 1);
-            if (!tokenResponse.getBackpointerMap().get(destination).equals(-1L)) {
+            if (tokenResponse.getBackpointerMap().get(destination) != null &&
+                    !tokenResponse.getBackpointerMap().get(destination).equals(-1L)) {
                 try {
                     runtime.getAddressSpaceView().fillHole(tokenResponse.getToken().getTokenValue());
                 } catch (OverwriteException oe) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/MultiStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/MultiStreamView.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.view;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.IDivisibleEntry;
 import org.corfudb.protocols.logprotocol.StreamCOWEntry;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TokenType;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
@@ -64,7 +65,7 @@ public class MultiStreamView {
                     runtime.getSequencerView().nextToken(Collections.singleton(destination), 1);
             if (!tokenResponse.getBackpointerMap().get(destination).equals(-1L)) {
                 try {
-                    runtime.getAddressSpaceView().fillHole(tokenResponse.getToken());
+                    runtime.getAddressSpaceView().fillHole(tokenResponse.getToken().getTokenValue());
                 } catch (OverwriteException oe) {
                     log.trace("Attempted to hole fill due to already-existing stream but hole filled by other party");
                 }
@@ -72,9 +73,8 @@ public class MultiStreamView {
             }
             StreamCOWEntry entry = new StreamCOWEntry(source, timestamp);
             try {
-                runtime.getAddressSpaceView().epochedWrite(tokenResponse.getToken(), Collections.singleton(destination),
-                        entry, tokenResponse.getBackpointerMap(), tokenResponse.getStreamAddresses(),
-                        tokenResponse.getEpoch());
+                runtime.getAddressSpaceView().write(tokenResponse.getToken(), Collections.singleton(destination),
+                        entry, tokenResponse.getBackpointerMap(), tokenResponse.getStreamAddresses());
                 written = true;
             } catch (OverwriteException oe) {
                 log.debug("hole fill during COW entry append, retrying...");
@@ -102,9 +102,8 @@ public class MultiStreamView {
     public void writeAt(TokenResponse address, Set<UUID> streamIDs, Object object) throws OverwriteException {
         Function<UUID, Object> partialEntryFunction =
                 object instanceof IDivisibleEntry ? ((IDivisibleEntry)object)::divideEntry : null;
-        runtime.getAddressSpaceView().epochedWrite(address.getToken(), streamIDs,
-                object, address.getBackpointerMap(), address.getStreamAddresses(), partialEntryFunction,
-                address.getEpoch());
+        runtime.getAddressSpaceView().write(address.getToken(), streamIDs,
+                object, address.getBackpointerMap(), address.getStreamAddresses(), partialEntryFunction);
     }
 
     /**
@@ -136,18 +135,18 @@ public class MultiStreamView {
         TokenResponse tokenResponse = null;
         while (true) {
             if (conflictInfo != null) {
-                long token;
+                Token token;
                 if (overwrite) {
 
                     // on retry, check for conflicts only from the previous
                     // attempt position
-                    conflictInfo.setSnapshotTimestamp(tokenResponse.getToken());
+                    conflictInfo.setSnapshotTimestamp(tokenResponse.getToken().getTokenValue());
 
                     TokenResponse temp =
                             runtime.getSequencerView().nextToken(streamIDs, 1, conflictInfo);
                     token = temp.getToken();
-                    tokenResponse = new TokenResponse(temp.getRespType(), token, temp.getBackpointerMap(), tokenResponse.getStreamAddresses(),
-                            temp.getEpoch());
+                    tokenResponse = new TokenResponse(temp.getRespType(), token, temp.getBackpointerMap(),
+                            tokenResponse.getStreamAddresses());
                 } else {
                     tokenResponse =
                             runtime.getSequencerView().nextToken(streamIDs, 1,  conflictInfo);
@@ -158,14 +157,14 @@ public class MultiStreamView {
                     if (!acquisitionCallback.apply(tokenResponse)) {
                         log.trace("Acquisition rejected token, hole filling acquired address.");
                         try {
-                            runtime.getAddressSpaceView().fillHole(token);
+                            runtime.getAddressSpaceView().fillHole(token.getTokenValue());
                         } catch (OverwriteException oe) {
                             log.trace("Hole fill completed by remote client.");
                         }
                         return -1L;
                     }
                 }
-                if (/* TODO: keeping for now; Remove: */ token == -1L ||
+                if (/* TODO: keeping for now; Remove: */ token.getTokenValue() == -1L ||
                         tokenResponse.getRespType() != TokenType.NORMAL) {
                     if (deacquisitionCallback != null && !deacquisitionCallback.apply(tokenResponse)) {
                         log.trace("Acquisition rejected overwrite at {}, not retrying.", token);
@@ -173,7 +172,7 @@ public class MultiStreamView {
 
                     if (tokenResponse.getRespType() == TokenType.TX_ABORT_CONFLICT)
                         throw new TransactionAbortedException(
-                                tokenResponse.getToken(),
+                                tokenResponse.getToken().getTokenValue(),
                                 AbortCause.CONFLICT
                     );
                     if (tokenResponse.getRespType() == TokenType.TX_ABORT_NEWSEQ)
@@ -186,10 +185,9 @@ public class MultiStreamView {
                     return -1L;
                 }
                 try {
-                    runtime.getAddressSpaceView().epochedWrite(token, streamIDs,
-                            object, tokenResponse.getBackpointerMap(), tokenResponse.getStreamAddresses(),
-                            tokenResponse.getEpoch());
-                    return token;
+                    runtime.getAddressSpaceView().write(token, streamIDs,
+                            object, tokenResponse.getBackpointerMap(), tokenResponse.getStreamAddresses());
+                    return token.getTokenValue();
                 } catch (ReplexOverwriteException re) {
                     if (deacquisitionCallback != null && !deacquisitionCallback.apply(tokenResponse)) {
                         log.trace("Acquisition rejected overwrite at {}, not retrying.", token);
@@ -205,13 +203,12 @@ public class MultiStreamView {
                     log.debug("Overwrite occurred at {}, retrying.", token);
                 }
             } else {
-                long token;
+                Token token;
                 if (overwrite) {
                     TokenResponse temp =
                             runtime.getSequencerView().nextToken(streamIDs, 1);
                     token = temp.getToken();
-                    tokenResponse = new TokenResponse(temp.getRespType(), token, temp.getBackpointerMap(), tokenResponse.getStreamAddresses(),
-                            temp.getEpoch());
+                    tokenResponse = new TokenResponse(temp.getRespType(), token, temp.getBackpointerMap(), tokenResponse.getStreamAddresses());
                 } else {
                     tokenResponse =
                             runtime.getSequencerView().nextToken(streamIDs, 1);
@@ -222,7 +219,7 @@ public class MultiStreamView {
                     if (!acquisitionCallback.apply(tokenResponse)) {
                         log.trace("Acquisition rejected token, hole filling acquired address.");
                         try {
-                            runtime.getAddressSpaceView().fillHole(token);
+                            runtime.getAddressSpaceView().fillHole(token.getTokenValue());
                         } catch (OverwriteException oe) {
                             log.trace("Hole fill completed by remote client.");
                         }
@@ -232,10 +229,9 @@ public class MultiStreamView {
                 try {
                     Function<UUID, Object> partialEntryFunction =
                             object instanceof IDivisibleEntry ? ((IDivisibleEntry)object)::divideEntry : null;
-                    runtime.getAddressSpaceView().epochedWrite(token, streamIDs,
-                            object, tokenResponse.getBackpointerMap(), tokenResponse.getStreamAddresses(), partialEntryFunction,
-                            tokenResponse.getEpoch());
-                    return token;
+                    runtime.getAddressSpaceView().write(token, streamIDs,
+                            object, tokenResponse.getBackpointerMap(), tokenResponse.getStreamAddresses(), partialEntryFunction);
+                    return token.getTokenValue();
                 } catch (ReplexOverwriteException re) {
                     if (deacquisitionCallback != null && !deacquisitionCallback.apply(tokenResponse)) {
                         log.trace("Acquisition rejected overwrite at {}, not retrying.", token);

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -69,11 +69,12 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             // to the client.
             try {
                 runtime.getAddressSpaceView()
-                        .write(tokenResponse.getToken(),
+                        .epochedWrite(tokenResponse.getToken(),
                                 Collections.singleton(ID),
                                 object,
                                 tokenResponse.getBackpointerMap(),
-                                tokenResponse.getStreamAddresses());
+                                tokenResponse.getStreamAddresses(),
+                                tokenResponse.getEpoch());
                 // The write completed successfully, so we return this
                 // address to the client.
                 return tokenResponse.getToken();

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -69,15 +69,14 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             // to the client.
             try {
                 runtime.getAddressSpaceView()
-                        .epochedWrite(tokenResponse.getToken(),
+                        .write(tokenResponse.getToken(),
                                 Collections.singleton(ID),
                                 object,
                                 tokenResponse.getBackpointerMap(),
-                                tokenResponse.getStreamAddresses(),
-                                tokenResponse.getEpoch());
+                                tokenResponse.getStreamAddresses());
                 // The write completed successfully, so we return this
                 // address to the client.
-                return tokenResponse.getToken();
+                return tokenResponse.getToken().getTokenValue();
             } catch (OverwriteException oe) {
                 log.trace("Overwrite occurred at {}", tokenResponse);
                 // We got overwritten, so we call the deacquisition callback
@@ -132,7 +131,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
     public boolean getHasNext(QueuedStreamContext context) {
         return  context.readQueue.isEmpty() ||
                 runtime.getSequencerView()
-                .nextToken(Collections.singleton(context.id), 0).getToken()
+                .nextToken(Collections.singleton(context.id), 0).getToken().getTokenValue()
                         > context.globalPointer;
     }
 
@@ -182,38 +181,38 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             return fillFromResolved(maxGlobal, context);
         }
 
-        Long latestToken = null;
+        Long latestTokenValue = null;
 
-        // If the max has bveen resolved, use it.
+        // If the max has been resolved, use it.
         if (maxGlobal != Address.MAX) {
-            latestToken = context.resolvedQueue.ceiling(maxGlobal);
+            latestTokenValue = context.resolvedQueue.ceiling(maxGlobal);
         }
 
         // If we don't have a larger token in resolved, or the request was for
         // a linearized read, fetch the token from the sequencer.
-        if (latestToken == null || maxGlobal == Address.MAX) {
-            latestToken = runtime.getSequencerView()
+        if (latestTokenValue == null || maxGlobal == Address.MAX) {
+            latestTokenValue = runtime.getSequencerView()
                     .nextToken(Collections.singleton(context.id), 0)
-                    .getToken();
+                    .getToken().getTokenValue();
         }
 
         // If the backpointer was unwritten, return, there is nothing to do
-        if (latestToken == Address.NEVER_READ) {
+        if (latestTokenValue == Address.NEVER_READ) {
             return false;
         }
 
         // If everything is available in the resolved
         // queue, use it
-        if (context.maxResolution > latestToken &&
+        if (context.maxResolution > latestTokenValue &&
                 context.minResolution < context.globalPointer) {
-            return fillFromResolved(latestToken, context);
+            return fillFromResolved(latestTokenValue, context);
         }
 
         // Now we start traversing backpointers, if they are available. We
         // start at the latest token and go backward, until we reach the
         // log pointer. For each address which is less than
         // maxGlobalAddress, we insert it into the read queue.
-        long currentRead = latestToken;
+        long currentRead = latestTokenValue;
 
         while (currentRead > context.globalPointer &&
                 currentRead != Address.NEVER_READ) {
@@ -287,7 +286,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             // queue, use it
             if (context.maxResolution > currentRead &&
                     context.minResolution < context.globalPointer) {
-                return fillFromResolved(latestToken, context);
+                return fillFromResolved(latestTokenValue, context);
             }
 
             // Now we calculate the next entry to read.

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/ReplexStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/ReplexStreamView.java
@@ -8,13 +8,10 @@ import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.OverwriteException;
-import org.corfudb.runtime.exceptions.ReplexOverwriteException;
 import org.corfudb.runtime.view.Address;
 
 import java.util.Collections;
-import java.util.NavigableSet;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.function.Function;
 
 /** A view of a stream implemented using Replex.
@@ -131,11 +128,12 @@ public class ReplexStreamView extends
             // to the client.
             try {
                 runtime.getAddressSpaceView()
-                        .write(tokenResponse.getToken(),
+                        .epochedWrite(tokenResponse.getToken(),
                                 Collections.singleton(ID),
                                 object,
                                 tokenResponse.getBackpointerMap(),
-                                tokenResponse.getStreamAddresses());
+                                tokenResponse.getStreamAddresses(),
+                                tokenResponse.getEpoch());
                 // The write completed successfully, so we return this
                 // address to the client.
                 return tokenResponse.getToken();

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/ReplexStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/ReplexStreamView.java
@@ -128,15 +128,14 @@ public class ReplexStreamView extends
             // to the client.
             try {
                 runtime.getAddressSpaceView()
-                        .epochedWrite(tokenResponse.getToken(),
+                        .write(tokenResponse.getToken(),
                                 Collections.singleton(ID),
                                 object,
                                 tokenResponse.getBackpointerMap(),
-                                tokenResponse.getStreamAddresses(),
-                                tokenResponse.getEpoch());
+                                tokenResponse.getStreamAddresses());
                 // The write completed successfully, so we return this
                 // address to the client.
-                return tokenResponse.getToken();
+                return tokenResponse.getToken().getTokenValue();
             }
             catch (OverwriteException oe) {
                 log.trace("Overwrite occurred at {}", tokenResponse);
@@ -320,7 +319,7 @@ public class ReplexStreamView extends
         return  context.knownStreamMax > context.streamPointer ||
                 runtime.getSequencerView()
                         .nextToken(Collections.singleton(context.id),
-                                0).getToken()
+                                0).getToken().getTokenValue()
                         > context.globalPointer;
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/TestLayoutBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestLayoutBuilder.java
@@ -17,6 +17,7 @@ public class TestLayoutBuilder {
 
     List<String> sequencerServers;
     List<String> layoutServers;
+    List<String> unresponsiveServers;
     List<TestSegmentBuilder> segments;
 
     @Getter
@@ -26,6 +27,7 @@ public class TestLayoutBuilder {
     public TestLayoutBuilder() {
         sequencerServers = new ArrayList<>();
         layoutServers = new ArrayList<>();
+        unresponsiveServers = new ArrayList<>();
         segments = new ArrayList<>();
     }
 
@@ -55,6 +57,11 @@ public class TestLayoutBuilder {
         return this;
     }
 
+    public TestLayoutBuilder addUnresponsiveServer(int port) {
+        unresponsiveServers.add(getEndpoint(port));
+        return this;
+    }
+
     private TestLayoutBuilder addSegment(TestSegmentBuilder builder) {
         segments.add(builder);
         return this;
@@ -72,6 +79,7 @@ public class TestLayoutBuilder {
         return new Layout(layoutServers,
                 sequencerServers,
                 segmentList,
+                unresponsiveServers,
                 epoch);
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -14,13 +14,10 @@ import org.corfudb.runtime.clients.TestChannelContext;
 import org.corfudb.runtime.clients.TestRule;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by mwei on 12/13/15.

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -34,7 +34,7 @@ public class SealIT {
         CorfuRuntime cr1 = new CorfuRuntime(layoutServers).connect();
         CorfuRuntime cr2 = new CorfuRuntime(layoutServers).connect();
 
-        Long beforeAddress = cr2.getSequencerView().nextToken(new HashSet<>(),1).getToken();
+        Long beforeAddress = cr2.getSequencerView().nextToken(new HashSet<>(),1).getToken().getTokenValue();
 
         /* We will trigger a Paxos round, this is what will happen:
          *   1. Set our layout (same than before) with a new Epoch
@@ -61,7 +61,7 @@ public class SealIT {
          *
          * These steps get cr2 in the new epoch.
          */
-        Long afterAddress = cr2.getSequencerView().nextToken(new HashSet<>(),1).getToken();
+        Long afterAddress = cr2.getSequencerView().nextToken(new HashSet<>(),1).getToken().getTokenValue();
         assertThat(cr2.getLayoutView().getCurrentLayout().getEpoch()).
             isEqualTo(cr1.getLayoutView().getCurrentLayout().getEpoch());
         assertThat(afterAddress).isEqualTo(beforeAddress+1);

--- a/test/src/test/java/org/corfudb/runtime/clients/SequencerClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/SequencerClientTest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import com.google.common.collect.ImmutableSet;
 import org.corfudb.infrastructure.AbstractServer;
 import org.corfudb.infrastructure.SequencerServer;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -42,17 +43,17 @@ public class SequencerClientTest extends AbstractClientTest {
     @Test
     public void tokensAreIncrementing()
             throws Exception {
-        long token = client.nextToken(Collections.<UUID>emptySet(), 1).get().getToken();
-        long token2 = client.nextToken(Collections.<UUID>emptySet(), 1).get().getToken();
-        assertThat(token2)
-                .isGreaterThan(token);
+        Token token = client.nextToken(Collections.<UUID>emptySet(), 1).get().getToken();
+        Token token2 = client.nextToken(Collections.<UUID>emptySet(), 1).get().getToken();
+        assertThat(token2.getTokenValue())
+                .isGreaterThan(token.getTokenValue());
     }
 
     @Test
     public void checkTokenPositionWorks()
             throws Exception {
-        long token = client.nextToken(Collections.<UUID>emptySet(), 1).get().getToken();
-        long token2 = client.nextToken(Collections.<UUID>emptySet(), 0).get().getToken();
+        Token token = client.nextToken(Collections.<UUID>emptySet(), 1).get().getToken();
+        Token token2 = client.nextToken(Collections.<UUID>emptySet(), 0).get().getToken();
         assertThat(token)
                 .isEqualTo(token2);
     }
@@ -63,18 +64,18 @@ public class SequencerClientTest extends AbstractClientTest {
         UUID streamA = UUID.nameUUIDFromBytes("streamA".getBytes());
         UUID streamB = UUID.nameUUIDFromBytes("streamB".getBytes());
         client.nextToken(Collections.singleton(streamA), 1).get();
-        long tokenA = client.nextToken(Collections.singleton(streamA), 1).get().getToken();
-        long tokenA2 = client.nextToken(Collections.singleton(streamA), 0).get().getToken();
+        Token tokenA = client.nextToken(Collections.singleton(streamA), 1).get().getToken();
+        Token tokenA2 = client.nextToken(Collections.singleton(streamA), 0).get().getToken();
         assertThat(tokenA)
                 .isEqualTo(tokenA2);
-        long tokenB = client.nextToken(Collections.singleton(streamB), 0).get().getToken();
+        Token tokenB = client.nextToken(Collections.singleton(streamB), 0).get().getToken();
         assertThat(tokenB)
                 .isNotEqualTo(tokenA2);
-        long tokenB2 = client.nextToken(Collections.singleton(streamB), 1).get().getToken();
-        long tokenB3 = client.nextToken(Collections.singleton(streamB), 0).get().getToken();
+        Token tokenB2 = client.nextToken(Collections.singleton(streamB), 1).get().getToken();
+        Token tokenB3 = client.nextToken(Collections.singleton(streamB), 0).get().getToken();
         assertThat(tokenB2)
                 .isEqualTo(tokenB3);
-        long tokenA3 = client.nextToken(Collections.singleton(streamA), 0).get().getToken();
+        Token tokenA3 = client.nextToken(Collections.singleton(streamA), 0).get().getToken();
         assertThat(tokenA3)
                 .isEqualTo(tokenA2);
     }

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -3,10 +3,12 @@ package org.corfudb.runtime.view;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
-import org.corfudb.infrastructure.*;
+import org.corfudb.infrastructure.LogUnitServerAssertions;
+import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.junit.Test;
 
@@ -77,8 +79,9 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().epochedWrite(0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(new Token(0L, r.getLayoutView().getLayout().getEpoch()),
+                Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap());
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -95,8 +98,9 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_2))
                 .isEmptyAtAddress(0);
 
-        r.getAddressSpaceView().epochedWrite(1, Collections.singleton(streamA),
-                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(new Token(1L, r.getLayoutView().getLayout().getEpoch()),
+                Collections.singleton(streamA),
+                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap());
         LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_0))
                 .matchesDataAtAddress(0, testPayload);
         LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_1))
@@ -139,18 +143,21 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         final long ADDRESS_0 = 0;
         final long ADDRESS_1 = 1;
         final long ADDRESS_2 = 3;
-        r.getAddressSpaceView().epochedWrite(ADDRESS_0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
+        Token token = new Token(ADDRESS_0, r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(token, Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap());
 
         assertThat(r.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
 
 
-        r.getAddressSpaceView().epochedWrite(ADDRESS_1, Collections.singleton(streamA),
-                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(new Token(ADDRESS_1, r.getLayoutView().getLayout().getEpoch()),
+                Collections.singleton(streamA),
+                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap());
 
-        r.getAddressSpaceView().epochedWrite(ADDRESS_2, Collections.singleton(streamA),
-                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(new Token(ADDRESS_2, r.getLayoutView().getLayout().getEpoch()),
+                Collections.singleton(streamA),
+                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap());
 
         RangeSet<Long> rs = TreeRangeSet.create();
         rs.add(Range.closed(0L, ADDRESS_2));
@@ -197,27 +204,32 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         UUID streamB = UUID.nameUUIDFromBytes("stream B".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        final int ADDRESS_0 = 0;
-        final int ADDRESS_1 = 1;
-        final int ADDRESS_2 = 2;
-        final int ADDRESS_3 = 3;
-        final int ADDRESS_4 = 5;
+        final long ADDRESS_0 = 0;
+        final long ADDRESS_1 = 1;
+        final long ADDRESS_2 = 2;
+        final long ADDRESS_3 = 3;
+        final long ADDRESS_4 = 5;
 
-        r.getAddressSpaceView().epochedWrite(ADDRESS_0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(new Token(ADDRESS_0, r.getLayoutView().getLayout().getEpoch()),
+                Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap());
 
 
-        r.getAddressSpaceView().epochedWrite(ADDRESS_1, Collections.singleton(streamA),
-                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(new Token(ADDRESS_1, r.getLayoutView().getLayout().getEpoch()),
+                Collections.singleton(streamA),
+                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap());
 
-        r.getAddressSpaceView().epochedWrite(ADDRESS_2, Collections.singleton(streamB),
-                "2".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(new Token(ADDRESS_2, r.getLayoutView().getLayout().getEpoch()),
+                Collections.singleton(streamB),
+                "2".getBytes(), Collections.emptyMap(), Collections.emptyMap());
 
-        r.getAddressSpaceView().epochedWrite(ADDRESS_3, Collections.singleton(streamA),
-                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(new Token(ADDRESS_3, r.getLayoutView().getLayout().getEpoch()),
+                Collections.singleton(streamA),
+                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap());
 
-        r.getAddressSpaceView().epochedWrite(ADDRESS_4, Collections.singleton(streamA),
-                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(new Token(ADDRESS_4, r.getLayoutView().getLayout().getEpoch()),
+                Collections.singleton(streamA),
+                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap());
 
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -7,11 +7,9 @@ import org.corfudb.infrastructure.*;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
-import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.junit.Test;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -79,8 +77,8 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(0, Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -97,8 +95,8 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_2))
                 .isEmptyAtAddress(0);
 
-        r.getAddressSpaceView().write(1, Collections.singleton(streamA),
-                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(1, Collections.singleton(streamA),
+                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
         LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_0))
                 .matchesDataAtAddress(0, testPayload);
         LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_1))
@@ -141,18 +139,18 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         final long ADDRESS_0 = 0;
         final long ADDRESS_1 = 1;
         final long ADDRESS_2 = 3;
-        r.getAddressSpaceView().write(ADDRESS_0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(ADDRESS_0, Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
 
         assertThat(r.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
 
 
-        r.getAddressSpaceView().write(ADDRESS_1, Collections.singleton(streamA),
-                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(ADDRESS_1, Collections.singleton(streamA),
+                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
 
-        r.getAddressSpaceView().write(ADDRESS_2, Collections.singleton(streamA),
-                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(ADDRESS_2, Collections.singleton(streamA),
+                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
 
         RangeSet<Long> rs = TreeRangeSet.create();
         rs.add(Range.closed(0L, ADDRESS_2));
@@ -205,21 +203,21 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         final int ADDRESS_3 = 3;
         final int ADDRESS_4 = 5;
 
-        r.getAddressSpaceView().write(ADDRESS_0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(ADDRESS_0, Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
 
 
-        r.getAddressSpaceView().write(ADDRESS_1, Collections.singleton(streamA),
-                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(ADDRESS_1, Collections.singleton(streamA),
+                "1".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
 
-        r.getAddressSpaceView().write(ADDRESS_2, Collections.singleton(streamB),
-                "2".getBytes(), Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(ADDRESS_2, Collections.singleton(streamB),
+                "2".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
 
-        r.getAddressSpaceView().write(ADDRESS_3, Collections.singleton(streamA),
-                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(ADDRESS_3, Collections.singleton(streamA),
+                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
 
-        r.getAddressSpaceView().write(ADDRESS_4, Collections.singleton(streamA),
-                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(ADDRESS_4, Collections.singleton(streamA),
+                "3".getBytes(), Collections.emptyMap(), Collections.emptyMap(), r.getLayoutView().getLayout().getEpoch());
 
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.view;
 
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.protocols.wireprotocol.IMetadata;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.junit.Test;
 
@@ -26,8 +27,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().epochedWrite(0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap(), 0L);
+        r.getAddressSpaceView().write(new Token(0L, 0L), Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap());
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -49,8 +50,9 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
             for (int i = base; i < base + numberRecords; i++) {
-                r.getAddressSpaceView().epochedWrite(i, Collections.singleton(CorfuRuntime.getStreamID("a")),
-                        Integer.toString(i).getBytes(), Collections.emptyMap(), Collections.emptyMap(), 0L);
+                r.getAddressSpaceView().write(new Token((long)i, 0L),
+                        Collections.singleton(CorfuRuntime.getStreamID("a")),
+                        Integer.toString(i).getBytes(), Collections.emptyMap(), Collections.emptyMap());
             }
         });
         executeScheduled(numberThreads, PARAMETERS.TIMEOUT_LONG);
@@ -95,8 +97,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().epochedWrite(0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap(), 0L);
+        r.getAddressSpaceView().write(new Token(0L, 0L), Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap());
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -134,8 +136,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().epochedWrite(0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap(), 0L);
+        r.getAddressSpaceView().write(new Token(0L, 0L), Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap());
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());

--- a/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.corfudb.infrastructure.LogUnitServerAssertions.assertThat;
@@ -27,8 +26,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(0, Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap(), 0L);
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -50,8 +49,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
             for (int i = base; i < base + numberRecords; i++) {
-                r.getAddressSpaceView().write(i, Collections.singleton(CorfuRuntime.getStreamID("a")),
-                        Integer.toString(i).getBytes(), Collections.emptyMap(), Collections.emptyMap());
+                r.getAddressSpaceView().epochedWrite(i, Collections.singleton(CorfuRuntime.getStreamID("a")),
+                        Integer.toString(i).getBytes(), Collections.emptyMap(), Collections.emptyMap(), 0L);
             }
         });
         executeScheduled(numberThreads, PARAMETERS.TIMEOUT_LONG);
@@ -96,8 +95,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(0, Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap(), 0L);
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -135,8 +134,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(0, Collections.singleton(streamA),
-                testPayload, Collections.emptyMap(), Collections.emptyMap());
+        r.getAddressSpaceView().epochedWrite(0, Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap(), 0L);
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1,8 +1,9 @@
 package org.corfudb.runtime.view;
 
+
 import com.google.common.reflect.TypeToken;
 import lombok.Getter;
-import org.corfudb.infrastructure.ManagementServer;
+
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.ServerContextBuilder;
@@ -16,16 +17,15 @@ import org.corfudb.runtime.collections.ISMRMap;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.stream.IStreamView;
-import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
+
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Test to verify the Management Server functionality.
@@ -38,11 +38,20 @@ public class ManagementViewTest extends AbstractViewTest {
     protected CorfuRuntime corfuRuntime = null;
 
     /**
-     * Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
-     * is sent by the Management client to its server.
+     * Sets aggressive timeouts for all the router endpoints on all the runtimes.
+     * <p>
+     * @param layout        Layout to get all server endpoints.
+     * @param corfuRuntimes All runtimes whose routers' timeouts are to be set.
      */
-    private static final Semaphore failureDetected = new Semaphore(1,
-            true);
+    public void setAggressiveTimeouts(Layout layout, CorfuRuntime... corfuRuntimes) {
+        layout.getAllServers().forEach(routerEndpoint -> {
+            for (CorfuRuntime runtime : corfuRuntimes) {
+                runtime.getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                runtime.getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                runtime.getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            }
+        });
+    }
 
     /**
      * Scenario with 2 nodes: SERVERS.PORT_0 and SERVERS.PORT_1.
@@ -54,6 +63,11 @@ public class ManagementViewTest extends AbstractViewTest {
     @Test
     public void invokeFailureHandler()
             throws Exception {
+
+        // Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
+        // is sent by the Management client to its server.
+        final Semaphore failureDetected = new Semaphore(1,true);
+
         addServer(SERVERS.PORT_0);
         addServer(SERVERS.PORT_1);
         Layout l = new TestLayoutBuilder()
@@ -76,12 +90,10 @@ public class ManagementViewTest extends AbstractViewTest {
         corfuRuntime.getRouter(SERVERS.ENDPOINT_1).getClient(ManagementClient.class).initiateFailureHandler().get();
 
 
-        // Reduce test execution time from 15+ seconds to about 8 seconds:
-        // Set aggressive timeouts for surviving MS that polls the dead MS.
-        ManagementServer ms = getManagementServer(SERVERS.PORT_1);
-        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        // Set aggressive timeouts.
+        setAggressiveTimeouts(l, corfuRuntime,
+                getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_1).getCorfuRuntime());
 
         failureDetected.acquire();
 
@@ -153,21 +165,10 @@ public class ManagementViewTest extends AbstractViewTest {
         }
 
         // Setting aggressive timeouts
-        List<Integer> serverPorts = new ArrayList<> ();
-        serverPorts.add(SERVERS.PORT_0);
-        serverPorts.add(SERVERS.PORT_1);
-        serverPorts.add(SERVERS.PORT_2);
-        List<String> routerEndpoints = new ArrayList<> ();
-        routerEndpoints.add(SERVERS.ENDPOINT_0);
-        routerEndpoints.add(SERVERS.ENDPOINT_1);
-        routerEndpoints.add(SERVERS.ENDPOINT_2);
-        serverPorts.forEach(serverPort -> {
-            routerEndpoints.forEach(routerEndpoint -> {
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            });
-        });
+        setAggressiveTimeouts(l, corfuRuntime,
+                getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_1).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_2).getCorfuRuntime());
 
         // Adding a rule on SERVERS.PORT_1 to drop all packets
         addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
@@ -184,9 +185,8 @@ public class ManagementViewTest extends AbstractViewTest {
         assertThat(l2.getLayoutServers().contains(SERVERS.ENDPOINT_1)).isFalse();
     }
 
-    protected void getManagementTstLayout1()
-        throws Exception {
-
+    protected void getManagementTestLayout()
+            throws Exception {
         addServer(SERVERS.PORT_0);
         addServer(SERVERS.PORT_1);
         addServer(SERVERS.PORT_2);
@@ -215,21 +215,148 @@ public class ManagementViewTest extends AbstractViewTest {
         }
 
         // Setting aggressive timeouts
-        List<Integer> serverPorts = new ArrayList<> ();
-        serverPorts.add(SERVERS.PORT_0);
-        serverPorts.add(SERVERS.PORT_1);
-        serverPorts.add(SERVERS.PORT_2);
-        List<String> routerEndpoints = new ArrayList<> ();
-        routerEndpoints.add(SERVERS.ENDPOINT_0);
-        routerEndpoints.add(SERVERS.ENDPOINT_1);
-        routerEndpoints.add(SERVERS.ENDPOINT_2);
-        serverPorts.forEach(serverPort -> {
-            routerEndpoints.forEach(routerEndpoint -> {
-                corfuRuntime.getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                corfuRuntime.getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                corfuRuntime.getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            });
-        });
+        setAggressiveTimeouts(l, corfuRuntime,
+                getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_1).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_2).getCorfuRuntime());
+    }
+
+    /**
+     * Scenario with 3 nodes: SERVERS.PORT_0, SERVERS.PORT_1 and SERVERS.PORT_2.
+     * Simulate transient failure of a server leading to a partial seal.
+     * Allow the management server to detect the partial seal and correct this.
+     * <p>
+     * Part 1.
+     * The partial seal causes SERVERS.PORT_0 to be at epoch 2 whereas,
+     * SERVERS.PORT_1 & SERVERS.PORT_2 fail to receive this message and are stuck at epoch 1.
+     * <p>
+     * Part 2.
+     * All the 3 servers are now functional and receive all messages.
+     * <p>
+     * Part 3.
+     * The PING message gets rejected by the partially sealed router (WrongEpoch)
+     * and the management server realizes of the partial seal and corrects this
+     * by issuing another failure detected message.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void handleTransientFailure()
+            throws Exception {
+        // Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
+        // is sent by the Management client to its server.
+        final Semaphore failureDetected = new Semaphore(2,true);
+
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
+        addServer(SERVERS.PORT_2);
+        Layout l = new TestLayoutBuilder()
+                .setEpoch(1L)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_0)
+                .buildSegment()
+                .setReplicationMode(Layout.ReplicationMode.QUORUM_REPLICATION)
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_1)
+                .addLogUnit(SERVERS.PORT_2)
+                .addToSegment()
+                .addToLayout()
+                .build();
+        bootstrapAllServers(l);
+        CorfuRuntime corfuRuntime = getRuntime(l).connect();
+
+        // Initiate SERVERS.ENDPOINT_0 failureHandler
+        corfuRuntime.getRouter(SERVERS.ENDPOINT_0).getClient(ManagementClient.class).initiateFailureHandler().get();
+
+        // Set aggressive timeouts.
+        setAggressiveTimeouts(l, corfuRuntime,
+                getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_1).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_2).getCorfuRuntime());
+
+        failureDetected.acquire(2);
+
+        // Only allow SERVERS.PORT_0 to manage failures.
+        getManagementServer(SERVERS.PORT_1).shutdown();
+        getManagementServer(SERVERS.PORT_2).shutdown();
+
+        // PART 1.
+        // Prevent ENDPOINT_1 from sealing.
+        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(), SERVERS.ENDPOINT_1,
+                new TestRule().matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.SET_EPOCH)).drop());
+        // Simulate ENDPOINT_2 failure from ENDPOINT_0 (only Management Server)
+        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(), SERVERS.ENDPOINT_2,
+                new TestRule().matches(corfuMsg -> true).drop());
+
+        // Adding a rule on SERVERS.PORT_1 to toggle the flag when it sends the
+        // MANAGEMENT_FAILURE_DETECTED message.
+        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                new TestRule().matches(corfuMsg -> {
+                    if (corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)) {
+                        failureDetected.release();
+                    }
+                    return true;
+                }));
+
+        // Go ahead when sealing of ENDPOINT_0 takes place.
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
+            if (getServerRouter(SERVERS.PORT_0).getServerEpoch() == 2L) {
+                failureDetected.release();
+                break;
+            }
+            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        }
+
+        assertThat(failureDetected.tryAcquire(2, PARAMETERS.TIMEOUT_NORMAL.toNanos(),
+                TimeUnit.NANOSECONDS)).isEqualTo(true);
+
+        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                new TestRule().matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)
+                ).drop());
+
+        // Assert that only a partial seal was successful.
+        // ENDPOINT_0 sealed. ENDPOINT_1 & ENDPOINT_2 not sealed.
+        assertThat(getServerRouter(SERVERS.PORT_0).getServerEpoch()).isEqualTo(2L);
+        assertThat(getServerRouter(SERVERS.PORT_1).getServerEpoch()).isEqualTo(1L);
+        assertThat(getServerRouter(SERVERS.PORT_2).getServerEpoch()).isEqualTo(1L);
+        assertThat(getLayoutServer(SERVERS.PORT_0).getCurrentLayout().getEpoch()).isEqualTo(1L);
+        assertThat(getLayoutServer(SERVERS.PORT_1).getCurrentLayout().getEpoch()).isEqualTo(1L);
+        assertThat(getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch()).isEqualTo(1L);
+
+        // PART 2.
+        // Simulate normal operations for all servers and clients.
+        clearClientRules(getManagementServer(SERVERS.PORT_0).getCorfuRuntime());
+
+        // PART 3.
+        // Allow management server to detect partial seal and correct this issue.
+        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                new TestRule().matches(corfuMsg -> {
+                    if (corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)) {
+                        failureDetected.release(2);
+                    }
+                    return true;
+                }));
+
+        assertThat(failureDetected.tryAcquire(2, PARAMETERS.TIMEOUT_NORMAL.toNanos(),
+                TimeUnit.NANOSECONDS)).isEqualTo(true);
+
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
+            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            // Assert successful seal of all servers.
+            if (getServerRouter(SERVERS.PORT_0).getServerEpoch() == 2L ||
+                getServerRouter(SERVERS.PORT_1).getServerEpoch() == 2L ||
+                getServerRouter(SERVERS.PORT_2).getServerEpoch() == 2L ||
+                getLayoutServer(SERVERS.PORT_0).getCurrentLayout().getEpoch() == 2L ||
+                getLayoutServer(SERVERS.PORT_1).getCurrentLayout().getEpoch() == 2L ||
+                getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch() == 2L) {
+                return;
+            }
+        }
+        fail();
+
     }
 
     protected void induceSequencerFailureAndWait()
@@ -264,7 +391,7 @@ public class ManagementViewTest extends AbstractViewTest {
      */
     @Test
     public void testSequencerFailover() throws Exception {
-        getManagementTstLayout1();
+        getManagementTestLayout();
 
         final long beforeFailure = 5L;
         final long afterFailure = 10L;
@@ -356,7 +483,7 @@ public class ManagementViewTest extends AbstractViewTest {
     @Test
     public void ckSequencerFailoverTXResolution()
         throws Exception {
-        getManagementTstLayout1();
+        getManagementTestLayout();
 
         Map<Integer, String> map = getMap();
 
@@ -426,7 +553,7 @@ public class ManagementViewTest extends AbstractViewTest {
     @Test
     public void ckSequencerFailoverTXResolution1()
             throws Exception {
-        getManagementTstLayout1();
+        getManagementTestLayout();
 
         Map<Integer, String> map = getMap();
         final String payload = "hello";
@@ -494,5 +621,4 @@ public class ManagementViewTest extends AbstractViewTest {
 
 
     }
-
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1,5 +1,8 @@
 package org.corfudb.runtime.view;
 
+import com.google.common.reflect.TypeToken;
+import lombok.Getter;
+import org.corfudb.infrastructure.ManagementServer;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.ServerContextBuilder;
@@ -9,13 +12,20 @@ import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.collections.ISMRMap;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.view.stream.IStreamView;
+import org.junit.Before;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 /**
  * Test to verify the Management Server functionality.
@@ -24,21 +34,15 @@ import static org.junit.Assert.fail;
  */
 public class ManagementViewTest extends AbstractViewTest {
 
+    @Getter
+    protected CorfuRuntime corfuRuntime = null;
+
     /**
-     * Sets aggressive timeouts for all the router endpoints on all the runtimes.
-     * <p>
-     * @param layout        Layout to get all server endpoints.
-     * @param corfuRuntimes All runtimes whose routers' timeouts are to be set.
+     * Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
+     * is sent by the Management client to its server.
      */
-    public void setAggressiveTimeouts(Layout layout, CorfuRuntime... corfuRuntimes) {
-        layout.getAllServers().forEach(routerEndpoint -> {
-            for (CorfuRuntime runtime : corfuRuntimes) {
-                runtime.getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                runtime.getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                runtime.getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            }
-        });
-    }
+    private static final Semaphore failureDetected = new Semaphore(1,
+            true);
 
     /**
      * Scenario with 2 nodes: SERVERS.PORT_0 and SERVERS.PORT_1.
@@ -50,11 +54,6 @@ public class ManagementViewTest extends AbstractViewTest {
     @Test
     public void invokeFailureHandler()
             throws Exception {
-
-        // Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
-        // is sent by the Management client to its server.
-        final Semaphore failureDetected = new Semaphore(1,true);
-
         addServer(SERVERS.PORT_0);
         addServer(SERVERS.PORT_1);
         Layout l = new TestLayoutBuilder()
@@ -77,10 +76,12 @@ public class ManagementViewTest extends AbstractViewTest {
         corfuRuntime.getRouter(SERVERS.ENDPOINT_1).getClient(ManagementClient.class).initiateFailureHandler().get();
 
 
-        // Set aggressive timeouts.
-        setAggressiveTimeouts(l, corfuRuntime,
-                getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
-                getManagementServer(SERVERS.PORT_1).getCorfuRuntime());
+        // Reduce test execution time from 15+ seconds to about 8 seconds:
+        // Set aggressive timeouts for surviving MS that polls the dead MS.
+        ManagementServer ms = getManagementServer(SERVERS.PORT_1);
+        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
 
         failureDetected.acquire();
 
@@ -152,10 +153,21 @@ public class ManagementViewTest extends AbstractViewTest {
         }
 
         // Setting aggressive timeouts
-        setAggressiveTimeouts(l, corfuRuntime,
-                getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
-                getManagementServer(SERVERS.PORT_1).getCorfuRuntime(),
-                getManagementServer(SERVERS.PORT_2).getCorfuRuntime());
+        List<Integer> serverPorts = new ArrayList<> ();
+        serverPorts.add(SERVERS.PORT_0);
+        serverPorts.add(SERVERS.PORT_1);
+        serverPorts.add(SERVERS.PORT_2);
+        List<String> routerEndpoints = new ArrayList<> ();
+        routerEndpoints.add(SERVERS.ENDPOINT_0);
+        routerEndpoints.add(SERVERS.ENDPOINT_1);
+        routerEndpoints.add(SERVERS.ENDPOINT_2);
+        serverPorts.forEach(serverPort -> {
+            routerEndpoints.forEach(routerEndpoint -> {
+                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            });
+        });
 
         // Adding a rule on SERVERS.PORT_1 to drop all packets
         addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
@@ -172,140 +184,315 @@ public class ManagementViewTest extends AbstractViewTest {
         assertThat(l2.getLayoutServers().contains(SERVERS.ENDPOINT_1)).isFalse();
     }
 
-    /**
-     * Scenario with 3 nodes: SERVERS.PORT_0, SERVERS.PORT_1 and SERVERS.PORT_2.
-     * Simulate transient failure of a server leading to a partial seal.
-     * Allow the management server to detect the partial seal and correct this.
-     * <p>
-     * Part 1.
-     * The partial seal causes SERVERS.PORT_0 to be at epoch 2 whereas,
-     * SERVERS.PORT_1 & SERVERS.PORT_2 fail to receive this message and are stuck at epoch 1.
-     * <p>
-     * Part 2.
-     * All the 3 servers are now functional and receive all messages.
-     * <p>
-     * Part 3.
-     * The PING message gets rejected by the partially sealed router (WrongEpoch)
-     * and the management server realizes of the partial seal and corrects this
-     * by issuing another failure detected message.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void handleTransientFailure()
-            throws Exception {
-        // Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
-        // is sent by the Management client to its server.
-        final Semaphore failureDetected = new Semaphore(2,true);
+    protected void getManagementTstLayout1()
+        throws Exception {
 
         addServer(SERVERS.PORT_0);
         addServer(SERVERS.PORT_1);
         addServer(SERVERS.PORT_2);
+
         Layout l = new TestLayoutBuilder()
                 .setEpoch(1L)
                 .addLayoutServer(SERVERS.PORT_0)
                 .addLayoutServer(SERVERS.PORT_1)
                 .addLayoutServer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_1)
                 .addSequencer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
-                .setReplicationMode(Layout.ReplicationMode.QUORUM_REPLICATION)
                 .buildStripe()
                 .addLogUnit(SERVERS.PORT_0)
-                .addLogUnit(SERVERS.PORT_1)
                 .addLogUnit(SERVERS.PORT_2)
                 .addToSegment()
                 .addToLayout()
                 .build();
         bootstrapAllServers(l);
-        CorfuRuntime corfuRuntime = getRuntime(l).connect();
+        corfuRuntime = getRuntime(l).connect();
 
-        // Initiate SERVERS.ENDPOINT_0 failureHandler
-        corfuRuntime.getRouter(SERVERS.ENDPOINT_0).getClient(ManagementClient.class).initiateFailureHandler().get();
-
-        // Set aggressive timeouts.
-        setAggressiveTimeouts(l, corfuRuntime,
-                getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
-                getManagementServer(SERVERS.PORT_1).getCorfuRuntime(),
-                getManagementServer(SERVERS.PORT_2).getCorfuRuntime());
-
-        failureDetected.acquire(2);
-
-        // Only allow SERVERS.PORT_0 to manage failures.
-        getManagementServer(SERVERS.PORT_1).shutdown();
-        getManagementServer(SERVERS.PORT_2).shutdown();
-
-        // PART 1.
-        // Prevent ENDPOINT_1 from sealing.
-        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(), SERVERS.ENDPOINT_1,
-                new TestRule().matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.SET_EPOCH)).drop());
-        // Simulate ENDPOINT_2 failure from ENDPOINT_0 (only Management Server)
-        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(), SERVERS.ENDPOINT_2,
-                new TestRule().matches(corfuMsg -> true).drop());
-
-        // Adding a rule on SERVERS.PORT_1 to toggle the flag when it sends the
-        // MANAGEMENT_FAILURE_DETECTED message.
-        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
-                new TestRule().matches(corfuMsg -> {
-                    if (corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)) {
-                        failureDetected.release();
-                    }
-                    return true;
-                }));
-
-        // Go ahead when sealing of ENDPOINT_0 takes place.
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
-            if (getServerRouter(SERVERS.PORT_0).getServerEpoch() == 2L) {
-                failureDetected.release();
-                break;
-            }
-            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        // Initiating all failure handlers.
+        for (String server: corfuRuntime.getLayoutView().getLayout().getAllServers()) {
+            corfuRuntime.getRouter(server).getClient(ManagementClient.class).initiateFailureHandler().get();
         }
 
-        assertThat(failureDetected.tryAcquire(2, PARAMETERS.TIMEOUT_NORMAL.toNanos(),
-                TimeUnit.NANOSECONDS)).isEqualTo(true);
-
-        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
-                new TestRule().matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)
-                ).drop());
-
-        // Assert that only a partial seal was successful.
-        // ENDPOINT_0 sealed. ENDPOINT_1 & ENDPOINT_2 not sealed.
-        assertThat(getServerRouter(SERVERS.PORT_0).getServerEpoch()).isEqualTo(2L);
-        assertThat(getServerRouter(SERVERS.PORT_1).getServerEpoch()).isEqualTo(1L);
-        assertThat(getServerRouter(SERVERS.PORT_2).getServerEpoch()).isEqualTo(1L);
-        assertThat(getLayoutServer(SERVERS.PORT_0).getCurrentLayout().getEpoch()).isEqualTo(1L);
-        assertThat(getLayoutServer(SERVERS.PORT_1).getCurrentLayout().getEpoch()).isEqualTo(1L);
-        assertThat(getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch()).isEqualTo(1L);
-
-        // PART 2.
-        // Simulate normal operations for all servers and clients.
-        clearClientRules(getManagementServer(SERVERS.PORT_0).getCorfuRuntime());
-
-        // PART 3.
-        // Allow management server to detect partial seal and correct this issue.
-        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
-                new TestRule().matches(corfuMsg -> {
-                    if (corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)) {
-                        failureDetected.release(2);
-                    }
-                    return true;
-                }));
-
-        assertThat(failureDetected.tryAcquire(2, PARAMETERS.TIMEOUT_NORMAL.toNanos(),
-                TimeUnit.NANOSECONDS)).isEqualTo(true);
-
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
-            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            // Assert successful seal of all servers.
-            if (getServerRouter(SERVERS.PORT_0).getServerEpoch() == 2L ||
-                getServerRouter(SERVERS.PORT_1).getServerEpoch() == 2L ||
-                getServerRouter(SERVERS.PORT_2).getServerEpoch() == 2L ||
-                getLayoutServer(SERVERS.PORT_0).getCurrentLayout().getEpoch() == 2L ||
-                getLayoutServer(SERVERS.PORT_1).getCurrentLayout().getEpoch() == 2L ||
-                getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch() == 2L) {
-                return;
-            }
-        }
-        fail();
+        // Setting aggressive timeouts
+        List<Integer> serverPorts = new ArrayList<> ();
+        serverPorts.add(SERVERS.PORT_0);
+        serverPorts.add(SERVERS.PORT_1);
+        serverPorts.add(SERVERS.PORT_2);
+        List<String> routerEndpoints = new ArrayList<> ();
+        routerEndpoints.add(SERVERS.ENDPOINT_0);
+        routerEndpoints.add(SERVERS.ENDPOINT_1);
+        routerEndpoints.add(SERVERS.ENDPOINT_2);
+        serverPorts.forEach(serverPort -> {
+            routerEndpoints.forEach(routerEndpoint -> {
+                corfuRuntime.getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                corfuRuntime.getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                corfuRuntime.getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            });
+        });
     }
+
+    protected void induceSequencerFailureAndWait()
+        throws Exception {
+
+        long currentEpoch = getCorfuRuntime().getLayoutView().getLayout().getEpoch();
+
+        // induce a failure to the server on PORT_1, where the current sequencer is active
+        //
+        getManagementServer(SERVERS.PORT_1).shutdown();
+        addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
+
+        // wait for failover to install a new epoch (and a new layout)
+        //
+        while (getCorfuRuntime().getLayoutView().getLayout().getEpoch() == currentEpoch) {
+            getCorfuRuntime().invalidateLayout();
+            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        }
+
+    }
+
+    /**
+     * Scenario with 3 nodes: SERVERS.PORT_0, SERVERS.PORT_1 and SERVERS.PORT_2.
+     * We fail SERVERS.PORT_1 and then wait for one of the other two servers to
+     * handle this failure, propose a new layout and we assert on the epoch change.
+     * The failure is handled by ConserveFailureHandlerPolicy.
+     * No nodes are removed from the layout, but are marked unresponsive.
+     * A sequencer failover takes place where the next working sequencer is reset
+     * and made the primary.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSequencerFailover() throws Exception {
+        getManagementTstLayout1();
+
+        final long beforeFailure = 5L;
+        final long afterFailure = 10L;
+
+        IStreamView sv = getCorfuRuntime().getStreamsView().get(CorfuRuntime.getStreamID("streamA"));
+        byte[] testPayload = "hello world".getBytes();
+        sv.append(testPayload);
+        sv.append(testPayload);
+        sv.append(testPayload);
+        sv.append(testPayload);
+        sv.append(testPayload);
+
+        assertThat(getSequencer(SERVERS.PORT_1).getGlobalLogTail().get()).isEqualTo(beforeFailure);
+        assertThat(getSequencer(SERVERS.PORT_0).getGlobalLogTail().get()).isEqualTo(0L);
+
+        induceSequencerFailureAndWait();
+
+        // verify that a failover sequencer was started with the correct starting-tail
+        //
+        assertThat(getSequencer(SERVERS.PORT_0).getGlobalLogTail().get()).isEqualTo(beforeFailure);
+
+        sv.append(testPayload);
+        sv.append(testPayload);
+        sv.append(testPayload);
+        sv.append(testPayload);
+        sv.append(testPayload);
+
+        // verify the failover layout
+        //
+        Layout expectedLayout = new TestLayoutBuilder()
+                .setEpoch(2L)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_2)
+                .buildSegment()
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_2)
+                .addToSegment()
+                .addToLayout()
+                .addUnresponsiveServer(SERVERS.PORT_1)
+                .build();
+
+        assertThat(getCorfuRuntime().getLayoutView().getLayout()).isEqualTo(expectedLayout);
+
+        // verify that the new sequencer is advancing the tail properly
+        assertThat(getSequencer(SERVERS.PORT_0).getGlobalLogTail().get()).isEqualTo(afterFailure);
+
+        // sanity check that no other sequencer is active
+        assertThat(getSequencer(SERVERS.PORT_2).getGlobalLogTail().get()).isEqualTo(0L);
+
+    }
+
+    protected <T> Object instantiateCorfuObject(TypeToken<T> tType, String name) {
+        return (T)
+                getCorfuRuntime().getObjectsView()
+                        .build()
+                        .setStreamName(name)     // stream name
+                        .setTypeToken(tType)    // a TypeToken of the specified class
+                        .open();                // instantiate the object!
+    }
+
+
+    protected ISMRMap<Integer, String> getMap() {
+        ISMRMap<Integer, String> testMap;
+
+        testMap = (ISMRMap<Integer, String>) instantiateCorfuObject(
+                new TypeToken<SMRMap<Integer, String>>() {
+                }, "test stream"
+        ) ;
+
+        return testMap;
+    }
+
+    protected void TXBegin() {
+        getCorfuRuntime().getObjectsView().TXBegin();
+    }
+
+    protected void TXEnd() {
+        getCorfuRuntime().getObjectsView().TXEnd();
+    }
+
+    /**
+     * check that transcation conflict resolution works properly in face of sequencer failover
+     */
+    @Test
+    public void ckSequencerFailoverTXResolution()
+        throws Exception {
+        getManagementTstLayout1();
+
+        Map<Integer, String> map = getMap();
+
+        // start a transaction and force it to obtain snapshot timestamp
+        // preceding the sequencer failover
+        t(0, () -> {
+            TXBegin();
+            map.get(0);
+        });
+
+        final String payload = "hello";
+        final int nUpdates = 5;
+
+        // in another thread, fill the log with a few entries
+        t(1, () -> {
+            for (int i = 0; i < nUpdates; i++)
+                map.put(i, payload);
+        });
+
+        // now, the tail of the log is at nUpdates;
+        // kill the sequencer, wait for a failover,
+        // and then resume the transaction above; it should abort
+        // (unnecessarily, but we are being conservative)
+        //
+        induceSequencerFailureAndWait();
+        t(0, () -> {
+            boolean commit = true;
+            map.put(nUpdates+1, payload); // should not conflict
+            try {
+                TXEnd();
+            } catch (TransactionAbortedException ta) {
+                commit = false;
+            }
+            assertThat(commit)
+                    .isFalse();
+        });
+
+        // now, check that the same scenario, starting anew, can succeed
+        t(0, () -> {
+            TXBegin();
+            map.get(0);
+        });
+
+        // in another thread, fill the log with a few entries
+        t(1, () -> {
+            for (int i = 0; i < nUpdates; i++)
+                map.put(i, payload+1);
+        });
+
+        t(0, () -> {
+            boolean commit = true;
+            map.put(nUpdates+1, payload); // should not conflict
+            try {
+                TXEnd();
+            } catch (TransactionAbortedException ta) {
+                commit = false;
+            }
+            assertThat(commit)
+                    .isTrue();
+        });
+    }
+
+
+    /**
+     * small variant on the above : don't start the first TX at the start of the log.
+     */
+    @Test
+    public void ckSequencerFailoverTXResolution1()
+            throws Exception {
+        getManagementTstLayout1();
+
+        Map<Integer, String> map = getMap();
+        final String payload = "hello";
+        final int nUpdates = 5;
+
+
+        for (int i = 0; i < nUpdates; i++)
+            map.put(i, payload);
+
+        // start a transaction and force it to obtain snapshot timestamp
+        // preceding the sequencer failover
+        t(0, () -> {
+            TXBegin();
+            map.get(0);
+        });
+
+        // in another thread, fill the log with a few entries
+        t(1, () -> {
+            for (int i = 0; i < nUpdates; i++)
+                map.put(i, payload+1);
+        });
+
+        // now, the tail of the log is at nUpdates;
+        // kill the sequencer, wait for a failover,
+        // and then resume the transaction above; it should abort
+        // (unnecessarily, but we are being conservative)
+        //
+        induceSequencerFailureAndWait();
+
+        t(0, () -> {
+            boolean commit = true;
+            map.put(nUpdates+1, payload); // should not conflict
+            try {
+                TXEnd();
+            } catch (TransactionAbortedException ta) {
+                commit = false;
+            }
+            assertThat(commit)
+                    .isFalse();
+        });
+
+        // now, check that the same scenario, starting anew, can succeed
+        t(0, () -> {
+            TXBegin();
+            map.get(0);
+        });
+
+        // in another thread, fill the log with a few entries
+        t(1, () -> {
+            for (int i = 0; i < nUpdates; i++)
+                map.put(i, payload+2);
+        });
+
+        t(0, () -> {
+            boolean commit = true;
+            map.put(nUpdates+1, payload); // should not conflict
+            try {
+                TXEnd();
+            } catch (TransactionAbortedException ta) {
+                commit = false;
+            }
+            assertThat(commit)
+                    .isTrue();
+        });
+
+
+    }
+
 }

--- a/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.view;
 
 import lombok.Getter;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.junit.Test;
 
@@ -21,25 +22,25 @@ public class SequencerViewTest extends AbstractViewTest {
     public void canAcquireFirstToken() {
         CorfuRuntime r = getDefaultRuntime();
         assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
-                .isEqualTo(0);
+                .isEqualTo(new Token(0L, 0L));
     }
 
     @Test
     public void tokensAreIncrementing() {
         CorfuRuntime r = getDefaultRuntime();
         assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
-                .isEqualTo(0);
+                .isEqualTo(new Token(0L, 0L));
         assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
-                .isEqualTo(1);
+                .isEqualTo(new Token(1L, 0L));
     }
 
     @Test
     public void checkTokenWorks() {
         CorfuRuntime r = getDefaultRuntime();
         assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
-                .isEqualTo(0);
+                .isEqualTo(new Token(0L, 0L));
         assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 0).getToken())
-                .isEqualTo(0);
+                .isEqualTo(new Token(0L, 0L));
     }
 
     @Test
@@ -49,15 +50,15 @@ public class SequencerViewTest extends AbstractViewTest {
         UUID streamB = UUID.nameUUIDFromBytes("stream B".getBytes());
 
         assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 1).getToken())
-                .isEqualTo(0);
+                .isEqualTo(new Token(0L, 0L));
         assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 0).getToken())
-                .isEqualTo(0);
+                .isEqualTo(new Token(0L, 0L));
         assertThat(r.getSequencerView().nextToken(Collections.singleton(streamB), 1).getToken())
-                .isEqualTo(1);
+                .isEqualTo(new Token(1L, 0L));
         assertThat(r.getSequencerView().nextToken(Collections.singleton(streamB), 0).getToken())
-                .isEqualTo(1);
+                .isEqualTo(new Token(1L, 0L));
         assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 0).getToken())
-                .isEqualTo(0);
+                .isEqualTo(new Token(0L, 0L));
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -295,10 +295,10 @@ public class StreamViewTest extends AbstractViewTest {
         //generate a stream hole
         TokenResponse tr =
                 r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
-        r.getAddressSpaceView().fillHole(tr.getToken());
+        r.getAddressSpaceView().fillHole(tr.getToken().getTokenValue());
 
         tr = r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
-        r.getAddressSpaceView().fillHole(tr.getToken());
+        r.getAddressSpaceView().fillHole(tr.getToken().getTokenValue());
 
         sv.append(testPayload2);
 

--- a/test/src/test/java/org/corfudb/runtime/view/StreamsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamsViewTest.java
@@ -41,7 +41,7 @@ public class StreamsViewTest extends AbstractViewTest {
         IStreamView svCopy = r.getStreamsView().copy(streamA, streamACopy,
                 sequencerView.nextToken(
                         Collections.singleton(sv.getID()),
-                        0).getToken());
+                        0).getToken().getTokenValue());
 
         assertThat(svCopy.next().getPayload(getRuntime()))
                 .isEqualTo(testPayload);


### PR DESCRIPTION
## Sequencer Failover

Update to #237 

### Fetch global tail of log unit server.
- Added an in-memory variable `maxAddressGlobalTail` in the BatchWriter. Every time it encounters a write operation it updates this with the maximum global address so far.
- When the Log unit server receives a `TAIL_REQUEST` it responds with this `maxAddressGlobalTail` in the `TAIL_RESPONSE`.

### Conservative Failure Handling policy
- This policy does not remove the failures from the layout. It marks the failed servers as unresponsive.
- It also modifies the sequencer server list such that a responsive sequencer is at the top (primary).

### Failure Handler
- 4 steps while correcting failures:
  - Generate new layout
  - Seal Layout
  - Reconfigure new servers
  - Run paxos
- To reconfigure new primary sequencer server, we request for the maximum token number written to any of the log unit servers. This token is then used to reset the new primary sequencer.

### Management Server
- Since the failed nodes are not removed from the layout, they continue to be monitored and flagged as failed servers.
- The unresponsiveServers list helps the management server to ignore these requests as the have already been taken care of.