### PR TITLE
Part 1 of splitting apart PR #670: non-unit-test stuff

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -96,8 +96,6 @@ public abstract class AbstractQueuedStreamView extends
         }
 
         // Otherwise we remove entries one at a time from the read queue.
-        // The entry may not actually be part of the stream, so we might
-        // have to perform several reads.
         if (getFrom.size() > 0) {
             final long thisRead = getFrom.pollFirst();
             ILogData ld = read(thisRead);


### PR DESCRIPTION
* Add a retry loop to MultiCheckpointWriter to handle cases of
TransactionAbortedException during a checkpoint.

    * This error was quite rare during 100's of runs of the stressful unit test `periodicCkpointTest`, appearing roughly 1% of the time.

* Fix comment in AbstractQueuedStreamView::getNextEntry that has
drifted from actual implementation.