### PR TITLE
Overloading SMR methods

### DIFF
--- a/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
+++ b/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
@@ -36,4 +36,12 @@ public @interface MutatorAccessor {
      * @return True, if the mutator resets the object.
      */
     boolean reset() default false;
+
+    /** Whether or not we should generate an upcall for this mutator. If set to
+     * true, no upcall will be generated - this is typically used when
+     * providing a mutator-only version of a mutatorAccessor
+     * (for example, "blindPut" and "put").
+     * @return True, if no upcall should be generated.
+     */
+    boolean noUpcall() default false;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -154,9 +154,9 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      * @throws IllegalArgumentException      if some property of the specified key
      *                                       or value prevents it from being stored in this map
      */
-    @Mutator(name = "put", noUpcall = true)
-    default void blindPut(@ConflictParameter K key, V value) {
-        put(key, value);
+    @MutatorAccessor(name = "put", noUpcall = true)
+    default V blindPut(@ConflictParameter K key, V value) {
+        return put(key, value);
     }
 
     /** Generate an undo record for a put, given the previous state of the map

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
@@ -73,7 +73,7 @@ public class WriteAfterWriteTransactionContextTest extends AbstractTransactionCo
         assertThat(entryMap.getUpdates().size()).isEqualTo(1);
         SMREntry smrEntry = entryMap.getUpdates().get(0);
         Object[] args = smrEntry.getSMRArguments();
-        assertThat(smrEntry.getSMRMethod()).isEqualTo("put");
+        assertThat(smrEntry.getSMRMethod()).isEqualTo("(V)put(K,V)");
         assertThat((String) args[0]).isEqualTo("k");
         assertThat((String) args[1]).isEqualTo("v2");
     }

--- a/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -152,7 +152,7 @@ public class ObjectsViewTest extends AbstractViewTest {
 
         SMREntry smrEntry = entryMap.getUpdates().get(0);
         Object[] args = smrEntry.getSMRArguments();
-        assertThat(smrEntry.getSMRMethod()).isEqualTo("put");
+        assertThat(smrEntry.getSMRMethod()).isEqualTo("(V)put(K,V)");
         assertThat((String) args[0]).isEqualTo("k");
         assertThat((String) args[1]).isEqualTo("v2");
     }


### PR DESCRIPTION
In order to support method overloading for SMRObjects we need
to persist the method signature in the SMREntries instead
of the method name only. When replaying SMREntries we need
the parameter types and return type to map to the correct method.
