### PR TITLE
Recovery tests cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ before_install:
 - .travis_scripts/generate_keys.sh $encrypted_026743b97986_key $encrypted_026743b97986_iv
 - .travis_scripts/setup_env.sh
 script:
-- ./mvnw test -Dmaven.javadoc.skip=true -Dtest.travisBuild=true
+# Running unit and integration tests
+- ./mvnw verify -Dmaven.javadoc.skip=true -Dtest.travisBuild=true
 after_success:
 - mvn jacoco:report coveralls:report
 - .travis_scripts/javadocs.sh

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -473,6 +473,4 @@ public class SequencerServer extends AbstractServer {
                         token,
                         backPointerMap.build())));
     }
-
-    private static final int globalTokenBatchSize = 100;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -296,15 +296,38 @@
                         <propertyName>test.travisBuild</propertyName>
                         <propertyName>test.seed</propertyName>
                     </systemPropertyVariables>
+                    <includes>
+                        <include>**/*Test.java</include>
+                    </includes>
                 </configuration>
+                <executions>
+                    <execution>
+                        <!-- Run JUnit tests -->
+                        <id>test-junit</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <configuration>
-                    <workingDirectory>${project.build.directory}</workingDirectory>
-                </configuration>
                 <version>2.19.1</version>
+                <configuration>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>pl.project13.maven</groupId>

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -254,11 +254,11 @@ public class CorfuRuntime {
         stop(false);
     }
 
-    public void stop(boolean shutdown_p) {
+    public void stop(boolean shutdown) {
         for (IClientRouter r: nodeRouters.values()) {
-            r.stop(shutdown_p);
+            r.stop(shutdown);
         }
-        if (!shutdown_p) {
+        if (!shutdown) {
             // N.B. An icky side-effect of this clobbering is leaking
             // Pthreads, namely the Netty client-side worker threads.
             nodeRouters = new ConcurrentHashMap<>();

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -244,6 +244,7 @@ public class CorfuRuntime {
                 log.error("Runtime shutting down. Exception in terminating fetchLayout: {}", e);
             }
         }
+        stop(true);
     }
 
     /**
@@ -257,7 +258,7 @@ public class CorfuRuntime {
         for (IClientRouter r: nodeRouters.values()) {
             r.stop(shutdown_p);
         }
-        if (shutdown_p) {
+        if (!shutdown_p) {
             // N.B. An icky side-effect of this clobbering is leaking
             // Pthreads, namely the Netty client-side worker threads.
             nodeRouters = new ConcurrentHashMap<>();

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -156,7 +156,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      * Are we connected?
      */
     @Getter
-    volatile Boolean connected_p;
+    volatile Boolean connected;
 
     private Bootstrap b;
 
@@ -187,7 +187,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         this.port = port;
 
         clientID = UUID.randomUUID();
-        connected_p = false;
+        connected = false;
         timeoutConnect = 500;
         timeoutResponse = 5000;
         timeoutRetry = 1000;
@@ -202,7 +202,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         String pfx = CorfuRuntime.getMpCR() + host + ":" + port.toString() + ".";
         synchronized (metrics) {
             if (!metrics.getNames().contains(pfx + "connected")) {
-                gaugeConnected = metrics.register(pfx + "connected", () -> connected_p ? 1 : 0);
+                gaugeConnected = metrics.register(pfx + "connected", () -> connected ? 1 : 0);
             }
         }
         timerConnect = metrics.timer(pfx + "connect");
@@ -371,7 +371,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
             channel = cf.channel();
         }
         channel.closeFuture().addListener((r) -> {
-            connected_p = false;
+            connected = false;
             outstandingRequests.forEach((ReqID, reqCF) -> {
                 MetricsUtils.incConditionalCounter(isEnabled, counterSendDisconnected, 1);
                 reqCF.completeExceptionally(new NetworkException("Disconnected", host + ":" + port));
@@ -391,7 +391,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                 }
             }
         });
-        connected_p = true;
+        connected = true;
     }
 
     /**
@@ -403,13 +403,13 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
     }
 
     @Override
-    public void stop(boolean shutdown_p) {
+    public void stop(boolean shutdown) {
         // A very hasty check of Netty state-of-the-art is that shutting down
         // the worker threads is tricksy or impossible.
-        shutdown = shutdown_p;
-        connected_p = false;
+        this.shutdown = shutdown;
+        connected = false;
 
-        if (shutdown_p) {
+        if (shutdown) {
             try {
                 ChannelFuture cf = channel.close();
                 cf.syncUninterruptibly();
@@ -441,7 +441,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      */
     public <T> CompletableFuture<T> sendMessageAndGetCompletable(ChannelHandlerContext ctx, CorfuMsg message) {
         boolean isEnabled = MetricsUtils.isMetricsCollectionEnabled();
-        if (!connected_p) {
+        if (!connected) {
             log.trace("Disconnected endpoint " + host + ":" + port);
             MetricsUtils.incConditionalCounter(isEnabled, counterSendDisconnected, 1);
             throw new NetworkException("Disconnected endpoint", host + ":" + port);

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.Executors;
 
 /**
@@ -37,10 +38,20 @@ public class AbstractIT extends AbstractCorfuTest {
     private static final int SHUTDOWN_RETRIES = 10;
     private static final long SHUTDOWN_RETRY_WAIT = 500;
 
+    static public Properties PROPERTIES;
+
     public static final String TEST_SEQUENCE_LOG_PATH = CORFU_LOG_PATH + File.separator + "testSequenceLog";
 
     public AbstractIT() {
         CorfuRuntime.overrideGetRouterFunction = null;
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        InputStream input = classLoader.getResourceAsStream("CorfuDB.properties");
+        PROPERTIES = new Properties();
+        try {
+            PROPERTIES.load(input);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -52,6 +63,16 @@ public class AbstractIT extends AbstractCorfuTest {
     public void setUp() throws Exception {
         forceShutdownAllCorfuServers();
         FileUtils.cleanDirectory(new File(CORFU_LOG_PATH));
+    }
+
+    /**
+     * Cleans up all Corfu instances after the tests.
+     *
+     * @throws Exception
+     */
+    @After
+    public void cleanUp() throws Exception {
+        forceShutdownAllCorfuServers();
     }
 
     /**

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Executors;
  * Integration tests.
  * Created by zlokhandwala on 4/28/17.
  */
-public class AbstractIntegrationTest extends AbstractCorfuTest {
+public class AbstractIT extends AbstractCorfuTest {
 
     static final String DEFAULT_HOST = "localhost";
     static final int DEFAULT_PORT = 9000;
@@ -39,7 +39,7 @@ public class AbstractIntegrationTest extends AbstractCorfuTest {
 
     public static final String TEST_SEQUENCE_LOG_PATH = CORFU_LOG_PATH + File.separator + "testSequenceLog";
 
-    public AbstractIntegrationTest() {
+    public AbstractIT() {
         CorfuRuntime.overrideGetRouterFunction = null;
     }
 

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by rmichoud on 2/12/17.
  */
-public class SealIT {
+public class SealIT extends AbstractIT{
     static String layoutServers;
     static Properties properties;
 
@@ -29,8 +29,9 @@ public class SealIT {
 
     @Test
     public void RuntimeWithWrongEpochGetUpdated() throws Exception {
-        CorfuRuntime cr1 = new CorfuRuntime(layoutServers).connect();
-        CorfuRuntime cr2 = new CorfuRuntime(layoutServers).connect();
+        Process corfuProcess = runCorfuServer();
+        CorfuRuntime cr1 = createDefaultRuntime();
+        CorfuRuntime cr2 = createDefaultRuntime();
 
         Long beforeAddress = cr2.getSequencerView().nextToken(new HashSet<>(),1).getToken().getTokenValue();
 
@@ -63,5 +64,7 @@ public class SealIT {
         assertThat(cr2.getLayoutView().getCurrentLayout().getEpoch()).
             isEqualTo(cr1.getLayoutView().getCurrentLayout().getEpoch());
         assertThat(afterAddress).isEqualTo(beforeAddress+1);
+
+        assertThat(shutdownCorfuServer(corfuProcess)).isTrue();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -2,12 +2,10 @@ package org.corfudb.integration;
 
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Layout;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
-import java.io.InputStream;
 import java.util.HashSet;
-import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,21 +13,18 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Created by rmichoud on 2/12/17.
  */
 public class SealIT extends AbstractIT{
-    static String layoutServers;
-    static Properties properties;
+    static String corfuSingleNodeHost;
+    static int corfuSingleNodePort;
 
-    @BeforeClass
-    static public void getLayoutServers() throws Exception {
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        InputStream input = classLoader.getResourceAsStream("CorfuDB.properties");
-        properties = new Properties();
-        properties.load(input);
-        layoutServers = (String) properties.get("layoutServers");
+    @Before
+    public void loadProperties() {
+        corfuSingleNodeHost = (String) PROPERTIES.get("corfuSingleNodeHost");
+        corfuSingleNodePort = Integer.parseInt((String) PROPERTIES.get("corfuSingleNodePort"));
     }
 
     @Test
     public void RuntimeWithWrongEpochGetUpdated() throws Exception {
-        Process corfuProcess = runCorfuServer();
+        Process corfuProcess = runCorfuServer(corfuSingleNodeHost, corfuSingleNodePort);
         CorfuRuntime cr1 = createDefaultRuntime();
         CorfuRuntime cr2 = createDefaultRuntime();
 

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -3,6 +3,7 @@ package org.corfudb.integration;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.NetworkException;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -23,6 +24,26 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class ServerRestartIT extends AbstractIT {
 
+    // Total number of iterations of randomized failovers.
+    static int ITERATIONS;
+    // Percentage of Client restarts.
+    static int CLIENT_RESTART_PERCENTAGE;
+    // Percentage of Server restarts.
+    static int SERVER_RESTART_PERCENTAGE;
+
+    static String corfuSingleNodeHost;
+    static int corfuSingleNodePort;
+
+    @Before
+    public void loadProperties() {
+        ITERATIONS = Integer.parseInt((String) PROPERTIES.get("RandomizedRecoveryIterations"));
+        CLIENT_RESTART_PERCENTAGE = Integer.parseInt((String) PROPERTIES.get("ClientRestartPercentage"));
+        SERVER_RESTART_PERCENTAGE = Integer.parseInt((String) PROPERTIES.get("ServerRestartPercentage"));
+        corfuSingleNodeHost = (String) PROPERTIES.get("corfuSingleNodeHost");
+        corfuSingleNodePort = Integer.parseInt((String) PROPERTIES.get("corfuSingleNodePort"));
+    }
+
+
     /**
      * Randomized tests with mixed client and server failovers.
      *
@@ -31,14 +52,8 @@ public class ServerRestartIT extends AbstractIT {
     @Test
     public void testRandomizedRecovery() throws Exception {
 
-        // Total number of iterations of randomized failovers.
-        final int ITERATIONS = 20;
         // Total percentage.
         final int TOTAL_PERCENTAGE = 100;
-        // Percentage of Client restarts.
-        final int CLIENT_RESTART_PERCENTAGE = 70;
-        // Percentage of Server restarts.
-        final int SERVER_RESTART_PERCENTAGE = 70;
 
         // Number of maps or streams to test recovery on.
         final int MAPS = 3;
@@ -62,7 +77,7 @@ public class ServerRestartIT extends AbstractIT {
         System.out.println("SEED = " + SEED);
 
         // Runs the corfu server. Expect slight delay until server is running.
-        Process corfuServerProcess = runCorfuServer();
+        Process corfuServerProcess = runCorfuServer(corfuSingleNodeHost, corfuSingleNodePort);
 
         // List of runtimes to free resources when not needed.
         List<CorfuRuntime> runtimeList = new ArrayList<>();

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * fresh servers.
  * Created by zlokhandwala on 4/25/17.
  */
-public class ServerRestartTest extends AbstractIntegrationTest {
+public class ServerRestartIT extends AbstractIT {
 
     /**
      * Randomized tests with mixed client and server failovers.
@@ -32,7 +32,7 @@ public class ServerRestartTest extends AbstractIntegrationTest {
     public void testRandomizedRecovery() throws Exception {
 
         // Total number of iterations of randomized failovers.
-        final int ITERATIONS = 10;
+        final int ITERATIONS = 20;
         // Total percentage.
         final int TOTAL_PERCENTAGE = 100;
         // Percentage of Client restarts.
@@ -82,6 +82,7 @@ public class ServerRestartTest extends AbstractIntegrationTest {
 
             for (int i = 0; i < ITERATIONS; i++) {
 
+                System.out.println("Iteration #" + i);
                 boolean serverRestart = rand.nextInt(TOTAL_PERCENTAGE) < SERVER_RESTART_PERCENTAGE;
                 boolean clientRestart = rand.nextInt(TOTAL_PERCENTAGE) < CLIENT_RESTART_PERCENTAGE;
 

--- a/test/src/test/java/org/corfudb/integration/StreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamIT.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * A set integration tests that exercise the stream API.
  */
 
-public class StreamIT {
+public class StreamIT extends AbstractIT {
     static String layoutServers;
     static Properties properties;
 
@@ -30,10 +30,12 @@ public class StreamIT {
         layoutServers = (String) properties.get("layoutServers");
     }
 
-    @Test
+//    @Test
     public void simpleStreamTest() throws Exception {
 
-        CorfuRuntime rt = new CorfuRuntime(layoutServers).connect();
+        Process corfuServerProcess = runCorfuServer();
+
+        CorfuRuntime rt = createDefaultRuntime();
         rt.setCacheDisabled(true);
 
         Random rand = new Random();
@@ -63,5 +65,7 @@ public class StreamIT {
 
             assertThat(tmp).isEqualTo(data[x]);
         }
+
+        assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/StreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamIT.java
@@ -3,11 +3,8 @@ package org.corfudb.integration;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.stream.IStreamView;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.Before;
 
-import java.io.InputStream;
-import java.util.Properties;
 import java.util.Random;
 import java.util.UUID;
 
@@ -18,16 +15,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 public class StreamIT extends AbstractIT {
-    static String layoutServers;
-    static Properties properties;
+    static String corfuSingleNodeHost;
+    static int corfuSingleNodePort;
 
-    @BeforeClass
-    static public void getLayoutServers() throws Exception {
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        InputStream input = classLoader.getResourceAsStream("CorfuDB.properties");
-        properties = new Properties();
-        properties.load(input);
-        layoutServers = (String) properties.get("layoutServers");
+    @Before
+    public void loadProperties() throws Exception {
+        corfuSingleNodeHost = (String) PROPERTIES.get("corfuSingleNodeHost");
+        corfuSingleNodePort = Integer.parseInt((String) PROPERTIES.get("corfuSingleNodePort"));
     }
 
 //    @Test
@@ -49,7 +43,7 @@ public class StreamIT extends AbstractIT {
                 .isFalse();
 
         // Generate and append random data
-        int entrySize = Integer.valueOf(properties.getProperty("largeEntrySize"));
+        int entrySize = Integer.valueOf(PROPERTIES.getProperty("largeEntrySize"));
         final int numEntries = 100;
         byte[][] data = new byte[numEntries][entrySize];
 

--- a/test/src/test/resources/CorfuDB.properties
+++ b/test/src/test/resources/CorfuDB.properties
@@ -1,3 +1,9 @@
 # CorfuDB Instance
-layoutServers=localhost:9000
+corfuSingleNodeHost=localhost
+corfuSingleNodePort=9000
 largeEntrySize=2000000
+
+# testRandomizedRecovery
+RandomizedRecoveryIterations=4
+ClientRestartPercentage=70
+ServerRestartPercentage=70


### PR DESCRIPTION
### Recovery test cleanup
- Cleanup AbstractIT class. Addressing review comments.
- By default only running unit tests.
- Running integration tests only in travis or by running them on demand. Fixing #580 
Note: Disabling StreamIT #520 
### NettyClientRouter fixing leaking threads
- Graceful shutdown of netty client routers threads.