### PR TITLE
Implement conflict paramters for bulk operations

### DIFF
--- a/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
+++ b/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
@@ -119,19 +119,19 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
     /** Class to hold data about SMR Methods. */
     class SMRMethodInfo {
         /** The method itself. */
-        ExecutableElement method;
+        final ExecutableElement method;
         /** The interface, if present, which provided the element. */
-        TypeElement interfaceOverride;
+        final TypeElement interfaceOverride;
         /** If the element should be excluded from instrumentation. */
-        boolean doNotAdd = false;
+        final boolean doNotAdd;
         /** If the element has conflictParameter annotations. */
         final boolean hasConflictAnnotations;
+        /** If the element has a function to calculate conflict params. */
+        final String conflictFunction;
 
         public SMRMethodInfo(ExecutableElement method,
                              TypeElement interfaceOverride) {
-            this.method = method;
-            this.interfaceOverride = interfaceOverride;
-            this.hasConflictAnnotations = checkForConflictAnnotations(method);
+            this(method, interfaceOverride, false);
         }
 
         public SMRMethodInfo(ExecutableElement method,
@@ -141,6 +141,29 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
             this.interfaceOverride = interfaceOverride;
             this.doNotAdd = doNotAdd;
             this.hasConflictAnnotations = checkForConflictAnnotations(method);
+
+
+            Accessor accessor = method.getAnnotation(Accessor.class);
+            MutatorAccessor mutatorAccessor = method.getAnnotation(MutatorAccessor.class);
+            Mutator mutator = method.getAnnotation(Mutator.class);
+
+            // Check if there is a conflictFunction
+            if (accessor != null && !accessor.conflictParameterFunction().equals("")) {
+                conflictFunction = accessor.conflictParameterFunction();
+            }else if (mutator != null && !mutator.conflictParameterFunction().equals("")) {
+                conflictFunction = mutator.conflictParameterFunction();
+            }
+            else if (mutatorAccessor != null && !mutatorAccessor.conflictParameterFunction().equals("")) {
+                conflictFunction = mutatorAccessor.conflictParameterFunction();
+            } else {
+                conflictFunction = null;
+            }
+
+            if (conflictFunction != null && hasConflictAnnotations) {
+                messager.printMessage(Diagnostic.Kind.ERROR, "Method " + method.getSimpleName() +
+                " cannot have both conflict annotations and conflict function '" + conflictFunction + "'");
+
+            }
         }
 
         /** Return whether the given method has conflict annotations.
@@ -391,8 +414,16 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                     }
 
                     // If there is conflict information, calculate the conflict set
+                    boolean hasConflictData = false;
                     final String conflictField = "conflictField" + CORFUSMR_FIELD;
-                    if (m.hasConflictAnnotations) {
+
+
+                    if (m.conflictFunction != null) {
+                        hasConflictData = true;
+                        addConflictFieldFromFunctionToMethod(ms, conflictField, m.conflictFunction, smrMethod);
+                    }
+                    else if (m.hasConflictAnnotations) {
+                        hasConflictData = true;
                         addConflictFieldToMethod(ms, conflictField, smrMethod);
                     }
 
@@ -406,7 +437,7 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                                 mutator != null ? "false" :
                                 // or mutatorAccessors which return void.
                                 smrMethod.getReturnType().getKind().equals(TypeKind.VOID) ? "false" : "true",
-                                m.hasConflictAnnotations ? conflictField : "null",
+                                hasConflictData ? conflictField : "null",
                                 smrMethod.getParameters().size() > 0 ? "," : "",
                                 smrMethod.getParameters().stream()
                                     .map(VariableElement::getSimpleName)
@@ -847,6 +878,22 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                         .stream()
                         .filter(y -> y.getAnnotation(ConflictParameter.class)
                                 != null)
+                        .map(y -> y.getSimpleName())
+                        .collect(Collectors.joining(", ")));
+    }
+
+    /** Add a conflict field to the method.
+     *
+     * @param ms                The builder to add the field to.
+     * @param conflictField     The name of the field to add
+     * @param functionName      The function to call to obtain the parameters.
+     * @param smrMethod         The method element.
+     */
+    public void addConflictFieldFromFunctionToMethod(MethodSpec.Builder ms, String conflictField, String functionName,
+                                                     ExecutableElement smrMethod) {
+        ms.addStatement("$T $L = $L($L)", Object[].class, conflictField, functionName,
+                smrMethod.getParameters()
+                        .stream()
                         .map(y -> y.getSimpleName())
                         .collect(Collectors.joining(", ")));
     }

--- a/annotations/src/main/java/org/corfudb/annotations/Accessor.java
+++ b/annotations/src/main/java/org/corfudb/annotations/Accessor.java
@@ -14,4 +14,11 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Inherited
 public @interface Accessor {
+
+    /** The name of the function used to generate conflict parameters, which
+     * will be used to generate conflict information.
+     * @return  The name of a conflict generation function.
+     */
+    String conflictParameterFunction() default "";
+
 }

--- a/annotations/src/main/java/org/corfudb/annotations/Mutator.java
+++ b/annotations/src/main/java/org/corfudb/annotations/Mutator.java
@@ -32,6 +32,12 @@ public @interface Mutator {
      */
     String undoRecordFunction() default "";
 
+    /** The name of the function used to generate conflict parameters, which
+     * will be used to generate conflict information.
+     * @return  The name of a conflict generation function.
+     */
+    String conflictParameterFunction() default "";
+
     /** Whether this mutator resets the state of this object. Typically used
      * for methods like clear().
      * @return True, if the mutator resets the object.

--- a/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
+++ b/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
@@ -31,6 +31,12 @@ public @interface MutatorAccessor {
      */
     String undoRecordFunction() default "";
 
+    /** The name of the function used to generate conflict parameters, which
+     * will be used to generate conflict information.
+     * @return  The name of a conflict generation function.
+     */
+    String conflictParameterFunction() default "";
+
     /** Whether this mutator resets the state of this object. Typically used
      * for methods like clear().
      * @return True, if the mutator resets the object.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -1,8 +1,14 @@
 package org.corfudb.runtime.collections;
 
-import org.corfudb.annotations.*;
+import com.google.common.collect.ImmutableMap;
+import org.corfudb.annotations.Accessor;
+import org.corfudb.annotations.ConflictParameter;
+import org.corfudb.annotations.Mutator;
+import org.corfudb.annotations.MutatorAccessor;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Created by mwei on 1/9/16.
@@ -10,120 +16,60 @@ import java.util.*;
 public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
 
     /**
-     * Returns the number of key-value mappings in this map.  If the
-     * map contains more than <tt>Integer.MAX_VALUE</tt> elements, returns
-     * <tt>Integer.MAX_VALUE</tt>.
+     * {@inheritDoc}
      *
-     * @return the number of key-value mappings in this map
+     * Conflicts: this operation conflicts with any modification to
+     * the map, since the size of the map could be potentially changed.
      */
     @Accessor
     @Override
     int size();
 
     /**
-     * Returns <tt>true</tt> if this map contains no key-value mappings.
+     * {@inheritDoc}
      *
-     * @return <tt>true</tt> if this map contains no key-value mappings
+     * Conflicts: this operation conflicts with any modification to
+     * the map, since the size of the map could be potentially changed.
      */
     @Accessor
     @Override
     boolean isEmpty();
 
     /**
-     * Returns <tt>true</tt> if this map contains a mapping for the specified
-     * key.  More formally, returns <tt>true</tt> if and only if
-     * this map contains a mapping for a key <tt>k</tt> such that
-     * <tt>(key==null ? k==null : key.equals(k))</tt>.  (There can be
-     * at most one such mapping.)
+     * {@inheritDoc}
      *
-     * @param key key whose presence in this map is to be tested
-     * @return <tt>true</tt> if this map contains a mapping for the specified
-     * key
-     * @throws ClassCastException   if the key is of an inappropriate type for
-     *                              this map
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException if the specified key is null and this map
-     *                              does not permit null keys
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
+     * Conflicts: this operation conflicts with any operation on the
+     * given key.
      */
     @Accessor
     @Override
     boolean containsKey(@ConflictParameter Object key);
 
     /**
-     * Returns <tt>true</tt> if this map maps one or more keys to the
-     * specified value.  More formally, returns <tt>true</tt> if and only if
-     * this map contains at least one mapping to a value <tt>v</tt> such that
-     * <tt>(value==null ? v==null : value.equals(v))</tt>.  This operation
-     * will probably require time linear in the map size for most
-     * implementations of the <tt>Map</tt> interface.
+     * {@inheritDoc}
      *
-     * @param value value whose presence in this map is to be tested
-     * @return <tt>true</tt> if this map maps one or more keys to the
-     * specified value
-     * @throws ClassCastException   if the value is of an inappropriate type for
-     *                              this map
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException if the specified value is null and this
-     *                              map does not permit null values
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
+     * Conflicts: this operation conflicts with any modification to
+     * the map, since the presence of values could be potentially changed.
      */
     @Accessor
     @Override
     boolean containsValue(Object value);
 
     /**
-     * Returns the value to which the specified key is mapped,
-     * or {@code null} if this map contains no mapping for the key.
-     * <p>
-     * <p>More formally, if this map contains a mapping from a key
-     * {@code k} to a value {@code v} such that {@code (key==null ? k==null :
-     * key.equals(k))}, then this method returns {@code v}; otherwise
-     * it returns {@code null}.  (There can be at most one such mapping.)
-     * <p>
-     * <p>If this map permits null values, then a return value of
-     * {@code null} does not <i>necessarily</i> indicate that the map
-     * contains no mapping for the key; it's also possible that the map
-     * explicitly maps the key to {@code null}.  The {@link #containsKey
-     * containsKey} operation may be used to distinguish these two cases.
+     * {@inheritDoc}
      *
-     * @param key the key whose associated value is to be returned
-     * @return the value to which the specified key is mapped, or
-     * {@code null} if this map contains no mapping for the key
-     * @throws ClassCastException   if the key is of an inappropriate type for
-     *                              this map
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException if the specified key is null and this map
-     *                              does not permit null keys
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
+     * Conflicts: this operation conflicts with any operation on the
+     * given key.
      */
     @Accessor
     @Override
     V get(@ConflictParameter Object key);
 
     /**
-     * Associates the specified value with the specified key in this map
-     * (optional operation).  If the map previously contained a mapping for
-     * the key, the old value is replaced by the specified value.  (A map
-     * <tt>m</tt> is said to contain a mapping for a key <tt>k</tt> if and only
-     * if {@link #containsKey(Object) m.containsKey(k)} would return
-     * <tt>true</tt>.)
+     * {@inheritDoc}
      *
-     * @param key   key with which the specified value is to be associated
-     * @param value value to be associated with the specified key
-     * @return the previous value associated with <tt>key</tt>, or
-     * <tt>null</tt> if there was no mapping for <tt>key</tt>.
-     * (A <tt>null</tt> return can also indicate that the map
-     * previously associated <tt>null</tt> with <tt>key</tt>,
-     * if the implementation supports <tt>null</tt> values.)
-     * @throws UnsupportedOperationException if the <tt>put</tt> operation
-     *                                       is not supported by this map
-     * @throws ClassCastException            if the class of the specified key or value
-     *                                       prevents it from being stored in this map
-     * @throws NullPointerException          if the specified key or value is null
-     *                                       and this map does not permit null keys or values
-     * @throws IllegalArgumentException      if some property of the specified key
-     *                                       or value prevents it from being stored in this map
+     * Conflicts: this operation produces a conflict with any other
+     * operation on the given key.
      */
     @MutatorAccessor(name = "put", undoFunction = "undoPut", undoRecordFunction = "undoPutRecord")
     @Override
@@ -131,23 +77,16 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
 
 
     /**
-     * Associates the specified value with the specified key in this map
-     * without return the previous value.  If the map previously contained a
-     * mapping for the key, the old value is replaced by the specified value.
-     * (A map <tt>m</tt> is said to contain a mapping for a key <tt>k</tt> if
-     * and only if {@link #containsKey(Object) m.containsKey(k)} would return
-     * <tt>true</tt>.)
+     * This operation behaves like a put operation, but does not
+     * return the previous value, and does not result in a read
+     * of the map.
      *
-     * @param key   key with which the specified value is to be associated
-     * @param value value to be associated with the specified key
-     * @throws UnsupportedOperationException if the <tt>put</tt> operation
-     *                                       is not supported by this map
-     * @throws ClassCastException            if the class of the specified key or value
-     *                                       prevents it from being stored in this map
-     * @throws NullPointerException          if the specified key or value is null
-     *                                       and this map does not permit null keys or values
-     * @throws IllegalArgumentException      if some property of the specified key
-     *                                       or value prevents it from being stored in this map
+     * Calling this operation produces the same put record as calling
+     * "put" directly. However, the runtime will not try to sync
+     * the object to obtain an upcall.
+     *
+     * Conflicts: this operation produces a conflict with any other
+     * operation on the given key.
      */
     @Mutator(name = "put", noUpcall = true)
     default void blindPut(@ConflictParameter K key, V value) {
@@ -187,34 +126,10 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
     }
 
     /**
-     * Removes the mapping for a key from this map if it is present
-     * (optional operation).   More formally, if this map contains a mapping
-     * from key <tt>k</tt> to value <tt>v</tt> such that
-     * <code>(key==null ?  k==null : key.equals(k))</code>, that mapping
-     * is removed.  (The map can contain at most one such mapping.)
-     * <p>
-     * <p>Returns the value to which this map previously associated the key,
-     * or <tt>null</tt> if the map contained no mapping for the key.
-     * <p>
-     * <p>If this map permits null values, then a return value of
-     * <tt>null</tt> does not <i>necessarily</i> indicate that the map
-     * contained no mapping for the key; it's also possible that the map
-     * explicitly mapped the key to <tt>null</tt>.
-     * <p>
-     * <p>The map will not contain a mapping for the specified key once the
-     * call returns.
+     * {@jnheritDoc}
      *
-     * @param key key whose mapping is to be removed from the map
-     * @return the previous value associated with <tt>key</tt>, or
-     * <tt>null</tt> if there was no mapping for <tt>key</tt>.
-     * @throws UnsupportedOperationException if the <tt>remove</tt> operation
-     *                                       is not supported by this map
-     * @throws ClassCastException            if the key is of an inappropriate type for
-     *                                       this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException          if the specified key is null and this
-     *                                       map does not permit null keys
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
+     * Conflicts: this operation produces a conflict with any other
+     * operation on the given key.
      */
     @MutatorAccessor(name="remove", undoFunction = "undoRemove", undoRecordFunction = "undoRemoveRecord")
     @Override
@@ -248,94 +163,108 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
     }
 
     /**
-     * Copies all of the mappings from the specified map to this map
-     * (optional operation).  The effect of this call is equivalent to that
-     * of calling {@link #put(Object, Object) put(k, v)} on this map once
-     * for each mapping from key <tt>k</tt> to value <tt>v</tt> in the
-     * specified map.  The behavior of this operation is undefined if the
-     * specified map is modified while the operation is in progress.
+     * {@inheritDoc}
      *
-     * @param m mappings to be stored in this map
-     * @throws UnsupportedOperationException if the <tt>putAll</tt> operation
-     *                                       is not supported by this map
-     * @throws ClassCastException            if the class of a key or value in the
-     *                                       specified map prevents it from being stored in this map
-     * @throws NullPointerException          if the specified map is null, or if
-     *                                       this map does not permit null keys or values, and the
-     *                                       specified map contains null keys or values
-     * @throws IllegalArgumentException      if some property of a key or value in
-     *                                       the specified map prevents it from being stored in this map
+     * Conflicts: this operation conflicts on any keys that are in the map given.
      */
-    @Mutator(name="putAll")
+    @Mutator(name="putAll", undoFunction="undoPutAll",
+            undoRecordFunction="undoPutAllRecord", conflictParameterFunction="putAllConflictFunction")
     @Override
     void putAll(Map<? extends K, ? extends V> m);
 
-    /**
-     * Removes all of the mappings from this map (optional operation).
-     * The map will be empty after this call returns.
+
+    /** Generate the conflict parameters for putAll, given the arguments to the
+     * putAll operation.
+     * @param m                 The map for the putAll operation.
+     * @return                  An array of conflict parameters, which are the
+     *                          hash codes of the keys given.
+     */
+    default Object[] putAllConflictFunction(Map<? extends K, ? extends V> m) {
+        return m.keySet().stream()
+                .map(Object::hashCode)
+                .toArray(Object[]::new);
+    }
+
+    enum UndoNullable {
+        NULL;
+    }
+
+    /** Generate an undo record for putAll, given the previous state of the map
+     * and the parameters to the putAll call.
      *
-     * @throws UnsupportedOperationException if the <tt>clear</tt> operation
-     *                                       is not supported by this map
+     * @param previousState     The previous state of the map
+     * @param m                 The map from the putAll call
+     * @return                  An undo record, which for a putAll is all the
+     *                          previous entries in the map.
+     */
+    default Map<K,V> undoPutAllRecord(ISMRMap<K,V> previousState, Map<? extends K, ? extends V> m) {
+        ImmutableMap.Builder<K,V> builder = ImmutableMap.builder();
+        m.keySet().forEach(k -> builder.put(k,
+                (previousState.get(k) == null ? (V) UndoNullable.NULL : previousState.get(k))));
+        return builder.build();
+    }
+
+    /** Undo a remove, given the current state of the map, an undo record
+     * and the arguments to the remove command to undo.
+     *
+     * @param map           The state of the map after the put to undo
+     * @param undoRecord    The undo record generated by undoRemoveRecord
+     */
+    default void undoPutAll(ISMRMap<K,V> map, Map<K,V> undoRecord, Map<? extends K, ? extends V> m) {
+        undoRecord.entrySet().forEach(e -> {
+            if (e.getValue() == UndoNullable.NULL) { map.remove(e.getKey()); }
+            else { map.put(e.getKey(), e.getValue()); }
+        });
+    }
+
+
+    /**
+     * {@inheritDoc}
+     *
+     * Conflicts: this operation conflicts with the entire map, since it drops
+     * all mappings which are present.
      */
     @Mutator(name="clear", reset=true)
     @Override
     void clear();
 
     /**
-     * Returns a {@link Set} view of the keys contained in this map.
-     * The set is backed by the map, so changes to the map are
-     * reflected in the set, and vice-versa.  If the map is modified
-     * while an iteration over the set is in progress (except through
-     * the iterator's own <tt>remove</tt> operation), the results of
-     * the iteration are undefined.  The set supports element removal,
-     * which removes the corresponding mapping from the map, via the
-     * <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
-     * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-     * operations.  It does not support the <tt>add</tt> or <tt>addAll</tt>
-     * operations.
+     * {@inheritDoc}
      *
-     * @return a set view of the keys contained in this map
+     * This function currently does not return a view like the java.util implementation,
+     * and changes to the keySet will *not* be reflected in the map.
+     *
+     * Conflicts: This operation currently conflicts with any modification
+     * to the map.
      */
     @Accessor
     @Override
     Set<K> keySet();
 
     /**
-     * Returns a {@link Collection} view of the values contained in this map.
-     * The collection is backed by the map, so changes to the map are
-     * reflected in the collection, and vice-versa.  If the map is
-     * modified while an iteration over the collection is in progress
-     * (except through the iterator's own <tt>remove</tt> operation),
-     * the results of the iteration are undefined.  The collection
-     * supports element removal, which removes the corresponding
-     * mapping from the map, via the <tt>Iterator.remove</tt>,
-     * <tt>Collection.remove</tt>, <tt>removeAll</tt>,
-     * <tt>retainAll</tt> and <tt>clear</tt> operations.  It does not
-     * support the <tt>add</tt> or <tt>addAll</tt> operations.
+     * {@inheritDoc}
      *
-     * @return a collection view of the values contained in this map
+     * This function currently does not return a view like the java.util implementation,
+     * and changes to the values will *not* be reflected in the map.
+     *
+     * Conflicts: This operation currently conflicts with any modification
+     * to the map.
      */
     @Accessor
     @Override
     Collection<V> values();
 
     /**
-     * Returns a {@link Set} view of the mappings contained in this map.
-     * The set is backed by the map, so changes to the map are
-     * reflected in the set, and vice-versa.  If the map is modified
-     * while an iteration over the set is in progress (except through
-     * the iterator's own <tt>remove</tt> operation, or through the
-     * <tt>setValue</tt> operation on a map entry returned by the
-     * iterator) the results of the iteration are undefined.  The set
-     * supports element removal, which removes the corresponding
-     * mapping from the map, via the <tt>Iterator.remove</tt>,
-     * <tt>Set.remove</tt>, <tt>removeAll</tt>, <tt>retainAll</tt> and
-     * <tt>clear</tt> operations.  It does not support the
-     * <tt>add</tt> or <tt>addAll</tt> operations.
+     * {@inheritDoc}
      *
-     * @return a set view of the mappings contained in this map
+     * This function currently does not return a view like the java.util implementation,
+     * and changes to the entrySet will *not* be reflected in the map.
+     *
+     * Conflicts: This operation currently conflicts with any modification
+     * to the map.
      */
     @Accessor
     @Override
     Set<Entry<K, V>> entrySet();
+
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRObject.java
@@ -10,114 +10,21 @@ import java.util.HashMap;
 public interface ISMRObject {
 
     /**
-     * Returns a hash code value for the object. This method is
-     * supported for the benefit of hash tables such as those provided by
-     * {@link HashMap}.
-     * <p>
-     * The general contract of {@code hashCode} is:
-     * <ul>
-     * <li>Whenever it is invoked on the same object more than once during
-     * an execution of a Java application, the {@code hashCode} method
-     * must consistently return the same integer, provided no information
-     * used in {@code equals} comparisons on the object is modified.
-     * This integer need not remain consistent from one execution of an
-     * application to another execution of the same application.
-     * <li>If two objects are equal according to the {@code equals(Object)}
-     * method, then calling the {@code hashCode} method on each of
-     * the two objects must produce the same integer result.
-     * <li>It is <em>not</em> required that if two objects are unequal
-     * according to the {@link Object#equals(Object)}
-     * method, then calling the {@code hashCode} method on each of the
-     * two objects must produce distinct integer results.  However, the
-     * programmer should be aware that producing distinct integer results
-     * for unequal objects may improve the performance of hash tables.
-     * </ul>
-     * <p>
-     * As much as is reasonably practical, the hashCode method defined by
-     * class {@code Object} does return distinct integers for distinct
-     * objects. (This is typically implemented by converting the internal
-     * address of the object into an integer, but this implementation
-     * technique is not required by the
-     * Java&trade; programming language.)
-     *
-     * @return a hash code value for this object.
-     * @see Object#equals(Object)
-     * @see System#identityHashCode
+     * {@inheritDoc}
      */
     @Override
     @Accessor
     int hashCode();
 
     /**
-     * Indicates whether some other object is "equal to" this one.
-     * <p>
-     * The {@code equals} method implements an equivalence relation
-     * on non-null object references:
-     * <ul>
-     * <li>It is <i>reflexive</i>: for any non-null reference value
-     * {@code x}, {@code x.equals(x)} should return
-     * {@code true}.
-     * <li>It is <i>symmetric</i>: for any non-null reference values
-     * {@code x} and {@code y}, {@code x.equals(y)}
-     * should return {@code true} if and only if
-     * {@code y.equals(x)} returns {@code true}.
-     * <li>It is <i>transitive</i>: for any non-null reference values
-     * {@code x}, {@code y}, and {@code z}, if
-     * {@code x.equals(y)} returns {@code true} and
-     * {@code y.equals(z)} returns {@code true}, then
-     * {@code x.equals(z)} should return {@code true}.
-     * <li>It is <i>consistent</i>: for any non-null reference values
-     * {@code x} and {@code y}, multiple invocations of
-     * {@code x.equals(y)} consistently return {@code true}
-     * or consistently return {@code false}, provided no
-     * information used in {@code equals} comparisons on the
-     * objects is modified.
-     * <li>For any non-null reference value {@code x},
-     * {@code x.equals(null)} should return {@code false}.
-     * </ul>
-     * <p>
-     * The {@code equals} method for class {@code Object} implements
-     * the most discriminating possible equivalence relation on objects;
-     * that is, for any non-null reference values {@code x} and
-     * {@code y}, this method returns {@code true} if and only
-     * if {@code x} and {@code y} refer to the same object
-     * ({@code x == y} has the value {@code true}).
-     * <p>
-     * Note that it is generally necessary to override the {@code hashCode}
-     * method whenever this method is overridden, so as to maintain the
-     * general contract for the {@code hashCode} method, which states
-     * that equal objects must have equal hash codes.
-     *
-     * @param obj the reference object with which to compare.
-     * @return {@code true} if this object is the same as the obj
-     * argument; {@code false} otherwise.
-     * @see #hashCode()
-     * @see HashMap
+     * {@inheritDoc}
      */
     @Override
     @Accessor
     boolean equals(Object obj);
 
     /**
-     * Returns a string representation of the object. In general, the
-     * {@code toString} method returns a string that
-     * "textually represents" this object. The result should
-     * be a concise but informative representation that is easy for a
-     * person to read.
-     * It is recommended that all subclasses override this method.
-     * <p>
-     * The {@code toString} method for class {@code Object}
-     * returns a string consisting of the name of the class of which the
-     * object is an instance, the at-sign character `{@code @}', and
-     * the unsigned hexadecimal representation of the hash code of the
-     * object. In other words, this method returns a string equal to the
-     * value of:
-     * <blockquote>
-     * <pre>
-     * getClass().getName() + '@' + Integer.toHexString(hashCode())
-     * </pre></blockquote>
-     *
-     * @return a string representation of the object.
+     * {@inheritDoc}
      */
     @Accessor
     String toString();


### PR DESCRIPTION
This PR is a cherry pick of #508, which implements conflict paramter
resolution for bulk operations such as putAll, which is calculated
using a custom conflict parameter function.

This PR closes #574.