### PR TITLE
Throw DataCorruption Exception on Bad Delimiter

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -489,7 +489,8 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             channelOffset += Short.BYTES;
 
             if (magic != RECORD_DELIMITER) {
-                return;
+                log.error("Expected a delimiter but found something else while trying to read file {}", sh.fileName);
+                throw new DataCorruptionException();
             }
 
             byte[] metadataBuf = new byte[METADATA_SIZE];


### PR DESCRIPTION
The readRecord method was returning null when it sees a bad
delimiter. This is incorrect because it can cause the logging unit
to accept writes to addresses that have already been written. The
correct behavior is to throw a DataCorruption Exception.