### PR TITLE
Cluster uuid

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IServerRouter.java
@@ -3,6 +3,8 @@ package org.corfudb.infrastructure;
 import io.netty.channel.ChannelHandlerContext;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 
+import java.util.UUID;
+
 /**
  * Created by mwei on 12/13/15.
  */
@@ -20,7 +22,17 @@ public interface IServerRouter {
     void setServerEpoch(long newEpoch);
 
     /**
-     * Register a server to route messages to.
+     * Get the cluster ID
+     */
+    UUID getClusterId();
+
+    /**
+     * Set the cluster ID
+     */
+    void setClusterId(UUID clusterId);
+
+    /**
+     * Register a server to route messages to
      * @param server    The server to route messages to
      */
     void addServer(AbstractServer server);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutWorkflowManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutWorkflowManager.java
@@ -259,7 +259,8 @@ public class LayoutWorkflowManager {
                 layout.getSequencers(),
                 layout.getSegments(),
                 layout.getUnresponsiveServers(),
-                this.epoch);
+                this.epoch,
+                layout.getClusterId());
     }
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.UUID;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -34,6 +35,8 @@ public class ServerContext {
     private static final String KEY_TAIL_SEGMENT = "CURRENT";
     private static final String PREFIX_STARTING_ADDRESS = "STARTING_ADDRESS";
     private static final String KEY_STARTING_ADDRESS = "CURRENT";
+    private static final String PREFIX_CLUSTER_ID = "UUID";
+    private static final String KEY_CLUSTER_ID = "CLUSTER_ID";
 
     /**
      * various duration constants.
@@ -125,5 +128,17 @@ public class ServerContext {
 
     public void setStartingAddress(long startingAddress) {
         dataStore.put(Long.class, PREFIX_STARTING_ADDRESS, KEY_STARTING_ADDRESS, startingAddress);
+    }
+
+    /**
+     * The ID for this cluster.
+     */
+    public synchronized UUID getClusterId() {
+        return dataStore.get(UUID.class, PREFIX_CLUSTER_ID, KEY_CLUSTER_ID);
+    }
+
+    public synchronized  void setClusterId(UUID clusterId) {
+        dataStore.put(UUID.class, PREFIX_CLUSTER_ID, KEY_CLUSTER_ID, clusterId);
+        serverRouter.setClusterId(clusterId);
     }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
@@ -45,6 +45,10 @@ public class CorfuMsg {
     long epoch;
 
     /**
+     * The cluster id of this request/response
+     */
+    UUID clusterId;
+    /**
      * The underlying ByteBuf, if present.
      */
     ByteBuf buf;
@@ -66,7 +70,7 @@ public class CorfuMsg {
     }
 
     // The wire format of the NettyCorfuMessage message is below:
-    //    markerField(1) | client ID(8) | request ID(8) |  epoch(8)   |  type(1)  |
+    // markerField(1) | client ID(16) | request ID(8) |  epoch(8) | cluster ID(16) | type(1) |
 
     /**
      * Take the given bytebuffer and deserialize it into a message.
@@ -83,12 +87,14 @@ public class CorfuMsg {
         UUID clientId = new UUID(buffer.readLong(), buffer.readLong());
         long requestId = buffer.readLong();
         long epoch = buffer.readLong();
+        UUID clusterId = new UUID(buffer.readLong(), buffer.readLong());
         CorfuMsgType message = typeMap.get(buffer.readByte());
         CorfuMsg msg = message.getConstructor().construct();
 
         msg.clientID = clientId;
         msg.requestID = requestId;
         msg.epoch = epoch;
+        msg.clusterId = clusterId;
         msg.msgType = message;
         msg.fromBuffer(buffer);
         msg.buf = buffer;
@@ -111,6 +117,13 @@ public class CorfuMsg {
         }
         buffer.writeLong(requestID);
         buffer.writeLong(epoch);
+        if (clusterId == null) {
+            buffer.writeLong(0L);
+            buffer.writeLong(0L);
+        } else {
+            buffer.writeLong(clusterId.getMostSignificantBits());
+            buffer.writeLong(clusterId.getLeastSignificantBits());
+        }
         buffer.writeByte(msgType.asByte());
     }
 
@@ -129,6 +142,7 @@ public class CorfuMsg {
         this.clientID = msg.clientID;
         this.epoch = msg.epoch;
         this.requestID = msg.requestID;
+        this.clusterId = msg.clusterId;
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -7,6 +7,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
+import java.util.UUID;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -21,7 +22,7 @@ import org.corfudb.runtime.view.Layout;
 @AllArgsConstructor
 public enum CorfuMsgType {
     // Base Messages
-    PING(0, TypeToken.of(CorfuMsg.class)),
+    PING(0, TypeToken.of(CorfuMsg.class), false, true),
     PONG(1, TypeToken.of(CorfuMsg.class), true),
     RESET(2, TypeToken.of(CorfuMsg.class), true),
     SET_EPOCH(3, new TypeToken<CorfuPayloadMsg<Long>>() {}, true),
@@ -33,15 +34,15 @@ public enum CorfuMsgType {
     NOT_READY(9, TypeToken.of(CorfuMsg.class), true),
 
     // Layout Messages
-    LAYOUT_REQUEST(10, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
-    LAYOUT_RESPONSE(11, TypeToken.of(LayoutMsg.class), true),
+    LAYOUT_REQUEST(10, new TypeToken<CorfuPayloadMsg<Long>>(){}, true, true),
+    LAYOUT_RESPONSE(11, TypeToken.of(LayoutMsg.class), true, true),
     LAYOUT_PREPARE(12, new TypeToken<CorfuPayloadMsg<LayoutPrepareRequest>>(){}, true),
     LAYOUT_PREPARE_REJECT(13, new TypeToken<CorfuPayloadMsg<LayoutPrepareResponse>>(){}),
     LAYOUT_PROPOSE(14, new TypeToken<CorfuPayloadMsg<LayoutProposeRequest>>(){}, true),
     LAYOUT_PROPOSE_REJECT(15, new TypeToken<CorfuPayloadMsg<LayoutProposeResponse>>(){}),
     LAYOUT_COMMITTED(16, new TypeToken<CorfuPayloadMsg<LayoutCommittedRequest>>(){}, true),
-    LAYOUT_QUERY(17, new TypeToken<CorfuPayloadMsg<Long>>(){}),
-    LAYOUT_BOOTSTRAP(18, new TypeToken<CorfuPayloadMsg<LayoutBootstrapRequest>>(){}, true),
+    LAYOUT_QUERY(17, new TypeToken<CorfuPayloadMsg<Long>>(){}, false, true),
+    LAYOUT_BOOTSTRAP(18, new TypeToken<CorfuPayloadMsg<LayoutBootstrapRequest>>(){}, true, true),
     LAYOUT_NOBOOTSTRAP(19, TypeToken.of(CorfuMsg.class), true),
 
     // Sequencer Messages
@@ -81,22 +82,31 @@ public enum CorfuMsgType {
     LAYOUT_PREPARE_ACK(61, new TypeToken<CorfuPayloadMsg<LayoutPrepareResponse>>(){}, true),
 
     // Management Messages
-    MANAGEMENT_BOOTSTRAP_REQUEST(70, new TypeToken<CorfuPayloadMsg<Layout>>(){}, true),
+    MANAGEMENT_BOOTSTRAP_REQUEST(70, new TypeToken<CorfuPayloadMsg<Layout>>(){}, true, true),
     MANAGEMENT_NOBOOTSTRAP_ERROR(71, TypeToken.of(CorfuMsg.class), true),
     MANAGEMENT_ALREADY_BOOTSTRAP_ERROR(72, TypeToken.of(CorfuMsg.class), true),
-    MANAGEMENT_START_FAILURE_HANDLER(73, TypeToken.of(CorfuMsg.class), true),
-    MANAGEMENT_FAILURE_DETECTED(74, new TypeToken<CorfuPayloadMsg<FailureDetectorMsg>>(){}, true),
-    HEARTBEAT_REQUEST(75, TypeToken.of(CorfuMsg.class), true),
-    HEARTBEAT_RESPONSE(76, new TypeToken<CorfuPayloadMsg<byte[]>>(){}, true),
+    MANAGEMENT_START_FAILURE_HANDLER(73, TypeToken.of(CorfuMsg.class), true, true),
+    MANAGEMENT_FAILURE_DETECTED(74, new TypeToken<CorfuPayloadMsg<FailureDetectorMsg>>(){}, true, true),
+    HEARTBEAT_REQUEST(75, TypeToken.of(CorfuMsg.class), true, true),
+    HEARTBEAT_RESPONSE(76, new TypeToken<CorfuPayloadMsg<byte[]>>(){}, true, true),
 
+    WRONG_CLUSTER_ID(80, new TypeToken<CorfuPayloadMsg<UUID>>() {},  true, true),
     ERROR_SERVER_EXCEPTION(200, new TypeToken<CorfuPayloadMsg<ExceptionMsg>>() {}, true)
     ;
 
+    CorfuMsgType(int type, TypeToken<? extends CorfuMsg> messageType, Boolean ignoreEpoch) {
+        this.type = type;
+        this.messageType = messageType;
+        this.ignoreEpoch = ignoreEpoch;
+    }
 
     public final int type;
     public final TypeToken<? extends CorfuMsg> messageType;
     //public final Class<? extends AbstractServer> handler;
     public Boolean ignoreEpoch = false;
+
+    @Getter
+    private Boolean ignoreClusterId = false;
 
     public <T> CorfuPayloadMsg<T> payloadMsg(T payload) {
         // todo:: maybe some typechecking here (performance impact?)

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.lang.invoke.MethodHandles;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import lombok.Getter;
@@ -16,6 +17,7 @@ import org.corfudb.protocols.wireprotocol.ExceptionMsg;
 import org.corfudb.protocols.wireprotocol.JSONPayloadMsg;
 import org.corfudb.protocols.wireprotocol.VersionInfo;
 import org.corfudb.runtime.exceptions.ServerNotReadyException;
+import org.corfudb.runtime.exceptions.WrongClusterIdException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 
 /**
@@ -162,6 +164,19 @@ public class BaseClient implements IClient {
     private static Object handleWrongEpoch(CorfuPayloadMsg<Long> msg, ChannelHandlerContext ctx,
                                            IClientRouter r) {
         throw new WrongEpochException(msg.getPayload());
+    }
+
+    /**
+     * Handle a WRONG_CLUSTER_ID response from the server.
+     *
+     * @param msg The wrong cluster id message
+     * @param ctx The context the message was sent under
+     * @param r   A reference to the router
+     * @return none, throw a wrong cluster id exception instead.
+     */
+    @ClientHandler(type = CorfuMsgType.WRONG_CLUSTER_ID)
+    private static Object handleWrongClusterId(CorfuPayloadMsg<UUID> msg, ChannelHandlerContext ctx, IClientRouter r) {
+        throw new WrongClusterIdException(msg.getPayload());
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.util.NoSuchElementException;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
@@ -136,6 +137,16 @@ public interface IClientRouter {
      * Set the current epoch.
      */
     void setEpoch(long newEpoch);
+
+    /**
+     * Get the cluster ID
+     */
+    UUID getClusterId();
+
+    /**
+     * Set the cluster ID
+     */
+    void setClusterId(UUID clusterId);
 
     /**
      * Set the Connect timeout

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -89,13 +89,23 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      *
      * @param epoch
      */
-    public void setEpoch(long epoch){
+    public void setEpoch(long epoch) {
         if (epoch < this.epoch) {
             log.warn("setEpoch: Rejected attempt to set the router {}:{} to epoch {} smaller than current epoch {}",
                     host, port, epoch, this.epoch);
             return;
         }
         this.epoch = epoch;
+    }
+
+    /**
+     * The cluster ID to be attached in every message.
+     */
+    @Getter
+    private UUID clusterId;
+
+    public void setClusterId (UUID clusterId) {
+        this.clusterId = this.clusterId == null ? clusterId : this.clusterId;
     }
 
     /**
@@ -525,6 +535,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
             message.setClientID(clientID);
             message.setRequestID(thisRequest);
             message.setEpoch(epoch);
+            message.setClusterId(clusterId);
 
             // Generate a future and put it in the completion table.
             final CompletableFuture<T> cf = new CompletableFuture<>();
@@ -576,6 +587,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         message.setClientID(clientID);
         message.setRequestID(thisRequest);
         message.setEpoch(epoch);
+        message.setClusterId(clusterId);
         // Write this message out on the channel.
         outContext.writeAndFlush(message);
 //        MetricsUtils.incConditionalCounter(MetricsUtils
@@ -594,6 +606,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
     public void sendResponseToServer(ChannelHandlerContext ctx, CorfuMsg inMsg, CorfuMsg outMsg) {
         outMsg.copyBaseFields(inMsg);
         outMsg.setEpoch(epoch);
+        outMsg.setClusterId(clusterId);
         ctx.writeAndFlush(outMsg);
         log.trace("Sent response: {}", outMsg);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/WrongClusterIdException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/WrongClusterIdException.java
@@ -1,0 +1,22 @@
+package org.corfudb.runtime.exceptions;
+
+import lombok.Getter;
+
+import java.util.UUID;
+
+/**
+ * Wrong Cluster ID Exception
+ * This is thrown when an incoming message has a cluster id not
+ * matching the router cluster id.
+ * <p>
+ * Created by zlokhandwala on 4/4/17.
+ */
+public class WrongClusterIdException extends RuntimeException {
+    @Getter
+    final UUID clusterId;
+
+    public WrongClusterIdException(UUID clusterId) {
+        super("Wrong cluster ID. [expected=" + clusterId + "]");
+        this.clusterId = clusterId;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -55,6 +55,11 @@ public class Layout implements Cloneable {
             .registerTypeAdapter(Layout.class, new LayoutDeserializer())
             .create();
     /**
+     * The clusterID of this layout cluster.
+     */
+    @Getter
+    final UUID clusterId;
+    /**
      * A list of layout servers in the layout.
      */
     @Getter
@@ -94,7 +99,7 @@ public class Layout implements Cloneable {
      */
     public Layout(@NonNull List<String> layoutServers, @NonNull List<String> sequencers,
                   @NonNull List<LayoutSegment> segments, @NonNull List<String> unresponsiveServers,
-                  long epoch) {
+                  long epoch, @NonNull UUID clusterId) {
 
         this.layoutServers = layoutServers;
         this.sequencers = sequencers;
@@ -118,11 +123,16 @@ public class Layout implements Cloneable {
                 throw new IllegalArgumentException("One segment has an empty list of stripes");
             }
         }
+        this.clusterId = clusterId;
+    }
+
+    public Layout(List<String> layoutServers, List<String> sequencers, List<LayoutSegment> segments, List<String> unresponsiveServers, long epoch) {
+        this(layoutServers, sequencers, segments, unresponsiveServers, epoch, UUID.randomUUID());
     }
 
     public Layout(List<String> layoutServers, List<String> sequencers, List<LayoutSegment> segments,
                   long epoch) {
-        this(layoutServers, sequencers, segments, new ArrayList<String>(), epoch);
+        this(layoutServers, sequencers, segments, new ArrayList<>(), epoch, UUID.randomUUID());
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutDeserializer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutDeserializer.java
@@ -8,6 +8,7 @@ import com.google.gson.JsonParseException;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.UUID;
 
 /**
  * Created by rmichoud on 4/13/17.
@@ -28,11 +29,13 @@ public class LayoutDeserializer implements JsonDeserializer {
         if (unsafeLayout.unresponsiveServers == null) {
             unsafeLayout.unresponsiveServers = new ArrayList<>();
         }
+        // Read clusterId from JSON. If not present generate one randomly.
+        UUID clusterId = unsafeLayout.clusterId == null ? UUID.randomUUID() : unsafeLayout.clusterId;
 
         /* Similar to a copy constructor. This constructor holds all the validation for
         constructing a layout. */
         Layout safeLayout = new Layout(unsafeLayout.layoutServers, unsafeLayout.sequencers,
-                unsafeLayout.segments, unsafeLayout.unresponsiveServers, unsafeLayout.epoch);
+                unsafeLayout.segments, unsafeLayout.unresponsiveServers, unsafeLayout.epoch, clusterId);
 
         return safeLayout;
 

--- a/test/src/test/java/org/corfudb/infrastructure/FailureHandlerDispatcherTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/FailureHandlerDispatcherTest.java
@@ -59,6 +59,7 @@ public class FailureHandlerDispatcherTest extends AbstractViewTest {
         failureHandlerDispatcher.dispatchHandler(failureHandlerPolicy, originalLayout, corfuRuntime, failedServers);
 
         Layout expectedLayout = new TestLayoutBuilder()
+                .setClusterId(originalLayout.getClusterId())
                 .setEpoch(2L)
                 .addLayoutServer(SERVERS.PORT_0)
                 .addLayoutServer(SERVERS.PORT_1)

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutWorkflowManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutWorkflowManagerTest.java
@@ -102,6 +102,7 @@ public class LayoutWorkflowManagerTest extends AbstractCorfuTest {
         // Deleting SERVERS.PORT_0 and SERVERS.PORT_4
         // Preparing new layout
         Layout expectedLayout = new TestLayoutBuilder()
+                .setClusterId(originalLayout.getClusterId())
                 .setEpoch(1L)
                 .addLayoutServer(SERVERS.PORT_1)
                 .addLayoutServer(SERVERS.PORT_2)
@@ -135,6 +136,7 @@ public class LayoutWorkflowManagerTest extends AbstractCorfuTest {
          */
 
         expectedLayout = new TestLayoutBuilder()
+                .setClusterId(originalLayout.getClusterId())
                 .setEpoch(1L)
                 .addLayoutServer(SERVERS.PORT_3)
                 .addSequencer(SERVERS.PORT_2)

--- a/test/src/test/java/org/corfudb/infrastructure/TestLayoutBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestLayoutBuilder.java
@@ -7,6 +7,7 @@ import org.corfudb.runtime.view.Layout;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
@@ -24,11 +25,19 @@ public class TestLayoutBuilder {
     @Setter
     long epoch = 0L;
 
+    @Getter
+    @Setter
+    UUID clusterId;
+
+    @Getter
+    static final UUID singleClusterId = UUID.randomUUID();
+
     public TestLayoutBuilder() {
         sequencerServers = new ArrayList<>();
         layoutServers = new ArrayList<>();
         unresponsiveServers = new ArrayList<>();
         segments = new ArrayList<>();
+        clusterId = UUID.randomUUID();
     }
 
     static String getEndpoint(int port) {
@@ -37,6 +46,7 @@ public class TestLayoutBuilder {
 
     public static Layout single(int port) {
         return new TestLayoutBuilder()
+                .setClusterId(singleClusterId)
                 .addLayoutServer(port)
                 .addSequencer(port)
                 .buildSegment()
@@ -80,7 +90,8 @@ public class TestLayoutBuilder {
                 sequencerServers,
                 segmentList,
                 unresponsiveServers,
-                epoch);
+                epoch,
+                clusterId);
     }
 
     @Accessors(chain = true)

--- a/test/src/test/java/org/corfudb/runtime/clients/LayoutClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LayoutClientTest.java
@@ -85,6 +85,7 @@ public class LayoutClientTest extends AbstractClientTest {
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         assertThat(client.bootstrapLayout(layout).get())
                 .isEqualTo(true);
+        client.getRouter().setClusterId(TestLayoutBuilder.getSingleClusterId());
         long epoch = layout.getEpoch();
         assertThat(client.prepare(epoch, RANK_HIGH).get() != null)
                 .isEqualTo(true);
@@ -105,6 +106,7 @@ public class LayoutClientTest extends AbstractClientTest {
         long epoch = layout.getEpoch();
         assertThat(client.bootstrapLayout(layout).get())
                 .isEqualTo(true);
+        client.getRouter().setClusterId(TestLayoutBuilder.getSingleClusterId());
 
         assertThat(client.prepare(epoch, RANK_HIGH).get() != null)
                 .isEqualTo(true);
@@ -124,6 +126,7 @@ public class LayoutClientTest extends AbstractClientTest {
         long epoch = layout.getEpoch();
         assertThat(client.bootstrapLayout(layout).get())
                 .isEqualTo(true);
+        client.getRouter().setClusterId(TestLayoutBuilder.getSingleClusterId());
 
         assertThat(client.prepare(epoch, RANK_HIGH).get() != null)
                 .isEqualTo(true);
@@ -146,6 +149,7 @@ public class LayoutClientTest extends AbstractClientTest {
         long epoch = layout.getEpoch();
         assertThat(client.bootstrapLayout(layout).get())
                 .isEqualTo(true);
+        client.getRouter().setClusterId(TestLayoutBuilder.getSingleClusterId());
 
         assertThat(client.prepare(epoch, RANK_HIGH).get() != null)
                 .isEqualTo(true);

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -80,6 +80,13 @@ public class TestClientRouter implements IClientRouter {
     @Setter
     public UUID clientID;
 
+
+    @Getter
+    private UUID clusterId;
+    public void setClusterId (UUID clusterId) {
+        this.clusterId = this.clusterId == null ? clusterId : this.clusterId;
+    }
+
     /**
      * New connection timeout (milliseconds)
      */
@@ -200,6 +207,7 @@ public class TestClientRouter implements IClientRouter {
         message.setClientID(clientID);
         message.setRequestID(thisRequest);
         message.setEpoch(getEpoch());
+        message.setClusterId(getClusterId());
         // Generate a future and put it in the completion table.
         final CompletableFuture<T> cf = new CompletableFuture<>();
         outstandingRequests.put(thisRequest, cf);
@@ -234,6 +242,7 @@ public class TestClientRouter implements IClientRouter {
         message.setClientID(clientID);
         message.setRequestID(thisRequest);
         message.setEpoch(getEpoch());
+        message.setClusterId(getClusterId());
         // Evaluate rules.
         if (rules.stream()
                 .map(x -> x.evaluate(message, this))

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -191,7 +191,7 @@ public class ManagementViewTest extends AbstractViewTest {
         assertThat(l2.getLayoutServers().contains(SERVERS.ENDPOINT_1)).isFalse();
     }
 
-    protected void getManagementTestLayout()
+    protected Layout getManagementTestLayout()
             throws Exception {
         addServer(SERVERS.PORT_0);
         addServer(SERVERS.PORT_1);
@@ -235,6 +235,8 @@ public class ManagementViewTest extends AbstractViewTest {
                 getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
                 getManagementServer(SERVERS.PORT_1).getCorfuRuntime(),
                 getManagementServer(SERVERS.PORT_2).getCorfuRuntime());
+
+        return l;
     }
 
     /**
@@ -407,7 +409,7 @@ public class ManagementViewTest extends AbstractViewTest {
      */
     @Test
     public void testSequencerFailover() throws Exception {
-        getManagementTestLayout();
+        Layout originalLayout = getManagementTestLayout();
 
         final long beforeFailure = 5L;
         final long afterFailure = 10L;
@@ -442,6 +444,7 @@ public class ManagementViewTest extends AbstractViewTest {
         // verify the failover layout
         //
         Layout expectedLayout = new TestLayoutBuilder()
+                .setClusterId(originalLayout.getClusterId())
                 .setEpoch(2L)
                 .addLayoutServer(SERVERS.PORT_0)
                 .addLayoutServer(SERVERS.PORT_1)


### PR DESCRIPTION
Added a cluster ID check on the serverRouters.
Every message now with the clientID, requestID and epoch also contains the clusterID.
The clusterID is set only once during the bootstrap of a node. All subsequent `setClusterId()` calls are ignored.

An example of the new layout with the cluster uuid:
```
{
  "clusterId": "d81d3808-fdd2-4f42-82d5-04f73da55845",
  "layoutServers": [
    "localhost:9000"
  ],
  "sequencers": [
    "localhost:9000"
  ],
  "segments": [
    {
      "replicationMode": "CHAIN_REPLICATION",
      "start": 0,
      "end": -1,
      "stripes": [
        {
          "logServers": [
            "localhost:9000"
          ]
        }
      ]
    }
  ],
  "unresponsiveServers": [],
  "epoch": 0
}
```

Will resolve #240 