### PR TITLE
This patch adds abort information to token-response

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -14,7 +14,11 @@ import java.util.UUID;
 @AllArgsConstructor
 public class TokenResponse implements ICorfuPayload<TokenResponse> {
 
-    /** The current token. */
+    /** the cause/type of response */
+    final TokenType respType;
+
+    /** The current token,
+     * or overload with "cause address" in case token request is denied. */
     final Long token;
 
     /** The backpointer map, if available. */
@@ -24,6 +28,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse> {
     final Map<UUID, Long> streamAddresses;
 
     public TokenResponse(ByteBuf buf) {
+        respType = TokenType.values()[ICorfuPayload.fromBuffer(buf, Byte.class)];
         token = ICorfuPayload.fromBuffer(buf, Long.class);
         backpointerMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
         streamAddresses = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
@@ -31,6 +36,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse> {
 
     @Override
     public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, respType);
         ICorfuPayload.serialize(buf, token);
         ICorfuPayload.serialize(buf, backpointerMap);
         ICorfuPayload.serialize(buf, streamAddresses);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenType.java
@@ -1,0 +1,36 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Created by dalia on 4/8/17.
+ */
+@RequiredArgsConstructor
+public enum  TokenType implements ICorfuPayload<TokenType> {
+    NORMAL((byte) 0),
+    QUERY((byte)1),
+    TX_ABORT_CONFLICT((byte)2),
+    TX_ABORT_NEWSEQ((byte) 3);
+
+    final int val;
+
+    byte asByte() {
+        return (byte) val;
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        buf.writeByte(asByte());
+    }
+
+    static Map<Byte, TokenType> typeMap =
+            Arrays.stream(TokenType.values())
+                    .collect(Collectors.toMap(TokenType::asByte, Function.identity()));
+
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
 import lombok.Getter;
 import lombok.Setter;
+import org.corfudb.util.Utils;
 
 import java.util.*;
 
@@ -101,5 +102,12 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
             ICorfuPayload.serialize(buf, x.getValue());
         });
     }
+
+    @Override
+    public String toString() {
+        return "TXINFO[" + Utils.toReadableID(TXid) + "](ts="
+                + snapshotTimestamp + ")";
+    }
+
 }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -12,7 +12,7 @@ import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.LayoutView;
 import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.runtime.view.SequencerView;
-import org.corfudb.runtime.view.StreamsView;
+import org.corfudb.runtime.view.MultiStreamView;
 import org.corfudb.util.GitRepositoryState;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Version;
@@ -66,7 +66,7 @@ public class CorfuRuntime {
      * A view of streams in the Corfu server instance.
      */
     @Getter(lazy = true)
-    private final StreamsView streamsView = new StreamsView(this);
+    private final MultiStreamView streamsView = new MultiStreamView(this);
 
     //region Address Space Options
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
@@ -1,0 +1,13 @@
+package org.corfudb.runtime.exceptions;
+
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Created by dalia on 4/8/17.
+ */
+@RequiredArgsConstructor
+public enum AbortCause {
+    CONFLICT,
+    NEW_SEQUENCER,
+    USER;
+}

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -1,7 +1,26 @@
 package org.corfudb.runtime.exceptions;
 
+import lombok.Getter;
+import org.corfudb.protocols.wireprotocol.TokenType;
+import org.corfudb.runtime.view.Layout;
+
 /**
  * Created by mwei on 1/11/16.
  */
 public class TransactionAbortedException extends RuntimeException {
+    @Getter
+    long conflictAddress;
+
+    @Getter
+    AbortCause abortCause;
+
+    public TransactionAbortedException(long conflictAddress, AbortCause abortCause) {
+
+        super("TX abort. " +
+                "cause=" + abortCause +
+                "; conflict address=" + conflictAddress );
+        this.abortCause = abortCause;
+        this.conflictAddress = conflictAddress;
+    }
+
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
 import org.corfudb.protocols.logprotocol.MultiSMREntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.TokenType;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.*;
 import org.corfudb.util.Utils;
@@ -198,11 +199,11 @@ public abstract class AbstractTransactionalContext implements
 
     /** Forcefully abort the transaction.
      */
-    public void abortTransaction() {
+    public void abortTransaction(TransactionAbortedException ae) {
         log.debug("TXAbort[{}]", this);
         commitAddress = ABORTED_ADDRESS;
         completionFuture
-                .completeExceptionally(new TransactionAbortedException());
+                .completeExceptionally(ae);
     }
 
     abstract public long obtainSnapshotTimestamp();

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -6,6 +6,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.*;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
@@ -182,7 +183,7 @@ public class ObjectsView extends AbstractView {
         if (context == null) {
             log.warn("Attempted to abort a transaction, but no transaction active!");
         } else {
-            context.abortTransaction();
+            context.abortTransaction(new TransactionAbortedException(-1L, AbortCause.USER));
             TransactionalContext.removeContext();
         }
     }

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -9,7 +9,7 @@
     <!-- Control logging levels for individual components here. -->
     <logger name="org.corfudb.runtime.object" level="TRACE"/>
     <logger name="org.corfudb.runtime.clients" level="INFO"/>
-    <logger name="org.corfudb.infrastructure" level="INFO"/>
+    <logger name="org.corfudb.infrastructure" level="TRACE"/>
     <logger name="io.netty.util" level="INFO"/>
     <logger name="io.netty.util.internal" level="INFO"/>
     <logger name="io.netty.buffer" level="INFO"/>


### PR DESCRIPTION
This is a small patch, that lets the sequencer return information on the cause for transaction abort. 

I also took the opportunity to rename StreamsView -> MultiStreamView