### PR TITLE
Introduce SMRMap state in-stream checkpoint writer

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -8,6 +8,11 @@ enum DataType {
     PROPOSAL = 4;
 }
 
+enum CheckpointEntryType {
+    START = 0;
+    CONTINUATION = 1;
+    END = 2;
+}
 
 message DataRank {
     required int64 rank = 1;
@@ -23,6 +28,9 @@ message LogEntry {
     map<string, int64> logical_addresses = 7;
     map<string, int64> backpointers = 8;
     optional DataRank rank = 9;
+    optional CheckpointEntryType checkpointEntryType = 10;
+    optional int64 checkpointID_most_significant = 11;
+    optional int64 checkpointID_least_significant = 12;
 }
 
 message LogHeader {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -4,6 +4,7 @@ import com.github.benmanes.caffeine.cache.CacheWriter;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.extern.slf4j.Slf4j;
+import org.codehaus.plexus.util.ExceptionUtils;
 import org.corfudb.infrastructure.log.LogAddress;
 import org.corfudb.infrastructure.log.StreamLog;
 import org.corfudb.protocols.wireprotocol.LogData;

--- a/logReader/src/main/java/org/corfudb/logReader/logReader.java
+++ b/logReader/src/main/java/org/corfudb/logReader/logReader.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.Map;
+import java.util.UUID;
 
 public class logReader {
     private static int metadataSize;
@@ -218,7 +219,7 @@ public class logReader {
                 System.out.println("DataType: TRIMMED");
                 break;
             default:
-                System.out.println("UNKNOWN DataType");
+                System.out.printf("UNKNOWN DataType %s\n", dt);
                 break;
         }
         if (showBinary) {
@@ -229,6 +230,16 @@ public class logReader {
                 dr.hasRank() ? dr.getRank() : 0L,
                 dr.hasUuidMostSignificant() ? dr.getUuidMostSignificant() : 0L,
                 dr.hasUuidLeastSignificant() ? dr.getUuidLeastSignificant() : 0L);
+        if (entry.hasCheckpointEntryType()) {
+            System.out.format("Checkpoint type: %s, ID %s\n",
+                    entry.getCheckpointEntryType(),
+                    new UUID(entry.hasCheckpointIDMostSignificant()
+                             ? entry.getCheckpointIDMostSignificant()
+                             : 0L,
+                             entry.hasCheckpointIDLeastSignificant()
+                             ? entry.getCheckpointIDLeastSignificant()
+                             : 0L));
+        }
     }
 
     // Read and conditionally replace a record

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
@@ -1,0 +1,194 @@
+package org.corfudb.protocols.logprotocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+import org.corfudb.runtime.CorfuRuntime;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Object & serialization methods for in-stream checkpoint
+ * summarization of SMR object state.
+ */
+@ToString(callSuper = true)
+@NoArgsConstructor
+public class CheckpointEntry extends LogEntry {
+
+    @RequiredArgsConstructor
+    public enum CheckpointEntryType {
+        START(0),           // Mandatory: 1st record in checkpoint
+        CONTINUATION(1),    // Optional: 2nd through (n-1)th record
+        END(2);             // Mandatory: final record checkpoint
+
+        public final int type;
+
+        public byte asByte() {
+            return (byte) type;
+        }
+
+        public static final Map<Byte, CheckpointEntryType> typeMap =
+                Arrays.stream(CheckpointEntryType.values())
+                        .collect(Collectors.toMap(CheckpointEntryType::asByte, Function.identity()));
+    };
+
+    @RequiredArgsConstructor
+    public enum CheckpointDictKey {
+        START_TIME(0),
+        END_TIME(1),
+        START_LOG_ADDRESS(2),
+        ENTRY_COUNT(3),
+        BYTE_COUNT(4);
+
+        public final int type;
+
+        public byte asByte() {
+            return (byte) type;
+        }
+
+        public static final Map<Byte, CheckpointDictKey> typeMap =
+                Arrays.stream(CheckpointDictKey.values())
+                        .collect(Collectors.toMap(CheckpointDictKey::asByte, Function.identity()));
+    }
+
+    /** Type of entry
+     */
+    @Getter
+    CheckpointEntryType cpType;
+
+    /**
+     * Unique identifier for this checkpoint.  All entries
+     * for the same checkpoint state must use the same ID.
+     */
+    @Getter
+    UUID checkpointID;
+
+    /** Author/cause/trigger of this checkpoint
+     */
+    @Getter
+    String checkpointAuthorID;
+
+    /** Map of checkpoint metadata, see key constants above
+     */
+    @Getter
+    Map<CheckpointDictKey, String> dict;
+
+    /** Optional: SMREntry objects that contain SMR
+     *  object state of the stream that we're checkpointing.
+     *  May be present in any CheckpointEntryType, but typically
+     *  used by CONTINUATION entries.
+     */
+    @Getter
+    @Setter
+    MultiSMREntry smrEntries;
+
+    /** Byte count of smrEntries in serialized form, zero
+     *  if smrEntries.size() is zero or if value is unknown.
+     */
+    @Getter
+    int smrEntriesBytes = 0;
+
+    public CheckpointEntry(CheckpointEntryType type, String authorID, UUID checkpointID,
+                           Map<CheckpointDictKey,String> dict, MultiSMREntry smrEntries) {
+        super(LogEntryType.SMR);
+        this.cpType = type;
+        this.checkpointID = checkpointID;
+        this.checkpointAuthorID = authorID;
+        this.dict = dict;
+        this.smrEntries = smrEntries;
+    }
+
+    /**
+     * This function provides the remaining buffer. Child entries
+     * should initialize their contents based on the buffer.
+     *
+     * @param b The remaining buffer.
+     * @param rt The CorfuRuntime used by the SMR object.
+     * @return A CheckpointEntry.
+     */
+    @Override
+    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
+        super.deserializeBuffer(b, rt);
+        cpType = CheckpointEntryType.typeMap.get(b.readByte());
+        checkpointID = new UUID(b.readLong(), b.readLong());
+        checkpointAuthorID = deserializeString(b);
+        dict = new HashMap<>();
+        short mapEntries = b.readShort();
+        for (short i = 0; i < mapEntries; i++) {
+            CheckpointDictKey k = CheckpointDictKey.typeMap.get(b.readByte());
+            String v = deserializeString(b);
+            dict.put(k, v);
+        }
+        smrEntries = null;
+        byte hasSMREntries = b.readByte();
+        if (hasSMREntries > 0) {
+            smrEntries = (MultiSMREntry) MultiSMREntry.deserialize(b, runtime);
+        }
+        smrEntriesBytes = b.readInt();
+    }
+
+    /**
+     * Serialize the given LogEntry into a given byte buffer.
+     *
+     * NOTE: This method has a side-effect of updating the
+     *       this.smrEntriesBytes field.
+     *
+     * @param b The buffer to serialize into.
+     */
+    @Override
+    public void serialize(ByteBuf b) {
+        super.serialize(b);
+        b.writeByte(cpType.asByte());
+        b.writeLong(checkpointID.getMostSignificantBits());
+        b.writeLong(checkpointID.getLeastSignificantBits());
+        serializeString(checkpointAuthorID, b);
+        b.writeShort(dict == null ? 0 : dict.size());
+        if (dict != null) {
+            dict.entrySet().stream()
+                    .forEach(x -> {
+                        b.writeByte(x.getKey().asByte());
+                        serializeString(x.getValue(), b);
+                    });
+        }
+        if (smrEntries != null) {
+            b.writeByte(1);
+            int byteStart = b.readableBytes();
+            smrEntries.serialize(b);
+            smrEntriesBytes = b.readableBytes() - byteStart;
+        } else {
+            b.writeShort(0);
+            smrEntriesBytes = 0;
+        }
+        b.writeInt(smrEntriesBytes);
+    }
+
+    /** Helper function to deserialize a String.
+     *
+     * @param b
+     * @return A String.
+     */
+    private String deserializeString(ByteBuf b) {
+        short len = b.readShort();
+        byte bytes[] = new byte[len];
+        b.readBytes(bytes, 0, len);
+        return new String(bytes);
+    }
+
+    /** Helper function to serialize a String.
+     *
+     * @param b
+     */
+    private void serializeString(String s, ByteBuf b) {
+        b.writeShort(s.length());
+        b.writeBytes(s.getBytes());
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
@@ -25,7 +25,6 @@ public enum DataType implements ICorfuPayload<DataType> {
     @Getter
     private boolean metadataAware;
 
-
     byte asByte() {
         return (byte) val;
     }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ICorfuPayload.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ICorfuPayload.java
@@ -3,6 +3,7 @@ package org.corfudb.protocols.wireprotocol;
 import com.google.common.collect.*;
 import com.google.common.reflect.TypeToken;
 import io.netty.buffer.ByteBuf;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.util.JSONUtils;
 
@@ -47,6 +48,8 @@ public interface ICorfuPayload<T> {
                 })
                 .put(IMetadata.DataRank.class, x ->
                         new IMetadata.DataRank(x.readLong(), new UUID(x.readLong(), x.readLong())))
+                .put(CheckpointEntry.CheckpointEntryType.class, x ->
+                    CheckpointEntry.CheckpointEntryType.typeMap.get(x.readByte()))
                 .put(UUID.class, x -> new UUID(x.readLong(), x.readLong()))
                 .put(byte[].class, x -> {
                     int length = x.readInt();
@@ -320,6 +323,8 @@ public interface ICorfuPayload<T> {
             buffer.writeLong(rank.getRank());
             buffer.writeLong(rank.getUuid().getMostSignificantBits());
             buffer.writeLong(rank.getUuid().getLeastSignificantBits());
+        } else if (payload instanceof CheckpointEntry.CheckpointEntryType) {
+            buffer.writeByte(((CheckpointEntry.CheckpointEntryType) payload).asByte());
         }
         else {
             throw new RuntimeException("Unknown class " + payload.getClass()

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -1,0 +1,226 @@
+package org.corfudb.runtime;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterators;
+import lombok.Getter;
+import lombok.Setter;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
+import org.corfudb.protocols.logprotocol.MultiSMREntry;
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
+import org.corfudb.runtime.view.StreamsView;
+import org.corfudb.runtime.view.stream.AbstractQueuedStreamView;
+import org.corfudb.runtime.view.stream.BackpointerStreamView;
+import org.corfudb.util.serializer.Serializers;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/** Checkpoint writer for SMRMaps: take a snapshot of the
+ *  object via TXBegin(), then dump the frozen object's
+ *  state into CheckpointEntry records into the object's
+ *  stream.
+ *
+ * TODO: Generalize to all SMR objects.
+ */
+public class CheckpointWriter {
+    /** Metadata to be stored in the CP's 'dict' map.
+     */
+    private UUID streamID;
+    private String author;
+    @Getter
+    private UUID checkpointID;
+    private LocalDateTime startTime;
+    private long startAddress, endAddress;
+    private long numEntries = 0, numBytes = 0;
+    Map<CheckpointEntry.CheckpointDictKey, String> mdKV = new HashMap<>();
+
+    /** Mutator lambda to change map key.  Typically used for
+     *  testing but could also be used for type conversion, etc.
+     */
+    @Getter
+    @Setter
+    Function<Object,Object> keyMutator = (x) -> x;
+
+    /** Mutator lambda to change map value.  Typically used for
+     *  testing but could also be used for type conversion, etc.
+     */
+    @Getter
+    @Setter
+    Function<Object,Object> valueMutator = (x) -> x;
+
+    /** Batch size: number of SMREntry in a single CONTINUATION.
+     */
+    @Getter
+    @Setter
+    private int batchSize = 50;
+
+    /** BiConsumer to run after every CheckpointEntry is appended
+     * to the stream
+     */
+    @Getter
+    @Setter
+    BiConsumer<CheckpointEntry,Long> postAppendFunc = (cp, l) -> {};
+
+    /** Local ref to the object's runtime.
+     */
+    private CorfuRuntime rt;
+
+    /** Local ref to the stream's view.
+     */
+    StreamsView sv;
+
+    /** Local ref to the object that we're dumping.
+     *  TODO: generalize to all SMR objects.
+     */
+    private SMRMap map;
+
+    public CheckpointWriter(CorfuRuntime rt, UUID streamID, String author, SMRMap map) {
+        this.rt = rt;
+        this.streamID = streamID;
+        this.author = author;
+        this.map = map;
+        checkpointID = UUID.randomUUID();
+        sv = rt.getStreamsView();
+    }
+
+    /** Static method for all steps necessary to append checkpoint
+     *  data for an SMRMap into its own stream.  An optimistic
+     *  read-only transaction is used to freeze the contents of
+     *  the map while the checkpoint entries are written to
+     *  the stream.
+     */
+
+    public List<Long> appendCheckpoint() {
+        return appendCheckpoint(cpw -> {});
+    }
+
+    /**
+     * @param setupWriter Lambda to transform the new CheckPointWriter
+     *                    object (e.g., change batch size, etc) prior
+     *                    to use.
+     * @return List of global addresses of all entries for this checkpoint.
+     */
+
+    public List<Long> appendCheckpoint(Consumer<CheckpointWriter> setupWriter) {
+        List<Long> addrs = new ArrayList<>();
+        setupWriter.accept(this);
+
+        rt.getObjectsView().TXBegin();
+        try {
+            addrs.add(startCheckpoint());
+            addrs.addAll(appendObjectState());
+            addrs.add(finishCheckpoint());
+            return addrs;
+        } finally {
+            rt.getObjectsView().TXAbort();
+        }
+    }
+
+    /** Append a checkpoint START record to this object's stream.
+     *
+     *  Corfu client transaction management, if desired, is the
+     *  caller's responsibility.
+     *
+     * @return Global log address of the START record.
+     */
+    public long startCheckpoint() {
+        startTime = LocalDateTime.now();
+        AbstractTransactionalContext context = TransactionalContext.getCurrentContext();
+        long txBeginGlobalAddress = context.getSnapshotTimestamp();
+
+        this.mdKV.put(CheckpointEntry.CheckpointDictKey.START_TIME, startTime.toString());
+        this.mdKV.put(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS, Long.toString(txBeginGlobalAddress));
+
+        ImmutableMap<CheckpointEntry.CheckpointDictKey,String> mdKV = ImmutableMap.copyOf(this.mdKV);
+        CheckpointEntry cp = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.START,
+                author, checkpointID, mdKV, null);
+        startAddress = sv.append(Collections.singleton(streamID), cp, null);
+        postAppendFunc.accept(cp, startAddress);
+        return startAddress;
+    }
+
+    /** Append zero or more CONTINUATION records to this
+     *  object's stream.  Each will contain a fraction of
+     *  the state of the object that we're checkpointing
+     *  (up to batchSize items at a time).
+     *
+     *  Corfu client transaction management, if desired, is the
+     *  caller's responsibility.
+     *
+     *  The Iterators class appears to preserve the laziness
+     *  of Stream processing; we don't wish to use more
+     *  memory than strictly necessary to generate the
+     *  checkpoint.  NOTE: It would be even more useful if
+     *  the map had a lazy iterator: the eagerness of
+     *  map.keySet().stream() is not ideal, but at least
+     *  it should be much smaller than the entire map.
+     *
+     *  NOTE: The postAppendFunc lambda is executed in the
+     *  current thread context, i.e., inside of a Corfu
+     *  transaction, and that transaction will be *aborted*
+     *  at the end of this function.  Any Corfu data
+     *  modifying ops will be undone by the TXAbort().
+     *
+     * @return Stream of global log addresses of the
+     * CONTINUATION records written.
+     */
+    public List<Long> appendObjectState() {
+        ImmutableMap<CheckpointEntry.CheckpointDictKey,String> mdKV = ImmutableMap.copyOf(this.mdKV);
+        List<Long> continuationAddresses = new ArrayList<>();
+
+        Iterators.partition(map.keySet().stream()
+                .map(k -> {
+                    return new SMREntry("put",
+                            new Object[]{keyMutator.apply(k), valueMutator.apply(map.get(k))},
+                            Serializers.JSON);
+                }).iterator(), batchSize)
+                .forEachRemaining(entries -> {
+                    MultiSMREntry smrEntries = new MultiSMREntry();
+                    for (int i = 0; i < ((List) entries).size(); i++) {
+                        smrEntries.addTo((SMREntry) ((List) entries).get(i));
+                    }
+                    CheckpointEntry cp = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.CONTINUATION,
+                            author, checkpointID, mdKV, smrEntries);
+                    long pos = sv.append(Collections.singleton(streamID), cp, null);
+
+                    postAppendFunc.accept(cp, pos);
+                    continuationAddresses.add(pos);
+
+                    numEntries++;
+                    // CheckpointEntry::serialize() has a side-effect we use
+                    // for an accurate count of serialized bytes of SRMEntries.
+                    numBytes += cp.getSmrEntriesBytes();
+                });
+        return continuationAddresses;
+    }
+
+    /** Append a checkpoint END record to this object's stream.
+     *
+     *  Corfu client transaction management, if desired, is the
+     *  caller's responsibility.
+     *
+     * @return Global log address of the END record.
+     */
+
+    public long finishCheckpoint() {
+        LocalDateTime endTime = LocalDateTime.now();
+        mdKV.put(CheckpointEntry.CheckpointDictKey.END_TIME, endTime.toString());
+        numEntries++;
+        numBytes++;
+        mdKV.put(CheckpointEntry.CheckpointDictKey.ENTRY_COUNT, Long.toString(numEntries));
+        mdKV.put(CheckpointEntry.CheckpointDictKey.BYTE_COUNT, Long.toString(numBytes));
+
+        CheckpointEntry cp = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.END,
+                author, checkpointID, mdKV, null);
+        endAddress = sv.append(Collections.singleton(streamID), cp, null);
+
+        postAppendFunc.accept(cp, endAddress);
+        return endAddress;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -521,7 +521,7 @@ public class VersionLockedObject<T> {
                             entry.setUpcallResult(res);
                         }
                         else if (pendingUpcalls.contains(entry.getEntry().getGlobalAddress())) {
-                            log.debug("Sync[{}] Upcall Result {}", entry.getEntry().getGlobalAddress());
+                            log.debug("Sync[{}] Upcall Result {}", this, entry.getEntry().getGlobalAddress());
                             upcallResults.put(entry.getEntry().getGlobalAddress(), res == null ?
                                     NullValue.NULL_VALUE : res);
                             pendingUpcalls.remove(entry.getEntry().getGlobalAddress());

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -27,17 +27,17 @@ import static org.corfudb.runtime.object.transactions.TransactionalContext.getRo
  * access() method. Likewise, if a Corfu object's method is a Mutator or Accessor-Mutator, it invokes the
  * proxy's logUpdate() method.
  *
- * Within transactional context, these methods invoke the transacationalContect accessor/mutator helper.
+ * Within transactional context, these methods invoke the transactionalContext accessor/mutator helper.
  *
  * For example, OptimisticTransactionalContext.access() is responsible for
- * sync'ing the proxy state to the snapshot version, adn then doing the access.
+ * sync'ing the proxy state to the snapshot version, and then doing the access.
  *
  * logUpdate() within transactional context is
  * responsible for updating the write-set.
  *
  * Finally, if a Corfu object's method is an Accessor-Mutator, then although the mutation is delayed,
  * it needs to obtain the result by invoking getUpcallResult() on the optimistic stream.
- * This is similar to the second stage of access(), accept working on the optimistic stream instead of the
+ * This is similar to the second stage of access(), except working on the optimistic stream instead of the
  * underlying stream.
  *
  * Created by mwei on 4/4/16.

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -6,6 +6,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IToken;
@@ -89,7 +90,8 @@ public class AddressSpaceView extends AbstractView {
      */
     public void write(IToken token, Object data)
         throws OverwriteException {
-        final ILogData ld = new LogData(data);
+        final ILogData ld = new LogData(DataType.DATA, data);
+
         layoutHelper(l -> {
             // Check if the token issued is in the same
             // epoch as the layout we are about to write
@@ -105,10 +107,8 @@ public class AddressSpaceView extends AbstractView {
             l.getReplicationMode(token.getTokenValue())
                         .getReplicationProtocol(runtime)
                         .write(l, ld);
-
             return null;
          });
-
 
         // Cache the successful write
         if (!runtime.isCacheDisabled()) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
@@ -277,8 +277,8 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
      * @param data  The entry to use to update the pointer.
      */
     protected void updatePointer(final ILogData data) {
-        // Update the global pointer, if it is data.
-        if (data.getType() == DataType.DATA) {
+        // Update the global pointer, if it is non-checkpoint data.
+        if (data.getType() == DataType.DATA && !data.hasCheckpointMetadata()) {
             getCurrentContext().globalPointer =
                     data.getGlobalAddress();
         }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -49,8 +49,10 @@ public abstract class AbstractQueuedStreamView extends
      * @param globalAddress     The resolved global address.
      */
     protected void addToResolvedQueue(QueuedStreamContext context,
-                                      long globalAddress) {
+                                      long globalAddress,
+                                      ILogData ld) {
         context.resolvedQueue.add(globalAddress);
+        context.resolvedEstBytes += ld.getSizeEstimate();
 
         if (context.maxResolution < globalAddress)
         {
@@ -71,9 +73,17 @@ public abstract class AbstractQueuedStreamView extends
             return null;
         }
 
-        // If the lowest element is greater than maxGlobal, there's nothing
+        // If checkpoint data is available, get from readCpQueue first
+        NavigableSet<Long> getFrom;
+        if (context.readCpQueue.size() > 0) {
+            getFrom = context.readCpQueue;
+        } else {
+            getFrom = context.readQueue;
+        }
+
+        // If the lowest DATA element is greater than maxGlobal, there's nothing
         // to return.
-        if (context.readQueue.first() > maxGlobal) {
+        if (context.readCpQueue.isEmpty() && context.readQueue.first() > maxGlobal) {
             return null;
         }
 
@@ -81,10 +91,13 @@ public abstract class AbstractQueuedStreamView extends
         // The entry may not actually be part of the stream, so we might
         // have to perform several reads.
         while (context.readQueue.size() > 0) {
-            final long thisRead = context.readQueue.pollFirst();
+            final long thisRead = getFrom.pollFirst();
             ILogData ld = read(thisRead);
             if (ld.containsStream(context.id)) {
-                addToResolvedQueue(context, thisRead);
+                // Only add to resolved if ld is from readQueue
+                if (getFrom == context.readQueue) {
+                    addToResolvedQueue(context, thisRead, ld);
+                }
                 return ld;
             }
         }
@@ -103,28 +116,36 @@ public abstract class AbstractQueuedStreamView extends
     @Override
     protected List<ILogData> getNextEntries(QueuedStreamContext context, long maxGlobal,
                                             Function<ILogData, Boolean> contextCheckFn) {
+        NavigableSet<Long> readSet = new TreeSet<>();
+
+        // Scan backward in the stream to find interesting
+        // log records less than or equal to maxGlobal.
+        // Boolean includes both CHECKPOINT & DATA entries.
+        boolean readQueueIsEmpty = !fillReadQueue(maxGlobal, context);
+
         // We always have to fill to the read queue to ensure we read up to
         // max global.
-        if (!fillReadQueue(maxGlobal, context)) {
+        if (readQueueIsEmpty) {
             return Collections.emptyList();
         }
 
-        // If the lowest element is greater than maxGlobal, there's nothing
-        // to return.
-        if (context.readQueue.first() > maxGlobal) {
-            return Collections.emptyList();
+        // If we witnessed a checkpoint during our scan that
+        // we should pay attention to, then start with them.
+        readSet.addAll(context.readCpQueue);
+
+        if (!context.readQueue.isEmpty() && context.readQueue.first() > maxGlobal) {
+            // If the lowest element is greater than maxGlobal, there's nothing
+            // more to return: readSet is ok as-is.
+        } else {
+            // Select everything in the read queue between
+            // the start and maxGlobal
+            readSet.addAll(context.readQueue.headSet(maxGlobal, true));
         }
-
-        // Select everything in the read queue between
-        // the start and maxGlobal
-        NavigableSet<Long> readSet =
-                context.readQueue.headSet(maxGlobal, true);
-
         List<Long> toRead = readSet.stream()
                 .collect(Collectors.toList());
 
         // The list to store read results in
-        List<ILogData> read = readAll(toRead).stream()
+        List<ILogData> readFrom = readAll(toRead).stream()
                 .filter(x -> x.getType() == DataType.DATA)
                 .filter(x -> x.containsStream(context.id))
                 .collect(Collectors.toList());
@@ -132,31 +153,30 @@ public abstract class AbstractQueuedStreamView extends
         // If any entries change the context,
         // don't return anything greater than
         // that entry
-        Optional<ILogData> contextEntry = read.stream()
+        Optional<ILogData> contextEntry = readFrom.stream()
                 .filter(contextCheckFn::apply).findFirst();
         if (contextEntry.isPresent()) {
             log.trace("getNextEntries[{}] context switch @ {}", this, contextEntry.get().getGlobalAddress());
-            int idx = read.indexOf(contextEntry.get());
-            read = read.subList(0, idx + 1);
+            int idx = readFrom.indexOf(contextEntry.get());
+            readFrom = readFrom.subList(0, idx + 1);
+            // NOTE: readSet's clear() changed underlying context.readQueue
             readSet.headSet(contextEntry.get().getGlobalAddress(), true).clear();
         } else {
             // Clear the entries which were read
-            readSet.clear();
+            context.readQueue.headSet(maxGlobal, true).clear();
         }
 
         // Transfer the addresses of the read entries to the resolved queue
-        read.stream()
-                .map(x -> x.getGlobalAddress())
-                .forEach(x -> addToResolvedQueue(context, x));
+        readFrom.stream()
+                .forEach(x -> addToResolvedQueue(context, x.getGlobalAddress(), x));
 
         // Update the global pointer
-        if (read.size() > 0) {
-            context.globalPointer = read.get(read.size() - 1)
+        if (readFrom.size() > 0) {
+            context.globalPointer = readFrom.get(readFrom.size() - 1)
                     .getGlobalAddress();
         }
 
-        // Return the list of entries read.
-        return read;
+        return readFrom;
     }
 
     /**
@@ -317,6 +337,21 @@ public abstract class AbstractQueuedStreamView extends
         final NavigableSet<Long> readQueue
                 = new TreeSet<>();
 
+        /** List of checkpoint records, if a successful checkpoint has been observed.
+         */
+        final NavigableSet<Long> readCpQueue = new TreeSet<>();
+
+        /** Info on checkpoint we used for initial stream replay,
+         *  other checkpoint-related info & stats.  Hodgepodge, clarify.
+         */
+        UUID checkpointSuccessID = null;
+        long checkpointSuccessStartAddr = Address.NEVER_READ;
+        long checkpointSuccessEndAddr = Address.NEVER_READ;
+        long checkpointSuccessNumEntries = 0L;
+        long checkpointSuccessBytes = 0L;
+        // No need to keep track of # of DATA entries, use context.resolvedQueue.size()?
+        long resolvedEstBytes = 0L;
+
         /** Create a new stream context with the given ID and maximum address
          * to read to.
          * @param id                  The ID of the stream to read from
@@ -331,6 +366,7 @@ public abstract class AbstractQueuedStreamView extends
         @Override
         void reset() {
             super.reset();
+            readCpQueue.clear();
             readQueue.clear();
         }
 
@@ -344,7 +380,7 @@ public abstract class AbstractQueuedStreamView extends
             // Update minResolution if necessary
             if (globalAddress >= maxResolution) {
                 log.warn("set min res to {}" , globalAddress);
-                minResolution = globalAddress;
+                minResolution = globalAddress; // TODO SLF wha? minResolution can be greater than maxResolution
             }
             // remove anything in the read queue LESS
             // than global address.

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -1,8 +1,10 @@
 package org.corfudb.runtime.view.stream;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.view.Address;
@@ -160,6 +162,23 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                                  final QueuedStreamContext context) {
         log.trace("Read_Fill_Queue[{}] Max: {}, Current: {}, Resolved: {} - {}", this,
                 maxGlobal, context.globalPointer, context.maxResolution, context.minResolution);
+
+        // considerCheckpoint: Use context.globalPointer as a signal of caller's intent:
+        // if globalPointer == -1, then the caller needs to replay the stream from the
+        // beginning because the caller has never read anything from the stream before.
+        // Thus, it could be a significant time & I/O saving for the client to playback
+        // from the latest checkpoint.
+        // On the other hand, if not -1, then we assume that the caller has already
+        // found the stream head and replayed some/all of it.
+        //
+        // We assume a "typical" case where the client probably needs to discover & replay
+        // just a few log entries, whereas the checkpoint data that this method may discover
+        // may be "huge" ... thus we favor ignoring the checkpoint data.  Such an assumption
+        // may be invalid for very small SMR objects, such as a simple counter, where
+        // checkpoint size would always be small enough to use checkpoint data instead of
+        // continuing backward to find individual updates.
+        boolean considerCheckpoint = context.globalPointer == -1;
+
         // The maximum address we will fill to.
         final long maxAddress =
                 Long.min(maxGlobal, context.maxGlobalAddress);
@@ -231,7 +250,20 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             // If the entry contains this context's stream,
             // we add it to the read queue.
             if (currentEntry.containsStream(context.id)) {
-                context.readQueue.add(currentRead);
+                if (currentEntry.hasCheckpointMetadata()) {
+                    examineCheckpointRecord(context, currentEntry,
+                            considerCheckpoint, currentRead);
+                } else {
+                    context.readQueue.add(currentRead);
+                }
+            }
+
+            // If we've reached the beginning of a successful checkpoint
+            // that the caller wants us to us, then we're done here.
+            if (considerCheckpoint && currentRead <= context.checkpointSuccessStartAddr) {
+                log.trace("Read_Fill_Queue[{}]: currentRead {} checkpointSuccessStartAddr {}",
+                        this, currentRead, context.checkpointSuccessStartAddr);
+                break;
             }
 
             // If everything left is available in the resolved
@@ -268,7 +300,56 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
 
         }
 
+        log.debug("Read_Fill_Queue[{}] Filled CP queue with {}", this, context.readCpQueue);
         log.debug("Read_Fill_Queue[{}] Filled queue with {}", this, context.readQueue);
-        return !context.readQueue.isEmpty();
+        return ! context.readCpQueue.isEmpty() || !context.readQueue.isEmpty();
+    }
+
+    private void examineCheckpointRecord(final QueuedStreamContext context,
+                                         ILogData currentEntry,
+                                         boolean considerCheckpoint, long currentRead) {
+        CheckpointEntry.CheckpointEntryType cpType = currentEntry.getCheckpointType();
+        UUID cpID = currentEntry.getCheckpointID();
+
+        if (context.checkpointSuccessID == null &&
+                cpType == CheckpointEntry.CheckpointEntryType.END) {
+            CheckpointEntry cpEntry = (CheckpointEntry) currentEntry.getPayload(runtime);
+            log.trace("Checkpoint: address {} found END, id {} author {}",
+                    currentRead, cpEntry.getCheckpointID(), cpEntry.getCheckpointAuthorID());
+            if (considerCheckpoint) {
+                context.checkpointSuccessID = cpEntry.getCheckpointID();
+                context.checkpointSuccessNumEntries = 1L;
+                context.checkpointSuccessBytes = (long) currentEntry.getSizeEstimate();
+                context.checkpointSuccessEndAddr = currentRead;
+            }
+        }
+        if (context.checkpointSuccessID != null &&
+                context.checkpointSuccessID.equals(cpID)) {
+            CheckpointEntry cpEntry = (CheckpointEntry) currentEntry.getPayload(runtime);
+            log.trace("Checkpoint: address {} type {} id {} author {}",
+                    currentRead, cpEntry.getCpType(),
+                    cpEntry.getCheckpointID(), cpEntry.getCheckpointAuthorID());
+            if (considerCheckpoint) {
+                context.readCpQueue.add(currentEntry.getGlobalAddress());
+                context.checkpointSuccessNumEntries++;
+                context.checkpointSuccessBytes += cpEntry.getSmrEntriesBytes();
+                if (cpEntry.getCpType().equals(CheckpointEntry.CheckpointEntryType.START)) {
+                    long cpStartAddr;
+                    if (cpEntry.getDict().get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS) != null) {
+                        cpStartAddr = Long.decode(cpEntry.getDict()
+                                .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS));
+                    } else {
+                        cpStartAddr = currentRead;
+                    }
+                    context.checkpointSuccessStartAddr = cpStartAddr;
+                    log.trace("Checkpoint: halt backpointer fill at address {} type {} id {} author {}",
+                            cpStartAddr, cpEntry.getCpType(),
+                            cpEntry.getCheckpointID(), cpEntry.getCheckpointAuthorID());
+                    return;
+                }
+            }
+        } else {
+            log.trace("Checkpoint: skip address {} type {} id {}", currentRead, cpType, cpID);
+        }
     }
 }

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 
+import io.netty.buffer.ByteBuf;
 import jdk.internal.org.objectweb.asm.ClassReader;
 import jdk.internal.org.objectweb.asm.tree.AbstractInsnNode;
 import jdk.internal.org.objectweb.asm.tree.ClassNode;
@@ -218,6 +219,35 @@ public class Utils {
             throw new RuntimeException(ce);
         }
     }
+
+    /**
+     * Hex dump readable contents of ByteBuf to stdout.
+     *
+     * @param b ByteBuf with readable bytes available.
+     */
+    public static void hexdump(ByteBuf b) {
+        byte[] bulk = new byte[b.readableBytes()];
+        int oldReaderIndex = b.readerIndex();
+        b.readBytes(bulk, 0, b.readableBytes() - 1);
+        b.readerIndex(oldReaderIndex);
+        hexdump(bulk);
+    }
+
+    /**
+     * Hex dump contents of byte[] to stdout.
+     *
+     * @param bulk Bytes.
+     */
+    public static void hexdump(byte[] bulk) {
+        if (bulk != null) {
+            System.out.printf("Bulk(%d): ", bulk.length);
+            for (int i = 0; i < bulk.length; i++) {
+                System.out.printf("%x,", bulk[i]);
+            }
+            System.out.printf("\n");
+        }
+    }
+
 
     static long rotl64(long x, int r) {
         return (x << r) | (x >> (64 - r));

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -1,0 +1,420 @@
+package org.corfudb.runtime.checkpoint;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.reflect.TypeToken;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
+import org.corfudb.protocols.logprotocol.MultiSMREntry;
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.runtime.CheckpointWriter;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.object.transactions.TransactionType;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.stream.BackpointerStreamView;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
+/**
+ * Basic smoke tests for checkpoint-in-stream PoC.
+ */
+
+public class CheckpointSmokeTest extends AbstractViewTest {
+
+    public CorfuRuntime r;
+
+    @Before
+    public void setRuntime() throws Exception {
+        // This module *really* needs separate & independent runtimes.
+        r = getDefaultRuntime().connect(); // side-effect of using AbstractViewTest::getRouterFunction
+        r = new CorfuRuntime(getDefaultEndpoint()).connect();
+    }
+
+    /** First smoke test, steps:
+     *
+     * 1. Put a couple of keys into an SMRMap "m"
+     * 2. Write a checkpoint (3 records total) into "m"'s stream.
+     *    The SMREntry records in the checkpoint will *not* match
+     *    the keys written by step #1.
+     * 3. Put a 3rd key into "m".
+     * 4. The current runtime should see all original values of
+     *    the three put() keys.
+     * 5. Open a new runtime and a new map "m2" on the same stream.
+     *    Verify via get() that we cannot see the first two keys,
+     *    we see the snapshot's keys 7 & 8, and we can also see
+     *    key 3.
+     *
+     * This is not correct map behavior: keys shouldn't be lost like
+     * this.  But that's the point: the checkpoint *writer* is guilty
+     * of the bad behavior, and the unit test is looking exactly for
+     * bad behavior to confirm that the checkpoint mechanism is doing
+     * something extremely out-of-the-ordinary.
+     *
+     * @throws Exception
+     */
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+	public void smoke1Test() throws Exception {
+        final String streamName = "mystream";
+        final UUID streamId = CorfuRuntime.getStreamID(streamName);
+        final String key1 = "key1";
+        final long key1Val = 42;
+        final String key2 = "key2";
+        final long key2Val = 4242;
+        final String key3 = "key3";
+        final long key3Val = 4343;
+
+        final String key7 = "key7";
+        final long key7Val = 7777;
+        final String key8 = "key8";
+        final long key8Val = 88;
+        final UUID checkpointId = UUID.randomUUID();
+        final String checkpointAuthor = "Hey, it's me!";
+
+        // Put keys 1 & 2 into m
+        Map<String, Long> m = instantiateMap(streamName);
+        m.put(key1, key1Val);
+        m.put(key2, key2Val);
+
+        // Write our successful checkpoint, 3 records total.
+        writeCheckpointRecords(streamId, checkpointAuthor, checkpointId,
+                new Object[]{new Object[]{key8, key8Val}, new Object[]{key7, key7Val}});
+
+        // Write our 3rd 'real' key, then check all 3 keys + the checkpoint keys
+        m.put(key3, key3Val);
+        assertThat(m.get(key1)).isEqualTo(key1Val);
+        assertThat(m.get(key2)).isEqualTo(key2Val);
+        assertThat(m.get(key3)).isEqualTo(key3Val);
+        assertThat(m.get(key7)).isNull();
+        assertThat(m.get(key8)).isNull();
+
+        // Make a new runtime & map, then look for expected bad behavior
+        setRuntime();
+        Map<String, Long> m2 = instantiateMap(streamName);
+        assertThat(m2.get(key1)).isNull();
+        assertThat(m2.get(key2)).isNull();
+        assertThat(m2.get(key3)).isEqualTo(key3Val);
+        assertThat(m2.get(key7)).isEqualTo(key7Val);
+        assertThat(m2.get(key8)).isEqualTo(key8Val);
+    }
+
+    /** Second smoke test, steps:
+     *
+     * 1. Put a few keys into an SMRMap "m" with prefix keyPrefixFirst.
+     * 2. Write a checkpoint (3 records totoal) into "m"'s stream.
+     *    The SMREntry records in the checkpoint will *not* match
+     *    the keys written by step #1.
+     *    In between the 3 CP records, write some additional keys to "m"
+     *    with prefixes keyPrefixMiddle1 & keyPrefixMiddle2.
+     *    As with the first smoke test, the checkpoint contains fake
+     *    keys & values (key7 and key8).
+     * 3. Put a few keys into an SMRMap "m" with prefix keyPrefixLast
+     * 4. Write an incomplete checkpoint (START and CONTINUATION but
+     *    no END).
+     *
+     * When a new map is instantiated, the keyPrefixFirst keys should
+     * _not_ visible, the fake checkpoint keys should be visible, and
+     * all middle* and last keys should be visible.
+     *
+     * Again, this is not correct map behavior, same as the first
+     * smoke test.  We don't have code yet to generate "real"
+     * checkpoint data; still PoC stage.
+     *
+     * @throws Exception
+     */
+
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+    public void smoke2Test() throws Exception {
+        final String streamName = "mystream2";
+        final UUID streamId = CorfuRuntime.getStreamID(streamName);
+        final UUID checkpointId = UUID.randomUUID();
+        final String checkpointAuthor = "Marty McFly";
+        final String keyPrefixFirst = "first";
+        final String keyPrefixMiddle1 = "middle1";
+        final String keyPrefixMiddle2 = "middle2";
+        final String keyPrefixLast = "last";
+        final int numKeys = 4;
+        final String key7 = "key7";
+        final long key7Val = 7777;
+        final String key8 = "key8";
+        final long key8Val = 88;
+        Consumer<Map<String, Long>> testAssertions = (map) -> {
+            for (int i = 0; i < numKeys; i++) {
+                assertThat(map.get(keyPrefixFirst + Integer.toString(i))).isNull();
+                assertThat(map.get(keyPrefixMiddle1 + Integer.toString(i))).isEqualTo(i);
+                assertThat(map.get(keyPrefixMiddle2 + Integer.toString(i))).isEqualTo(i);
+                assertThat(map.get(keyPrefixLast + Integer.toString(i))).isEqualTo(i);
+            }
+            assertThat(map.get(key7)).isEqualTo(key7Val);
+            assertThat(map.get(key8)).isEqualTo(key8Val);
+        };
+
+        Map<String, Long> m = instantiateMap(streamName);
+        for (int i = 0; i < numKeys; i++) {
+            m.put(keyPrefixFirst + Integer.toString(i), (long) i);
+        }
+
+        writeCheckpointRecords(streamId, checkpointAuthor, checkpointId,
+                new Object[]{new Object[]{key8, key8Val}, new Object[]{key7, key7Val}},
+                () -> { for (int i = 0; i < numKeys; i++) { m.put(keyPrefixMiddle1 + Integer.toString(i), (long) i); } },
+                () -> { for (int i = 0; i < numKeys; i++) { m.put(keyPrefixMiddle2 + Integer.toString(i), (long) i); } },
+                true, true, true);
+        for (int i = 0; i < numKeys; i++) {
+            m.put(keyPrefixLast + Integer.toString(i), (long) i);
+        }
+
+        setRuntime();
+        Map<String, Long> m2 = instantiateMap(streamName);
+        testAssertions.accept(m2);
+
+        // Write incomplete checkpoint (no END record) with key7 and key8 values
+        // different than testAssertions() expects.  The incomplete CP should
+        // be ignored, and the new m3 map should have same values as m2 map.
+        final UUID checkpointId2 = UUID.randomUUID();
+        final String checkpointAuthor2 = "Incomplete 2";
+        writeCheckpointRecords(streamId, checkpointAuthor2, checkpointId2,
+                new Object[]{new Object[]{key8, key8Val*2}, new Object[]{key7, key7Val*2}},
+                () -> {}, () -> {}, true, true, false);
+
+        setRuntime();
+        Map<String, Long> m3 = instantiateMap(streamName);
+        testAssertions.accept(m3);
+    }
+
+    /** Test the CheckpointWriter class, part 1.
+     */
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+    public void checkpointWriterTest() throws Exception {
+        final String streamName = "mystream4";
+        final UUID streamId = CorfuRuntime.getStreamID(streamName);
+        final String keyPrefix = "a-prefix";
+        final int numKeys = 5;
+        final String author = "Me, myself, and I";
+        final Long fudgeFactor = 75L;
+
+        Map<String, Long> m = instantiateMap(streamName);
+        for (int i = 0; i < numKeys; i++) {
+            m.put(keyPrefix + Integer.toString(i), (long) i);
+        }
+
+        /*
+         * Current implementation of a CP's log replay will include
+         * all CP data plus one DATA entry from the last map mutation
+         * plus any other DATA entries that were written concurrently
+         * with the CP.  Later, we check the values of the
+         * keyPrefix keys, and we wish to observe the CHECKPOINT
+         * version of those keys, not DATA.
+         */
+        m.put("just one more", 0L);
+
+        // Set up CP writer.  Add fudgeFactor to all CP data,
+        // also used for assertion checks later.
+        CheckpointWriter cpw = new CheckpointWriter(getRuntime(), streamId, author, (SMRMap) m);
+        cpw.setValueMutator((l) -> (Long) l + fudgeFactor);
+        cpw.setBatchSize(4);
+
+        // Write all CP data.
+        r.getObjectsView().TXBegin();
+        try {
+            long startAddress = cpw.startCheckpoint();
+            List<Long> continuationAddrs = cpw.appendObjectState();
+            long endAddress = cpw.finishCheckpoint();
+
+            // Instantiate new runtime & map.  All map entries (except 'just one more')
+            // should have fudgeFactor added.
+            setRuntime();
+            Map<String, Long> m2 = instantiateMap(streamName);
+            for (int i = 0; i < numKeys; i++) {
+                assertThat(m2.get(keyPrefix + Integer.toString(i))).describedAs("get " + i)
+                        .isEqualTo(i + fudgeFactor);
+            }
+        } finally {
+            r.getObjectsView().TXAbort();
+        }
+    }
+
+    static long middleTracker;
+
+    /** Test the CheckpointWriter class, part 2.  We write data to a
+     *  map before, during/interleaved with, and after a checkpoint
+     *  has been successfully completed.
+     *
+     *  Our sanity criteria: no matter where in the log, we use a
+     *  snapshot transaction to look at the map at that log
+     *  address ... a new map's contents should match exactly the
+     *  'snapshot' maps inside the 'history' that we created while
+     *  we updated the map.
+     *
+     *  The one exception is for snapshot TXN with an address prior
+     *  to the 'startAddress' of the checkpoint; stream history is
+     *  destroyed (logically, not physically) by the CP, so we have
+     *  to use a different position 'history' for our assertion
+     *  check.
+     */
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+    public void checkpointWriterInterleavedTest() throws Exception {
+        final String streamName = "mystream3";
+        final UUID streamId = CorfuRuntime.getStreamID(streamName);
+        final String keyPrefixFirst = "first";
+        final String keyPrefixMiddle = "middle";
+        final String keyPrefixLast = "last";
+        final int numKeys = 3;
+        final String author = "Me, myself, and I";
+        Map<String,Long> snapshot = new HashMap<>();
+        // We assume that we start at global address 0.
+        List<Map<String,Long>> history = new ArrayList<>();
+        // Small DRY helper to avoid history tracking errors
+        BiConsumer<String,Long> saveHist = ((k, v) -> {
+            snapshot.put(k, v);
+            history.add(ImmutableMap.copyOf(snapshot));
+        });
+
+        // Instantiate map and write first keys
+        Map<String, Long> m = instantiateMap(streamName);
+        for (int i = 0; i < numKeys; i++) {
+            String key = keyPrefixFirst + Integer.toString(i);
+            m.put(key, (long) i);
+            saveHist.accept(key, (long) i);
+        }
+
+        // Set up CP writer, with interleaved writes for middle keys
+        middleTracker = -1;
+        CheckpointWriter cpw = new CheckpointWriter(getRuntime(), streamId, author, (SMRMap) m);
+        cpw.setBatchSize(1);
+        cpw.setPostAppendFunc((cp, pos) -> {
+            // No mutation, be we need to add a history snapshot at this START/END location.
+            history.add(ImmutableMap.copyOf(snapshot));
+
+            if (cp.getCpType() == CheckpointEntry.CheckpointEntryType.CONTINUATION) {
+                if (middleTracker < 0) {
+                    middleTracker = 0;
+                }
+                String k = keyPrefixMiddle + Long.toString(middleTracker);
+                // This lambda is executing in a Corfu txn that will be
+                // aborted.  We need a new thread to perform this put.
+                Thread t = new Thread(() -> {
+                    m.put(k, middleTracker);
+                    saveHist.accept(k, middleTracker);
+                });
+                t.start();
+                try { t.join(); } catch (Exception e) { System.err.printf("BAD: exception %s\n", e); }
+                middleTracker++;
+            }
+        });
+
+        // Write all CP data + interleaving middle map updates
+        List<Long> addresses = cpw.appendCheckpoint();
+        long startAddress = addresses.get(0);
+        // Batch size is 1, so there should be 1 CONTINUATION
+        // entry for each of the numKeys put()s that we wrote
+        // for keyPrefixFirst.
+        assertThat(addresses.size()).isEqualTo(numKeys + 2);
+
+        // Write last keys
+        for (int i = 0; i < numKeys; i++) {
+            String key = keyPrefixLast + Integer.toString(i);
+            m.put(key, (long) i);
+            saveHist.accept(key, (long) i);
+        }
+
+        // No matter where we take a snapshot of the log, a new
+        // map using that snapshot should equal our history map.
+        for (int globalAddr = 0; globalAddr < history.size(); globalAddr++) {
+            Map<String,Long> expectedHistory;
+            if (globalAddr <= startAddress) {
+                // Detailed history prior to startAddress is lost.
+                // The CP summary is the only data available.
+                expectedHistory = history.get((int) startAddress);
+            } else {
+                expectedHistory = history.get(globalAddr);
+            }
+
+            // Instantiate new runtime & map @ snapshot of globalAddress
+            setRuntime();
+            Map<String, Long> m2 = instantiateMap(streamName);
+            r.getObjectsView().TXBuild()
+                    .setType(TransactionType.SNAPSHOT)
+                    .setSnapshot(globalAddr)
+                    .begin();
+
+            assertThat(m2.entrySet())
+                    .describedAs("Snapshot at global log address " + globalAddr)
+                    .isEqualTo(expectedHistory.entrySet());
+            r.getObjectsView().TXAbort();
+        }
+    }
+
+    private Map<String, Long> instantiateMap(String streamName) {
+        return r.getObjectsView()
+                .build()
+                .setStreamName(streamName)
+                .setTypeToken(new TypeToken<SMRMap<String, Long>>() {})
+                .open();
+    }
+
+    private void writeCheckpointRecords(UUID streamId, String checkpointAuthor, UUID checkpointId,
+                                        Object[] objects)
+            throws Exception {
+        Runnable l = () -> {};
+        writeCheckpointRecords(streamId, checkpointAuthor, checkpointId, objects,
+                l, l, true, true, true);
+    }
+
+    @SuppressWarnings("checkstyle:magicnumber")
+    private void writeCheckpointRecords(UUID streamId, String checkpointAuthor, UUID checkpointId,
+                                        Object[] objects, Runnable l1, Runnable l2,
+                                        boolean write1, boolean write2, boolean write3)
+            throws Exception {
+        BackpointerStreamView sv = new BackpointerStreamView(r, streamId);
+        Map<CheckpointEntry.CheckpointDictKey, String> mdKV = new HashMap<>();
+        mdKV.put(CheckpointEntry.CheckpointDictKey.START_TIME, "The perfect time");
+
+        // Write cp #1 of 3
+        if (write1) {
+            TokenResponse tokResp1 = r.getSequencerView().nextToken(Collections.singleton(streamId), 0);
+            long addr1 = tokResp1.getToken().getTokenValue();
+            mdKV.put(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS, Long.toString(addr1 + 1));
+            CheckpointEntry cp1 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.START,
+                    checkpointAuthor, checkpointId, mdKV, null);
+            sv.append(cp1, null, null);
+        }
+
+        // Interleaving opportunity #1
+        l1.run();
+
+        // Write cp #2 of 3
+        if (write2) {
+            MultiSMREntry smrEntries = new MultiSMREntry();
+            if (objects != null) {
+                for (int i = 0; i < objects.length; i++) {
+                    smrEntries.addTo(new SMREntry("put", (Object[]) objects[i], Serializers.JSON));
+                }
+            }
+            CheckpointEntry cp2 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.CONTINUATION,
+                    checkpointAuthor, checkpointId, mdKV, smrEntries);
+            sv.append(cp2, null, null);
+        }
+
+        // Interleaving opportunity #2
+        l2.run();
+
+        // Write cp #3 of 3
+        if (write3) {
+            CheckpointEntry cp3 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.END,
+                    checkpointAuthor, checkpointId, mdKV, null);
+            sv.append(cp3, null, null);
+        }
+    }
+
+}


### PR DESCRIPTION
I've eliminated (I hope) the double-serialization, added a wrapper class that writes all checkpoint records for a given stream & SMRMap, updated unit tests, rebased to master (and compensated for the Spliterator refactoring), and fixed all other failing unit tests (which had been disturbed by serialization changes).

API for checkpoint dumping is currently via Java or Clojure.  For Clojure, use the following to set a runtime that connects to `localhost:9000` and uses an SMRMap on top of a stream called `my-stream`.  First, run `bin/shell`, then enter at the prompt:

    (get-runtime "localhost:9000")
    (.connect *r)
    (def my-stream "my-stream")
    (def my-stream-id (uuid-from-string my-stream))
    (def m (.. *r getObjectsView build (setType org.corfudb.runtime.collections.SMRMap) (setStreamName my-stream) open))

If the map is empty, here is a snippet to write 7 keys.
    
    (doseq [x [1 2 3 4 5 6 7]] (.put m (.concat "key" (Integer/toString x)) (+ 42 x)))

Then to checkpoint the map (by writing summary state into the same `my-stream` stream):

    (org.corfudb.runtime.CheckpointWriter/appendCheckpoint *r my-stream-id "Your name here" m)

Squash & rebase of slfritchie/checkpoint-in-stream2 at
commit 1e49965e490cf4dcfc62522a74987432433eb5f8

