### PR TITLE
Make Throwables More Specific

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -62,7 +62,7 @@ public abstract class AbstractView {
      * @param <D>      Any exception the function may throw.
      * @return The return value of the function.
      */
-    public <T, A extends Throwable, B extends Throwable, C extends Throwable, D extends Throwable>
+    public <T, A extends RuntimeException, B extends RuntimeException, C extends RuntimeException, D extends RuntimeException>
     T layoutHelper(LayoutFunction<Layout, T, A, B, C, D> function)
             throws A, B, C, D {
         while (true) {
@@ -98,7 +98,7 @@ public abstract class AbstractView {
     }
 
     @FunctionalInterface
-    public interface LayoutFunction<Layout, R, A extends Throwable,
+    public interface LayoutFunction<v, R, A extends Throwable,
             B extends Throwable, C extends Throwable, D extends Throwable> {
         R apply(Layout l) throws A, B, C, D;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -30,7 +30,7 @@ import static java.util.Objects.requireNonNull;
  */
 @Slf4j
 @Data
-@ToString(exclude = {"runtime", "replicationViewCache"})
+@ToString(exclude = {"runtime"})
 @EqualsAndHashCode
 public class Layout implements Cloneable {
     /**


### PR DESCRIPTION
layoutHelper only throws Exceptions that are extended from
RuntimeException(s), so this patch makes the layoutHelper
to only throw exceptions extended from RuntimeException.