### PR TITLE
Add module suppress check abbreviation warning

### DIFF
--- a/checks.xml
+++ b/checks.xml
@@ -34,8 +34,9 @@
         <module name="FileTabCharacter">
             <property name="eachLine" value="true"/>
         </module>
-
+    <module name="SuppressWarningsFilter" />
     <module name="TreeWalker">
+	<module name="SuppressWarningsHolder" />
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>


### PR DESCRIPTION
Adding two modules to checks.xml file to suppress checkstyle abbreviation and
member pattern warnings.

For use, add to the top of the class/method/field:

@SuppressWarnings("checkstyle:abbreviationaswordinname")
@SuppressWarnings("checkstyle:membername")