### PR TITLE
Properly Resolve Overloaded Methods

### DIFF
--- a/annotations/src/main/java/org/corfudb/annotations/Mutator.java
+++ b/annotations/src/main/java/org/corfudb/annotations/Mutator.java
@@ -39,7 +39,7 @@ public @interface Mutator {
     boolean reset() default false;
 
     /** Whether or not we should generate an upcall for this mutator. If set to
-     * false, no upcall will be generated - this is typically used when
+     * true, no upcall will be generated - this is typically used when
      * providing a mutator-only version of a mutatorAccessor
      * (for example, "blindPut" and "put").
      * @return True, if no upcall should be generated.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
@@ -1,10 +1,9 @@
 package org.corfudb.runtime.collections;
 
-import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import org.corfudb.annotations.Accessor;
 import org.corfudb.annotations.CorfuObject;
-import org.corfudb.annotations.InterfaceOverride;
 import org.corfudb.annotations.TransactionalMethod;
 
 import java.util.Collection;


### PR DESCRIPTION
SMRObjects can overload methods via annotations. For example,
methods that are annotated will be persisted with the annotation
name instead of the actual method name. In certain cases, this
allows some types to escape the java typing system and thus
method collisions that could have been detected during compile
time would surface at runtime.

Since annotation overloading can only affect the method name,
only two cases need to be verified during processing. In order
to detect if there is a collision, we need to check if two
methods have the same signature, but different return type and
two methods with the same signature and same return type.