### PR TITLE
Add systemd support for corfu-server

### DIFF
--- a/debian/pom.xml
+++ b/debian/pom.xml
@@ -54,6 +54,16 @@
                                         <filemode>755</filemode>
                                     </mapper>
                                 </data>
+                                <!-- systemd service script -->
+                                <data>
+                                    <src>src/deb/systemd/corfu-server.service</src>
+                                    <type>file</type>
+                                    <mapper>
+                                        <type>perm</type>
+                                        <prefix>/usr/lib/systemd/system</prefix>
+                                        <filemode>755</filemode>
+                                    </mapper>
+                                </data>
                                 <!-- infrastructure is a dependency of cmdlets so it is included -->
                                 <data>
                                     <src>${session.executionRootDirectory}/cmdlets/target/cmdlets-${project.version}-shaded.jar</src>

--- a/debian/src/deb/systemd/corfu-server.service
+++ b/debian/src/deb/systemd/corfu-server.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Corfu Infrastructure Server
+Documentation=https://github.com/corfudb/corfudb
+After=remote-fs.target systemd-journald-dev-log.socket
+
+[Service]
+Type=forking
+PIDFile=/var/run/corfu.pid
+ExecStart=/etc/init.d/corfu-server start
+ExecStop=/etc/init.d/corfu-server stop
+ExecReload=/etc/init.d/corfu-server restart
+KillMode=process
+Restart=on-failure
+RestartSec=10
+RemainAfterExit=no
+
+[Install]
+WantedBy=multi-user.target
+WantedBy=graphical.target


### PR DESCRIPTION
Add a systemd service file to corfu-server. Set corfu to restart
on failure automatically (effective on wrapper file). The systemd
service reuses sysv init script so we don't need to repeat code.

Related: #497 
Need review: @zalokhan 

This change doesn't ready add a watchdog to corfu-server, but it
provides the potential with the help of systemd. When the corfu
wrapper script `/usr/local/bin/corfu_server` exits in abnormal way,
systemd can detect the situation, terminate the whole process tree,
and restart script after a period of time. With the ability to assure
the aliveness of wrapper script, watchdog is easy to implement by
monitoring the exit code of java process.