### PR TITLE
Cleanup of runtime interface

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -47,33 +47,79 @@ public class CorfuRuntime {
 
     @Getter
     private final CorfuRuntimeParameters parameters = new CorfuRuntimeParameters();
-    /**
-     * A view of the layout service in the Corfu server instance.
+
+    /** A view of the layout. */
+    private final LayoutView layout = new LayoutView(this);
+
+    /** A view of the sequencer. */
+    private final SequencerView sequencer = new SequencerView(this);
+
+    /** A view of the address space. */
+    private final AddressSpaceView addressSpace = new AddressSpaceView(this);
+
+    /** A view of streams. */
+    private final StreamsView streams = new StreamsView(this);
+
+    /** A view of objects. */
+    private final ObjectsView objects= new ObjectsView(this);
+
+    /** New, less verbose getters. */
+
+    /** Get a view of the layout.
+     * @return  A layout view, which allows interaction with the layout.
      */
-    @Getter(lazy = true)
-    private final LayoutView layoutView = new LayoutView(this);
-    /**
-     * A view of the sequencer server in the Corfu server instance.
+    public LayoutView layout() { return layout; }
+
+    /** Get a view of the sequencer.
+     * @return  A sequencer view, which allows interaction with the sequencer.
      */
-    @Getter(lazy = true)
-    private final SequencerView sequencerView = new SequencerView(this);
-    /**
-     * A view of the address space in the Corfu server instance.
+    public SequencerView sequencer() { return sequencer; }
+
+    /** Get a view of the address space.
+     * @return  An address space view, which allows interaction with the address space.
      */
-    @Getter(lazy = true)
-    private final AddressSpaceView addressSpaceView = new AddressSpaceView(this);
-    /**
-     * A view of streamsView in the Corfu server instance.
+    public AddressSpaceView addressSpace() { return addressSpace; }
+
+    /** Get a view of the streams.
+     * @return  A streams view, which allows interaction with streams.
      */
-    @Getter(lazy = true)
-    private final StreamsView streamsView = new StreamsView(this);
+    public StreamsView streams() { return streams; }
+
+    /** Get a view of objects.
+     * @return  A objects view, which allows interaction with objects.
+     */
+    public ObjectsView objects() { return objects; }
+
+
+    /** Deprecated getters */
+
+    /** @deprecated This getter will be removed in the next release of Corfu,
+     * please use layout() instead. */
+    @Deprecated
+    public LayoutView getLayoutView() {return layout;}
+
+    /** @deprecated This getter will be removed in the next release of Corfu,
+     * please use sequencer() instead. */
+    @Deprecated
+    public SequencerView getSequencerView() {return sequencer; }
+
+    /** @deprecated This getter will be removed in the next release of Corfu,
+     * please use addressSpace() instead. */
+    @Deprecated
+    public AddressSpaceView getAddressSpaceView() {return addressSpace; }
+
+    /** @deprecated This getter will be removed in the next release of Corfu,
+     * please use streams() instead. */
+    @Deprecated
+    public StreamsView getStreamsView() { return streams; }
+
+    /** @deprecated This getter will be removed in the next release of Corfu,
+     * please use objects() instead. */
+    @Deprecated
+    public ObjectsView getObjectsView() {return objects; }
 
     //region Address Space Options
-    /**
-     * Views of objects in the Corfu server instance.
-     */
-    @Getter(lazy = true)
-    private final ObjectsView objectsView = new ObjectsView(this);
+
     /**
      * A list of known layout servers.
      */
@@ -85,9 +131,9 @@ public class CorfuRuntime {
      */
     public Map<String, IClientRouter> nodeRouters;
     /**
-     * A completable future containing a layout, when completed.
+     * A completable future containing a layoutFuture, when completed.
      */
-    public volatile CompletableFuture<Layout> layout;
+    public volatile CompletableFuture<Layout> layoutFuture;
     /**
      * The rate in seconds to retry accessing a layout, in case of a failure.
      */
@@ -235,11 +281,11 @@ public class CorfuRuntime {
      */
     public void shutdown() {
 
-        // Stopping async task from fetching layout.
+        // Stopping async task from fetching layoutFuture.
         isShutdown = true;
-        if (layout != null) {
+        if (layoutFuture != null) {
             try {
-                layout.cancel(true);
+                layoutFuture.cancel(true);
             } catch (Exception e) {
                 log.error("Runtime shutting down. Exception in terminating fetchLayout: {}", e);
             }
@@ -357,16 +403,16 @@ public class CorfuRuntime {
      */
     public synchronized void invalidateLayout() {
         // Is there a pending request to retrieve the layout?
-        if (!layout.isDone()) {
+        if (!layoutFuture.isDone()) {
             // Don't create a new request for a layout if there is one pending.
             return;
         }
-        layout = fetchLayout();
+        layoutFuture = fetchLayout();
     }
 
 
     /**
-     * Return a completable future which is guaranteed to contain a layout.
+     * Return a completable future which is guaranteed to contain a layout
      * This future will continue retrying until it gets a layout. If you need this completable future to fail,
      * you should chain it with a timeout.
      *
@@ -385,12 +431,12 @@ public class CorfuRuntime {
                         IClientRouter router = getRouter(s);
                         // Try to get a layout.
                         CompletableFuture<Layout> layoutFuture = router.getClient(LayoutClient.class).getLayout();
-                        // Wait for layout
+                        // Wait for layoutFuture
                         Layout l = layoutFuture.get();
                         l.setRuntime(this);
-                        // this.layout should only be assigned to the new layout future once it has been
-                        // completely constructed and initialized. For example, assigning this.layout = l
-                        // before setting the layout's runtime can result in other threads trying to access a layout
+                        // this.layoutFuture should only be assigned to the new layoutFuture future once it has been
+                        // completely constructed and initialized. For example, assigning this.layoutFuture = l
+                        // before setting the layoutFuture's runtime can result in other threads trying to access a layoutFuture
                         // with  a null runtime.
                         //FIXME Synchronization START
                         // We are updating multiple variables and we need the update to be synchronized across all variables.
@@ -399,7 +445,7 @@ public class CorfuRuntime {
                         // but setEpoch of routers needs to be synchronized as those variables are not local.
                         l.getAllServers().stream().map(getRouterFunction).forEach(x -> x.setEpoch(l.getEpoch()));
                         layoutServers = l.getLayoutServers();
-                        layout = layoutFuture;
+                        this.layoutFuture = layoutFuture;
                         //FIXME Synchronization END
 
                         log.debug("Layout server {} responded with layout {}", s, l);
@@ -426,12 +472,12 @@ public class CorfuRuntime {
      * When this function returns, the Corfu server is ready to be accessed.
      */
     public synchronized CorfuRuntime connect() {
-        if (layout == null) {
+        if (layoutFuture == null) {
             log.info("Connecting to Corfu server instance, layout servers={}", layoutServers);
             // Fetch the current layout and save the future.
-            layout = fetchLayout();
+            layoutFuture = fetchLayout();
             try {
-                layout.get();
+                layoutFuture.get();
             } catch (Exception e) {
                 // A serious error occurred trying to connect to the Corfu instance.
                 log.error("Fatal error connecting to Corfu server instance.", e);

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -37,7 +37,7 @@ public abstract class AbstractView {
     public Layout getCurrentLayout() {
         while (true) {
             try {
-                return runtime.layout.get();
+                return runtime.layoutFuture.get();
             } catch (Exception ex) {
                 log.warn("Error executing remote call, invalidating view and retrying in {}s", runtime.retryRate, ex);
                 runtime.invalidateLayout();
@@ -67,7 +67,7 @@ public abstract class AbstractView {
             throws A, B, C, D {
         while (true) {
             try {
-                return function.apply(runtime.layout.get());
+                return function.apply(runtime.layoutFuture.get());
             } catch (RuntimeException re) {
                 if (re.getCause() instanceof TimeoutException) {
                     log.warn("Timeout executing remote call, invalidating view and retrying in {}s", runtime.retryRate);

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -16,8 +16,8 @@ public class CorfuRuntimeTest extends AbstractViewTest {
 
         CorfuRuntime rt = getDefaultRuntime().connect();
 
-        // Check that access to the CorfuRuntime layout is always valid. Specifically, access to the layout
-        // while a new layout is being fetched/set concurrently.
+        // Check that access to the CorfuRuntime layoutFuture is always valid. Specifically, access to the layoutFuture
+        // while a new layoutFuture is being fetched/set concurrently.
 
         scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LARGE, (v) -> {
             rt.invalidateLayout();
@@ -25,7 +25,7 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         });
 
         scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LARGE, (v) -> {
-            assertThat(rt.layout.get().getRuntime()).isEqualTo(rt);
+            assertThat(rt.layoutFuture.get().getRuntime()).isEqualTo(rt);
         });
 
         executeScheduled(PARAMETERS.CONCURRENCY_TWO, PARAMETERS.TIMEOUT_LONG);

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
@@ -14,7 +14,7 @@ public class QuorumReplicationStreamViewTest extends StreamViewTest {
     public void setRuntime() throws Exception {
         r = getDefaultRuntime().connect();
         // First commit a layout that uses Replex
-        Layout newLayout = r.layout.get();
+        Layout newLayout = r.layoutFuture.get();
         newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.QUORUM_REPLICATION);
         newLayout.setEpoch(1);
         r.setCacheDisabled(true);

--- a/test/src/test/java/org/corfudb/runtime/view/ReplexStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ReplexStreamViewTest.java
@@ -16,7 +16,7 @@ public class ReplexStreamViewTest extends StreamViewTest {
     public void setRuntime() throws Exception {
         r = getDefaultRuntime().connect();
         // First commit a layout that uses Replex
-        Layout newLayout = r.layout.get();
+        Layout newLayout = r.layoutFuture.get();
         newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.REPLEX);
         newLayout.getSegment(0L).setReplexes(Collections.singletonList(
                 new Layout.LayoutStripe(Collections.singletonList(defaultConfigurationString))));


### PR DESCRIPTION
This patch introduces a less verbose interface to the runtime, dropping
the "get" prefix and the "view" suffix. The old interface is retained
but marked for deprecation. In addition, the layout "future" has been
renamed to distinguish it from the layout view.