### PR TITLE
Checkstyle fixups for org.corfudb.runtime.view.replication.*

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocol.java
@@ -1,11 +1,11 @@
 package org.corfudb.runtime.view.replication;
 
+import javax.annotation.Nonnull;
+
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.exceptions.HoleFillRequiredException;
 import org.corfudb.runtime.view.Layout;
-
-import javax.annotation.Nonnull;
 
 /**
  * Created by mwei on 4/6/17.
@@ -14,21 +14,20 @@ import javax.annotation.Nonnull;
 public abstract class AbstractReplicationProtocol implements IReplicationProtocol {
 
     /** The hole fill policy to apply. */
-    final protected IHoleFillPolicy holeFillPolicy;
+    protected final IHoleFillPolicy holeFillPolicy;
 
     /** Build the replication protocol using the given hole filling policy.
      *
      * @param holeFillPolicy    The hole filling policy to be applied when
      *                          a read returns uncommitted data.
      */
-    public AbstractReplicationProtocol(IHoleFillPolicy holeFillPolicy)
-    {
+    public AbstractReplicationProtocol(IHoleFillPolicy holeFillPolicy) {
         this.holeFillPolicy = holeFillPolicy;
     }
 
     /** {@inheritDoc}
      *
-     *  In the base implementation, we attempt to read data
+     *  <p>In the base implementation, we attempt to read data
      *  using the peek method. If data is returned by peek,
      *  we use it. Otherwise, we invoke the hole filling
      *  protocol.
@@ -58,5 +57,5 @@ public abstract class AbstractReplicationProtocol implements IReplicationProtoco
      *
      * @param globalAddress  The address to hole fill.
      */
-    abstract protected void holeFill(Layout layout, long globalAddress);
+    protected abstract void holeFill(Layout layout, long globalAddress);
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/AlwaysHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/AlwaysHoleFillPolicy.java
@@ -1,19 +1,20 @@
 package org.corfudb.runtime.view.replication;
 
+import java.util.function.Function;
+import javax.annotation.Nonnull;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.exceptions.HoleFillRequiredException;
-
-import javax.annotation.Nonnull;
-import java.util.function.Function;
 
 /** A simple hole filling policy which aggressively
  * fills holes whenever there is a failed read.
  *
- * Created by mwei on 4/6/17.
+ * <p>Created by mwei on 4/6/17.
  */
 public class AlwaysHoleFillPolicy implements IHoleFillPolicy {
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Nonnull
     @Override
     public ILogData peekUntilHoleFillRequired(long address,

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/IHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/IHoleFillPolicy.java
@@ -1,10 +1,10 @@
 package org.corfudb.runtime.view.replication;
 
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.exceptions.HoleFillRequiredException;
-
-import javax.annotation.Nonnull;
-import java.util.function.Function;
 
 /**
  * Created by mwei on 4/6/17.

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/IReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/IReplicationProtocol.java
@@ -1,31 +1,34 @@
 package org.corfudb.runtime.view.replication;
 
+import java.util.AbstractMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.view.Layout;
 
-import javax.annotation.Nonnull;
-import java.util.*;
-import java.util.stream.Collectors;
 
 /** The public interface to a replication protocol.
  *
- * A replication protocol exposes three public functions, which
+ * <p>A replication protocol exposes three public functions, which
  * permit reading and writing to the log.
  *
- * Created by mwei on 4/6/17.
+ * <p>Created by mwei on 4/6/17.
  */
 public interface IReplicationProtocol {
 
     /** Write data to the log at the given address.
      *
-     * This function blocks until -a- write at the global address
+     * <p>This function blocks until -a- write at the global address
      * is committed to the log.
      *
-     * If the write which is committed to the log was this write,
+     * <p>If the write which is committed to the log was this write,
      * the function returns normally.
      *
-     * If the write which was committed to the log was not the result
+     * <p>If the write which was committed to the log was not the result
      * of this call, an OverwriteException is thrown.
      *
      * @param  layout               The layout to use for the write.
@@ -37,7 +40,7 @@ public interface IReplicationProtocol {
 
     /** Read data from a given address.
      *
-     * This function only returns committed data. If the
+     * <p>This function only returns committed data. If the
      * address given has not committed, the implementation may
      * either block until it is committed, or commit a hole filling
      * entry to that address.
@@ -52,10 +55,10 @@ public interface IReplicationProtocol {
 
     /** Read data from all the given addresses.
      *
-     * This method functions exactly like a read, except
+     * <p>This method functions exactly like a read, except
      * that it returns the result for multiple addresses.
      *
-     * An implementation may optimize for this type of
+     * <p>An implementation may optimize for this type of
      * bulk request, but the default implementation
      * just performs multiple reads (possible in parallel).
      *
@@ -64,7 +67,8 @@ public interface IReplicationProtocol {
      * @return                      A map of addresses to committed
      *                              addresses, hole filling if necessary.
      */
-    default @Nonnull Map<Long, ILogData> readAll(Layout layout, Set<Long> globalAddresses) {
+    default @Nonnull
+            Map<Long, ILogData> readAll(Layout layout, Set<Long> globalAddresses) {
         return globalAddresses.parallelStream()
                 .map(a -> new AbstractMap.SimpleImmutableEntry<>(a, read(layout, a)))
                 .collect(Collectors.toMap(r -> r.getKey(), r -> r.getValue()));
@@ -72,7 +76,7 @@ public interface IReplicationProtocol {
 
     /** Peek data from a given address.
      *
-     * This function -may- return null if there was no entry
+     * <p>This function -may- return null if there was no entry
      * committed at the given global address, otherwise it
      * returns committed data at the given global address. It
      * does not attempt to hole fill if there was no entry.
@@ -87,10 +91,10 @@ public interface IReplicationProtocol {
 
     /** Peek data from all the given addresses.
      *
-     * This method functions exactly like a peek, except
+     * <p>This method functions exactly like a peek, except
      * that it returns the result for multiple addresses.
      *
-     * An implementation may optimize for this type of
+     * <p>An implementation may optimize for this type of
      * bulk request, but the default implementation
      * just performs multiple peeks (possibly in parallel).
      *

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/NeverHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/NeverHoleFillPolicy.java
@@ -1,18 +1,19 @@
 package org.corfudb.runtime.view.replication;
 
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.exceptions.HoleFillRequiredException;
 
-import javax.annotation.Nonnull;
-import java.util.function.Function;
 
 /**
  * This hole fill policy keeps retrying and never requires
  * a hole fill. It waits a static amount of time before
  * retrying.
  *
- * Created by mwei on 4/6/17.
+ * <p>Created by mwei on 4/6/17.
  */
 @Slf4j
 public class NeverHoleFillPolicy implements IHoleFillPolicy {
@@ -28,7 +29,9 @@ public class NeverHoleFillPolicy implements IHoleFillPolicy {
         this.waitMs = waitMs;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Nonnull
     @Override
     public ILogData peekUntilHoleFillRequired(long address,

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
@@ -1,8 +1,18 @@
 /**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance
- * with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
  */
+
 package org.corfudb.runtime.view.replication;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -26,14 +36,6 @@ import org.corfudb.util.retry.ExponentialBackoffRetry;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.RetryNeededException;
 
-import java.time.Duration;
-import java.util.Comparator;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-
 /**
  * Created by kspirov on 4/23/17.
  */
@@ -48,7 +50,8 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
     private static final Consumer<ExponentialBackoffRetry> WRITE_RETRY_SETTINGS = x -> {
         x.setBase(QUORUM_RECOVERY_READ_EXPONENTIAL_RETRY_BASE);
         x.setExtraWait(QUORUM_RECOVERY_READ_EXTRA_WAIT_MILLIS);
-        x.setBackoffDuration(Duration.ofSeconds(QUORUM_RECOVERY_READ_EXPONENTIAL_RETRY_BACKOFF_DURATION_SECONDS));
+        x.setBackoffDuration(Duration.ofSeconds(
+                QUORUM_RECOVERY_READ_EXPONENTIAL_RETRY_BACKOFF_DURATION_SECONDS));
         x.setRandomPortion(QUORUM_RECOVERY_READ_WAIT_RANDOM_PART);
     };
 
@@ -57,7 +60,9 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
     }
 
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ILogData peek(Layout layout, long address) {
         int numUnits = layout.getSegmentLength(address);
@@ -69,8 +74,9 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
                 for (int i = 0; i < numUnits; i++) {
                     futures[i] = layout.getLogUnitClient(address, i).read(address);
                 }
-                QuorumFuturesFactory.CompositeFuture<ReadResponse> future = QuorumFuturesFactory.getQuorumFuture(
-                        new ReadResponseComparator(address), futures);
+                QuorumFuturesFactory.CompositeFuture<ReadResponse> future =
+                        QuorumFuturesFactory.getQuorumFuture(new ReadResponseComparator(address),
+                                futures);
                 readResponse = CFUtils.getUninterruptibly(future, QuorumUnreachableException.class);
             } catch (QuorumUnreachableException e) {
                 e.printStackTrace();
@@ -96,12 +102,15 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
     protected void holeFill(Layout layout, long globalAddress) {
         int numUnits = layout.getSegmentLength(globalAddress);
         log.trace("fillHole[{}]: quorum head {}/{}", globalAddress, 1, numUnits);
-        try (ILogData.SerializationHandle holeData = createEmptyData(globalAddress, DataType.HOLE, new IMetadata.DataRank(0))) {
+        try (ILogData.SerializationHandle holeData = createEmptyData(globalAddress,
+                DataType.HOLE, new IMetadata.DataRank(0))) {
             recoveryWrite(layout, holeData.getSerialized());
         }
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void write(Layout layout, ILogData data) throws OverwriteException {
         final long globalAddress = data.getGlobalAddress();
@@ -113,14 +122,16 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
             try (ILogData.SerializationHandle sh =
                          data.getSerializedForm()) {
                 future = getWriteFuture(layout, sh.getSerialized());
-                CFUtils.getUninterruptibly(future, QuorumUnreachableException.class, OverwriteException.class, DataOutrankedException.class);
+                CFUtils.getUninterruptibly(future, QuorumUnreachableException.class,
+                        OverwriteException.class, DataOutrankedException.class);
             }
         } catch (OverwriteException e) {
-            log.error("Client implementation error, race in phase 1. Broken sequencer, data consistency in danger.");
+            log.error("Client implementation error, race in phase 1. "
+                    + "Broken sequencer, data consistency in danger.");
             throw e;
         } catch (LogUnitException | QuorumUnreachableException e) {
-            if (future.containsThrowableFrom(DataOutrankedException.class) ||
-                    future.containsThrowableFrom(ValueAdoptedException.class)) {
+            if (future.containsThrowableFrom(DataOutrankedException.class)
+                    || future.containsThrowableFrom(ValueAdoptedException.class)) {
                 // we are competing with other client that writes the same data or fills a hole
                 boolean adopted = recoveryWrite(layout, data);
                 if (!adopted) {
@@ -132,7 +143,8 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
     }
 
 
-    private ILogData.SerializationHandle createEmptyData(long position, DataType type, IMetadata.DataRank rank) {
+    private ILogData.SerializationHandle createEmptyData(
+            long position, DataType type, IMetadata.DataRank rank) {
         ILogData data = new LogData(type);
         data.setRank(rank);
         data.setGlobalAddress(position);
@@ -154,8 +166,7 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
             logData.setRank(new IMetadata.DataRank(0));
         }
         try {
-            IRetry.build(ExponentialBackoffRetry.class, () ->
-            {
+            IRetry.build(ExponentialBackoffRetry.class, () -> {
                 QuorumFuturesFactory.CompositeFuture<Boolean> future = null;
                 try {
                     log.debug("Recovery write loop for " + log);
@@ -163,7 +174,7 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
                     dh.getRef().releaseBuffer();
                     dh.getRef().setRank(dh.getRef().getRank().buildHigherRank());
                     // peek for existing
-                    if (retryCount.getAndIncrement()>0) {
+                    if (retryCount.getAndIncrement() > 0) {
                         try {
                             return holeFillPolicy
                                     .peekUntilHoleFillRequired(address,
@@ -174,12 +185,17 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
                         }
                     }
                     // phase 1
-                    try (ILogData.SerializationHandle ph1 = createEmptyData(dh.getRef().getGlobalAddress(), DataType.RANK_ONLY, dh.getRef().getRank())) {
+                    try (ILogData.SerializationHandle ph1 = createEmptyData(
+                            dh.getRef().getGlobalAddress(),
+                            DataType.RANK_ONLY,
+                            dh.getRef().getRank())) {
                         future = getWriteFuture(layout, ph1.getSerialized());
-                        CFUtils.getUninterruptibly(future, QuorumUnreachableException.class,  OverwriteException.class, DataOutrankedException.class);
+                        CFUtils.getUninterruptibly(future, QuorumUnreachableException.class,
+                                OverwriteException.class, DataOutrankedException.class);
                     } catch (LogUnitException | QuorumUnreachableException e) {
                         e.printStackTrace();
-                        ReadResponse rr = getAdoptedValueWithHighestRankIfPresent(address, future.getThrowables());
+                        ReadResponse rr = getAdoptedValueWithHighestRankIfPresent(
+                                address, future.getThrowables());
                         if (rr != null) { // check
                             LogData logDataExisting = rr.getReadSet().get(address);
                             logDataExisting.releaseBuffer();
@@ -193,7 +209,8 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
                     }
                     // phase 2 - only if exception is not thrown from phase 1
                     future = getWriteFuture(layout, dh.getRef());
-                    CFUtils.getUninterruptibly(future, QuorumUnreachableException.class, OverwriteException.class, DataOutrankedException.class);
+                    CFUtils.getUninterruptibly(future, QuorumUnreachableException.class,
+                            OverwriteException.class, DataOutrankedException.class);
                     log.trace("Write done[{}]: {}", address);
                     return dh.getRef();
                 } catch (QuorumUnreachableException | DataOutrankedException e) {
@@ -214,7 +231,8 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
 
     }
 
-    private QuorumFuturesFactory.CompositeFuture<Boolean> getWriteFuture(Layout layout, ILogData data) {
+    private QuorumFuturesFactory.CompositeFuture<Boolean> getWriteFuture(
+            Layout layout, ILogData data) {
         int numUnits = layout.getSegmentLength(data.getGlobalAddress());
         long globalAddress = data.getGlobalAddress();
         CompletableFuture<Boolean>[] futures = new CompletableFuture[numUnits];
@@ -228,7 +246,8 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
         return future;
     }
 
-    private ReadResponse getAdoptedValueWithHighestRankIfPresent(Long position, Set<Throwable> throwables) {
+    private ReadResponse getAdoptedValueWithHighestRankIfPresent(
+            Long position, Set<Throwable> throwables) {
         ReadResponse result = null;
         IMetadata.DataRank maxRank = null;
         for (Throwable t : throwables) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
@@ -1,16 +1,17 @@
 package org.corfudb.runtime.view.replication;
 
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.exceptions.HoleFillRequiredException;
 
-import javax.annotation.Nonnull;
-import java.util.function.Function;
 
 /** A hole filling policy which reads several times,
  * waiting a static amount of time in between, before
  * requiring a hole fill.
  *
- * Created by mwei on 4/6/17.
+ * <p>Created by mwei on 4/6/17.
  */
 public class ReadWaitHoleFillPolicy implements IHoleFillPolicy {
 
@@ -31,11 +32,13 @@ public class ReadWaitHoleFillPolicy implements IHoleFillPolicy {
         this.numRetries = numRetries;
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     */
     @Nonnull
     @Override
-    public ILogData peekUntilHoleFillRequired(long address,
-           Function<Long, ILogData> peekFunction) throws HoleFillRequiredException {
+    public ILogData peekUntilHoleFillRequired(long address, Function<Long, ILogData> peekFunction)
+            throws HoleFillRequiredException {
         int tryNum = 0;
         do {
             // If this is not the first try, sleep before trying again


### PR DESCRIPTION
Checkstyle error fixes: comments, indentation, etc. for org.corfudb.view.replication.*