### PR TITLE
Memoize de-serialized objects

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -93,6 +93,10 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         this.metadataMap = new EnumMap<>(IMetadata.LogUnitMetadataType.class);
     }
 
+    public void setDeserializedData(Object object) {
+        this.payload.set(object);
+    }
+
     public LogData(ByteBuf buf, EnumMap<LogUnitMetadataType, Object> metadataMap) {
         this.type = DataType.DATA;
         this.data = byteArrayFromBuf(buf);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WriteRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WriteRequest.java
@@ -28,10 +28,15 @@ public class WriteRequest implements ICorfuPayload<WriteRequest>, IMetadata {
         data = ICorfuPayload.fromBuffer(buf, LogData.class);
     }
 
-    public WriteRequest(WriteMode writeMode, Map<UUID, Long> streamAddresses, ByteBuf buf) {
+    public WriteRequest(WriteMode writeMode, Map<UUID, Long> streamAddresses,
+                        ByteBuf buf) {
         this.writeMode = writeMode;
         this.streamAddresses = streamAddresses;
         this.data = new LogData(DataType.DATA, buf);
+    }
+
+    public void setDeserializedData(Object object) {
+        this.data.setDeserializedData(object);
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -183,6 +183,7 @@ public class LogUnitClient implements IClient {
         ByteBuf payload = ByteBufAllocator.DEFAULT.buffer();
         Serializers.CORFU.serialize(writeObject, payload);
         WriteRequest wr = new WriteRequest(WriteMode.NORMAL, null, payload);
+        wr.setDeserializedData(writeObject);
         wr.setStreams(streams);
         wr.setRank(rank);
         wr.setBackpointerMap(backpointerMap);
@@ -204,9 +205,11 @@ public class LogUnitClient implements IClient {
      * write completes.
      */
     public CompletableFuture<Boolean> write(long address, Set<UUID> streams, long rank,
-                                            ByteBuf buffer, Map<UUID, Long> backpointerMap) {
+                                            ByteBuf buffer, Object writeObject,
+                                            Map<UUID, Long> backpointerMap) {
         Timer.Context context = getTimerContext("writeByteBuf");
         WriteRequest wr = new WriteRequest(WriteMode.NORMAL, null, buffer);
+        wr.setDeserializedData(writeObject);
         wr.setStreams(streams);
         wr.setRank(rank);
         wr.setBackpointerMap(backpointerMap);

--- a/runtime/src/main/java/org/corfudb/runtime/view/ChainReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ChainReplicationView.java
@@ -59,6 +59,7 @@ public class ChainReplicationView extends AbstractReplicationView {
             Serializers.CORFU.serialize(data, b);
 
             LogData ld = new LogData(DataType.DATA, b);
+            ld.setDeserializedData(data);
             ld.setBackpointerMap(backpointerMap);
             ld.setStreams(stream);
             ld.setGlobalAddress(address);

--- a/runtime/src/main/java/org/corfudb/runtime/view/ReplexReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ReplexReplicationView.java
@@ -57,6 +57,7 @@ public class ReplexReplicationView extends AbstractReplicationView {
             // Need this for txns to work, in particular, TXEntry.java requires this info.
             // We don't set the backpointers, to trigger using Replex to do reads.
             LogData ld = new LogData(DataType.DATA, b);
+            ld.setDeserializedData(data);
             ld.setGlobalAddress(address);
             ld.setLogicalAddresses(streamAddresses);
 
@@ -72,7 +73,8 @@ public class ReplexReplicationView extends AbstractReplicationView {
                 log.trace("Write, Global[{}]: chain {}/{}", address, i + 1, numUnits);
                 CFUtils.getUninterruptibly(
                         getLayout().getLogUnitClient(address, i)
-                                .write(getLayout().getLocalAddress(address), stream, 0L, b, Collections.emptyMap()), OverwriteException.class);
+                                .write(getLayout().getLocalAddress(address), stream, 0L, b, data,
+                                        Collections.emptyMap()), OverwriteException.class);
             }
 
             // Write to the secondary / stream index units. To reduce the amount of network traffic, aggregate all


### PR DESCRIPTION
Previously, LogData was doing unnecessary de-serializations -- in most
cases that information is available during the construction of LogData.