### PR TITLE
Improvements in QuorumFuture exception management

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/QuorumFuturesFactory.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/QuorumFuturesFactory.java
@@ -208,6 +208,10 @@ class QuorumFuturesFactory {
             return conflict;
         }
 
+        /**
+         * Returns a set of Throwable classes from all futures that completed in any exceptional fashion.
+         * @return Read-only set containing the Throwable classes
+         */
         public Set<Throwable> getThrowables() {
             return ImmutableSet.copyOf(throwables);
         }


### PR DESCRIPTION
The client changes requre QuorumFuture to permit:

* collection of all exceptions (not only the last). We need it when
  there is existing value from the server,in order to collect the one
  with highest rank.

* fail fast exceptions that will cause the future to return result imediately
(DataOutrankedException is such example)

(cherry picked from commit d6c2eec)