### PR TITLE
Update style org.corfudb.protocols.wireprotocol

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
@@ -1,13 +1,16 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.*;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Created by mwei on 9/15/15.
@@ -18,38 +21,43 @@ import java.util.stream.Collectors;
 public class CorfuMsg {
 
     /**
-     * Marker field value, should equal 0xC0FC0FC0
+     * Marker field value, should equal 0xC0FC0FC0.
      */
-    final static int markerField = 0xC0FC0FC0;
+    static final int markerField = 0xC0FC0FC0;
     static Map<Byte, CorfuMsgType> typeMap =
             Arrays.<CorfuMsgType>stream(CorfuMsgType.values())
                     .collect(Collectors.toMap(CorfuMsgType::asByte, Function.identity()));
     /**
-     * The unique id of the client making the request
+     * The unique id of the client making the request.
      */
+    @SuppressWarnings({"checkstyle:abbreviationaswordinname", "checkstyle:membername"})
     UUID clientID;
+
     /**
-     * The request id of this request/response
+     * The request id of this request/response.
      */
+    @SuppressWarnings({"checkstyle:abbreviationaswordinname", "checkstyle:membername"})
     long requestID;
+
     /**
-     * The epoch of this request/response
+     * The epoch of this request/response.
      */
     long epoch;
+
     /**
      * The underlying ByteBuf, if present.
      */
     ByteBuf buf;
 
-    ;
     /**
-     * The type of message
+     * The type of message.
      */
     CorfuMsgType msgType;
 
     /**
      * Constructor which generates a message based only the message type.
-     * Typically used for generating error messages, since sendmessage will populate the rest of the fields.
+     * Typically used for generating error messages, since sendmessage
+     * will populate the rest of the fields.
      *
      * @param type The type of message to send.
      */
@@ -57,10 +65,8 @@ public class CorfuMsg {
         this.msgType = type;
     }
 
-        /* The wire format of the NettyCorfuMessage message is below:
-        markerField(1) | client ID(8) | request ID(8) |  epoch(8)   |  type(1)  |
-*/
-
+    // The wire format of the NettyCorfuMessage message is below:
+    //    markerField(1) | client ID(8) | request ID(8) |  epoch(8)   |  type(1)  |
 
     /**
      * Take the given bytebuffer and deserialize it into a message.
@@ -74,14 +80,14 @@ public class CorfuMsg {
             throw new RuntimeException("Attempt to deserialize a message which is not a CorfuMsg, "
                     + "Marker = " + marker + " but expected 0xC0FC0FC0");
         }
-        UUID clientID = new UUID(buffer.readLong(), buffer.readLong());
-        long requestID = buffer.readLong();
+        UUID clientId = new UUID(buffer.readLong(), buffer.readLong());
+        long requestId = buffer.readLong();
         long epoch = buffer.readLong();
         CorfuMsgType message = typeMap.get(buffer.readByte());
         CorfuMsg msg = message.getConstructor().construct();
 
-        msg.clientID = clientID;
-        msg.requestID = requestID;
+        msg.clientID = clientId;
+        msg.requestID = requestId;
         msg.epoch = epoch;
         msg.msgType = message;
         msg.fromBuffer(buffer);
@@ -111,15 +117,13 @@ public class CorfuMsg {
     /**
      * Parse the rest of the message from the buffer. Classes that extend CorfuMsg
      * should parse their fields in this method.
-     *
-     * @param buffer
-     */
+     **/
     public void fromBuffer(ByteBuf buffer) {
         // we don't do anything here since in the base message, no fields remain.
     }
 
     /**
-     * Copy the base fields over to this message
+     * Copy the base fields over to this message.
      */
     public void copyBaseFields(CorfuMsg msg) {
         this.clientID = msg.clientID;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -1,15 +1,18 @@
 package org.corfudb.protocols.wireprotocol;
 
 import com.google.common.reflect.TypeToken;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import org.corfudb.runtime.view.Layout;
+
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import org.corfudb.runtime.view.Layout;
 
 /**
  * Created by mwei on 8/8/16.
@@ -101,7 +104,7 @@ public enum CorfuMsgType {
         T construct();
     }
 
-    @Getter(lazy=true)
+    @Getter(lazy = true)
     private final MessageConstructor<? extends CorfuMsg> constructor = resolveConstructor();
 
     public byte asByte() {
@@ -120,8 +123,9 @@ public enum CorfuMsgType {
             MethodHandle mh = lookup.unreflectConstructor(t);
             MethodType mt = MethodType.methodType(Object.class);
             try {
-                return (MessageConstructor<? extends CorfuMsg>) LambdaMetafactory.metafactory(lookup,
-                        "construct", MethodType.methodType(MessageConstructor.class),
+                return (MessageConstructor<? extends CorfuMsg>) LambdaMetafactory.metafactory(
+                        lookup, "construct",
+                        MethodType.methodType(MessageConstructor.class),
                         mt, mh, mh.type())
                         .getTarget().invokeExact();
             } catch (Throwable th) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuPayload.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuPayload.java
@@ -1,6 +1,10 @@
 package org.corfudb.protocols.wireprotocol;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Created by mwei on 8/8/16.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuPayloadMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuPayloadMsg.java
@@ -1,22 +1,24 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+
+import java.lang.reflect.ParameterizedType;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.lang.reflect.ParameterizedType;
 
 /**
  * A message type which represents an encapsulated Corfu
  * payload.
  *
- * T should be either of a primitive boxed type (Long, Integer, etc)
- * or of ICorfuPayload.
+ * <p>T should be either of a primitive boxed type (Long, Integer, etc)
+ * or of ICorfuPayload.</p>
  *
- * NEVER, EVER use this class as a raw type. This class DEPENDS on
- * the generic captured at runtime by CorfuMsg (via TypeToken).
+ * <p>NEVER, EVER use this class as a raw type. This class DEPENDS on
+ * the generic captured at runtime by CorfuMsg (via TypeToken).</p>
  *
- * Created by mwei on 8/1/16.
+ * <p>Created by mwei on 8/1/16.</p>
  */
 @NoArgsConstructor
 public class CorfuPayloadMsg<T> extends CorfuMsg {
@@ -48,7 +50,7 @@ public class CorfuPayloadMsg<T> extends CorfuMsg {
      * Parse the rest of the message from the buffer. Classes that extend CorfuMsg
      * should parse their fields in this method.
      *
-     * @param buffer
+     * @param buffer contains the message from the buffer
      */
     @Override
     @SuppressWarnings("unchecked")

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
@@ -1,13 +1,14 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 /**
  * Created by mwei on 8/16/16.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/FailureDetectorMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/FailureDetectorMsg.java
@@ -1,10 +1,11 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.Set;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 /**
  * Trigger sent to the management server with the failures detected.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/FillHoleRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/FillHoleRequest.java
@@ -1,13 +1,15 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
 
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
 /**
- * Created by Maithem on 10/13/2016
+ * Request sent to fill a hole.
+ * Created by Maithem on 10/13/2016.
  */
 @CorfuPayload
 @Data
@@ -17,18 +19,26 @@ public class FillHoleRequest implements ICorfuPayload<FillHoleRequest> {
     final UUID stream;
     final Long prefix;
 
+    /**
+     * Constructor to generate a Fill Hole Request Payload.
+     *
+     * @param buf The buffer to deserialize.
+     */
     public FillHoleRequest(ByteBuf buf) {
-        if (ICorfuPayload.fromBuffer(buf, Boolean.class))
+        if (ICorfuPayload.fromBuffer(buf, Boolean.class)) {
             stream = ICorfuPayload.fromBuffer(buf, UUID.class);
-        else stream = null;
+        } else {
+            stream = null;
+        }
         prefix = ICorfuPayload.fromBuffer(buf, Long.class);
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, stream != null);
-        if (stream != null)
+        if (stream != null) {
             ICorfuPayload.serialize(buf, stream);
+        }
         ICorfuPayload.serialize(buf, prefix);
     }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -1,21 +1,20 @@
 package org.corfudb.protocols.wireprotocol;
 
+import java.util.UUID;
+
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.runtime.CorfuRuntime;
 
-import java.util.UUID;
-
 /** An interface to log data entries.
- *
  * Log data entries represent data stored in the actual log,
  * with convenience methods for software to retrieve the
  * stored information.
- *
  * Created by mwei on 8/17/16.
  */
 public interface ILogData extends IMetadata, Comparable<ILogData> {
 
     Object getPayload(CorfuRuntime t);
+
     DataType getType();
 
     @Override
@@ -44,13 +43,14 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
          * to the log data.
          * @param data  The log data to manage.
          */
-        public SerializationHandle(ILogData data)
-        {
+        public SerializationHandle(ILogData data) {
             this.data = data;
             data.acquireBuffer();
         }
 
-        /** {@inheritDoc} */
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public void close() {
             data.releaseBuffer();
@@ -58,10 +58,13 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
     }
 
     void releaseBuffer();
+
     void acquireBuffer();
+
     default SerializationHandle getSerializedForm() {
         return new SerializationHandle(this);
     }
+
     /**
      * Return whether or not this entry is a log entry.
      */
@@ -79,24 +82,26 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
     /**
      * Return if there is backpointer for a particular stream.
      */
-    default boolean hasBackpointer(UUID streamID) {
+    default boolean hasBackpointer(UUID streamId) {
         return getBackpointerMap() != null
-                && getBackpointerMap().containsKey(streamID);
+                && getBackpointerMap().containsKey(streamId);
     }
 
     /**
      * Return the backpointer for a particular stream.
      */
-    default Long getBackpointer(UUID streamID) {
-        if (!hasBackpointer(streamID)) return null;
-        return getBackpointerMap().get(streamID);
+    default Long getBackpointer(UUID streamId) {
+        if (!hasBackpointer(streamId)) {
+            return null;
+        }
+        return getBackpointerMap().get(streamId);
     }
 
     /**
      * Return if this is the first entry in a particular stream.
      */
-    default boolean isFirstEntry(UUID streamID) {
-        return getBackpointer(streamID) == -1L;
+    default boolean isFirstEntry(UUID streamId) {
+        return getBackpointer(streamId) == -1L;
     }
 
     /**
@@ -114,7 +119,9 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
     }
 
     /** Return whether the entry represents an empty entry or not. */
-    default boolean isEmpty() { return getType() == DataType.EMPTY;}
+    default boolean isEmpty() {
+        return getType() == DataType.EMPTY;
+    }
 
     /** Assign a given token to this log data.
      *

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -2,13 +2,7 @@ package org.corfudb.protocols.wireprotocol;
 
 import com.esotericsoftware.kryo.NotNull;
 import com.google.common.reflect.TypeToken;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Value;
-import org.corfudb.protocols.logprotocol.CheckpointEntry;
 
-import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -18,6 +12,15 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Value;
+
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
 
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_ID;
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_TYPE;
@@ -95,12 +98,18 @@ public interface IMetadata {
         getMetadataMap().put(LogUnitMetadataType.GLOBAL_ADDRESS, address);
     }
 
+    /**
+     * Get Log's global address (global tail).
+     * @return global address
+     */
     @SuppressWarnings("unchecked")
     default Long getGlobalAddress() {
-        if (getMetadataMap() == null || getMetadataMap().get(LogUnitMetadataType.GLOBAL_ADDRESS) == null) {
+        if (getMetadataMap() == null
+                || getMetadataMap().get(LogUnitMetadataType.GLOBAL_ADDRESS) == null) {
             return -1L;
         }
-        return Optional.ofNullable((Long) getMetadataMap().get(LogUnitMetadataType.GLOBAL_ADDRESS)).orElse((long) -1);
+        return Optional.ofNullable((Long) getMetadataMap()
+                .get(LogUnitMetadataType.GLOBAL_ADDRESS)).orElse((long) -1);
     }
 
     default void clearCommit() {
@@ -112,10 +121,12 @@ public interface IMetadata {
     }
 
     default boolean hasCheckpointMetadata() {
-        return getCheckpointType() != null &&
-               getCheckpointID() != null;
+        return getCheckpointType() != null && getCheckpointID() != null;
     }
 
+    /**
+     * Get checkpoint type.
+     */
     @Nullable
     default CheckpointEntry.CheckpointEntryType getCheckpointType() {
         return (CheckpointEntry.CheckpointEntryType) getMetadataMap()
@@ -128,13 +139,15 @@ public interface IMetadata {
     }
 
     @Nullable
+    @SuppressWarnings({"checkstyle:abbreviationaswordinname", "checkstyle:membername"})
     default UUID getCheckpointID() {
         return (UUID) getMetadataMap().getOrDefault(LogUnitMetadataType.CHECKPOINT_ID,
                 null);
     }
 
-    default void setCheckpointID(UUID ID) {
-        getMetadataMap().put(CHECKPOINT_ID, ID);
+    @SuppressWarnings({"checkstyle:abbreviationaswordinname", "checkstyle:membername"})
+    default void setCheckpointID(UUID id) {
+        getMetadataMap().put(CHECKPOINT_ID, id);
     }
 
     @RequiredArgsConstructor
@@ -156,7 +169,8 @@ public interface IMetadata {
 
         public static Map<Byte, LogUnitMetadataType> typeMap =
                 Arrays.<LogUnitMetadataType>stream(LogUnitMetadataType.values())
-                        .collect(Collectors.toMap(LogUnitMetadataType::asByte, Function.identity()));
+                        .collect(Collectors.toMap(LogUnitMetadataType::asByte,
+                                Function.identity()));
     }
 
     @Value
@@ -171,13 +185,13 @@ public interface IMetadata {
         }
 
         public DataRank buildHigherRank() {
-            return new DataRank(rank+1, uuid);
+            return new DataRank(rank + 1, uuid);
         }
 
         @Override
         public int compareTo(DataRank o) {
             int rankCompared = Long.compare(this.rank, o.rank);
-            if (rankCompared==0) {
+            if (rankCompared == 0) {
                 return uuid.compareTo(o.getUuid());
             } else {
                 return rankCompared;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IToken.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IToken.java
@@ -6,10 +6,10 @@ import java.util.UUID;
 
 /** Represents a token, which is a reservation on the log.
  *
- * Clients must obtain a token to write to the log using the normal
- * writing protocol.
+ * <p>Clients must obtain a token to write to the log using the normal
+ * writing protocol.</p>
  *
- * Created by mwei on 4/14/17.
+ * <p>Created by mwei on 4/14/17.</p>
  */
 public interface IToken {
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ITypedEnum.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ITypedEnum.java
@@ -9,6 +9,7 @@ import io.netty.buffer.ByteBuf;
 public interface ITypedEnum<T extends Enum<T>> extends ICorfuPayload<T>  {
 
     TypeToken<?> getComponentType();
+
     byte asByte();
 
     @Override

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/JSONPayloadMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/JSONPayloadMsg.java
@@ -2,16 +2,19 @@ package org.corfudb.protocols.wireprotocol;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import io.netty.buffer.ByteBuf;
-import lombok.NoArgsConstructor;
 
 import java.lang.reflect.ParameterizedType;
 import java.nio.charset.StandardCharsets;
+
+import lombok.NoArgsConstructor;
 
 /**
  * Created by mwei on 7/27/16.
  */
 @NoArgsConstructor
+@SuppressWarnings({"checkstyle:abbreviationaswordinname", "checkstyle:membername"})
 public class JSONPayloadMsg<T> extends CorfuMsg {
 
     static final Gson parser = new GsonBuilder().create();
@@ -48,7 +51,7 @@ public class JSONPayloadMsg<T> extends CorfuMsg {
      * Parse the rest of the message from the buffer. Classes that extend CorfuMsg
      * should parse their fields in this method.
      *
-     * @param buffer
+     * @param buffer to parse message from
      */
     @Override
     public void fromBuffer(ByteBuf buffer) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutBootstrapRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutBootstrapRequest.java
@@ -1,9 +1,12 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
+
 import org.corfudb.runtime.view.Layout;
+
 
 /**
  * Request sent to bootstrap the server with a {@link Layout}.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutCommittedRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutCommittedRequest.java
@@ -1,15 +1,17 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
+
 import org.corfudb.runtime.view.Layout;
 
 /**
  * If the first two phases (prepare and propose)  of paxos have been accepted,
  * the proposer sends a Committed message to commit the proposed {@link Layout}.
  *
- * Created by mdhawan on 10/24/16.
+ * <p>Created by mdhawan on 10/24/16.</p>
  */
 @Data
 @AllArgsConstructor

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutMsg.java
@@ -2,14 +2,17 @@ package org.corfudb.protocols.wireprotocol;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import io.netty.buffer.ByteBuf;
+
+import java.nio.charset.StandardCharsets;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.corfudb.runtime.view.Layout;
 
-import java.nio.charset.StandardCharsets;
+import org.corfudb.runtime.view.Layout;
 
 /**
  * Created by mwei on 12/14/15.
@@ -48,7 +51,7 @@ public class LayoutMsg extends CorfuMsg {
      * Parse the rest of the message from the buffer. Classes that extend CorfuMsg
      * should parse their fields in this method.
      *
-     * @param buffer
+     * @param buffer The buffer to deserialize.
      */
     @Override
     public void fromBuffer(ByteBuf buffer) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutPrepareRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutPrepareRequest.java
@@ -1,12 +1,12 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
 /**
- *  Request in first phase of paxos.
- *
+ * Request in first phase of paxos.
  * Created by mdhawan on 10/24/16.
  */
 @Data

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutPrepareResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutPrepareResponse.java
@@ -1,19 +1,21 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
+
 import org.corfudb.runtime.view.Layout;
 
 /**
- *
- * {@link org.corfudb.infrastructure.LayoutServer} response in phase1 of paxos can be an accept or reject.
+ * {@link org.corfudb.infrastructure.LayoutServer} response in phase1 of paxos
+ * can be an accept or reject.
  * If a {@link org.corfudb.infrastructure.LayoutServer} accepts (the proposal rank is higher than
  * any seen by the server so far), it will send back a previously agreed {@link Layout}.
- * {@link org.corfudb.infrastructure.LayoutServer} will reject any proposal with a rank less than or equal to
- * any already seen by the server.
+ * {@link org.corfudb.infrastructure.LayoutServer} will reject any proposal with a rank
+ * less than or equal to any already seen by the server.
  *
- * Created by mdhawan on 10/24/16.
+ * <p>Created by mdhawan on 10/24/16.</p>
  */
 @Data
 @AllArgsConstructor
@@ -21,11 +23,13 @@ public class LayoutPrepareResponse implements ICorfuPayload<LayoutPrepareRespons
     private long rank;
     private Layout layout;
 
-
+    /**
+     * Constructor for layout server response in first phase of Paxos.
+     */
     public LayoutPrepareResponse(ByteBuf buf) {
         rank = ICorfuPayload.fromBuffer(buf, Long.class);
         boolean layoutPresent = ICorfuPayload.fromBuffer(buf, Boolean.class);
-        if(layoutPresent) {
+        if (layoutPresent) {
             layout = ICorfuPayload.fromBuffer(buf, Layout.class);
         }
     }
@@ -35,7 +39,7 @@ public class LayoutPrepareResponse implements ICorfuPayload<LayoutPrepareRespons
         ICorfuPayload.serialize(buf, rank);
         boolean layoutPresent = layout != null;
         ICorfuPayload.serialize(buf, layoutPresent);
-        if(layoutPresent) {
+        if (layoutPresent) {
             ICorfuPayload.serialize(buf, layout);
         }
     }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutProposeRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutProposeRequest.java
@@ -7,7 +7,6 @@ import org.corfudb.runtime.view.Layout;
 
 /**
  * Request in second phase of Paxos.
- *
  * Created by mdhawan on 10/24/16.
  */
 @Data
@@ -20,6 +19,9 @@ public class LayoutProposeRequest implements ICorfuPayload<LayoutProposeRequest>
     // Value proposed
     private Layout layout;
 
+    /**
+     * Constructor for layout request in second phase of Paxos.
+     */
     public LayoutProposeRequest(ByteBuf buf) {
         epoch = ICorfuPayload.fromBuffer(buf, Long.class);
         rank = ICorfuPayload.fromBuffer(buf, Long.class);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutProposeResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LayoutProposeResponse.java
@@ -6,10 +6,10 @@ import lombok.Data;
 
 /**
  * {@link org.corfudb.infrastructure.LayoutServer} response in second phase of paxos.
- * {@link org.corfudb.infrastructure.LayoutServer} will reject the proposal if the last accepted prepare
- * was not for this propose.
+ * {@link org.corfudb.infrastructure.LayoutServer} will reject the proposal
+ * if the last accepted prepare was not for this propose.
  *
- * Created by mdhawan on 10/24/16.
+ * <p>Created by mdhawan on 10/24/16.</p>
  */
 @Data
 @AllArgsConstructor

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -2,14 +2,16 @@ package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+
+import java.util.EnumMap;
+import java.util.concurrent.atomic.AtomicReference;
+
 import lombok.Getter;
+
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.Serializers;
-
-import java.util.EnumMap;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Created by mwei on 8/15/16.
@@ -27,8 +29,11 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
 
     private ByteBuf serializedCache = null;
 
-    private transient final AtomicReference<Object> payload = new AtomicReference<>();
+    private final transient AtomicReference<Object> payload = new AtomicReference<>();
 
+    /**
+     * Return the payload.
+     */
     public Object getPayload(CorfuRuntime runtime) {
         Object value = payload.get();
         if (value == null) {
@@ -74,8 +79,7 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         if (serializedCache == null) {
             serializedCache = Unpooled.buffer();
             doSerializeInternal(serializedCache);
-        }
-        else {
+        } else {
             serializedCache.retain();
         }
     }
@@ -91,6 +95,9 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
     @Getter
     final EnumMap<LogUnitMetadataType, Object> metadataMap;
 
+    /**
+     * Return the payload.
+     */
     public LogData(ByteBuf buf) {
         type = ICorfuPayload.fromBuffer(buf, DataType.class);
         if (type == DataType.DATA) {
@@ -107,12 +114,23 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         }
     }
 
+    /**
+     * Constructor for generating LogData.
+     *
+     * @param type The type of log data to instantiate.
+     */
     public LogData(DataType type) {
         this.type = type;
         this.data = null;
         this.metadataMap = new EnumMap<>(IMetadata.LogUnitMetadataType.class);
     }
 
+    /**
+     * Constructor for generating LogData.
+     *
+     * @param type The type of log data to instantiate.
+     * @param object The actual data/value
+     */
     public LogData(DataType type, final Object object) {
         if (object instanceof ByteBuf) {
             this.type = type;
@@ -134,6 +152,11 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         }
     }
 
+    /**
+     * Return a byte array from buffer.
+     *
+     * @param buf The buffer to read from
+     */
     public byte[] byteArrayFromBuf(final ByteBuf buf) {
         ByteBuf readOnlyCopy = buf.asReadOnly();
         readOnlyCopy.resetReaderIndex();

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageDecoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageDecoder.java
@@ -4,9 +4,10 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Created by mwei on 10/1/15.
@@ -15,19 +16,21 @@ import java.util.List;
 public class NettyCorfuMessageDecoder extends ByteToMessageDecoder {
 
     @Override
-    protected void decode(ChannelHandlerContext channelHandlerContext, ByteBuf byteBuf, List<Object> list) throws Exception {
+    protected void decode(ChannelHandlerContext channelHandlerContext, ByteBuf byteBuf,
+                          List<Object> list) throws Exception {
         list.add(CorfuMsg.deserialize(byteBuf));
     }
 
     @Override
     protected void decodeLast(ChannelHandlerContext ctx, ByteBuf in,
                               List<Object> out) throws Exception {
-        //log.info("Netty channel handler context goes inactive, received out size is {}", (out == null) ? null : out.size());
+        //log.info("Netty channel handler context goes inactive, received out size is {}",
+        // (out == null) ? null : out.size());
 
         if (in != Unpooled.EMPTY_BUFFER) {
             this.decode(ctx, in, out);
         }
-        // ignore the Netty generated {@link EmptyByteBuf empty ByteBuf message} when channel handler goes inactive (typically happened after each received
-        // burst of batch of messages)
+        // ignore the Netty generated {@link EmptyByteBuf empty ByteBuf message} when channel
+        // handler goes inactive (typically happened after each received burst of batch of messages)
     }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
@@ -3,6 +3,7 @@ package org.corfudb.protocols.wireprotocol;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
+
 import lombok.extern.slf4j.Slf4j;
 
 /**

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ReadRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ReadRequest.java
@@ -1,10 +1,13 @@
 package org.corfudb.protocols.wireprotocol;
 
 import com.google.common.collect.Range;
+
 import io.netty.buffer.ByteBuf;
+
+import java.util.UUID;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import java.util.UUID;
 
 /**
  * Created by mwei on 8/11/16.
@@ -14,14 +17,19 @@ import java.util.UUID;
 public class ReadRequest implements ICorfuPayload<ReadRequest> {
 
     final Range<Long> range;
+    @SuppressWarnings({"checkstyle:abbreviationaswordinname", "checkstyle:membername"})
     final UUID streamID;
 
+    /**
+     * Deserialization Constructor from ByteBuf to ReadRequest.
+     *
+     * @param buf The buffer to deserialize
+     */
     public ReadRequest(ByteBuf buf) {
         range = ICorfuPayload.rangeFromBuffer(buf, Long.class);
         if (ICorfuPayload.fromBuffer(buf, Boolean.class)) {
             streamID = ICorfuPayload.fromBuffer(buf, UUID.class);
-        }
-        else {
+        } else {
             streamID = null;
         }
     }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ReadResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ReadResponse.java
@@ -1,11 +1,13 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+
+import java.util.HashMap;
+import java.util.Map;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
-
-import java.util.*;
 
 /**
  * Created by mwei on 8/15/16.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/Token.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/Token.java
@@ -6,8 +6,8 @@ import lombok.Data;
 /**
  * Token returned by the sequencer is a combination of the
  * sequence number and the epoch at which it was acquired.
- * <p>
- * Created by zlokhandwala on 4/7/17.
+ *
+ * <p>Created by zlokhandwala on 4/7/17.</p>
  */
 @Data
 @AllArgsConstructor

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenRequest.java
@@ -1,25 +1,26 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.Set;
 import java.util.UUID;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
 /**
  * A token request is at the heart of the Corfu log protocol.
  *
- * There are four token request scenarios, designated by the relevant constants :
+ * <p>There are four token request scenarios, designated by the relevant constants :
  * 0. {@link TokenRequest::TK_QUERY} : Query of the current log tail and of specific stream-tails.
  * 1. {@link TokenRequest::TK_RAW} : Ask for raw (global) log token(s).
  *              This extends the global log tail by the requested # of tokens.
- * 2. {@link TokenRequest::TK_STREAM} : Ask for token(s) on a specific stream.
- *          This extends both the global log tail, and the specific stream tail, by the requested # of tokens.
- * 3. {@link TokenRequest::TK_MULTI_STREAM} : Ask for token(s) on multiple streams.
- *          This extends both the global log tail, and each of the specified stream tails, by the requested # of tokens.
- * 4. {@link TokenRequest::TK_TX} :
- *          First, check transaction resolution. If transaction can commit, then behave like {@link TokenRequest::TK_MULTI_STREAM}.
+ * 2. {@link TokenRequest::TK_MULTI_STREAM} : Ask for token(s) on multiple streams.
+ *          This extends both the global log tail, and each of the specified stream tails,
+ *          by the requested # of tokens.
+ * 3. {@link TokenRequest::TK_TX} :
+ *          First, check transaction resolution. If transaction can commit, then behave
+ *          like {@link TokenRequest::TK_MULTI_STREAM}.</p>
  */
 @Data
 @AllArgsConstructor
@@ -31,7 +32,7 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
     public static final byte TK_MULTI_STREAM = 3;
     public static final byte TK_TX = 4;
 
-    /** The type of request, one of the above */
+    /** The type of request, one of the above. */
     final byte reqType;
 
     /** The number of tokens to request. */
@@ -43,6 +44,13 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
     /* used for transaction resolution. */
     final TxResolutionInfo txnResolution;
 
+    /**
+     * Constructor for generating TokenRequest.
+     *
+     * @param numTokens number of tokens to request
+     * @param streams streams UUIDs required in the token request
+     * @param conflictInfo transaction resolution information
+     */
     public TokenRequest(Long numTokens, Set<UUID> streams,
                         TxResolutionInfo conflictInfo) {
         reqType = TK_TX;
@@ -51,18 +59,30 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
         txnResolution = conflictInfo;
     }
 
+    /**
+     * Constructor for generating TokenRequest.
+     *
+     * @param numTokens number of tokens to request
+     * @param streams streams UUIDs required in the token request
+     */
     public TokenRequest(Long numTokens, Set<UUID> streams) {
-        if (numTokens == 0)
+        if (numTokens == 0) {
             this.reqType = TK_QUERY;
-        else if (streams == null || streams.size() == 0)
+        } else if (streams == null || streams.size() == 0) {
             this.reqType = TK_RAW;
-        else
+        } else {
             this.reqType = TK_MULTI_STREAM;
+        }
         this.numTokens = numTokens;
         this.streams = streams;
         txnResolution = null;
     }
 
+    /**
+     * Deserialization Constructor from Bytebuf to TokenRequest.
+     *
+     * @param buf The buffer to deserialize
+     */
     public TokenRequest(ByteBuf buf) {
         reqType = ICorfuPayload.fromBuffer(buf, Byte.class);
 
@@ -103,13 +123,16 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, reqType);
-        if (reqType != TK_QUERY)
+        if (reqType != TK_QUERY) {
             ICorfuPayload.serialize(buf, numTokens);
+        }
 
-        if (reqType != TK_RAW)
+        if (reqType != TK_RAW) {
             ICorfuPayload.serialize(buf, streams);
+        }
 
-        if (reqType == TK_TX)
+        if (reqType == TK_TX) {
             ICorfuPayload.serialize(buf, txnResolution);
+        }
     }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -1,11 +1,12 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.AllArgsConstructor;
-import lombok.Data;
 
 import java.util.Map;
 import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 /**
  * Created by mwei on 8/8/16.
@@ -16,13 +17,21 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
 
     public static Integer NO_CONFLICT_KEY = Integer.MIN_VALUE;
 
+    /**
+     * Constructor for TokenResponse.
+     *
+     * @param tokenValue token value
+     * @param epoch current epoch
+     * @param backpointerMap  map of backpointers for all requested streams
+     */
     public TokenResponse(long tokenValue, long epoch, Map<UUID, Long> backpointerMap) {
         respType = TokenType.NORMAL;
         conflictKey = NO_CONFLICT_KEY;
         token = new Token(tokenValue, epoch);
         this.backpointerMap = backpointerMap;
     }
-    /** the cause/type of response */
+
+    /** the cause/type of response. */
     final TokenType respType;
 
     /**
@@ -37,7 +46,11 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
     /** The backpointer map, if available. */
     final Map<UUID, Long> backpointerMap;
 
-
+    /**
+     * Deserialization Constructor from a Bytebuf to TokenResponse.
+     *
+     * @param buf The buffer to deserialize
+     */
     public TokenResponse(ByteBuf buf) {
         respType = TokenType.values()[ICorfuPayload.fromBuffer(buf, Byte.class)];
         conflictKey = ICorfuPayload.fromBuffer(buf, Integer.class);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenType.java
@@ -1,12 +1,13 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
 
 /** An enum for distinguishing different response from the sequencer.
  * Created by dalia on 4/8/17.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TrimRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TrimRequest.java
@@ -1,10 +1,11 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
 
 import java.util.UUID;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Created by mwei on 8/8/16.
@@ -17,18 +18,26 @@ public class TrimRequest implements ICorfuPayload<TrimRequest> {
     final UUID stream;
     final Long address;
 
+    /**
+     * Deserialization Constructor from Bytebuf to TrimRequest.
+     *
+     * @param buf The buffer to deserialize
+     */
     public TrimRequest(ByteBuf buf) {
-        if (ICorfuPayload.fromBuffer(buf, Boolean.class))
+        if (ICorfuPayload.fromBuffer(buf, Boolean.class)) {
             stream = ICorfuPayload.fromBuffer(buf, UUID.class);
-        else stream = null;
+        } else {
+            stream = null;
+        }
         address = ICorfuPayload.fromBuffer(buf, Long.class);
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, stream != null);
-        if (stream != null)
+        if (stream != null) {
             ICorfuPayload.serialize(buf, stream);
+        }
         ICorfuPayload.serialize(buf, address);
     }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
@@ -1,12 +1,18 @@
 package org.corfudb.protocols.wireprotocol;
 
 import com.google.common.collect.ImmutableMap;
+
 import io.netty.buffer.ByteBuf;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
 import lombok.Getter;
 import lombok.Setter;
-import org.corfudb.util.Utils;
 
-import java.util.*;
+import org.corfudb.util.Utils;
 
 /**
  * Created by dmalkhi on 12/26/16.
@@ -15,6 +21,7 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
 
     @Getter
     @Setter
+    @SuppressWarnings({"checkstyle:abbreviationaswordinname", "checkstyle:membername"})
     UUID TXid; // transaction ID, mostly for debugging purposes
 
     /* snapshot timestamp of the txn. */
@@ -28,17 +35,31 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
     @Getter
     final Map<UUID, Set<Integer>>  writeConflictParams;
 
-    public TxResolutionInfo(UUID TXid, long snapshotTS) {
-        this.TXid = TXid;
-        this.snapshotTimestamp = snapshotTS;
+    /**
+     * Constructor for TxResolutionInfo.
+     *
+     * @param txId transaction identifier
+     * @param snapshotTimestamp transaction snapshot timestamp
+     */
+    public TxResolutionInfo(UUID txId, long snapshotTimestamp) {
+        this.TXid = txId;
+        this.snapshotTimestamp = snapshotTimestamp;
         this.conflictSet = Collections.emptyMap();
         this.writeConflictParams = Collections.emptyMap();
     }
 
-    public TxResolutionInfo(UUID TXid, long snapshotTS, Map<UUID, Set<Integer>>
+    /**
+     * Constructor for TxResolutionInfo.
+     *
+     * @param txId transaction identifier
+     * @param snapshotTimestamp transaction snapshot timestamp
+     * @param conflictMap map of conflict parameters, arranged by stream IDs
+     * @param writeConflictParams map of write conflict parameters, arranged by stream IDs
+     */
+    public TxResolutionInfo(UUID txId, long snapshotTimestamp, Map<UUID, Set<Integer>>
             conflictMap, Map<UUID, Set<Integer>> writeConflictParams) {
-        this.TXid = TXid;
-        this.snapshotTimestamp = snapshotTS;
+        this.TXid = txId;
+        this.snapshotTimestamp = snapshotTimestamp;
         this.conflictSet = conflictMap;
         this.writeConflictParams = writeConflictParams;
     }
@@ -46,9 +67,10 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
     /**
      * fast, specialized deserialization constructor, from a ByteBuf to this object
      *
-     * The first entry is a long, the snapshot timestamp.
+     * <p>The first entry is a long, the snapshot timestamp.
      * The second is an int, the size of the map.
-     * Next, entries are serialized one by one, first the key, then each value, itself a set of objects.
+     * Next, entries are serialized one by one, first the key, then each value,
+     * itself a set of objects.</p>
      *
      * @param buf        The buffer to deserialize.
      */
@@ -60,9 +82,9 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
         int numEntries = buf.readInt();
         ImmutableMap.Builder<UUID, Set<Integer>> conflictMapBuilder = new ImmutableMap.Builder<>();
         for (int i = 0; i < numEntries; i++) {
-            UUID K = ICorfuPayload.fromBuffer(buf, UUID.class);
-            Set<Integer> V = ICorfuPayload.setFromBuffer(buf, Integer.class);
-            conflictMapBuilder.put(K, V);
+            UUID k = ICorfuPayload.fromBuffer(buf, UUID.class);
+            Set<Integer> v = ICorfuPayload.setFromBuffer(buf, Integer.class);
+            conflictMapBuilder.put(k, v);
         }
         conflictSet = conflictMapBuilder.build();
 
@@ -70,16 +92,17 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
         numEntries = buf.readInt();
         ImmutableMap.Builder<UUID, Set<Integer>> writeMapBuilder = new ImmutableMap.Builder<>();
         for (int i = 0; i < numEntries; i++) {
-            UUID K = ICorfuPayload.fromBuffer(buf, UUID.class);
-            Set<Integer> V = ICorfuPayload.setFromBuffer(buf, Integer.class);
-            writeMapBuilder.put(K, V);
+            UUID k = ICorfuPayload.fromBuffer(buf, UUID.class);
+            Set<Integer> v = ICorfuPayload.setFromBuffer(buf, Integer.class);
+            writeMapBuilder.put(k, v);
         }
         writeConflictParams = writeMapBuilder.build();
     }
 
     /**
-     * fast , specialized serialization of object into ByteBuf
-     * @param buf
+     * fast , specialized serialization of object into ByteBuf.
+     *
+     * @param buf The buffer to serialize object into
      */
     @Override
     public void doSerialize(ByteBuf buf) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/VersionInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/VersionInfo.java
@@ -1,9 +1,9 @@
 package org.corfudb.protocols.wireprotocol;
 
-import lombok.Getter;
-
 import java.lang.management.ManagementFactory;
 import java.util.Map;
+
+import lombok.Getter;
 
 /**
  * Created by mwei on 7/27/16.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WriteMode.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WriteMode.java
@@ -1,12 +1,13 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.RequiredArgsConstructor;
 
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import lombok.RequiredArgsConstructor;
 
 /**
  * Created by mwei on 8/9/16.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WriteRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WriteRequest.java
@@ -1,9 +1,14 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.*;
 
-import java.util.*;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 
 /**
  * Created by mwei on 8/9/16.
@@ -28,7 +33,8 @@ public class WriteRequest implements ICorfuPayload<WriteRequest>, IMetadata {
         this(writeMode, DataType.DATA, streamAddresses, buf);
     }
 
-    public WriteRequest(WriteMode writeMode, DataType dataType, Map<UUID, Long> streamAddresses, ByteBuf buf) {
+    public WriteRequest(WriteMode writeMode, DataType dataType, Map<UUID, Long> streamAddresses,
+                        ByteBuf buf) {
         this.writeMode = writeMode;
         this.data = new LogData(dataType, buf);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -2,7 +2,9 @@ package org.corfudb.runtime.view;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.StreamCOWEntry;
-import org.corfudb.protocols.wireprotocol.*;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.protocols.wireprotocol.TokenType;
+import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
@@ -15,7 +17,6 @@ import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 /**


### PR DESCRIPTION
Update to new style guidelines package 
org.corfudb.protocols.wireprotocol.

This closes Issue: #690 

**Note:** the only rule in the checkstyle that we do not comply with is placing static imports at the beginning of imports for the file IMetadata, as this causes 'IMetadata.java:[153,5] error: cannot find symbol' related to lombok annotation. 
