### PR TITLE
Suppress systemd warning

### DIFF
--- a/debian/pom.xml
+++ b/debian/pom.xml
@@ -61,7 +61,7 @@
                                     <mapper>
                                         <type>perm</type>
                                         <prefix>/usr/lib/systemd/system</prefix>
-                                        <filemode>755</filemode>
+                                        <filemode>644</filemode>
                                     </mapper>
                                 </data>
                                 <!-- infrastructure is a dependency of cmdlets so it is included -->


### PR DESCRIPTION
In current debian packaging stage, systemd service file has
been assigned with executable permission. Which will cause
the following warning:

> Configuration file /usr/lib/systemd/system/corfu-server.service
> is marked executable. Please remove executable permission bits.
> Proceeding anyway.

Review needed: @zalokhan 
This patch removes the executable permission to suppress the warning.