### PR TITLE
added a test of map 'set' operations

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapEntrySetTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapEntrySetTest.java
@@ -1,0 +1,162 @@
+package org.corfudb.runtime.collections;
+
+import org.corfudb.runtime.collections.SMRMap;
+import lombok.Getter;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.object.transactions.AbstractObjectTest;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Created by dmalkhi on 3/20/17.
+ */
+public class SMRMapEntrySetTest extends AbstractObjectTest {
+    @Getter
+    final String defaultConfigurationString = getDefaultEndpoint();
+
+    public CorfuRuntime r;
+
+
+    @Before
+    public void setRuntime() throws Exception {
+        r = getDefaultRuntime().connect();
+    }
+
+    @Test
+    public void manipulateSets()
+            throws Exception {
+        Map<Long, Long> testMap = instantiateCorfuObject(SMRMap.class,
+                "mapsettest");
+
+
+        // populate the map
+        for (long i = 0; i < (long) PARAMETERS.NUM_ITERATIONS_LOW; i++)
+            testMap.put(i, i);
+
+        assertThat(testMap.get(0L))
+                .isEqualTo(0L);
+        assertThat(testMap.size())
+                .isEqualTo(PARAMETERS.NUM_ITERATIONS_LOW);
+
+        // get a snapshot of the keys
+        Set<Long> keys = testMap.keySet();
+        assertThat(keys.size())
+                .isEqualTo(PARAMETERS.NUM_ITERATIONS_LOW);
+        assertThat(keys.contains(0L))
+                .isTrue();
+
+        // manipulate the map, verify that keys set is unmodified,
+        // the original map is modified
+        testMap.remove(0L);
+
+        assertThat(keys.size())
+                .isEqualTo(PARAMETERS.NUM_ITERATIONS_LOW);
+        assertThat(keys.contains(0L))
+                .isTrue();
+
+        assertThat(testMap.containsKey(0L))
+                .isFalse();
+        assertThat(testMap.size())
+                .isEqualTo(PARAMETERS.NUM_ITERATIONS_LOW-1);
+
+    }
+
+    @Test
+    public void manipulateSetsConcurrent()
+            throws Exception {
+        Map<Long, Long> testMap = instantiateCorfuObject(SMRMap.class,
+                "mapsettest");
+        CountDownLatch l1 = new CountDownLatch(1);
+        CountDownLatch l2 = new CountDownLatch(1);
+        CountDownLatch l3 = new CountDownLatch(1);
+        CountDownLatch l4 = new CountDownLatch(1);
+
+        // first thread: create and manipulate map
+        scheduleConcurrently(t -> {
+
+            // signal start to second thread
+            l1.countDown();
+
+            // populate the map
+            for (long i = 0; i < (long) PARAMETERS.NUM_ITERATIONS_LOW; i++)
+                testMap.put(i, i);
+
+            assertThat(testMap.get(0L))
+                    .isEqualTo(0L);
+            assertThat(testMap.size())
+                    .isEqualTo(PARAMETERS.NUM_ITERATIONS_LOW);
+
+            // wait for second thread to advance
+            l2.await();
+
+            // manipulate the map, verify that keys set is unmodified,
+            // the original map is modified
+            testMap.remove(0L);
+
+            assertThat(testMap.containsKey(0L))
+                    .isFalse();
+            assertThat(testMap.size())
+                    .isEqualTo(PARAMETERS.NUM_ITERATIONS_LOW - 1);
+
+            // allow third thread to proceed
+            l3.countDown();
+        });
+
+        // 2nd thread: get an immutable copy of the keys in the
+        // at an arbitrary snapshot
+        scheduleConcurrently(t -> {
+            l1.await();
+
+            // get a snapshot of the keys;
+            // we don't know at which point the snapshot will be,
+            // relative to the other thread
+            Set<Long> keys = testMap.keySet();
+            int snapshotSize = keys.size();
+
+            if (snapshotSize > 0)
+                assertThat(keys.contains(0L))
+                        .isTrue();
+
+            // signal that one snapshot was taken already
+            l2.countDown();
+
+            // verify that the immutable snapshot remains immutable
+            while (l3.getCount() > 0) {
+                assertThat(keys.size())
+                        .isEqualTo(snapshotSize);
+                if (snapshotSize > 0)
+                    assertThat(keys.contains(0L))
+                            .isTrue();
+            }
+            l3.await();
+            assertThat(keys.size())
+                    .isEqualTo(snapshotSize);
+            if (snapshotSize > 0)
+                assertThat(keys.contains(0L))
+                        .isTrue();
+        } );
+
+        scheduleConcurrently(t -> {
+            l3.await();
+
+            // get a snapshot of the keys;
+            Set<Long> keys = testMap.keySet();
+            assertThat(keys.size())
+                    .isEqualTo(PARAMETERS.NUM_ITERATIONS_LOW-1);
+            assertThat(keys.contains(0L))
+                    .isFalse();
+        });
+
+        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_SHORT);
+
+    }
+
+}

--- a/test/src/test/java/org/corfudb/runtime/concurrent/MultipleNonOverlappingTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/MultipleNonOverlappingTest.java
@@ -54,9 +54,8 @@ public class MultipleNonOverlappingTest extends AbstractObjectTest {
             for (int j = 0; j < OBJECT_NUM; j += STEP) {
                 NonOverlappingWriter n = new NonOverlappingWriter(i + 1, j, j + STEP, VAL);
                 scheduleConcurrently(t -> { n.dowork();});
-                executeScheduled(THREAD_NUM, PARAMETERS.TIMEOUT_NORMAL);
             }
-
+            executeScheduled(THREAD_NUM, PARAMETERS.TIMEOUT_NORMAL);
         }
 
         Assert.assertEquals(testMap.size(), FINAL_SUM);
@@ -95,8 +94,8 @@ public class MultipleNonOverlappingTest extends AbstractObjectTest {
             for (int j = 0; j < OBJECT_NUM; j += STEP) {
                 NonOverlappingWriter n = new NonOverlappingWriter(i + 1, j, j + STEP, VAL);
                 scheduleConcurrently(t -> { n.dowork2();});
-                executeScheduled(THREAD_NUM, PARAMETERS.TIMEOUT_NORMAL);
             }
+            executeScheduled(THREAD_NUM, PARAMETERS.TIMEOUT_NORMAL);
 
         }
 


### PR DESCRIPTION
Reminder: All three of the methods of SMRMap ,

	SMRMap::keyset
	SMRMap::valueSet
	SMRMap::entitySet

currently return -immutable copies- of the underlying map. As in Java, taking
the key/value/entry-set over a map which is concurrently being manipulated yield
undefined results. Any manipulation to the map –after- the set was snapshot does
not affect it. And operations like add/remove are not supported (it is
immutable).

This PR also fixes MultipleOverlappingConcurrent, to address note by @slfritchie 