### PR TITLE
FastSmrMapsLoader without support of checkpoints/trim

### DIFF
--- a/runtime/src/main/java/org/corfudb/recovery/FastSmrMapsLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastSmrMapsLoader.java
@@ -1,0 +1,336 @@
+package org.corfudb.recovery;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.Range;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.LogEntry;
+import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.object.CorfuCompileProxy;
+import org.corfudb.runtime.object.ICorfuSMR;
+import org.corfudb.runtime.view.ObjectsView;
+
+/** The FastSmrMapsLoader reconstructs the coalesced state of SMRMaps through sequential log read
+ *
+ * This utility reads Log entries sequentially extracting the SMRUpdates from each entry
+ * and build the Maps as we go. In the presence of checkpoints, the checkpoint entries will
+ * be applied before the normal entries starting after the checkpoint start address.
+ *
+ * As current state, it doesn't support checkpoints/trim.
+ *
+ *
+ * Created by rmichoud on 6/14/17.
+ */
+
+@Slf4j
+@Accessors(chain = true)
+public class FastSmrMapsLoader {
+
+    static final long DEFAULT_BATCH_FOR_FAST_LOADER = 5;
+    static final int DEFAULT_TIMEOUT_MINUTES_FAST_LOADING = 30;
+    static final int STATUS_UPDATE_PACE = 10000;
+
+    private CorfuRuntime runtime;
+
+    @Setter
+    @Getter
+    private boolean loadInCache;
+
+    @Setter
+    @Getter
+    private long logHead = -1;
+
+    @Setter
+    @Getter
+    private long logTail = -1;
+
+    @Setter
+    @Getter
+    private long batchReadSize = DEFAULT_BATCH_FOR_FAST_LOADER;
+
+    @Setter
+    @Getter
+    private int timeoutInMinutesForLoading = DEFAULT_TIMEOUT_MINUTES_FAST_LOADING;
+
+
+    @Setter
+    @Getter
+    private boolean recoverSequencerMode;
+
+    private long addressProcessed = -1;
+
+    // In charge of summoning Corfu maps back in this world
+    private ExecutorService necromancer;
+
+    private Map<UUID, StreamMetaData> streamsMetaData;
+
+    @Getter
+    private Map<UUID, Long> streamTails = new HashMap<>();
+
+    public FastSmrMapsLoader(@Nonnull final CorfuRuntime corfuRuntime) {
+        this.runtime = corfuRuntime;
+        loadInCache = !corfuRuntime.cacheDisabled;
+        streamsMetaData = new HashMap<>();
+        necromancer = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+                .setNameFormat("necromancer-%d").build());
+    }
+
+    /** Check if this entry is relevant
+     *
+     * Entries before checkpoint starts are irrelevant since they are
+     * contained in the checkpoint.
+     *
+     * @param streamId identifies the Corfu stream
+     * @param entry entry to potentially apply
+     * @return if we need to apply the entry.
+     */
+    private boolean shouldEntryBeApplied(UUID streamId, SMREntry entry) {
+        if (!streamsMetaData.containsKey(streamId)) {
+            return true;
+        }
+
+        return (entry.getEntry().getGlobalAddress() >=
+                streamsMetaData.get(streamId).getHeadAddress());
+    }
+
+    private ObjectsView.ObjectID getObjectIdFromStreamID(UUID streamId) {
+        return new ObjectsView.ObjectID(streamId, SMRMap.class);
+    }
+
+    /** Update the corfu object and it's underlying stream with the new entry.
+     *
+     * @param streamId identifies the Corfu stream
+     * @param entry entry to apply
+     */
+    private void applySmrEntryToStream(UUID streamId, SMREntry entry) {
+        if (shouldEntryBeApplied(streamId, entry)) {
+            createSmrMapIfNotExist(streamId);
+
+            ObjectsView.ObjectID thisObjectId = new ObjectsView.ObjectID(streamId, SMRMap.class);
+            CorfuCompileProxy cp = ((CorfuCompileProxy) ((ICorfuSMR) runtime.getObjectsView().getObjectCache().get(thisObjectId)).
+                    getCorfuSMRProxy());
+
+            cp.getUnderlyingObject().applyUpdateToStreamUnsafe(entry);
+        }
+    }
+
+    /** Fetch LogData from Corfu server
+     *
+     * @param address address to be fetched
+     * @return LogData at address
+     */
+    private ILogData getLogData(long address) {
+        if (loadInCache) {
+            return runtime.getAddressSpaceView().read(address);
+        } else {
+            return runtime.getAddressSpaceView().fetch(address);
+        }
+    }
+
+    /** Get a range of LogData from the server
+     *
+     * This is using the underlying bulk read implementation for
+     * fetching a range of addresses. This read will return
+     * a map ordered by address.
+     *
+     * It uses a ClosedOpen range : [start, end)
+     * (e.g [0, 5) == (0,1,2,3,4))
+     *
+     * @param start start address for the bulk read
+     * @param end end address for the bulk read
+     * @return logData map ordered by addresses (increasing)
+     */
+    private Map<Long, ILogData> getLogData(long start, long end) {
+        return runtime.getAddressSpaceView()
+                .cacheFetch(ContiguousSet.create(Range.closedOpen(start, end), DiscreteDomain.longs()));
+    }
+
+
+    /** Create a new object SMRMap as recipient of SMRUpdates (if doesn't exist yet)
+     *
+     * @param streamId
+     */
+    private void createSmrMapIfNotExist(UUID streamId) {
+        if (!runtime.getObjectsView().getObjectCache().containsKey(getObjectIdFromStreamID(streamId))) {
+            runtime.getObjectsView().build()
+                    .setStreamID(streamId)
+                    .setType(SMRMap.class)
+                    .open();
+        }
+    }
+
+    /** Deserialize a logData by getting the logEntry
+     *
+     * Getting the underlying logEntry should trigger deserialization only once.
+     * Next access should just returned the logEntry direclty.
+     *
+     * @param logData
+     * @return
+     * @throws Exception
+     */
+    public LogEntry deserializeLogData(ILogData logData) throws Exception{
+        return logData.getLogEntry(runtime);
+    }
+
+    /** Extract log entries from logData and update the Corfu Objects
+     *
+     * @param logData LogData received from Corfu server.
+     */
+    private void processLogData(ILogData logData) {
+
+        LogEntry logEntry;
+        try {
+            logEntry = deserializeLogData(logData);
+        } catch (Exception e) {
+            log.error("Cannot deserialize log entry" + logData.getGlobalAddress(), e);
+            return;
+        }
+
+        if (logEntry.getType() == LogEntry.LogEntryType.SMR) {
+            // Just one stream, always
+            UUID streamId = logData.getStreams().iterator().next();
+            applySmrEntryToStream(streamId, (SMREntry) logEntry);
+        }
+        else if (logEntry.getType() == LogEntry.LogEntryType.MULTIOBJSMR) {
+            MultiObjectSMREntry multiObjectLogEntry = (MultiObjectSMREntry) logEntry;
+            multiObjectLogEntry.getEntryMap().forEach((stream, multiSmrEntry) -> {
+                multiSmrEntry.getSMRUpdates(stream).forEach((smrEntry) -> {
+                    applySmrEntryToStream(stream, smrEntry);
+                });
+            });
+        }
+    }
+
+    private void findAndSetLogHead() {
+        logHead = 0;
+    }
+
+    private void findAndSetLogTail() {
+        logTail = runtime.getSequencerView().nextToken(Collections.emptySet(), 0).getTokenValue();
+    }
+
+    /** Initialize log head and log tails
+     *
+     * If logHead and logTail has not been initialized by
+     * the user, initialize to default.
+     *
+     */
+    private void initializeHeadAndTails() {
+        if (logHead < 0) {
+            findAndSetLogHead();
+        }
+
+        if (logTail < 0) {
+            findAndSetLogTail();
+        }
+    }
+
+    /** Book keeping of the the stream tails
+     *
+     * @param logData
+     */
+    public void updateStreamTails(ILogData logData) {
+         for (UUID streamId : logData.getStreams()) {
+             streamTails.put(streamId, logData.getGlobalAddress());
+            }
+    }
+
+    /** Processing logdata at a given log address
+     *
+     * @param logData
+     * @param address
+     */
+    public void processAddressLogData(ILogData logData, long address) {
+        switch (logData.getType()) {
+            case DATA:
+                processLogData(logData);
+                break;
+            case HOLE:
+                break;
+            case TRIMMED:
+                log.warn("loadMaps[{}, start={}]: address is trimmed", address, logHead);
+                // Should not happen
+            case EMPTY:
+                log.warn("loadMaps[address={}]: is empty", address);
+                break;
+            case RANK_ONLY:
+                break;
+            default:
+                break;
+        }
+    }
+
+
+    /** Entry point to load the SMRMaps in memory.
+     *
+     * When this function returns, the maps are fully loaded.
+     *
+     */
+    public void loadMaps() {
+        log.info("loadMaps: Starting to resurrect maps");
+        initializeHeadAndTails();
+
+        long nextRead = 0;
+        while (nextRead <= logTail) {
+            final long start = nextRead;
+            final long stopNotIncluded = Math.min(start + batchReadSize, logTail + 1);
+            nextRead = stopNotIncluded;
+            final Map<Long, ILogData> range = getLogData(start, stopNotIncluded);
+            for (Long address : range.keySet()) {
+                if (address != addressProcessed + 1) {
+                    throw new RuntimeException("loadMaps: Missed an entry, this implies correctness issues");
+                }
+                addressProcessed++;
+                if (addressProcessed % STATUS_UPDATE_PACE == 0) {
+                    log.info("LoadMaps: read up to {}", address);
+                }
+            }
+
+            necromancer.execute(() -> {
+                range.forEach((address, logData) -> {
+                    if (recoverSequencerMode) {
+                        updateStreamTails(logData);
+                    } else {
+                        processAddressLogData(logData, address);
+                    }
+                });
+            });
+        }
+
+        necromancer.shutdown();
+
+        try {
+            necromancer.awaitTermination(timeoutInMinutesForLoading, TimeUnit.MINUTES);
+            log.info("loadMaps[startAddress: {}, stopAddress (included): {}, addressProcessed: {}]",
+                    logHead, logTail, addressProcessed);
+            log.info("loadMaps: Loading successful, Corfu maps are alive!");
+        } catch (InterruptedException e) {
+            log.warn("loadMaps: Taking too long to load the maps. Gave up.");
+        }
+    }
+
+    @Data
+    private class StreamMetaData {
+        UUID streamId;
+        long headAddress;
+    }
+}
+

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -481,7 +481,7 @@ public class VersionLockedObject<T> {
      *
      * @param entry The entry to apply.
      */
-    protected Object applyUpdateUnsafe(SMREntry entry) {
+    public Object applyUpdateUnsafe(SMREntry entry) {
         log.trace("Apply[{}] of {}@{} ({})", this, entry.getSMRMethod(),
                 entry.getEntry() != null ? entry.getEntry().getGlobalAddress() : "OPT",
                 entry.getSMRArguments());
@@ -619,5 +619,17 @@ public class VersionLockedObject<T> {
             log.debug("OptimisticRollback[{}] failed", this);
             resetUnsafe();
         }
+    }
+
+    /** Apply an SMREntry to the version object, while
+     * doing bookkeeping for the underlying stream.
+     *
+     * @param entry
+     */
+    public void applyUpdateToStreamUnsafe(SMREntry entry) {
+        long entryAddress = entry.getEntry().getGlobalAddress();
+
+        applyUpdateUnsafe(entry);
+        seek(entryAddress + 1);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -278,7 +278,7 @@ public class AddressSpaceView extends AbstractView {
      * @param addresses collection of addresses to read from.
      * @return A result to be cached
      */
-    private @Nonnull Map<Long, ILogData> cacheFetch(Iterable<Long> addresses) {
+    public @Nonnull Map<Long, ILogData> cacheFetch(Iterable<Long> addresses) {
         //turn the addresses into Set for now to satisfy signature requirement down the line
         Set<Long> readAddresses = new TreeSet<>();
         Iterator<Long> iterator = addresses.iterator();

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -413,8 +413,8 @@ public abstract class AbstractQueuedStreamView extends
             log.trace("Seek[{}]({}), min={} max={}", this,  globalAddress, minResolution, maxResolution);
             // Update minResolution if necessary
             if (globalAddress >= maxResolution) {
-                log.warn("set min res to {}" , globalAddress);
-                minResolution = globalAddress; // TODO SLF wha? minResolution can be greater than maxResolution
+                log.trace("set min res to {}" , globalAddress);
+                minResolution = globalAddress;
             }
             // remove anything in the read queue LESS
             // than global address.

--- a/test/src/test/java/org/corfudb/recovery/FastSmrMapsLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastSmrMapsLoaderTest.java
@@ -1,0 +1,288 @@
+package org.corfudb.recovery;
+
+import com.google.common.reflect.TypeToken;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.IMetadata;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.clients.SequencerClient;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.object.CorfuCompileProxy;
+import org.corfudb.runtime.object.ICorfuSMR;
+import org.corfudb.runtime.object.VersionLockedObject;
+import org.corfudb.runtime.object.transactions.TransactionType;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.ObjectsView;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by rmichoud on 6/16/17.
+ */
+public class FastSmrMapsLoaderTest extends AbstractViewTest {
+
+    private ILogData.SerializationHandle createEmptyData(long position, DataType type, IMetadata.DataRank rank) {
+        ILogData data = new LogData(type);
+        data.setRank(rank);
+        data.setGlobalAddress(position);
+        return data.getSerializedForm();
+    }
+
+    private VersionLockedObject getVersionLockedObject(CorfuRuntime cr, String streamName) {
+        ObjectsView.ObjectID mapId = new ObjectsView.
+                ObjectID(CorfuRuntime.getStreamID(streamName), SMRMap.class);
+
+        CorfuCompileProxy cp = ((CorfuCompileProxy) ((ICorfuSMR) cr.getObjectsView().
+                getObjectCache().
+                get(mapId)).
+                getCorfuSMRProxy());
+        return cp.getUnderlyingObject();
+    }
+
+    private Map<String, String> createMap(String streamName, CorfuRuntime cr) {
+        return cr.getObjectsView().build()
+                .setStreamName(streamName)
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {
+                })
+                .open();
+    }
+
+    private void assertThatMapIsBuilt(CorfuRuntime rt1, CorfuRuntime rt2, String streamName,
+                                      Map<String, String> map) {
+
+        // Get raw maps (VersionLockedObject)
+        VersionLockedObject vo1 = getVersionLockedObject(rt1, streamName);
+        VersionLockedObject vo1Prime = getVersionLockedObject(rt2, streamName);
+
+        // Assert that UnderlyingObjects are at the same version
+        // If they are at the same version, a sync on the object will
+        // be a no op for the new runtime.
+        assertThat(vo1.getVersionUnsafe()).isEqualTo(vo1Prime.getVersionUnsafe());
+        assertThat(rt1.getObjectsView().getObjectCache().size())
+                .isEqualTo(rt2.getObjectsView().getObjectCache().size());
+
+        Map<String, String> mapPrime = createMap(streamName, rt2);
+        assertThat(map.size()).isEqualTo(mapPrime.size());
+        map.forEach((key, value) -> assertThat(value).isEqualTo(mapPrime.get(key)));
+    }
+
+
+    /** Test that the maps are reloaded after runtime.connect()
+     *
+     * By checking the version of the underlying objects, we ensure that
+     * they are the same in the previous runtime and the new one.
+     *
+     * If they are at the same version, upon access the map will not be
+     * modified. All the subsequent asserts are on the pre-built map.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void canReloadMaps() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map2.put("k4", "v4");
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+
+    }
+
+    @Test
+    public void canReadWithCacheDisable() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .setCacheDisabled(true)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+
+
+    }
+
+
+
+    /**
+     * This test ensure that reading Holes will not affect the recovery.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void canReadHoles() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+
+        LogUnitClient luc = rt1.getRouter(getDefaultConfigurationString())
+                .getClient(LogUnitClient.class);
+        SequencerClient seq = rt1.getRouter(getDefaultConfigurationString())
+                .getClient(SequencerClient.class);
+
+        seq.nextToken(null, 1);
+        luc.fillHole(rt1.getSequencerView()
+                .nextToken(Collections.emptySet(), 0)
+                .getTokenValue());
+
+        map1.put("k3", "v3");
+
+        seq.nextToken(null, 1);
+        luc.fillHole(rt1.getSequencerView()
+                .nextToken(Collections.emptySet(), 0)
+                .getTokenValue());
+
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+     assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+
+    }
+
+    /** Ensures that we are able to do rollback after the fast loading
+     *
+     * It is by design that reading the entries will not populate the
+     * streamView context queue. Snapshot transaction to addresses before
+     * the initialization log tail should seldom happen.
+     *
+     * In the case it does happen, the stream view will follow the backpointers
+     * to figure out which are the addresses that it should rollback to.
+     *
+     * We don't need to optimize this path, since we don't need the stream view context
+     * queue to be in a steady state. If the user really want snapshot back in time,
+     * he/she will take the hit.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void canRollBack() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        Map<String, String> map1Prime = createMap("Map1", rt2);
+
+        rt2.getObjectsView().TXBuild().setType(TransactionType.SNAPSHOT).setSnapshot(0).begin();
+        assertThat(map1Prime.get("k1")).isEqualTo("v1");
+        assertThat(map1Prime.get("k2")).isNull();
+        rt2.getObjectsView().TXEnd();
+
+    }
+
+    @Test
+    public void canLoadWithCustomBulkRead() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map1.put("k3", "v3");
+        map1.put("k4", "v4");
+        map1.put("k5", "v5");
+
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .setBulkReadSizeForFastLoader(2l)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+    }
+
+    @Test
+    public void canFindTailsRecoverSequencerMode() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map2.put("k4", "v4");
+
+        UUID stream1 = CorfuRuntime.getStreamID("Map1");
+        UUID stream2 = CorfuRuntime.getStreamID("Map2");
+
+
+
+        long tail1 = rt1.getSequencerView().nextToken(Collections.singleton(stream1), 0).getToken().getTokenValue();
+        long tail2 = rt1.getSequencerView().nextToken(Collections.singleton(stream2), 0).getToken().getTokenValue();
+
+
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .connect();
+
+        FastSmrMapsLoader fsml = new FastSmrMapsLoader(rt2);
+        fsml.setRecoverSequencerMode(true);
+        fsml.loadMaps();
+
+        Map <UUID, Long> streamTails = fsml.getStreamTails();
+
+        assertThat(streamTails.get(stream1)).isEqualTo(tail1);
+        assertThat(streamTails.get(stream2)).isEqualTo(tail2);
+    }
+
+    @Test
+    public void canReadRankOnlyEntries() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+
+        UUID stream1 = CorfuRuntime.getStreamID("Map1");
+        UUID stream2 = CorfuRuntime.getStreamID("Map2");
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+
+        LogUnitClient luc = rt1.getRouter(getDefaultConfigurationString())
+                .getClient(LogUnitClient.class);
+        SequencerClient seq = rt1.getRouter(getDefaultConfigurationString())
+                .getClient(SequencerClient.class);
+
+        long address = seq.nextToken(Collections.emptySet(),1).get().getTokenValue();
+        ILogData data = createEmptyData(address, DataType.RANK_ONLY,  new IMetadata.DataRank(2))
+                .getSerialized();
+        luc.write(data).get();
+
+        map2.put("k3", "v3");
+
+        address = seq.nextToken(Collections.emptySet(),1).get().getTokenValue();
+        data = createEmptyData(address, DataType.RANK_ONLY,  new IMetadata.DataRank(2))
+                .getSerialized();
+        luc.write(data).get();
+
+        map2.put("k4", "v4");
+
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+    }
+
+}


### PR DESCRIPTION
First version of the FastSmrMapsLoader that will reconstruct all the SMR
Maps present in the log in one pass. It reads sequentially all entries
from 0 to log tail and dispatch the SMREntries to its map backed by a
Corfu stream. Every time it encounters a new stream, it creates a new Corfu
Object.