### PR TITLE
Rename TXConflictScenarios & TXsFromTwoRuntimes with 'Test' suffix

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTXConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTXConcurrencyTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by dalia on 12/8/16.
  */
-public class OptimisticTXConcurrencyTest extends TXConflictScenarios {
+public class OptimisticTXConcurrencyTest extends TXConflictScenariosTest {
 
     @Override
     protected void TXBegin() {

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/TXConflictScenariosTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/TXConflictScenariosTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * Created by dalia on 12/29/16.
  */
-public abstract class TXConflictScenarios extends AbstractTransactionContextTest {
+public abstract class TXConflictScenariosTest extends AbstractTransactionContextTest {
 
     /**
      * test concurrent transactions for opacity. This works as follows:

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/TXsFromTwoRuntimesTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/TXsFromTwoRuntimesTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by dalia on 1/6/17.
  */
-public class TXsFromTwoRuntimes extends AbstractObjectTest {
+public class TXsFromTwoRuntimesTest extends AbstractObjectTest {
 
     @Test
     public void staggeredTXsConflict() throws Exception {

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/WriteWriteTXConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/WriteWriteTXConcurrencyTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * Created by dmalkhi on 12/13/16.
  */
-public class WriteWriteTXConcurrencyTest extends TXConflictScenarios {
+public class WriteWriteTXConcurrencyTest extends TXConflictScenariosTest {
 
     // override {@link AbstractObjectTest ::TXBegin() } in order to set write-write isolation level
     @Override


### PR DESCRIPTION
These two classes contain @Test annotations that aren't being run by typical unit test executions, including TravisCI's runs.  Renaming with a `Test` suffix should get them run regularly again.