### PR TITLE
Get the version under a lock

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -361,7 +361,8 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
      */
     @Override
     public long getVersion() {
-        return underlyingObject.getVersionUnsafe();
+        return access(o -> underlyingObject.getVersionUnsafe(),
+                null);
     }
 
     /** Get a new instance of the real underlying object.


### PR DESCRIPTION
This PR patches the compile proxy to get the version from the version
locked object, which is an unsafe call, under a lock.