### PR TITLE
Runtime hint for stream tails to the Sequencer

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -7,6 +7,8 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
+import java.util.Map;
+import java.util.UUID;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -47,6 +49,7 @@ public enum CorfuMsgType {
     TOKEN_REQ(20, new TypeToken<CorfuPayloadMsg<TokenRequest>>(){}),
     TOKEN_RES(21, new TypeToken<CorfuPayloadMsg<TokenResponse>>(){}),
     RESET_SEQUENCER(22, new TypeToken<CorfuPayloadMsg<Long>>(){}),
+    TAILS_HINT(23, new TypeToken<CorfuPayloadMsg<StreamTailsHintMsg>>(){}),
 
     // Logging Unit Messages
     WRITE(30, new TypeToken<CorfuPayloadMsg<WriteRequest>>() {}),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/StreamTailsHintMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/StreamTailsHintMsg.java
@@ -1,0 +1,27 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Created by rmichoud on 6/20/17.
+ */
+@Data
+@AllArgsConstructor
+public class StreamTailsHintMsg implements ICorfuPayload<StreamTailsHintMsg> {
+    private Map<UUID, Long> streamTailHint;
+
+    public StreamTailsHintMsg(ByteBuf buf) {
+        streamTailHint = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, streamTailHint);
+    }
+}
+

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -72,5 +73,15 @@ public class SequencerClient implements IClient {
     public CompletableFuture<Boolean> reset(Long initialToken) {
         return router.sendMessageAndGetCompletable(CorfuMsgType.RESET_SEQUENCER
                 .payloadMsg(initialToken));
+    }
+
+    /**
+     * Provide a hint to the sequencer about stream tail addresses.
+     *
+     * @param tokenHints
+     * @return
+     */
+    public CompletableFuture<Boolean> tokenHint(Map<UUID, Long> tokenHints) {
+        return router.sendMessageAndGetCompletable(CorfuMsgType.TAILS_HINT.payloadMsg(tokenHints));
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -4,6 +4,8 @@ import org.corfudb.protocols.wireprotocol.*;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -155,4 +157,52 @@ public class SequencerServerTest extends AbstractServerTest {
         }
     }
 
+    @Test
+    public void SequencerWillTakeCorrectHint() throws Exception {
+        UUID streamA = UUID.nameUUIDFromBytes("streamA".getBytes());
+        UUID streamB = UUID.nameUUIDFromBytes("streamB".getBytes());
+        UUID streamC = UUID.nameUUIDFromBytes("streamC".getBytes());
+
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
+                new TokenRequest(1L, Collections.singleton(streamA))));
+        long tailA = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
+
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
+                new TokenRequest(1L, Collections.singleton(streamB))));
+        long tailB = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
+
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
+                new TokenRequest(1L, Collections.singleton(streamC))));
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
+                new TokenRequest(1L, Collections.singleton(streamC))));
+
+        long tailC = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
+
+        // Construct new tails
+        Map<UUID, Long> tailMap = new HashMap<>();
+        long newTailA = tailA + 2;
+        long newTailB = tailB + 1;
+        // This one should not be updated
+        long newTailC = tailC - 1;
+
+        tailMap.put(streamA, newTailA);
+        tailMap.put(streamB, newTailB);
+        tailMap.put(streamC, newTailC);
+
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TAILS_HINT,
+                new StreamTailsHintMsg(tailMap)));
+
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
+                new TokenRequest(0L, Collections.singleton(streamA))));
+        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue()).isEqualTo(newTailA);
+
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
+                new TokenRequest(0L, Collections.singleton(streamB))));
+        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue()).isEqualTo(newTailB);
+
+        // We should have the same value than before
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
+                new TokenRequest(0L, Collections.singleton(streamC))));
+        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue()).isEqualTo(tailC);
+    }
 }


### PR DESCRIPTION
This API is principally meant to be used for recovery purposes. The runtime
can propose hit stream tails to the sequencer. If the sequencer doesn't have
a better information, it will update its stream tails to the hint.