### PR TITLE
first round of changes to expose streams to the log unit

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -26,18 +26,7 @@ import org.corfudb.infrastructure.log.InMemoryStreamLog;
 import org.corfudb.infrastructure.log.LogAddress;
 import org.corfudb.infrastructure.log.StreamLog;
 import org.corfudb.infrastructure.log.StreamLogFiles;
-import org.corfudb.protocols.wireprotocol.CommitRequest;
-import org.corfudb.protocols.wireprotocol.CorfuMsg;
-import org.corfudb.protocols.wireprotocol.CorfuMsgType;
-import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
-import org.corfudb.protocols.wireprotocol.DataType;
-import org.corfudb.protocols.wireprotocol.IMetadata;
-import org.corfudb.protocols.wireprotocol.LogData;
-import org.corfudb.protocols.wireprotocol.ReadRequest;
-import org.corfudb.protocols.wireprotocol.ReadResponse;
-import org.corfudb.protocols.wireprotocol.TrimRequest;
-import org.corfudb.protocols.wireprotocol.WriteMode;
-import org.corfudb.protocols.wireprotocol.WriteRequest;
+import org.corfudb.protocols.wireprotocol.*;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.DataOutrankedException;
 import org.corfudb.runtime.exceptions.OverwriteException;
@@ -100,12 +89,12 @@ public class LogUnitServer extends AbstractServer {
      * This cache services requests for data at various addresses. In a memory implementation,
      * it is not backed by anything, but in a disk implementation it is backed by persistent storage.
      */
-    private final LoadingCache<LogAddress, LogData> dataCache;
+    private final LoadingCache<LogAddress, ILogData> dataCache;
     private final long maxCacheSize;
 
     private final StreamLog streamLog;
 
-    private final BatchWriter<LogAddress, LogData> batchWriter;
+    private final BatchWriter<LogAddress, ILogData> batchWriter;
 
     private static final String metricsPrefix = "corfu.server.logunit.";
 
@@ -131,8 +120,8 @@ public class LogUnitServer extends AbstractServer {
 
         batchWriter = new BatchWriter(streamLog);
 
-        dataCache = Caffeine.<LogAddress, LogData>newBuilder()
-                .<LogAddress, LogData>weigher((k, v) -> v.getData() == null ? 1 : v.getData().length)
+        dataCache = Caffeine.<LogAddress, ILogData>newBuilder()
+                .<LogAddress, ILogData>weigher((k, v) -> ((LogData)v).getData() == null ? 1 : ((LogData)v).getData().length)
                 .maximumWeight(maxCacheSize)
                 .removalListener(this::handleEviction)
                 .writer(batchWriter)
@@ -188,7 +177,7 @@ public class LogUnitServer extends AbstractServer {
         Map<UUID, Long> streamAddresses = msg.getPayload().getStreams();
         if (streamAddresses == null) {
             // Then this is a commit bit for the global log.
-            LogData entry = dataCache.get(new LogAddress(msg.getPayload().getAddress(), null));
+            ILogData entry = dataCache.get(new LogAddress(msg.getPayload().getAddress(), null));
             if (entry == null) {
                 r.sendResponse(ctx, msg, CorfuMsgType.ERROR_NOENTRY.msg());
                 return;
@@ -197,7 +186,7 @@ public class LogUnitServer extends AbstractServer {
             }
         } else {
             for (UUID streamID : msg.getPayload().getStreams().keySet()) {
-                LogData entry = dataCache.get(new LogAddress(streamAddresses.get(streamID), streamID));
+                ILogData entry = dataCache.get(new LogAddress(streamAddresses.get(streamID), streamID));
                 if (entry == null) {
                     r.sendResponse(ctx, msg, CorfuMsgType.ERROR_NOENTRY.msg());
                     // TODO: Crap, we have to go back and undo all the commit bits??
@@ -221,13 +210,13 @@ public class LogUnitServer extends AbstractServer {
             for (Long l = msg.getPayload().getRange().lowerEndpoint();
                  l < msg.getPayload().getRange().upperEndpoint() + 1L; l++) {
                 LogAddress logAddress = new LogAddress(l, msg.getPayload().getStreamID());
-                LogData e = dataCache.get(logAddress);
+                ILogData e = dataCache.get(logAddress);
                 if (e == null) {
                     rr.put(l, LogData.EMPTY);
                 } else if (e.getType() == DataType.HOLE) {
                     rr.put(l, LogData.HOLE);
                 } else {
-                    rr.put(l, e);
+                    rr.put(l, (LogData)e);
                 }
             }
             r.sendResponse(ctx, msg, CorfuMsgType.READ_RESPONSE.payloadMsg(rr));
@@ -284,16 +273,16 @@ public class LogUnitServer extends AbstractServer {
      * the read() and append(). Any address that cannot be retrieved should be returned as
      * unwritten (null).
      */
-    public synchronized LogData handleRetrieval(LogAddress logAddress) {
+    public synchronized ILogData handleRetrieval(LogAddress logAddress) {
         LogData entry = streamLog.read(logAddress);
         log.trace("Retrieved[{} : {}]", logAddress, entry);
         return entry;
     }
 
 
-    public synchronized void handleEviction(LogAddress logAddress, LogData entry, RemovalCause cause) {
+    public synchronized void handleEviction(LogAddress logAddress, ILogData entry, RemovalCause cause) {
         log.trace("Eviction[{}]: {}", logAddress, cause);
-        streamLog.release(logAddress, entry);
+        streamLog.release(logAddress, (LogData) entry);
     }
 
     /**
@@ -306,7 +295,7 @@ public class LogUnitServer extends AbstractServer {
     }
 
     @VisibleForTesting
-    LoadingCache<LogAddress, LogData> getDataCache() {
+    LoadingCache<LogAddress, ILogData> getDataCache() {
         return dataCache;
     }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/StreamData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/StreamData.java
@@ -14,8 +14,8 @@ public class StreamData {
     /** The id of the stream this stream data belongs to. */
     UUID streamId;
 
-    /** The set of backpointers for this stream data. */
-    Set<Long> backpointerSet;
+    /** The backpointer this stream data. */
+    Long backpointer;
 
     /** The log entry (to be renamed stream entry) at this stream data. */
     LogEntry streamEntry;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/StreamedLogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/StreamedLogData.java
@@ -1,48 +1,142 @@
 package org.corfudb.protocols.logprotocol;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import lombok.Getter;
 import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ICorfuPayload;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
 
 import javax.annotation.Nonnull;
-import java.util.EnumMap;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.BiConsumer;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * Temporary class for transition to log data.
  *
  * Created by mwei on 4/6/17.
  */
-public class StreamedLogData implements ILogData {
+public class StreamedLogData implements ILogData, ICorfuPayload<StreamedLogData>{
 
+    /** A map of stream data. */
     @Getter
     public final @Nonnull
-    Map<UUID, StreamData> entryMap;
+    Map<UUID, StreamData> streamDataMap;
 
-    public StreamedLogData(Map<UUID, StreamData> entryMap) {
-        this.entryMap = entryMap;
+    /** The metadata for this log entry. */
+    @Getter
+    final EnumMap<LogUnitMetadataType, Object> metadataMap;
+
+    /** The serialized form, cached during writing only
+     * and auto-released by the handle.
+     */
+    protected ByteBuf serializedForm;
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<UUID> getStreams() {
+        return streamDataMap.keySet();
     }
 
-    public void getSerializedForm(BiConsumer<Object, ByteBuf> serializer, ByteBuf b) {
-        // go through each stream data and serialize it.
+    /** {@inheritDoc} */
+    @Override
+    public boolean containsStream(UUID stream) {
+        return streamDataMap.containsKey(stream);
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public Map<UUID, Long> getBackpointerMap() {
+        return streamDataMap.entrySet().stream()
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue().backpointer));
+    }
+
+    /** Serialize to the given buffer, using the cached form
+     * if possible.
+     * @param buf   The buffer to serialize.
+     */
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        // If we don't have a cached version, we serialized directly
+        if (serializedForm == null) {
+            doSerialize(buf);
+        } else {
+            serializedForm.resetReaderIndex();
+            buf.writeBytes(serializedForm);
+        }
+    }
+
+    /** This class provides a serialization handle, which
+     * manages the lifetime of the serialized copy of this
+     * entry.
+     */
+    public static class SerializationHandle implements AutoCloseable {
+
+        /** A reference to the log data. */
+        final StreamedLogData data;
+
+        /** Explicitly request the serialized form of this log data
+         * which only exists for the lifetime of this handle.
+         * @return  The serialized form of this handle.
+         */
+        public StreamedLogData getSerialized() {
+            return data;
+        }
+
+        /** Create a new serialized handle with a reference
+         * to the log data.
+         * @param data  The log data to manage.
+         */
+        public SerializationHandle(StreamedLogData data)
+        {
+            this.data = data;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public void close() {
+            data.serializedForm.release();
+            data.serializedForm = null;
+        }
+    }
+
+    public StreamedLogData(long address, Map<UUID, StreamData> streamDataMap) {
+        this.setGlobalAddress(address);
+        this.streamDataMap = streamDataMap;
+        this.metadataMap = new EnumMap<>(LogUnitMetadataType.class);
+    }
+
+    public StreamedLogData(ByteBuf buf) {
+        ICorfuPayload.fromBuffer(buf, DataType.class);
+        streamDataMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, StreamData.class);
+        metadataMap = ICorfuPayload.enumMapFromBuffer(buf, LogUnitMetadataType.class, Object.class);
+    }
+
+    /** Get the serialization handle. */
+    public SerializationHandle getSerializedForm() {
+        serializedForm = Unpooled.buffer();
+        serializedDataToBuffer(serializedForm);
+        return new SerializationHandle(this);
+    }
+
+    /** Serialize the data to the given buffer. */
+    private void serializedDataToBuffer(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, DataType.DATA);
+        ICorfuPayload.serialize(buf, streamDataMap);
+        ICorfuPayload.serialize(buf, metadataMap);
+    }
+
+    /** The payload of an entry with streams is the map. */
     @Override
     public Object getPayload(CorfuRuntime t) {
-        return null;
+        return streamDataMap;
     }
 
+    /** Streamed log data always contain data. */
     @Override
     public DataType getType() {
-        return null;
+        return DataType.DATA;
     }
 
-    @Override
-    public EnumMap<LogUnitMetadataType, Object> getMetadataMap() {
-        return null;
-    }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WriteRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WriteRequest.java
@@ -17,7 +17,7 @@ public class WriteRequest implements ICorfuPayload<WriteRequest>, IMetadata {
     @Getter
     final Map<UUID, Long> streamAddresses;
     @Getter
-    final LogData data;
+    final ILogData data;
 
     @SuppressWarnings("unchecked")
     public WriteRequest(ByteBuf buf) {
@@ -38,6 +38,11 @@ public class WriteRequest implements ICorfuPayload<WriteRequest>, IMetadata {
         this.data = new LogData(dataType, buf);
     }
 
+    public WriteRequest(ILogData data) {
+        writeMode = WriteMode.NORMAL;
+        this.data = data;
+        streamAddresses = null;
+    }
 
     @Override
     public void doSerialize(ByteBuf buf) {

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -234,7 +234,15 @@ public class LogUnitClient implements IClient {
     }
 
 
-
+    /**
+     * Asynchronously write to the logging unit.
+     * @param payload   The log data to write to the logging unit.
+     * @return          A CompletableFuture which will complete with the WriteResult once the
+     *                  write completes.
+     */
+    public CompletableFuture<Boolean> write(ILogData payload) {
+        return router.sendMessageAndGetCompletable(CorfuMsgType.WRITE.payloadMsg(new WriteRequest(payload)));
+    }
 
     /**
      * Asynchronously write to the logging unit.

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
@@ -32,25 +32,25 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
 
     /** {@inheritDoc} */
     @Override
-    public void write(long globalAddress,
+    public ILogData write(long globalAddress,
                       @Nonnull Map<UUID, StreamData> entryMap) throws OverwriteException {
         int numUnits = layout.getSegmentLength(globalAddress);
 
-        try (AutoClosableByteBuf b = new AutoClosableByteBuf()) {
-            // To reduce the overhead of serialization, we serialize only the
-            // first time we write, saving when we go down the chain.
-            StreamedLogData sld = new StreamedLogData(entryMap);
-            sld.getSerializedForm(Serializers.CORFU::serialize, b.getBuf());
 
+        StreamedLogData sld = new StreamedLogData(globalAddress, entryMap);
+
+        // To reduce the overhead of serialization, we serialize only the
+        // first time we write, saving when we go down the chain.
+        try (StreamedLogData.SerializationHandle sh =
+                     sld.getSerializedForm()) {
             log.trace("Write[{}]: chain head {}/{}", 1, numUnits);
             // In chain replication, we start at the chain head.
                 try {
                     CFUtils.getUninterruptibly(
                             layout.getLogUnitClient(globalAddress, 0)
-                                    // TODO: Currently, this call won't work until the log unit client is refactored.
-                                    .write(globalAddress, null, null, b, null)
+                                    .write(sh.getSerialized())
                             , OverwriteException.class);
-                    propagate(globalAddress, b.getBuf());
+                    propagate(globalAddress, sh.getSerialized());
                 } catch (OverwriteException oe) {
                     // Some other wrote here (usually due to hole fill)
                     // We need to invoke the recovery protocol, in case
@@ -59,6 +59,8 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
                     throw oe;
                 }
         }
+
+        return sld;
     }
 
     /** {@inheritDoc} */
@@ -84,7 +86,7 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
      * @param data          The data to propagate, or NULL,
      *                      if it is to be a hole.
      */
-    protected void propagate(long globalAddress, @Nullable ByteBuf data) {
+    protected void propagate(long globalAddress, @Nullable ILogData data) {
         int numUnits = layout.getSegmentLength(globalAddress);
 
         for (int i = 1; i < numUnits; i++) {
@@ -95,8 +97,7 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
                 if (data != null) {
                     CFUtils.getUninterruptibly(
                             layout.getLogUnitClient(globalAddress, i)
-                                    // TODO: Currently, this call won't work until the log unit client is refactored.
-                                    .write(globalAddress, null, null, data, null)
+                                    .write(data)
                             , OverwriteException.class);
                 } else {
                     CFUtils.getUninterruptibly(layout.getLogUnitClient(globalAddress, i)
@@ -152,8 +153,7 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
             try {
                 CFUtils.getUninterruptibly(
                         layout.getLogUnitClient(globalAddress, i)
-                                // TODO: Currently, this call won't work until the log unit client is refactored.
-                                .write(globalAddress, null, null, ld, null)
+                                .write(ld)
                         , OverwriteException.class);
                 // We successfully recovered a write to this member of the chain
                 log.debug("Recover[{}]: recovered write at chain {}/{}", layout, i + 1, numUnits);

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/IReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/IReplicationProtocol.java
@@ -31,10 +31,12 @@ public interface IReplicationProtocol {
      * @param globalAddress         The global address to write the data at.
      * @param entryMap              A map of stream IDs to stream entries to
      *                              write to the log.
+     * @return                      The ILogData that was generated, for
+     *                              caching writes.
      * @throws OverwriteException   If a write was committed to the log and
      *                              it was not the result of this call.
      */
-    void write(long globalAddress,
+    ILogData write(long globalAddress,
                @Nonnull Map<UUID, StreamData> entryMap) throws OverwriteException;
 
     /** Read data from a given address.

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerAssertions.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerAssertions.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.assertj.core.api.AbstractAssert;
 import org.corfudb.infrastructure.log.LogAddress;
+import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.util.serializer.Serializers;
 
 
@@ -66,8 +67,8 @@ public class LogUnitServerAssertions extends AbstractAssert<LogUnitServerAsserti
             byte[] expected = new byte[b.readableBytes()];
             b.getBytes(0, expected);
 
-            org.assertj.core.api.Assertions.assertThat(actual.getDataCache()
-                    .get(new LogAddress(address, null)).getData())
+            org.assertj.core.api.Assertions.assertThat(((LogData)actual.getDataCache()
+                    .get(new LogAddress(address, null))).getData())
                     .isEqualTo(expected);
 
         }


### PR DESCRIPTION
This PR introduces the first round of changes which will
expose the contents of each stream to the logging units.

The log unit interface has been simplified to take a
single parameter, which is the log data itself.

Managining serialization during a write to multiple
logging units has also been enhanced.