### PR TITLE
change cache readAll() to utilize ranged read instead of single reads

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -1,9 +1,13 @@
 package org.corfudb.runtime.view;
 
+import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.Range;
 import org.corfudb.infrastructure.LogUnitServerAssertions;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.protocols.wireprotocol.*;
 import org.corfudb.runtime.CorfuRuntime;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.*;
@@ -15,10 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class AddressSpaceViewTest extends AbstractViewTest {
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void ensureStripingWorks()
-            throws Exception {
+    @Before
+    public void setup(){
         addServer(SERVERS.PORT_0);
         addServer(SERVERS.PORT_1);
         addServer(SERVERS.PORT_2);
@@ -40,7 +42,12 @@ public class AddressSpaceViewTest extends AbstractViewTest {
                 .addToSegment()
                 .addToLayout()
                 .build());
+    }
 
+    @Test
+    @SuppressWarnings("unchecked")
+    public void ensureStripingWorks()
+            throws Exception {
         CorfuRuntime r = getRuntime().connect();
 
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
@@ -81,31 +88,9 @@ public class AddressSpaceViewTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void ensureStripingReadAllWorks()
             throws Exception {
-        addServer(SERVERS.PORT_0);
-        addServer(SERVERS.PORT_1);
-        addServer(SERVERS.PORT_2);
-
-        bootstrapAllServers(new TestLayoutBuilder()
-                .setEpoch(1L)
-                .addLayoutServer(SERVERS.PORT_0)
-                .addSequencer(SERVERS.PORT_0)
-                .buildSegment()
-                .buildStripe()
-                .addLogUnit(SERVERS.PORT_0)
-                .addToSegment()
-                .buildStripe()
-                .addLogUnit(SERVERS.PORT_1)
-                .addToSegment()
-                .buildStripe()
-                .addLogUnit(SERVERS.PORT_2)
-                .addToSegment()
-                .addToLayout()
-                .build());
-
         //configure the layout accordingly
         CorfuRuntime r = getRuntime().connect();
 
-        UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
         final long ADDRESS_0 = 0;
@@ -137,5 +122,34 @@ public class AddressSpaceViewTest extends AbstractViewTest {
                 .isEqualTo("1".getBytes());
         assertThat(m.get(ADDRESS_2).getPayload(getRuntime()))
                 .isEqualTo("3".getBytes());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void readAllWithHoleFill()
+            throws Exception {
+        //configure the layout accordingly
+        CorfuRuntime r = getRuntime().connect();
+
+        byte[] testPayload = "hello world".getBytes();
+
+        final long ADDRESS_0 = 0;
+        final long ADDRESS_1 = 1;
+        final long ADDRESS_2 = 3;
+        Token token = new Token(ADDRESS_0, r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(token, testPayload);
+
+        assertThat(r.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
+                .isEqualTo("hello world".getBytes());
+
+        Range range = Range.closed(ADDRESS_0, ADDRESS_2);
+        ContiguousSet<Long> addresses = ContiguousSet.create(range, DiscreteDomain.longs());
+
+        Map<Long, ILogData> m = r.getAddressSpaceView().read(addresses);
+
+        assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
+                .isEqualTo("hello world".getBytes());
+        assertThat(m.get(ADDRESS_1).isHole());
+        assertThat(m.get(ADDRESS_2).isHole());
     }
 }


### PR DESCRIPTION
Issue #724 

Only implemented ChainReplicationProtocol for now.

Couple of issues/questions:
1. API currently supports ranged read, not random reads
2. Method signatures need to be changed when 1) is resolved. Either user of these methods need to supply list of ranges (user do more work), or readAll() needs to be able to properly compile a list of ranges.
3. Is this the right way to handle hole filling?
4. In cacheFetch(), can these different address have different replication protocols?