### PR TITLE
direct initial implementation

### DIFF
--- a/annotationProcessor/pom.xml
+++ b/annotationProcessor/pom.xml
@@ -11,6 +11,33 @@
 
     <artifactId>annotationProcessor</artifactId>
 
+    <profiles>
+        <profile>
+            <id>windows-profile</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+                <file>
+                    <exists>${JAVA_HOME}/lib/tools.jar</exists>
+                </file>
+            </activation>
+            <properties>
+                <toolsjar>${JAVA_HOME}/lib/tools.jar</toolsjar>
+            </properties>
+        </profile>
+        <profile>
+            <id>mac-profile</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <file>
+                    <exists>${java.home}/../lib/tools.jar</exists>
+                </file>
+            </activation>
+            <properties>
+                <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
+            </properties>
+        </profile>
+    </profiles>
+
     <dependencies>
         <dependency>
             <groupId>org.corfudb</groupId>
@@ -22,7 +49,14 @@
         <dependency>
             <groupId>com.squareup</groupId>
             <artifactId>javapoet</artifactId>
-            <version>1.7.0</version>
+            <version>1.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>jdk.tools</groupId>
+            <artifactId>jdk.tools</artifactId>
+            <version>jdk1.8.0</version>
+            <scope>system</scope>
+            <systemPath>${toolsjar}</systemPath>
         </dependency>
     </dependencies>
 

--- a/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
+++ b/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
@@ -8,14 +8,15 @@ import org.corfudb.runtime.object.*;
 import javax.annotation.processing.*;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.*;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.type.*;
+import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.*;
+import com.sun.tools.javac.code.Type;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -413,6 +414,28 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                                 + e.getMessage());
                     }
 
+                    // also deal with the return type if we came from an interface
+                    Optional<ExecutableElement> oe = ElementFilter.methodsIn(
+                            processingEnv.getTypeUtils().asElement(classElement.getSuperclass()).getEnclosedElements())
+                            .stream()
+                            .filter(e -> e.getSimpleName().toString().equals(smrMethod.getSimpleName().toString()))
+                            .filter(e -> e.getParameters().size() == smrMethod.getParameters().size())
+                            .filter(e -> {
+                                        for (int i = 0; i < e.getParameters().size(); i++) {
+                                            if (!e.getParameters().get(i).asType().equals(
+                                                    smrMethod.getParameters().get(i).asType()
+                                            )) {
+                                                return false;
+                                            }
+                                        }
+                                        return true;
+                                    })
+                            .findAny();
+
+                    if (oe.isPresent()) {
+                        ms.returns(ParameterizedTypeName.get(oe.get().getReturnType()));
+                    }
+
                     // If there is conflict information, calculate the conflict set
                     boolean hasConflictData = false;
                     final String conflictField = "conflictField" + CORFUSMR_FIELD;
@@ -425,6 +448,24 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                     else if (m.hasConflictAnnotations) {
                         hasConflictData = true;
                         addConflictFieldToMethod(ms, conflictField, smrMethod);
+                    }
+
+                    // If wrapping was requested, generate a wrapper class
+                    // Currently, we assume that the return type is an interface
+                    // If it's not an interface we can't yet process anything
+                    boolean isWrapped = false;
+                    try {
+                        if ((accessor != null && accessor.accessWrapReturn() ||
+                                mutatorAccessor != null && mutatorAccessor.accessWrapReturn())) {
+                            String[] deepWrap = accessor != null ? accessor.deepAccessWrap() :
+                                    mutatorAccessor.deepAccessWrap();
+                            generateAccessWrapper(smrMethod, typeSpecBuilder,
+                                    originalName, classElement, Arrays.asList(deepWrap),
+                                    (DeclaredType) smrMethod.getEnclosingElement().asType());
+                            isWrapped = true;
+                        }
+                    } catch (Exception e) {
+                        messager.printMessage(Diagnostic.Kind.ERROR, e.toString());
                     }
 
                     // If a mutator, then log the update.
@@ -504,9 +545,13 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                     else if (mutator == null) {
                         // Otherwise, just force the access to access the underlying call.
                         ms.addStatement((smrMethod.getReturnType().getKind().equals(TypeKind.VOID) ? "" :
-                                        "return ") +"proxy" + CORFUSMR_FIELD + ".access(" +
+                                        "return ") +
+                                        "$Lproxy" + CORFUSMR_FIELD + ".access(" +
                                         "o" + CORFUSMR_FIELD + " -> {$Lo" + CORFUSMR_FIELD + ".$L($L);$L}," +
-                                        "$L)",
+                                        "$L)$L",
+                                (isWrapped ? "new " + ((Type)smrMethod.getReturnType())
+                                        .asElement().getSimpleName() + "$" +
+                                        smrMethod.getSimpleName() + "$Wrapper(" : "" ),
                                 smrMethod.getReturnType().getKind().equals(TypeKind.VOID) ?
                                         "" : "return ",
                                 smrMethod.getSimpleName(),
@@ -516,7 +561,8 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                                 smrMethod.getReturnType().getKind().equals(TypeKind.VOID) ?
                                         "return null;" : "",
                                 (m.hasConflictAnnotations ?
-                                        conflictField : "null")
+                                        conflictField : "null"),
+                                (isWrapped ? ", proxy" + CORFUSMR_FIELD + ")" : "")
                         );
                     }
                     typeSpecBuilder.addMethod(ms.build());
@@ -539,6 +585,100 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                 .build();
 
         javaFile.writeTo(filer);
+    }
+
+    void generateAccessWrapper(ExecutableElement method,
+                               TypeSpec.Builder typeSpecBuilder,
+                               TypeName originalName,
+                               TypeElement classElement, List<String> deepWrap, DeclaredType parentType) {
+        // Get the "fixed version" of the enclosing type.
+        ExecutableType newRetType = (ExecutableType) processingEnv.getTypeUtils()
+                .asMemberOf(parentType, method);
+
+        TypeMirror retType = newRetType.getReturnType();
+        TypeElement element = (TypeElement) ((Type) retType).asElement();
+
+        // Check if it's an interface
+        if (element.getKind() != ElementKind.INTERFACE) {
+            messager.printMessage(Diagnostic.Kind.ERROR,
+                    "Can't process accessWrapReturn for " + method.getSimpleName() +
+                            ", not a interface");
+        }
+
+        // Generate the wrapper class
+        TypeSpec.Builder innerTypeSpec = TypeSpec.classBuilder(
+                element.getSimpleName().toString() + "$"
+                        + method.getSimpleName().toString() + "$Wrapper");
+        ;
+
+
+        // The original field contains the object to be wrapped.
+        innerTypeSpec.addMethod(
+                MethodSpec.constructorBuilder().addParameter(
+                        ParameterSpec.builder(TypeName.get(retType),
+                                "original"
+                        ).build())
+                        .addParameter(ParameterSpec.builder(
+                                ParameterizedTypeName.get(ClassName.get(ICorfuSMRProxy.class),
+                                        originalName)
+                                , "proxy").build())
+                        .addStatement("super($L,$L)",  "original", "proxy")
+                        .build());
+
+
+        innerTypeSpec.addSuperinterface(ParameterizedTypeName.get(retType));
+        innerTypeSpec.superclass(ParameterizedTypeName.get(
+                ClassName.get(CorfuAccessWrapper.class),
+                ParameterizedTypeName.get(retType),
+                ParameterizedTypeName.get(classElement.asType())));
+
+        // Implement each of the calls of the interface by proxying to the
+        // original.
+        for (ExecutableElement e :
+                ElementFilter.methodsIn(element.getEnclosedElements())) {
+            if (e.getModifiers().contains(Modifier.PUBLIC)) {
+                MethodSpec.Builder wrapperMethod =
+                        newRetType.getReturnType() instanceof DeclaredType ?
+                        MethodSpec.overriding(e, (DeclaredType) newRetType.getReturnType(),
+                                processingEnv.getTypeUtils()) : MethodSpec.overriding(e);
+                if (e.getReturnType().getKind() != TypeKind.VOID) {
+                    try {
+                        if (deepWrap.contains(e.getSimpleName().toString())) {
+                            // Need to deep wrap this object
+                            generateAccessWrapper(e, innerTypeSpec, originalName, classElement, deepWrap,
+                                    newRetType.getReturnType() instanceof DeclaredType ?
+                                    (DeclaredType) newRetType.getReturnType() : parentType);
+                            wrapperMethod.addStatement("return new " + ((TypeElement) ((Type) e.getReturnType())
+                                            .asElement()).getSimpleName().toString() + "$$"
+                                            + e.getSimpleName().toString() + "$$Wrapper(" +
+                                            "wrappedAccess((w,p) -> w.$L($L), null), getProxy())",
+                                    e.getSimpleName(),
+                                    e.getParameters().stream()
+                                            .map(x -> x.getSimpleName())
+                                            .collect(Collectors.joining(",")));
+                        } else {
+                            wrapperMethod.addStatement("return wrappedAccess((w,p) -> w.$L($L), null)",
+                                    e.getSimpleName(),
+                                    e.getParameters().stream()
+                                            .map(x -> x.getSimpleName())
+                                            .collect(Collectors.joining(",")));
+                        }
+                    } catch (Exception ex) {
+                        messager.printMessage(Diagnostic.Kind.ERROR, ex.getMessage());
+                    }
+                } else {
+                    wrapperMethod.addStatement(
+                            "wrappedAccess((w,p) -> {$L($L); return null;}, null)",
+                            e.getSimpleName(),
+                            e.getParameters().stream()
+                                    .map(x -> x.getSimpleName())
+                                    .collect(Collectors.joining(",")));
+                }
+                innerTypeSpec.addMethod(wrapperMethod.build());
+            }
+        }
+
+        typeSpecBuilder.addType(innerTypeSpec.build());
     }
 
     /*

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -45,5 +45,17 @@
             </plugin>
         </plugins>
     </build>
+    <dependencies>
+        <dependency>
+            <groupId>org.corfudb</groupId>
+            <artifactId>format</artifactId>
+            <version>0.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.corfudb</groupId>
+            <artifactId>format</artifactId>
+            <version>0.1-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/annotations/src/main/java/org/corfudb/annotations/Accessor.java
+++ b/annotations/src/main/java/org/corfudb/annotations/Accessor.java
@@ -21,4 +21,19 @@ public @interface Accessor {
      */
     String conflictParameterFunction() default "";
 
+    /** Whether to wrap the return in a wrapper which ensures
+     * that accesses occur inside a lock.
+     * @return  True, if the return value should be wrapped,
+     *          False otherwise.
+     */
+    boolean accessWrapReturn() default false;
+
+    /** An array of function names which deep access wrapping should be
+     * enabled on. Deep wrapped functions are only used if accessWrapReturn
+     * is set to true.
+     *
+     * @return  A list of functions in which deep access wrapping will be
+     *          run against.
+     */
+    String[] deepAccessWrap() default {};
 }

--- a/annotations/src/main/java/org/corfudb/annotations/Accessor.java
+++ b/annotations/src/main/java/org/corfudb/annotations/Accessor.java
@@ -36,4 +36,11 @@ public @interface Accessor {
      *          run against.
      */
     String[] deepAccessWrap() default {};
+
+    /** A list of functions to dispatch to perform a direct read.
+     *
+     * @return  A list of functions which direct reads can be
+     *          performed against.
+     */
+    String[] directReadFunctions() default {};
 }

--- a/annotations/src/main/java/org/corfudb/annotations/DirectReadFunction.java
+++ b/annotations/src/main/java/org/corfudb/annotations/DirectReadFunction.java
@@ -1,0 +1,16 @@
+package org.corfudb.annotations;
+
+/** A direct read function supports reading an update from
+ * a single SMREntry, without reading the entire history
+ * of the object.
+ *
+ * Created by mwei on 5/19/17.
+ */
+public @interface DirectReadFunction {
+
+    /** The name of the mutator this direct
+     * read function handles.
+     * @return  The name of the mutator.
+     * */
+    String mutatorName() default "";
+}

--- a/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
+++ b/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
@@ -50,4 +50,20 @@ public @interface MutatorAccessor {
      * @return True, if no upcall should be generated.
      */
     boolean noUpcall() default false;
+
+    /** Whether to wrap the return in a wrapper which ensures
+     * that accesses occur inside a lock.
+     * @return  True, if the return value should be wrapped,
+     *          False otherwise.
+     */
+    boolean accessWrapReturn() default false;
+
+    /** An array of function names which deep access wrapping should be
+     * enabled on. Deep wrapped functions are only used if accessWrapReturn
+     * is set to true.
+     *
+     * @return  A list of functions in which deep access wrapping will be
+     *          run against.
+     */
+    String[] deepAccessWrap() default {};
 }

--- a/annotations/src/main/java/org/corfudb/runtime/object/CorfuAccessWrapper.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/CorfuAccessWrapper.java
@@ -1,0 +1,49 @@
+package org.corfudb.runtime.object;
+
+import lombok.Getter;
+
+import java.util.function.BiFunction;
+
+
+/** This wrapper class forces accesses to go through the proxy,
+ * which synchronizes any accesses to the correct version.
+ *
+ * @param <T>   The type of the object being wrapped.
+ * @param <P>   The type of the proxy being used.
+ * Created by mwei on 5/18/17.
+ */
+public class CorfuAccessWrapper<T, P> {
+
+    /** The object which is being wrapped. */
+    @Getter
+    private final T object;
+
+    /** The proxy to synchronize accesses against. */
+    @Getter
+    private final ICorfuSMRProxy<P> proxy;
+
+    /** Generate a new wrapper.
+     *
+     * @param wrappedObject     The object to wrap.
+     * @param parentProxy             The proxy to use.
+     */
+    public CorfuAccessWrapper(final T wrappedObject,
+                              final ICorfuSMRProxy<P> parentProxy) {
+        this.object = wrappedObject;
+        this.proxy = parentProxy;
+    }
+
+    /** Perform a wrapped access, which executes the given function
+     * under the correct version.
+     * @param wrapFunction      The function to wrap.
+     * @param conflictObjects   The set of conflict objects.
+     * @param <R>               The return type of the wrapFunction.
+     * @return                  The return value calculated by the
+     *                          wrap function.
+     */
+    public <R> R wrappedAccess(final BiFunction<T, P, R> wrapFunction,
+                               final Object[] conflictObjects) {
+        return proxy.access(o -> wrapFunction.apply(object, o),
+                conflictObjects);
+    }
+}

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuAccessWrapper.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuAccessWrapper.java
@@ -34,6 +34,6 @@ public interface ICorfuAccessWrapper<T, P> {
                                final Object[] conflictObjects) {
         return getProxy$CORFUSMR().access(o ->
                         wrapFunction.apply(getObject$CORFUSMR(), o),
-                conflictObjects);
+                conflictObjects, null);
     }
 }

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuAccessWrapper.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuAccessWrapper.java
@@ -1,7 +1,5 @@
 package org.corfudb.runtime.object;
 
-import lombok.Getter;
-
 import java.util.function.BiFunction;
 
 
@@ -12,26 +10,16 @@ import java.util.function.BiFunction;
  * @param <P>   The type of the proxy being used.
  * Created by mwei on 5/18/17.
  */
-public class CorfuAccessWrapper<T, P> {
+public interface ICorfuAccessWrapper<T, P> {
 
-    /** The object which is being wrapped. */
-    @Getter
-    private final T object;
+    /** Get the object which is being wrapped.
+     * @return The object that was wrapped.
+     * */
+    T getObject$CORFUSMR();
 
-    /** The proxy to synchronize accesses against. */
-    @Getter
-    private final ICorfuSMRProxy<P> proxy;
-
-    /** Generate a new wrapper.
-     *
-     * @param wrappedObject     The object to wrap.
-     * @param parentProxy             The proxy to use.
-     */
-    public CorfuAccessWrapper(final T wrappedObject,
-                              final ICorfuSMRProxy<P> parentProxy) {
-        this.object = wrappedObject;
-        this.proxy = parentProxy;
-    }
+    /** Get a proxy to synchronize accesses against.
+     * @return  The proxy this wrapped object came from. */
+    ICorfuSMRProxy<P> getProxy$CORFUSMR();
 
     /** Perform a wrapped access, which executes the given function
      * under the correct version.
@@ -41,9 +29,11 @@ public class CorfuAccessWrapper<T, P> {
      * @return                  The return value calculated by the
      *                          wrap function.
      */
-    public <R> R wrappedAccess(final BiFunction<T, P, R> wrapFunction,
+    default <R> R wrappedAccess$CORFUSMR(
+            final BiFunction<T, P, R> wrapFunction,
                                final Object[] conflictObjects) {
-        return proxy.access(o -> wrapFunction.apply(object, o),
+        return getProxy$CORFUSMR().access(o ->
+                        wrapFunction.apply(getObject$CORFUSMR(), o),
                 conflictObjects);
     }
 }

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
@@ -1,5 +1,8 @@
 package org.corfudb.runtime.object;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 
@@ -13,10 +16,14 @@ public interface ICorfuSMRProxy<T> {
     /** Access the state of the object.
      * @param accessMethod      The method to execute when accessing an object.
      * @param conflictObject    Fine-grained conflict information, if available.
+     * @param directAccessMap   A map of direct access functions, if available.
      * @param <R>               The type to return.
      * @return                  The result of the accessMethod
      */
-    <R> R access(ICorfuSMRAccess<R, T> accessMethod, Object[] conflictObject);
+    <R> R access(@Nonnull ICorfuSMRAccess<R, T> accessMethod,
+                 @Nullable Object[] conflictObject,
+                 @Nullable Map<String, IDirectAccessFunction<R>>
+                         directAccessMap);
 
     /**
      * Record an SMR function to the log before returning.
@@ -30,8 +37,8 @@ public interface ICorfuSMRProxy<T> {
      *
      * @return  The address in the log the SMR function was recorded at.
      */
-    long logUpdate(String smrUpdateFunction, boolean keepUpcallResult,
-                   Object[] conflictObject, Object... args);
+    long logUpdate(@Nonnull String smrUpdateFunction, boolean keepUpcallResult,
+                   @Nullable Object[] conflictObject, Object... args);
 
     /**
      * Return the result of an upcall at the given timestamp.
@@ -41,7 +48,7 @@ public interface ICorfuSMRProxy<T> {
      * @param <R>                   The type of the upcall to return.
      * @return                      The result of the upcall.
      */
-    <R> R getUpcallResult(long timestamp, Object[] conflictObject);
+    <R> R getUpcallResult(long timestamp, @Nullable Object[] conflictObject);
 
     /**
      * Update the proxy to the latest committed version.

--- a/annotations/src/main/java/org/corfudb/runtime/object/IDirectAccessFunction.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/IDirectAccessFunction.java
@@ -1,0 +1,22 @@
+package org.corfudb.runtime.object;
+
+/** Interface for implementing functions which directly
+ *  read.
+ *
+ *  @param <R> The return type of the function.
+ *
+ * Created by mwei on 5/19/17.
+ */
+@FunctionalInterface
+public interface IDirectAccessFunction<R> {
+
+    /** Compute the result for a direct access.
+     *
+     * @param accessArgs    The arguments to the accessor
+     * @param mutatorArgs   The arguments from the mutator
+     * @return              The return value, as if SMR playback
+     *                      were to occur.
+     */
+    R compute(Object[] accessArgs, Object[] mutatorArgs);
+
+}

--- a/format/src/main/java/org/corfudb/format/log/ISMREntry.java
+++ b/format/src/main/java/org/corfudb/format/log/ISMREntry.java
@@ -1,0 +1,15 @@
+package org.corfudb.format.log;
+
+/**
+ * Created by mwei on 5/19/17.
+ */
+public interface ISMREntry {
+
+    /** Return the name of the SMR mutator
+     * this entry applies to the object.
+     *
+     * @return  The name of the mutator to
+     *          apply to the object.
+     */
+    String getSMRMethod();
+}

--- a/format/src/main/java/org/corfudb/format/log/package-info.java
+++ b/format/src/main/java/org/corfudb/format/log/package-info.java
@@ -1,0 +1,6 @@
+/** This package contains formats which
+ *  are persisted into the log.
+ *
+ * Created by mwei on 5/19/17.
+ */
+package org.corfudb.format.log;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
@@ -95,17 +95,6 @@ public class LogEntry implements ICorfuSerializable {
         b.writeByte(type.asByte());
     }
 
-    /**
-     * Returns whether the entry changes the contents of the stream.
-     * For example, an aborted transaction does not change the content of the stream.
-     *
-     * @return True, if the entry changes the contents of the stream,
-     * False otherwise.
-     */
-    public boolean isMutation(UUID stream) {
-        return true;
-    }
-
     @RequiredArgsConstructor
     public enum LogEntryType {
         // Base Messages

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -2,6 +2,7 @@ package org.corfudb.protocols.logprotocol;
 
 import io.netty.buffer.ByteBuf;
 import lombok.*;
+import org.corfudb.format.log.ISMREntry;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
@@ -16,7 +17,7 @@ import java.util.UUID;
  */
 @ToString(callSuper = true)
 @NoArgsConstructor
-public class SMREntry extends LogEntry implements ISMRConsumable {
+public class SMREntry extends LogEntry implements ISMRConsumable, ISMREntry {
 
     /**
      * The name of the SMR method. Note that this is limited to the size of a short.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -1,10 +1,8 @@
 package org.corfudb.runtime.collections;
 
 import com.google.common.collect.ImmutableMap;
-import org.corfudb.annotations.Accessor;
-import org.corfudb.annotations.ConflictParameter;
-import org.corfudb.annotations.Mutator;
-import org.corfudb.annotations.MutatorAccessor;
+import org.corfudb.annotations.*;
+import org.corfudb.format.log.ISMREntry;
 
 import java.util.Collection;
 import java.util.Map;
@@ -61,9 +59,19 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      * Conflicts: this operation conflicts with any operation on the
      * given key.
      */
-    @Accessor
+    @Accessor(directReadFunctions = {"getPutDirectReader"} )
     @Override
     V get(@ConflictParameter Object key);
+
+    @DirectReadFunction(mutatorName = "put")
+    default V getPutDirectReader(Object getKey, Object putKey, V value) {
+        if (getKey.equals(putKey)) {
+            return value;
+        } else {
+            throw new UnsupportedOperationException("Attempted to read " +
+                    "from an entry which doesn't update the same key!");
+        }
+    }
 
     /**
      * {@inheritDoc}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -231,39 +231,30 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
     /**
      * {@inheritDoc}
      *
-     * This function currently does not return a view like the java.util implementation,
-     * and changes to the keySet will *not* be reflected in the map.
-     *
      * Conflicts: This operation currently conflicts with any modification
      * to the map.
      */
-    @Accessor
+    @Accessor(accessWrapReturn = true, deepAccessWrap = {"iterator", "spliterator"})
     @Override
     Set<K> keySet();
 
     /**
      * {@inheritDoc}
      *
-     * This function currently does not return a view like the java.util implementation,
-     * and changes to the values will *not* be reflected in the map.
-     *
      * Conflicts: This operation currently conflicts with any modification
      * to the map.
      */
-    @Accessor
+    @Accessor(accessWrapReturn = true, deepAccessWrap = {"iterator", "spliterator"})
     @Override
     Collection<V> values();
 
     /**
      * {@inheritDoc}
      *
-     * This function currently does not return a view like the java.util implementation,
-     * and changes to the entrySet will *not* be reflected in the map.
-     *
      * Conflicts: This operation currently conflicts with any modification
      * to the map.
      */
-    @Accessor
+    @Accessor(accessWrapReturn = true, deepAccessWrap = {"iterator", "spliterator"})
     @Override
     Set<Entry<K, V>> entrySet();
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRConcurrentMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRConcurrentMap.java
@@ -1,0 +1,294 @@
+package org.corfudb.runtime.collections;
+
+import org.corfudb.annotations.CorfuObject;
+import org.corfudb.annotations.TransactionalMethod;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+
+/**
+ * Created by mwei on 5/19/17.
+ */
+@CorfuObject
+public class SMRConcurrentMap<K,V> extends ConcurrentMapWrapper<K,V>
+        implements ISMRMap<K,V>, Map<K,V> {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod(readOnly = true)
+    public V getOrDefault(Object key, V defaultValue) {
+        V v;
+        return (((v = get(key)) != null) || containsKey(key))
+                ? v
+                : defaultValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod
+    public void forEach(BiConsumer<? super K, ? super V> action) {
+        Objects.requireNonNull(action);
+        for (Map.Entry<K, V> entry : entrySet()) {
+            K k;
+            V v;
+            try {
+                k = entry.getKey();
+                v = entry.getValue();
+            } catch(IllegalStateException ise) {
+                // this usually means the entry is no longer in the map.
+                throw new ConcurrentModificationException(ise);
+            }
+            action.accept(k, v);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod
+    public void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {
+        Objects.requireNonNull(function);
+        for (Map.Entry<K, V> entry : entrySet()) {
+            K k;
+            V v;
+            try {
+                k = entry.getKey();
+                v = entry.getValue();
+            } catch(IllegalStateException ise) {
+                // this usually means the entry is no longer in the map.
+                throw new ConcurrentModificationException(ise);
+            }
+
+            // ise thrown from function is not a cme.
+            v = function.apply(k, v);
+
+            try {
+                entry.setValue(v);
+            } catch(IllegalStateException ise) {
+                // this usually means the entry is no longer in the map.
+                throw new ConcurrentModificationException(ise);
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod
+    public V putIfAbsent(K key, V value) {
+        V v = get(key);
+        if (v == null) {
+            v = put(key, value);
+        }
+
+        return v;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod
+    public boolean remove(Object key, Object value) {
+        Object curValue = get(key);
+        if (!Objects.equals(curValue, value) ||
+                (curValue == null && !containsKey(key))) {
+            return false;
+        }
+        remove(key);
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod
+    public boolean replace(K key, V oldValue, V newValue) {
+        Object curValue = get(key);
+        if (!Objects.equals(curValue, oldValue) ||
+                (curValue == null && !containsKey(key))) {
+            return false;
+        }
+        put(key, newValue);
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod
+    public V replace(K key, V value) {
+        V curValue;
+        if (((curValue = get(key)) != null) || containsKey(key)) {
+            curValue = put(key, value);
+        }
+        return curValue;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod
+    public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+
+        Objects.requireNonNull(mappingFunction);
+        V v;
+        if ((v = get(key)) == null) {
+            V newValue;
+            if ((newValue = mappingFunction.apply(key)) != null) {
+                put(key, newValue);
+                return newValue;
+            }
+        }
+
+        return v;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod
+    public V computeIfPresent(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+        Objects.requireNonNull(remappingFunction);
+        V oldValue;
+        if ((oldValue = get(key)) != null) {
+            V newValue = remappingFunction.apply(key, oldValue);
+            if (newValue != null) {
+                put(key, newValue);
+                return newValue;
+            } else {
+                remove(key);
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod
+    public V compute(K key, BiFunction<? super K, ? super V, ? extends V> remappingFunction) {
+
+        Objects.requireNonNull(remappingFunction);
+        V oldValue = get(key);
+
+        V newValue = remappingFunction.apply(key, oldValue);
+
+        if (newValue == null) {
+            // delete mapping
+            if (oldValue != null || containsKey(key)) {
+                // something to remove
+                remove(key);
+                return null;
+            } else {
+                // nothing to do. Leave things as they were.
+                return null;
+            }
+        } else {
+            // add or replace old mapping
+            put(key, newValue);
+            return newValue;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @TransactionalMethod
+    public V merge(K key, V value, BiFunction<? super V, ? super V, ? extends V> remappingFunction) {
+        Objects.requireNonNull(remappingFunction);
+        Objects.requireNonNull(value);
+        V oldValue = get(key);
+        V newValue = (oldValue == null) ? value :
+                remappingFunction.apply(oldValue, value);
+        if(newValue == null) {
+            remove(key);
+        } else {
+            put(key, newValue);
+        }
+        return newValue;
+    }
+}
+
+
+// TODO: Automatically generate this wrapper.
+class ConcurrentMapWrapper<K,V> implements Map<K,V> {
+    final ConcurrentHashMap<K,V> map = new ConcurrentHashMap<>();
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+        return map.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+        return map.get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+        return map.put(key, value);
+    }
+
+    @Override
+    public V remove(Object key) {
+        return map.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+        map.putAll(m);
+    }
+
+    @Override
+    public void clear() {
+        map.clear();
+    }
+
+    @Override
+    public Set<K> keySet() {
+        return map.keySet();
+    }
+
+    @Override
+    public Collection<V> values() {
+        return map.values();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return map.entrySet();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRConcurrentMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRConcurrentMap.java
@@ -10,12 +10,16 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 
-/**
+/** This is a concurrent SMR map implementation which does not
+ * throw a ConcurrentModificationException during iteration
+ * and traversal of entrySet, keySet or values.
+ *
  * Created by mwei on 5/19/17.
  */
 @CorfuObject
 public class SMRConcurrentMap<K,V> extends ConcurrentMapWrapper<K,V>
         implements ISMRMap<K,V>, Map<K,V> {
+
     /**
      * {@inheritDoc}
      */

--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
@@ -1,17 +1,12 @@
 package org.corfudb.runtime.collections;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import org.corfudb.annotations.CorfuObject;
 import org.corfudb.annotations.TransactionalMethod;
 
-import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
-import java.util.concurrent.ConcurrentMap;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
@@ -23,85 +23,7 @@ import java.util.function.Function;
 public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
 
     /**
-     * Returns a {@link Set} view of the keys contained in this map.
-     * The set is backed by the map, so changes to the map are
-     * reflected in the set, and vice-versa.  If the map is modified
-     * while an iteration over the set is in progress (except through
-     * the iterator's own <tt>remove</tt> operation), the results of
-     * the iteration are undefined.  The set supports element removal,
-     * which removes the corresponding mapping from the map, via the
-     * <tt>Iterator.remove</tt>, <tt>Set.remove</tt>,
-     * <tt>removeAll</tt>, <tt>retainAll</tt>, and <tt>clear</tt>
-     * operations.  It does not support the <tt>add</tt> or <tt>addAll</tt>
-     * operations.
-     *
-     * @return a set view of the keys contained in this map
-     */
-    @Override
-    public Set<K> keySet() {
-        return ImmutableSet.copyOf(super.keySet());
-    }
-
-    /**
-     * Returns a {@link Collection} view of the values contained in this map.
-     * The collection is backed by the map, so changes to the map are
-     * reflected in the collection, and vice-versa.  If the map is
-     * modified while an iteration over the collection is in progress
-     * (except through the iterator's own <tt>remove</tt> operation),
-     * the results of the iteration are undefined.  The collection
-     * supports element removal, which removes the corresponding
-     * mapping from the map, via the <tt>Iterator.remove</tt>,
-     * <tt>Collection.remove</tt>, <tt>removeAll</tt>,
-     * <tt>retainAll</tt> and <tt>clear</tt> operations.  It does not
-     * support the <tt>add</tt> or <tt>addAll</tt> operations.
-     *
-     * @return a view of the values contained in this map
-     */
-    @Override
-    public Collection<V> values() {
-        return ImmutableList.copyOf(super.values());
-    }
-
-    /**
-     * Returns a {@link Set} view of the mappings contained in this map.
-     * The set is backed by the map, so changes to the map are
-     * reflected in the set, and vice-versa.  If the map is modified
-     * while an iteration over the set is in progress (except through
-     * the iterator's own <tt>remove</tt> operation, or through the
-     * <tt>setValue</tt> operation on a map entry returned by the
-     * iterator) the results of the iteration are undefined.  The set
-     * supports element removal, which removes the corresponding
-     * mapping from the map, via the <tt>Iterator.remove</tt>,
-     * <tt>Set.remove</tt>, <tt>removeAll</tt>, <tt>retainAll</tt> and
-     * <tt>clear</tt> operations.  It does not support the
-     * <tt>add</tt> or <tt>addAll</tt> operations.
-     *
-     * @return a set view of the mappings contained in this map
-     */
-    @Override
-    public Set<Entry<K, V>> entrySet() {
-        return ImmutableSet.copyOf(super.entrySet());
-    }
-
-    /**
-     * Returns the value to which the specified key is mapped, or
-     * {@code defaultValue} if this map contains no mapping for the key.
-     *
-     * @param key          the key whose associated value is to be returned
-     * @param defaultValue the default mapping of the key
-     * @return the value to which the specified key is mapped, or
-     * {@code defaultValue} if this map contains no mapping for the key
-     * @throws ClassCastException   if the key is of an inappropriate type for
-     *                              this map
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException if the specified key is null and this map
-     *                              does not permit null keys
-     *                              (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @implSpec The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod(readOnly = true)
@@ -113,27 +35,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     }
 
     /**
-     * Performs the given action for each entry in this map until all entries
-     * have been processed or the action throws an exception.   Unless
-     * otherwise specified by the implementing class, actions are performed in
-     * the order of entry set iteration (if an iteration order is specified.)
-     * Exceptions thrown by the action are relayed to the caller.
-     *
-     * @param action The action to be performed for each entry
-     * @throws NullPointerException            if the specified action is null
-     * @throws ConcurrentModificationException if an entry is found to be
-     *                                         removed during iteration
-     * @implSpec The default implementation is equivalent to, for this {@code map}:
-     * <pre> {@code
-     * for (Map.Entry<K, V> entry : map.entrySet())
-     *     action.accept(entry.getKey(), entry.getValue());
-     * }</pre>
-     * <p>
-     * The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod
@@ -154,41 +56,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     }
 
     /**
-     * Replaces each entry's value with the result of invoking the given
-     * function on that entry until all entries have been processed or the
-     * function throws an exception.  Exceptions thrown by the function are
-     * relayed to the caller.
-     *
-     * @param function the function to apply to each entry
-     * @throws UnsupportedOperationException   if the {@code set} operation
-     *                                         is not supported by this map's entry set iterator.
-     * @throws ClassCastException              if the class of a replacement value
-     *                                         prevents it from being stored in this map
-     * @throws NullPointerException            if the specified function is null, or the
-     *                                         specified replacement value is null, and this map does not permit null
-     *                                         values
-     * @throws ClassCastException              if a replacement value is of an inappropriate
-     *                                         type for this map
-     *                                         (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException            if function or a replacement value is null,
-     *                                         and this map does not permit null keys or values
-     *                                         (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws IllegalArgumentException        if some property of a replacement value
-     *                                         prevents it from being stored in this map
-     *                                         (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws ConcurrentModificationException if an entry is found to be
-     *                                         removed during iteration
-     * @implSpec <p>The default implementation is equivalent to, for this {@code map}:
-     * <pre> {@code
-     * for (Map.Entry<K, V> entry : map.entrySet())
-     *     entry.setValue(function.apply(entry.getKey(), entry.getValue()));
-     * }</pre>
-     * <p>
-     * <p>The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod
@@ -218,45 +86,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     }
 
     /**
-     * If the specified key is not already associated with a value (or is mapped
-     * to {@code null}) associates it with the given value and returns
-     * {@code null}, else returns the current value.
-     *
-     * @param key   key with which the specified value is to be associated
-     * @param value value to be associated with the specified key
-     * @return the previous value associated with the specified key, or
-     * {@code null} if there was no mapping for the key.
-     * (A {@code null} return can also indicate that the map
-     * previously associated {@code null} with the key,
-     * if the implementation supports null values.)
-     * @throws UnsupportedOperationException if the {@code put} operation
-     *                                       is not supported by this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws ClassCastException            if the key or value is of an inappropriate
-     *                                       type for this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException          if the specified key or value is null,
-     *                                       and this map does not permit null keys or values
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws IllegalArgumentException      if some property of the specified key
-     *                                       or value prevents it from being stored in this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @implSpec The default implementation is equivalent to, for this {@code
-     * map}:
-     * <p>
-     * <pre> {@code
-     * V v = map.get(key);
-     * if (v == null)
-     *     v = map.put(key, value);
-     *
-     * return v;
-     * }</pre>
-     * <p>
-     * <p>The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod
@@ -270,36 +100,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     }
 
     /**
-     * Removes the entry for the specified key only if it is currently
-     * mapped to the specified value.
-     *
-     * @param key   key with which the specified value is associated
-     * @param value value expected to be associated with the specified key
-     * @return {@code true} if the value was removed
-     * @throws UnsupportedOperationException if the {@code remove} operation
-     *                                       is not supported by this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws ClassCastException            if the key or value is of an inappropriate
-     *                                       type for this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException          if the specified key or value is null,
-     *                                       and this map does not permit null keys or values
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @implSpec The default implementation is equivalent to, for this {@code map}:
-     * <p>
-     * <pre> {@code
-     * if (map.containsKey(key) && Objects.equals(map.get(key), value)) {
-     *     map.remove(key);
-     *     return true;
-     * } else
-     *     return false;
-     * }</pre>
-     * <p>
-     * <p>The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod
@@ -314,44 +115,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     }
 
     /**
-     * Replaces the entry for the specified key only if currently
-     * mapped to the specified value.
-     *
-     * @param key      key with which the specified value is associated
-     * @param oldValue value expected to be associated with the specified key
-     * @param newValue value to be associated with the specified key
-     * @return {@code true} if the value was replaced
-     * @throws UnsupportedOperationException if the {@code put} operation
-     *                                       is not supported by this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws ClassCastException            if the class of a specified key or value
-     *                                       prevents it from being stored in this map
-     * @throws NullPointerException          if a specified key or newValue is null,
-     *                                       and this map does not permit null keys or values
-     * @throws NullPointerException          if oldValue is null and this map does not
-     *                                       permit null values
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws IllegalArgumentException      if some property of a specified key
-     *                                       or value prevents it from being stored in this map
-     * @implSpec The default implementation is equivalent to, for this {@code map}:
-     * <p>
-     * <pre> {@code
-     * if (map.containsKey(key) && Objects.equals(map.get(key), value)) {
-     *     map.put(key, newValue);
-     *     return true;
-     * } else
-     *     return false;
-     * }</pre>
-     * <p>
-     * The default implementation does not throw NullPointerException
-     * for maps that do not support null values if oldValue is null unless
-     * newValue is also null.
-     * <p>
-     * <p>The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod
@@ -366,40 +130,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     }
 
     /**
-     * Replaces the entry for the specified key only if it is
-     * currently mapped to some value.
-     *
-     * @param key   key with which the specified value is associated
-     * @param value value to be associated with the specified key
-     * @return the previous value associated with the specified key, or
-     * {@code null} if there was no mapping for the key.
-     * (A {@code null} return can also indicate that the map
-     * previously associated {@code null} with the key,
-     * if the implementation supports null values.)
-     * @throws UnsupportedOperationException if the {@code put} operation
-     *                                       is not supported by this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws ClassCastException            if the class of the specified key or value
-     *                                       prevents it from being stored in this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException          if the specified key or value is null,
-     *                                       and this map does not permit null keys or values
-     * @throws IllegalArgumentException      if some property of the specified key
-     *                                       or value prevents it from being stored in this map
-     * @implSpec The default implementation is equivalent to, for this {@code map}:
-     * <p>
-     * <pre> {@code
-     * if (map.containsKey(key)) {
-     *     return map.put(key, value);
-     * } else
-     *     return null;
-     * }</pre>
-     * <p>
-     * <p>The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod
@@ -412,60 +143,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     }
 
     /**
-     * If the specified key is not already associated with a value (or is mapped
-     * to {@code null}), attempts to compute its value using the given mapping
-     * function and enters it into this map unless {@code null}.
-     * <p>
-     * <p>If the function returns {@code null} no mapping is recorded. If
-     * the function itself throws an (unchecked) exception, the
-     * exception is rethrown, and no mapping is recorded.  The most
-     * common usage is to construct a new object serving as an initial
-     * mapped value or memoized result, as in:
-     * <p>
-     * <pre> {@code
-     * map.computeIfAbsent(key, k -> new Value(f(k)));
-     * }</pre>
-     * <p>
-     * <p>Or to implement a multi-value map, {@code Map<K,Collection<V>>},
-     * supporting multiple values per key:
-     * <p>
-     * <pre> {@code
-     * map.computeIfAbsent(key, k -> new HashSet<V>()).add(v);
-     * }</pre>
-     *
-     * @param key             key with which the specified value is to be associated
-     * @param mappingFunction the function to compute a value
-     * @return the current (existing or computed) value associated with
-     * the specified key, or null if the computed value is null
-     * @throws NullPointerException          if the specified key is null and
-     *                                       this map does not support null keys, or the mappingFunction
-     *                                       is null
-     * @throws UnsupportedOperationException if the {@code put} operation
-     *                                       is not supported by this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws ClassCastException            if the class of the specified key or value
-     *                                       prevents it from being stored in this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @implSpec The default implementation is equivalent to the following steps for this
-     * {@code map}, then returning the current value or {@code null} if now
-     * absent:
-     * <p>
-     * <pre> {@code
-     * if (map.get(key) == null) {
-     *     V newValue = mappingFunction.apply(key);
-     *     if (newValue != null)
-     *         map.put(key, newValue);
-     * }
-     * }</pre>
-     * <p>
-     * <p>The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties. In particular, all implementations of
-     * subinterface {@link ConcurrentMap} must document
-     * whether the function is applied once atomically only if the value is not
-     * present.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod
@@ -485,48 +163,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     }
 
     /**
-     * If the value for the specified key is present and non-null, attempts to
-     * compute a new mapping given the key and its current mapped value.
-     * <p>
-     * <p>If the function returns {@code null}, the mapping is removed.  If the
-     * function itself throws an (unchecked) exception, the exception is
-     * rethrown, and the current mapping is left unchanged.
-     *
-     * @param key               key with which the specified value is to be associated
-     * @param remappingFunction the function to compute a value
-     * @return the new value associated with the specified key, or null if none
-     * @throws NullPointerException          if the specified key is null and
-     *                                       this map does not support null keys, or the
-     *                                       remappingFunction is null
-     * @throws UnsupportedOperationException if the {@code put} operation
-     *                                       is not supported by this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws ClassCastException            if the class of the specified key or value
-     *                                       prevents it from being stored in this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @implSpec The default implementation is equivalent to performing the following
-     * steps for this {@code map}, then returning the current value or
-     * {@code null} if now absent:
-     * <p>
-     * <pre> {@code
-     * if (map.get(key) != null) {
-     *     V oldValue = map.get(key);
-     *     V newValue = remappingFunction.apply(key, oldValue);
-     *     if (newValue != null)
-     *         map.put(key, newValue);
-     *     else
-     *         map.remove(key);
-     * }
-     * }</pre>
-     * <p>
-     * <p>The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties. In particular, all implementations of
-     * subinterface {@link ConcurrentMap} must document
-     * whether the function is applied once atomically only if the value is not
-     * present.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod
@@ -548,60 +185,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     }
 
     /**
-     * Attempts to compute a mapping for the specified key and its current
-     * mapped value (or {@code null} if there is no current mapping). For
-     * example, to either create or append a {@code String} msg to a value
-     * mapping:
-     * <p>
-     * <pre> {@code
-     * map.compute(key, (k, v) -> (v == null) ? msg : v.concat(msg))}</pre>
-     * (Method {@link #merge merge()} is often simpler to use for such purposes.)
-     * <p>
-     * <p>If the function returns {@code null}, the mapping is removed (or
-     * remains absent if initially absent).  If the function itself throws an
-     * (unchecked) exception, the exception is rethrown, and the current mapping
-     * is left unchanged.
-     *
-     * @param key               key with which the specified value is to be associated
-     * @param remappingFunction the function to compute a value
-     * @return the new value associated with the specified key, or null if none
-     * @throws NullPointerException          if the specified key is null and
-     *                                       this map does not support null keys, or the
-     *                                       remappingFunction is null
-     * @throws UnsupportedOperationException if the {@code put} operation
-     *                                       is not supported by this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws ClassCastException            if the class of the specified key or value
-     *                                       prevents it from being stored in this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @implSpec The default implementation is equivalent to performing the following
-     * steps for this {@code map}, then returning the current value or
-     * {@code null} if absent:
-     * <p>
-     * <pre> {@code
-     * V oldValue = map.get(key);
-     * V newValue = remappingFunction.apply(key, oldValue);
-     * if (oldValue != null ) {
-     *    if (newValue != null)
-     *       map.put(key, newValue);
-     *    else
-     *       map.remove(key);
-     * } else {
-     *    if (newValue != null)
-     *       map.put(key, newValue);
-     *    else
-     *       return null;
-     * }
-     * }</pre>
-     * <p>
-     * <p>The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties. In particular, all implementations of
-     * subinterface {@link ConcurrentMap} must document
-     * whether the function is applied once atomically only if the value is not
-     * present.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod
@@ -630,60 +214,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     }
 
     /**
-     * If the specified key is not already associated with a value or is
-     * associated with null, associates it with the given non-null value.
-     * Otherwise, replaces the associated value with the results of the given
-     * remapping function, or removes if the result is {@code null}. This
-     * method may be of use when combining multiple mapped values for a key.
-     * For example, to either create or append a {@code String msg} to a
-     * value mapping:
-     * <p>
-     * <pre> {@code
-     * map.merge(key, msg, String::concat)
-     * }</pre>
-     * <p>
-     * <p>If the function returns {@code null} the mapping is removed.  If the
-     * function itself throws an (unchecked) exception, the exception is
-     * rethrown, and the current mapping is left unchanged.
-     *
-     * @param key               key with which the resulting value is to be associated
-     * @param value             the non-null value to be merged with the existing value
-     *                          associated with the key or, if no existing value or a null value
-     *                          is associated with the key, to be associated with the key
-     * @param remappingFunction the function to recompute a value if present
-     * @return the new value associated with the specified key, or null if no
-     * value is associated with the key
-     * @throws UnsupportedOperationException if the {@code put} operation
-     *                                       is not supported by this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws ClassCastException            if the class of the specified key or value
-     *                                       prevents it from being stored in this map
-     *                                       (<a href="{@docRoot}/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException          if the specified key is null and this map
-     *                                       does not support null keys or the value or remappingFunction is
-     *                                       null
-     * @implSpec The default implementation is equivalent to performing the following
-     * steps for this {@code map}, then returning the current value or
-     * {@code null} if absent:
-     * <p>
-     * <pre> {@code
-     * V oldValue = map.get(key);
-     * V newValue = (oldValue == null) ? value :
-     *              remappingFunction.apply(oldValue, value);
-     * if (newValue == null)
-     *     map.remove(key);
-     * else
-     *     map.put(key, newValue);
-     * }</pre>
-     * <p>
-     * <p>The default implementation makes no guarantees about synchronization
-     * or atomicity properties of this method. Any implementation providing
-     * atomicity guarantees must override this method and document its
-     * concurrency properties. In particular, all implementations of
-     * subinterface {@link ConcurrentMap} must document
-     * whether the function is applied once atomically only if the value is not
-     * present.
-     * @since 1.8
+     * {@inheritDoc}
      */
     @Override
     @TransactionalMethod

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -112,18 +112,21 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
      */
     @Override
     public <R> R access(ICorfuSMRAccess<R, T> accessMethod,
-                        Object[] conflictObject) {
+                        Object[] conflictObject,
+                        Map<String, IDirectAccessFunction<R>> directAccessFunctionMap) {
         boolean isEnabled = MetricsUtils.isMetricsCollectionEnabled();
         try (Timer.Context context = MetricsUtils.getConditionalContext(isEnabled, timerAccess)){
-            return accessInner(accessMethod, conflictObject, isEnabled);
+            return accessInner(accessMethod, conflictObject, directAccessFunctionMap, isEnabled);
         }
     }
 
     private <R> R accessInner(ICorfuSMRAccess<R, T> accessMethod,
-                              Object[] conflictObject, boolean isMetricsEnabled) {
+                              Object[] conflictObject,
+                              Map<String, IDirectAccessFunction<R>> directAccessFunctionMap,
+                              boolean isMetricsEnabled) {
         if (TransactionalContext.isInTransaction()) {
             return TransactionalContext.getCurrentContext()
-                    .access(this, accessMethod, conflictObject);
+                    .access(this, accessMethod, conflictObject, directAccessFunctionMap);
         }
 
         // Linearize this read against a timestamp

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -138,7 +138,8 @@ public abstract class AbstractTransactionalContext implements
      */
     abstract public <R,T> R access(ICorfuSMRProxyInternal<T> proxy,
                                    ICorfuSMRAccess<R,T> accessFunction,
-                                   Object[] conflictObject);
+                                   Object[] conflictObject,
+                                   Map<String, IDirectAccessFunction<R>> directAccessFunctionMap);
 
     /** Get the result of an upcall.
      *

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -9,6 +9,7 @@ import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.ICorfuSMRAccess;
 import org.corfudb.runtime.object.ICorfuSMRProxyInternal;
+import org.corfudb.runtime.object.IDirectAccessFunction;
 import org.corfudb.runtime.object.VersionLockedObject;
 
 import java.util.*;
@@ -74,7 +75,8 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
     @Override
     public <R, T> R access(ICorfuSMRProxyInternal<T> proxy,
                            ICorfuSMRAccess<R, T> accessFunction,
-                           Object[] conflictObject) {
+                           Object[] conflictObject,
+                           Map<String, IDirectAccessFunction<R>> directAccessFunctionMap) {
         log.debug("Access[{},{}] conflictObj={}", this, proxy, conflictObject);
         // First, we add this access to the read set
         addToReadSet(proxy, conflictObject);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.object.ICorfuSMRAccess;
 import org.corfudb.runtime.object.ICorfuSMRProxyInternal;
+import org.corfudb.runtime.object.IDirectAccessFunction;
 
 import java.util.*;
 
@@ -35,7 +36,8 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
     @Override
     public <R, T> R access(ICorfuSMRProxyInternal<T> proxy,
                            ICorfuSMRAccess<R, T> accessFunction,
-                           Object[] conflictObject) {
+                           Object[] conflictObject,
+                           Map<String, IDirectAccessFunction<R>> directAccessFunctionMap) {
 
         // In snapshot transactions, there are no conflicts.
         // Hence, we do not need to add this access to a conflict set

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRConcurrentMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRConcurrentMapTest.java
@@ -1,0 +1,60 @@
+package org.corfudb.runtime.collections;
+
+import com.google.common.reflect.TypeToken;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.junit.Test;
+
+import java.util.ConcurrentModificationException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Created by mwei on 5/19/17.
+ */
+public class SMRConcurrentMapTest extends AbstractViewTest {
+
+    @Test
+    public void concurrentModificationThrowsException() {
+        Map<String, String> map = getDefaultRuntime().getObjectsView()
+                .build()
+                .setTypeToken(new TypeToken<SMRConcurrentMap<String, String>>() {})
+                .setStreamName("test")
+                .open();
+
+        // Add some elements to the map
+        t1(() -> map.put("a", "a"));
+        t1(() -> map.put("b", "b"));
+        t1(() -> map.put("c", "c"));
+        t1(() -> map.put("d", "d"));
+        t1(() -> map.put("e", "e"));
+        t1(() -> map.put("f", "f"));
+
+        // Obtain a keyset and it's iterator
+        final AtomicReference<Set<String>> keySet =
+                new AtomicReference<>();
+        final AtomicReference<Iterator<String>> keyIterator =
+                new AtomicReference<>();
+        t1(() -> keySet.set(map.keySet()));
+        t1(() -> keyIterator.set(keySet.get().iterator()));
+
+        // Begin partial iteration.
+        t1(() -> keyIterator.get().next())
+                .assertResult()
+                .isEqualTo("a");
+        t1(() -> keyIterator.get().next())
+                .assertResult()
+                .isEqualTo("b");
+
+        // On another thread, delete some elements
+        t2(() -> map.remove("a"));
+        t2(() -> map.remove("d"));
+        t2(() -> map.remove("f"));
+
+        // Now continue iteration
+        t1(() -> keyIterator.get().next())
+                .assertResult()
+                .isEqualTo("c");
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/concurrent/MapsAsMQsTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/MapsAsMQsTest.java
@@ -1,11 +1,15 @@
 package org.corfudb.runtime.concurrent;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.annotations.ConflictParameter;
+import org.corfudb.runtime.collections.ISMRMap;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.object.transactions.AbstractTransactionsTest;
 import org.junit.Test;
 
+import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -1,9 +1,13 @@
 package org.corfudb.runtime.object.transactions;
 
+import com.google.common.reflect.TypeToken;
+import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.ConflictParameterClass;
 import org.junit.Test;
 
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -60,7 +64,6 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
 
         getRuntime().getObjectsView().TXAbort();
     }
-
 
     /** In an optimistic transaction, we should be able to
      *  read our own writes in the same thread.


### PR DESCRIPTION
This PR introduces the first part of the implementation of the issue
introduced in #620, which allows an accessor to be serviced directly
from the read of a single SMREntry instead of playing back the log.
This PR does not yet modify the behavior of the runtime, rather, it
adds several annotations and provides the information necessary
for CorfuCompileProxy to service an accessor directly from a single
SMREntry.

This PR introduces the DirectReadFunction annotation, which marks
a function which can take the arguments of an accessor and the
most recent mutator, and generate a return value for the accessor.
There can be one DirectReadFunction for every mutator+accessor
combination. MutatorAccessors cannot be directly serviced. In addition,
the accessor annotation also has a new field, directReadFunctions, which
specifies an array of named DirectReadFunctions.

The annotationProcessor generates a map of these functions and provides
them as a SMRMethodName -> DirectReadFunction map during the call to
ICorfuSMRProxy::access. If the runtime can determine that the conflictKeys
for the accessor and the mutator match, and that the mutator is the most
recent update to that conflictKey, the proxy can retrieve the directAccessFunction
and obtain the result as if it had played back the object by retrieving the 
directAccessFunction from the map and calling it with the arguments to the
accessor and mutator.