### PR TITLE
Add runtime's dependencies to Corfu-Repos Maven repo

### DIFF
--- a/.travis_scripts/mvnrepo.sh
+++ b/.travis_scripts/mvnrepo.sh
@@ -8,7 +8,9 @@ if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; th
         mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
         ./mvnw deploy -DskipTests=true
         cp -R target/mvn-repo $HOME/mvn-repo-current
-        cp -R runtime/target/mvn-repo/* $HOME/mvn-repo-current
+        for pkg in runtime annotations annotationProcessor; do
+            cp -R $pkg/target/mvn-repo/* $HOME/mvn-repo-current
+        done
         cd $HOME
         git config --global user.email "travis@travis-ci.org"
         git config --global user.name "travis-ci"


### PR DESCRIPTION
Fixes #567.

Changes to SMR object annotations compilation also created
dependencies on Corfu JAR files outside of runtime's.
I'm not 100% sure that this small patch is sufficient; a Maven
repo wizard (@no2chem?) should review.

Prior to this patch, when using a `pom.xml` file as described
in the README (such as
https://gist.github.com/slfritchie/c02493a9aad7e69b143208148ba2b959)
results in the following Maven messages:

    [WARNING] The POM for org.corfudb:annotations:jar:0.1-2762 is missing, no dependency information available
    [WARNING] The POM for org.corfudb:annotationProcessor:jar:0.1-2762 is missing, no dependency information available

... and then ending with:

    [ERROR] Failed to execute goal on project test: Could not resolve dependencies for project org.corfudb.gh567:test:jar:0.01: The following artifacts could not be resolved: org.corfudb:annotations:jar:0.1-2762, org.corfudb:annotationProcessor:jar:0.1-2762: Could not find artifact org.corfudb:annotations:jar:0.1-2762 in corfu-mvn-repo (https://raw.github.com/CorfuDB/Corfu-Repos/mvn-repo/) -> [Help 1]