### PR TITLE
chain replication implementation

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/StreamedLogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/StreamedLogData.java
@@ -1,0 +1,48 @@
+package org.corfudb.protocols.logprotocol;
+
+import io.netty.buffer.ByteBuf;
+import lombok.Getter;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.runtime.CorfuRuntime;
+
+import javax.annotation.Nonnull;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+
+/**
+ * Temporary class for transition to log data.
+ *
+ * Created by mwei on 4/6/17.
+ */
+public class StreamedLogData implements ILogData {
+
+    @Getter
+    public final @Nonnull
+    Map<UUID, StreamData> entryMap;
+
+    public StreamedLogData(Map<UUID, StreamData> entryMap) {
+        this.entryMap = entryMap;
+    }
+
+    public void getSerializedForm(BiConsumer<Object, ByteBuf> serializer, ByteBuf b) {
+        // go through each stream data and serialize it.
+    }
+
+    @Override
+    public Object getPayload(CorfuRuntime t) {
+        return null;
+    }
+
+    @Override
+    public DataType getType() {
+        return null;
+    }
+
+    @Override
+    public EnumMap<LogUnitMetadataType, Object> getMetadataMap() {
+        return null;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/HoleFillRequiredException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/HoleFillRequiredException.java
@@ -4,9 +4,9 @@ package org.corfudb.runtime.exceptions;
  * by policy.
  * Created by mwei on 4/6/17.
  */
-public class HoleFillPolicyException extends Exception {
+public class HoleFillRequiredException extends Exception {
 
-    public HoleFillPolicyException(String message) {
+    public HoleFillRequiredException(String message) {
         super(message);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/RecoveryException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/RecoveryException.java
@@ -1,0 +1,10 @@
+package org.corfudb.runtime.exceptions;
+
+/**
+ * Created by mwei on 4/7/17.
+ */
+public class RecoveryException extends RuntimeException {
+    public RecoveryException(String message) {
+        super(message);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocol.java
@@ -2,7 +2,7 @@ package org.corfudb.runtime.view.replication;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.ILogData;
-import org.corfudb.runtime.exceptions.HoleFillPolicyException;
+import org.corfudb.runtime.exceptions.HoleFillRequiredException;
 
 import javax.annotation.Nonnull;
 
@@ -39,7 +39,7 @@ public abstract class AbstractReplicationProtocol implements IReplicationProtoco
         try {
             return holeFillPolicy
                 .peekUntilHoleFillRequired(globalAddress, this::peek);
-        } catch (HoleFillPolicyException e) {
+        } catch (HoleFillRequiredException e) {
             log.debug("HoleFill[{}] due to {}", e.getMessage());
             holeFill(globalAddress);
             return peek(globalAddress);

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/AlwaysHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/AlwaysHoleFillPolicy.java
@@ -1,7 +1,7 @@
 package org.corfudb.runtime.view.replication;
 
 import org.corfudb.protocols.wireprotocol.ILogData;
-import org.corfudb.runtime.exceptions.HoleFillPolicyException;
+import org.corfudb.runtime.exceptions.HoleFillRequiredException;
 
 import javax.annotation.Nonnull;
 import java.util.function.Function;
@@ -17,10 +17,10 @@ public class AlwaysHoleFillPolicy implements IHoleFillPolicy {
     @Nonnull
     @Override
     public ILogData peekUntilHoleFillRequired(long address,
-               Function<Long, ILogData> peekFunction) throws HoleFillPolicyException {
+               Function<Long, ILogData> peekFunction) throws HoleFillRequiredException {
         ILogData data = peekFunction.apply(address);
         if (data == null) {
-            throw new HoleFillPolicyException("No data at address");
+            throw new HoleFillRequiredException("No data at address");
         }
         return data;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
@@ -1,0 +1,155 @@
+package org.corfudb.runtime.view.replication;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.StreamData;
+import org.corfudb.protocols.logprotocol.StreamedLogData;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.util.CFUtils;
+import org.corfudb.util.serializer.Serializers;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Created by mwei on 4/6/17.
+ */
+@Slf4j
+public class ChainReplicationProtocol extends AbstractReplicationProtocol {
+
+    final Layout layout;
+
+    public ChainReplicationProtocol(IHoleFillPolicy holeFillPolicy, Layout layout) {
+        super(holeFillPolicy);
+        this.layout = layout;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void write(long globalAddress,
+                      @Nonnull Map<UUID, StreamData> entryMap) throws OverwriteException {
+        int numUnits = layout.getSegmentLength(globalAddress);
+
+        ByteBuf b = Unpooled.buffer();
+        try {
+            // To reduce the overhead of serialization, we serialize only the
+            // first time we write, saving when we go down the chain.
+            StreamedLogData sld = new StreamedLogData(entryMap);
+            sld.getSerializedForm(Serializers.CORFU::serialize, b);
+
+            for (int i = 0; i < numUnits; i++) {
+                log.trace("Write[{}]: chain {}/{}", layout, i + 1, numUnits);
+                // In chain replication, we write synchronously to every unit
+                // in the chain.
+                try {
+                    CFUtils.getUninterruptibly(
+                            layout.getLogUnitClient(globalAddress, i)
+                                    // TODO: Currently, this call won't work until the log unit client is refactored.
+                                    .write(globalAddress, null, null, b, null)
+                            , OverwriteException.class);
+                } catch (OverwriteException oe) {
+                    // Some other wrote here (usually due to hole fill)
+                    // We need to invoke the recovery protocol, in case
+                    // the write wasn't driven to completion.
+                    recover(globalAddress);
+                    throw oe;
+                }
+            }
+        } finally {
+            b.release();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public ILogData peek(long globalAddress) {
+        int numUnits = layout.getSegmentLength(globalAddress);
+        log.trace("Read[{}]: chain {}/{}", globalAddress, numUnits, numUnits);
+        // In chain replication, we read from the last unit, though we can optimize if we
+        // know where the committed tail is.
+        return CFUtils.getUninterruptibly(layout
+                .getLogUnitClient(globalAddress, numUnits - 1)
+                                    .read(globalAddress)).getReadSet()
+                .getOrDefault(globalAddress, null);
+    }
+
+    /** Recover a failed write at the given global address,
+     * driving it to completion by invoking the recovery
+     * protocol.
+     *
+     * When this function returns the given globalAddress
+     * is guaranteed to contain a committed value.
+     *
+     * If there was no data previously written at the address,
+     * this function will throw a runtime exception. The
+     * recovery protocol should -only- be invoked if we
+     * previously were overwritten.
+     *
+     * @param globalAddress     The global address to drive
+     *                          the recovery protocol
+     *
+     */
+    protected void recover(long globalAddress) {
+        // In chain replication, we started writing from the head,
+        // and propagated down to the tail. To recover, we start
+        // reading from the head, which should have the data
+        // we are trying to recover
+        int numUnits = layout.getSegmentLength(globalAddress);
+        log.debug("Recover[{}]: read chain head {}/{}", globalAddress, 1, numUnits);
+        ILogData ld = CFUtils.getUninterruptibly(layout.getLogUnitClient(globalAddress, 0)
+                .read(globalAddress)).getReadSet().getOrDefault(globalAddress, null);
+        // If nothing was at the head, this is a bug and we
+        // should fail with a runtime exception, as there
+        // was nothing to recover - if the head was removed
+        // due to a reconfiguration, a network exception
+        // would have been thrown and the client should have
+        // retried it's operation (in this case of a write,
+        // it should have read to determine whether the
+        // write was successful or not.
+        if (ld == null) {
+            throw new RuntimeException();
+        }
+        // now we go down the chain and write, ignoring any overwrite exception we get.
+        for (int i = 1; i < numUnits; i++) {
+            log.debug("Recover[{}]: write chain {}/{}", layout, i + 1, numUnits);
+            // In chain replication, we write synchronously to every unit
+            // in the chain.
+            try {
+                CFUtils.getUninterruptibly(
+                        layout.getLogUnitClient(globalAddress, i)
+                                // TODO: Currently, this call won't work until the log unit client is refactored.
+                                .write(globalAddress, null, null, ld, null)
+                        , OverwriteException.class);
+                // We successfully recovered a write to this member of the chain
+                log.debug("Recover[{}]: recovered write at chain {}/{}", layout, i + 1, numUnits);
+            } catch (OverwriteException oe) {
+                // This member already had this data (in some cases, the write might have
+                // been committed to all members, so this is normal).
+                log.debug("Recover[{}]: overwritten at chain {}/{}", layout, i + 1, numUnits);
+            }
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected void holeFill(long globalAddress) {
+        int numUnits = layout.getSegmentLength(globalAddress);
+        for (int i = 0; i < numUnits; i++) {
+            log.trace("fillHole[{}]: chain {}/{}", globalAddress, i + 1, numUnits);
+            // In chain replication, we write synchronously to every unit in
+            // the chain.
+            try {
+                CFUtils.getUninterruptibly(layout.getLogUnitClient(globalAddress, i)
+                        .fillHole(globalAddress), OverwriteException.class);
+            } catch (OverwriteException oe) {
+                // The hole-fill failed. We must ensure the other writer's
+                // value is adopted before returning.
+                recover(globalAddress);
+            }
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/IHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/IHoleFillPolicy.java
@@ -1,7 +1,7 @@
 package org.corfudb.runtime.view.replication;
 
 import org.corfudb.protocols.wireprotocol.ILogData;
-import org.corfudb.runtime.exceptions.HoleFillPolicyException;
+import org.corfudb.runtime.exceptions.HoleFillRequiredException;
 
 import javax.annotation.Nonnull;
 import java.util.function.Function;
@@ -13,7 +13,7 @@ public interface IHoleFillPolicy {
 
     /** Apply the given peek function until hole filling is required or
      * committed data is returned. If hole filling is required a
-     * HoleFillPolicyException is thrown.
+     * HoleFillRequiredException is thrown.
      *
      * @param address                   The address to apply the function.
      *
@@ -21,10 +21,10 @@ public interface IHoleFillPolicy {
      *                                  from the log.
      *
      * @return                          The committed data at the given address.
-     * @throws HoleFillPolicyException  If hole filling is required.
+     * @throws HoleFillRequiredException  If hole filling is required.
      */
     @Nonnull
     ILogData peekUntilHoleFillRequired(long address,
                                        Function<Long, ILogData> peekFunction)
-            throws HoleFillPolicyException;
+            throws HoleFillRequiredException;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/NeverHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/NeverHoleFillPolicy.java
@@ -2,7 +2,7 @@ package org.corfudb.runtime.view.replication;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.ILogData;
-import org.corfudb.runtime.exceptions.HoleFillPolicyException;
+import org.corfudb.runtime.exceptions.HoleFillRequiredException;
 
 import javax.annotation.Nonnull;
 import java.util.function.Function;
@@ -32,19 +32,20 @@ public class NeverHoleFillPolicy implements IHoleFillPolicy {
     @Nonnull
     @Override
     public ILogData peekUntilHoleFillRequired(long address,
-            Function<Long, ILogData> peekFunction) throws HoleFillPolicyException {
+            Function<Long, ILogData> peekFunction) throws HoleFillRequiredException {
         ILogData data = null;
         int tryNum = 0;
         do {
             if (tryNum != 0) {
                 try {
-                    log.trace("Peek[{}] Retrying read", tryNum);
+                    log.trace("Peek[{}] Retrying read {}", address, tryNum);
                     Thread.sleep(waitMs);
                 } catch (InterruptedException ie) {
                     throw new RuntimeException(ie);
                 }
             }
             data = peekFunction.apply(address);
+            tryNum++;
         } while (data == null);
         return data;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/NeverHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/NeverHoleFillPolicy.java
@@ -18,7 +18,15 @@ import java.util.function.Function;
 public class NeverHoleFillPolicy implements IHoleFillPolicy {
 
     /** The amount of time to wait before retries. */
-    int waitMs;
+    final int waitMs;
+
+    /** Create a new neverHoleFillPolicy with the given wait time.
+     *
+     * @param waitMs    The time to wait, in milliseconds.
+     */
+    public NeverHoleFillPolicy(int waitMs) {
+        this.waitMs = waitMs;
+    }
 
     /** {@inheritDoc} */
     @Nonnull

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
@@ -1,7 +1,7 @@
 package org.corfudb.runtime.view.replication;
 
 import org.corfudb.protocols.wireprotocol.ILogData;
-import org.corfudb.runtime.exceptions.HoleFillPolicyException;
+import org.corfudb.runtime.exceptions.HoleFillRequiredException;
 
 import javax.annotation.Nonnull;
 import java.util.function.Function;
@@ -35,7 +35,7 @@ public class ReadWaitHoleFillPolicy implements IHoleFillPolicy {
     @Nonnull
     @Override
     public ILogData peekUntilHoleFillRequired(long address,
-           Function<Long, ILogData> peekFunction) throws HoleFillPolicyException {
+           Function<Long, ILogData> peekFunction) throws HoleFillRequiredException {
         int tryNum = 0;
         do {
             // If this is not the first try, sleep before trying again
@@ -56,6 +56,6 @@ public class ReadWaitHoleFillPolicy implements IHoleFillPolicy {
             tryNum++;
         } while (numRetries > tryNum);
 
-        throw new HoleFillPolicyException("No data after " + numRetries + " retries");
+        throw new HoleFillRequiredException("No data after " + numRetries + " retries");
     }
 }

--- a/runtime/src/main/java/org/corfudb/util/AutoClosableByteBuf.java
+++ b/runtime/src/main/java/org/corfudb/util/AutoClosableByteBuf.java
@@ -1,0 +1,38 @@
+package org.corfudb.util;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import lombok.Data;
+
+/**
+ * A class for dealing with automatically closing allocated bytebufs.
+ *
+ * Created by mwei on 4/7/17.
+ */
+@Data
+public class AutoClosableByteBuf implements AutoCloseable {
+
+    /** The underlying bytebuf */
+    final ByteBuf buf;
+
+    /** Grab a bytebuf from the default unpooled buffer. */
+    public AutoClosableByteBuf() {
+        buf = Unpooled.buffer();
+    }
+
+    /** Grab a bytebuf from the specified pool. */
+    public AutoClosableByteBuf(PooledByteBufAllocator pool) {
+        buf = pool.buffer();
+    }
+
+
+
+    /** {@inheritDoc}
+     * Release the underlying buffer.
+     * */
+    @Override
+    public void close() {
+        buf.release();
+    }
+}


### PR DESCRIPTION
This PR implements a basic chain replication protcol on top of the new 
replication protocol abstraction. 

The implementation is not yet fully functional, since the log unit
client needs to be modified to not perform serialization or
handle metadata.

Also, bulk operators for read and peek are added (but not implemented
in chain replication, only default implementations are added).