### PR TITLE
Option To Disable Force Sync

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -94,7 +94,7 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                     currOp = operationsQueue.poll();
 
                     if (currOp == null || processed == BATCH_SIZE || currOp == BatchWriterOperation.SHUTDOWN) {
-                        streamLog.sync();
+                        streamLog.sync(true);
                         log.trace("Sync'd {} writes", processed);
 
                         for (BatchWriterOperation operation : res) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -86,7 +86,7 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
     }
 
     @Override
-    public void sync(){
+    public void sync(boolean force){
         //no-op
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -39,8 +39,10 @@ public interface StreamLog {
 
     /**
      * Sync the stream log file to secondary storage.
+     *
+     * @param force force data to secondary storage if true
      */
-    void sync() throws IOException;
+    void sync(boolean force) throws IOException;
 
     /**
      * Close the stream log.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -155,9 +155,11 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     }
 
     @Override
-    public void sync() throws IOException {
-        for (FileChannel ch : channelsToSync) {
-            ch.force(true);
+    public void sync(boolean force) throws IOException {
+        if(force) {
+            for (FileChannel ch : channelsToSync) {
+                ch.force(true);
+            }
         }
         log.debug("Sync'd {} channels", channelsToSync.size());
         channelsToSync.clear();

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -196,7 +196,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
 
         assertThat(log.getChannelsToSync().size()).isEqualTo(3);
 
-        log.sync();
+        log.sync(true);
 
         assertThat(log.getChannelsToSync().size()).isEqualTo(0);
     }


### PR DESCRIPTION
In certain situations it might be fine to acknowledge writes
without forcing the write to secondary storage.