### PR TITLE
Ranked address space support.

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -5,17 +5,25 @@ enum DataType {
     EMPTY = 1;
     HOLE = 2;
     TRIMMED = 3;
+    PROPOSAL = 4;
+}
+
+
+message DataRank {
+    required int64 rank = 1;
+    required int64 uuid_most_significant = 2;
+    required int64 uuid_least_significant = 3;
 }
 
 message LogEntry {
     optional DataType data_type = 1;
     optional bytes data = 2;
     optional int64 global_address = 3;
-    optional int64 rank = 4;
     optional bool commit = 5;
     repeated string	streams = 6;
     map<string, int64> logical_addresses = 7;
     map<string, int64> backpointers = 8;
+    optional DataRank rank = 9;
 }
 
 message LogHeader {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -124,7 +124,7 @@ public class LogUnitServer extends AbstractServer {
             String logdir = opts.get("--log-path") + File.separator + "log";
             File dir = new File(logdir);
             if (!dir.exists()) {
-                dir.mkdir();
+                dir.mkdirs();
             }
             streamLog = new StreamLogFiles(logdir, (Boolean) opts.get("--no-verify"));
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/MultiReadWriteLock.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/MultiReadWriteLock.java
@@ -36,12 +36,11 @@ public class MultiReadWriteLock {
         readLock.lock();
         AtomicBoolean closed = new AtomicBoolean(false);
         return () -> {
-            if (!closed.get()) {
+            if (!closed.getAndSet(true)) {
                 try {
                     readLock.unlock();
                     clearEventuallyLockFor(address);
                 } finally {
-                    closed.set(true);
                     deregisterLockReference(address, false);
                 }
             }
@@ -61,12 +60,11 @@ public class MultiReadWriteLock {
         writeLock.lock();
         AtomicBoolean closed = new AtomicBoolean(false);
         return () -> {
-            if (!closed.get()) {
+            if (!closed.getAndSet(true)) {
                 try {
                     writeLock.unlock();
                     clearEventuallyLockFor(address);
                 } finally {
-                    closed.set(true);
                     deregisterLockReference(address, true);
                 }
             }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -14,22 +14,11 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.LinkedHashMultiset;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.protobuf.AbstractMessage;
@@ -44,6 +33,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.io.FileUtils;
+import org.corfudb.format.Types;
 import org.corfudb.format.Types.TrimEntry;
 import org.corfudb.format.Types.DataType;
 import org.corfudb.format.Types.LogEntry;
@@ -55,6 +45,8 @@ import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 
+import javax.annotation.Nullable;
+
 
 /**
  * This class implements the StreamLog by persisting the stream log as records in multiple files.
@@ -65,7 +57,7 @@ import org.corfudb.runtime.exceptions.TrimmedException;
  */
 
 @Slf4j
-public class StreamLogFiles implements StreamLog {
+public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpace {
 
     static public final short RECORD_DELIMITER = 0x4C45;
     static public int VERSION = 1;
@@ -81,6 +73,7 @@ public class StreamLogFiles implements StreamLog {
     public final String logDir;
     private Map<String, SegmentHandle> writeChannels;
     private Set<FileChannel> channelsToSync;
+    private MultiReadWriteLock segmentLocks = new MultiReadWriteLock();
 
     public StreamLogFiles(String logDir, boolean noVerify) {
         this.logDir = logDir;
@@ -130,14 +123,14 @@ public class StreamLogFiles implements StreamLog {
                         throw new RuntimeException(msg);
                     }
 
-                    if (noVerify == false && header.getVerifyChecksum() == false) {
+                    if (!noVerify && !header.getVerifyChecksum()) {
                         String msg = String.format("Log file {} not generated with checksums, can't verify!",
                                 file.getAbsoluteFile());
                         throw new RuntimeException(msg);
                     }
 
                 } catch (IOException e) {
-                    throw new RuntimeException(e.getMessage(), e.getCause());
+                    throw new RuntimeException(e.getMessage(), e);
                 }
             }
         }
@@ -167,16 +160,13 @@ public class StreamLogFiles implements StreamLog {
                 handle.getPendingTrims().contains(logAddress.getAddress())) {
             return;
         }
-
         TrimEntry entry = TrimEntry.newBuilder()
                 .setChecksum(getChecksum(logAddress.getAddress()))
                 .setAddress(logAddress.getAddress())
                 .build();
 
         // TODO(Maithem) possibly move this to SegmentHandle. Do we need to close and flush?
-        OutputStream outputStream = Channels.newOutputStream(handle.getPendingTrimChannel());
-
-        try {
+        try (OutputStream outputStream = Channels.newOutputStream(handle.getPendingTrimChannel())) {
             entry.writeDelimitedTo(outputStream);
             outputStream.flush();
             handle.pendingTrims.add(logAddress.getAddress());
@@ -203,7 +193,7 @@ public class StreamLogFiles implements StreamLog {
             //what if pending size  == knownaddresses size ?
             if (pending.size() < TRIM_THRESHOLD) {
                 log.trace("Thresh hold not exceeded. Ratio {} threshold {}", pending.size(), TRIM_THRESHOLD);
-                return;
+                return; // TODO - should not return if compact on ranked address space is necessary
             }
 
             try {
@@ -223,9 +213,9 @@ public class StreamLogFiles implements StreamLog {
         FileChannel fc2 = FileChannel.open(FileSystems.getDefault().getPath(getTrimmedFilePath(filePath)),
                 EnumSet.of(StandardOpenOption.APPEND));
 
-        Pair<LogHeader, List<LogEntry>> log = getCompactedEntries(filePath, pendingTrim);
+        Pair<LogHeader, Collection<LogEntry>> log = getCompactedEntries(filePath, pendingTrim);
         LogHeader header = log.getKey();
-        List<LogEntry> compacted = log.getValue();
+        Collection<LogEntry> compacted = log.getValue();
 
         writeHeader(fc, header.getVersion(), header.getVerifyChecksum());
 
@@ -245,18 +235,17 @@ public class StreamLogFiles implements StreamLog {
         fc.force(true);
         fc.close();
 
-        OutputStream outputStream = Channels.newOutputStream(fc2);
-
-        // Todo(Maithem) How do we verify that the compacted file is correct?
-        for (Long address : pendingTrim) {
-            TrimEntry entry = TrimEntry.newBuilder()
-                    .setChecksum(getChecksum(address))
-                    .setAddress(address)
-                    .build();
-            entry.writeDelimitedTo(outputStream);
+        try (OutputStream outputStream = Channels.newOutputStream(fc2)) {
+            // Todo(Maithem) How do we verify that the compacted file is correct?
+            for (Long address : pendingTrim) {
+                TrimEntry entry = TrimEntry.newBuilder()
+                        .setChecksum(getChecksum(address))
+                        .setAddress(address)
+                        .build();
+                entry.writeDelimitedTo(outputStream);
+            }
+            outputStream.flush();
         }
-
-        outputStream.flush();
         fc2.force(true);
         fc2.close();
 
@@ -266,7 +255,7 @@ public class StreamLogFiles implements StreamLog {
         writeChannels.remove(filePath);
     }
 
-    Pair<LogHeader, List<LogEntry>> getCompactedEntries(String filePath, Set<Long> pendingTrim) throws IOException {
+    Pair<LogHeader, Collection<LogEntry>> getCompactedEntries(String filePath, Set<Long> pendingTrim) throws IOException {
         FileChannel fc = getChannel(filePath, true);
 
         // Skip the header
@@ -286,7 +275,7 @@ public class StreamLogFiles implements StreamLog {
         fc.close();
         o.flip();
 
-        List<LogEntry> compacted = new LinkedList();
+        LinkedHashMap<Long, LogEntry> compacted = new LinkedHashMap<>();
 
         while (o.hasRemaining()) {
 
@@ -313,7 +302,7 @@ public class StreamLogFiles implements StreamLog {
                 }
 
                 if (!pendingTrim.contains(entry.getGlobalAddress())) {
-                    compacted.add(entry);
+                    compacted.put(entry.getGlobalAddress(), entry);
                 }
 
             } catch (InvalidProtocolBufferException e) {
@@ -321,7 +310,7 @@ public class StreamLogFiles implements StreamLog {
             }
         }
 
-        return new Pair(header, compacted);
+        return new Pair(header, compacted.values());
     }
 
     /**
@@ -379,7 +368,7 @@ public class StreamLogFiles implements StreamLog {
         logData.setGlobalAddress(entry.getGlobalAddress());
         logData.setBackpointerMap(getUUIDLongMap(entry.getLogicalAddressesMap()));
         logData.setStreams(getStreamsSet(entry.getStreamsList().asByteStringList()));
-        logData.setRank(entry.getRank());
+        logData.setRank(createDataRank(entry));
 
         logData.clearCommit();
 
@@ -408,7 +397,8 @@ public class StreamLogFiles implements StreamLog {
     private void readAddressSpace(SegmentHandle sh) throws IOException {
         long logFileSize;
 
-        synchronized (sh.lock) {
+
+        try (MultiReadWriteLock.AutoCloseableLock ignored = segmentLocks.acquireReadLock(sh.getSegment())) {
             logFileSize = sh.logChannel.size();
         }
 
@@ -557,7 +547,7 @@ public class StreamLogFiles implements StreamLog {
 
                 writeHeader(fc1, VERSION, verify);
                 log.trace("Opened new log file at {}", a);
-                SegmentHandle sh = new SegmentHandle(fc1, fc2, fc3, a);
+                SegmentHandle sh = new SegmentHandle(segment, fc1, fc2, fc3, a);
                 // The first time we open a file we should read to the end, to load the
                 // map of entries we already have.
                 readAddressSpace(sh);
@@ -575,7 +565,7 @@ public class StreamLogFiles implements StreamLog {
         long pendingTrimSize;
 
         //TODO(Maithem) compute checksums and refactor
-        synchronized (sh.lock) {
+        try (MultiReadWriteLock.AutoCloseableLock ignored = segmentLocks.acquireReadLock(sh.getSegment())) {
             trimmedSize = sh.getTrimmedChannel().size();
             pendingTrimSize = sh.getPendingTrimChannel().size();
         }
@@ -656,18 +646,44 @@ public class StreamLogFiles implements StreamLog {
             setCommit = (boolean) val;
         }
 
-        LogEntry logEntry = LogEntry.newBuilder()
+        LogEntry.Builder logEntryBuilder = LogEntry.newBuilder()
                 .setDataType(DataType.forNumber(entry.getType().ordinal()))
                 .setData(ByteString.copyFrom(data))
                 .setGlobalAddress(address)
-                .setRank(entry.getRank())
                 .setCommit(setCommit)
                 .addAllStreams(getStrUUID(entry.getStreams()))
                 .putAllLogicalAddresses(getStrLongMap(entry.getLogicalAddresses()))
-                .putAllBackpointers(getStrLongMap(entry.getBackpointerMap()))
-                .build();
+                .putAllBackpointers(getStrLongMap(entry.getBackpointerMap()));
 
-        return logEntry;
+        Optional<Types.DataRank> rank = createProtobufsDataRank(entry);
+        if (rank.isPresent()) {
+            logEntryBuilder.setRank(rank.get());
+        }
+
+        return logEntryBuilder.build();
+    }
+
+
+    private Optional<Types.DataRank> createProtobufsDataRank(IMetadata entry) {
+        IMetadata.DataRank rank = entry.getRank();
+        if (rank==null) {
+            return Optional.empty();
+        }
+        Types.DataRank result = Types.DataRank.newBuilder().
+                setRank(rank.getRank()).
+                setUuidLeastSignificant(rank.getUuid().getLeastSignificantBits()).
+                setUuidMostSignificant(rank.getUuid().getMostSignificantBits()).
+                build();
+        return Optional.of(result);
+    }
+
+    private @Nullable IMetadata.DataRank createDataRank(LogEntry entity) {
+        if (!entity.hasRank()) {
+            return null;
+        }
+        Types.DataRank rank = entity.getRank();
+        return new IMetadata.DataRank(rank.getRank(),
+                new UUID(rank.getUuidMostSignificant(), rank.getUuidLeastSignificant()));
     }
 
     static int getChecksum(byte[] bytes) {
@@ -707,7 +723,7 @@ public class StreamLogFiles implements StreamLog {
 
         long channelOffset;
 
-        synchronized (fh.lock) {
+        try (MultiReadWriteLock.AutoCloseableLock ignored = segmentLocks.acquireWriteLock(fh.getSegment())) {
             channelOffset = fh.logChannel.position() + Short.BYTES + METADATA_SIZE;
             fh.logChannel.write(recordBuf);
             channelsToSync.add(fh.logChannel);
@@ -725,7 +741,23 @@ public class StreamLogFiles implements StreamLog {
             SegmentHandle fh = getSegmentHandleForAddress(logAddress);
             if (fh.getKnownAddresses().containsKey(logAddress.address) ||
                     fh.getTrimmedAddresses().contains(logAddress.address)) {
-                throw new OverwriteException();
+                if (entry.getRank()==null) {
+                    throw new OverwriteException();
+                } else {
+                    try (MultiReadWriteLock.AutoCloseableLock ignored = segmentLocks.acquireWriteLock(fh.getSegment())) {
+                        Optional<Boolean> canAppend = isAppendPermitted(logAddress, entry);
+                        if (canAppend.isPresent()) {
+                            if (canAppend.get()) {
+                                AddressMetaData addressMetaData = writeRecord(fh, logAddress.address, entry);
+                                fh.getKnownAddresses().put(logAddress.address, addressMetaData);
+                            } else {
+                                throw new OverwriteException();
+                            }
+                        } else {
+                            log.debug("Duplicate requests for {} ", logAddress);
+                        }
+                    }
+                }
             } else {
                 AddressMetaData addressMetaData = writeRecord(fh, logAddress.address, entry);
                 fh.getKnownAddresses().put(logAddress.address, addressMetaData);
@@ -754,20 +786,22 @@ public class StreamLogFiles implements StreamLog {
      * A SegmentHandle is a range view of consecutive addresses in the log. It contains
      * the address space along with metadata like addresses that are trimmed and pending trims.
      */
+
     @Data
     class SegmentHandle {
+        private final long segment;
         @NonNull
-        private FileChannel logChannel;
+        private final FileChannel logChannel;
         @NonNull
-        private FileChannel trimmedChannel;
+        private final FileChannel trimmedChannel;
         @NonNull
-        private FileChannel pendingTrimChannel;
+        private final FileChannel pendingTrimChannel;
         @NonNull
         private String fileName;
         private Map<Long, AddressMetaData> knownAddresses = new ConcurrentHashMap();
         private Set<Long> trimmedAddresses = Collections.newSetFromMap(new ConcurrentHashMap<>());
         private Set<Long> pendingTrims = Collections.newSetFromMap(new ConcurrentHashMap<>());
-        private final Lock lock = new ReentrantLock();
+
 
         public void close() {
             Set<FileChannel> channels = new HashSet(Arrays.asList(logChannel, trimmedChannel, pendingTrimChannel));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -166,7 +166,8 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                 .build();
 
         // TODO(Maithem) possibly move this to SegmentHandle. Do we need to close and flush?
-        try (OutputStream outputStream = Channels.newOutputStream(handle.getPendingTrimChannel())) {
+        OutputStream outputStream = Channels.newOutputStream(handle.getPendingTrimChannel());
+        try {
             entry.writeDelimitedTo(outputStream);
             outputStream.flush();
             handle.pendingTrims.add(logAddress.getAddress());
@@ -245,8 +246,8 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                 entry.writeDelimitedTo(outputStream);
             }
             outputStream.flush();
+            fc2.force(true);
         }
-        fc2.force(true);
         fc2.close();
 
         Files.move(Paths.get(filePath + ".copy"), Paths.get(filePath), StandardCopyOption.ATOMIC_MOVE);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpace.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpace.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.infrastructure.log;
+
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.LogData;
+
+import java.util.Optional;
+
+/**
+ * Stream log that is able to compare the data on the same log address using the rank and type.
+ *
+ * Created by Konstantin Spirov on 3/15/2017.
+ */
+public interface StreamLogWithRankedAddressSpace extends StreamLog {
+    /**
+     * Check whether the data can be appended to a given log address
+     * @param logAddress
+     * @param newEntry
+     * @return true if the new entry can be appended, false if the new entry cannot be appended,
+     * empty if the entry is the same so the request should be ignored in order to be idempotent.
+     */
+    default Optional<Boolean> isAppendPermitted(LogAddress logAddress, LogData newEntry) {
+        LogData oldEntry = read(logAddress);
+        if (oldEntry.getType()==DataType.EMPTY) {
+            return Optional.of(Boolean.TRUE);
+        }
+        if (newEntry.getType()==DataType.PROPOSAL && oldEntry.getType() != DataType.PROPOSAL) {
+            // the new data is a proposal, the other data is not, so the old value should be accepted
+            return Optional.of(Boolean.FALSE);
+        }
+        int compare = newEntry.getRank().compareTo(oldEntry.getRank());
+        return compare==0? Optional.empty(): compare<0? Optional.of(Boolean.FALSE): Optional.of(Boolean.TRUE);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
@@ -16,7 +16,8 @@ public enum DataType implements ICorfuPayload<DataType> {
     DATA(0),
     EMPTY(1),
     HOLE(2),
-    TRIMMED(3);
+    TRIMMED(3),
+    PROPOSAL(4);
 
     final int val;
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -1,19 +1,17 @@
 package org.corfudb.protocols.wireprotocol;
 
+import com.esotericsoftware.kryo.NotNull;
 import com.google.common.reflect.TypeToken;
-import lombok.Data;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.*;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -22,7 +20,7 @@ import java.util.stream.Collectors;
  */
 public interface IMetadata {
 
-    public static Map<Byte, LogUnitMetadataType> metadataTypeMap =
+    Map<Byte, LogUnitMetadataType> metadataTypeMap =
             Arrays.<LogUnitMetadataType>stream(LogUnitMetadataType.values())
                     .collect(Collectors.toMap(LogUnitMetadataType::asByte, Function.identity()));
 
@@ -67,9 +65,10 @@ public interface IMetadata {
      * @return The rank of this append.
      */
     @SuppressWarnings("unchecked")
-    default Long getRank() {
-        return (Long) getMetadataMap().getOrDefault(IMetadata.LogUnitMetadataType.RANK,
-                0L);
+    @Nullable
+    default DataRank getRank() {
+        return (DataRank) getMetadataMap().getOrDefault(IMetadata.LogUnitMetadataType.RANK,
+                null);
     }
 
     /**
@@ -77,7 +76,7 @@ public interface IMetadata {
      *
      * @param rank The rank of this append.
      */
-    default void setRank(long rank) {
+    default void setRank(@Nullable DataRank rank) {
         getMetadataMap().put(IMetadata.LogUnitMetadataType.RANK, rank);
     }
 
@@ -163,4 +162,28 @@ public interface IMetadata {
                 Arrays.<LogUnitMetadataType>stream(LogUnitMetadataType.values())
                         .collect(Collectors.toMap(LogUnitMetadataType::asByte, Function.identity()));
     }
+
+    @Value
+    @AllArgsConstructor
+    class DataRank implements Comparable<DataRank> {
+        public long rank;
+        @NotNull
+        public UUID uuid;
+
+        public DataRank(long rank) {
+            this(rank, UUID.randomUUID());
+        }
+
+        @Override
+        public int compareTo(DataRank o) {
+            int rankCompared = Long.compare(this.rank, o.rank);
+            if (rankCompared==0) {
+                return uuid.compareTo(o.getUuid());
+            } else {
+                return rankCompared;
+            }
+        }
+    }
+
+    
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -67,7 +67,7 @@ public interface IMetadata {
     @SuppressWarnings("unchecked")
     @Nullable
     default DataRank getRank() {
-        return (DataRank) getMetadataMap().getOrDefault(IMetadata.LogUnitMetadataType.RANK,
+        return (DataRank) getMetadataMap().getOrDefault(LogUnitMetadataType.RANK,
                 null);
     }
 
@@ -77,7 +77,14 @@ public interface IMetadata {
      * @param rank The rank of this append.
      */
     default void setRank(@Nullable DataRank rank) {
-        getMetadataMap().put(IMetadata.LogUnitMetadataType.RANK, rank);
+        EnumMap<LogUnitMetadataType, Object> map = getMetadataMap();
+        if (rank != null) {
+            map.put(LogUnitMetadataType.RANK, rank);
+        } else {
+            if (map.containsKey(LogUnitMetadataType.RANK)) {
+                map.remove(LogUnitMetadataType.RANK);
+            }
+        }
     }
 
     /**
@@ -144,7 +151,7 @@ public interface IMetadata {
     @RequiredArgsConstructor
     public enum LogUnitMetadataType implements ITypedEnum {
         STREAM(0, new TypeToken<Set<UUID>>() {}),
-        RANK(1, TypeToken.of(Long.class)),
+        RANK(1, TypeToken.of(DataRank.class)),
         STREAM_ADDRESSES(2, new TypeToken<Map<UUID, Long>>() {}),
         BACKPOINTER_MAP(3, new TypeToken<Map<UUID, Long>>() {}),
         GLOBAL_ADDRESS(4, TypeToken.of(Long.class)),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -177,7 +177,7 @@ public class LogUnitClient implements IClient {
      * @return A CompletableFuture which will complete with the WriteResult once the
      * write completes.
      */
-    public CompletableFuture<Boolean> write(long address, Set<UUID> streams, long rank,
+    public CompletableFuture<Boolean> write(long address, Set<UUID> streams, IMetadata.DataRank rank,
                                             Object writeObject, Map<UUID, Long> backpointerMap) {
         Timer.Context context = getTimerContext("writeObject");
         ByteBuf payload = ByteBufAllocator.DEFAULT.buffer();
@@ -203,7 +203,7 @@ public class LogUnitClient implements IClient {
      * @return A CompletableFuture which will complete with the WriteResult once the
      * write completes.
      */
-    public CompletableFuture<Boolean> write(long address, Set<UUID> streams, long rank,
+    public CompletableFuture<Boolean> write(long address, Set<UUID> streams, IMetadata.DataRank rank,
                                             ByteBuf buffer, Map<UUID, Long> backpointerMap) {
         Timer.Context context = getTimerContext("writeByteBuf");
         WriteRequest wr = new WriteRequest(WriteMode.NORMAL, null, buffer);

--- a/runtime/src/main/java/org/corfudb/runtime/view/ChainReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ChainReplicationView.java
@@ -76,7 +76,7 @@ public class ChainReplicationView extends AbstractReplicationView {
                 // in the chain.
                 CFUtils.getUninterruptibly(
                         getLayout().getLogUnitClient(address, i)
-                                .write(address, stream, 0L, data, backpointerMap), OverwriteException.class);
+                                .write(address, stream, null, data, backpointerMap), OverwriteException.class);
             }
         }
         return payloadBytes;

--- a/runtime/src/main/java/org/corfudb/runtime/view/ReplexReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ReplexReplicationView.java
@@ -72,7 +72,7 @@ public class ReplexReplicationView extends AbstractReplicationView {
                 log.trace("Write, Global[{}]: chain {}/{}", address, i + 1, numUnits);
                 CFUtils.getUninterruptibly(
                         getLayout().getLogUnitClient(address, i)
-                                .write(getLayout().getLocalAddress(address), stream, 0L, b, Collections.emptyMap()), OverwriteException.class);
+                                .write(getLayout().getLocalAddress(address), stream, null, b, Collections.emptyMap()), OverwriteException.class);
             }
 
             // Write to the secondary / stream index units. To reduce the amount of network traffic, aggregate all

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure;
 
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import edu.umd.cs.findbugs.SystemProperties;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import org.assertj.core.api.Assertions;
@@ -11,6 +12,8 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.util.serializer.Serializers;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -25,6 +28,7 @@ import static org.corfudb.infrastructure.LogUnitServerAssertions.assertThat;
  * Created by mwei on 2/4/16.
  */
 public class LogUnitServerTest extends AbstractServerTest {
+
 
     @Override
     public AbstractServer getDefaultServer() {
@@ -55,7 +59,6 @@ public class LogUnitServerTest extends AbstractServerTest {
         m.setGlobalAddress(ADDRESS_0);
         // m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
         m.setStreams(Collections.EMPTY_SET);
-        m.setRank(ADDRESS_0);
         m.setBackpointerMap(Collections.emptyMap());
         sendMessage(CorfuMsgType.WRITE.payloadMsg(m));
 
@@ -73,7 +76,6 @@ public class LogUnitServerTest extends AbstractServerTest {
         m2.setGlobalAddress(ADDRESS_0);
         // m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
         m2.setStreams(Collections.EMPTY_SET);
-        m2.setRank(ADDRESS_0);
         m2.setBackpointerMap(Collections.emptyMap());
 
         sendMessage(CorfuMsgType.WRITE.payloadMsg(m2));
@@ -107,7 +109,6 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .build();
         m.setGlobalAddress(LOW_ADDRESS);
         m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
-        m.setRank(0L);
         m.setBackpointerMap(Collections.emptyMap());
         sendMessage(CorfuMsgType.WRITE.payloadMsg(m));
         //100
@@ -119,7 +120,6 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .build();
         m.setGlobalAddress(MID_ADDRESS);
         m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
-        m.setRank(0L);
         m.setBackpointerMap(Collections.emptyMap());
         sendMessage(CorfuMsgType.WRITE.payloadMsg(m));
         //and 10000000
@@ -131,7 +131,6 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .build();
         m.setGlobalAddress(HIGH_ADDRESS);
         m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
-        m.setRank(0L);
         m.setBackpointerMap(Collections.emptyMap());
         sendMessage(CorfuMsgType.WRITE.payloadMsg(m));
 
@@ -209,5 +208,93 @@ public class LogUnitServerTest extends AbstractServerTest {
         ServerContext context = builder.build();
         LogUnitServer logunit = new LogUnitServer(context);
     }
+
+
+    @Test
+    public void checkOverwriteExceptionIsNotThrownWhenTheRankIsHigher() throws Exception {
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+
+        LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
+                .setLogPath(serviceDir)
+                .setMemory(false)
+                .build());
+
+        this.router.reset();
+        this.router.addServer(s1);
+
+        final long ADDRESS_0 = 0L;
+        final long ADDRESS_1 = 100L;
+        //write at 0
+        ByteBuf b = ByteBufAllocator.DEFAULT.buffer();
+        Serializers.CORFU.serialize("0".getBytes(), b);
+        WriteRequest m = WriteRequest.builder()
+                .writeMode(WriteMode.NORMAL)
+                .data(new LogData(DataType.DATA, b))
+                .build();
+        m.setGlobalAddress(ADDRESS_0);
+        // m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
+        m.setStreams(Collections.EMPTY_SET);
+        m.setRank(new IMetadata.DataRank(0));
+        m.setBackpointerMap(Collections.emptyMap());
+        sendMessage(CorfuMsgType.WRITE.payloadMsg(m));
+
+        assertThat(s1)
+                .containsDataAtAddress(ADDRESS_0);
+        assertThat(s1)
+                .isEmptyAtAddress(ADDRESS_1);
+
+
+        // repeat: do not throw exception, the overwrite is forced
+        b.clear();
+        b = ByteBufAllocator.DEFAULT.buffer();
+        Serializers.CORFU.serialize("1".getBytes(), b);
+        m = WriteRequest.builder()
+                .writeMode(WriteMode.NORMAL)
+                .data(new LogData(DataType.DATA, b))
+                .build();
+        m.setGlobalAddress(ADDRESS_0);
+        // m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
+        m.setStreams(Collections.EMPTY_SET);
+        m.setBackpointerMap(Collections.emptyMap());
+
+
+        WriteRequest m2 = WriteRequest.builder()
+                .writeMode(WriteMode.NORMAL)
+                .data(new LogData(DataType.DATA, b))
+                .build();
+
+        m2.setGlobalAddress(ADDRESS_0);
+        // m.setStreams(Collections.singleton(CorfuRuntime.getStreamID("a")));
+        m2.setStreams(Collections.EMPTY_SET);
+        m2.setRank(new IMetadata.DataRank(0));
+        m2.setBackpointerMap(Collections.emptyMap());
+
+        sendMessage(CorfuMsgType.WRITE.payloadMsg(m2));
+        Assertions.assertThat(getLastMessage().getMsgType())
+                .isEqualTo(CorfuMsgType.WRITE_OK);
+
+        // now let's read again and see what we have, we should have the second value (not the first)
+
+        assertThat(s1)
+                .containsDataAtAddress(ADDRESS_0);
+        assertThat(s1)
+                .matchesDataAtAddress(ADDRESS_0, "1".getBytes());
+
+        // and now without the local cache
+        LogUnitServer s2 = new LogUnitServer(new ServerContextBuilder()
+                .setLogPath(serviceDir)
+                .setMemory(false)
+                .build());
+        this.router.reset();
+        this.router.addServer(s2);
+
+        assertThat(s2)
+                .containsDataAtAddress(ADDRESS_0);
+        assertThat(s2)
+                .matchesDataAtAddress(ADDRESS_0, "1".getBytes());
+
+    }
+
+
 }
 

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -79,6 +79,29 @@ public class LogUnitClientTest extends AbstractClientTest {
     }
 
     @Test
+    public void canReadWriteRanked()
+            throws Exception {
+        byte[] testString = "hello world".getBytes();
+        IMetadata.DataRank rank = new IMetadata.DataRank(1);
+        client.write(0, Collections.<UUID>emptySet(), rank, testString, Collections.emptyMap()).get();
+        LogData r = client.read(0).get().getReadSet().get(0L);
+        assertThat(r.getType())
+                .isEqualTo(DataType.DATA);
+        assertThat(r.getPayload(new CorfuRuntime()))
+                .isEqualTo(testString);
+        client.write(0, Collections.<UUID>emptySet(), rank, testString, Collections.emptyMap()).get();
+        // no error - we are idempotent
+        byte[] testString2 = "hello world 2".getBytes();
+        client.write(0, Collections.<UUID>emptySet(), new IMetadata.DataRank(2), testString2, Collections.emptyMap()).get();
+        r = client.read(0).get().getReadSet().get(0L);
+        assertThat(r.getType())
+                .isEqualTo(DataType.DATA);
+        assertThat(r.getPayload(new CorfuRuntime()))
+                .isEqualTo(testString2);
+    }
+
+
+    @Test
     public void overwriteThrowsException()
             throws Exception {
         byte[] testString = "hello world".getBytes();

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -70,7 +70,7 @@ public class LogUnitClientTest extends AbstractClientTest {
     public void canReadWrite()
             throws Exception {
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
+        client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get();
         LogData r = client.read(0).get().getReadSet().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
@@ -82,8 +82,8 @@ public class LogUnitClientTest extends AbstractClientTest {
     public void overwriteThrowsException()
             throws Exception {
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
-        assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), 0,
+        client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get();
+        assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), null,
                 testString, Collections.emptyMap()).get())
                 .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(OverwriteException.class);
@@ -98,7 +98,7 @@ public class LogUnitClientTest extends AbstractClientTest {
         assertThat(r.getType())
                 .isEqualTo(DataType.HOLE);
 
-        assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get())
+        assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get())
                 .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(OverwriteException.class);
     }
@@ -107,7 +107,7 @@ public class LogUnitClientTest extends AbstractClientTest {
     public void holeFillCannotOverwrite()
             throws Exception {
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
+        client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get();
 
         LogData r = client.read(0).get().getReadSet().get(0L);
         assertThat(r.getType())
@@ -125,7 +125,7 @@ public class LogUnitClientTest extends AbstractClientTest {
         final long ADDRESS_1 = 1338L;
 
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString,
+        client.write(0, Collections.<UUID>emptySet(), null, testString,
                 ImmutableMap.<UUID, Long>builder()
                         .put(CorfuRuntime.getStreamID("hello"), ADDRESS_0)
                         .put(CorfuRuntime.getStreamID("hello2"), ADDRESS_1)
@@ -142,7 +142,7 @@ public class LogUnitClientTest extends AbstractClientTest {
     public void canCommitWrite()
             throws Exception {
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
+        client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get();
         client.writeCommit(null, 0, true).get();
         LogData r = client.read(0).get().getReadSet().get(0L);
         assertThat(r.getType())
@@ -167,7 +167,7 @@ public class LogUnitClientTest extends AbstractClientTest {
     @Test
     public void CorruptedDataReadThrowsException() throws Exception {
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
+        client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get();
         LogData r = client.read(0).get().getReadSet().get(0L);
         // Verify that the data has been written correctly
         assertThat(r.getPayload(null)).isEqualTo(testString);


### PR DESCRIPTION
* Rank is a separate class, with basic part and UUID.
* PROPOSAL DataType and write operations based on rank only when a rank is given (for quorum).
* Using the new read/write locks in StreamLogFiles (deadlock protection and multiple readers)
* Single address from the global space for the compact operation
* Bugfixes relatred to closing of  streams and channels (more to come)