### PR TITLE
reset TX resolution information on sequencer-reset

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1,5 +1,7 @@
 package org.corfudb.runtime.view;
 
+import com.google.common.reflect.TypeToken;
+import lombok.Getter;
 import org.corfudb.infrastructure.ManagementServer;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.infrastructure.ServerContext;
@@ -10,11 +12,16 @@ import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.collections.ISMRMap;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.stream.IStreamView;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
@@ -26,6 +33,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Created by zlokhandwala on 11/9/16.
  */
 public class ManagementViewTest extends AbstractViewTest {
+
+    @Getter
+    protected CorfuRuntime corfuRuntime = null;
 
     /**
      * Boolean flag turned to true when the MANAGEMENT_FAILURE_DETECTED message
@@ -174,19 +184,9 @@ public class ManagementViewTest extends AbstractViewTest {
         assertThat(l2.getLayoutServers().contains(SERVERS.ENDPOINT_1)).isFalse();
     }
 
-    /**
-     * Scenario with 3 nodes: SERVERS.PORT_0, SERVERS.PORT_1 and SERVERS.PORT_2.
-     * We fail SERVERS.PORT_1 and then wait for one of the other two servers to
-     * handle this failure, propose a new layout and we assert on the epoch change.
-     * The failure is handled by ConserveFailureHandlerPolicy.
-     * No nodes are removed from the layout, but are marked unresponsive.
-     * A sequencer failover takes place where the next working sequencer is reset
-     * and made the primary.
-     *
-     * @throws Exception
-     */
-    @Test
-    public void testSequencerFailover() throws Exception {
+    protected void getManagementTstLayout1()
+        throws Exception {
+
         addServer(SERVERS.PORT_0);
         addServer(SERVERS.PORT_1);
         addServer(SERVERS.PORT_2);
@@ -207,10 +207,10 @@ public class ManagementViewTest extends AbstractViewTest {
                 .addToLayout()
                 .build();
         bootstrapAllServers(l);
+        corfuRuntime = getRuntime(l).connect();
 
-        CorfuRuntime corfuRuntime = getRuntime(l).connect();
         // Initiating all failure handlers.
-        for (String server: l.getAllServers()) {
+        for (String server: corfuRuntime.getLayoutView().getLayout().getAllServers()) {
             corfuRuntime.getRouter(server).getClient(ManagementClient.class).initiateFailureHandler().get();
         }
 
@@ -225,16 +225,51 @@ public class ManagementViewTest extends AbstractViewTest {
         routerEndpoints.add(SERVERS.ENDPOINT_2);
         serverPorts.forEach(serverPort -> {
             routerEndpoints.forEach(routerEndpoint -> {
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-                getManagementServer(serverPort).getCorfuRuntime().getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                corfuRuntime.getRouter(routerEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                corfuRuntime.getRouter(routerEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+                corfuRuntime.getRouter(routerEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
             });
         });
+    }
+
+    protected void induceSequencerFailureAndWait()
+        throws Exception {
+
+        long currentEpoch = getCorfuRuntime().getLayoutView().getLayout().getEpoch();
+
+        // induce a failure to the server on PORT_1, where the current sequencer is active
+        //
+        getManagementServer(SERVERS.PORT_1).shutdown();
+        addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
+
+        // wait for failover to install a new epoch (and a new layout)
+        //
+        while (getCorfuRuntime().getLayoutView().getLayout().getEpoch() == currentEpoch) {
+            getCorfuRuntime().invalidateLayout();
+            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        }
+
+    }
+
+    /**
+     * Scenario with 3 nodes: SERVERS.PORT_0, SERVERS.PORT_1 and SERVERS.PORT_2.
+     * We fail SERVERS.PORT_1 and then wait for one of the other two servers to
+     * handle this failure, propose a new layout and we assert on the epoch change.
+     * The failure is handled by ConserveFailureHandlerPolicy.
+     * No nodes are removed from the layout, but are marked unresponsive.
+     * A sequencer failover takes place where the next working sequencer is reset
+     * and made the primary.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSequencerFailover() throws Exception {
+        getManagementTstLayout1();
 
         final long beforeFailure = 5L;
         final long afterFailure = 10L;
 
-        IStreamView sv = corfuRuntime.getStreamsView().get(CorfuRuntime.getStreamID("streamA"));
+        IStreamView sv = getCorfuRuntime().getStreamsView().get(CorfuRuntime.getStreamID("streamA"));
         byte[] testPayload = "hello world".getBytes();
         sv.append(testPayload);
         sv.append(testPayload);
@@ -245,14 +280,10 @@ public class ManagementViewTest extends AbstractViewTest {
         assertThat(getSequencer(SERVERS.PORT_1).getGlobalLogTail().get()).isEqualTo(beforeFailure);
         assertThat(getSequencer(SERVERS.PORT_0).getGlobalLogTail().get()).isEqualTo(0L);
 
-        getManagementServer(SERVERS.PORT_1).shutdown();
-        addServerRule(SERVERS.PORT_1, new TestRule().always().drop());
+        induceSequencerFailureAndWait();
 
-        while (corfuRuntime.getLayoutView().getLayout().getEpoch() == l.getEpoch()) {
-            corfuRuntime.invalidateLayout();
-            Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-        }
-
+        // verify that a failover sequencer was started with the correct starting-tail
+        //
         assertThat(getSequencer(SERVERS.PORT_0).getGlobalLogTail().get()).isEqualTo(beforeFailure);
 
         sv.append(testPayload);
@@ -261,6 +292,8 @@ public class ManagementViewTest extends AbstractViewTest {
         sv.append(testPayload);
         sv.append(testPayload);
 
+        // verify the failover layout
+        //
         Layout expectedLayout = new TestLayoutBuilder()
                 .setEpoch(2L)
                 .addLayoutServer(SERVERS.PORT_0)
@@ -278,9 +311,188 @@ public class ManagementViewTest extends AbstractViewTest {
                 .addUnresponsiveServer(SERVERS.PORT_1)
                 .build();
 
+        assertThat(getCorfuRuntime().getLayoutView().getLayout()).isEqualTo(expectedLayout);
+
+        // verify that the new sequencer is advancing the tail properly
         assertThat(getSequencer(SERVERS.PORT_0).getGlobalLogTail().get()).isEqualTo(afterFailure);
-        assertThat(corfuRuntime.getLayoutView().getLayout()).isEqualTo(expectedLayout);
+
+        // sanity check that no other sequencer is active
         assertThat(getSequencer(SERVERS.PORT_2).getGlobalLogTail().get()).isEqualTo(0L);
 
     }
+
+    protected <T> Object instantiateCorfuObject(TypeToken<T> tType, String name) {
+        return (T)
+                getCorfuRuntime().getObjectsView()
+                        .build()
+                        .setStreamName(name)     // stream name
+                        .setTypeToken(tType)    // a TypeToken of the specified class
+                        .open();                // instantiate the object!
+    }
+
+
+    protected ISMRMap<Integer, String> getMap() {
+        ISMRMap<Integer, String> testMap;
+
+        testMap = (ISMRMap<Integer, String>) instantiateCorfuObject(
+                new TypeToken<SMRMap<Integer, String>>() {
+                }, "test stream"
+        ) ;
+
+        return testMap;
+    }
+
+    protected void TXBegin() {
+        getCorfuRuntime().getObjectsView().TXBegin();
+    }
+
+    protected void TXEnd() {
+        getCorfuRuntime().getObjectsView().TXEnd();
+    }
+
+    /**
+     * check that transcation conflict resolution works properly in face of sequencer failover
+     */
+    @Test
+    public void ckSequencerFailoverTXResolution()
+        throws Exception {
+        getManagementTstLayout1();
+
+        Map<Integer, String> map = getMap();
+
+        // start a transaction and force it to obtain snapshot timestamp
+        // preceding the sequencer failover
+        t(0, () -> {
+            TXBegin();
+            map.get(0);
+        });
+
+        final String payload = "hello";
+        final int nUpdates = 5;
+
+        // in another thread, fill the log with a few entries
+        t(1, () -> {
+            for (int i = 0; i < nUpdates; i++)
+                map.put(i, payload);
+        });
+
+        // now, the tail of the log is at nUpdates;
+        // kill the sequencer, wait for a failover,
+        // and then resume the transaction above; it should abort
+        // (unnecessarily, but we are being conservative)
+        //
+        induceSequencerFailureAndWait();
+        t(0, () -> {
+            boolean commit = true;
+            map.put(nUpdates+1, payload); // should not conflict
+            try {
+                TXEnd();
+            } catch (TransactionAbortedException ta) {
+                commit = false;
+            }
+            assertThat(commit)
+                    .isFalse();
+        });
+
+        // now, check that the same scenario, starting anew, can succeed
+        t(0, () -> {
+            TXBegin();
+            map.get(0);
+        });
+
+        // in another thread, fill the log with a few entries
+        t(1, () -> {
+            for (int i = 0; i < nUpdates; i++)
+                map.put(i, payload+1);
+        });
+
+        t(0, () -> {
+            boolean commit = true;
+            map.put(nUpdates+1, payload); // should not conflict
+            try {
+                TXEnd();
+            } catch (TransactionAbortedException ta) {
+                commit = false;
+            }
+            assertThat(commit)
+                    .isTrue();
+        });
+    }
+
+
+    /**
+     * small variant on the above : don't start the first TX at the start of the log.
+     */
+    @Test
+    public void ckSequencerFailoverTXResolution1()
+            throws Exception {
+        getManagementTstLayout1();
+
+        Map<Integer, String> map = getMap();
+        final String payload = "hello";
+        final int nUpdates = 5;
+
+
+        for (int i = 0; i < nUpdates; i++)
+            map.put(i, payload);
+
+        // start a transaction and force it to obtain snapshot timestamp
+        // preceding the sequencer failover
+        t(0, () -> {
+            TXBegin();
+            map.get(0);
+        });
+
+        // in another thread, fill the log with a few entries
+        t(1, () -> {
+            for (int i = 0; i < nUpdates; i++)
+                map.put(i, payload+1);
+        });
+
+        // now, the tail of the log is at nUpdates;
+        // kill the sequencer, wait for a failover,
+        // and then resume the transaction above; it should abort
+        // (unnecessarily, but we are being conservative)
+        //
+        induceSequencerFailureAndWait();
+
+        t(0, () -> {
+            boolean commit = true;
+            map.put(nUpdates+1, payload); // should not conflict
+            try {
+                TXEnd();
+            } catch (TransactionAbortedException ta) {
+                commit = false;
+            }
+            assertThat(commit)
+                    .isFalse();
+        });
+
+        // now, check that the same scenario, starting anew, can succeed
+        t(0, () -> {
+            TXBegin();
+            map.get(0);
+        });
+
+        // in another thread, fill the log with a few entries
+        t(1, () -> {
+            for (int i = 0; i < nUpdates; i++)
+                map.put(i, payload+2);
+        });
+
+        t(0, () -> {
+            boolean commit = true;
+            map.put(nUpdates+1, payload); // should not conflict
+            try {
+                TXEnd();
+            } catch (TransactionAbortedException ta) {
+                commit = false;
+            }
+            assertThat(commit)
+                    .isTrue();
+        });
+
+
+    }
+
 }


### PR DESCRIPTION
if the sequencer is reset, then we can't know when was the latest update to any stream or conflict parameter.

hence, we want to conservatively abort any transaction with snapshot
time preceding the reset-time of this sequencer.

This PR is an add-on over #485 , to merged into it.