### PR TITLE
update lombok, caffeine and netty versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,23 +120,23 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.16.10</version>
+            <version>1.16.16</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>2.3.5</version>
+            <version>2.4.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>20.0</version>
+            <version>21.0</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
-            <version>4.1.6.Final</version>
+            <version>4.1.9.Final</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Updated dependencies:
lombok: 1.16.16
caffeine: 2.4.0
guava: 21.0
netty: 4.1.9