### PR TITLE
FastSmrMapLoader checkpoint/trim support

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -29,8 +29,10 @@ message LogEntry {
     map<string, int64> backpointers = 8;
     optional DataRank rank = 9;
     optional CheckpointEntryType checkpointEntryType = 10;
-    optional int64 checkpointID_most_significant = 11;
-    optional int64 checkpointID_least_significant = 12;
+    optional int64 checkpointId_most_significant = 11;
+    optional int64 checkpointId_least_significant = 12;
+    optional int64 checkpointedStreamId_most_significant = 13;
+    optional int64 checkpointedStreamdId_least_significant = 14;
 }
 
 message LogHeader {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -543,16 +543,22 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             logData.setCheckpointType(CheckpointEntry.CheckpointEntryType
                     .typeMap.get((byte) entry.getCheckpointEntryType().ordinal()));
 
-            if (!entry.hasCheckpointIDLeastSignificant()
-                    || !entry.hasCheckpointIDMostSignificant()) {
+            if (!entry.hasCheckpointIdLeastSignificant()
+                    || !entry.hasCheckpointIdMostSignificant()) {
                 log.error("Checkpoint has missing information {}", entry);
             }
 
-            long lsd = entry.getCheckpointIDLeastSignificant();
-            long msd = entry.getCheckpointIDMostSignificant();
+            long lsd = entry.getCheckpointIdLeastSignificant();
+            long msd = entry.getCheckpointIdMostSignificant();
             UUID checkpointId = new UUID(msd, lsd);
 
-            logData.setCheckpointID(checkpointId);
+            logData.setCheckpointId(checkpointId);
+
+            lsd = entry.getCheckpointedStreamdIdLeastSignificant();
+            msd = entry.getCheckpointedStreamIdMostSignificant();
+            UUID streamId = new UUID(msd, lsd);
+
+            logData.setCheckpointedStreamId(streamId);
         }
 
         return logData;
@@ -833,10 +839,14 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             logEntryBuilder.setCheckpointEntryType(
                     Types.CheckpointEntryType.forNumber(
                             entry.getCheckpointType().ordinal()));
-            logEntryBuilder.setCheckpointIDMostSignificant(
-                    entry.getCheckpointID().getMostSignificantBits());
-            logEntryBuilder.setCheckpointIDLeastSignificant(
-                    entry.getCheckpointID().getLeastSignificantBits());
+            logEntryBuilder.setCheckpointIdMostSignificant(
+                    entry.getCheckpointId().getMostSignificantBits());
+            logEntryBuilder.setCheckpointIdLeastSignificant(
+                    entry.getCheckpointId().getLeastSignificantBits());
+            logEntryBuilder.setCheckpointedStreamdIdLeastSignificant(
+                    entry.getCheckpointedStreamId().getLeastSignificantBits());
+            logEntryBuilder.setCheckpointedStreamIdMostSignificant(
+                    entry.getCheckpointedStreamId().getMostSignificantBits());
         }
 
         return logEntryBuilder.build();

--- a/logReader/src/main/java/org/corfudb/logReader/logReader.java
+++ b/logReader/src/main/java/org/corfudb/logReader/logReader.java
@@ -233,11 +233,11 @@ public class logReader {
         if (entry.hasCheckpointEntryType()) {
             System.out.format("Checkpoint type: %s, ID %s\n",
                     entry.getCheckpointEntryType(),
-                    new UUID(entry.hasCheckpointIDMostSignificant()
-                             ? entry.getCheckpointIDMostSignificant()
+                    new UUID(entry.hasCheckpointIdMostSignificant()
+                             ? entry.getCheckpointIdMostSignificant()
                              : 0L,
-                             entry.hasCheckpointIDLeastSignificant()
-                             ? entry.getCheckpointIDLeastSignificant()
+                             entry.hasCheckpointIdLeastSignificant()
+                             ? entry.getCheckpointIdLeastSignificant()
                              : 0L));
         }
     }

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
@@ -76,14 +76,17 @@ public class CheckpointEntry extends LogEntry {
     @Deprecated // TODO: Add replacement method that conforms to style
     @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
     @Getter
-    UUID checkpointID;
+    UUID checkpointId;
 
-    /** Author/cause/trigger of this checkpoint.
+    @Getter
+    UUID streamId;
+
+    /** Author/cause/trigger of this checkpoint
      */
     @Deprecated // TODO: Add replacement method that conforms to style
     @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
     @Getter
-    String checkpointAuthorID;
+    String checkpointAuthorId;
 
     /** Map of checkpoint metadata, see key constants above.
      */
@@ -107,13 +110,13 @@ public class CheckpointEntry extends LogEntry {
     @Getter
     int smrEntriesBytes = 0;
 
-    /** CheckpointEntry constructor. */
     public CheckpointEntry(CheckpointEntryType type, String authorId, UUID checkpointId,
-                           Map<CheckpointDictKey,String> dict, MultiSMREntry smrEntries) {
+                           UUID streamId, Map<CheckpointDictKey,String> dict, MultiSMREntry smrEntries) {
         super(LogEntryType.CHECKPOINT);
         this.cpType = type;
-        this.checkpointID = checkpointId;
-        this.checkpointAuthorID = authorId;
+        this.checkpointId = checkpointId;
+        this.streamId = streamId;
+        this.checkpointAuthorId = authorId;
         this.dict = dict;
         this.smrEntries = smrEntries;
     }
@@ -130,8 +133,9 @@ public class CheckpointEntry extends LogEntry {
     void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
         super.deserializeBuffer(b, rt);
         cpType = CheckpointEntryType.typeMap.get(b.readByte());
-        checkpointID = new UUID(b.readLong(), b.readLong());
-        checkpointAuthorID = deserializeString(b);
+        checkpointId = new UUID(b.readLong(), b.readLong());
+        streamId = new UUID(b.readLong(), b.readLong());
+        checkpointAuthorId = deserializeString(b);
         dict = new HashMap<>();
         short mapEntries = b.readShort();
         for (short i = 0; i < mapEntries; i++) {
@@ -159,9 +163,11 @@ public class CheckpointEntry extends LogEntry {
     public void serialize(ByteBuf b) {
         super.serialize(b);
         b.writeByte(cpType.asByte());
-        b.writeLong(checkpointID.getMostSignificantBits());
-        b.writeLong(checkpointID.getLeastSignificantBits());
-        serializeString(checkpointAuthorID, b);
+        b.writeLong(checkpointId.getMostSignificantBits());
+        b.writeLong(checkpointId.getLeastSignificantBits());
+        b.writeLong(streamId.getMostSignificantBits());
+        b.writeLong(streamId.getLeastSignificantBits());
+        serializeString(checkpointAuthorId, b);
         b.writeShort(dict == null ? 0 : dict.size());
         if (dict != null) {
             dict.entrySet().stream()

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -43,7 +43,7 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
     /** Extract a particular stream's entry from this object.
      *
      * @param streamID StreamID
-     * @return the MultiSMREntry corresponding to streamID
+     * @return the MultiSMREntry corresponding to streamId
      */
     protected MultiSMREntry getStreamEntry(UUID streamID) {
         return getEntryMap().computeIfAbsent(streamID, u -> {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -22,6 +22,7 @@ import lombok.Value;
 
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 
+import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_ID;
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_ID;
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_TYPE;
 
@@ -121,7 +122,7 @@ public interface IMetadata {
     }
 
     default boolean hasCheckpointMetadata() {
-        return getCheckpointType() != null && getCheckpointID() != null;
+        return getCheckpointType() != null && getCheckpointId() != null;
     }
 
     /**
@@ -140,14 +141,23 @@ public interface IMetadata {
 
     @Nullable
     @SuppressWarnings({"checkstyle:abbreviationaswordinname", "checkstyle:membername"})
-    default UUID getCheckpointID() {
+    default UUID getCheckpointId() {
         return (UUID) getMetadataMap().getOrDefault(LogUnitMetadataType.CHECKPOINT_ID,
                 null);
     }
 
     @SuppressWarnings({"checkstyle:abbreviationaswordinname", "checkstyle:membername"})
-    default void setCheckpointID(UUID id) {
+    default void setCheckpointId(UUID id) {
         getMetadataMap().put(CHECKPOINT_ID, id);
+    }
+
+    default UUID getCheckpointedStreamId() {
+        return (UUID) getMetadataMap().getOrDefault(LogUnitMetadataType.CHECKPOINTED_STREAM_ID,
+                null);
+    }
+
+    default void setCheckpointedStreamId(UUID Id) {
+        getMetadataMap().put(CHECKPOINTED_STREAM_ID, Id);
     }
 
     @RequiredArgsConstructor
@@ -157,7 +167,8 @@ public interface IMetadata {
         GLOBAL_ADDRESS(4, TypeToken.of(Long.class)),
         COMMIT(5, TypeToken.of(Boolean.class)),
         CHECKPOINT_TYPE(6, TypeToken.of(CheckpointEntry.CheckpointEntryType.class)),
-        CHECKPOINT_ID(7, TypeToken.of(UUID.class))
+        CHECKPOINT_ID(7, TypeToken.of(UUID.class)),
+        CHECKPOINTED_STREAM_ID(8, TypeToken.of(UUID.class))
         ;
         final int type;
         @Getter

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -148,7 +148,8 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
             if (object instanceof CheckpointEntry) {
                 CheckpointEntry cp = (CheckpointEntry) object;
                 setCheckpointType(cp.getCpType());
-                setCheckpointID(cp.getCheckpointID());
+                setCheckpointId(cp.getCheckpointId());
+                setCheckpointedStreamId(cp.getStreamId());
             }
         }
     }

--- a/runtime/src/main/java/org/corfudb/recovery/FastSmrMapsLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastSmrMapsLoader.java
@@ -1,32 +1,37 @@
 package org.corfudb.recovery;
 
 import javax.annotation.Nonnull;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiConsumer;
 
-import com.google.common.collect.ContiguousSet;
-import com.google.common.collect.DiscreteDomain;
-import com.google.common.collect.Range;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.object.CorfuCompileProxy;
-import org.corfudb.runtime.object.ICorfuSMR;
-import org.corfudb.runtime.view.ObjectsView;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.util.Utils;
+
+import static org.corfudb.recovery.RecoveryUtils.*;
 
 /** The FastSmrMapsLoader reconstructs the coalesced state of SMRMaps through sequential log read
  *
@@ -34,8 +39,7 @@ import org.corfudb.runtime.view.ObjectsView;
  * and build the Maps as we go. In the presence of checkpoints, the checkpoint entries will
  * be applied before the normal entries starting after the checkpoint start address.
  *
- * As current state, it doesn't support checkpoints/trim.
- *
+ * If used in the recoverSequencer mode, it will reconstruct the stream tails.
  *
  * Created by rmichoud on 6/14/17.
  */
@@ -44,8 +48,9 @@ import org.corfudb.runtime.view.ObjectsView;
 @Accessors(chain = true)
 public class FastSmrMapsLoader {
 
-    static final long DEFAULT_BATCH_FOR_FAST_LOADER = 5;
+    static final long DEFAULT_BATCH_FOR_FAST_LOADER = 10;
     static final int DEFAULT_TIMEOUT_MINUTES_FAST_LOADING = 30;
+    static final int NUMBER_OF_ATTEMPT = 3;
     static final int STATUS_UPDATE_PACE = 10000;
 
     private CorfuRuntime runtime;
@@ -70,12 +75,22 @@ public class FastSmrMapsLoader {
     @Getter
     private int timeoutInMinutesForLoading = DEFAULT_TIMEOUT_MINUTES_FAST_LOADING;
 
-
     @Setter
     @Getter
     private boolean recoverSequencerMode;
 
-    private long addressProcessed = -1;
+    @Setter
+    @Getter
+    private boolean logHasNoCheckPoint = false;
+
+    /**
+     * We can add streams to be ignored during the
+     * reconstruction of the state (e.g. raw streams)
+     */
+    @Getter
+    private Set<UUID> streamsToIgnore = new HashSet<>();
+
+    private long addressProcessed;
 
     // In charge of summoning Corfu maps back in this world
     private ExecutorService necromancer;
@@ -85,15 +100,95 @@ public class FastSmrMapsLoader {
     @Getter
     private Map<UUID, Long> streamTails = new HashMap<>();
 
+    @Setter
+    @Getter
+    private int numberOfAttempt = NUMBER_OF_ATTEMPT;
+
+    private boolean logContainsCheckpoints = false;
+    private int retryIteration = 0;
+    private long nextRead;
+
     public FastSmrMapsLoader(@Nonnull final CorfuRuntime corfuRuntime) {
         this.runtime = corfuRuntime;
         loadInCache = !corfuRuntime.cacheDisabled;
         streamsMetaData = new HashMap<>();
+    }
+
+    public void addStreamToIgnore(String streamName) {
+        streamsToIgnore.add(CorfuRuntime.getStreamID(streamName));
+    }
+
+    /**
+     * Necromancer Utilities
+     *
+     * Necromancy is a supposed practice of magic involving communication with the deceased
+     * – either by summoning their spirit as an apparition or raising them bodily. This suits
+     * what this thread is tasked with, bringing back the SMR Maps from their grave (the Log).
+     *
+     */
+    private void summonNecromancer() {
         necromancer = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
                 .setNameFormat("necromancer-%d").build());
     }
 
-    /** Check if this entry is relevant
+    private void invokeNecromancer(Map<Long, ILogData> logDataMap, BiConsumer<Long, ILogData> resurrectionSpell) {
+        necromancer.execute(() -> {
+            logDataMap.forEach((address, logData) -> {
+                resurrectionSpell.accept(address, logData);
+            });
+
+        });
+    }
+
+    private void killNecromancer() {
+        necromancer.shutdown();
+        try {
+            necromancer.awaitTermination(timeoutInMinutesForLoading, TimeUnit.MINUTES);
+        } catch (InterruptedException e) {
+            String msg = "Necromancer is taking too long to load the maps. Gave up.";
+            log.error(msg);
+            fail(msg);
+        }
+    }
+
+    /**
+     * These two functions are called if no parameter were supplied
+     * by the user.
+     */
+    private void findAndSetLogHead() {
+         logHead = runtime.getAddressSpaceView().getTrimMark();
+    }
+
+    private void findAndSetLogTail() {
+        logTail = runtime.getSequencerView().nextToken(Collections.emptySet(), 0).getTokenValue();
+    }
+
+    private void resetAddressProcessed() {
+        addressProcessed = logHead - 1;
+    }
+
+    /**
+     * Book keeping of the the stream tails
+     *
+     * @param logData
+     */
+    public void updateStreamTails(long address, ILogData logData) {
+        // On checkpoint, we also need to track the stream tail of the checkpoint
+        if (isCheckPointEntry(logData)) {
+            // Need to deserialize
+            CheckpointEntry checkpointEntry = (CheckpointEntry) logData.getLogEntry(runtime);
+            if (checkpointEntry.getCpType() == CheckpointEntry.CheckpointEntryType.END) {
+                streamTails.put(checkpointEntry.getStreamId(), getStartAddressOfCheckPoint(checkpointEntry));
+            }
+        }
+        for (UUID streamId : logData.getStreams()) {
+                streamTails.put(streamId, address);
+        }
+    }
+
+
+    /**
+     * Check if this entry is relevant
      *
      * Entries before checkpoint starts are irrelevant since they are
      * contained in the checkpoint.
@@ -103,131 +198,113 @@ public class FastSmrMapsLoader {
      * @return if we need to apply the entry.
      */
     private boolean shouldEntryBeApplied(UUID streamId, SMREntry entry) {
-        if (!streamsMetaData.containsKey(streamId)) {
-            return true;
+        // We ignore the transaction stream ID because it is a raw stream
+        // We don't want to create a Map for it.
+        if (streamId == runtime.getObjectsView().TRANSACTION_STREAM_ID || streamsToIgnore.contains(streamId)) {
+            return false;
         }
 
-        return (entry.getEntry().getGlobalAddress() >=
-                streamsMetaData.get(streamId).getHeadAddress());
+        if (!streamsMetaData.containsKey(streamId) || entry.getEntry().getGlobalAddress() >
+                streamsMetaData.get(streamId).getHeadAddress()) {
+            return true;
+        }
+        return false;
     }
 
-    private ObjectsView.ObjectID getObjectIdFromStreamID(UUID streamId) {
-        return new ObjectsView.ObjectID(streamId, SMRMap.class);
-    }
 
-    /** Update the corfu object and it's underlying stream with the new entry.
+    /**
+     * Update the corfu object and it's underlying stream with the new entry.
      *
      * @param streamId identifies the Corfu stream
      * @param entry entry to apply
+     * @param globalAddress global address of the entry
+     * @param isCheckPointEntry
      */
-    private void applySmrEntryToStream(UUID streamId, SMREntry entry) {
-        if (shouldEntryBeApplied(streamId, entry)) {
-            createSmrMapIfNotExist(streamId);
-
-            ObjectsView.ObjectID thisObjectId = new ObjectsView.ObjectID(streamId, SMRMap.class);
-            CorfuCompileProxy cp = ((CorfuCompileProxy) ((ICorfuSMR) runtime.getObjectsView().getObjectCache().get(thisObjectId)).
-                    getCorfuSMRProxy());
-
-            cp.getUnderlyingObject().applyUpdateToStreamUnsafe(entry);
+    private void applySmrEntryToStream(UUID streamId, SMREntry entry,
+                                       long globalAddress, boolean isCheckPointEntry) {
+        if (isCheckPointEntry || shouldEntryBeApplied(streamId, entry)) {
+            // Create an Object only for non-checkpoints
+            createSmrMapIfNotExist(runtime, streamId);
+            CorfuCompileProxy cp = getCorfuCompileProxy(runtime, streamId);
+            cp.getUnderlyingObject().applyUpdateToStreamUnsafe(entry, globalAddress);
         }
     }
 
-    /** Fetch LogData from Corfu server
-     *
-     * @param address address to be fetched
-     * @return LogData at address
-     */
-    private ILogData getLogData(long address) {
-        if (loadInCache) {
-            return runtime.getAddressSpaceView().read(address);
-        } else {
-            return runtime.getAddressSpaceView().fetch(address);
+    private void applySmrEntryToStream(UUID streamId, SMREntry entry, long globalAddress) {
+        applySmrEntryToStream(streamId, entry, globalAddress, false);
+
+    }
+
+
+    private void updateCorfuObjectWithSmrEntry(ILogData logData, LogEntry logEntry, long globalAddress) {
+        UUID streamId = logData.getStreams().iterator().next();
+        applySmrEntryToStream(streamId, (SMREntry) logEntry, globalAddress);
+    }
+
+    private void updateCorfuObjectWithMultiObjSmrEntry(LogEntry logEntry, long globalAddress) {
+        MultiObjectSMREntry multiObjectLogEntry = (MultiObjectSMREntry) logEntry;
+        multiObjectLogEntry.getEntryMap().forEach((streamId, multiSmrEntry) -> {
+            multiSmrEntry.getSMRUpdates(streamId).forEach((smrEntry) -> {
+                applySmrEntryToStream(streamId, smrEntry, globalAddress);
+            });
+        });
+    }
+
+    private void updateCorfuObjectWithCheckPointEntry(ILogData logData, LogEntry logEntry) {
+        CheckpointEntry checkPointEntry = (CheckpointEntry) logEntry;
+        // Just one stream, always
+        UUID streamId = checkPointEntry.getStreamId();
+        UUID checkPointId = checkPointEntry.getCheckpointId();
+
+        // We need to apply the start address for the version of the object
+        long startAddress = streamsMetaData.get(streamId)
+                .getCheckPoint(checkPointId)
+                .getStartAddress();
+
+        // We don't know in advance if there will be smrEntries
+        if (checkPointEntry.getSmrEntries() != null) {
+            checkPointEntry.getSmrEntries().getSMRUpdates(streamId).forEach((smrEntry) -> {
+                applySmrEntryToStream(checkPointEntry.getStreamId(), smrEntry,
+                        startAddress, true);
+            });
         }
     }
 
-    /** Get a range of LogData from the server
-     *
-     * This is using the underlying bulk read implementation for
-     * fetching a range of addresses. This read will return
-     * a map ordered by address.
-     *
-     * It uses a ClosedOpen range : [start, end)
-     * (e.g [0, 5) == (0,1,2,3,4))
-     *
-     * @param start start address for the bulk read
-     * @param end end address for the bulk read
-     * @return logData map ordered by addresses (increasing)
-     */
-    private Map<Long, ILogData> getLogData(long start, long end) {
-        return runtime.getAddressSpaceView()
-                .cacheFetch(ContiguousSet.create(Range.closedOpen(start, end), DiscreteDomain.longs()));
-    }
-
-
-    /** Create a new object SMRMap as recipient of SMRUpdates (if doesn't exist yet)
-     *
-     * @param streamId
-     */
-    private void createSmrMapIfNotExist(UUID streamId) {
-        if (!runtime.getObjectsView().getObjectCache().containsKey(getObjectIdFromStreamID(streamId))) {
-            runtime.getObjectsView().build()
-                    .setStreamID(streamId)
-                    .setType(SMRMap.class)
-                    .open();
-        }
-    }
-
-    /** Deserialize a logData by getting the logEntry
-     *
-     * Getting the underlying logEntry should trigger deserialization only once.
-     * Next access should just returned the logEntry direclty.
-     *
-     * @param logData
-     * @return
-     * @throws Exception
-     */
-    public LogEntry deserializeLogData(ILogData logData) throws Exception{
-        return logData.getLogEntry(runtime);
-    }
-
-    /** Extract log entries from logData and update the Corfu Objects
+    /**
+     * Extract log entries from logData and update the Corfu Objects
      *
      * @param logData LogData received from Corfu server.
      */
-    private void processLogData(ILogData logData) {
-
+    private void updateCorfuObject(ILogData logData) {
         LogEntry logEntry;
         try {
-            logEntry = deserializeLogData(logData);
+            logEntry = deserializeLogData(runtime, logData);
         } catch (Exception e) {
             log.error("Cannot deserialize log entry" + logData.getGlobalAddress(), e);
             return;
         }
 
-        if (logEntry.getType() == LogEntry.LogEntryType.SMR) {
-            // Just one stream, always
-            UUID streamId = logData.getStreams().iterator().next();
-            applySmrEntryToStream(streamId, (SMREntry) logEntry);
+        long globalAddress = logData.getGlobalAddress();
+
+        switch (logEntry.getType()) {
+            case SMR:
+                updateCorfuObjectWithSmrEntry(logData, logEntry, globalAddress);
+                break;
+            case MULTIOBJSMR:
+                updateCorfuObjectWithMultiObjSmrEntry(logEntry, globalAddress);
+                break;
+            case CHECKPOINT:
+                updateCorfuObjectWithCheckPointEntry(logData, logEntry);
+                break;
+            default:
+                log.warn("updateCorfuObject[address = {}]: Unknown data type");
+
         }
-        else if (logEntry.getType() == LogEntry.LogEntryType.MULTIOBJSMR) {
-            MultiObjectSMREntry multiObjectLogEntry = (MultiObjectSMREntry) logEntry;
-            multiObjectLogEntry.getEntryMap().forEach((stream, multiSmrEntry) -> {
-                multiSmrEntry.getSMRUpdates(stream).forEach((smrEntry) -> {
-                    applySmrEntryToStream(stream, smrEntry);
-                });
-            });
-        }
     }
 
-    private void findAndSetLogHead() {
-        logHead = 0;
-    }
 
-    private void findAndSetLogTail() {
-        logTail = runtime.getSequencerView().nextToken(Collections.emptySet(), 0).getTokenValue();
-    }
-
-    /** Initialize log head and log tails
+    /**
+     * Initialize log head and log tails
      *
      * If logHead and logTail has not been initialized by
      * the user, initialize to default.
@@ -241,35 +318,66 @@ public class FastSmrMapsLoader {
         if (logTail < 0) {
             findAndSetLogTail();
         }
+
+        resetAddressProcessed();
     }
 
-    /** Book keeping of the the stream tails
+    private void cleanUpForRetry() {
+        runtime.getAddressSpaceView().invalidateClientCache();
+        runtime.getObjectsView().getObjectCache().clear();
+        streamTails.clear();
+        nextRead = logHead;
+        resetAddressProcessed();
+
+        // Re ask for the Head, if it changes while we were trying
+        findAndSetLogHead();
+    }
+    /**
+     * Increment the retry iteration.
      *
-     * @param logData
+     * If we reached the max number of entry, throw a Runtime Exception.
      */
-    public void updateStreamTails(ILogData logData) {
-         for (UUID streamId : logData.getStreams()) {
-             streamTails.put(streamId, logData.getGlobalAddress());
-            }
+    private void handleRetry() {
+
+        retryIteration++;
+        if (retryIteration > numberOfAttempt) {
+            log.error("processLogData[]: retried {} number of times and failed", retryIteration);
+            throw new RuntimeException("FastSmrMapsLoader failed after too many retry (" + retryIteration + ")");
+        }
+        else {
+            cleanUpForRetry();
+        }
     }
 
-    /** Processing logdata at a given log address
+    /**
+     * Fail the FastSmrMapsLoader throwing a RuntimeException
      *
-     * @param logData
+     * @param msg message passed in the RuntimeException
+     */
+    private void fail(String msg) {
+        throw new RuntimeException(msg);
+    }
+
+    /**
+     * Dispatch logData given it's type
+     *
      * @param address
+     * @param logData
      */
-    public void processAddressLogData(ILogData logData, long address) {
+    private void processLogData(long address, ILogData logData) {
         switch (logData.getType()) {
             case DATA:
-                processLogData(logData);
+                // Checkpoint should have been processed first
+                if (!isCheckPointEntry(logData)) {
+                    updateCorfuObject(logData);
+                }
                 break;
             case HOLE:
                 break;
             case TRIMMED:
-                log.warn("loadMaps[{}, start={}]: address is trimmed", address, logHead);
-                // Should not happen
+                break;
             case EMPTY:
-                log.warn("loadMaps[address={}]: is empty", address);
+                log.warn("applyForEachAddress[address={}] is empty");
                 break;
             case RANK_ONLY:
                 break;
@@ -278,59 +386,243 @@ public class FastSmrMapsLoader {
         }
     }
 
+    /**
+     * When we encounter a start checkpoint, we need to create the new entry in the Stream
+     * @param address
+     * @param logData
+     * @param streamId
+     * @param checkPointId
+     * @param streamMeta
+     */
+    private void handleStartCheckPoint(long address, ILogData logData, UUID streamId,
+                                       UUID checkPointId, StreamMetaData streamMeta) {
+        try {
+            CheckpointEntry logEntry = (CheckpointEntry) deserializeLogData(runtime, logData);
+            long snapshotAddress = getSnapShotAddressOfCheckPoint(logEntry);
+            long startAddress = getStartAddressOfCheckPoint(logEntry);
 
-    /** Entry point to load the SMRMaps in memory.
+            streamMeta.addCheckPoint(new CheckPoint(checkPointId)
+                    .addAddress(address)
+                    .setSnapshotAddress(snapshotAddress)
+                    .setStartAddress(startAddress)
+                    .setStarted(true));
+
+        } catch (Exception e) {
+            log.error("findCheckpointsInLogAddress[address = {}]: " +
+                    "Couldn't get the snapshotAddress", e);
+            fail("Couldn't get the snapshotAddress at address " + address);
+        }
+    }
+
+    /**
+     * Find if there is a checkpoint in the current logAddress
+     *
+     * If there is a checkpoint, the streamsMetadata map will be
+     * updated accordingly.
+     *
+     * We will only use the first checkpoint
+     *
+     * @param address
+     * @param logData
+     */
+    private void findCheckPointsInLogAddress(long address, ILogData logData) {
+        if (logData.hasCheckpointMetadata()) {
+            // Only one stream per checkpoint
+            UUID streamId = logData.getCheckpointedStreamId();
+            StreamMetaData streamMeta;
+            streamMeta = streamsMetaData.computeIfAbsent(streamId, (id) -> new StreamMetaData(id));
+            UUID checkPointId = logData.getCheckpointId();
+
+            switch (logData.getCheckpointType()) {
+                case START:
+                    handleStartCheckPoint(address, logData, streamId, checkPointId, streamMeta);
+
+                    break;
+                case CONTINUATION:
+                    if (streamMeta.checkPointExists(checkPointId)) {
+                        streamMeta.getCheckPoint(checkPointId).addAddress(address);
+                    }
+
+                    break;
+                case END:
+                    if (streamMeta.checkPointExists(checkPointId)) {
+                        streamMeta.getCheckPoint(checkPointId).setEnded(true).addAddress(address);
+                        streamMeta.updateLatestCheckpointIfLater(checkPointId);
+                    }
+                    break;
+                default:
+                    log.warn("findCheckPointsInLog[address = {}] Unknown checkpoint type", address);
+                    break;
+            }
+        }
+    }
+
+
+    /**
+     * Apply the checkPoints in parallel
+     *
+     * Since each checkpoint is mapped to a single stream, we can parallelize
+     * this operation.
+     *
+     */
+    private void resurrectCheckpoints() {
+        streamsMetaData.entrySet().parallelStream()
+                .forEach(entry -> {
+                    CheckPoint checkPoint = entry.getValue().getLatestCheckPoint();
+                    if (checkPoint == null) {
+                        log.info("resurrectCheckpoints[{}]: Truncated checkpoint for this stream",
+                                Utils.toReadableID(entry.getKey()));
+                        return;
+                    }
+
+                    // For now one by one read and apply
+                    for (long address : checkPoint.getAddresses()) {
+                        updateCorfuObject(getLogData(runtime, loadInCache, address));
+                    }
+                });
+    }
+
+    /**
+     * This method will only resurrect the stream tails. It is used
+     * to recover a sequencer.
+     */
+    private void recoverSequencer() {
+        log.info("recoverSequencer: Resurrecting the stream tails");
+        applyForEachAddress(this::updateStreamTails);
+    }
+
+    /**
+     * This method will use the checkpoints and the entries
+     * after checkpoints to resurrect the SMRMaps
+     */
+    private void recoverRuntime() {
+        log.info("recoverRuntime: Resurrecting the runtime");
+
+        // If the user is sure that he has no checkpoint,
+        // we can just do the last step. Risky, but the flag is
+        // explicit enough.
+        if (logHasNoCheckPoint) {
+            applyForEachAddress(this::processLogData);
+        } else {
+            applyForEachAddress(this::findCheckPointsInLogAddress);
+            resurrectCheckpoints();
+
+            resetAddressProcessed();
+            applyForEachAddress(this::processLogData);
+        }
+
+    }
+
+    /**
+     * Entry point to load the SMRMaps in memory.
      *
      * When this function returns, the maps are fully loaded.
-     *
      */
     public void loadMaps() {
         log.info("loadMaps: Starting to resurrect maps");
         initializeHeadAndTails();
 
-        long nextRead = 0;
+        if(recoverSequencerMode) {
+            recoverSequencer();
+        }
+        else {
+            recoverRuntime();
+        }
+
+        log.info("loadMaps[startAddress: {}, stopAddress (included): {}, addressProcessed: {}]",
+                logHead, logTail, addressProcessed);
+        log.info("loadMaps: Loading successful, Corfu maps are alive!");
+    }
+
+
+    /**
+     * This method will apply for each address the consumer given in parameter.
+     *
+     * The Necromancer thread is used to do the heavy lifting.
+     * @param logDataProcessor
+     */
+    private void applyForEachAddress(BiConsumer<Long, ILogData> logDataProcessor) {
+
+        summonNecromancer();
+        nextRead = logHead;
         while (nextRead <= logTail) {
             final long start = nextRead;
             final long stopNotIncluded = Math.min(start + batchReadSize, logTail + 1);
             nextRead = stopNotIncluded;
-            final Map<Long, ILogData> range = getLogData(start, stopNotIncluded);
-            for (Long address : range.keySet()) {
+            final Map<Long, ILogData> range = getLogData(runtime, start, stopNotIncluded);
+
+            // Sanity
+            boolean canProcessRange = true;
+            for(Map.Entry<Long, ILogData> entry : range.entrySet()) {
+                long address = entry.getKey();
+                ILogData logData = entry.getValue();
                 if (address != addressProcessed + 1) {
-                    throw new RuntimeException("loadMaps: Missed an entry, this implies correctness issues");
+                    fail("We missed an entry. It can lead to correctness issues.");
                 }
                 addressProcessed++;
-                if (addressProcessed % STATUS_UPDATE_PACE == 0) {
-                    log.info("LoadMaps: read up to {}", address);
+
+                if (logData.getType() == DataType.TRIMMED) {
+                    log.warn("applyForEachAddress[{}, start={}] address is trimmed", address, logHead);
+                    handleRetry();
+                    canProcessRange = false;
+                    break;
+                }
+
+                if(address % STATUS_UPDATE_PACE == 0) {
+                    log.info("applyForEachAddress: read up to {}", address);
                 }
             }
-
-            necromancer.execute(() -> {
-                range.forEach((address, logData) -> {
-                    if (recoverSequencerMode) {
-                        updateStreamTails(logData);
-                    } else {
-                        processAddressLogData(logData, address);
-                    }
-                });
-            });
+            if (canProcessRange) {
+                invokeNecromancer(range, logDataProcessor);
+            }
         }
+        killNecromancer();
+    }
 
-        necromancer.shutdown();
+    @Data
+    private class CheckPoint {
+        final UUID checkPointId;
+        long snapshotAddress;
+        long startAddress;
+        boolean ended = false;
+        boolean started = false;
+        List<Long> addresses = new ArrayList<>();
 
-        try {
-            necromancer.awaitTermination(timeoutInMinutesForLoading, TimeUnit.MINUTES);
-            log.info("loadMaps[startAddress: {}, stopAddress (included): {}, addressProcessed: {}]",
-                    logHead, logTail, addressProcessed);
-            log.info("loadMaps: Loading successful, Corfu maps are alive!");
-        } catch (InterruptedException e) {
-            log.warn("loadMaps: Taking too long to load the maps. Gave up.");
+        public CheckPoint addAddress(long address) {
+            addresses.add(address);
+            return this;
         }
     }
 
     @Data
     private class StreamMetaData {
-        UUID streamId;
-        long headAddress;
+        final UUID streamId;
+        CheckPoint latestCheckPoint;
+        Map<UUID, CheckPoint> checkPoints = new HashMap<>();
+
+        public Long getHeadAddress() {
+            return latestCheckPoint != null ? latestCheckPoint.snapshotAddress : Address.NEVER_READ;
+        }
+
+        public void addCheckPoint(CheckPoint cp) {
+            checkPoints.put(cp.getCheckPointId(), cp);
+        }
+
+        public CheckPoint getCheckPoint(UUID checkPointId) {
+            return checkPoints.get(checkPointId);
+        }
+
+        public boolean checkPointExists(UUID checkPointId) {
+            return checkPoints.containsKey(checkPointId);
+        }
+
+        public void updateLatestCheckpointIfLater(UUID checkPointId) {
+            CheckPoint contender = getCheckPoint(checkPointId);
+            if (latestCheckPoint == null ||
+                    contender.getSnapshotAddress() > latestCheckPoint.getSnapshotAddress()) {
+                        latestCheckPoint = contender;
+            }
+        }
     }
 }
 

--- a/runtime/src/main/java/org/corfudb/recovery/RecoveryUtils.java
+++ b/runtime/src/main/java/org/corfudb/recovery/RecoveryUtils.java
@@ -1,0 +1,113 @@
+package org.corfudb.recovery;
+
+import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.Range;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
+import org.corfudb.protocols.logprotocol.LogEntry;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.object.CorfuCompileProxy;
+import org.corfudb.runtime.object.ICorfuSMR;
+import org.corfudb.runtime.view.ObjectsView;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.corfudb.protocols.logprotocol.CheckpointEntry.CheckpointDictKey.SNAPSHOT_ADDRESS;
+import static org.corfudb.protocols.logprotocol.CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS;
+
+/**
+ * Created by rmichoud on 6/22/17.
+ */
+public class RecoveryUtils {
+
+    static ObjectsView.ObjectID getObjectIdFromStreamId(UUID streamId) {
+        return new ObjectsView.ObjectID(streamId, SMRMap.class);
+    }
+    static boolean isCheckPointEntry(ILogData logData) {
+        return logData.hasCheckpointMetadata();
+    }
+
+    static long getSnapShotAddressOfCheckPoint(CheckpointEntry logEntry) {
+        return Long.parseLong(logEntry.getDict().get(SNAPSHOT_ADDRESS));
+    }
+
+    static long getStartAddressOfCheckPoint(CheckpointEntry logEntry) {
+        return Long.parseLong(logEntry.getDict().get(START_LOG_ADDRESS));
+    }
+
+    /** Create a new object SMRMap as recipient of SMRUpdates (if doesn't exist yet)
+     *
+     * @param streamId
+     */
+    static void createSmrMapIfNotExist(CorfuRuntime runtime, UUID streamId) {
+        if (!runtime.getObjectsView().getObjectCache()
+                .containsKey(RecoveryUtils.getObjectIdFromStreamId(streamId))) {
+            runtime.getObjectsView().build()
+                    .setStreamID(streamId)
+                    .setType(SMRMap.class)
+                    .open();
+        }
+    }
+
+    /**
+     * Fetch LogData from Corfu server
+     *
+     * @param address address to be fetched
+     * @return LogData at address
+     */
+    static ILogData getLogData(CorfuRuntime runtime, boolean loadInCache, long address) {
+        if (loadInCache) {
+            return runtime.getAddressSpaceView().read(address);
+        } else {
+            return runtime.getAddressSpaceView().fetch(address);
+        }
+    }
+
+    /**
+     * Get a range of LogData from the server
+     *
+     * This is using the underlying bulk read implementation for
+     * fetching a range of addresses. This read will return
+     * a map ordered by address.
+     *
+     * It uses a ClosedOpen range : [start, end)
+     * (e.g [0, 5) == (0,1,2,3,4))
+     *
+     * @param start start address for the bulk read
+     * @param end end address for the bulk read
+     * @return logData map ordered by addresses (increasing)
+     */
+    static Map<Long, ILogData> getLogData(CorfuRuntime runtime, long start, long end) {
+        return runtime.getAddressSpaceView().
+                cacheFetch(ContiguousSet.create(Range.closedOpen(start, end), DiscreteDomain.longs()));
+    }
+
+    /** Deserialize a logData by getting the logEntry
+     *
+     * Getting the underlying logEntry should trigger deserialization only once.
+     * Next access should just returned the logEntry direclty.
+     *
+     * @param logData
+     * @return
+     * @throws Exception
+     */
+    public static LogEntry deserializeLogData(CorfuRuntime runtime, ILogData logData) throws Exception{
+        return logData.getLogEntry(runtime);
+    }
+
+    /**
+     * Look in the objectCache for the corresponding CorfuCompileProxy
+     *
+     * @param runtime
+     * @param streamId
+     * @return
+     */
+    static CorfuCompileProxy getCorfuCompileProxy(CorfuRuntime runtime, UUID streamId) {
+        ObjectsView.ObjectID thisObjectId = new ObjectsView.ObjectID(streamId, SMRMap.class);
+        return ((CorfuCompileProxy) ((ICorfuSMR) runtime.getObjectsView().getObjectCache().get(thisObjectId)).
+                getCorfuSMRProxy());
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -20,6 +20,7 @@ import org.corfudb.runtime.object.transactions.WriteSetSMRStream;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.Utils;
 
+//TODO Discard TransactionStream for building maps but not for constructing tails
 
 /**
  * The VersionLockedObject maintains a versioned object which is
@@ -626,10 +627,9 @@ public class VersionLockedObject<T> {
      *
      * @param entry
      */
-    public void applyUpdateToStreamUnsafe(SMREntry entry) {
-        long entryAddress = entry.getEntry().getGlobalAddress();
-
+    public void applyUpdateToStreamUnsafe(SMREntry entry, long globalAddress) {
         applyUpdateUnsafe(entry);
-        seek(entryAddress + 1);
+        seek(globalAddress + 1);
     }
+
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -261,17 +261,19 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
         if (data.hasCheckpointMetadata()) {
             CheckpointEntry cpEntry = (CheckpointEntry)
                     data.getPayload(runtime);
-            if (context.checkpointSuccessId == null
-                    && cpEntry.getCpType() == CheckpointEntry.CheckpointEntryType.END) {
+
+            if (context.checkpointSuccessId == null &&
+                    cpEntry.getCpType() == CheckpointEntry.CheckpointEntryType.END) {
                 log.trace("Checkpoint[{}] END found at address {} type {} id {} author {}",
                         this, data.getGlobalAddress(), cpEntry.getCpType(),
-                        Utils.toReadableID(cpEntry.getCheckpointID()),
-                        cpEntry.getCheckpointAuthorID());
-                context.checkpointSuccessId = cpEntry.getCheckpointID();
+                        Utils.toReadableID(cpEntry.getCheckpointId()),
+                        cpEntry.getCheckpointAuthorId());
+                context.checkpointSuccessId = cpEntry.getCheckpointId();
                 context.checkpointSuccessNumEntries = 1L;
                 context.checkpointSuccessBytes = (long) data.getSizeEstimate();
                 context.checkpointSuccessEndAddr = data.getGlobalAddress();
-            } else if (data.getCheckpointID().equals(context.checkpointSuccessId)) {
+            }
+            else if (data.getCheckpointId().equals(context.checkpointSuccessId)) {
                 context.checkpointSuccessNumEntries++;
                 context.checkpointSuccessBytes += cpEntry.getSmrEntriesBytes();
                 if (cpEntry.getCpType().equals(CheckpointEntry.CheckpointEntryType.START)) {
@@ -292,8 +294,8 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                     log.trace("Checkpoint[{}] HALT due to START at address {} startAddr"
                             + " {} type {} id {} author {}",
                             this, data.getGlobalAddress(), cpStartAddr, cpEntry.getCpType(),
-                            Utils.toReadableID(cpEntry.getCheckpointID()),
-                            cpEntry.getCheckpointAuthorID());
+                            Utils.toReadableID(cpEntry.getCheckpointId()), cpEntry.getCheckpointAuthorId());
+
                     return BackpointerOp.INCLUDE_STOP;
                 }
             } else {
@@ -315,8 +317,8 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
         // If the stream has just been reset and we don't have
         // any checkpoint entries, we should consult
         // a checkpoint first.
-        if (context.globalPointer == Address.NEVER_READ
-                && context.checkpointSuccessId == null) {
+        if (context.globalPointer == Address.NEVER_READ &&
+                context.checkpointSuccessId == null) {
             // The checkpoint stream ID is the UUID appended with CP
             final UUID checkpointId = CorfuRuntime
                     .getStreamID(context.id.toString() + "_cp");
@@ -369,7 +371,6 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                     .nextToken(Collections.singleton(context.id), 0)
                     .getToken().getTokenValue();
         }
-
         // If there is no information on the tail of the stream, return,
         // there is nothing to do
         if (Address.nonAddress(latestTokenValue)) {
@@ -406,3 +407,4 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
         return ! context.readCpQueue.isEmpty() || !context.readQueue.isEmpty();
     }
 }
+

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -34,8 +34,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.recovery.RecoveryUtils;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.recovery.FastSmrMapsLoader;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.object.CorfuCompileProxy;
+import org.corfudb.runtime.object.ICorfuSMR;
+import org.corfudb.runtime.view.ObjectsView;
 
 
 /**
@@ -388,10 +393,10 @@ public class Utils {
      *
      * @param logData
      */
-    private void printLogAnatomy(CorfuRuntime runtime, ILogData logData) {
+    public static void printLogAnatomy(CorfuRuntime runtime, ILogData logData) {
         FastSmrMapsLoader fastLoader = new FastSmrMapsLoader(runtime);
         try {
-            LogEntry le = fastLoader.deserializeLogData(logData);
+            LogEntry le = RecoveryUtils.deserializeLogData(runtime, logData);
             if (le.getType() == LogEntry.LogEntryType.SMR) {
                 log.info("printLogAnatomy: Number of Streams: 1");
                 log.info("printLogAnatomy: Number of Entries: 1");

--- a/test/src/test/java/org/corfudb/recovery/FastSmrMapsLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastSmrMapsLoaderTest.java
@@ -5,21 +5,30 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.runtime.CheckpointWriter;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.clients.SequencerClient;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.VersionLockedObject;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.ObjectsView;
+import org.corfudb.util.serializer.ISerializer;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,6 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Created by rmichoud on 6/16/17.
  */
 public class FastSmrMapsLoaderTest extends AbstractViewTest {
+    static final int NUMBER_OF_CHECKPOINTS = 20;
+    static final int NUMBER_OF_PUT = 100;
 
     private ILogData.SerializationHandle createEmptyData(long position, DataType type, IMetadata.DataRank rank) {
         ILogData data = new LogData(type);
@@ -54,6 +65,34 @@ public class FastSmrMapsLoaderTest extends AbstractViewTest {
                 .open();
     }
 
+    private void doCheckPointsAfterSnapshot(List<ICorfuSMR<Map>> maps, String author, CorfuRuntime rt){
+        try {
+            for (ICorfuSMR<Map> map : maps) {
+                UUID streamID = map.getCorfuStreamID();
+                while (true) {
+                    CheckpointWriter cpw = new CheckpointWriter(rt, streamID, author, (SMRMap) map);
+                    ISerializer serializer =
+                            ((CorfuCompileProxy<Map>) map.getCorfuSMRProxy())
+                                    .getSerializer();
+                    cpw.setSerializer(serializer);
+                    try {
+                        List<Long> addresses = cpw.appendCheckpoint();
+                        break;
+                    } catch (TransactionAbortedException ae) {
+                        // Don't break!
+                    }
+                }
+            }
+        } finally {
+            rt.getObjectsView().TXEnd();
+        }
+    }
+
+    private void assertThatObjectCacheIsTheSameSize(CorfuRuntime rt1, CorfuRuntime rt2) {
+        assertThat(rt2.getObjectsView().getObjectCache().size())
+                .isEqualTo(rt1.getObjectsView().getObjectCache().size());
+    }
+
     private void assertThatMapIsBuilt(CorfuRuntime rt1, CorfuRuntime rt2, String streamName,
                                       Map<String, String> map) {
 
@@ -64,13 +103,23 @@ public class FastSmrMapsLoaderTest extends AbstractViewTest {
         // Assert that UnderlyingObjects are at the same version
         // If they are at the same version, a sync on the object will
         // be a no op for the new runtime.
-        assertThat(vo1.getVersionUnsafe()).isEqualTo(vo1Prime.getVersionUnsafe());
-        assertThat(rt1.getObjectsView().getObjectCache().size())
-                .isEqualTo(rt2.getObjectsView().getObjectCache().size());
+        assertThat(vo1Prime.getVersionUnsafe()).isEqualTo(vo1.getVersionUnsafe());
+
 
         Map<String, String> mapPrime = createMap(streamName, rt2);
-        assertThat(map.size()).isEqualTo(mapPrime.size());
-        map.forEach((key, value) -> assertThat(value).isEqualTo(mapPrime.get(key)));
+        assertThat(mapPrime.size()).isEqualTo(map.size());
+        mapPrime.forEach((key, value) -> assertThat(value).isEqualTo(map.get(key)));
+    }
+
+    private void assertThatMapIsNotReBuilt(CorfuRuntime rt1, CorfuRuntime rt2, String streamName) {
+        ObjectsView.ObjectID mapId = new ObjectsView.
+                ObjectID(CorfuRuntime.getStreamID(streamName), SMRMap.class);
+
+        assertThat((rt1.getObjectsView().getObjectCache().
+                containsKey(mapId))).isTrue();
+
+        assertThat((rt2.getObjectsView().getObjectCache().
+                containsKey(mapId))).isFalse();
     }
 
 
@@ -102,6 +151,7 @@ public class FastSmrMapsLoaderTest extends AbstractViewTest {
 
         assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
         assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
 
     }
 
@@ -118,10 +168,9 @@ public class FastSmrMapsLoaderTest extends AbstractViewTest {
                 .connect();
 
         assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
-
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
 
     }
-
 
 
     /**
@@ -157,7 +206,8 @@ public class FastSmrMapsLoaderTest extends AbstractViewTest {
                 .setLoadSmrMapsAtConnect(true)
                 .connect();
 
-     assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
 
     }
 
@@ -212,6 +262,218 @@ public class FastSmrMapsLoaderTest extends AbstractViewTest {
                 .connect();
 
         assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+    }
+
+    @Test
+    public void canReadCheckpointWithoutTrim() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map1.put("k3", "v3");
+        map1.put("k4", "v4");
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.appendCheckpoints(getRuntime(), "author");
+
+        // Clear are interesting because if applied in wrong order the map might end up wrong
+        map1.clear();
+        map1.put("k5", "v5");
+
+
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        Map<String, String> mapPrime = createMap("Map1", rt2);
+        mapPrime.size();
+
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+
+    }
+
+    @Test
+    public void canReadCheckPointMultipleStream() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map2.put("k3", "v3");
+        map3.put("k5", "v5");
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        mcw.appendCheckpoints(getRuntime(), "author");
+
+        map1.clear();
+        map2.clear();
+        map3.clear();
+
+        map1.put("k2", "v2");
+        map2.put("k4", "v4");
+        map3.put("k6", "v6");
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+    }
+
+    @Test
+    public void canReadMultipleCheckPointMultipleStreams() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map2.put("k3", "v3");
+        map3.put("k5", "v5");
+
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        mcw.appendCheckpoints(getRuntime(), "author");
+
+        map1.clear();
+        map2.clear();
+        map3.clear();
+
+        map1.put("k2", "v2");
+        map2.put("k4", "v4");
+        map3.put("k6", "v6");
+
+        map1.put("k7", "v7");
+        map2.put("k9", "v9");
+        map3.put("k11", "v11");
+
+        mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        mcw.appendCheckpoints(getRuntime(), "author");
+
+        map1.clear();
+        map2.clear();
+        map3.clear();
+
+        map1.put("k8", "v8");
+        map2.put("k10", "v10");
+        map3.put("k12", "v12");
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatMapIsBuilt(rt1, rt2, "Map3", map3);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+
+    }
+
+    @Test
+    public void canReadCheckPointMultipleStreamsTrim() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map2.put("k3", "v3");
+        map3.put("k5", "v5");
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        long checkpointAddress = mcw.appendCheckpoints(getRuntime(), "author");
+
+        map1.clear();
+        map2.clear();
+        map3.clear();
+
+        map1.put("k2", "v2");
+        map2.put("k4", "v4");
+        map3.put("k6", "v6");
+
+        // Trim the log
+        getRuntime().getAddressSpaceView().prefixTrim(checkpointAddress - 1);
+        getRuntime().getAddressSpaceView().gc();
+        getRuntime().getAddressSpaceView().invalidateServerCaches();
+        getRuntime().getAddressSpaceView().invalidateClientCache();
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatMapIsBuilt(rt1, rt2, "Map3", map3);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+    }
+
+    @Test
+    public void canReadCheckPointMultipleStreamTrimWithLeftOver() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map2.put("k3", "v3");
+        map3.put("k5", "v5");
+
+
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        long checkpointAddress = mcw.appendCheckpoints(getRuntime(), "author");
+
+        // Clear are interesting because if applied in wrong order the map might end up wrong
+        map1.clear();
+        map2.clear();
+        map3.clear();
+        map3.put("k6", "v6");
+        map1.put("k2", "v2");
+        map2.put("k4", "v4");
+
+        // Trim the log
+        getRuntime().getAddressSpaceView().prefixTrim(2);
+        getRuntime().getAddressSpaceView().gc();
+        getRuntime().getAddressSpaceView().invalidateServerCaches();
+        getRuntime().getAddressSpaceView().invalidateClientCache();
+
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatMapIsBuilt(rt1, rt2, "Map3", map3);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+
+
     }
 
     @Test
@@ -227,6 +489,10 @@ public class FastSmrMapsLoaderTest extends AbstractViewTest {
         UUID stream1 = CorfuRuntime.getStreamID("Map1");
         UUID stream2 = CorfuRuntime.getStreamID("Map2");
 
+        LogUnitClient luc = rt1.getRouter(getDefaultConfigurationString())
+                .getClient(LogUnitClient.class);
+        SequencerClient seq = rt1.getRouter(getDefaultConfigurationString())
+                .getClient(SequencerClient.class);
 
 
         long tail1 = rt1.getSequencerView().nextToken(Collections.singleton(stream1), 0).getToken().getTokenValue();
@@ -244,6 +510,111 @@ public class FastSmrMapsLoaderTest extends AbstractViewTest {
 
         assertThat(streamTails.get(stream1)).isEqualTo(tail1);
         assertThat(streamTails.get(stream2)).isEqualTo(tail2);
+    }
+
+    @Test
+    public void canFindTailsWithCheckPoints() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        int mapCount = 0;
+        Map<String, String> map1 = createMap("Map1", rt1);
+        mapCount++;
+        Map<String, String> map2 = createMap("Map2", rt1);
+        mapCount++;
+        Map<String, String> map3 = createMap("Map3", rt1);
+        mapCount++;
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map2.put("k4", "v4");
+        map3.put("k5", "v5");
+
+        UUID stream1 = CorfuRuntime.getStreamID("Map1");
+        UUID stream2 = CorfuRuntime.getStreamID("Map2");
+        UUID stream3 = CorfuRuntime.getStreamID("Map3");
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        mcw.appendCheckpoints(getRuntime(), "author");
+
+        long tail1 = rt1.getSequencerView().nextToken(Collections.singleton(stream1), 0).getToken().getTokenValue();
+        long tail2 = rt1.getSequencerView().nextToken(Collections.singleton(stream2), 0).getToken().getTokenValue();
+        long tail3 = rt1.getSequencerView().nextToken(Collections.singleton(stream3), 0).getToken().getTokenValue();
+
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        FastSmrMapsLoader fsm = new FastSmrMapsLoader(rt2);
+        fsm.setRecoverSequencerMode(true);
+        fsm.loadMaps();
+
+        Map<UUID, Long> streamTails = fsm.getStreamTails();
+
+
+        assertThat(streamTails.get(stream1)).isEqualTo(tail1);
+        assertThat(streamTails.get(stream2)).isEqualTo(tail2);
+        assertThat(streamTails.get(stream3)).isEqualTo(tail3);
+
+        // Need to have checkpoint for each stream
+        assertThat(streamTails.size()).isEqualTo(mapCount * 2);
+    }
+
+    @Test
+    public void canFindTailsWithOnlyCheckpointAndTrim() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        int mapCount = 0;
+        Map<String, String> map1 = createMap("Map1", rt1);
+        mapCount++;
+        Map<String, String> map2 = createMap("Map2", rt1);
+        mapCount++;
+        Map<String, String> map3 = createMap("Map3", rt1);
+        mapCount++;
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map2.put("k4", "v4");
+        map3.put("k5", "v5");
+
+        UUID stream1 = CorfuRuntime.getStreamID("Map1");
+        UUID stream2 = CorfuRuntime.getStreamID("Map2");
+        UUID stream3 = CorfuRuntime.getStreamID("Map3");
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        long address = mcw.appendCheckpoints(getRuntime(), "author");
+
+        long tail1 = rt1.getSequencerView().nextToken(Collections.singleton(stream1), 0).getToken().getTokenValue();
+        long tail2 = rt1.getSequencerView().nextToken(Collections.singleton(stream2), 0).getToken().getTokenValue();
+        long tail3 = rt1.getSequencerView().nextToken(Collections.singleton(stream3), 0).getToken().getTokenValue();
+
+        getRuntime().getAddressSpaceView().prefixTrim(address - 1);
+        getRuntime().getAddressSpaceView().gc();
+        getRuntime().getAddressSpaceView().invalidateServerCaches();
+        getRuntime().getAddressSpaceView().invalidateClientCache();
+
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .connect();
+
+        FastSmrMapsLoader fsm = new FastSmrMapsLoader(rt2);
+        fsm.setRecoverSequencerMode(true);
+        fsm.loadMaps();
+
+        Map<UUID, Long> streamTails = fsm.getStreamTails();
+
+
+        assertThat(streamTails.get(stream1)).isEqualTo(tail1);
+        assertThat(streamTails.get(stream2)).isEqualTo(tail2);
+        assertThat(streamTails.get(stream3)).isEqualTo(tail3);
+
+        // Need to have checkpoint for each stream
+        assertThat(streamTails.size()).isEqualTo(mapCount * 2);
+
     }
 
     @Test
@@ -283,6 +654,448 @@ public class FastSmrMapsLoaderTest extends AbstractViewTest {
 
         assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
         assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
     }
+
+    /**
+     * Interleaving checkpoint entries and normal entries through multithreading
+     *
+     * @throws Exception
+     */
+    @Test
+    public void canReadWithEntriesInterleavingCPS() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        int mapCount = 0;
+
+        Map<String, String> map1 = createMap("Map1", rt1);
+        mapCount++;
+        Map<String, String> map2 = createMap("Map2", rt1);
+        mapCount++;
+        Map<String, String> map3 = createMap("Map3", rt1);
+        mapCount++;
+
+        // Keeping track of maps
+        List<Map<String, String>> bareMaps = new ArrayList<>();
+        bareMaps.add(map1);
+        bareMaps.add(map2);
+        bareMaps.add(map3);
+
+        // Keeping track of maps
+        map1.put("k1", "v1");
+        map2.put("k2", "v2");
+        map3.put("k3", "v3");
+
+        List<ICorfuSMR<Map>> maps = new ArrayList<>();
+        maps.add((ICorfuSMR<Map>) map1);
+        maps.add((ICorfuSMR<Map>) map2);
+        maps.add((ICorfuSMR<Map>) map3);
+
+
+        ExecutorService checkPointThread = Executors.newFixedThreadPool(1);
+        checkPointThread.execute(() -> {
+            for (int i = 0; i < NUMBER_OF_CHECKPOINTS; i++) {
+                try {
+                    MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+                    mcw.addMap((SMRMap) map1);
+                    mcw.addMap((SMRMap) map2);
+                    mcw.addMap((SMRMap) map3);
+                    long address = mcw.appendCheckpoints(getRuntime(), "author");
+                } catch (Exception e) {
+
+                }
+            }
+        });
+
+
+        for (int i = 0; i < NUMBER_OF_PUT; i++) {
+            bareMaps.get(i % maps.size()).put("k" + Integer.toString(i),
+                    "v" + Integer.toString(i));
+        }
+
+
+        try {
+            checkPointThread.shutdown();
+            final int timeout = 10;
+            checkPointThread.awaitTermination(timeout, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+
+        }
+
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatMapIsBuilt(rt1, rt2, "Map3", map3);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+
+
+        // Also test it cans find the tails
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt3 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+
+        FastSmrMapsLoader fastLoader = new FastSmrMapsLoader(rt3);
+        fastLoader.setRecoverSequencerMode(true);
+        fastLoader.loadMaps();
+
+        Map<UUID, Long> streamTails = fastLoader.getStreamTails();
+
+        UUID stream1 = CorfuRuntime.getStreamID("Map1");
+        UUID stream2 = CorfuRuntime.getStreamID("Map2");
+        UUID stream3 = CorfuRuntime.getStreamID("Map3");
+
+
+        long tail1 = rt1.getSequencerView().nextToken(Collections.singleton(stream1), 0).getToken().getTokenValue();
+        long tail2 = rt1.getSequencerView().nextToken(Collections.singleton(stream2), 0).getToken().getTokenValue();
+        long tail3 = rt1.getSequencerView().nextToken(Collections.singleton(stream3), 0).getToken().getTokenValue();
+
+        assertThat(streamTails.get(stream1)).isEqualTo(tail1);
+        assertThat(streamTails.get(stream2)).isEqualTo(tail2);
+        assertThat(streamTails.get(stream3)).isEqualTo(tail3);
+
+        // Need to have checkpoint for each stream
+        assertThat(streamTails.size()).isEqualTo(mapCount * 2);
+
+    }
+
+    @Test
+    public void canReadWithTruncatedCheckPoint() throws Exception{
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map2.put("k3", "v3");
+        map3.put("k5", "v5");
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        long firstCheckpointAddress = mcw.appendCheckpoints(rt1, "author");
+
+        map3.put("k6", "v6");
+        map1.put("k2", "v2");
+        map2.put("k4", "v4");
+
+        mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        mcw.appendCheckpoints(rt1, "author");
+
+        // Trim the log removing the checkpoint start of the first checkpoint
+        getRuntime().getAddressSpaceView().prefixTrim(firstCheckpointAddress);
+        getRuntime().getAddressSpaceView().gc();
+        getRuntime().getAddressSpaceView().invalidateServerCaches();
+        getRuntime().getAddressSpaceView().invalidateClientCache();
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatMapIsBuilt(rt1, rt2, "Map3", map3);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+
+    }
+
+    @Test
+    public void canReadLogTerminatedWithCheckpoint() throws Exception{
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map2.put("k4", "v4");
+        map3.put("k5", "v5");
+        map3.put("k6", "v6");
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        mcw.appendCheckpoints(rt1, "author");
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .setLoadSmrMapsAtConnect(true)
+                .connect();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatMapIsBuilt(rt1, rt2, "Map3", map3);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+    }
+
+    @Test
+    public void canReadWhenTheUserHasNoCheckpoint() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map2.put("k4", "v4");
+        map3.put("k5", "v5");
+        map3.put("k6", "v6");
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .connect();
+
+        FastSmrMapsLoader fsm = new FastSmrMapsLoader(rt2);
+        fsm.setLogHasNoCheckPoint(true);
+        fsm.loadMaps();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatMapIsBuilt(rt1, rt2, "Map3", map3);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+
+    }
+
+    @Test
+    public void ignoreStreamForRuntimeButNotStreamTails() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map2.put("k4", "v4");
+        map3.put("k5", "v5");
+        map3.put("k6", "v6");
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .connect();
+
+        FastSmrMapsLoader fsm = new FastSmrMapsLoader(rt2);
+        fsm.addStreamToIgnore("Map1");
+        fsm.loadMaps();
+
+        assertThatMapIsNotReBuilt(rt1, rt2, "Map1");
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatMapIsBuilt(rt1, rt2, "Map3", map3);
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt3 = new CorfuRuntime(getDefaultConfigurationString())
+                .connect();
+
+        fsm = new FastSmrMapsLoader(rt3);
+        fsm.addStreamToIgnore("Map1");
+        fsm.setRecoverSequencerMode(true);
+        fsm.loadMaps();
+
+
+        UUID stream1 = CorfuRuntime.getStreamID("Map1");
+        UUID stream2 = CorfuRuntime.getStreamID("Map2");
+        UUID stream3 = CorfuRuntime.getStreamID("Map3");
+        Map<UUID, Long> streamTails = fsm.getStreamTails();
+
+        long tail1 = rt1.getSequencerView().nextToken(Collections.singleton(stream1), 0).getToken().getTokenValue();
+        long tail2 = rt1.getSequencerView().nextToken(Collections.singleton(stream2), 0).getToken().getTokenValue();
+        long tail3 = rt1.getSequencerView().nextToken(Collections.singleton(stream3), 0).getToken().getTokenValue();
+
+        assertThat(streamTails.get(stream1)).isEqualTo(tail1);
+        assertThat(streamTails.get(stream2)).isEqualTo(tail2);
+        assertThat(streamTails.get(stream3)).isEqualTo(tail3);
+
+
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void failBecauseOfTrimAnd1Attempt() throws Exception {
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map2.put("k4", "v4");
+        map3.put("k5", "v5");
+        map2.put("k6", "v6");
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .connect();
+
+        int firstMileStone = 2;
+        FastSmrMapsLoader incrementalLoader = new FastSmrMapsLoader(rt2);
+        incrementalLoader.setNumberOfAttempt(1);
+        incrementalLoader.setLogTail(firstMileStone);
+        incrementalLoader.loadMaps();
+
+        rt1.getAddressSpaceView().prefixTrim(firstMileStone+2);
+        rt1.getAddressSpaceView().gc();
+        rt1.getAddressSpaceView().invalidateServerCaches();
+        rt1.getAddressSpaceView().invalidateClientCache();
+
+        incrementalLoader.setLogHead(firstMileStone + 1);
+        incrementalLoader.setLogTail(rt1.getSequencerView().nextToken(Collections.emptySet(), 0).getTokenValue());
+        incrementalLoader.loadMaps();
+
+    }
+
+    @Test
+    public void doNotFailBecauseTrimIsFirst() throws Exception{
+        CorfuRuntime rt1 = getDefaultRuntime();
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map2.put("k4", "v4");
+        map3.put("k5", "v5");
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) map1);
+        mcw.addMap((SMRMap) map2);
+        mcw.addMap((SMRMap) map3);
+        long snapShotAddress = mcw.appendCheckpoints(getRuntime(), "author");
+
+        getRuntime().getAddressSpaceView().prefixTrim(snapShotAddress - 1);
+        getRuntime().getAddressSpaceView().gc();
+        getRuntime().getAddressSpaceView().invalidateServerCaches();
+        getRuntime().getAddressSpaceView().invalidateClientCache();
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .connect();
+
+        // Force a read from 0
+        FastSmrMapsLoader fsm = new FastSmrMapsLoader(rt2);
+        fsm.setLogHead(0L);
+        fsm.loadMaps();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatMapIsBuilt(rt1, rt2, "Map3", map3);
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+    }
+
+    @Test
+    public void doNotReconstructTransactionStreams() throws Exception {
+        addSingleServer(SERVERS.PORT_0);
+        CorfuRuntime rt1 = new CorfuRuntime(getDefaultConfigurationString())
+                .setTransactionLogging(true)
+                .connect();
+
+        Map<String, String> map1 = createMap("Map1", rt1);
+        Map<String, String> map2 = createMap("Map2", rt1);
+        Map<String, String> map3 = createMap("Map3", rt1);
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map3.put("k0", "v0");
+        rt1.getObjectsView().TXBegin();
+        map2.put("k4", "v4");
+        map3.put("k5", "v5");
+        rt1.getObjectsView().TXEnd();
+
+        // We need to read the maps to get to the current version in rt1
+        map2.get("k4");
+        map3.get("k5");
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .connect();
+
+        FastSmrMapsLoader fsm = new FastSmrMapsLoader(rt2);
+        fsm.loadMaps();
+
+        assertThatMapIsBuilt(rt1, rt2, "Map1", map1);
+        assertThatMapIsBuilt(rt1, rt2, "Map2", map2);
+        assertThatMapIsBuilt(rt1, rt2, "Map3", map3);
+
+        // Ensure that we didn't create a map for the transaction stream.
+        assertThatObjectCacheIsTheSameSize(rt1, rt2);
+    }
+
+    @Test
+    public void doReconstructTransactionStreamTail() throws Exception {
+        addSingleServer(SERVERS.PORT_0);
+        CorfuRuntime rt1 = new CorfuRuntime(getDefaultConfigurationString())
+                .setTransactionLogging(true)
+                .connect();
+
+        int mapCount = 0;
+
+        Map<String, String> map1 = createMap("Map1", rt1);
+        mapCount++;
+        Map<String, String> map2 = createMap("Map2", rt1);
+        mapCount++;
+        Map<String, String> map3 = createMap("Map3", rt1);
+        mapCount++;
+
+        map1.put("k1", "v1");
+        map1.put("k2", "v2");
+        map2.put("k3", "v3");
+        map3.put("k0", "v0");
+        rt1.getObjectsView().TXBegin();
+        map2.put("k4", "v4");
+        map3.put("k5", "v5");
+        rt1.getObjectsView().TXEnd();
+
+        // Create a new runtime with fastloader
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultConfigurationString())
+                .connect();
+
+        FastSmrMapsLoader fsm = new FastSmrMapsLoader(rt2);
+        fsm.setRecoverSequencerMode(true);
+        fsm.loadMaps();
+
+        UUID stream1 = CorfuRuntime.getStreamID("Map1");
+        UUID stream2 = CorfuRuntime.getStreamID("Map2");
+        UUID stream3 = CorfuRuntime.getStreamID("Map3");
+        Map<UUID, Long> streamTails = fsm.getStreamTails();
+
+        long tail1 = rt1.getSequencerView().nextToken(Collections.singleton(stream1), 0).
+                getToken().getTokenValue();
+        long tail2 = rt1.getSequencerView().nextToken(Collections.singleton(stream2), 0).
+                getToken().getTokenValue();
+        long tail3 = rt1.getSequencerView().nextToken(Collections.singleton(stream3), 0).
+                getToken().getTokenValue();
+
+
+        UUID transactionStreams = rt1.getObjectsView().TRANSACTION_STREAM_ID;
+        long tailTransactionStream = rt1.getSequencerView()
+                .nextToken(Collections.singleton(transactionStreams), 0).
+                getToken().getTokenValue();
+
+        assertThat(streamTails.get(stream1)).isEqualTo(tail1);
+        assertThat(streamTails.get(stream2)).isEqualTo(tail2);
+        assertThat(streamTails.get(stream3)).isEqualTo(tail3);
+        assertThat(streamTails.get(transactionStreams)).isEqualTo(tailTransactionStream);
+
+        // Also recover the Transaction Stream
+        assertThat(streamTails.size() == mapCount + 1);
+
+
+    }
+
 
 }

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -409,7 +409,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
             long addr1 = tokResp1.getToken().getTokenValue();
             mdKV.put(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS, Long.toString(addr1 + 1));
             CheckpointEntry cp1 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.START,
-                    checkpointAuthor, checkpointId, mdKV, null);
+                    checkpointAuthor, checkpointId, streamId, mdKV, null);
             sv.append(cp1, null, null);
         }
 
@@ -425,7 +425,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
                 }
             }
             CheckpointEntry cp2 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.CONTINUATION,
-                    checkpointAuthor, checkpointId, mdKV, smrEntries);
+                    checkpointAuthor, checkpointId, streamId, mdKV, smrEntries);
             sv.append(cp2, null, null);
         }
 
@@ -435,7 +435,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         // Write cp #3 of 3
         if (write3) {
             CheckpointEntry cp3 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.END,
-                    checkpointAuthor, checkpointId, mdKV, null);
+                    checkpointAuthor, checkpointId, streamId, mdKV, null);
             sv.append(cp3, null, null);
         }
     }


### PR DESCRIPTION
The FastSmrMapLoader is now able to load trimm/checkpoint. Here are the 3 steps of
the recovery:
1. Search for the checkpoints (for now, we have to read the whole log to find them)
2. Apply the checkpoints update in parallel
3. Go through the the whole log and apply only the entries after the checkpoints