### PR TITLE
Fix for consecutive nested transactions

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -276,23 +276,14 @@ public abstract class AbstractTransactionalContext implements
 
     void mergeWriteSetInto(Map<UUID, AbstractMap.SimpleEntry<Set<Integer>, List<SMREntry>>> otherWSet) {
         otherWSet.entrySet().forEach(e-> {
-            // create an entry for this streamID
-            writeSet.computeIfAbsent(e.getKey(),                    // the streamID
-                    u -> new AbstractMap.SimpleEntry<>(new HashSet<>(), new ArrayList<>() ));
 
-            // copy all the conflict-params set for this streamID
-            writeSet.get(e.getKey())                 // the entry pair for this streamID
-                    .getKey()                        // the left componentof the pair is a conflict-param set
-                    .addAll(e.getValue()             // the pair from the otherWSet
-                            .getKey());              // the left component of the pair
-
-            // copy all the WriteSetEntry list for this streamID
-            writeSet.get(e.getKey())                 // the entry pair for this streamID
-                    .getValue()                      // the right componentof the pair is a WriteSetEntry list
-                    .addAll(e.getValue()             // the pair from the otherWSet
-                            .getValue());            // the right component of the pair
-
-
+            // Since nested transactions inherit the write set of its parent, in order to merge the
+            // write set of the child transaction, we only need to add new entries for non-existing
+            // streams.
+            // For entries that were inherited, they share the same reference in the write set map. Any
+            // modification of it will also appear in the parent write set.
+            writeSet.computeIfAbsent(e.getKey(),
+                    k -> e.getValue());
         });
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -84,8 +84,8 @@ public class WriteSetSMRStream implements ISMRStream {
      *          False otherwise.
      */
     public boolean isStreamForThisTransaction() {
-            return contexts.get(0)
-                    .equals(TransactionalContext.getRootContext());
+        return contexts.get(currentContext)
+                .equals(TransactionalContext.getCurrentContext());
     }
 
     void mergeTransaction() {


### PR DESCRIPTION
This fix ensures that upon consecutive nested transactions, latest transactions can see optimistic updates from previous ones.

This commit introduces various fixes:

1. When accessing/modifying an object, we need to verify that its WriteSetSMRStream correctly reflects the current transactions
   that modified this object. WriteSetSMRStream contains a list of transaction context that have modified this stream.

   Upon access/modification of an object, we would check if the object's WriteSetSMRStream was the correct one by
   comparing if the root transaction context of the WriteSetSMRStream was the same than the root transaction
   context of the thread.

   In the case of consecutive nested transactions, when entering subsequent nested tx, the root tx would still
   be the same, but the WriteSetSMRStream of the object would reflect the previous nested tx. By checking if the
   root tx is the same, we would miss this state change.

   In our fix, we test that the thread's current transaction, is the current tx in the WriteSetSMRStream of the
   underlying object.

2. In order to simplify the sharing of write set between nested transactions, we made the nested tx inherit the
   write set of its parent. This allows the child tx to operate on the current WriteSetSMRStream without further
   optimistic syncing.

   When merging the nested tx in the parent one, we add new write set entries (corresponding to new streams) into
   the parent write set. Since both write set share reference of already present entries, these get updated automatically.

3. When setting a new WriteSetSMRStream for an object, we were not setting its current context to the current tx context
   of the thread. By default, it was being set to the root tx context.

   We ensured that the correct tx context was set.

We also added a test to validate correct execution of consecutive nested transaction