### PR TITLE
Fix nested transaction default type

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -105,8 +105,16 @@ public class ObjectsView extends AbstractView {
      * to other threads or clients until TXEnd is called.
      */
     public void TXBegin() {
+        TransactionType type = TransactionType.OPTIMISTIC;
+
+        /* If it is a nested transaction, inherit type of parent */
+        if (TransactionalContext.isInTransaction()) {
+            type = TransactionalContext.getCurrentContext().getBuilder().getType();
+            log.trace("Inheriting parent's transaction type {}", type);
+        }
+
         TXBuild()
-                .setType(TransactionType.OPTIMISTIC)
+                .setType(type)
                 .begin();
     }
 

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/SnapshotTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/SnapshotTransactionContextTest.java
@@ -1,5 +1,7 @@
 package org.corfudb.runtime.object.transactions;
 
+import com.google.common.reflect.TypeToken;
+import org.corfudb.runtime.collections.SMRMap;
 import org.junit.Test;
 
 /**
@@ -48,4 +50,43 @@ public class SnapshotTransactionContextTest extends AbstractTransactionContextTe
         t2(this::TXEnd);
     }
 
+    /* Test if we can have implicit nested transaction for SnapshotTransactions. */
+    @Test
+    public void testSnapshotTxNestedImplicitTx() {
+        SMRMap<String, Integer> map = (SMRMap<String, Integer>)
+                instantiateCorfuObject(
+                        new TypeToken<SMRMap<String, Integer>>() {
+                        },
+                        "A"
+                );
+        t(0, () -> map.put("a", 1));
+        t(0, () -> map.put("b", 1));
+        t(0, this::SnapshotTXBegin);
+        t(0, () -> map.forEach((k,v) ->{
+            return;
+        }));
+        t(0, () -> TXEnd());
+    }
+
+    /* Test if we can have explicit nested transaction for SnapshotTransactions. */
+    @Test
+    public void testSnapshotTxNestedExplicitTx() {
+        SMRMap<String, Integer> map = (SMRMap<String, Integer>)
+                instantiateCorfuObject(
+                        new TypeToken<SMRMap<String, Integer>>() {
+                        },
+                        "A"
+                );
+        t(0, () -> map.put("a", 1));
+        t(0, () -> map.put("b", 1));
+        t(0, this::SnapshotTXBegin);
+
+        t(0, this::TXBegin);
+        t(0, () -> map.forEach((k,v) ->{
+            return;
+        }));
+        t(0, this::TXEnd);
+        t(0, this::TXEnd);
+
+    }
 }


### PR DESCRIPTION
Implicit nested transaction from transactional methods inherit
transactional context parent type.