### PR TITLE
Introduce Stream Options

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -420,8 +420,8 @@ public class Layout implements Cloneable {
             }
 
             @Override
-            public IStreamView  getStreamView(CorfuRuntime r, UUID streamId) {
-                return new BackpointerStreamView(r, streamId);
+            public IStreamView  getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
+                return new BackpointerStreamView(r, streamId, options);
             }
 
             @Override
@@ -446,8 +446,8 @@ public class Layout implements Cloneable {
 
 
             @Override
-            public IStreamView getStreamView(CorfuRuntime r, UUID streamId) {
-                return new BackpointerStreamView(r, streamId);
+            public IStreamView getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
+                return new BackpointerStreamView(r, streamId, options);
             }
 
             @Override
@@ -470,7 +470,7 @@ public class Layout implements Cloneable {
             }
 
             @Override
-            public IStreamView getStreamView(CorfuRuntime r, UUID streamId) {
+            public IStreamView getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
                 throw new UnsupportedOperationException("Stream view used without a"
                         + " replication mode");
             }
@@ -484,7 +484,7 @@ public class Layout implements Cloneable {
                                                          completableFutureMap)
                 throws QuorumUnreachableException;
 
-        public abstract IStreamView getStreamView(CorfuRuntime r, UUID streamId);
+        public abstract IStreamView getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options);
 
         public IReplicationProtocol getReplicationProtocol(CorfuRuntime r) {
             throw new UnsupportedOperationException();

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamOptions.java
@@ -1,0 +1,35 @@
+package org.corfudb.runtime.view;
+
+/**
+ * Created by maithem on 6/20/17.
+ */
+public class StreamOptions {
+    public static StreamOptions DEFAULT = new StreamOptions(false);
+
+    public final boolean ignoreTrimmed;
+
+    public StreamOptions(boolean ignoreTrimmed) {
+        this.ignoreTrimmed = ignoreTrimmed;
+    }
+
+    public static StreamOptionsBuilder builder() {
+        return new StreamOptionsBuilder();
+    }
+
+    public static class StreamOptionsBuilder {
+        private boolean ignoreTrimmed;
+
+        public StreamOptionsBuilder() {
+
+        }
+
+        public StreamOptionsBuilder ignoreTrimmed(boolean ignore) {
+            this.ignoreTrimmed = ignore;
+            return this;
+        }
+
+        public StreamOptions build() {
+            return new StreamOptions(ignoreTrimmed);
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -38,9 +38,19 @@ public class StreamsView extends AbstractView {
      * @return A view
      */
     public IStreamView get(UUID stream) {
+        return this.get(stream, StreamOptions.DEFAULT);
+    }
+
+    /**
+     * Get a view on a stream. The view has its own pointer to the stream.
+     *
+     * @param stream The UUID of the stream to get a view on.
+     * @return A view
+     */
+    public IStreamView get(UUID stream, StreamOptions options) {
         return runtime.getLayoutView().getLayout().getSegments().get(
                 runtime.getLayoutView().getLayout().getSegments().size() - 1)
-                .getReplicationMode().getStreamView(runtime, stream);
+                .getReplicationMode().getStreamView(runtime, stream, options);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.view;
 
 import lombok.Getter;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TrimmedException;
@@ -9,6 +10,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,6 +46,43 @@ public class StreamViewTest extends AbstractViewTest {
 
         assertThat(sv.next())
                 .isEqualTo(null);
+    }
+
+    /**
+     * Test that a client can call IStreamView.remainingUpTo after a prefix trim.
+     * If remainingUpTo contains trimmed addresses, then they are ignored.
+     */
+    @Test
+    public void testRemainingUpToWithTrim() {
+        StreamOptions options = StreamOptions.builder()
+                .ignoreTrimmed(true)
+                .build();
+
+        IStreamView txStream = runtime.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID, options);
+        final int firstIter = 50;
+        for (int x = 0; x < firstIter; x++) {
+            byte[] data = "Hello World!".getBytes();
+            txStream.append(data);
+        }
+
+        List<ILogData> entries = txStream.remainingUpTo((firstIter - 1) / 2);
+        assertThat(entries.size()).isEqualTo(firstIter / 2);
+
+        runtime.getAddressSpaceView().prefixTrim((firstIter - 1) / 2);
+        runtime.getAddressSpaceView().invalidateServerCaches();
+        runtime.getAddressSpaceView().invalidateClientCache();
+
+        entries = txStream.remainingUpTo((firstIter - 1) / 2);
+        assertThat(entries.size()).isEqualTo(0);
+
+        entries = txStream.remainingUpTo(firstIter);
+        assertThat(entries.size()).isEqualTo((firstIter / 2));
+
+        // Open the stream with a new client
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultEndpoint()).connect();
+        txStream = rt2.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID, options);
+        entries = txStream.remainingUpTo(Long.MAX_VALUE);
+        assertThat(entries.size()).isEqualTo((firstIter / 2));
     }
 
     @Test


### PR DESCRIPTION
This patch introduces options that can be passed when a stream
is opened. One such option is to ignore addresses when
backpointers are traversed.