### PR TITLE
Add Cache Eviction Timer

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -105,6 +105,13 @@ public class CorfuRuntime {
     public long maxCacheSize = 4_000_000_000L;
 
     /**
+     * Sets expireAfterAccess and expireAfterWrite in seconds.
+     */
+    @Getter
+    @Setter
+    public long cacheExpiryTime = Long.MAX_VALUE;
+
+    /**
      * Whether or not to disable backpointers.
      */
     @Getter

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -18,6 +18,7 @@ import org.corfudb.runtime.exceptions.WrongEpochException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -36,6 +37,8 @@ public class AddressSpaceView extends AbstractView {
     final LoadingCache<Long, ILogData> readCache = Caffeine.<Long, ILogData>newBuilder()
             .<Long, ILogData>weigher((k, v) -> v.getSizeEstimate())
             .maximumWeight(runtime.getMaxCacheSize())
+            .expireAfterAccess(runtime.getCacheExpiryTime(), TimeUnit.SECONDS)
+            .expireAfterWrite(runtime.getCacheExpiryTime(), TimeUnit.SECONDS)
             .recordStats()
             .build(new CacheLoader<Long, ILogData>() {
                 @Override


### PR DESCRIPTION
In certian cases, the full size of the cache is only utilized
during object initialization, then only a small part of the
cache is used. The timer will evict un-used entries after a
period of time.