### PR TITLE
Bind to 127.0.0.1

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -96,7 +96,7 @@ public class CorfuServer {
                     + " -l <path>, --log-path=<path>                                                           Set the path to the storage file for the log unit.\n"
                     + " -s, --single                                                                           Deploy a single-node configuration.\n"
                     + "                                                                                        The server will be bootstrapped with a simple one-unit layout.\n"
-                    + " -a <address>, --address=<address>                                                      IP address to advertise to external clients [default: localhost].\n"
+                    + " -a <address>, --address=<address>                                                      IP address to advertise to external clients [default: 127.0.0.1].\n"
                     + " -m, --memory                                                                           Run the unit in-memory (non-persistent).\n"
                     + "                                                                                        Data will be lost when the server exits!\n"
                     + " -c <ratio>, --cache-heap-ratio=<ratio>                                                 The ratio of jvm max heap size we will use for the the in-memory cache to serve requests from -\n"


### PR DESCRIPTION
When starting a server in single mode without specifying -a option
and a layout file, the server will automatically create a layout
for the localhost. As a consequence, the server will reply with
localhost addresses, this wont work for external clients. This
patch binds to 127.0.0.1 so that external connections cannot
connect to the server and thus it wont be able to reply with
localhost addresses.