### PR TITLE
Clean up FileChannel leak

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -501,7 +501,9 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                 throw new DataCorruptionException();
             }
         } finally {
-            fc.close();
+            if (fc != null) {
+                fc.close();
+            }
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -483,21 +483,25 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
      */
     private LogData  readRecord(SegmentHandle sh, long address)
             throws IOException {
-
-        FileChannel fc = getChannel(sh.fileName, true);
-        AddressMetaData metaData = sh.getKnownAddresses().get(address);
-        if (metaData == null) {
-            return null;
-        }
-
-        fc.position(metaData.offset);
-
+        FileChannel fc = null;
         try {
-            ByteBuffer entryBuf = ByteBuffer.allocate(metaData.length);
-            fc.read(entryBuf);
-            return getLogData(LogEntry.parseFrom(entryBuf.array()));
-        } catch (InvalidProtocolBufferException e) {
-            throw new DataCorruptionException();
+            fc = getChannel(sh.fileName, true);
+            AddressMetaData metaData = sh.getKnownAddresses().get(address);
+            if (metaData == null) {
+                return null;
+            }
+
+            fc.position(metaData.offset);
+
+            try {
+                ByteBuffer entryBuf = ByteBuffer.allocate(metaData.length);
+                fc.read(entryBuf);
+                return getLogData(LogEntry.parseFrom(entryBuf.array()));
+            } catch (InvalidProtocolBufferException e) {
+                throw new DataCorruptionException();
+            }
+        } finally {
+            fc.close();
         }
     }
 


### PR DESCRIPTION
In the readRecord function (that is called when we fetch the entry from the file in the cache on the logUnitServer) we never close the FileChannel.

This problem got exposed on longevity testing. After a while, performance dropped completely and I had ~ 300'000 File Descriptor open on the same log file.

#548