### PR TITLE
Handling transient node failure by management server

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IFailureDetectorPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IFailureDetectorPolicy.java
@@ -3,8 +3,6 @@ package org.corfudb.infrastructure;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Layout;
 
-import java.util.HashMap;
-
 /**
  * Failure Detection Policies.
  * Created by zlokhandwala on 9/29/16.
@@ -23,5 +21,5 @@ public interface IFailureDetectorPolicy {
      *
      * @return A hash map containing servers mapped to their failure status.
      */
-    HashMap<String, Boolean> getServerStatus();
+    PollReport getServerStatus();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -368,7 +368,7 @@ public class ManagementServer extends AbstractServer {
 
         // Get the server status from the policy and check for failures.
         Map map = failureDetectorPolicy.getServerStatus();
-        if (!map.isEmpty()) {
+        if (map != null) {
             log.info("Failures detected. Failed nodes : {}", map.toString());
             // If map not empty, failures present. Trigger handler.
             // Check if handler has been initiated.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/PollReport.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/PollReport.java
@@ -1,0 +1,56 @@
+package org.corfudb.infrastructure;
+
+import com.google.common.collect.ImmutableMap;
+import lombok.Data;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Created by zlokhandwala on 3/21/17.
+ */
+@Data
+public class PollReport {
+
+    private final Boolean isFailurePresent;
+    private final Set<String> failingNodes;
+    private final ImmutableMap<String, Long> outOfPhaseEpochNodes;
+
+    private PollReport(PollReportBuilder pollReportBuilder) {
+        this.isFailurePresent = pollReportBuilder.isFailurePresent;
+        this.failingNodes = pollReportBuilder.failingNodes;
+        this.outOfPhaseEpochNodes = pollReportBuilder.outOfPhaseEpochNodes;
+    }
+
+    public static class PollReportBuilder {
+
+        private Boolean isFailurePresent = false;
+        private Set<String> failingNodes;
+        private ImmutableMap<String, Long> outOfPhaseEpochNodes;
+
+        public PollReportBuilder setIsStatusChangePresent() {
+            isFailurePresent = true;
+            return this;
+        }
+
+        public PollReportBuilder setFailingNodes(Set<String> failingNodes) {
+            if (!failingNodes.isEmpty()) {
+                isFailurePresent = true;
+            }
+            this.failingNodes = failingNodes;
+            return this;
+        }
+
+        public PollReportBuilder setOutOfPhaseEpochNodes(Map<String, Long> outOfPhaseEpochNodes) {
+            if (!outOfPhaseEpochNodes.isEmpty()) {
+                isFailurePresent = true;
+            }
+            this.outOfPhaseEpochNodes = ImmutableMap.copyOf(outOfPhaseEpochNodes);
+            return this;
+        }
+
+        public PollReport build() {
+            return new PollReport(this);
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -18,7 +18,7 @@ import java.lang.reflect.Constructor;
 @AllArgsConstructor
 public enum CorfuMsgType {
     // Base Messages
-    PING(0, TypeToken.of(CorfuMsg.class), true),
+    PING(0, TypeToken.of(CorfuMsg.class)),
     PONG(1, TypeToken.of(CorfuMsg.class), true),
     RESET(2, TypeToken.of(CorfuMsg.class), true),
     SET_EPOCH(3, new TypeToken<CorfuPayloadMsg<Long>>() {}, true),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/FailureDetectorMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/FailureDetectorMsg.java
@@ -4,7 +4,7 @@ import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
-import java.util.Map;
+import java.util.Set;
 
 /**
  * Trigger sent to the management server with the failures detected.
@@ -13,10 +13,10 @@ import java.util.Map;
 @Data
 @AllArgsConstructor
 public class FailureDetectorMsg implements ICorfuPayload<FailureDetectorMsg> {
-    private Map<String, Boolean> nodes;
+    private Set<String> nodes;
 
     public FailureDetectorMsg(ByteBuf buf) {
-        nodes = ICorfuPayload.mapFromBuffer(buf, String.class, Boolean.class);
+        nodes = ICorfuPayload.setFromBuffer(buf, String.class);
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -12,7 +12,6 @@ import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.NoBootstrapException;
 import org.corfudb.runtime.view.Layout;
 
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
@@ -83,7 +82,7 @@ public class ManagementClient implements IClient {
      * @param nodes The failed nodes map to be handled.
      * @return A future which will be return TRUE if completed successfully else returns FALSE.
      */
-    public CompletableFuture<Boolean> handleFailure(Map nodes) {
+    public CompletableFuture<Boolean> handleFailure(Set nodes) {
         return router.sendMessageAndGetCompletable(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(nodes)));
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
@@ -6,8 +6,8 @@ import org.corfudb.runtime.view.Layout;
 import org.junit.After;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -62,13 +62,13 @@ public class ManagementServerTest extends AbstractServerTest {
     @Test
     public void triggerFailureHandler() {
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
-        Map<String, Boolean> map = new HashMap<>();
-        map.put("key", true);
-        sendMessage(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(map)));
+        Set<String> set = new HashSet<>();
+        set.add("key");
+        sendMessage(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(set)));
         assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP_ERROR);
         sendMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST.payloadMsg(layout));
         assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
-        sendMessage(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(map)));
+        sendMessage(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(new FailureDetectorMsg(set)));
         assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
@@ -82,7 +82,7 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
         // A little more than responseTimeout for periodicPolling
         Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
         Map<String, Boolean> result = failureDetectorPolicy.getServerStatus();
-        assertThat(result.isEmpty()).isEqualTo(true);
+        assertThat(result).isNull();
 
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/PeriodicPollPolicyTest.java
@@ -1,7 +1,5 @@
 package org.corfudb.infrastructure;
 
-import org.corfudb.protocols.wireprotocol.CorfuMsgType;
-import org.corfudb.protocols.wireprotocol.LayoutBootstrapRequest;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.TestRule;
 import org.corfudb.runtime.view.AbstractViewTest;
@@ -48,20 +46,20 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
                 .addToSegment()
                 .addToLayout()
                 .build();
-
-        // Bootstrapping only the layout servers.
-        // Failure-correction/updateLayout will cause test to give a non-deterministic output.
-
-        getLayoutServer(SERVERS.PORT_0).handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(layout)),
-                null, getServerRouter(SERVERS.PORT_0));
-        getLayoutServer(SERVERS.PORT_1).handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(layout)),
-                null, getServerRouter(SERVERS.PORT_1));
-        getLayoutServer(SERVERS.PORT_2).handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(layout)),
-                null, getServerRouter(SERVERS.PORT_2));
+        bootstrapAllServers(layout);
+        getManagementServer(SERVERS.PORT_0).shutdown();
+        getManagementServer(SERVERS.PORT_1).shutdown();
+        getManagementServer(SERVERS.PORT_2).shutdown();
 
         corfuRuntime = new CorfuRuntime();
         layout.getLayoutServers().forEach(corfuRuntime::addLayoutServer);
         corfuRuntime.connect();
+
+        layout.getAllServers().forEach(serverEndpoint -> {
+            corfuRuntime.getRouter(serverEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            corfuRuntime.getRouter(serverEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            corfuRuntime.getRouter(serverEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        });
 
         failureDetectorPolicy = new PeriodicPollPolicy();
     }
@@ -101,24 +99,12 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
         addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
         addServerRule(SERVERS.PORT_2, new TestRule().always().drop());
 
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
-            failureDetectorPolicy.executePolicy(layout, corfuRuntime);
-            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-        }
-
         Map<String, Boolean> expectedResult = new HashMap<>();
         expectedResult.put(getEndpoint(SERVERS.PORT_0), false);
         expectedResult.put(getEndpoint(SERVERS.PORT_1), false);
         expectedResult.put(getEndpoint(SERVERS.PORT_2), false);
 
-        Map<String, Boolean> actualResult = new HashMap<>();
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LARGE; i++) {
-            failureDetectorPolicy.getServerStatus().forEach(actualResult::putIfAbsent);
-            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
-            if (actualResult.equals(expectedResult)) break;
-        }
-
-        assertThat(actualResult).isEqualTo(expectedResult);
+        pollAndMatchExpectedResult(expectedResult);
 
         /*
          * Restarting the server SERVERS.PORT_0. Pings should work normally now.
@@ -127,23 +113,31 @@ public class PeriodicPollPolicyTest extends AbstractViewTest {
          */
 
         clearServerRules(SERVERS.PORT_0);
+        // Has only SERVERS.PORT_1 & SERVERS.PORT_2
+        expectedResult.remove(getEndpoint(SERVERS.PORT_0));
 
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
+        pollAndMatchExpectedResult(expectedResult);
+
+    }
+
+    private void pollAndMatchExpectedResult(Map<String, Boolean> expectedResult)
+            throws InterruptedException {
+
+        final int pollsToDeclareFailure = 10;
+        for (int i = 0; i < pollsToDeclareFailure; i++) {
             failureDetectorPolicy.executePolicy(layout, corfuRuntime);
             Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         }
 
-        expectedResult.remove(getEndpoint(SERVERS.PORT_0));
-
-        actualResult = new HashMap<>();
+        Map<String, Boolean> actualResult = new HashMap<>();
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LARGE; i++) {
-            failureDetectorPolicy.getServerStatus().forEach(actualResult::putIfAbsent);
+            Map<String, Boolean> tempMap = failureDetectorPolicy.getServerStatus();
+            if (tempMap != null) {
+                tempMap.forEach(actualResult::putIfAbsent);
+            }
             Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
             if (actualResult.equals(expectedResult)) break;
         }
-
-        // Has only SERVERS.PORT_1 & SERVERS.PORT_2
         assertThat(actualResult).isEqualTo(expectedResult);
-
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -125,11 +125,15 @@ public class TestServerRouter implements IServerRouter {
 
     public void sendServerMessage(CorfuMsg msg, ChannelHandlerContext ctx) {
         AbstractServer as = handlerMap.get(msg.getMsgType());
-        if (as != null) {
-            as.handleMessage(msg, ctx, this);
-        }
-        else {
-            log.trace("Unregistered message of type {} sent to router", msg.getMsgType());
+        if (validateEpoch(msg, ctx)) {
+            if (as != null) {
+                as.handleMessage(msg, ctx, this);
+            }
+            else {
+                log.trace("Unregistered message of type {} sent to router", msg.getMsgType());
+            }
+        } else {
+            log.trace("Message with wrong epoch {}, expected {}", msg.getEpoch(), serverEpoch);
         }
     }
 

--- a/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
@@ -3,11 +3,11 @@ package org.corfudb.runtime.clients;
 import com.google.common.collect.ImmutableSet;
 import org.corfudb.format.Types.NodeMetrics;
 import org.corfudb.infrastructure.*;
+import org.corfudb.infrastructure.ManagementServer;
 import org.junit.After;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
@@ -80,9 +80,9 @@ public class ManagementClientTest extends AbstractClientTest {
             throws Exception {
 
         // Since the servers are started as single nodes thus already bootstrapped.
-        Map map = new HashMap<String, Boolean>();
-        map.put("Key", true);
-        assertThat(client.handleFailure(map).get()).isEqualTo(true);
+        Set<String> set = new HashSet<>();
+        set.add("Key");
+        assertThat(client.handleFailure(set).get()).isEqualTo(true);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutSealTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutSealTest.java
@@ -56,14 +56,14 @@ public class LayoutSealTest extends AbstractViewTest {
         bootstrapAllServers(l);
         CorfuRuntime corfuRuntime = getRuntime(l).connect();
         l.setRuntime(corfuRuntime);
-        setAggressiveTimeouts();
+        setAggressiveTimeouts(l);
         return l;
     }
 
     /**
      * Sets aggressive timeouts for all test routers.
      */
-    public void setAggressiveTimeouts() {
+    public void setAggressiveTimeouts(Layout layout) {
         // Setting aggressive timeouts
         List<Integer> serverPorts = new ArrayList<>();
         serverPorts.add(SERVERS.PORT_0);
@@ -79,9 +79,9 @@ public class LayoutSealTest extends AbstractViewTest {
         routerEndpoints.add(SERVERS.ENDPOINT_4);
         serverPorts.forEach(serverPort -> {
             routerEndpoints.forEach(routerEndpoint -> {
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                layout.getRuntime().getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                layout.getRuntime().getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                layout.getRuntime().getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
             });
         });
     }

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1,6 +1,5 @@
 package org.corfudb.runtime.view;
 
-import org.corfudb.infrastructure.ManagementServer;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.runtime.CorfuRuntime;
@@ -8,8 +7,6 @@ import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.clients.TestRule;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
@@ -21,6 +18,22 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Created by zlokhandwala on 11/9/16.
  */
 public class ManagementViewTest extends AbstractViewTest {
+
+    /**
+     * Sets aggressive timeouts for all the router endpoints on all the runtimes.
+     * <p>
+     * @param layout        Layout to get all server endpoints.
+     * @param corfuRuntimes All runtimes whose routers' timeouts are to be set.
+     */
+    public void setAggressiveTimeouts(Layout layout, CorfuRuntime... corfuRuntimes) {
+        layout.getAllServers().forEach(routerEndpoint -> {
+            for (CorfuRuntime runtime : corfuRuntimes) {
+                runtime.getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                runtime.getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                runtime.getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            }
+        });
+    }
 
     /**
      * Scenario with 2 nodes: SERVERS.PORT_0 and SERVERS.PORT_1.
@@ -59,12 +72,10 @@ public class ManagementViewTest extends AbstractViewTest {
         corfuRuntime.getRouter(SERVERS.ENDPOINT_1).getClient(ManagementClient.class).initiateFailureHandler().get();
 
 
-        // Reduce test execution time from 15+ seconds to about 8 seconds:
-        // Set aggressive timeouts for surviving MS that polls the dead MS.
-        ManagementServer ms = getManagementServer(SERVERS.PORT_1);
-        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-        ms.getCorfuRuntime().getRouter(SERVERS.ENDPOINT_0).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        // Set aggressive timeouts.
+        setAggressiveTimeouts(l, corfuRuntime,
+                getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_1).getCorfuRuntime());
 
         failureDetected.acquire();
 
@@ -126,21 +137,10 @@ public class ManagementViewTest extends AbstractViewTest {
         }
 
         // Setting aggressive timeouts
-        List<Integer> serverPorts = new ArrayList<> ();
-        serverPorts.add(SERVERS.PORT_0);
-        serverPorts.add(SERVERS.PORT_1);
-        serverPorts.add(SERVERS.PORT_2);
-        List<String> routerEndpoints = new ArrayList<> ();
-        routerEndpoints.add(SERVERS.ENDPOINT_0);
-        routerEndpoints.add(SERVERS.ENDPOINT_1);
-        routerEndpoints.add(SERVERS.ENDPOINT_2);
-        serverPorts.forEach(serverPort -> {
-            routerEndpoints.forEach(routerEndpoint -> {
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            });
-        });
+        setAggressiveTimeouts(l, corfuRuntime,
+                getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_1).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_2).getCorfuRuntime());
 
         // Adding a rule on SERVERS.PORT_1 to drop all packets
         addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
@@ -207,23 +207,11 @@ public class ManagementViewTest extends AbstractViewTest {
         // Initiate SERVERS.ENDPOINT_0 failureHandler
         corfuRuntime.getRouter(SERVERS.ENDPOINT_0).getClient(ManagementClient.class).initiateFailureHandler().get();
 
-        // Reduce test execution time from 15+ seconds to about 8 seconds:
-        // Set aggressive timeouts for surviving MS that polls the dead MS.
-        List<Integer> serverPorts = new ArrayList<> ();
-        serverPorts.add(SERVERS.PORT_0);
-        serverPorts.add(SERVERS.PORT_1);
-        serverPorts.add(SERVERS.PORT_2);
-        List<String> routerEndpoints = new ArrayList<> ();
-        routerEndpoints.add(SERVERS.ENDPOINT_0);
-        routerEndpoints.add(SERVERS.ENDPOINT_1);
-        routerEndpoints.add(SERVERS.ENDPOINT_2);
-        serverPorts.forEach(serverPort -> {
-            routerEndpoints.forEach(routerEndpoint -> {
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            });
-        });
+        // Set aggressive timeouts.
+        setAggressiveTimeouts(l, corfuRuntime,
+                getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_1).getCorfuRuntime(),
+                getManagementServer(SERVERS.PORT_2).getCorfuRuntime());
 
         failureDetected.acquire(2);
 

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -11,6 +11,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Test to verify the Management Server functionality.
@@ -280,17 +281,17 @@ public class ManagementViewTest extends AbstractViewTest {
                 TimeUnit.NANOSECONDS)).isEqualTo(true);
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
-            if (getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch() == 2L) break;
             Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            // Assert successful seal of all servers.
+            if (getServerRouter(SERVERS.PORT_0).getServerEpoch() == 2L ||
+                getServerRouter(SERVERS.PORT_1).getServerEpoch() == 2L ||
+                getServerRouter(SERVERS.PORT_2).getServerEpoch() == 2L ||
+                getLayoutServer(SERVERS.PORT_0).getCurrentLayout().getEpoch() == 2L ||
+                getLayoutServer(SERVERS.PORT_1).getCurrentLayout().getEpoch() == 2L ||
+                getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch() == 2L) {
+                return;
+            }
         }
-
-        // Assert successful seal of all servers.
-        assertThat(getServerRouter(SERVERS.PORT_0).getServerEpoch()).isEqualTo(2L);
-        assertThat(getServerRouter(SERVERS.PORT_1).getServerEpoch()).isEqualTo(2L);
-        assertThat(getServerRouter(SERVERS.PORT_2).getServerEpoch()).isEqualTo(2L);
-        assertThat(getLayoutServer(SERVERS.PORT_0).getCurrentLayout().getEpoch()).isEqualTo(2L);
-        assertThat(getLayoutServer(SERVERS.PORT_1).getCurrentLayout().getEpoch()).isEqualTo(2L);
-        assertThat(getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch()).isEqualTo(2L);
-
+        fail();
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -23,13 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ManagementViewTest extends AbstractViewTest {
 
     /**
-     * Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
-     * is sent by the Management client to its server.
-     */
-    private static final Semaphore failureDetected = new Semaphore(1,
-            true);
-
-    /**
      * Scenario with 2 nodes: SERVERS.PORT_0 and SERVERS.PORT_1.
      * We fail SERVERS.PORT_0 and then listen to intercept the message
      * sent by SERVERS.PORT_1's client to the server to handle the failure.
@@ -39,6 +32,11 @@ public class ManagementViewTest extends AbstractViewTest {
     @Test
     public void invokeFailureHandler()
             throws Exception {
+
+        // Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
+        // is sent by the Management client to its server.
+        final Semaphore failureDetected = new Semaphore(1,true);
+
         addServer(SERVERS.PORT_0);
         addServer(SERVERS.PORT_1);
         Layout l = new TestLayoutBuilder()
@@ -157,5 +155,154 @@ public class ManagementViewTest extends AbstractViewTest {
         assertThat(l2.getEpoch()).isEqualTo(2L);
         assertThat(l2.getLayoutServers().size()).isEqualTo(2);
         assertThat(l2.getLayoutServers().contains(SERVERS.ENDPOINT_1)).isFalse();
+    }
+
+    /**
+     * Scenario with 3 nodes: SERVERS.PORT_0, SERVERS.PORT_1 and SERVERS.PORT_2.
+     * Simulate transient failure of a server leading to a partial seal.
+     * Allow the management server to detect the partial seal and correct this.
+     * <p>
+     * Part 1.
+     * The partial seal causes SERVERS.PORT_0 to be at epoch 2 whereas,
+     * SERVERS.PORT_1 & SERVERS.PORT_2 fail to receive this message and are stuck at epoch 1.
+     * <p>
+     * Part 2.
+     * All the 3 servers are now functional and receive all messages.
+     * <p>
+     * Part 3.
+     * The PING message gets rejected by the partially sealed router (WrongEpoch)
+     * and the management server realizes of the partial seal and corrects this
+     * by issuing another failure detected message.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void handleTransientFailure()
+            throws Exception {
+        // Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
+        // is sent by the Management client to its server.
+        final Semaphore failureDetected = new Semaphore(2,true);
+
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
+        addServer(SERVERS.PORT_2);
+        Layout l = new TestLayoutBuilder()
+                .setEpoch(1L)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_0)
+                .buildSegment()
+                .setReplicationMode(Layout.ReplicationMode.QUORUM_REPLICATION)
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_1)
+                .addLogUnit(SERVERS.PORT_2)
+                .addToSegment()
+                .addToLayout()
+                .build();
+        bootstrapAllServers(l);
+        CorfuRuntime corfuRuntime = getRuntime(l).connect();
+
+        // Initiate SERVERS.ENDPOINT_0 failureHandler
+        corfuRuntime.getRouter(SERVERS.ENDPOINT_0).getClient(ManagementClient.class).initiateFailureHandler().get();
+
+        // Reduce test execution time from 15+ seconds to about 8 seconds:
+        // Set aggressive timeouts for surviving MS that polls the dead MS.
+        List<Integer> serverPorts = new ArrayList<> ();
+        serverPorts.add(SERVERS.PORT_0);
+        serverPorts.add(SERVERS.PORT_1);
+        serverPorts.add(SERVERS.PORT_2);
+        List<String> routerEndpoints = new ArrayList<> ();
+        routerEndpoints.add(SERVERS.ENDPOINT_0);
+        routerEndpoints.add(SERVERS.ENDPOINT_1);
+        routerEndpoints.add(SERVERS.ENDPOINT_2);
+        serverPorts.forEach(serverPort -> {
+            routerEndpoints.forEach(routerEndpoint -> {
+                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            });
+        });
+
+        failureDetected.acquire(2);
+
+        // Only allow SERVERS.PORT_0 to manage failures.
+        getManagementServer(SERVERS.PORT_1).shutdown();
+        getManagementServer(SERVERS.PORT_2).shutdown();
+
+        // PART 1.
+        // Prevent ENDPOINT_1 from sealing.
+        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(), SERVERS.ENDPOINT_1,
+                new TestRule().matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.SET_EPOCH)).drop());
+        // Simulate ENDPOINT_2 failure from ENDPOINT_0 (only Management Server)
+        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(), SERVERS.ENDPOINT_2,
+                new TestRule().matches(corfuMsg -> true).drop());
+
+        // Adding a rule on SERVERS.PORT_1 to toggle the flag when it sends the
+        // MANAGEMENT_FAILURE_DETECTED message.
+        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                new TestRule().matches(corfuMsg -> {
+                    if (corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)) {
+                        failureDetected.release();
+                    }
+                    return true;
+                }));
+
+        // Go ahead when sealing of ENDPOINT_0 takes place.
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
+            if (getServerRouter(SERVERS.PORT_0).getServerEpoch() == 2L) {
+                failureDetected.release();
+                break;
+            }
+            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        }
+
+        assertThat(failureDetected.tryAcquire(2, PARAMETERS.TIMEOUT_NORMAL.toNanos(),
+                TimeUnit.NANOSECONDS)).isEqualTo(true);
+
+        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                new TestRule().matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)
+                ).drop());
+
+        // Assert that only a partial seal was successful.
+        // ENDPOINT_0 sealed. ENDPOINT_1 & ENDPOINT_2 not sealed.
+        assertThat(getServerRouter(SERVERS.PORT_0).getServerEpoch()).isEqualTo(2L);
+        assertThat(getServerRouter(SERVERS.PORT_1).getServerEpoch()).isEqualTo(1L);
+        assertThat(getServerRouter(SERVERS.PORT_2).getServerEpoch()).isEqualTo(1L);
+        assertThat(getLayoutServer(SERVERS.PORT_0).getCurrentLayout().getEpoch()).isEqualTo(1L);
+        assertThat(getLayoutServer(SERVERS.PORT_1).getCurrentLayout().getEpoch()).isEqualTo(1L);
+        assertThat(getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch()).isEqualTo(1L);
+
+        // PART 2.
+        // Simulate normal operations for all servers and clients.
+        clearClientRules(getManagementServer(SERVERS.PORT_0).getCorfuRuntime());
+
+        // PART 3.
+        // Allow management server to detect partial seal and correct this issue.
+        addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
+                new TestRule().matches(corfuMsg -> {
+                    if (corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)) {
+                        failureDetected.release(2);
+                    }
+                    return true;
+                }));
+
+        assertThat(failureDetected.tryAcquire(2, PARAMETERS.TIMEOUT_NORMAL.toNanos(),
+                TimeUnit.NANOSECONDS)).isEqualTo(true);
+
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
+            if (getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch() == 2L) break;
+            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        }
+
+        // Assert successful seal of all servers.
+        assertThat(getServerRouter(SERVERS.PORT_0).getServerEpoch()).isEqualTo(2L);
+        assertThat(getServerRouter(SERVERS.PORT_1).getServerEpoch()).isEqualTo(2L);
+        assertThat(getServerRouter(SERVERS.PORT_2).getServerEpoch()).isEqualTo(2L);
+        assertThat(getLayoutServer(SERVERS.PORT_0).getCurrentLayout().getEpoch()).isEqualTo(2L);
+        assertThat(getLayoutServer(SERVERS.PORT_1).getCurrentLayout().getEpoch()).isEqualTo(2L);
+        assertThat(getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch()).isEqualTo(2L);
+
     }
 }


### PR DESCRIPTION
## Partial Seal Bug Fix

Fixes #491 

Consider the following scenario:
3 Servers
SERVER_0, 
SERVER_1,
SERVER_2
Log Unit Servers (quorum replicated): SERVER_0, SERVER_1, SERVER_2
For convenience assume that only SERVER_0 manages and corrects failures.

SERVER_2 stops responding. SERVER_0 detects this and attempts to seal the current layout and mark the failed node unresponsive.
During seal we are able to seal SERVER_0. Seal for SERVER & SERVER_2 fails. A seal failure causes the Management server to retry polling and check if failures are still present.

Now all the three servers are up and running. (SERVER_0, SERVER_1 and SERVER_2)
When the management server polls again it does not see the failure.
The data path is now blocked as SERVER_0 has been sealed while the others are not.

To correct this issue we make the `PING` message epochAware. This allows us to detect partial seals and correct them.

### Other minor fix
#### Layout Seal Tests
Corrected aggressive timeouts. Reduced test running time from 20 to 2 secs.
#### PeriodicPollingPolicy
Removed setting timeouts. The routers will rely on their default timeouts.