### PR TITLE
Scan & Filter for SMRMap Queries

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
@@ -5,6 +5,9 @@ import com.google.common.collect.ImmutableSet;
 import org.corfudb.annotations.CorfuObject;
 import org.corfudb.annotations.TransactionalMethod;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.function.Predicate;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
@@ -60,6 +63,18 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     @Override
     public Collection<V> values() {
         return ImmutableList.copyOf(super.values());
+    }
+
+    /**
+     * Returns a filtered {@link List} view of the values contained in this map.
+     * This method has a memory/CPU advantage over the map iterators as no deep copy
+     * is actually performed. 
+     *
+     * @param p java predicate (function to evaluate)
+     * @return a view of the values contained in this map meeting the predicate condition.   
+     */
+    public List<V> scanAndFilter(Predicate<? super V> p) {
+        return super.values().parallelStream().filter(p).collect(Collectors.toList());
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -61,6 +61,35 @@ public class SMRMapTest extends AbstractViewTest {
 
     @Test
     @SuppressWarnings("unchecked")
+    public void canWriteScanAndFilterToSingle()
+            throws Exception {
+        Map<String, String> corfuInstancesMap = getRuntime()
+                .getObjectsView()
+                .build()
+                .setStreamName("test")
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
+                .open();
+
+        corfuInstancesMap.clear();
+        assertThat(corfuInstancesMap.put("a", "CorfuServer"))
+                .isNull();
+        assertThat(corfuInstancesMap.put("b", "CorfuClient"))
+                .isNull();
+        assertThat(corfuInstancesMap.put("c", "CorfuClient"))
+                .isNull();
+        assertThat(corfuInstancesMap.put("d", "CorfuServer"))
+                .isNull();
+        List<String> corfuServerList = ((SMRMap)corfuInstancesMap).scanAndFilter(p -> p.equals("CorfuServer"));
+
+        assertThat(corfuServerList.size()).isEqualTo(2);
+
+        for(String corfuInstance : corfuServerList) {
+            assertThat(corfuInstance).isEqualTo("CorfuServer");
+        }
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     public void canGetID()
             throws Exception {
         UUID id = UUID.randomUUID();


### PR DESCRIPTION
- Introducing a scanAndFilter method into SMRMap which avoids the cost
  in performance when using iterators for queries over large maps.