### PR TITLE
Fix getSegmentHandleForAddress

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -554,6 +554,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         return writeChannels.computeIfAbsent(filePath, a -> {
 
             try {
+
                 FileChannel fc1 = getChannel(a, false);
                 FileChannel fc2 = getChannel(getTrimmedFilePath(a), false);
                 FileChannel fc3 = getChannel(getPendingTrimsFilePath(a), false);
@@ -564,7 +565,10 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                     verify = false;
                 }
 
-                writeHeader(fc1, VERSION, verify);
+                if(fc1.size() == 0) {
+                    writeHeader(fc1, VERSION, verify);
+                    log.trace("Opened new segment file, writing header for {}", a);
+                }
                 log.trace("Opened new log file at {}", a);
                 SegmentHandle sh = new SegmentHandle(segment, fc1, fc2, fc3, a);
                 // The first time we open a file we should read to the end, to load the

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -305,4 +305,17 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
                     .isInstanceOf(OverwriteException.class);
         }
     }
+
+    @Test
+    public void testWritingFileHeader() throws Exception {
+        String path = getDirPath();
+        StreamLogFiles log = new StreamLogFiles(path, false);
+        writeToLog(log, 0L);
+        log.sync(true);
+        StreamLogFiles log2 = new StreamLogFiles(path, false);
+        writeToLog(log2, 1L);
+        log2.sync(true);
+        StreamLogFiles log3 = new StreamLogFiles(path, false);
+        assertThat(log3.read(new LogAddress(1L, null))).isNotNull();
+    }
 }


### PR DESCRIPTION
On a server restart opening a segment will cause the header to
be written multiple times which breaks readAddressSpace. This
patch will only write the header if the file size is zero.