### PR TITLE
fix issue with nested TX with no stream present

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -169,16 +169,17 @@ public class WriteSetSMRStream implements ISMRStream {
         currentContextPos--;
         // Pop the context if we're at the beginning of it
         if (currentContextPos <= Address.maxNonAddress()) {
-            if (currentContext == 0) {
-                throw new RuntimeException("Attempted to pop first context (pos=" + pos() + ")");
-            }
-            else {
-                currentContext--;
-            }
-
+            do {
+                if (currentContext == 0) {
+                    throw new RuntimeException("Attempted to pop first context (pos=" + pos() + ")");
+                } else {
+                    currentContext--;
+                }
+            } while (!contexts.get(currentContext).getWriteSet().containsKey(id));
             currentContextPos = contexts.get(currentContext)
                     .getWriteSet().get(id).getValue().size() - 1;
         }
+
         return current();
     }
 

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTXConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTXConcurrencyTest.java
@@ -1,7 +1,12 @@
 package org.corfudb.runtime.object.transactions;
 
+import com.google.common.reflect.TypeToken;
+import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -92,5 +97,44 @@ public class OptimisticTXConcurrencyTest extends TXConflictScenariosTest {
         concurrentAbortTest(false);
 
         // no assertion, just print abort rate
+    }
+
+    @Test
+    public void checkRollbackNested()  throws Exception {
+        ArrayList<Map> maps = new ArrayList<>();
+
+        final int nmaps = 2;
+        for (int i = 0; i < nmaps; i++)
+            maps.add( (SMRMap<Integer, String>) instantiateCorfuObject(
+                    new TypeToken<SMRMap<Integer, String>>() {}, "test stream" + i)
+            );
+        final int key1 = 1, key2 = 2, key3 = 3;
+        final String tst1 = "foo", tst2 = "bar";
+        final int nNests = PARAMETERS.NUM_ITERATIONS_LOW;
+
+        // start tx in one thread, establish snapshot time
+        t(1, () -> {
+            TXBegin();
+            maps.get(0).get(key1);
+            maps.get(1).get(key1);
+        });
+
+        // in another thread, nest nNests transactions writing to different streams
+        t(2, () -> {
+            for (int i = 0; i < nNests; i++) {
+                TXBegin();
+                maps.get((i%nmaps)).put(key1, (i % nmaps) == 0 ? tst1 : tst2);
+                maps.get((i%nmaps)).put(key2, (i % nmaps) == 0 ? tst1 : tst2);
+                maps.get((i%nmaps)).put(key3, (i % nmaps) == 0 ? tst1 : tst2);
+            }
+        });
+
+        t(1, () -> {
+            assertThat(maps.get(0).get(key1))
+                    .isEqualTo(null);
+            assertThat(maps.get(1).get(key1))
+                    .isEqualTo(null);
+        });
+
     }
 }


### PR DESCRIPTION
This PR fixes #570, which was occurring when a nested transaction
existed that did modify the TX was present, for example:

TX1:
modifies a

TX2:
modifies b

TX3:
modifies a

A call to previous on  would crash with a NPE because TX2 did
not contain a. This patch fixes the logic to skip over empty
sets.