### PR TITLE
added a few more details to object logging messages

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.object.transactions;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.util.Utils;
 
 import java.time.Duration;
 import java.util.*;
@@ -84,6 +85,7 @@ public class TransactionalContext {
      * @return          The context which was added to the transaction stack.
      */
     public static AbstractTransactionalContext newContext(AbstractTransactionalContext context) {
+        log.trace("TX begin[{}]", Utils.toReadableID(context.transactionID));
         getTransactionStack().addFirst(context);
         return context;
     }


### PR DESCRIPTION
I added logging messages on all corfu-object operations.

On every mutator call, you get 
    - the method-name, 
    - its arguments, 
    - the conflict-parameters, 
    - if it is invoked within a transactional context, a TX-mark and the TX-id.

On every accessor call, you cannot get the method-name (because it is a lambda built on-the-fly), but you get as a hint the conflict-parameters. so you get
    - the conflict-parameters, 
    - if it is invoked within a transactional context, a TX-mark and the TX-id.

