### PR TITLE
Return DataType.TRIMMED

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -195,15 +195,11 @@ public class LogUnitServer extends AbstractServer {
                 ILogData e = dataCache.get(l);
                 if (e == null) {
                     rr.put(l, LogData.EMPTY);
-                } else if (e.getType() == DataType.HOLE) {
-                    rr.put(l, LogData.HOLE);
                 } else {
                     rr.put(l, (LogData) e);
                 }
             }
             r.sendResponse(ctx, msg, CorfuMsgType.READ_RESPONSE.payloadMsg(rr));
-        } catch (TrimmedException e) {
-            r.sendResponse(ctx, msg, CorfuMsgType.ERROR_TRIMMED.msg());
         } catch (DataCorruptionException e) {
             r.sendResponse(ctx, msg, CorfuMsgType.ERROR_DATA_CORRUPTION.msg());
         }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -123,6 +123,11 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
         return getType() == DataType.EMPTY;
     }
 
+    /** Return true if and only if the entry represents a trimmed address.*/
+    default boolean isTrimmed() {
+        return getType() == DataType.TRIMMED;
+    }
+
     /** Assign a given token to this log data.
      *
      * @param token     The token to use.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -20,6 +20,7 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
 
     public static final LogData EMPTY = new LogData(DataType.EMPTY);
     public static final LogData HOLE = new LogData(DataType.HOLE);
+    public static final LogData TRIMMED = new LogData(DataType.TRIMMED);
 
     @Getter
     final DataType type;

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -23,6 +23,7 @@ import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.util.CFUtils;
 
@@ -152,6 +153,8 @@ public class AddressSpaceView extends AbstractView {
             if (data == null || data.getType() == DataType.EMPTY) {
                 throw new RuntimeException("Unexpected return of empty data at address "
                         + address + " on read");
+            } else if (data.isTrimmed()) {
+                throw new TrimmedException();
             }
             return data;
         }

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -21,6 +21,7 @@ import org.corfudb.format.Types.Metadata;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.OverwriteException;
@@ -259,8 +260,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
                 .isInstanceOf(OverwriteException.class);
 
         // Read trimmed address
-        assertThatThrownBy(() -> log.read(address))
-                .isInstanceOf(TrimmedException.class);
+        assertThat(log.read(address).isTrimmed()).isTrue();
     }
 
     private void writeToLog(StreamLog log, long address) {
@@ -319,8 +319,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         // Verify that the trimmed addresses cannot be written to or read from after compaction
         for (long x = 0; x < logChunk; x++) {
             long address = x;
-            assertThatThrownBy(() -> log.read(address))
-                    .isInstanceOf(TrimmedException.class);
+            assertThat(log.read(address).isTrimmed()).isTrue();
             assertThatThrownBy(() -> writeToLog(log, address))
                     .isInstanceOf(OverwriteException.class);
         }
@@ -412,9 +411,8 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
 
         // Try to read trimmed addresses
         for(long x = 0; x < numSegments * StreamLogFiles.RECORDS_PER_LOG_FILE; x++) {
-            try {
-                log.read(x);
-            } catch (TrimmedException e) {
+            ILogData logData = log.read(x);
+            if(logData.isTrimmed()) {
                 trimmedExceptions++;
             }
         }

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitClientTest.java
@@ -104,9 +104,7 @@ public class LogUnitClientTest extends AbstractClientTest {
         serverRouter.reset();
         serverRouter.addServer(server2);
 
-        assertThatThrownBy(() -> client.read(0).get().getReadSet().get(0L))
-                .isInstanceOf(ExecutionException.class)
-                .hasCauseInstanceOf(TrimmedException.class);
+        assertThat(client.read(0).get().getReadSet().get(0L).isTrimmed()).isTrue();
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
     }


### PR DESCRIPTION
Instead of throwing an exception on reading trimmed addresses,
this changes makes the logging unit return a trimmed entry.