### PR TITLE
Optimize Checkpoint Batching

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CPSerializer.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CPSerializer.java
@@ -1,0 +1,79 @@
+package org.corfudb.runtime.checkpoint;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.util.serializer.ISerializer;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.lang.reflect.Type;
+import java.util.Map;
+
+/**
+ * A special serializer for checkpoint testing
+ */
+public class CPSerializer implements ISerializer {
+    GsonBuilder gsonBuilder = new GsonBuilder();
+    Gson gson = gsonBuilder.create();
+
+    private final byte type;
+
+    public CPSerializer(byte type) {
+        this.type = type;
+    }
+
+    public byte getType() {
+        return type;
+    }
+
+    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+        Type mapType = new TypeToken<Map<String, Long>>(){}.getType();
+
+        int classNameLength = b.readShort();
+        byte[] classNameBytes = new byte[classNameLength];
+        b.readBytes(classNameBytes, 0, classNameLength);
+        String className = new String(classNameBytes);
+        boolean isMap = false;
+
+        if (className.equals("null")) {
+            return null;
+        } else if (className.endsWith("HashMap")) {
+            isMap = true;
+        }
+
+        try (ByteBufInputStream bbis = new ByteBufInputStream(b)) {
+            try (InputStreamReader r = new InputStreamReader(bbis)) {
+                if (isMap) {
+                    return gson.fromJson(r, mapType);
+                } else {
+                    return gson.fromJson(r, Class.forName(className));
+                }
+            }
+        } catch (IOException | ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void serialize(Object o, ByteBuf b) {
+        String className = o == null ? "null" : o.getClass().getName();
+        byte[] classNameBytes = className.getBytes();
+        b.writeShort(classNameBytes.length);
+        b.writeBytes(classNameBytes);
+        if (o == null) {
+            return;
+        }
+        try (ByteBufOutputStream bbos = new ByteBufOutputStream(b)) {
+            try (OutputStreamWriter osw = new OutputStreamWriter(bbos)) {
+                gson.toJson(o, osw);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -10,6 +10,8 @@ import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.AbstractObjectTest;
 import org.corfudb.runtime.object.transactions.TransactionType;
+import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.Serializers;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -32,12 +34,15 @@ public class CheckpointTest extends AbstractObjectTest {
     }
 
     Map<String, Long> instantiateMap(String mapName) {
+        final byte serializerByte = (byte) 20;
+        ISerializer serializer = new CPSerializer(serializerByte);
+        Serializers.registerSerializer(serializer);
         return (SMRMap<String, Long>)
                 instantiateCorfuObject(
                         getMyRuntime(),
-                        new TypeToken<SMRMap<String, Long>>() {
-                        },
-                        mapName);
+                        new TypeToken<SMRMap<String, Long>>() {},
+                        mapName,
+                        serializer);
     }
 
     final String streamNameA = "mystreamA";

--- a/test/src/test/java/org/corfudb/runtime/object/AbstractObjectTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/AbstractObjectTest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.object;
 import com.google.common.reflect.TypeToken;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.util.serializer.ISerializer;
 
 /**
  * Created by dalia on 4/11/17.
@@ -58,6 +59,16 @@ public class AbstractObjectTest extends AbstractViewTest {
     }
     protected <T> Object instantiateCorfuObject(TypeToken<T> tType, String name) {
         return instantiateCorfuObject(getRuntime(), tType, name);
+    }
+
+    protected <T> Object instantiateCorfuObject(CorfuRuntime r, TypeToken<T> tType, String name, ISerializer serializer) {
+        return (T)
+                r.getObjectsView()
+                        .build()
+                        .setStreamName(name)     // stream name
+                        .setTypeToken(tType)    // a TypeToken of the specified class
+                        .setSerializer(serializer)
+                        .open();                // instantiate the object!
     }
 
 }


### PR DESCRIPTION
The CP implementation used to create an SMREntry for each key,
this patch changes that behavior. Now multiple keys are grouped
into a single SMREntry as a putAll.