### PR TITLE
Quorum replication - the remaining cient part

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -184,6 +184,10 @@ public interface IMetadata {
             this(rank, UUID.randomUUID());
         }
 
+        public DataRank buildHigherRank() {
+            return new DataRank(rank+1, uuid);
+        }
+
         @Override
         public int compareTo(DataRank o) {
             int rankCompared = Long.compare(this.rank, o.rank);

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -3,7 +3,6 @@ package org.corfudb.runtime.clients;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.Range;
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
@@ -220,6 +219,18 @@ public class LogUnitClient implements IClient {
         wr.setBackpointerMap(backpointerMap);
         wr.setGlobalAddress(address);
         CompletableFuture<Boolean> cf = router.sendMessageAndGetCompletable(CorfuMsgType.WRITE.payloadMsg(wr));
+        return cf.thenApply(x -> { context.stop(); return x; });
+    }
+
+    /**
+     * Asynchronously write to the logging unit a previousely prepared write request.
+     * @param  request  The request to be written
+     * @return          A CompletableFuture which will complete with the WriteResult once the
+     *                  write completes.
+     */
+    public CompletableFuture<Boolean> writeRequest(WriteRequest request) {
+        Timer.Context context = getTimerContext("writeObject");
+        CompletableFuture<Boolean> cf = router.sendMessageAndGetCompletable(CorfuMsgType.WRITE.payloadMsg(request));
         return cf.thenApply(x -> { context.stop(); return x; });
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -364,12 +364,12 @@ public class Layout implements Cloneable {
 
             @Override
             public AbstractReplicationView getReplicationView(Layout l, LayoutSegment ls) {
-                throw new UnsupportedOperationException("Not implemented yet");
+                return new QuorumReplicationView(l, ls);
             }
 
             @Override
             public IStreamView getStreamView(CorfuRuntime r, UUID streamId) {
-                throw new UnsupportedOperationException("Not implemented yet");
+                return new BackpointerStreamView(r, streamId);
             }
         },
         REPLEX {

--- a/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationView.java
@@ -34,11 +34,16 @@ import java.util.function.Function;
 public class QuorumReplicationView extends AbstractReplicationView {
 
     private static final int QUORUM_READ_ATTEMPTS_WHEN_OUTRANKED = 5;
+    private static final int QUORUM_RECOVERY_READ_EXPONENTIAL_RETRY_BASE = 3;
+    private static final int QUORUM_RECOVERY_READ_EXPONENTIAL_RETRY_BACKOFF_DURATION_SECONDS = 10;
+    private static final int QUORUM_RECOVERY_READ_EXTRA_WAIT_MILLIS = 20;
+    private static final float QUORUM_RECOVERY_READ_WAIT_RANDOM_PART = .5f;
+
     private static final Consumer<ExponentialBackoffRetry> RETRY_SETTINGS = x -> {
-        x.setBase(3);
-        x.setExtraWait(20);
-        x.setBackoffDuration(Duration.ofSeconds(10));
-        x.setRandomPortion(.5f);
+        x.setBase(QUORUM_RECOVERY_READ_EXPONENTIAL_RETRY_BASE);
+        x.setExtraWait(QUORUM_RECOVERY_READ_EXTRA_WAIT_MILLIS);
+        x.setBackoffDuration(Duration.ofSeconds(QUORUM_RECOVERY_READ_EXPONENTIAL_RETRY_BACKOFF_DURATION_SECONDS));
+        x.setRandomPortion(QUORUM_RECOVERY_READ_WAIT_RANDOM_PART);
     };
 
     public QuorumReplicationView(Layout l, Layout.LayoutSegment ls) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/QuorumReplicationView.java
@@ -1,0 +1,347 @@
+package org.corfudb.runtime.view;
+
+import com.esotericsoftware.minlog.Log;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.format.Types;
+import org.corfudb.protocols.logprotocol.LogEntry;
+import org.corfudb.protocols.wireprotocol.*;
+import org.corfudb.runtime.exceptions.*;
+import org.corfudb.util.CFUtils;
+import org.corfudb.util.Holder;
+import org.corfudb.util.retry.ExponentialBackoffRetry;
+import org.corfudb.util.retry.IRetry;
+import org.corfudb.util.retry.RetryNeededException;
+import org.corfudb.util.serializer.Serializers;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * In quorum-based replication, there are 2F+1 replicas, and the read and write protocols can operate over
+ * any subset of F+1. The advantage of quorum-based replication is that the write protocol can commit a
+ * value using the fastest majority of replicas, and not have to wait for a slow (or failed) replica.
+ * Quorums can replace majorities wherever they are used below, we use these terms interchangeably.
+ */
+@Slf4j
+public class QuorumReplicationView extends AbstractReplicationView {
+
+    private static final int QUORUM_READ_ATTEMPTS_WHEN_OUTRANKED = 5;
+    private static final Consumer<ExponentialBackoffRetry> RETRY_SETTINGS = x -> {
+        x.setBase(3);
+        x.setExtraWait(20);
+        x.setBackoffDuration(Duration.ofSeconds(10));
+        x.setRandomPortion(.5f);
+    };
+
+    public QuorumReplicationView(Layout l, Layout.LayoutSegment ls) {
+        super(l, ls);
+    }
+
+
+    /**
+     * Write the given object to an address and streams, using the replication method given.
+     *
+     * @param address An address to write to.
+     * @param stream  The streams which will belong on this entry.
+     * @param data    The data to write.
+     */
+    @Override
+    public int write(long address, Set<UUID> stream, Object data, Map<UUID, Long> backpointerMap,
+                     Map<UUID, Long> streamAddresses, Function<UUID, Object> partialEntryFunction)
+            throws OverwriteException {
+        int payloadBytes = 0;
+        IMetadata.DataRank rank = new IMetadata.DataRank(0);
+        QuorumFuturesFactory.CompositeFuture<Boolean> future = null;
+        ByteBuf b = Unpooled.buffer();
+        try {
+            if (data instanceof Types.LogEntry) {
+                addSerializationToLogEntityData((LogEntry) data, DataType.DATA, rank, b, address, stream, backpointerMap);
+            }
+            payloadBytes = b.readableBytes();
+            future = getWriteFuture(address, stream, data, DataType.DATA,
+                    rank, backpointerMap);
+            CFUtils.getUninterruptibly(future, QuorumUnreachableException.class, DataRejectedException.class);
+        } catch (DataOutrankedException e) {
+            if (future.containsThrowableFrom(DataOutrankedException.class) ||
+                    future.containsThrowableFrom(ValueAdoptedException.class)) {
+                // we are competing with other client that writes the same data or fills a hole
+                if (data instanceof LogData) {
+                    LogData result = recoveryWrite(address, stream, (LogData) data, DataType.DATA);
+                    if (result.getType() == DataType.DATA) {
+                        // we managed to recover the data, we are OK
+                        return payloadBytes;
+                    }
+                }
+            }
+            throw new OverwriteException();
+        } catch (QuorumUnreachableException e) {
+            log.error(e.getMessage(), e);
+            throw new OverwriteException();
+        } finally {
+            b.clear();
+        }
+        return payloadBytes;
+    }
+
+    private boolean isTypeForRecovery(DataType type) {
+        return type == DataType.RANK_ONLY || type == DataType.EMPTY;
+    }
+
+
+    private LogData recoveryWrite(long address, Set<UUID> stream, LogData data, DataType type) {
+        log.debug("Recovery write at {} " + address);
+        IMetadata.DataRank rank = null;
+        if (data != null) {
+            rank = data.getRank();
+        }
+        if (rank == null) {
+            rank = new IMetadata.DataRank(0);
+        }
+        final Holder<IMetadata.DataRank> rankHolder = new Holder(rank);
+        final Holder<LogData> dataHolder = new Holder(data);
+        final Holder<DataType> typeHolder = new Holder(type);
+
+        try {
+            LogData resultLogData = IRetry.build(ExponentialBackoffRetry.class, () ->
+            {
+                QuorumFuturesFactory.CompositeFuture<Boolean> future = null;
+                try {
+                    log.debug("Recovery write loop for " + log);
+                    rankHolder.setRef(rankHolder.getRef().buildHigherRank());
+                    // first - try to read few times - maybe the data is OK now?
+                    try {
+                        ReadResponse rr = fewQuorumReads(address);
+                        LogData recoveredLogData = rr.getReadSet().get(address);
+                        DataType recoveredType = recoveredLogData.getType();
+                        if (!isTypeForRecovery(recoveredType)) {
+                            return recoveredLogData;
+                        }
+                    } catch (QuorumUnreachableException e) {
+                        log.debug("Quorum unreachable at position " + address);
+                        // continue further
+                    }
+                    // phase 1
+                    try {
+                        future = getWriteFuture(address, stream, null,
+                                DataType.RANK_ONLY, rankHolder.getRef(), null);
+                        CFUtils.getUninterruptibly(future, QuorumUnreachableException.class, DataRejectedException.class);
+                    } catch (DataRejectedException | QuorumUnreachableException e) {
+                        ReadResponse rr = getAdoptedValueWithHighestRankIfPresent(address, future.getThrowables());
+                        if (rr != null) { // check
+                            LogData logData = rr.getReadSet().get(address);
+                            if (logData != null) {
+                                logData.setRank(rankHolder.getRef());
+                            }
+                            dataHolder.setRef(logData);
+                            typeHolder.setRef(logData.getType());
+                            // value adopted - retry on phase 2
+                        } else {
+                            throw e;
+                        }
+                    }
+                    // phase 2 - only if exception is not thrown from phase 1
+                    LogData ld = dataHolder.getRef();
+                    future = getWriteFuture(address, stream, ld,
+                            typeHolder.getRef(),
+                            rankHolder.getRef(),
+                            ld == null ? null : ld.getBackpointerMap());
+
+                    CFUtils.getUninterruptibly(future, QuorumUnreachableException.class, DataRejectedException.class);
+                    log.trace("Write[{}]: {}", address);
+                    return ld;
+                } catch (QuorumUnreachableException | DataOutrankedException e) {
+                    throw new RetryNeededException();
+                } catch (RuntimeException e) {
+                    throw e;
+                }
+            }).setOptions(RETRY_SETTINGS).run();
+            return resultLogData;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("interrupted", e);
+        } catch (RuntimeException e) {
+            throw e;
+        }
+
+    }
+
+    private QuorumFuturesFactory.CompositeFuture<Boolean> getWriteFuture(long address, Set<UUID> stream, Object data, DataType targetType, IMetadata.DataRank rank, Map<UUID, Long> backpointerMap)
+            throws OverwriteException {
+
+        int numUnits = getLayout().getSegmentLength(address);
+
+        // To reduce the overhead of serialization, we serialize only the first time we write, saving
+        // when we go down the chain.
+        CompletableFuture<Boolean>[] futures = new CompletableFuture[numUnits];
+        for (int i = 0; i < numUnits; i++) {
+            log.trace("Write[{}]: quorum {}/{}", address, i + 1, numUnits);
+            if (data == null) {
+                futures[i] = getLayout().getLogUnitClient(address, i).writeEmptyData(address, targetType, stream == null ? Collections.<UUID>emptySet() : stream, rank);
+            } else if (data instanceof LogData) {
+                WriteRequest m = WriteRequest.builder()
+                        .writeMode(WriteMode.NORMAL)
+                        .data((LogData) data)
+                        .build();
+                futures[i] = getLayout().getLogUnitClient(address, i).writeRequest(m);
+            } else {
+                futures[i] = getLayout().getLogUnitClient(address, i).write(address, stream, rank, data, backpointerMap);
+            }
+        }
+        QuorumFuturesFactory.CompositeFuture<Boolean> future =
+                QuorumFuturesFactory.getQuorumFuture(Boolean::compareTo, futures,
+                        OverwriteException.class, DataOutrankedException.class);
+        return future;
+
+    }
+
+
+    private void addSerializationToLogEntityData(LogEntry data, DataType dt, IMetadata.DataRank rank, ByteBuf b, long address, Set<UUID> stream, Map<UUID, Long> backpointerMap) {
+        Serializers.CORFU.serialize(data, b);
+        LogData ld = new LogData(dt, b);
+        ld.setBackpointerMap(backpointerMap);
+        ld.setStreams(stream);
+        ld.setRank(rank);
+        ld.setGlobalAddress(address);
+        data.setRuntime(getLayout().getRuntime());
+    }
+
+
+    /**
+     * Read the given object from an address, using the quorum replication.
+     *
+     * @param address The address to read from.
+     * @return The result of the read.
+     */
+    @Override
+    public LogData read(long address) {
+        try {
+            do {
+                boolean quorumReachable = true;
+                ReadResponse readResponse = null;
+                try {
+                    readResponse = singleQuorumRead(address);
+                } catch (QuorumUnreachableException e) {
+                    quorumReachable = false;
+                }
+                if (quorumReachable && readResponse != null) {
+                    LogData data = readResponse.getReadSet().get(address);
+                    if (data.getType() == DataType.EMPTY) {
+                        return data; // otherwise we could fill as hole entries not allocated by sequencer yet
+                    }
+                    if (!isTypeForRecovery(data.getType())) {
+                        return data;
+                    }
+                }
+                fillHole(address);
+            } while (true);
+        } catch (RuntimeException e) {
+            throw e;
+        }
+    }
+
+    private ReadResponse singleQuorumRead(long address) throws QuorumUnreachableException {
+        int numUnits = getLayout().getSegmentLength(address);
+        log.trace("Read[{}]: quorum {}/{}", address, numUnits, numUnits);
+        CompletableFuture<ReadResponse>[] futures = new CompletableFuture[numUnits];
+        for (int i = 0; i < numUnits; i++) {
+            futures[i] = getLayout().getLogUnitClient(address, i).read(address);
+        }
+        QuorumFuturesFactory.CompositeFuture<ReadResponse> future = QuorumFuturesFactory.getQuorumFuture(
+                new ReadResponseComparator(address), futures);
+        ReadResponse response = CFUtils.getUninterruptibly(future, QuorumUnreachableException.class);
+        return response;
+    }
+
+    private ReadResponse fewQuorumReads(long addresss) throws QuorumUnreachableException {
+        AtomicInteger retries = new AtomicInteger(0);
+        try {
+            ReadResponse readResponse = IRetry.build(ExponentialBackoffRetry.class, QuorumUnreachableException.class,
+                    () -> {
+                        try {
+                            return singleQuorumRead(addresss);
+                        } catch (QuorumUnreachableException e) {
+                            if (retries.incrementAndGet() == QUORUM_READ_ATTEMPTS_WHEN_OUTRANKED) {
+                                throw e;
+                            } else {
+                                throw new RetryNeededException();
+                            }
+                        }
+                    }
+            ).setOptions(RETRY_SETTINGS).run();
+            return readResponse;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("interrupted", e);
+        }
+    }
+
+    /**
+     * Read a stream prefix, using the replication method given.
+     *
+     * @param stream the stream to read from.
+     * @return A map containing the results of the read.
+     */
+    @Override
+    public Map<Long, LogData> read(UUID stream, long offset, long size) {
+        // TODO: when chain replication is used, scan
+        throw new UnsupportedOperationException("not supported in chain replication");
+    }
+
+
+    /**
+     * Fill a hole at an address, using the replication method given.
+     *
+     * @param address The address to hole fill at.
+     */
+    @Override
+    public void fillHole(long address) throws OverwriteException {
+        recoveryWrite(address, null, null, DataType.HOLE);
+    }
+
+    private ReadResponse getAdoptedValueWithHighestRankIfPresent(Long position, Set<Throwable> throwables) {
+        ReadResponse result = null;
+        IMetadata.DataRank maxRank = null;
+        for (Throwable t : throwables) {
+            if (t instanceof ValueAdoptedException) {
+                ValueAdoptedException ve = (ValueAdoptedException) t;
+                ReadResponse r = ve.getReadResponse();
+                LogData ld = r.getReadSet().get(position);
+                if (maxRank == null || maxRank.compareTo(ld.getRank()) < 0) {
+                    maxRank = ld.getRank();
+                    result = r;
+                }
+            }
+        }
+        return result;
+    }
+
+
+    @Data
+    @AllArgsConstructor
+    private class ReadResponseComparator implements Comparator<ReadResponse> {
+        private long logPosition;
+
+        @Override
+        public int compare(ReadResponse o1, ReadResponse o2) {
+            LogData ld1 = o1.getReadSet().get(logPosition);
+            LogData ld2 = o2.getReadSet().get(logPosition);
+            IMetadata.DataRank rank1 = ld1.getRank();
+            IMetadata.DataRank rank2 = ld2.getRank();
+            if (rank1 == null) {
+                return rank2 == null ? 0 : 1;
+            }
+            if (rank2 == null) {
+                return -1;
+            }
+            return rank1.compareTo(rank2);
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/util/Holder.java
+++ b/runtime/src/main/java/org/corfudb/util/Holder.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.util;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Holds a reference to a given object
+ *
+ * Created by Konstantin Spirov on 4/7/2017.
+ */
+@AllArgsConstructor
+public class Holder<T> {
+    @Getter
+    @Setter
+    private T ref;
+}

--- a/runtime/src/main/java/org/corfudb/util/retry/ExponentialBackoffRetry.java
+++ b/runtime/src/main/java/org/corfudb/util/retry/ExponentialBackoffRetry.java
@@ -46,7 +46,7 @@ public class ExponentialBackoffRetry<E extends Exception, F extends Exception, G
      */
     @Getter
     @Setter
-    private long extraRetry = 0;
+    private long extraWait = 0;
 
     public ExponentialBackoffRetry(IRetryable runFunction) {
         super(runFunction);
@@ -59,13 +59,13 @@ public class ExponentialBackoffRetry<E extends Exception, F extends Exception, G
         }
         retryCounter++;
         long sleepTime = (long) Math.pow(base, retryCounter);
-        sleepTime += extraRetry;
+        sleepTime += extraWait;
         float randomPart = new Random().nextFloat()*randomPortion;
         sleepTime -= sleepTime*randomPart;
         if (System.currentTimeMillis()+sleepTime>nextBackoffTime) {
             nextBackoffTime = 0;
             retryCounter = 1;
-            sleepTime = base + extraRetry;
+            sleepTime = base + extraWait;
             sleepTime -= sleepTime*randomPart;
         }
         Thread.sleep(sleepTime);

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
@@ -1,0 +1,99 @@
+package org.corfudb.runtime.view;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by kspirov
+ */
+public class QuorumReplicationStreamViewTest extends StreamViewTest {
+    @Before
+    @Override
+    public void setRuntime() throws Exception {
+        r = getDefaultRuntime().connect();
+        // First commit a layout that uses Replex
+        Layout newLayout = r.layout.get();
+        newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.QUORUM_REPLICATION);
+        newLayout.setEpoch(1);
+        r.setCacheDisabled(true);
+        r.getLayoutView().committed(1L, newLayout);
+        r.invalidateLayout();
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadWriteFromStream()
+            throws Exception {
+        super.canReadWriteFromStream();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadWriteFromStreamConcurrent()
+            throws Exception {
+        super.canReadWriteFromStreamConcurrent();
+        assertNotNull(r.getAddressSpaceView().read(0L).getRank());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadWriteFromStreamWithoutBackpointers()
+            throws Exception {
+        super.canReadWriteFromStreamWithoutBackpointers();
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadWriteFromCachedStream()
+            throws Exception {
+        super.canReadWriteFromCachedStream();
+    }
+
+    @Test
+    public void canSeekOnStream()
+            throws Exception
+    {
+        super.canSeekOnStream();
+    }
+
+    @Test
+    public void canFindInStream()
+            throws Exception
+    {
+        super.canFindInStream();
+    }
+
+    @Test
+    public void canDoPreviousOnStream()
+            throws Exception
+    {
+        super.canDoPreviousOnStream();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void streamCanSurviveOverwriteException()
+            throws Exception {
+        super.streamCanSurviveOverwriteException();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void streamWillHoleFill()
+            throws Exception {
+        super.streamWillHoleFill();
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void streamWithHoleFill()
+            throws Exception {
+        super.streamWithHoleFill();
+    }
+
+}

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationViewTest.java
@@ -285,10 +285,11 @@ public class QuorumReplicationViewTest extends  AbstractViewTest {
         assertThat(sv.next().getPayload(getRuntime()))
                 .isEqualTo(testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0).getType()).isEqualTo(DataType.HOLE);
-        assertThat(r.getAddressSpaceView().read(1).getType()).isEqualTo(DataType.DATA);
-        assertThat(r.getAddressSpaceView().read(2).getType()).isEqualTo(DataType.HOLE);
-        assertThat(r.getAddressSpaceView().read(3).getType()).isEqualTo(DataType.EMPTY);
+        int address = 0;
+        assertThat(r.getAddressSpaceView().read(address++).getType()).isEqualTo(DataType.HOLE);
+        assertThat(r.getAddressSpaceView().read(address++).getType()).isEqualTo(DataType.DATA);
+        assertThat(r.getAddressSpaceView().read(address++).getType()).isEqualTo(DataType.HOLE);
+        assertThat(r.getAddressSpaceView().read(address++).getType()).isEqualTo(DataType.EMPTY);
 
 
     }

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationViewTest.java
@@ -1,0 +1,311 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.corfudb.runtime.view;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.assertj.core.api.Assertions;
+import org.corfudb.infrastructure.LogUnitServer;
+import org.corfudb.infrastructure.LogUnitServerAssertions;
+import org.corfudb.infrastructure.SequencerServer;
+import org.corfudb.infrastructure.ServerContextBuilder;
+import org.corfudb.infrastructure.TestLayoutBuilder;
+import org.corfudb.infrastructure.TestServerRouter;
+import org.corfudb.protocols.wireprotocol.CorfuMsg;
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.IMetadata;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.TokenRequest;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.protocols.wireprotocol.WriteMode;
+import org.corfudb.protocols.wireprotocol.WriteRequest;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.stream.IStreamView;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * Created by Konstantin Spirov on 1/30/2017.
+ */
+public class QuorumReplicationViewTest extends  AbstractViewTest {
+
+
+    public static final UUID testClientId = UUID.nameUUIDFromBytes("TEST_CLIENT".getBytes());
+    private Layout layout = null;
+    private CorfuRuntime corfuRuntime = null;
+
+    @Before
+    public void before() {
+
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
+        addServer(SERVERS.PORT_2);
+
+        layout = new TestLayoutBuilder()
+                .setEpoch(1L)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_0)
+                .buildSegment()
+                .setReplicationMode(Layout.ReplicationMode.QUORUM_REPLICATION)
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_1)
+                .addLogUnit(SERVERS.PORT_2)
+                .addToSegment()
+                .addToLayout()
+                .build();
+        bootstrapAllServers(layout);
+        getManagementServer(SERVERS.PORT_0).shutdown();
+        getManagementServer(SERVERS.PORT_1).shutdown();
+        getManagementServer(SERVERS.PORT_2).shutdown();
+
+        layout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.QUORUM_REPLICATION);
+
+        corfuRuntime = new CorfuRuntime();
+        corfuRuntime.setCacheDisabled(true);
+        layout.getLayoutServers().forEach(corfuRuntime::addLayoutServer);
+        corfuRuntime.connect();
+
+        layout.getAllServers().forEach(serverEndpoint -> {
+            corfuRuntime.getRouter(serverEndpoint).setTimeoutConnect(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            corfuRuntime.getRouter(serverEndpoint).setTimeoutResponse(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            corfuRuntime.getRouter(serverEndpoint).setTimeoutRetry(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        });
+
+    }
+
+
+  public CorfuRuntime getDefaultRuntime() {
+        return corfuRuntime;
+  }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadWrite()
+            throws Exception {
+        CorfuRuntime r = getDefaultRuntime();
+        UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
+        byte[] testPayload = "hello world".getBytes();
+
+        r.getAddressSpaceView().write(new Token(0L, 1L), Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap());
+
+        ILogData x = r.getAddressSpaceView().read(0);
+        assertNotNull(x.getRank());
+        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+                .isEqualTo("hello world".getBytes());
+
+        assertThat((Set<UUID>) r.getAddressSpaceView().read(0L).getMetadataMap()
+                .get(IMetadata.LogUnitMetadataType.STREAM))
+                .contains(streamA);
+
+        assertThat((IMetadata.DataRank) r.getAddressSpaceView().read(0L).getMetadataMap()
+                .get(IMetadata.LogUnitMetadataType.RANK)).isNotNull();
+
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadWriteConcurrent()
+            throws Exception {
+        CorfuRuntime r = getDefaultRuntime();
+
+        final int numberThreads = 5;
+        final int numberRecords = 1_000;
+
+        scheduleConcurrently(numberThreads, threadNumber -> {
+            int base = threadNumber * numberRecords;
+            for (long i = base; i < base + numberRecords; i++) {
+                r.getAddressSpaceView().write(new Token(i, 1l), Collections.singleton(CorfuRuntime.getStreamID("a")),
+                        Long.toString(i).getBytes(), Collections.emptyMap(), Collections.emptyMap());
+            }
+        });
+        executeScheduled(numberThreads, PARAMETERS.TIMEOUT_LONG);
+
+        scheduleConcurrently(numberThreads, threadNumber -> {
+            int base = threadNumber * numberRecords;
+            for (int i = base; i < base + numberRecords; i++) {
+                assertThat(r.getAddressSpaceView().read(i).getPayload(getRuntime()))
+                        .isEqualTo(Integer.toString(i).getBytes());
+            }
+        });
+        executeScheduled(numberThreads, PARAMETERS.TIMEOUT_LONG);
+        assertNotNull(r.getAddressSpaceView().read(1L).getRank());
+        assertThat((IMetadata.DataRank) r.getAddressSpaceView().read(1L).getMetadataMap()
+                .get(IMetadata.LogUnitMetadataType.RANK)).isNotNull();
+
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadWriteToMultiple()
+            throws Exception {
+
+        CorfuRuntime r = getDefaultRuntime();
+
+        UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
+        byte[] testPayload = "hello world".getBytes();
+
+        r.getAddressSpaceView().write(new Token(0L, 1L), Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap());
+
+        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+                .isEqualTo("hello world".getBytes());
+
+        assertThat((Set<UUID>) r.getAddressSpaceView().read(0L).getMetadataMap()
+                .get(IMetadata.LogUnitMetadataType.STREAM))
+                .contains(streamA);
+
+
+        assertThat((IMetadata.DataRank) r.getAddressSpaceView().read(0L).getMetadataMap()
+                .get(IMetadata.LogUnitMetadataType.RANK)).isNotNull();
+
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ensureAllUnitsContainData()
+            throws Exception {
+
+        //configure the layout accordingly
+        CorfuRuntime r = getDefaultRuntime();
+
+        UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
+        byte[] testPayload = "hello world".getBytes();
+
+        r.getAddressSpaceView().write(new Token(0L, 1L), Collections.singleton(streamA),
+                testPayload, Collections.emptyMap(), Collections.emptyMap());
+
+        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+                .isEqualTo("hello world".getBytes());
+
+        assertThat((Set<UUID>) r.getAddressSpaceView().read(0L).getMetadataMap()
+                .get(IMetadata.LogUnitMetadataType.STREAM))
+                .contains(streamA);
+
+        // Ensure that the data was written to each logunit.
+        LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_0))
+                .matchesDataAtAddress(0, testPayload);
+        LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_1))
+                .matchesDataAtAddress(0, testPayload);
+        LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_2))
+                .matchesDataAtAddress(0, testPayload);
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkRecoveryWriteRecoversDataWhenTheQuorumIsLost()
+            throws Exception {
+
+        //configure the layout accordingly
+        CorfuRuntime r = getDefaultRuntime();
+
+        LogUnitServer u0 = getLogUnit(SERVERS.PORT_0);
+        LogUnitServer u1 = getLogUnit(SERVERS.PORT_1);
+        LogUnitServer u2 = getLogUnit(SERVERS.PORT_2);
+
+        final long ADDRESS_0 = 0L;
+
+        //write at 0
+        ByteBuf b = Unpooled.buffer();
+        Serializers.CORFU.serialize("0".getBytes(), b);
+        WriteRequest m = WriteRequest.builder()
+                .writeMode(WriteMode.NORMAL)
+                .data(new LogData(DataType.DATA, b))
+                .build();
+        m.setGlobalAddress(ADDRESS_0);
+        m.setStreams(Collections.EMPTY_SET);
+        m.setRank(new IMetadata.DataRank(0));
+        m.setBackpointerMap(Collections.emptyMap());
+
+        sendMessage(u1, CorfuMsgType.WRITE.payloadMsg(m));
+        sendMessage(u2, CorfuMsgType.WRITE.payloadMsg(m));
+        u2.setShutdown(true);
+        u2.shutdown();
+
+        LogUnitServerAssertions.assertThat(u0)
+                .isEmptyAtAddress(ADDRESS_0);
+
+        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+                .isEqualTo("0".getBytes());
+
+        LogUnitServerAssertions.assertThat(u1)
+                .matchesDataAtAddress(ADDRESS_0, "0".getBytes());
+
+        LogUnitServerAssertions.assertThat(u0)
+                .matchesDataAtAddress(ADDRESS_0, "0".getBytes());
+
+    }
+
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void checkReadOnEmptyPosition()
+            throws Exception {
+
+        //configure the layout accordingly
+        CorfuRuntime r = getDefaultRuntime();
+
+        LogUnitServer u0 = getLogUnit(SERVERS.PORT_0);
+
+        UUID streamA = CorfuRuntime.getStreamID("stream A");
+
+        byte[] testPayload = "hello world".getBytes();
+
+
+        //generate a stream hole
+        TokenResponse tr =
+                r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
+
+        IStreamView sv = r.getStreamsView().get(streamA);
+        sv.append(testPayload);
+
+        tr = r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
+
+        //make sure we can still read the stream.
+        assertThat(sv.next().getPayload(getRuntime()))
+                .isEqualTo(testPayload);
+
+        assertThat(r.getAddressSpaceView().read(0).getType()).isEqualTo(DataType.HOLE);
+        assertThat(r.getAddressSpaceView().read(1).getType()).isEqualTo(DataType.DATA);
+        assertThat(r.getAddressSpaceView().read(2).getType()).isEqualTo(DataType.HOLE);
+        assertThat(r.getAddressSpaceView().read(3).getType()).isEqualTo(DataType.EMPTY);
+
+
+    }
+
+
+
+    public void sendMessage(LogUnitServer s, CorfuMsg message) {
+        TestServerRouter router = new TestServerRouter();
+        router.addServer(s);
+        message.setClientID(testClientId);
+        message.setRequestID(requestCounter.getAndIncrement());
+        router.sendServerMessage(message);
+    }
+
+
+    private AtomicInteger requestCounter = new AtomicInteger(0);
+
+
+
+}


### PR DESCRIPTION
Compared to what we reviewed previously:

We use IRetry

Always before the hole fill or after being outranked, we have some grace period for the other client
to complete + do some reads.

We have test that does hole fill + a test, that makes sure the recovery write will work after one of the servers  fails with timeout (see the last 2 tests in QuorumReplicationViewTest)