### PR TITLE
Percolate additional data during Transaction Abort

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -14,13 +14,21 @@ import java.util.UUID;
 @AllArgsConstructor
 public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
 
+    public static Integer NO_CONFLICT_KEY = Integer.MIN_VALUE;
+
     public TokenResponse(long tokenValue, long epoch, Map<UUID, Long> backpointerMap) {
         respType = TokenType.NORMAL;
+        conflictKey = NO_CONFLICT_KEY;
         token = new Token(tokenValue, epoch);
         this.backpointerMap = backpointerMap;
     }
     /** the cause/type of response */
     final TokenType respType;
+
+    /**
+     * In case there is a conflict, signal to the client which key was responsible for the conflict.
+     */
+    final Integer conflictKey;
 
     /** The current token,
      * or overload with "cause address" in case token request is denied. */
@@ -32,6 +40,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
 
     public TokenResponse(ByteBuf buf) {
         respType = TokenType.values()[ICorfuPayload.fromBuffer(buf, Byte.class)];
+        conflictKey = ICorfuPayload.fromBuffer(buf, Integer.class);
         Long tokenValue = ICorfuPayload.fromBuffer(buf, Long.class);
         Long epoch = ICorfuPayload.fromBuffer(buf, Long.class);
         token = new Token(tokenValue, epoch);
@@ -41,6 +50,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, respType);
+        ICorfuPayload.serialize(buf, conflictKey);
         ICorfuPayload.serialize(buf, token.getTokenValue());
         ICorfuPayload.serialize(buf, token.getEpoch());
         ICorfuPayload.serialize(buf, backpointerMap);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
@@ -12,6 +12,7 @@ import java.util.*;
  * Created by dmalkhi on 12/26/16.
  */
 public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
+
     @Getter
     @Setter
     UUID TXid; // transaction ID, mostly for debugging purposes
@@ -27,21 +28,18 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
     @Getter
     final Map<UUID, Set<Integer>>  writeConflictParams;
 
-    public TxResolutionInfo(UUID TXid, long snapshotTS, Map<UUID, Set<Integer>> conflictMap, Map<UUID, Set<Integer>> writeConflictParams) {
+    public TxResolutionInfo(UUID TXid, long snapshotTS) {
+        this.TXid = TXid;
+        this.snapshotTimestamp = snapshotTS;
+        this.conflictSet = Collections.emptyMap();
+        this.writeConflictParams = Collections.emptyMap();
+    }
+
+    public TxResolutionInfo(UUID TXid, long snapshotTS, Map<UUID, Set<Integer>>
+            conflictMap, Map<UUID, Set<Integer>> writeConflictParams) {
         this.TXid = TXid;
         this.snapshotTimestamp = snapshotTS;
         this.conflictSet = conflictMap;
-        this.writeConflictParams = writeConflictParams;
-    }
-
-
-    public TxResolutionInfo(UUID TXid, long readTS, Set<UUID> streams,  Map<UUID, Set<Integer>> writeConflictParams) {
-        this.TXid = TXid;
-        this.snapshotTimestamp = readTS;
-        ImmutableMap.Builder<UUID, Set<Integer>> conflictMapBuilder = new ImmutableMap.Builder<>();
-        if (streams != null)
-            streams.forEach(streamID -> conflictMapBuilder.put(streamID, new HashSet<>()));
-        conflictSet = conflictMapBuilder.build();
         this.writeConflictParams = writeConflictParams;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -1,24 +1,34 @@
 package org.corfudb.runtime.exceptions;
 
+import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
+
 import lombok.Getter;
 
 /**
  * Created by mwei on 1/11/16.
  */
 public class TransactionAbortedException extends RuntimeException {
-    @Getter
-    long conflictAddress;
 
     @Getter
     AbortCause abortCause;
 
-    public TransactionAbortedException(long conflictAddress, AbortCause abortCause) {
+    @Getter
+    TxResolutionInfo txResolutionInfo;
 
-        super("TX abort. " +
-                "cause=" + abortCause +
-                "; conflict address=" + conflictAddress );
+    @Getter
+    Integer conflictKey;
+
+    public TransactionAbortedException(
+            TxResolutionInfo txResolutionInfo,
+            Integer conflictKey, AbortCause abortCause) {
+        super("TX ABORT " +
+                " | Snapshot Time = " + txResolutionInfo.getSnapshotTimestamp() +
+                " | Transaction ID = " + txResolutionInfo.getTXid() +
+                " | Conflict Key = " + conflictKey +
+                " | Cause = " + abortCause );
+        this.txResolutionInfo = txResolutionInfo;
+        this.conflictKey = conflictKey;
         this.abortCause = abortCause;
-        this.conflictAddress = conflictAddress;
     }
 
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
@@ -125,7 +126,10 @@ public class ObjectsView extends AbstractView {
         if (context == null) {
             log.warn("Attempted to abort a transaction, but no transaction active!");
         } else {
-            context.abortTransaction(new TransactionAbortedException(-1L, AbortCause.USER));
+            TxResolutionInfo txInfo = new TxResolutionInfo(
+                    context.getTransactionID(), context.getSnapshotTimestamp());
+            context.abortTransaction(new TransactionAbortedException(
+                    txInfo, null, AbortCause.USER));
             TransactionalContext.removeContext();
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -101,13 +101,15 @@ public class StreamsView {
             // Is our token a valid type?
             if (tokenResponse.getRespType() == TokenType.TX_ABORT_CONFLICT)
                 throw new TransactionAbortedException(
-                        tokenResponse.getToken().getTokenValue(),
+                        conflictInfo,
+                        tokenResponse.getConflictKey(),
                         AbortCause.CONFLICT
                 );
 
             if (tokenResponse.getRespType() == TokenType.TX_ABORT_NEWSEQ)
                 throw new TransactionAbortedException(
-                        Address.NON_EXIST,
+                        conflictInfo,
+                        tokenResponse.getConflictKey(),
                         AbortCause.NEW_SEQUENCER
                 );
 
@@ -132,8 +134,9 @@ public class StreamsView {
 
                 // We need to fix the token (to use the stream addresses- may
                 // eventually be deprecated since these are no longer used)
-                tokenResponse = new TokenResponse(temp.getRespType(), temp.getToken(),
-                        temp.getBackpointerMap());
+                tokenResponse = new TokenResponse(
+                        temp.getRespType(), tokenResponse.getConflictKey(),
+                        temp.getToken(), temp.getBackpointerMap());
             }
         }
 


### PR DESCRIPTION
Currently it is very difficult for the consumer of CorfuClient to
troubleshoot an aborted transaction since no useful information is
being provided. This patch addresses this by providing additional
information to TransactionAbortedException. Namely two items:

  * TxResolutionInfo: Information that is provided to the Sequencer when
    we ask for a new token.
  * ConflictKey: A key that was part of the conflict set that caused the
    transaction to be aborted.