### PR TITLE
guarding logging from evaluation

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -127,7 +127,9 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
             } else {
                 if (validateEpoch(m, ctx)) {
                     // Route the message to the handler.
-                    log.trace("Message routed to {}: {}", handler.getClass().getSimpleName(), msg);
+                    if (log.isTraceEnabled()) {
+                        log.trace("Message routed to {}: {}", handler.getClass().getSimpleName(), msg);
+                    }
                     handlerWorkers.submit(() -> handler.handleMessage(m, ctx, this));
                 }
             }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -594,7 +594,9 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
             } else {
                 if (validateEpochAndClientID(m, ctx)) {
                     // Route the message to the handler.
-                    log.trace("Message routed to {}: {}", handler.getClass().getSimpleName(), m);
+                    if (log.isTraceEnabled()) {
+                        log.trace("Message routed to {}: {}", handler.getClass().getSimpleName(), m);
+                    }
                     handler.handleMessage(m, ctx);
                 }
             }


### PR DESCRIPTION
Guarding logging from evaluating statement.
Even if tracing is not enabled, this is evaluated though not logged resulting in CPU utilization.

Note: Consider moving to Log4j to incorporate lambda based logging which avoids need for such guarding and is evaluated only if logging level is satisfied.