### PR TITLE
Properly Construct CP Entries

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -11,9 +11,6 @@ import org.corfudb.util.serializer.Serializers;
 import java.util.EnumMap;
 import java.util.concurrent.atomic.AtomicReference;
 
-import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_ID;
-import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_TYPE;
-
 /**
  * Created by mwei on 8/15/16.
  */


### PR DESCRIPTION
When a checkpoint(CP)  entry is retrieved from secondary storage,
it not properly constructed. The CP type and UUID are not set. As
a consequence, the stream view ignores the those CP entries
resulting in intermittent problems and data loss.