### PR TITLE
keep track of snapshot addresses, fix issue with fresh streams

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
@@ -47,7 +47,8 @@ public class CheckpointEntry extends LogEntry {
         END_TIME(1),
         START_LOG_ADDRESS(2),
         ENTRY_COUNT(3),
-        BYTE_COUNT(4);
+        BYTE_COUNT(4),
+        SNAPSHOT_ADDRESS(5);
 
         public final int type;
 

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -150,6 +150,8 @@ public class CheckpointWriter {
         ICorfuSMR<SMRMap> corfuObject = (ICorfuSMR<SMRMap>) this.map;
         this.mdKV.put(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS,
                 Long.toString(corfuObject.getCorfuSMRProxy().getVersion()));
+        this.mdKV.put(CheckpointEntry.CheckpointDictKey.SNAPSHOT_ADDRESS,
+                Long.toString(txBeginGlobalAddress));
 
         ImmutableMap<CheckpointEntry.CheckpointDictKey,String> mdKV = ImmutableMap.copyOf(this.mdKV);
         CheckpointEntry cp = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.START,

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/LogUnitException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/LogUnitException.java
@@ -4,4 +4,12 @@ package org.corfudb.runtime.exceptions;
  * Created by mwei on 12/14/15.
  */
 public class LogUnitException extends RuntimeException {
+
+    public LogUnitException() {
+
+    }
+
+    public LogUnitException(String message) {
+        super(message);
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedException.java
@@ -5,4 +5,10 @@ package org.corfudb.runtime.exceptions;
  * that has been trimmed.
  */
 public class TrimmedException extends LogUnitException {
+    public TrimmedException() {
+
+    }
+    public TrimmedException(String message) {
+        super(message);
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedUpcallException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedUpcallException.java
@@ -1,0 +1,16 @@
+package org.corfudb.runtime.exceptions;
+
+/**
+ * This exception is thrown when a client attempts to resolve
+ * an upcall, but the address is trimmed before the upcall
+ * result can be resolved.
+ *
+ * Created by mwei on 6/7/17.
+ */
+public class TrimmedUpcallException extends TrimmedException {
+
+    public TrimmedUpcallException(long address) {
+        super("Attempted to get upcall result @" + address +
+                " but it was trimmed before we could read it");
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -371,6 +371,11 @@ public abstract class AbstractQueuedStreamView extends
         long checkpointSuccessBytes = 0L;
         // No need to keep track of # of DATA entries, use context.resolvedQueue.size()?
         long resolvedEstBytes = 0L;
+        /** The address the current checkpoint snapshot was taken at.
+         *  The checkpoint guarantees for this stream there are no entries
+         *  between checkpointSuccessStartAddr and checkpointSnapshotAddress.
+         */
+        long checkpointSnapshotAddress = Address.NEVER_READ;
 
         /** Create a new stream context with the given ID and maximum address
          * to read to.
@@ -395,6 +400,7 @@ public abstract class AbstractQueuedStreamView extends
             checkpointSuccessID = null;
             checkpointSuccessStartAddr = Address.NEVER_READ;
             checkpointSuccessEndAddr = Address.NEVER_READ;
+            checkpointSnapshotAddress = Address.NEVER_READ;
             checkpointSuccessNumEntries = 0;
             checkpointSuccessBytes = 0;
             resolvedEstBytes = 0;

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -83,6 +83,11 @@ public class CheckpointTest extends AbstractObjectTest {
                 mcw1.addMap((SMRMap) m2B);
                 long checkpointAddress = mcw1.appendCheckpoints(currentRuntime, author);
 
+                try {
+                    Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
+                } catch (InterruptedException ie) {
+                    //
+                }
                 // Trim the log
                 currentRuntime.getAddressSpaceView().prefixTrim(checkpointAddress - 1);
                 currentRuntime.getAddressSpaceView().gc();

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -6,12 +6,14 @@ import lombok.Getter;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.SMRMap;
-import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.AbstractObjectTest;
+import org.corfudb.runtime.object.transactions.TransactionType;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,243 +34,429 @@ public class CheckpointTest extends AbstractObjectTest {
         return (SMRMap<String, Long>)
                 instantiateCorfuObject(
                         getMyRuntime(),
-                        new TypeToken<SMRMap<String, Long>>() {},
+                        new TypeToken<SMRMap<String, Long>>() {
+                        },
                         mapName);
     }
 
+    final String streamNameA = "mystreamA";
+    final String streamNameB = "mystreamB";
+    final String author = "ckpointTest";
+    protected Map<String, Long> m2A;
+    protected Map<String, Long> m2B;
+
+    /**
+     * common initialization for tests: establish Corfu runtime and instantiate two maps
+     */
+    @Before
+    public void instantiateMaps() {
+
+        myRuntime = getDefaultRuntime().connect();
+
+        m2A = instantiateMap(streamNameA);
+        m2B = instantiateMap(streamNameB);
+    }
+
+    /**
+     * checkpoint the maps
+     */
+    void mapCkpoint() throws Exception {
+        CorfuRuntime currentRuntime = getMyRuntime();
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+            MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
+            mcw1.addMap((SMRMap) m2A);
+            mcw1.addMap((SMRMap) m2B);
+            long firstGlobalAddress1 = mcw1.appendCheckpoints(currentRuntime, author);
+        }
+    }
+
+    /**
+     * checkpoint the maps, and then trim the log
+     */
+    void mapCkpointAndTrim() throws Exception {
+        CorfuRuntime currentRuntime = getMyRuntime();
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+            MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
+            mcw1.addMap((SMRMap) m2A);
+            mcw1.addMap((SMRMap) m2B);
+            long checkpointAddress = mcw1.appendCheckpoints(currentRuntime, author);
+
+            // Trim the log
+            currentRuntime.getAddressSpaceView().prefixTrim(checkpointAddress - 1);
+            currentRuntime.getAddressSpaceView().gc();
+            currentRuntime.getAddressSpaceView().invalidateServerCaches();
+            currentRuntime.getAddressSpaceView().invalidateClientCache();
+
+        }
+    }
+
+    /**
+     *  Start a fresh runtime and instantiate the maps.
+     * This time the we check that the new map instances contains all values
+     * @param mapSize
+     * @param expectedFullsize
+     */
+    void validateMapRebuild(int mapSize, boolean expectedFullsize) {
+        setRuntime();
+        Map<String, Long> localm2A = instantiateMap(streamNameA);
+        Map<String, Long> localm2B = instantiateMap(streamNameB);
+        for (int i = 0; i < localm2A.size(); i++) {
+            assertThat(localm2A.get(String.valueOf(i))).isEqualTo((long) i);
+        }
+        for (int i = 0; i < localm2B.size(); i++) {
+            assertThat(localm2B.get(String.valueOf(i))).isEqualTo(0L);
+        }
+        if (expectedFullsize) {
+            assertThat(localm2A.size()).isEqualTo(mapSize);
+            assertThat(localm2B.size()).isEqualTo(mapSize);
+        }
+    }
+
+    /**
+     * initialize the two maps, the second one is all zeros
+     * @param mapSize
+     */
+    void populateMaps(int mapSize) {
+        for (int i = 0; i < mapSize; i++) {
+            m2A.put(String.valueOf(i), (long) i);
+            m2B.put(String.valueOf(i), (long) 0);
+        }
+    }
+
+    /**
+     * this test builds two maps, m2A m2B, and brings up three threads:
+     * <p>
+     * 1. one pupolates the maps with mapSize items
+     * 2. one does a periodic checkpoint of the maps, repeating ITERATIONS_VERY_LOW times
+     * 3. one repeatedly (LOW times) starts a fresh runtime, and instantiates the maps.
+     * they should rebuild from the latest checkpoint (if available).
+     * this thread performs some sanity checks on the map state
+     * <p>
+     * Finally, after all three threads finish, again we start a fresh runtime and instante the maps.
+     * This time the we check that the new map instances contains all values
+     *
+     * @throws Exception
+     */
     @Test
     public void periodicCkpointTest() throws Exception {
-        final String streamNameA = "mystreamA";
-        final String streamNameB = "mystreamB";
-        final String author = "periodicCkpoint";
-        final int sizeAdjustment = 16; // size reduction to accomodate TRACE level debugging
-        final int mapSize = PARAMETERS.NUM_ITERATIONS_MODERATE / sizeAdjustment;
+        final int mapSize = PARAMETERS.NUM_ITERATIONS_LOW;
 
-        myRuntime = getDefaultRuntime().connect();
-
-        Map<String, Long> m2A = instantiateMap(streamNameA);
-        Map<String, Long> m2B = instantiateMap(streamNameB);
-
+        // thread 1: pupolates the maps with mapSize items
         scheduleConcurrently(1, ignored_task_num -> {
-            for (int i = 0; i < mapSize; i++) {
-                m2A.put(String.valueOf(i), (long)i);
-                m2B.put(String.valueOf(i), (long)0);
-            }
-        });
+                    populateMaps(mapSize);
+                });
 
-        scheduleConcurrently(1, ignored_task_num -> {
-            CorfuRuntime currentRuntime = getMyRuntime();
-            for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
-                MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
-                mcw1.addMap((SMRMap) m2A);
-                mcw1.addMap((SMRMap) m2B);
-                long firstGlobalAddress1 = mcw1.appendCheckpoints(currentRuntime, author);
-            }
-        });
+        // thread 2: periodic checkpoint of the maps, repeating ITERATIONS_VERY_LOW times
 
+
+        // thread 3: repeated ITERATION_LOW times starting a fresh runtime, and instantiating the maps.
+        // they should rebuild from the latest checkpoint (if available).
+        // performs some sanity checks on the map state
         scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW, ignored_task_num -> {
-            setRuntime();
-            Map<String, Long> localm2A = instantiateMap(streamNameA);
-            Map<String, Long> localm2B = instantiateMap(streamNameB);
-            for (int i = 0; i < mapSize; i++) {
-                assertThat(localm2A.get(String.valueOf(i)) == null ||
-                        localm2A.get(String.valueOf(i)) == (long) i
-                ).isTrue();
-                assertThat(localm2B.get(String.valueOf(i)) == null ||
-                        localm2B.get(String.valueOf(i)) == (long) 0
-                ).isTrue();
-            }
+            validateMapRebuild(mapSize, false);
         });
 
         executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_LONG);
 
-        setRuntime();
-        Map<String, Long> localm2A = instantiateMap(streamNameA);
-        Map<String, Long> localm2B = instantiateMap(streamNameB);
-        for (int i = 0; i < mapSize; i++) {
-            assertThat(localm2A.get(String.valueOf(i)) ).isEqualTo((long)i);
-            assertThat(localm2B.get(String.valueOf(i)) ).isEqualTo(0L);
-        }
-
+        // finally, after all three threads finish, again we start a fresh runtime and instante the maps.
+        // This time the we check that the new map instances contains all values
+        validateMapRebuild(mapSize, true);
     }
 
+    /**
+     * this test builds two maps, m2A m2B, and brings up two threads:
+     * <p>
+     * 1. one thread performs ITERATIONS_VERY_LOW checkpoints
+     * 2. one thread repeats ITERATIONS_LOW times starting a fresh runtime, and instantiating the maps.
+     * they should be empty.
+     * <p>
+     * Finally, after the two threads finish, again we start a fresh runtime and instante the maps.
+     * Then verify they are empty.
+     *
+     * @throws Exception
+     */
     @Test
     public void emptyCkpointTest() throws Exception {
-        final String streamNameA = "mystreamA";
-        final String streamNameB = "mystreamB";
-        final String author = "periodicCkpoint";
-        final int sizeAdjustment = 16; // size reduction to accomodate TRACE level debugging
-        final int mapSize = PARAMETERS.NUM_ITERATIONS_MODERATE / sizeAdjustment;
-
-        myRuntime = getDefaultRuntime().connect();
-
-        Map<String, Long> m2A = instantiateMap(streamNameA);
-        Map<String, Long> m2B = instantiateMap(streamNameB);
+        final int mapSize = 0;
 
         scheduleConcurrently(1, ignored_task_num -> {
-            CorfuRuntime currentRuntime = getMyRuntime();
-            for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
-                MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
-                mcw1.addMap((SMRMap) m2A);
-                mcw1.addMap((SMRMap) m2B);
-                long firstGlobalAddress1 = mcw1.appendCheckpoints(currentRuntime, author);
-            }
+            mapCkpoint();
         });
 
+        // thread 2: repeat ITERATIONS_LOW times starting a fresh runtime, and instantiating the maps.
+        // they should be empty.
         scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW, ignored_task_num -> {
-            setRuntime();
-            Map<String, Long> localm2A = instantiateMap(streamNameA);
-            Map<String, Long> localm2B = instantiateMap(streamNameB);
-            for (int i = 0; i < mapSize; i++) {
-                assertThat(localm2A.get(String.valueOf(i)) ).isNull();
-                assertThat(localm2B.get(String.valueOf(i)) ).isNull();
-            }
+            validateMapRebuild(mapSize, true);
         });
 
         executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_LONG);
 
-        setRuntime();
-        Map<String, Long> localm2A = instantiateMap(streamNameA);
-        Map<String, Long> localm2B = instantiateMap(streamNameB);
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
-            assertThat(localm2A.get(String.valueOf(i)) ).isNull();
-            assertThat(localm2B.get(String.valueOf(i)) ).isNull();
-        }
-
+        // Finally, after the two threads finish, again we start a fresh runtime and instante the maps.
+        // Then verify they are empty.
+        validateMapRebuild(mapSize, true);
     }
 
+    /**
+     * this test is similar to periodicCkpointTest(), but populating the maps is done BEFORE starting the checkpoint/recovery threads.
+     * <p>
+     * First, the test builds two maps, m2A m2B, and populates them with mapSize items.
+     * <p>
+     * Then, it brings up two threads:
+     * <p>
+     * 1. one does a periodic checkpoint of the maps, repeating ITERATIONS_VERY_LOW times
+     * 2. one repeatedly (LOW times) starts a fresh runtime, and instantiates the maps.
+     * they should rebuild from the latest checkpoint (if available).
+     * this thread checks that all values are present in the maps
+     * <p>
+     * Finally, after all three threads finish, again we start a fresh runtime and instante the maps.
+     * This time the we check that the new map instances contains all values
+     *
+     * @throws Exception
+     */
     @Test
     public void periodicCkpointNoUpdatesTest() throws Exception {
-        final String streamNameA = "mystreamA";
-        final String streamNameB = "mystreamB";
-        final String author = "periodicCkpoint";
-        final int sizeAdjustment = 16; // size reduction to accomodate TRACE level debugging
-        final int mapSize = PARAMETERS.NUM_ITERATIONS_MODERATE / sizeAdjustment;
-
-        myRuntime = getDefaultRuntime().connect();
-
-        Map<String, Long> m2A = instantiateMap(streamNameA);
-        Map<String, Long> m2B = instantiateMap(streamNameB);
+        final int mapSize = PARAMETERS.NUM_ITERATIONS_LOW;
 
         // pre-populate map
-        for (int i = 0; i < mapSize; i++) {
-            m2A.put(String.valueOf(i), (long)i);
-            m2B.put(String.valueOf(i), (long)0);
-        }
+        populateMaps(mapSize);
 
+        // thread 1: perform a periodic checkpoint of the maps, repeating ITERATIONS_VERY_LOW times
         scheduleConcurrently(1, ignored_task_num -> {
-            CorfuRuntime currentRuntime = getMyRuntime();
-            for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
-                MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
-                mcw1.addMap((SMRMap) m2A);
-                mcw1.addMap((SMRMap) m2B);
-                mcw1.appendCheckpoints(currentRuntime, author);
-            }
+            mapCkpoint();
         });
 
+        // repeated ITERATIONS_LOW times starting a fresh runtime, and instantiating the maps.
+        // they should rebuild from the latest checkpoint (if available).
+        // this thread checks that all values are present in the maps
         scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW, ignored_task_num -> {
-            setRuntime();
-            Map<String, Long> localm2A = instantiateMap(streamNameA);
-            Map<String, Long> localm2B = instantiateMap(streamNameB);
-            for (int i = 0; i < mapSize; i++) {
-                assertThat(localm2A.get(String.valueOf(i))).isEqualTo((long) i);
-                assertThat(localm2B.get(String.valueOf(i)) ).isEqualTo((long) 0);
-            }
+            validateMapRebuild(mapSize, true);
         });
 
         executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_LONG);
 
-        setRuntime();
-        Map<String, Long> localm2A = instantiateMap(streamNameA);
-        Map<String, Long> localm2B = instantiateMap(streamNameB);
-        for (int i = 0; i < mapSize; i++) {
-            assertThat(localm2A.get(String.valueOf(i)) ).isEqualTo((long)i);
-            assertThat(localm2B.get(String.valueOf(i)) ).isEqualTo(0L);
-        }
-
+        // Finally, after all three threads finish, again we start a fresh runtime and instante the maps.
+        // This time the we check that the new map instances contains all values
+        validateMapRebuild(mapSize, true);
     }
+
+    /**
+     * this test is similar to periodicCkpointTest(), but adds simultaneous log prefix-trimming.
+     * <p>
+     * the test builds two maps, m2A m2B, and brings up three threads:
+     * <p>
+     * 1. one pupolates the maps with mapSize items
+     * 2. one does a periodic checkpoint of the maps, repeating ITERATIONS_VERY_LOW times,
+     * and immediately trims the log up to the checkpoint position.
+     * 3. one repeats ITERATIONS_LOW starting a fresh runtime, and instantiating the maps.
+     * they should rebuild from the latest checkpoint (if available).
+     * this thread performs some sanity checks on the map state
+     * <p>
+     * Finally, after all three threads finish, again we start a fresh runtime and instante the maps.
+     * This time the we check that the new map instances contains all values
+     *
+     * @throws Exception
+     */
+
     @Test
     public void periodicCkpointTrimTest() throws Exception {
-        final String streamNameA = "mystreamA";
-        final String streamNameB = "mystreamB";
-        final String author = "periodicCkpoint";
-        final int sizeAdjustment = 16; // size reduction to accomodate TRACE level debugging
-        final int mapSize = PARAMETERS.NUM_ITERATIONS_MODERATE / sizeAdjustment;
+        final int mapSize = PARAMETERS.NUM_ITERATIONS_LOW;
 
-        myRuntime = getDefaultRuntime().connect();
-
-        Map<String, Long> m2A = instantiateMap(streamNameA);
-        Map<String, Long> m2B = instantiateMap(streamNameB);
-
+        // thread 1: pupolates the maps with mapSize items
         scheduleConcurrently(1, ignored_task_num -> {
-            for (int i = 0; i < mapSize; i++) {
-                // If TrimmedException, it happens during syncStreamUnsafe.
-                // We assume that the put is always successful.
-                try {
-                    m2A.put(String.valueOf(i), (long) i);
-                } catch (TrimmedException te) { }
-                try {
-                    m2B.put(String.valueOf(i), 0L);
-                } catch (TrimmedException te) { }
-            }
+            populateMaps(mapSize);
         });
 
+        // thread 2: periodic checkpoint of the maps, repeating ITERATIONS_VERY_LOW times,
+        // and immediate prefix-trim of the log up to the checkpoint position
         scheduleConcurrently(1, ignored_task_num -> {
-            CorfuRuntime currentRuntime = getMyRuntime();
-            for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
-
-                // i'th checkpoint
-                MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
-                mcw1.addMap((SMRMap) m2A);
-                mcw1.addMap((SMRMap) m2B);
-                long checkpointAddress = mcw1.appendCheckpoints(currentRuntime, author);
-
-                // Trim the log
-                currentRuntime.getAddressSpaceView().prefixTrim(checkpointAddress - 1);
-                currentRuntime.getAddressSpaceView().gc();
-                currentRuntime.getAddressSpaceView().invalidateServerCaches();
-                currentRuntime.getAddressSpaceView().invalidateClientCache();
-
-            }
+            mapCkpointAndTrim();
         });
 
+        // thread 3: repeated ITERATION_LOW times starting a fresh runtime, and instantiating the maps.
+        // they should rebuild from the latest checkpoint (if available).
+        // performs some sanity checks on the map state
         scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW, ignored_task_num -> {
-            setRuntime();
-            Map<String, Long> localm2A = instantiateMap(streamNameA);
-            Map<String, Long> localm2B = instantiateMap(streamNameB);
-
-            int currentMapSize = Integer.min(localm2A.size(), localm2B.size());
-            for (int i = 0; i < currentMapSize; i++) {
-                Object gotval; // Use intermediate var for logging in error cases
-
-                gotval = localm2A.get(String.valueOf(i));
-                log.trace("Check localm2A.get({}) -> {} by {}", i, gotval, Thread.currentThread().getName());
-                if (gotval == null) {
-                    log.error("Null value at key {}, localm2A = {}", i, localm2A.toString());
-                }
-                assertThat((Long) gotval).describedAs(Thread.currentThread().getName() + " A index " + i)
-                        .isEqualTo((long) i);
-
-                gotval = localm2B.get(String.valueOf(i));
-                log.trace("Check localm2B.get({}) -> {} by {} {}", i, gotval, Thread.currentThread().getName(), Thread.currentThread().hashCode());
-                if (gotval == null) {
-                    log.error("Null value at key {}, localm2B = {}", i, localm2B.toString());
-                }
-                assertThat((Long) gotval).describedAs(Thread.currentThread().getName() + " B index " + i)
-                        .isEqualTo((long) 0);
-            }
+            validateMapRebuild(mapSize, false);
         });
 
         executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_LONG);
 
-        setRuntime();
-        Map<String, Long> localm2A = instantiateMap(streamNameA);
-        Map<String, Long> localm2B = instantiateMap(streamNameB);
-        for (int i = 0; i < mapSize; i++) {
-            assertThat(localm2A.get(String.valueOf(i)) ).isEqualTo((long)i);
-            assertThat(localm2A).hasSize(mapSize);
-            assertThat(localm2B.get(String.valueOf(i)) ).isEqualTo(0L);
-            assertThat(localm2B).hasSize(mapSize);
-        }
+        // finally, after all three threads finish, again we start a fresh runtime and instante the maps.
+        // This time the we check that the new map instances contains all values
+        validateMapRebuild(mapSize, true);
     }
+
+    /**
+     * This test verifies that a client that recovers a map from checkpoint,
+     * but wants the map at a snapshot -earlier- than the snapshot,
+     * will either get a transactionAbortException, or get the right version of
+     * the map.
+     * <p>
+     * It works as follows.
+     * We build a map with one hundred entries [0, 1, 2, 3, ...., 99].
+     * <p>
+     * Note that, each entry is one put, so if a TX starts at snapshot at 77, it should see a map with 77 items 0, 1, 2, ..., 76.
+     * We are going to verify that this works even if we checkpoint the map, and trim a prefix, say of the first 50 put's.
+     * <p>
+     * First, we then take a checkpoint of the map.
+     * <p>
+     * Then, we prefix-trim the log up to position 50.
+     * <p>
+     * Now, we start a new runtime and instantiate this map. It should build the map from a snapshot.
+     * <p>
+     * Finally, we start a snapshot-TX at timestamp 77. We verify that the map state is [0, 1, 2, 3, ..., 76].
+     */
+    @Test
+    public void undoCkpointTest() throws Exception {
+        final int mapSize = PARAMETERS.NUM_ITERATIONS_LOW;
+        final int trimPosition = mapSize / 2;
+        final int snapshotPosition = trimPosition + 2;
+
+        t(1, () -> {
+
+                    // first, populate the map
+                    for (int i = 0; i < mapSize; i++) {
+                        m2A.put(String.valueOf(i), (long) i);
+                    }
+
+                    // now, take a checkpoint and perform a prefix-trim
+                    MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
+                    mcw1.addMap((SMRMap) m2A);
+                    long checkpointAddress = mcw1.appendCheckpoints(getMyRuntime(), author);
+
+                    // Trim the log
+                    getMyRuntime().getAddressSpaceView().prefixTrim(trimPosition);
+                    getMyRuntime().getAddressSpaceView().gc();
+                    getMyRuntime().getAddressSpaceView().invalidateServerCaches();
+                    getMyRuntime().getAddressSpaceView().invalidateClientCache();
+
+                }
+        );
+
+        AtomicBoolean trimExceptionFlag = new AtomicBoolean(false);
+
+        // start a new runtime
+        t(2, () -> {
+                    setRuntime();
+
+                    Map<String, Long> localm2A = instantiateMap(streamNameA);
+
+                    // start a snapshot TX at position snapshotPosition
+                    getMyRuntime().getObjectsView().TXBuild()
+                            .setType(TransactionType.SNAPSHOT)
+                            .setSnapshot(snapshotPosition - 1)
+                            .begin();
+
+                    // finally, instantiate the map for the snapshot and assert is has the right state
+                    try {
+                        localm2A.get(0);
+                    } catch (TransactionAbortedException te) {
+                        // this is an expected behavior!
+                        trimExceptionFlag.set(true);
+                    }
+
+                    if (trimExceptionFlag.get() == false) {
+                        assertThat(localm2A.size())
+                                .isEqualTo(snapshotPosition);
+
+                        // check map positions 0..(snapshot-1)
+                        for (int i = 0; i < snapshotPosition; i++) {
+                            assertThat(localm2A.get(String.valueOf(i)))
+                                    .isEqualTo((long) i);
+                        }
+
+                        // check map positions snapshot..(mapSize-1)
+                        for (int i = snapshotPosition; i < mapSize; i++) {
+                            assertThat(localm2A.get(String.valueOf(i)))
+                                    .isEqualTo(null);
+                        }
+                    }
+                }
+        );
+
+    }
+
+    /**
+     * This test intentionally "delays" a checkpoint, to allow additional
+     * updates to be appended to the stream after.
+     * <p>
+     * It works as follows. First, a transcation is started in order to set a
+     * snapshot time.
+     * <p>
+     * Then, some updates are appended.
+     * <p>
+     * Finally, we take checkpoints. Since checkpoints occur within
+     * transactions, they will be nested inside the outermost transaction.
+     * Therefore, they will inherit their snapshot time from the outermost TX.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void delayedCkpointTest() throws Exception {
+        final int mapSize = PARAMETERS.NUM_ITERATIONS_LOW;
+        final int additional = mapSize / 2;
+
+        // first, populate the map
+        for (int i = 0; i < mapSize; i++) {
+            m2A.put(String.valueOf(i), (long) i);
+        }
+
+        // in one thread, start a snapshot transaction and leave it open
+        t(1, () -> {
+            // start a snapshot TX at position snapshotPosition
+            getMyRuntime().getObjectsView().TXBuild()
+                    .setType(TransactionType.SNAPSHOT)
+//                    .setForceSnapshot(false) // force snapshot when nesting
+                    .setSnapshot(mapSize - 1)
+                    .begin();
+                }
+        );
+
+        // now delay
+        // in another thread, introduce new updates to the map
+        t(2, () -> {
+            for (int i = 0; i < additional; i++) {
+                        m2A.put(String.valueOf(mapSize+i), (long) (mapSize+i));
+                    }
+                }
+        );
+
+        // back in the first thread, checkpoint and trim
+        t(1, () -> {
+            // now, take a checkpoint and perform a prefix-trim
+            MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
+            mcw1.addMap((SMRMap) m2A);
+            long checkpointAddress = mcw1.appendCheckpoints(getMyRuntime(), author);
+
+            // Trim the log
+            getMyRuntime().getAddressSpaceView().prefixTrim(checkpointAddress);
+            getMyRuntime().getAddressSpaceView().gc();
+            getMyRuntime().getAddressSpaceView().invalidateServerCaches();
+            getMyRuntime().getAddressSpaceView().invalidateClientCache();
+
+            getMyRuntime().getObjectsView().TXEnd();
+
+        });
+
+        // finally, verify that a thread can build the map correctly
+        t(2, () -> {
+            setRuntime();
+
+            Map<String, Long> localm2A = instantiateMap(streamNameA);
+
+            assertThat(localm2A.size())
+                    .isEqualTo(mapSize+additional);
+            for (int i = 0; i < mapSize; i++) {
+                assertThat(localm2A.get(String.valueOf(i)))
+                        .isEqualTo((long) i);
+            }
+            for (int i = mapSize; i < mapSize+additional; i++) {
+                assertThat(localm2A.get(String.valueOf(i)))
+                        .isEqualTo((long) i);
+            }
+
+        });
+    }
+
 }
+

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -5,6 +5,12 @@
             <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{3}</pattern>
         </encoder>
     </appender>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>${user.home}/corfudb.log</file>
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{3}</pattern>
+        </encoder>
+    </appender>
 
     <!-- Control logging levels for individual components here. -->
     <logger name="org.corfudb.runtime.object" level="TRACE"/>
@@ -15,6 +21,7 @@
     <logger name="io.netty.buffer" level="INFO"/>
 
     <root level="TRACE">
+        <!--<appender-ref ref="FILE" /-->
         <!--<appender-ref ref="STDOUT" />-->
     </root>
 </configuration>


### PR DESCRIPTION
This PR addrsses two issues with checkpoints:

The first is that if there is a new stream, but no checkpoint, a stack overflow error would be encountered because a trim would be encountered while trying to find the checkpoint,
this patch tells the implementation to continue searching for regular entries on trimmed exception.

The second is that sometimes an implementation could try to seek before the snapshot the checkpoint was taken at, but after the version of the object at the snapshot (say, object@6, snapshot@10). The trim would be taken at 10, but the implementation would sometimes seek to say 9, due to holes for example, and end up trying forever with TrimmedException. I added a snapshot address field to the checkpoint so this no longer happens.