### PR TITLE
change readCache to final

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
@@ -99,7 +99,7 @@ public class CheckpointEntry extends LogEntry {
 
     public CheckpointEntry(CheckpointEntryType type, String authorID, UUID checkpointID,
                            Map<CheckpointDictKey,String> dict, MultiSMREntry smrEntries) {
-        super(LogEntryType.SMR);
+        super(LogEntryType.CHECKPOINT);
         this.cpType = type;
         this.checkpointID = checkpointID;
         this.checkpointAuthorID = authorID;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
@@ -113,7 +113,8 @@ public class LogEntry implements ICorfuSerializable {
         SMR(1, SMREntry.class),
         STREAM_COW(4, StreamCOWEntry.class),
         MULTIOBJSMR(7, MultiObjectSMREntry.class),
-        MULTISMR(8, MultiSMREntry.class);
+        MULTISMR(8, MultiSMREntry.class),
+        CHECKPOINT(10, CheckpointEntry.class);
 
         public final int type;
         public final Class<? extends LogEntry> entryType;

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 
+import javax.annotation.Nonnull;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
@@ -23,9 +24,9 @@ import java.util.concurrent.TimeoutException;
 @Slf4j
 public abstract class AbstractView {
 
-    CorfuRuntime runtime;
+    final CorfuRuntime runtime;
 
-    public AbstractView(CorfuRuntime runtime) {
+    public AbstractView(@Nonnull final CorfuRuntime runtime) {
         this.runtime = runtime;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -8,6 +8,7 @@ import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.util.CFUtils;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -22,7 +23,7 @@ import static java.util.Arrays.stream;
 @Slf4j
 public class LayoutView extends AbstractView {
 
-    public LayoutView(CorfuRuntime runtime) {
+    public LayoutView(@Nonnull final CorfuRuntime runtime) {
         super(runtime);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -18,6 +18,7 @@ import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.serializer.Serializers;
 
+import javax.annotation.Nonnull;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
@@ -44,7 +45,7 @@ public class ObjectsView extends AbstractView {
     @Getter
     Map<ObjectID, Object> objectCache = new ConcurrentHashMap<>();
 
-    public ObjectsView(CorfuRuntime runtime) {
+    public ObjectsView(@Nonnull final CorfuRuntime runtime) {
         super(runtime);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -15,21 +15,17 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**
  * Created by mwei on 12/11/15.
  */
 @Slf4j
-public class StreamsView {
+public class StreamsView extends AbstractView {
 
-    /**
-     * The org.corfudb.runtime which backs this view.
-     */
-    CorfuRuntime runtime;
-
-    public StreamsView(CorfuRuntime runtime) {
-        this.runtime = runtime;
+    public StreamsView(final CorfuRuntime runtime) {
+        super(runtime);
     }
 
     /**


### PR DESCRIPTION
This PR changes the readCache from being static (global) to a final instance
field, preventing possible odd behaviors from occurring and runtimes sharing
caches (which they shouldn't, as they should operate independently).

In addition, this patch now also contains a fix to the checkpoint entry type, and
since we have sort of a chicken-and-egg problem of unit tests and fixes
 (the unit tests are "fixed" by this PR, but the code is "fixed" by fixes to the 
checkpointing entries), they are all in this PR.