### PR TITLE
Proper synchronization of optimistic updates in nested transactions.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -324,7 +324,7 @@ public class VersionLockedObject<T> {
      *          False otherwise.
      */
     public boolean optimisticallyOwnedByThreadUnsafe() {
-        return optimisticStream == null ? false : optimisticStream.isStreamForThisTransaction();
+        return optimisticStream == null ? false : optimisticStream.isStreamForThisThread();
     }
 
     /** Set the optimistic stream for this thread, rolling back

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -75,17 +75,30 @@ public class WriteSetSMRStream implements ISMRStream {
         reset();
     }
 
-    /** Return whether we are the stream for this thread's transactions.
+    /** Return whether stream current transaction is the thread current transaction.
      *
-     * This is checked by checking whether the root context
-     * for this stream is the same as for this thread.
+     * This is validated by checking whether the current context
+     * for this stream is the same as the current context for this thread.
      *
-     * @return  True, if we are the stream for this transaction.
+     * @return  True, if the stream current context is the thread current context.
      *          False otherwise.
      */
-    public boolean isStreamForThisTransaction() {
+    public boolean isStreamCurrentContextThreadCurrentContext() {
         return contexts.get(currentContext)
                 .equals(TransactionalContext.getCurrentContext());
+    }
+
+    /** Return whether we are the stream for this current thread
+     *
+     * This is validated by checking whether the root context
+     * for this stream is the same as the root context for this thread.
+     *
+     * @return  True, if the thread owns the optimistic stream
+     *          False otherwise.
+     */
+    public boolean isStreamForThisThread() {
+        return contexts.get(0)
+                .equals(TransactionalContext.getRootContext());
     }
 
     void mergeTransaction() {

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractObjectTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractObjectTest.java
@@ -69,4 +69,8 @@ public class AbstractObjectTest extends AbstractViewTest {
         getRuntime().getObjectsView().TXEnd();
     }
 
+
+    protected void TXAbort() {
+        getRuntime().getObjectsView().TXAbort();
+    }
 }


### PR DESCRIPTION
The issue was that we were using the same validation function for 2 different conditions.

When we test if the optimisticStream of the underlying object is the correct one for our current transaction, we need to check that current context of the optimisticStream is the same as the current context of the thread.

When we test if the thread owns the optimisticStream of the underlying object, we need to check if the root context of the optimisticStream is the same as the root context of the current thread. 

Usually, on context switch (or on starting nested transaction), we will have the optimisticStream at it's root context. (We unrolled optimistic updates pertaining to the thread we are coming from). This is expected. The current thread, though, is in the nested transaction context. In that case, we need to use the function that test for the root condition.

Then, we proceed on synchronizing the object by applying optimistic updates of nested transactions starting from the root. At the end of the process, the underlying object is in the state of the top of nested transactions stack.

This fix also revert changes of mergeWriteSetInto and remove write set inheritance in nested transactions.

