### PR TITLE
Add coalesce support, cleanup map interface

### DIFF
--- a/annotations/src/main/java/org/corfudb/annotations/Accessor.java
+++ b/annotations/src/main/java/org/corfudb/annotations/Accessor.java
@@ -14,4 +14,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface Accessor {
+    /** The name of the function used to generate conflict parameters, which
+     * will be used to generate conflict information.
+     * @return  The name of a conflict generation function.
+     */
+    String conflictParameterFunction() default "";
 }

--- a/annotations/src/main/java/org/corfudb/annotations/Mutator.java
+++ b/annotations/src/main/java/org/corfudb/annotations/Mutator.java
@@ -32,6 +32,12 @@ public @interface Mutator {
      */
     String undoRecordFunction() default "";
 
+    /** The name of the function used to generate conflict parameters, which
+     * will be used to generate conflict information.
+     * @return  The name of a conflict generation function.
+     */
+    String conflictParameterFunction() default "";
+
     /** Whether this mutator resets the state of this object. Typically used
      * for methods like clear().
      * @return True, if the mutator resets the object.

--- a/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
+++ b/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
@@ -31,6 +31,12 @@ public @interface MutatorAccessor {
      */
     String undoRecordFunction() default "";
 
+    /** The name of the function used to generate conflict parameters, which
+     * will be used to generate conflict information.
+     * @return  The name of a conflict generation function.
+     */
+    String conflictParameterFunction() default "";
+
     /** Whether this mutator resets the state of this object. Typically used
      * for methods like clear().
      * @return True, if the mutator resets the object.

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICoalescableObject.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICoalescableObject.java
@@ -1,0 +1,25 @@
+package org.corfudb.runtime.object;
+
+import java.util.List;
+
+/** Represents an object which can coalesce updates, reducing the
+ * number of updates which must be applied.
+ *
+ *
+ * Created by mwei on 3/21/17.
+ */
+public interface ICoalescableObject {
+
+    /** Given a list of SMR updates, coalesce the updates into a
+     * smaller update set.
+     *
+     * @param updates           A list of ordered updates to coalesce
+     * @param generator         A generator which creates SMR entries.
+     *
+     * @return                  A list of compacted entries, or the
+     *                          original list, if coalescing was
+     *                          unsuccessful.
+     */
+    List<ISMREntry> coalesceUpdates(List<ISMREntry> updates,
+                                    ISMREntryGenerator generator);
+}

--- a/annotations/src/main/java/org/corfudb/runtime/object/ISMREntry.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ISMREntry.java
@@ -1,0 +1,29 @@
+package org.corfudb.runtime.object;
+
+/**
+ * Created by mwei on 3/21/17.
+ */
+public interface ISMREntry {
+
+    /** The method which was called.
+     * @return The method to be called. */
+    String getSMRMethod();
+
+    /** The arguments to the method.
+     * @return The arguments to be called. */
+    Object[] getSMRArguments();
+
+    /** Whether or not this entry has undo information.
+     * @return  True, if the entry has undo information
+     *          False otherwise.
+     */
+    boolean isUndoable();
+
+    /** Obtain the undo record for this entry.
+     * @return  The undo record for this entry.
+     */
+    Object getUndoRecord();
+
+    /** Clear the undo record for an entry. */
+    void clearUndoRecord();
+}

--- a/annotations/src/main/java/org/corfudb/runtime/object/ISMREntryGenerator.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ISMREntryGenerator.java
@@ -1,0 +1,22 @@
+package org.corfudb.runtime.object;
+
+/** A Function interface which generates SMREntries.
+ * Created by mwei on 3/21/17.
+ */
+@FunctionalInterface
+public interface ISMREntryGenerator {
+
+    /** Generate a new SMR Entry.
+     *
+     * @param smrMethod     The method to call
+     * @param arguments     The arguments to the method
+     * @param hasUndo       True, if the entry contains undo information
+     * @param undoRecord    The undo record, or null, if there is no
+     *                      undo record.
+     * @return              An ISMREntry.
+     */
+    ISMREntry generate(String smrMethod,
+                       Object[] arguments,
+                       boolean hasUndo,
+                       Object undoRecord);
+}

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
@@ -68,4 +68,8 @@ public class MultiSMREntry extends LogEntry implements ISMRConsumable {
         // but replex erases this information.
         return updates;
     }
+
+    public void setSMRUpdates(List<SMREntry> newList) {
+        updates = newList;
+    }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -3,6 +3,7 @@ package org.corfudb.protocols.logprotocol;
 import io.netty.buffer.ByteBuf;
 import lombok.*;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.object.ISMREntry;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
 
@@ -16,7 +17,7 @@ import java.util.UUID;
  */
 @ToString(callSuper = true)
 @NoArgsConstructor
-public class SMREntry extends LogEntry implements ISMRConsumable {
+public class SMREntry extends LogEntry implements ISMRConsumable, ISMREntry {
 
     /**
      * The name of the SMR method. Note that this is limited to the size of a short.

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -43,6 +43,9 @@ public class CorfuRuntime {
 
         /** Number of times to attempt to read before hole filling. */
         int holeFillRetry = 10;
+
+        /** Whether or not coalescing, which condenses SMR entries in transactions, is enabled. */
+        boolean coalesceDisabled = false;
     }
 
     @Getter

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -159,13 +159,25 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
     /**
      * {@inheritDoc}
      *
-     * Conflicts: this operation currently conflicts with the entire map, until
-     * custom conflict parameter generation is introduced.
+     * Conflicts: this operation conflicts on any keys that are in the map given.
      */
-    @Mutator(name="putAll", undoFunction="undoPutAll", undoRecordFunction="undoPutAllRecord")
+    @Mutator(name="putAll", undoFunction="undoPutAll",
+            undoRecordFunction="undoPutAllRecord", conflictParameterFunction="putAllConflictFunction")
     @Override
     void putAll(Map<? extends K, ? extends V> m);
 
+
+    /** Generate the conflict parameters for putAll, given the arguments to the
+     * putAll operation.
+     * @param m                 The map for the putAll operation.
+     * @return                  An array of conflict parameters, which are the
+     *                          hash codes of the keys given.
+     */
+    default Object[] putAllConflictFunction(Map<? extends K, ? extends V> m) {
+        return m.keySet().stream()
+                .map(Object::hashCode)
+                .toArray(Object[]::new);
+    }
 
     /** Generate an undo record for putAll, given the previous state of the map
      * and the parameters to the putAll call.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -1,14 +1,8 @@
 package org.corfudb.runtime.collections;
 
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMap;
 import org.corfudb.annotations.*;
-import org.corfudb.runtime.object.ISMRInterface;
-
 import java.util.*;
-import java.util.concurrent.ConcurrentMap;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 /**
  * Created by mwei on 1/9/16.
@@ -16,120 +10,60 @@ import java.util.function.Function;
 public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
 
     /**
-     * Returns the number of key-value mappings in this map.  If the
-     * map contains more than <tt>Integer.MAX_VALUE</tt> elements, returns
-     * <tt>Integer.MAX_VALUE</tt>.
+     * {@inheritDoc}
      *
-     * @return the number of key-value mappings in this map
+     * Conflicts: this operation conflicts with any modification to
+     * the map, since the size of the map could be potentially changed.
      */
     @Accessor
     @Override
     int size();
 
     /**
-     * Returns <tt>true</tt> if this map contains no key-value mappings.
+     * {@inheritDoc}
      *
-     * @return <tt>true</tt> if this map contains no key-value mappings
+     * Conflicts: this operation conflicts with any modification to
+     * the map, since the size of the map could be potentially changed.
      */
     @Accessor
     @Override
     boolean isEmpty();
 
     /**
-     * Returns <tt>true</tt> if this map contains a mapping for the specified
-     * key.  More formally, returns <tt>true</tt> if and only if
-     * this map contains a mapping for a key <tt>k</tt> such that
-     * <tt>(key==null ? k==null : key.equals(k))</tt>.  (There can be
-     * at most one such mapping.)
+     * {@inheritDoc}
      *
-     * @param key key whose presence in this map is to be tested
-     * @return <tt>true</tt> if this map contains a mapping for the specified
-     * key
-     * @throws ClassCastException   if the key is of an inappropriate type for
-     *                              this map
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException if the specified key is null and this map
-     *                              does not permit null keys
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
+     * Conflicts: this operation conflicts with any operation on the
+     * given key.
      */
     @Accessor
     @Override
     boolean containsKey(@ConflictParameter Object key);
 
     /**
-     * Returns <tt>true</tt> if this map maps one or more keys to the
-     * specified value.  More formally, returns <tt>true</tt> if and only if
-     * this map contains at least one mapping to a value <tt>v</tt> such that
-     * <tt>(value==null ? v==null : value.equals(v))</tt>.  This operation
-     * will probably require time linear in the map size for most
-     * implementations of the <tt>Map</tt> interface.
+     * {@inheritDoc}
      *
-     * @param value value whose presence in this map is to be tested
-     * @return <tt>true</tt> if this map maps one or more keys to the
-     * specified value
-     * @throws ClassCastException   if the value is of an inappropriate type for
-     *                              this map
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException if the specified value is null and this
-     *                              map does not permit null values
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
+     * Conflicts: this operation conflicts with any modification to
+     * the map, since the presence of values could be potentially changed.
      */
     @Accessor
     @Override
     boolean containsValue(Object value);
 
     /**
-     * Returns the value to which the specified key is mapped,
-     * or {@code null} if this map contains no mapping for the key.
-     * <p>
-     * <p>More formally, if this map contains a mapping from a key
-     * {@code k} to a value {@code v} such that {@code (key==null ? k==null :
-     * key.equals(k))}, then this method returns {@code v}; otherwise
-     * it returns {@code null}.  (There can be at most one such mapping.)
-     * <p>
-     * <p>If this map permits null values, then a return value of
-     * {@code null} does not <i>necessarily</i> indicate that the map
-     * contains no mapping for the key; it's also possible that the map
-     * explicitly maps the key to {@code null}.  The {@link #containsKey
-     * containsKey} operation may be used to distinguish these two cases.
+     * {@inheritDoc}
      *
-     * @param key the key whose associated value is to be returned
-     * @return the value to which the specified key is mapped, or
-     * {@code null} if this map contains no mapping for the key
-     * @throws ClassCastException   if the key is of an inappropriate type for
-     *                              this map
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException if the specified key is null and this map
-     *                              does not permit null keys
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
+     * Conflicts: this operation conflicts with any operation on the
+     * given key.
      */
     @Accessor
     @Override
     V get(@ConflictParameter Object key);
 
     /**
-     * Associates the specified value with the specified key in this map
-     * (optional operation).  If the map previously contained a mapping for
-     * the key, the old value is replaced by the specified value.  (A map
-     * <tt>m</tt> is said to contain a mapping for a key <tt>k</tt> if and only
-     * if {@link #containsKey(Object) m.containsKey(k)} would return
-     * <tt>true</tt>.)
+     * {@inheritDoc}
      *
-     * @param key   key with which the specified value is to be associated
-     * @param value value to be associated with the specified key
-     * @return the previous value associated with <tt>key</tt>, or
-     * <tt>null</tt> if there was no mapping for <tt>key</tt>.
-     * (A <tt>null</tt> return can also indicate that the map
-     * previously associated <tt>null</tt> with <tt>key</tt>,
-     * if the implementation supports <tt>null</tt> values.)
-     * @throws UnsupportedOperationException if the <tt>put</tt> operation
-     *                                       is not supported by this map
-     * @throws ClassCastException            if the class of the specified key or value
-     *                                       prevents it from being stored in this map
-     * @throws NullPointerException          if the specified key or value is null
-     *                                       and this map does not permit null keys or values
-     * @throws IllegalArgumentException      if some property of the specified key
-     *                                       or value prevents it from being stored in this map
+     * Conflicts: this operation produces a conflict with any other
+     * operation on the given key.
      */
     @MutatorAccessor(name = "put", undoFunction = "undoPut", undoRecordFunction = "undoPutRecord")
     @Override
@@ -137,23 +71,16 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
 
 
     /**
-     * Associates the specified value with the specified key in this map
-     * without return the previous value.  If the map previously contained a
-     * mapping for the key, the old value is replaced by the specified value.
-     * (A map <tt>m</tt> is said to contain a mapping for a key <tt>k</tt> if
-     * and only if {@link #containsKey(Object) m.containsKey(k)} would return
-     * <tt>true</tt>.)
+     * This operation behaves like a put operation, but does not
+     * return the previous value, and does not result in a read
+     * of the map.
      *
-     * @param key   key with which the specified value is to be associated
-     * @param value value to be associated with the specified key
-     * @throws UnsupportedOperationException if the <tt>put</tt> operation
-     *                                       is not supported by this map
-     * @throws ClassCastException            if the class of the specified key or value
-     *                                       prevents it from being stored in this map
-     * @throws NullPointerException          if the specified key or value is null
-     *                                       and this map does not permit null keys or values
-     * @throws IllegalArgumentException      if some property of the specified key
-     *                                       or value prevents it from being stored in this map
+     * Calling this operation produces the same put record as calling
+     * "put" directly. However, the runtime will not try to sync
+     * the object to obtain an upcall.
+     *
+     * Conflicts: this operation produces a conflict with any other
+     * operation on the given key.
      */
     @Mutator(name = "put", noUpcall = true)
     default void blindPut(@ConflictParameter K key, V value) {
@@ -193,34 +120,10 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
     }
 
     /**
-     * Removes the mapping for a key from this map if it is present
-     * (optional operation).   More formally, if this map contains a mapping
-     * from key <tt>k</tt> to value <tt>v</tt> such that
-     * <code>(key==null ?  k==null : key.equals(k))</code>, that mapping
-     * is removed.  (The map can contain at most one such mapping.)
-     * <p>
-     * <p>Returns the value to which this map previously associated the key,
-     * or <tt>null</tt> if the map contained no mapping for the key.
-     * <p>
-     * <p>If this map permits null values, then a return value of
-     * <tt>null</tt> does not <i>necessarily</i> indicate that the map
-     * contained no mapping for the key; it's also possible that the map
-     * explicitly mapped the key to <tt>null</tt>.
-     * <p>
-     * <p>The map will not contain a mapping for the specified key once the
-     * call returns.
+     * {@jnheritDoc}
      *
-     * @param key key whose mapping is to be removed from the map
-     * @return the previous value associated with <tt>key</tt>, or
-     * <tt>null</tt> if there was no mapping for <tt>key</tt>.
-     * @throws UnsupportedOperationException if the <tt>remove</tt> operation
-     *                                       is not supported by this map
-     * @throws ClassCastException            if the key is of an inappropriate type for
-     *                                       this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException          if the specified key is null and this
-     *                                       map does not permit null keys
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
+     * Conflicts: this operation produces a conflict with any other
+     * operation on the given key.
      */
     @MutatorAccessor(name="remove", undoFunction = "undoRemove", undoRecordFunction = "undoRemoveRecord")
     @Override
@@ -254,92 +157,88 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
     }
 
     /**
-     * Copies all of the mappings from the specified map to this map
-     * (optional operation).  The effect of this call is equivalent to that
-     * of calling {@link #put(Object, Object) put(k, v)} on this map once
-     * for each mapping from key <tt>k</tt> to value <tt>v</tt> in the
-     * specified map.  The behavior of this operation is undefined if the
-     * specified map is modified while the operation is in progress.
+     * {@inheritDoc}
      *
-     * @param m mappings to be stored in this map
-     * @throws UnsupportedOperationException if the <tt>putAll</tt> operation
-     *                                       is not supported by this map
-     * @throws ClassCastException            if the class of a key or value in the
-     *                                       specified map prevents it from being stored in this map
-     * @throws NullPointerException          if the specified map is null, or if
-     *                                       this map does not permit null keys or values, and the
-     *                                       specified map contains null keys or values
-     * @throws IllegalArgumentException      if some property of a key or value in
-     *                                       the specified map prevents it from being stored in this map
+     * Conflicts: this operation currently conflicts with the entire map, until
+     * custom conflict parameter generation is introduced.
      */
-    @Mutator(name="putAll")
+    @Mutator(name="putAll", undoFunction="undoPutAll", undoRecordFunction="undoPutAllRecord")
     @Override
     void putAll(Map<? extends K, ? extends V> m);
 
-    /**
-     * Removes all of the mappings from this map (optional operation).
-     * The map will be empty after this call returns.
+
+    /** Generate an undo record for putAll, given the previous state of the map
+     * and the parameters to the putAll call.
      *
-     * @throws UnsupportedOperationException if the <tt>clear</tt> operation
-     *                                       is not supported by this map
+     * @param previousState     The previous state of the map
+     * @param m                 The map from the putAll call
+     * @return                  An undo record, which for a putAll is all the
+     *                          previous entries in the map.
+     */
+    default Map<K,V> undoPutAllRecord(ISMRMap<K,V> previousState, Map<? extends K, ? extends V> m) {
+        ImmutableMap.Builder<K,V> builder = ImmutableMap.builder();
+        m.keySet().forEach(k -> builder.put(k, previousState.get(k)));
+        return builder.build();
+    }
+
+    /** Undo a remove, given the current state of the map, an undo record
+     * and the arguments to the remove command to undo.
+     *
+     * @param map           The state of the map after the put to undo
+     * @param undoRecord    The undo record generated by undoRemoveRecord
+     */
+    default void undoPutAll(ISMRMap<K,V> map, Map<K,V> undoRecord, Map<? extends K, ? extends V> m) {
+        undoRecord.entrySet().forEach(e -> {
+                    if (e.getValue() == null) { map.remove(e.getKey()); }
+                    else { map.put(e.getKey(), e.getValue()); }
+                });
+    }
+
+
+    /**
+     * {@inheritDoc}
+     *
+     * Conflicts: this operation conflicts with the entire map, since it drops
+     * all mappings which are present.
      */
     @Mutator(name="clear", reset=true)
     @Override
     void clear();
 
     /**
-     * Returns a {@link Set} view of the keys contained in this map.
-     * The set is backed by the map, so changes to the map are
-     * reflected in the set, and vice-versa.  If the map is modified
-     * while an iteration over the set is in progress (except through
-     * the iterator's own <tt>remove</tt> operation), the results of
-     * the iteration are undefined.  The set supports element removal,
-     * which removes the corresponding mapping from the map, via the
-     * <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
-     * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-     * operations.  It does not support the <tt>add</tt> or <tt>addAll</tt>
-     * operations.
+     * {@inheritDoc}
      *
-     * @return a set view of the keys contained in this map
+     * This function currently does not return a view like the java.util implementation,
+     * and changes to the keySet will *not* be reflected in the map.
+     *
+     * Conflicts: This operation currently conflicts with any modification
+     * to the map.
      */
     @Accessor
     @Override
     Set<K> keySet();
 
     /**
-     * Returns a {@link Collection} view of the values contained in this map.
-     * The collection is backed by the map, so changes to the map are
-     * reflected in the collection, and vice-versa.  If the map is
-     * modified while an iteration over the collection is in progress
-     * (except through the iterator's own <tt>remove</tt> operation),
-     * the results of the iteration are undefined.  The collection
-     * supports element removal, which removes the corresponding
-     * mapping from the map, via the <tt>Iterator.remove</tt>,
-     * <tt>Collection.remove</tt>, <tt>removeAll</tt>,
-     * <tt>retainAll</tt> and <tt>clear</tt> operations.  It does not
-     * support the <tt>add</tt> or <tt>addAll</tt> operations.
+     * {@inheritDoc}
      *
-     * @return a collection view of the values contained in this map
+     * This function currently does not return a view like the java.util implementation,
+     * and changes to the values will *not* be reflected in the map.
+     *
+     * Conflicts: This operation currently conflicts with any modification
+     * to the map.
      */
     @Accessor
     @Override
     Collection<V> values();
 
     /**
-     * Returns a {@link Set} view of the mappings contained in this map.
-     * The set is backed by the map, so changes to the map are
-     * reflected in the set, and vice-versa.  If the map is modified
-     * while an iteration over the set is in progress (except through
-     * the iterator's own <tt>remove</tt> operation, or through the
-     * <tt>setValue</tt> operation on a map entry returned by the
-     * iterator) the results of the iteration are undefined.  The set
-     * supports element removal, which removes the corresponding
-     * mapping from the map, via the <tt>Iterator.remove</tt>,
-     * <tt>Set.remove</tt>, <tt>removeAll</tt>, <tt>retainAll</tt> and
-     * <tt>clear</tt> operations.  It does not support the
-     * <tt>add</tt> or <tt>addAll</tt> operations.
+     * {@inheritDoc}
      *
-     * @return a set view of the mappings contained in this map
+     * This function currently does not return a view like the java.util implementation,
+     * and changes to the entrySet will *not* be reflected in the map.
+     *
+     * Conflicts: This operation currently conflicts with any modification
+     * to the map.
      */
     @Accessor
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRObject.java
@@ -10,114 +10,21 @@ import java.util.HashMap;
 public interface ISMRObject {
 
     /**
-     * Returns a hash code value for the object. This method is
-     * supported for the benefit of hash tables such as those provided by
-     * {@link HashMap}.
-     * <p>
-     * The general contract of {@code hashCode} is:
-     * <ul>
-     * <li>Whenever it is invoked on the same object more than once during
-     * an execution of a Java application, the {@code hashCode} method
-     * must consistently return the same integer, provided no information
-     * used in {@code equals} comparisons on the object is modified.
-     * This integer need not remain consistent from one execution of an
-     * application to another execution of the same application.
-     * <li>If two objects are equal according to the {@code equals(Object)}
-     * method, then calling the {@code hashCode} method on each of
-     * the two objects must produce the same integer result.
-     * <li>It is <em>not</em> required that if two objects are unequal
-     * according to the {@link Object#equals(Object)}
-     * method, then calling the {@code hashCode} method on each of the
-     * two objects must produce distinct integer results.  However, the
-     * programmer should be aware that producing distinct integer results
-     * for unequal objects may improve the performance of hash tables.
-     * </ul>
-     * <p>
-     * As much as is reasonably practical, the hashCode method defined by
-     * class {@code Object} does return distinct integers for distinct
-     * objects. (This is typically implemented by converting the internal
-     * address of the object into an integer, but this implementation
-     * technique is not required by the
-     * Java&trade; programming language.)
-     *
-     * @return a hash code value for this object.
-     * @see Object#equals(Object)
-     * @see System#identityHashCode
+     * {@inheritDoc}
      */
     @Override
     @Accessor
     int hashCode();
 
     /**
-     * Indicates whether some other object is "equal to" this one.
-     * <p>
-     * The {@code equals} method implements an equivalence relation
-     * on non-null object references:
-     * <ul>
-     * <li>It is <i>reflexive</i>: for any non-null reference value
-     * {@code x}, {@code x.equals(x)} should return
-     * {@code true}.
-     * <li>It is <i>symmetric</i>: for any non-null reference values
-     * {@code x} and {@code y}, {@code x.equals(y)}
-     * should return {@code true} if and only if
-     * {@code y.equals(x)} returns {@code true}.
-     * <li>It is <i>transitive</i>: for any non-null reference values
-     * {@code x}, {@code y}, and {@code z}, if
-     * {@code x.equals(y)} returns {@code true} and
-     * {@code y.equals(z)} returns {@code true}, then
-     * {@code x.equals(z)} should return {@code true}.
-     * <li>It is <i>consistent</i>: for any non-null reference values
-     * {@code x} and {@code y}, multiple invocations of
-     * {@code x.equals(y)} consistently return {@code true}
-     * or consistently return {@code false}, provided no
-     * information used in {@code equals} comparisons on the
-     * objects is modified.
-     * <li>For any non-null reference value {@code x},
-     * {@code x.equals(null)} should return {@code false}.
-     * </ul>
-     * <p>
-     * The {@code equals} method for class {@code Object} implements
-     * the most discriminating possible equivalence relation on objects;
-     * that is, for any non-null reference values {@code x} and
-     * {@code y}, this method returns {@code true} if and only
-     * if {@code x} and {@code y} refer to the same object
-     * ({@code x == y} has the value {@code true}).
-     * <p>
-     * Note that it is generally necessary to override the {@code hashCode}
-     * method whenever this method is overridden, so as to maintain the
-     * general contract for the {@code hashCode} method, which states
-     * that equal objects must have equal hash codes.
-     *
-     * @param obj the reference object with which to compare.
-     * @return {@code true} if this object is the same as the obj
-     * argument; {@code false} otherwise.
-     * @see #hashCode()
-     * @see HashMap
+     * {@inheritDoc}
      */
     @Override
     @Accessor
     boolean equals(Object obj);
 
     /**
-     * Returns a string representation of the object. In general, the
-     * {@code toString} method returns a string that
-     * "textually represents" this object. The result should
-     * be a concise but informative representation that is easy for a
-     * person to read.
-     * It is recommended that all subclasses override this method.
-     * <p>
-     * The {@code toString} method for class {@code Object}
-     * returns a string consisting of the name of the class of which the
-     * object is an instance, the at-sign character `{@code @}', and
-     * the unsigned hexadecimal representation of the hash code of the
-     * object. In other words, this method returns a string equal to the
-     * value of:
-     * <blockquote>
-     * <pre>
-     * getClass().getName() + '@' + Integer.toHexString(hashCode())
-     * </pre></blockquote>
-     *
-     * @return a string representation of the object.
+     * {@inheritDoc}
      */
     @Accessor
     String toString();

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -98,11 +98,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
 
     public CorfuCompileProxy(CorfuRuntime rt, UUID streamID, Class<T> type, Object[] args,
                              ISerializer serializer,
-                             Map<String, ICorfuSMRUpcallTarget<T>> upcallTargetMap,
-                             Map<String, IUndoFunction<T>> undoTargetMap,
-                             Map<String, IUndoRecordFunction<T>> undoRecordTargetMap,
-                             Set<String> resetSet
-                             ) {
+                             ICorfuSMR<T> wrapperObject) {
         this.rt = rt;
         this.streamID = streamID;
         this.type = type;
@@ -111,8 +107,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
 
         underlyingObject = new VersionLockedObject<T>(this::getNewInstance,
                 new StreamViewSMRAdapter(rt, rt.getStreamsView().get(streamID)),
-                upcallTargetMap, undoRecordTargetMap,
-                undoTargetMap, resetSet);
+                wrapperObject);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -45,10 +45,7 @@ public class CorfuCompileWrapperBuilder {
         // instances of this object. The wrapper delegates calls to the proxy.
         wrapperObject.setCorfuSMRProxy(new CorfuCompileProxy<>(rt, streamID,
                 type, args, serializer,
-                wrapperObject.getCorfuSMRUpcallMap(),
-                wrapperObject.getCorfuUndoMap(),
-                wrapperObject.getCorfuUndoRecordMap(),
-                wrapperObject.getCorfuResetSet()));
+                wrapperObject));
 
         if (wrapperObject instanceof ICorfuSMRProxyWrapper) {
             ((ICorfuSMRProxyWrapper) wrapperObject)

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.object;
 
 import io.netty.util.internal.ConcurrentSet;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.exceptions.NoRollbackException;
@@ -73,34 +74,20 @@ public class VersionLockedObject<T> {
      */
     private WriteSetSMRStream optimisticStream;
 
-    /** The upcall map for this object. */
-    private final Map<String, ICorfuSMRUpcallTarget<T>> upcallTargetMap;
-
-    /** The undo record function map for this object. */
-    private final Map<String, IUndoRecordFunction<T>> undoRecordFunctionMap;
-
-    /** The undo target map for this object. */
-    private final Map<String, IUndoFunction<T>> undoFunctionMap;
-
-    /** The reset set for this object. */
-    private final Set<String> resetSet;
+    /** The wrapper object making calls into this version locked object. */
+    @Getter
+    private final ICorfuSMR<T> wrapperObject;
 
     /** A function that generates a new instance of this object. */
     private final Supplier<T> newObjectFn;
 
     public VersionLockedObject(Supplier<T> newObjectFn,
                                StreamViewSMRAdapter smrStream,
-                  Map<String, ICorfuSMRUpcallTarget<T>> upcallTargets,
-                  Map<String, IUndoRecordFunction<T>> undoRecordTargets,
-                  Map<String, IUndoFunction<T>> undoTargets,
-                  Set<String> resetSet)
+                               ICorfuSMR<T> wrapperObject)
     {
         this.smrStream = smrStream;
 
-        this.upcallTargetMap = upcallTargets;
-        this.undoRecordFunctionMap = undoRecordTargets;
-        this.undoFunctionMap = undoTargets;
-        this.resetSet = resetSet;
+        this.wrapperObject = wrapperObject;
 
         this.newObjectFn = newObjectFn;
         this.object = newObjectFn.get();
@@ -391,7 +378,7 @@ public class VersionLockedObject<T> {
                 record.getEntry() != null ? record.getEntry().getGlobalAddress() : "OPT",
                 record.getUndoRecord());
         IUndoFunction<T> undoFunction =
-                undoFunctionMap.get(record.getSMRMethod());
+                wrapperObject.getCorfuUndoMap().get(record.getSMRMethod());
         // If the undo function exists, apply it.
         if (undoFunction != null) {
             undoFunction.doUndo(object, record.getUndoRecord(),
@@ -400,7 +387,7 @@ public class VersionLockedObject<T> {
         }
         // If this is a reset, undo by restoring the
         // previous state.
-        else if (resetSet.contains(record.getSMRMethod())) {
+        else if (wrapperObject.getCorfuResetSet().contains(record.getSMRMethod())) {
             object = (T) record.getUndoRecord();
             // clear the undo record, since it is now
             // consumed (the object may change)
@@ -423,7 +410,7 @@ public class VersionLockedObject<T> {
                 entry.getEntry() != null ? entry.getEntry().getGlobalAddress() : "OPT",
                 entry.getSMRArguments());
 
-        ICorfuSMRUpcallTarget<T> target = upcallTargetMap.get(entry.getSMRMethod());
+        ICorfuSMRUpcallTarget<T> target = wrapperObject.getCorfuSMRUpcallMap().get(entry.getSMRMethod());
         if (target == null) {
             throw new RuntimeException("Unknown upcall " + entry.getSMRMethod());
         }
@@ -432,13 +419,14 @@ public class VersionLockedObject<T> {
         if (!entry.isUndoable()) {
             // Can we generate an undo record?
             IUndoRecordFunction<T> undoRecordTarget =
-                    undoRecordFunctionMap
+                    wrapperObject.getCorfuUndoRecordMap()
                             .get(entry.getSMRMethod());
             if (undoRecordTarget != null) {
                 // calculate the undo record
                 entry.setUndoRecord(undoRecordTarget
                         .getUndoRecord(object, entry.getSMRArguments()));
-            } else if (resetSet.contains(entry.getSMRMethod())) {
+            } else if (wrapperObject.getCorfuResetSet()
+                    .contains(entry.getSMRMethod())) {
                 // This entry actually resets the object. So here
                 // we can safely get a new instance, and add the
                 // previous instance to the undo log.

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -470,7 +470,7 @@ public class VersionLockedObject<T> {
         List<SMREntry> entries =  stream.current();
 
         while(entries != null) {
-            if (entries.stream().allMatch(x -> x.isUndoable())) {
+            if (entries.stream().allMatch(SMREntry::isUndoable)) {
                 // start from the end, process one at a time
                 ListIterator<SMREntry> it =
                         entries.listIterator(entries.size());

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -3,16 +3,16 @@ package org.corfudb.runtime.object.transactions;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.ISMRConsumable;
+import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.exceptions.NoRollbackException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.object.ICorfuSMRAccess;
-import org.corfudb.runtime.object.ICorfuSMRProxyInternal;
-import org.corfudb.runtime.object.VersionLockedObject;
+import org.corfudb.runtime.object.*;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.util.serializer.ISerializer;
 
 import java.util.*;
 import java.util.function.Consumer;
@@ -53,6 +53,8 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
     private final Set<ICorfuSMRProxyInternal> modifiedProxies =
             new HashSet<>();
 
+    /** Temp var until we put write set proxies somewhere. */
+    private final Set<ICorfuSMRProxyInternal> writeProxies = new HashSet<>();
 
     OptimisticTransactionalContext(TransactionBuilder builder) {
         super(builder);
@@ -196,6 +198,8 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         // Insert the modification into writeSet.
         addToWriteSet(proxy, updateEntry, conflictObjects);
 
+        writeProxies.add(proxy);
+
         // Return the "address" of the update; used for retrieving results from operations via getUpcallRestult.
         return writeSet.get(proxy.getStreamID()).getValue().size() - 1;
     }
@@ -257,6 +261,28 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
             affectedStreams.add(TRANSACTION_STREAM_ID);
         }
 
+        MultiObjectSMREntry entry = collectWriteSetEntries();
+
+        // for each modified proxy, attempt to condense the write sets
+        writeProxies.stream()
+                .forEach(x -> {
+                    if (writeSet.get(x.getStreamID()).getValue().size() >= 2) {
+                        ISerializer serializer = writeSet.get(x.getStreamID()).getValue().get(0).getSerializerType();
+                        if (x.getUnderlyingObject().getWrapperObject() instanceof ICoalescableObject) {
+                            entry.getEntryMap().get(x.getStreamID()).setSMRUpdates((List)
+                                    ((ICoalescableObject) x.getUnderlyingObject().getWrapperObject())
+                                    .coalesceUpdates((List)writeSet.get(x.getStreamID()).getValue(),
+                                            (method, args, isUndoable, undoRecord) -> {
+                                    SMREntry e = new SMREntry(method, args, serializer);
+                                    if (isUndoable) {
+                                        e.setUndoRecord(undoRecord);
+                                    }
+                                        return e;
+                                    }));
+                        }
+                    }
+                });
+
         // Now we obtain a conditional address from the sequencer.
         // This step currently happens all at once, and we get an
         // address of -1L if it is rejected.
@@ -267,7 +293,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                         affectedStreams,
 
                         // a MultiObjectSMREntry that contains the update(s) to objects
-                        collectWriteSetEntries(),
+                        entry,
 
                         // nothing to do after successful acquisition and after deacquisition
                         t->true, t->true,

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -2,14 +2,14 @@ package org.corfudb.runtime.object.transactions;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
+import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.object.ICoalescableObject;
 import org.corfudb.runtime.object.ICorfuSMRProxyInternal;
+import org.corfudb.util.serializer.ISerializer;
 
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static org.corfudb.runtime.view.ObjectsView.TRANSACTION_STREAM_ID;
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -25,6 +25,8 @@ import org.corfudb.util.CFUtils;
 import org.corfudb.util.Utils;
 import org.corfudb.util.serializer.Serializers;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -174,8 +176,13 @@ public class AddressSpaceView extends AbstractView {
         return this.cacheFetch(Utils.discretizeRangeSet(addresses));
     }
 
-    public Map<Long, ILogData> read(List<Long> addresses) {
 
+    /**
+     * Read from a list of addresses
+     * @param addresses     The addresses to read from
+     * @return              A map from log addresses to data contained at that address.
+     */
+    public @Nonnull Map<Long, ILogData> read(@Nonnull List<Long> addresses) {
         if (!runtime.isCacheDisabled()) {
             return readCache.getAll(addresses);
         }
@@ -189,7 +196,7 @@ public class AddressSpaceView extends AbstractView {
      * @return A result to be cached. If the readresult is empty,
      * This entry will be scheduled to self invalidate.
      */
-    private LogData cacheFetch(long address) {
+    private @Nullable LogData cacheFetch(long address) {
         log.trace("Cache miss @ {}, fetching.", address);
         LogData result = fetch(address);
         if (result.getType() == DataType.EMPTY) {

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -230,6 +230,34 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
                 .containsEntry("k", "v2");
     }
 
+    /** This test makes sure that coalesable writes (lots of put operations)
+     * are properly coalesced.
+     */
+    @Test
+    public void coalescbleWrites() {
+        // Write a complex transaction to be coalesced.
+        TXBegin();
+        put("k1", "v1");
+        put("k2", "v1");
+        getMap().clear();
+        put("k1", "v2");
+        put("k2", "v2");
+        put("k1", "v3");
+        put("k2", "v3");
+        put("k1", "v4");
+        put("k2", "v4");
+        put("k3", "v4");
+        put("k4", "v4");
+        TXEnd();
+
+        // Make sure the map was correctly coalesced.
+        assertThat(getMap())
+                .containsEntry("k1", "v4")
+                .containsEntry("k2", "v4")
+                .containsEntry("k3", "v4")
+                .containsEntry("k4", "v4");
+    }
+
     @Override
     protected void TXBegin() {
         getRuntime().getObjectsView().TXBuild()


### PR DESCRIPTION
This patch adds conflict and undo support for the putAll operation,
as well as support for coalescing operations during transactions.

Coalesced operations have a much smaller write set. In the map implementation,
redundant operations (such as operations before a clear, or remove operations
before a put operation on the same key) are removed, and all put operations are
combined into a single putAll operation. This should reduce both the
serialization and playback overhead of large transactions.