### PR TITLE
UnsupportedOperationException error handling

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -58,6 +58,9 @@ public class CorfuRuntime {
 
         /** Number of times to attempt to read before hole filling. */
         int holeFillRetry = 10;
+
+        /** Maximum number of retries before we give up retrying an implicit transaction. */
+        int maxNumOfImplicitTxRetries = 20;
     }
 
     @Getter

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
@@ -11,6 +11,7 @@ public enum AbortCause {
     NEW_SEQUENCER,
     USER,
     NETWORK,
+    UNSUPPORTED_OPERATION,
     TRIM, /** Aborted because an access to this snapshot resulted in a trim exception. */
     UNDEFINED;
 }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
@@ -39,6 +39,10 @@ public abstract class AbstractTransactionContextTest extends AbstractTransaction
         return getMap().put(key, value);
     }
 
+    String putIfAbsent(String key, String value) {
+        return getMap().putIfAbsent(key, value);
+    }
+
     String get(String key) {
         return getMap().get(key);
     }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/SnapshotTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/SnapshotTransactionContextTest.java
@@ -2,15 +2,18 @@ package org.corfudb.runtime.object.transactions;
 
 import com.google.common.reflect.TypeToken;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.exceptions.AbortCause;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * Created by mwei on 11/22/16.
  */
 public class SnapshotTransactionContextTest extends AbstractTransactionContextTest {
+
     @Override
     public void TXBegin() { SnapshotTXBegin(); }
-
 
 
     /** Check if we can read a snapshot from the past, without
@@ -87,6 +90,22 @@ public class SnapshotTransactionContextTest extends AbstractTransactionContextTe
         }));
         t(0, this::TXEnd);
         t(0, this::TXEnd);
+    }
 
+
+    /**
+     * Ensure that TransactionAbortedException(AbortCause.UNSUPPORTED_OPERATION) is thrown when
+     * doing a mutation inside of a snapshot read.
+     */
+    @Test
+    public void testUnsupportedOperationException() {
+        try {
+            SnapshotTXBegin();
+            putIfAbsent("k" , "v1");
+            TXEnd();
+            Assert.fail();
+        } catch (TransactionAbortedException e) {
+            Assert.assertTrue(e.getAbortCause() == AbortCause.UNSUPPORTED_OPERATION);
+        }
     }
 }


### PR DESCRIPTION
An AbortedTransaction whose cause is UnsupportedOperationException
should not be retried, but propagated to the consumer.