### PR TITLE
Ranked address space support.

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -5,17 +5,25 @@ enum DataType {
     EMPTY = 1;
     HOLE = 2;
     TRIMMED = 3;
+    PROPOSAL = 4;
+}
+
+
+message DataRank {
+    required int64 rank = 1;
+    required int64 uuid_most_significant = 2;
+    required int64 uuid_least_significant = 3;
 }
 
 message LogEntry {
     optional DataType data_type = 1;
     optional bytes data = 2;
     optional int64 global_address = 3;
-    optional int64 rank = 4;
     optional bool commit = 5;
     repeated string	streams = 6;
     map<string, int64> logical_addresses = 7;
     map<string, int64> backpointers = 8;
+    optional DataRank rank = 9;
 }
 
 message LogHeader {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -57,7 +57,7 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
             throw new OverwriteException();
         } else {
             // the method below might throw DataOutrankedException or ValueAdoptedException
-            assertAppendPermitted(logAddress, entry);
+            assertAppendPermittedUnsafe(logAddress, entry);
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -17,7 +17,7 @@ import org.corfudb.runtime.exceptions.TrimmedException;
  *
  * Created by maithem on 7/21/16.
  */
-public class InMemoryStreamLog implements StreamLog {
+public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressSpace {
 
     private Map<Long, LogData> logCache;
     private Map<UUID, Map<Long, LogData>> streamCache;
@@ -33,7 +33,7 @@ public class InMemoryStreamLog implements StreamLog {
     public synchronized void append(LogAddress logAddress, LogData entry) {
         if (logAddress.getStream() == null) {
             if(logCache.containsKey(logAddress.address)) {
-                throw new OverwriteException();
+                throwLogUnitExceptionsIfNecessary(logAddress, entry);
             }
             logCache.put(logAddress.address, entry);
         } else {
@@ -45,10 +45,19 @@ public class InMemoryStreamLog implements StreamLog {
             }
 
             if(stream.containsKey(logAddress.address)) {
-                throw new OverwriteException();
-            } else {
-                stream.put(logAddress.address, entry);
+                throwLogUnitExceptionsIfNecessary(logAddress, entry);
             }
+            stream.put(logAddress.address, entry);
+
+        }
+    }
+
+    private void throwLogUnitExceptionsIfNecessary(LogAddress logAddress, LogData entry) {
+        if (entry.getRank()==null) {
+            throw new OverwriteException();
+        } else {
+            // the method below might throw DataOutrankedException or ValueAdoptedException
+            assertAppendPermitted(logAddress, entry);
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/MultiReadWriteLock.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/MultiReadWriteLock.java
@@ -36,12 +36,11 @@ public class MultiReadWriteLock {
         readLock.lock();
         AtomicBoolean closed = new AtomicBoolean(false);
         return () -> {
-            if (!closed.get()) {
+            if (!closed.getAndSet(true)) {
                 try {
                     readLock.unlock();
                     clearEventuallyLockFor(address);
                 } finally {
-                    closed.set(true);
                     deregisterLockReference(address, false);
                 }
             }
@@ -61,12 +60,11 @@ public class MultiReadWriteLock {
         writeLock.lock();
         AtomicBoolean closed = new AtomicBoolean(false);
         return () -> {
-            if (!closed.get()) {
+            if (!closed.getAndSet(true)) {
                 try {
                     writeLock.unlock();
                     clearEventuallyLockFor(address);
                 } finally {
-                    closed.set(true);
                     deregisterLockReference(address, true);
                 }
             }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -756,7 +756,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                     throw new OverwriteException();
                 } else {
                     // the method below might throw DataOutrankedException or ValueAdoptedException
-                    assertAppendPermitted(logAddress, entry);
+                    assertAppendPermittedUnsafe(logAddress, entry);
                     AddressMetaData addressMetaData = writeRecord(fh, logAddress.address, entry);
                     fh.getKnownAddresses().put(logAddress.address, addressMetaData);
                 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpace.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpace.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.infrastructure.log;
+
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.ReadResponse;
+import org.corfudb.runtime.exceptions.DataOutrankedException;
+import org.corfudb.runtime.exceptions.ValueAdoptedException;
+
+
+/**
+ * Stream log that is able to compare the data on the same log address using the rank and type.
+ *
+ * Created by Konstantin Spirov on 3/15/2017.
+ */
+public interface StreamLogWithRankedAddressSpace extends StreamLog {
+
+    /**
+     * Check whether the data can be appended to a given log address
+     * @param logAddress
+     * @param newEntry
+     * @throws DataOutrankedException if the log entry cannot be assigned to this log address as there is a data with higher rank
+     * @throws ValueAdoptedException if the new message is a proposal during the two phase recovery write and there is an existing
+     * data at this log address already.
+     */
+    default void assertAppendPermitted(LogAddress logAddress, LogData newEntry) throws DataOutrankedException, ValueAdoptedException {
+        LogData oldEntry = read(logAddress);
+        if (oldEntry.getType()==DataType.EMPTY) {
+             return;
+        }
+        int compare = newEntry.getRank().compareTo(oldEntry.getRank());
+        if (compare<0) {
+            throw new DataOutrankedException();
+        }
+        if (compare>0) {
+            if (newEntry.getType()==DataType.RANK_ONLY && oldEntry.getType() != DataType.RANK_ONLY) {
+                // the new data is a proposal, the other data is not, so the old value should be adopted
+                ReadResponse resp = new ReadResponse();
+                resp.put(logAddress.getAddress(), oldEntry);
+                throw new ValueAdoptedException(resp);
+            } else {
+                return;
+            }
+        }
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpace.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpace.java
@@ -19,14 +19,17 @@ import org.corfudb.runtime.exceptions.ValueAdoptedException;
 public interface StreamLogWithRankedAddressSpace extends StreamLog {
 
     /**
-     * Check whether the data can be appended to a given log address
+     * Check whether the data can be appended to a given log address.
+     * Note that it is not permitted multiple threads to access the same log address
+     * concurrently through this method, this method does not lock or synchronize.
+     * This method needs
      * @param logAddress
      * @param newEntry
      * @throws DataOutrankedException if the log entry cannot be assigned to this log address as there is a data with higher rank
      * @throws ValueAdoptedException if the new message is a proposal during the two phase recovery write and there is an existing
      * data at this log address already.
      */
-    default void assertAppendPermitted(LogAddress logAddress, LogData newEntry) throws DataOutrankedException, ValueAdoptedException {
+    default void assertAppendPermittedUnsafe(LogAddress logAddress, LogData newEntry) throws DataOutrankedException, ValueAdoptedException {
         LogData oldEntry = read(logAddress);
         if (oldEntry.getType()==DataType.EMPTY) {
              return;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -63,6 +63,9 @@ public enum CorfuMsgType {
     ERROR_NOENTRY(55, TypeToken.of(CorfuMsg.class)),
     ERROR_REPLEX_OVERWRITE(56, TypeToken.of(CorfuMsg.class)),
     ERROR_DATA_CORRUPTION(57, new TypeToken<CorfuPayloadMsg<ReadResponse>>() {}),
+    ERROR_DATA_OUTRANKED(58, TypeToken.of(CorfuMsg.class)),
+    ERROR_VALUE_ADOPTED(59,new TypeToken<CorfuPayloadMsg<ReadResponse>>() {}),
+
 
     // EXTRA CODES
     LAYOUT_ALREADY_BOOTSTRAP(60, TypeToken.of(CorfuMsg.class), true),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
@@ -1,6 +1,8 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
@@ -11,14 +13,19 @@ import java.util.stream.Collectors;
 /**
  * Created by mwei on 8/16/16.
  */
-@RequiredArgsConstructor
+@AllArgsConstructor
 public enum DataType implements ICorfuPayload<DataType> {
-    DATA(0),
-    EMPTY(1),
-    HOLE(2),
-    TRIMMED(3);
+    DATA(0, true),
+    EMPTY(1, false),
+    HOLE(2, true),
+    TRIMMED(3, false),
+    RANK_ONLY(4, true);
 
     final int val;
+
+    @Getter
+    private boolean metadataAware;
+
 
     byte asByte() {
         return (byte) val;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -1,19 +1,20 @@
 package org.corfudb.protocols.wireprotocol;
 
+import com.esotericsoftware.kryo.NotNull;
 import com.google.common.reflect.TypeToken;
-import lombok.Data;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 
+import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -22,7 +23,7 @@ import java.util.stream.Collectors;
  */
 public interface IMetadata {
 
-    public static Map<Byte, LogUnitMetadataType> metadataTypeMap =
+    Map<Byte, LogUnitMetadataType> metadataTypeMap =
             Arrays.<LogUnitMetadataType>stream(LogUnitMetadataType.values())
                     .collect(Collectors.toMap(LogUnitMetadataType::asByte, Function.identity()));
 
@@ -67,9 +68,10 @@ public interface IMetadata {
      * @return The rank of this append.
      */
     @SuppressWarnings("unchecked")
-    default Long getRank() {
-        return (Long) getMetadataMap().getOrDefault(IMetadata.LogUnitMetadataType.RANK,
-                0L);
+    @Nullable
+    default DataRank getRank() {
+        return (DataRank) getMetadataMap().getOrDefault(LogUnitMetadataType.RANK,
+                null);
     }
 
     /**
@@ -77,8 +79,15 @@ public interface IMetadata {
      *
      * @param rank The rank of this append.
      */
-    default void setRank(long rank) {
-        getMetadataMap().put(IMetadata.LogUnitMetadataType.RANK, rank);
+    default void setRank(@Nullable DataRank rank) {
+        EnumMap<LogUnitMetadataType, Object> map = getMetadataMap();
+        if (rank != null) {
+            map.put(LogUnitMetadataType.RANK, rank);
+        } else {
+            if (map.containsKey(LogUnitMetadataType.RANK)) {
+                map.remove(LogUnitMetadataType.RANK);
+            }
+        }
     }
 
     /**
@@ -145,7 +154,7 @@ public interface IMetadata {
     @RequiredArgsConstructor
     public enum LogUnitMetadataType implements ITypedEnum {
         STREAM(0, new TypeToken<Set<UUID>>() {}),
-        RANK(1, TypeToken.of(Long.class)),
+        RANK(1, TypeToken.of(DataRank.class)),
         STREAM_ADDRESSES(2, new TypeToken<Map<UUID, Long>>() {}),
         BACKPOINTER_MAP(3, new TypeToken<Map<UUID, Long>>() {}),
         GLOBAL_ADDRESS(4, TypeToken.of(Long.class)),
@@ -163,4 +172,28 @@ public interface IMetadata {
                 Arrays.<LogUnitMetadataType>stream(LogUnitMetadataType.values())
                         .collect(Collectors.toMap(LogUnitMetadataType::asByte, Function.identity()));
     }
+
+    @Value
+    @AllArgsConstructor
+    class DataRank implements Comparable<DataRank> {
+        public long rank;
+        @NotNull
+        public UUID uuid;
+
+        public DataRank(long rank) {
+            this(rank, UUID.randomUUID());
+        }
+
+        @Override
+        public int compareTo(DataRank o) {
+            int rankCompared = Long.compare(this.rank, o.rank);
+            if (rankCompared==0) {
+                return uuid.compareTo(o.getUuid());
+            } else {
+                return rankCompared;
+            }
+        }
+    }
+
+    
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -71,12 +71,14 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         type = ICorfuPayload.fromBuffer(buf, DataType.class);
         if (type == DataType.DATA) {
             data = ICorfuPayload.fromBuffer(buf, byte[].class);
+        } else  {
+            data = null;
+        }
+        if (type.isMetadataAware()) {
             metadataMap =
                     ICorfuPayload.enumMapFromBuffer(buf,
                             IMetadata.LogUnitMetadataType.class, Object.class);
-        } else
-        {
-            data = null;
+        } else {
             metadataMap = new EnumMap<>(IMetadata.LogUnitMetadataType.class);
         }
     }
@@ -112,6 +114,8 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         ICorfuPayload.serialize(buf, type);
         if (type == DataType.DATA) {
             ICorfuPayload.serialize(buf, data);
+        }
+        if (type.isMetadataAware()) {
             ICorfuPayload.serialize(buf, metadataMap);
         }
     }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WriteRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WriteRequest.java
@@ -29,10 +29,15 @@ public class WriteRequest implements ICorfuPayload<WriteRequest>, IMetadata {
     }
 
     public WriteRequest(WriteMode writeMode, Map<UUID, Long> streamAddresses, ByteBuf buf) {
+        this(writeMode, DataType.DATA, streamAddresses, buf);
+    }
+
+    public WriteRequest(WriteMode writeMode, DataType dataType,  Map<UUID, Long> streamAddresses, ByteBuf buf) {
         this.writeMode = writeMode;
         this.streamAddresses = streamAddresses;
-        this.data = new LogData(DataType.DATA, buf);
+        this.data = new LogData(dataType, buf);
     }
+
 
     @Override
     public void doSerialize(ByteBuf buf) {

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -2,18 +2,15 @@ package org.corfudb.runtime.clients;
 
 import com.codahale.metrics.Timer;
 import com.google.common.collect.Range;
-import com.google.common.collect.RangeSet;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
 import lombok.Setter;
+import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.wireprotocol.*;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.exceptions.DataCorruptionException;
-import org.corfudb.runtime.exceptions.OutOfSpaceException;
-import org.corfudb.runtime.exceptions.OverwriteException;
-import org.corfudb.runtime.exceptions.ReplexOverwriteException;
+import org.corfudb.runtime.exceptions.*;
 import org.corfudb.util.serializer.Serializers;
 
 import java.lang.invoke.MethodHandles;
@@ -82,6 +79,28 @@ public class LogUnitClient implements IClient {
             throws Exception
     {
         throw new OverwriteException();
+    }
+
+    /** Handle an ERROR_DATA_OUTRANKED message.
+     *
+     * @param msg   Incoming Message
+     * @param ctx   Context
+     * @param r     Router
+     * @throws      OverwriteException
+     */
+    @ClientHandler(type=CorfuMsgType.ERROR_DATA_OUTRANKED)
+    private static Object handleDataOutranked(CorfuMsg msg, ChannelHandlerContext ctx, IClientRouter r)
+            throws Exception
+    {
+        throw new DataOutrankedException();
+    }
+
+
+
+    @ClientHandler(type=CorfuMsgType.ERROR_VALUE_ADOPTED)
+    private static Object handleValueAdoptedResponse(CorfuPayloadMsg<ReadResponse> msg,
+                                             ChannelHandlerContext ctx, IClientRouter r) {
+        throw new ValueAdoptedException(msg.getPayload());
     }
 
     /** Handle an ERROR_REPLEX_OVERWRITE message.
@@ -177,7 +196,7 @@ public class LogUnitClient implements IClient {
      * @return A CompletableFuture which will complete with the WriteResult once the
      * write completes.
      */
-    public CompletableFuture<Boolean> write(long address, Set<UUID> streams, long rank,
+    public CompletableFuture<Boolean> write(long address, Set<UUID> streams, IMetadata.DataRank rank,
                                             Object writeObject, Map<UUID, Long> backpointerMap) {
         Timer.Context context = getTimerContext("writeObject");
         ByteBuf payload = ByteBufAllocator.DEFAULT.buffer();
@@ -192,6 +211,29 @@ public class LogUnitClient implements IClient {
     }
 
     /**
+     * Asynchronously write a proposal to a logging unit with ranked address space. This proposal data keeps
+     * the rank to the log unit during the two phase recovery write in the quorum replication.
+     *
+     * @param address        The address to write to.
+     * @param streams        The streams, if any, that this write belongs to.
+     * @param rank           The rank of this write]
+     *
+     */
+    CompletableFuture<Boolean> writeProposal(long address, Set<UUID> streams, IMetadata.DataRank rank) {
+        Timer.Context context = getTimerContext("writeObject");
+        LogEntry entry = new LogEntry(LogEntry.LogEntryType.NOP);
+        ByteBuf payload = ByteBufAllocator.DEFAULT.buffer();
+        Serializers.CORFU.serialize(entry, payload);
+        WriteRequest wr = new WriteRequest(WriteMode.NORMAL, DataType.RANK_ONLY,  null,  payload);
+        wr.setStreams(streams);
+        wr.setRank(rank);
+        wr.setGlobalAddress(address);
+        CompletableFuture<Boolean> cf = router.sendMessageAndGetCompletable(CorfuMsgType.WRITE.payloadMsg(wr));
+        return cf.thenApply(x -> { context.stop(); return x; });
+    }
+
+
+    /**
      * Asynchronously write to the logging unit.
      *
      * @param address        The address to write to.
@@ -203,7 +245,7 @@ public class LogUnitClient implements IClient {
      * @return A CompletableFuture which will complete with the WriteResult once the
      * write completes.
      */
-    public CompletableFuture<Boolean> write(long address, Set<UUID> streams, long rank,
+    public CompletableFuture<Boolean> write(long address, Set<UUID> streams, IMetadata.DataRank rank,
                                             ByteBuf buffer, Map<UUID, Long> backpointerMap) {
         Timer.Context context = getTimerContext("writeByteBuf");
         WriteRequest wr = new WriteRequest(WriteMode.NORMAL, null, buffer);

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/DataOutrankedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/DataOutrankedException.java
@@ -1,0 +1,12 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.exceptions;
+
+/**
+ * Thrown when the log entry cannot be appended as it has lower rank than the other on the same log position
+ * Created by Konstantin Spirov on 3/18/2017.
+ */
+public class DataOutrankedException extends DataRejectedException {
+}

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/DataRejectedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/DataRejectedException.java
@@ -1,0 +1,9 @@
+package org.corfudb.runtime.exceptions;
+
+/**
+ * Thrown when the data was rejected from the server and the stream is hinted to retry the existing value at a different position
+ * Created by kspirov on 3/20/17.
+ */
+public class DataRejectedException extends LogUnitException {
+}
+

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/OverwriteException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/OverwriteException.java
@@ -3,5 +3,5 @@ package org.corfudb.runtime.exceptions;
 /**
  * Created by mwei on 12/14/15.
  */
-public class OverwriteException extends LogUnitException {
+public class OverwriteException extends DataRejectedException {
 }

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/ValueAdoptedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/ValueAdoptedException.java
@@ -1,0 +1,15 @@
+package org.corfudb.runtime.exceptions;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.corfudb.protocols.wireprotocol.ReadResponse;
+
+/**
+ * Returned during recovery write of the quorum replication, when a new value should be adopted
+ * Created by kspirov on 3/21/17.
+ */
+@Data
+@AllArgsConstructor
+public class ValueAdoptedException extends DataRejectedException {
+    private ReadResponse readResponse;
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/ChainReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ChainReplicationView.java
@@ -76,7 +76,7 @@ public class ChainReplicationView extends AbstractReplicationView {
                 // in the chain.
                 CFUtils.getUninterruptibly(
                         getLayout().getLogUnitClient(address, i)
-                                .write(address, stream, 0L, data, backpointerMap), OverwriteException.class);
+                                .write(address, stream, null, data, backpointerMap), OverwriteException.class);
             }
         }
         return payloadBytes;

--- a/runtime/src/main/java/org/corfudb/runtime/view/ReplexReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ReplexReplicationView.java
@@ -72,7 +72,7 @@ public class ReplexReplicationView extends AbstractReplicationView {
                 log.trace("Write, Global[{}]: chain {}/{}", address, i + 1, numUnits);
                 CFUtils.getUninterruptibly(
                         getLayout().getLogUnitClient(address, i)
-                                .write(getLayout().getLocalAddress(address), stream, 0L, b, Collections.emptyMap()), OverwriteException.class);
+                                .write(getLayout().getLocalAddress(address), stream, null, b, Collections.emptyMap()), OverwriteException.class);
             }
 
             // Write to the secondary / stream index units. To reduce the amount of network traffic, aggregate all

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpaceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpaceTest.java
@@ -1,0 +1,212 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.infrastructure.log;
+
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+
+import java.io.File;
+
+import org.corfudb.AbstractCorfuTest;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.IMetadata;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.runtime.exceptions.DataOutrankedException;
+import org.corfudb.runtime.exceptions.ValueAdoptedException;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Created by Konstantin Spirov on 3/15/2017.
+ */
+public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
+
+    private static final int RECORDS_TO_WRITE = 10;
+    @Test
+    @Ignore // compact on ranked address space not activated yet
+    public void testCompact() throws Exception {
+        StreamLogFiles log = new StreamLogFiles(getDirPath(), false);
+
+        LogAddress address = new LogAddress(0l, null);
+        for (long x = 0; x < RECORDS_TO_WRITE; x++) {
+            writeToLog(log, address, DataType.DATA, "Payload", x);
+        }
+        LogData value1 = log.read(address);
+        long size1 = new File(log.getSegmentHandleForAddress(address).getFileName()).length();
+        log.compact();
+        LogData value2 = log.read(address);
+        long size2 = new File(log.getSegmentHandleForAddress(address).getFileName()).length();
+        assertEquals(value1.getRank(), value2.getRank());
+        assertNotEquals(size2, size1);
+    }
+
+    @Test
+    public void testHigherRank() {
+        StreamLogFiles log = new StreamLogFiles(getDirPath(), false);
+        LogAddress address = new LogAddress(0l, null);
+        writeToLog(log, address, DataType.DATA, "v-1", 1);
+        LogData value1 = log.read(address);
+        assertTrue(new String(value1.getData()).contains("v-1"));
+        writeToLog(log, address, DataType.DATA, "v-2", 2);
+        LogData value2 = log.read(address);
+        assertTrue(new String(value2.getData()).contains("v-2"));
+        log.close();
+    }
+
+    @Test
+    public void testLowerRank() {
+        StreamLogFiles log = new StreamLogFiles(getDirPath(), false);
+        LogAddress address = new LogAddress(0l, null);
+        writeToLog(log, address, DataType.DATA, "v-1", 2);
+        LogData value1 = log.read(address);
+        assertTrue(new String(value1.getData()).contains("v-1"));
+        try {
+            writeToLog(log, address, DataType.DATA, "v-2", 1);
+            fail();
+        } catch (DataOutrankedException e) {
+            // expected
+        }
+        LogData value2 = log.read(address);
+        assertTrue(new String(value2.getData()).contains("v-1"));
+        log.close();
+    }
+
+    @Test
+    public void testHigherRankAgainstProposal() {
+        StreamLogFiles log = new StreamLogFiles(getDirPath(), false);
+        LogAddress address = new LogAddress(0l, null);
+        writeToLog(log, address, DataType.RANK_ONLY, "v-1", 1);
+        LogData value1 = log.read(address);
+        assertTrue(new String(value1.getData()).contains("v-1"));
+        writeToLog(log, address, DataType.DATA, "v-2", 2);
+        LogData value2 = log.read(address);
+        assertTrue(new String(value2.getData()).contains("v-2"));
+        log.close();
+    }
+
+    @Test
+    public void testLowerRankAgainstProposal() {
+        StreamLogFiles log = new StreamLogFiles(getDirPath(), false);
+        LogAddress address = new LogAddress(0l, null);
+        writeToLog(log, address, DataType.RANK_ONLY, "v-1", 2);
+        LogData value1 = log.read(address);
+        assertTrue(new String(value1.getData()).contains("v-1"));
+        try {
+            writeToLog(log, address, DataType.DATA, "v-2", 1);
+            fail();
+        } catch (DataOutrankedException e) {
+            // expected
+        }
+        LogData value2 = log.read(address);
+        assertTrue(new String(value2.getData()).contains("v-1"));
+        log.close();
+    }
+
+    @Test
+    public void testProposalWithHigherRankAgainstData() {
+        StreamLogFiles log = new StreamLogFiles(getDirPath(), false);
+        LogAddress address = new LogAddress(0l, null);
+        writeToLog(log, address, DataType.DATA, "v-1", 1);
+        LogData value1 = log.read(address);
+        assertTrue(new String(value1.getData()).contains("v-1"));
+        try {
+            writeToLog(log, address, DataType.RANK_ONLY, "v-2", 2);
+            fail();
+        } catch (ValueAdoptedException e) {
+            LogData logData = e.getReadResponse().getReadSet().get(0l);
+            assertTrue(new String(logData.getData()).contains("v-1"));
+        }
+        LogData value2 = log.read(address);
+        assertTrue(new String(value2.getData()).contains("v-1"));
+        log.close();
+    }
+
+
+    @Test
+    public void testProposalWithLowerRankAgainstData() {
+        StreamLogFiles log = new StreamLogFiles(getDirPath(), false);
+        LogAddress address = new LogAddress(0l, null);
+        writeToLog(log, address, DataType.DATA, "v-1", 2);
+        LogData value1 = log.read(address);
+        assertTrue(new String(value1.getData()).contains("v-1"));
+        try {
+            writeToLog(log, address, DataType.RANK_ONLY, "v-2", 1);
+            fail();
+        } catch (DataOutrankedException e) {
+            // expected
+        }
+        LogData value2 = log.read(address);
+        assertTrue(new String(value2.getData()).contains("v-1"));
+        log.close();
+    }
+
+
+    @Test
+    public void testProposalsHigherRank() {
+        StreamLogFiles log = new StreamLogFiles(getDirPath(), false);
+        LogAddress address = new LogAddress(0l, null);
+        writeToLog(log, address, DataType.RANK_ONLY, "v-1", 1);
+        LogData value1 = log.read(address);
+        assertTrue(new String(value1.getData()).contains("v-1"));
+        writeToLog(log, address, DataType.RANK_ONLY, "v-2", 2);
+        LogData value2 = log.read(address);
+        assertTrue(new String(value2.getData()).contains("v-2"));
+        log.close();
+    }
+
+    @Test
+    public void testProposalsLowerRank() {
+        StreamLogFiles log = new StreamLogFiles(getDirPath(), false);
+        LogAddress address = new LogAddress(0l, null);
+        writeToLog(log, address, DataType.RANK_ONLY, "v-1", 2);
+        LogData value1 = log.read(address);
+        assertTrue(new String(value1.getData()).contains("v-1"));
+        try {
+            writeToLog(log, address, DataType.RANK_ONLY, "v-2", 1);
+            fail();
+        } catch (DataOutrankedException e) {
+            // expected
+        }
+        LogData value2 = log.read(address);
+        assertTrue(new String(value2.getData()).contains("v-1"));
+        log.close();
+    }
+
+    @Test
+    public void checkProposalIsIdempotent() {
+        StreamLogFiles log = new StreamLogFiles(getDirPath(), false);
+        LogAddress address = new LogAddress(0l, null);
+        IMetadata.DataRank sameRank = new IMetadata.DataRank(1);
+        writeToLog(log, address, DataType.DATA, "v-1", sameRank);
+        LogData value1 = log.read(address);
+        assertTrue(new String(value1.getData()).contains("v-1"));
+        writeToLog(log, address, DataType.DATA, "v-1", sameRank);
+        LogData value2 = log.read(address);
+        assertTrue(new String(value2.getData()).contains("v-1"));
+    }
+
+    private void writeToLog(StreamLog log, LogAddress address, DataType dataType, String payload, long rank) {
+        this.writeToLog(log, address, dataType, payload, new IMetadata.DataRank(rank));
+    }
+
+    private void writeToLog(StreamLog log, LogAddress address, DataType dataType, String payload, IMetadata.DataRank rank) {
+        ByteBuf b = ByteBufAllocator.DEFAULT.buffer();
+        byte[] streamEntry = payload.getBytes();
+        Serializers.CORFU.serialize(streamEntry, b);
+        LogData data = new LogData(dataType, b);
+        data.setRank(rank);
+        log.append(address, data);
+    }
+
+    private String getDirPath() {
+        return PARAMETERS.TEST_TEMP_DIR + File.separator;
+    }
+
+}

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -11,9 +11,12 @@ import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
+import org.corfudb.runtime.exceptions.DataOutrankedException;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.exceptions.ValueAdoptedException;
 import org.junit.Test;
 
 import java.io.File;
@@ -27,6 +30,9 @@ import java.util.concurrent.ExecutionException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.corfudb.infrastructure.log.StreamLogFiles.METADATA_SIZE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
 
 /**
  * Created by mwei on 12/14/15.
@@ -70,7 +76,7 @@ public class LogUnitClientTest extends AbstractClientTest {
     public void canReadWrite()
             throws Exception {
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
+        client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get();
         LogData r = client.read(0).get().getReadSet().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
@@ -79,11 +85,86 @@ public class LogUnitClientTest extends AbstractClientTest {
     }
 
     @Test
+    public void canReadWriteRanked()
+            throws Exception {
+        byte[] testString = "hello world".getBytes();
+
+        client.write(0, Collections.<UUID>emptySet(), new IMetadata.DataRank(1), testString, Collections.emptyMap()).get();
+        LogData r = client.read(0).get().getReadSet().get(0L);
+        assertThat(r.getType())
+                .isEqualTo(DataType.DATA);
+        assertThat(r.getPayload(new CorfuRuntime()))
+                .isEqualTo(testString);
+
+        byte[] testString2 = "hello world 2".getBytes();
+        client.write(0, Collections.<UUID>emptySet(), new IMetadata.DataRank(2), testString2, Collections.emptyMap()).get();
+        r = client.read(0).get().getReadSet().get(0L);
+        assertThat(r.getType())
+                .isEqualTo(DataType.DATA);
+        assertThat(r.getPayload(new CorfuRuntime()))
+                .isEqualTo(testString2);
+    }
+
+
+    @Test
+    public void cannotOutrank() throws ExecutionException, InterruptedException {
+        byte[] testString = "hello world".getBytes();
+
+        client.write(0, Collections.<UUID>emptySet(), new IMetadata.DataRank(2), testString, Collections.emptyMap()).get();
+        LogData r = client.read(0).get().getReadSet().get(0L);
+        assertThat(r.getType())
+                .isEqualTo(DataType.DATA);
+        assertThat(r.getPayload(new CorfuRuntime()))
+                .isEqualTo(testString);
+
+        byte[] testString2 = "hello world 2".getBytes();
+        try {
+            client.write(0, Collections.<UUID>emptySet(), new IMetadata.DataRank(1), testString2, Collections.emptyMap()).get();
+            fail();
+        } catch (ExecutionException e) {
+            // expected
+            assertEquals(DataOutrankedException.class, e.getCause().getClass());
+        }
+        r = client.read(0).get().getReadSet().get(0L);
+        assertThat(r.getType())
+                .isEqualTo(DataType.DATA);
+        assertThat(r.getPayload(new CorfuRuntime()))
+                .isEqualTo(testString);
+    }
+
+    @Test
+    public void valueCanBeAdopted() throws ExecutionException, InterruptedException {
+        byte[] testString = "hello world".getBytes();
+
+        client.write(0, Collections.<UUID>emptySet(), new IMetadata.DataRank(1), testString, Collections.emptyMap()).get();
+        LogData r = client.read(0).get().getReadSet().get(0L);
+        assertThat(r.getType()) .isEqualTo(DataType.DATA);
+        assertThat(r.getPayload(new CorfuRuntime()))
+                .isEqualTo(testString);
+
+        try {
+            client.writeProposal(0, Collections.<UUID>emptySet(), new IMetadata.DataRank(2)).get();
+            fail();
+        } catch (Exception e) {
+            // expected
+            assertEquals(ValueAdoptedException.class, e.getCause().getClass());
+            ValueAdoptedException ex = (ValueAdoptedException)e.getCause();
+            ReadResponse read = ex.getReadResponse();
+            LogData log = read.getReadSet().get(0l);
+            assertThat(log.getType()).isEqualTo(DataType.DATA);
+            assertThat(log.getPayload(new CorfuRuntime())).isEqualTo(testString);;
+        }
+        r = client.read(0).get().getReadSet().get(0L);
+        assertThat(r.getType()).isEqualTo(DataType.DATA);
+        assertThat(r.getPayload(new CorfuRuntime())).isEqualTo(testString);
+    }
+
+    @Test
     public void overwriteThrowsException()
             throws Exception {
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
-        assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), 0,
+        client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get();
+        assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), null,
                 testString, Collections.emptyMap()).get())
                 .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(OverwriteException.class);
@@ -98,7 +179,7 @@ public class LogUnitClientTest extends AbstractClientTest {
         assertThat(r.getType())
                 .isEqualTo(DataType.HOLE);
 
-        assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get())
+        assertThatThrownBy(() -> client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get())
                 .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(OverwriteException.class);
     }
@@ -107,7 +188,7 @@ public class LogUnitClientTest extends AbstractClientTest {
     public void holeFillCannotOverwrite()
             throws Exception {
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
+        client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get();
 
         LogData r = client.read(0).get().getReadSet().get(0L);
         assertThat(r.getType())
@@ -125,7 +206,7 @@ public class LogUnitClientTest extends AbstractClientTest {
         final long ADDRESS_1 = 1338L;
 
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString,
+        client.write(0, Collections.<UUID>emptySet(), null, testString,
                 ImmutableMap.<UUID, Long>builder()
                         .put(CorfuRuntime.getStreamID("hello"), ADDRESS_0)
                         .put(CorfuRuntime.getStreamID("hello2"), ADDRESS_1)
@@ -142,7 +223,7 @@ public class LogUnitClientTest extends AbstractClientTest {
     public void canCommitWrite()
             throws Exception {
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
+        client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get();
         client.writeCommit(null, 0, true).get();
         LogData r = client.read(0).get().getReadSet().get(0L);
         assertThat(r.getType())
@@ -167,7 +248,7 @@ public class LogUnitClientTest extends AbstractClientTest {
     @Test
     public void CorruptedDataReadThrowsException() throws Exception {
         byte[] testString = "hello world".getBytes();
-        client.write(0, Collections.<UUID>emptySet(), 0, testString, Collections.emptyMap()).get();
+        client.write(0, Collections.<UUID>emptySet(), null, testString, Collections.emptyMap()).get();
         LogData r = client.read(0).get().getReadSet().get(0L);
         // Verify that the data has been written correctly
         assertThat(r.getPayload(null)).isEqualTo(testString);

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -143,7 +143,7 @@ public class LogUnitClientTest extends AbstractClientTest {
                 .isEqualTo(testString);
 
         try {
-            client.writeProposal(0, Collections.<UUID>emptySet(), new IMetadata.DataRank(2)).get();
+            client.writeEmptyData(0, DataType.RANK_ONLY, Collections.<UUID>emptySet(), new IMetadata.DataRank(2)).get();
             fail();
         } catch (Exception e) {
             // expected


### PR DESCRIPTION
* Rank is a separate class, with basic part and UUID.
* New DataType PROPOSAL and write operations based on rank and data type only when a rank is given (for quorum).
* Using the new read/write locks in StreamLogFiles (deadlock protection and multiple readers)
* Single address from the global space for the compact operation
* Bugfixes relatred to closing of  streams and channels (more to come)