### PR TITLE
Allow suppression of checkstyle warnings for deprecated classes

### DIFF
--- a/checks.xml
+++ b/checks.xml
@@ -172,6 +172,7 @@
             <property name="arrayInitIndent" value="4"/>
         </module>
         <module name="AbbreviationAsWordInName">
+            <property name="id" value="abbreviation"/>
             <property name="ignoreFinal" value="false"/>
             <property name="allowedAbbreviationLength" value="1"/>
         </module>
@@ -228,5 +229,11 @@
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
+
+        <module name="SuppressWarnings">
+            <property name="id" value="checkstyle:suppresswarnings"/>
+        </module>
     </module>
+
+    <module name="SuppressWarningsFilter"/>
 </module>


### PR DESCRIPTION
This PR enables the @SuppressWarnings annotations for checkstyle, enabling turning off warnings for deprecated code.