### PR TITLE
SMR MultiIndex initial implementation

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMultiIndex.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMultiIndex.java
@@ -1,0 +1,108 @@
+package org.corfudb.runtime.collections;
+
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.corfudb.annotations.*;
+
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.IntStream;
+
+/** This object implements a multi-indexed map.
+ *
+ * Maps are indexed by their row index, R, as well as multiple column indexes
+ * calculated at insert time using a set of index functions, which generate
+ * indexes from the inserted value.
+ *
+ * The map can be queried via the row index or by any column index. Multiple
+ * values may exist at any given column index, and the implementation returns
+ * a collection.
+ *
+ * Created by mwei on 4/7/17.
+ */
+@CorfuObject
+public class SMRMultiIndex<R, V> implements ISMRObject {
+
+    /** The interface for an index function.
+     * @param <V>   The type of the object being indexed.
+     */
+    @FunctionalInterface
+    interface IndexFunction<V> {
+        Object generateIndex(V val);
+    }
+
+    /** A list of indexing functions. */
+    final List<IndexFunction<V>> indexFunctions;
+
+    /** The map indexed by the row key. */
+    final Map<R, V> mainMap;
+
+    /** The multi maps indexed by each column key. */
+    final List<Multimap<Object,V>> indexList;
+
+    /** Create a new in-memory multi-index given
+     * a set of indexing functions. */
+    public SMRMultiIndex(List<IndexFunction<V>> indexFunctions) {
+        this.indexFunctions = indexFunctions;
+        this.mainMap = new HashMap<>();
+        this.indexList = new ArrayList<>();
+        IntStream.range(0, indexFunctions.size())
+                .forEach(i -> this.indexList.add(HashMultimap.create()));
+    }
+
+    /** Put the object into the multi index, given the value and it's rowkey.
+     *
+     * @param rowKey    The rowKey to insert the object at.
+     * @param value     The value to insert.
+     * @return          The previous value at the row key.
+     */
+    @MutatorAccessor(name = "put")
+    void put(@ConflictParameter R rowKey, V value) {
+        mainMap.put(rowKey, value);
+        IntStream.range(0, indexFunctions.size())
+                .forEach(i -> indexList.get(i).put(
+                        indexFunctions.get(i).generateIndex(value), value));
+    }
+
+    /** Get a value by it's row key.
+     *
+     * @param rowKey    The row key to retrieve.
+     * @return          The object at the row key, or
+     *                  NULL, if no object was mapped.
+     */
+    @Accessor
+    @Nullable V getByRowIndex(@ConflictParameter R rowKey) {
+        return mainMap.get(rowKey);
+    }
+
+    /** Get a value by a given column key.
+     *
+     * @param indexNum  The index of the index function from the list
+     *                  passed in at construction time.
+     * @param columnKey The column index to use.
+     * @return          A set of values which match the given column index.
+     */
+    @Accessor
+    Collection<V> getByColumnIndex(int indexNum, Object columnKey) {
+        return indexList.get(indexNum).get(columnKey);
+    }
+
+    /** Get the size of the multi-index.
+     * @return  The number of entries mapped (rows).
+     */
+    @Accessor
+    int size() {
+        return mainMap.size();
+    }
+
+    /** Clear the multi-index.
+     */
+    @Mutator(reset = true)
+    void clear() {
+        mainMap.clear();
+        IntStream.range(0, indexFunctions.size())
+                .forEach(i -> indexList.get(i).clear());
+    }
+
+}

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMultiIndexTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMultiIndexTest.java
@@ -1,0 +1,147 @@
+package org.corfudb.runtime.collections;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+import lombok.Data;
+import lombok.Getter;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by mwei on 4/7/17.
+ */
+public class SMRMultiIndexTest extends AbstractViewTest {
+
+    @Getter
+    final String defaultConfigurationString = getDefaultEndpoint();
+
+    public CorfuRuntime r;
+
+    public class IndexRow {
+
+        @Getter
+        final int id;
+
+        @Getter
+        final String i0;
+
+        @Getter
+        final String i1;
+
+        @Getter
+        final String i2;
+
+        public IndexRow(int id, String i0, String i1, String i2)
+        {
+            this.id = id;
+            this.i0 = i0;
+            this.i1 = i1;
+            this.i2 = i2;
+        }
+
+    }
+
+    @Before
+    public void setRuntime() throws Exception {
+        r = getDefaultRuntime().connect();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadFromEachIndex()
+            throws Exception {
+
+        List<SMRMultiIndex.IndexFunction<IndexRow>> indexFunctions =
+                ImmutableList.<SMRMultiIndex.IndexFunction<IndexRow>>builder()
+                .add(r -> r.getI0())
+                .add(r -> r.getI1())
+                .add(r -> r.getI2())
+                .build();
+
+        SMRMultiIndex<String, IndexRow> testMap = getRuntime()
+                .getObjectsView()
+                .build()
+                .setStreamName("test")
+                .setTypeToken(new TypeToken<SMRMultiIndex<String, IndexRow>>() {})
+                .setArguments(indexFunctions)
+                .open();
+
+        IndexRow row0 =  new IndexRow(0, "a0", "b0", "c0");
+        IndexRow row1 =  new IndexRow(1, "a1", "b1", "c1");
+
+        testMap.put("test0", row0);
+        testMap.put("test1", row1);
+
+        assertThat(testMap.getByRowIndex("test0").getId())
+                .isEqualTo(0);
+        assertThat(testMap.getByRowIndex("test1").getId())
+                .isEqualTo(1);
+
+        assertThat(testMap.getByColumnIndex(0, "a0"))
+                .contains(row0);
+        assertThat(testMap.getByColumnIndex(1, "b0"))
+                .contains(row0);
+        assertThat(testMap.getByColumnIndex(2, "c0"))
+                .contains(row0);
+
+        assertThat(testMap.getByColumnIndex(0, "a1"))
+                .contains(row1);
+        assertThat(testMap.getByColumnIndex(1, "b1"))
+                .contains(row1);
+        assertThat(testMap.getByColumnIndex(2, "c1"))
+                .contains(row1);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void indexContainsMultipleCols()
+            throws Exception {
+
+        List<SMRMultiIndex.IndexFunction<IndexRow>> indexFunctions =
+                ImmutableList.<SMRMultiIndex.IndexFunction<IndexRow>>builder()
+                        .add(r -> r.getI0())
+                        .add(r -> r.getI1())
+                        .add(r -> r.getI2())
+                        .build();
+
+        SMRMultiIndex<String, IndexRow> testMap = getRuntime()
+                .getObjectsView()
+                .build()
+                .setStreamName("test")
+                .setTypeToken(new TypeToken<SMRMultiIndex<String, IndexRow>>() {})
+                .setArguments(indexFunctions)
+                .open();
+
+        IndexRow row0 =  new IndexRow(0, "a0", "b0", "c0");
+        IndexRow row1 =  new IndexRow(1, "a0", "b1", "c0");
+
+        testMap.put("test0", row0);
+        testMap.put("test1", row1);
+
+        assertThat(testMap.getByRowIndex("test0").getId())
+                .isEqualTo(0);
+        assertThat(testMap.getByRowIndex("test1").getId())
+                .isEqualTo(1);
+
+        assertThat(testMap.getByColumnIndex(0, "a0"))
+                .contains(row0)
+                .contains(row0);
+
+        assertThat(testMap.getByColumnIndex(1, "b0"))
+                .contains(row0);
+
+        assertThat(testMap.getByColumnIndex(1, "b1"))
+                .contains(row1);
+
+        assertThat(testMap.getByColumnIndex(2, "c0"))
+                .contains(row0)
+                .contains(row1);
+    }
+}


### PR DESCRIPTION
This PR implements a basic multi index, which is a map the supports multiple indexes.

Each entry in the multi index is indexed by a row key and multiple column keys. 
Each value has a one-to-one mapping with a row key, but multiple values can
be mapped to a single column key.

This implementation does not yet support undo.