### PR TITLE
Prefix Implementation

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
@@ -15,7 +15,8 @@ public class BatchWriterOperation {
     public enum Type {
         SHUTDOWN,
         WRITE,
-        TRIM
+        TRIM,
+        PREFIX_TRIM
     }
 
     private final Type type;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -29,6 +29,7 @@ import org.corfudb.protocols.wireprotocol.*;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.DataOutrankedException;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.ValueAdoptedException;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Utils;
@@ -222,6 +223,17 @@ public class LogUnitServer extends AbstractServer {
         //TODO(Maithem): should we return an error if the write fails
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
     }
+
+    @ServerHandler(type = CorfuMsgType.PREFIX_TRIM)
+    private void prefixTrim(CorfuPayloadMsg<TrimRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
+        try {
+            batchWriter.trim(new LogAddress(msg.getPayload().getPrefix(), msg.getPayload().getStream()));
+            r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
+        } catch (TrimmedException ex) {
+            r.sendResponse(ctx, msg, CorfuMsgType.ERROR_TRIMMED.msg());
+        }
+    }
+
 
     /**
      * Retrieve the LogUnitEntry from disk, given an address.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -33,6 +33,12 @@ public interface StreamLog {
     void trim(LogAddress logAddress);
 
     /**
+     * Prefix trim the global log
+     * @param logAddress Address to trim the log up to
+     */
+    void prefixTrim(LogAddress logAddress);
+
+    /**
      * Remove all trimmed addresses from the StreamLog.
      */
     void compact();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -122,6 +122,11 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         }
     }
 
+    @Override
+    public void prefixTrim(LogAddress logAddress) {
+        //No-op
+    }
+
     private void initializeMaxGlobalAddress() {
         long tailSegment = serverContext.getTailSegment();
         long addressInTailSegment = (tailSegment * RECORDS_PER_LOG_FILE) + 1;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -54,6 +54,7 @@ public enum CorfuMsgType {
     FORCE_GC(35, TypeToken.of(CorfuMsg.class)),
     GC_INTERVAL(36, new TypeToken<CorfuPayloadMsg<Long>>() {}),
     FORCE_COMPACT(37, TypeToken.of(CorfuMsg.class)),
+    PREFIX_TRIM(38, new TypeToken<CorfuPayloadMsg<TrimRequest>>() {}),
     TAIL_REQUEST(41, TypeToken.of(CorfuMsg.class), true),
     TAIL_RESPONSE(42, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -64,7 +64,7 @@ public class LogUnitClient implements IClient {
     private static Object handleTrimmed(CorfuMsg msg, ChannelHandlerContext ctx, IClientRouter r)
     throws Exception
     {
-        throw new Exception("Trimmed");
+        throw new TrimmedException();
     }
 
     /** Handle an ERROR_OVERWRITE message.
@@ -278,6 +278,14 @@ public class LogUnitClient implements IClient {
      */
     public void trim(UUID stream, long prefix) {
         router.sendMessage(CorfuMsgType.TRIM.payloadMsg(new TrimRequest(stream, prefix)));
+    }
+
+    /**
+     * Send a prefix trim request that will trim the log up to a certian address
+     * @param address An address to trim up to (i.e. [0, address))
+     */
+    public void prefixTrim(long address) {
+        router.sendMessageAndGetCompletable(CorfuMsgType.PREFIX_TRIM.payloadMsg(new TrimRequest(null, address)));
     }
 
     /**


### PR DESCRIPTION
This patch introduces the ability to trim the global log up to
a certain address (i.e. [0, prefixAddress). A prefix trim
followed by a compact will deleted the underlaying files that
correspond to that prefix.