### PR TITLE
Use a two-level map for conflicts, support poisoning

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -15,7 +15,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
 
-    public static Integer NO_CONFLICT_KEY = Integer.MIN_VALUE;
+    public static long NO_CONFLICT_KEY = Long.MIN_VALUE;
 
     /**
      * Constructor for TokenResponse.
@@ -37,7 +37,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
     /**
      * In case there is a conflict, signal to the client which key was responsible for the conflict.
      */
-    final Integer conflictKey;
+    final Long conflictKey;
 
     /** The current token,
      * or overload with "cause address" in case token request is denied. */
@@ -53,7 +53,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
      */
     public TokenResponse(ByteBuf buf) {
         respType = TokenType.values()[ICorfuPayload.fromBuffer(buf, Byte.class)];
-        conflictKey = ICorfuPayload.fromBuffer(buf, Integer.class);
+        conflictKey = ICorfuPayload.fromBuffer(buf, Long.class);
         Long tokenValue = ICorfuPayload.fromBuffer(buf, Long.class);
         Long epoch = ICorfuPayload.fromBuffer(buf, Long.class);
         token = new Token(tokenValue, epoch);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
@@ -29,11 +29,15 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
     @Setter
     Long snapshotTimestamp;
 
+    /** A set of poisoned streams, which have a conflict against all updates. */
     @Getter
-    final Map<UUID, Set<Integer>> conflictSet;
+    final Set<UUID> poisonedStreams;
 
     @Getter
-    final Map<UUID, Set<Integer>>  writeConflictParams;
+    final Map<UUID, Set<Long>> conflictSet;
+
+    @Getter
+    final Map<UUID, Set<Long>>  writeConflictParams;
 
     /**
      * Constructor for TxResolutionInfo.
@@ -46,6 +50,7 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
         this.snapshotTimestamp = snapshotTimestamp;
         this.conflictSet = Collections.emptyMap();
         this.writeConflictParams = Collections.emptyMap();
+        this.poisonedStreams = Collections.emptySet();
     }
 
     /**
@@ -55,13 +60,16 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
      * @param snapshotTimestamp transaction snapshot timestamp
      * @param conflictMap map of conflict parameters, arranged by stream IDs
      * @param writeConflictParams map of write conflict parameters, arranged by stream IDs
+     * @param poisonedStreams set of poisoned streams, which have a conflict against all updates
      */
-    public TxResolutionInfo(UUID txId, long snapshotTimestamp, Map<UUID, Set<Integer>>
-            conflictMap, Map<UUID, Set<Integer>> writeConflictParams) {
+    public TxResolutionInfo(UUID txId, long snapshotTimestamp, Map<UUID, Set<Long>>
+            conflictMap, Map<UUID, Set<Long>> writeConflictParams,
+                            Set<UUID> poisonedStreams) {
         this.TXid = txId;
         this.snapshotTimestamp = snapshotTimestamp;
         this.conflictSet = conflictMap;
         this.writeConflictParams = writeConflictParams;
+        this.poisonedStreams = poisonedStreams;
     }
 
     /**
@@ -80,23 +88,26 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
 
         // conflictSet
         int numEntries = buf.readInt();
-        ImmutableMap.Builder<UUID, Set<Integer>> conflictMapBuilder = new ImmutableMap.Builder<>();
+        ImmutableMap.Builder<UUID, Set<Long>> conflictMapBuilder = new ImmutableMap.Builder<>();
         for (int i = 0; i < numEntries; i++) {
             UUID k = ICorfuPayload.fromBuffer(buf, UUID.class);
-            Set<Integer> v = ICorfuPayload.setFromBuffer(buf, Integer.class);
+            Set<Long> v = ICorfuPayload.setFromBuffer(buf, Long.class);
             conflictMapBuilder.put(k, v);
         }
         conflictSet = conflictMapBuilder.build();
 
         // writeConflictParams
         numEntries = buf.readInt();
-        ImmutableMap.Builder<UUID, Set<Integer>> writeMapBuilder = new ImmutableMap.Builder<>();
+        ImmutableMap.Builder<UUID, Set<Long>> writeMapBuilder = new ImmutableMap.Builder<>();
         for (int i = 0; i < numEntries; i++) {
             UUID k = ICorfuPayload.fromBuffer(buf, UUID.class);
-            Set<Integer> v = ICorfuPayload.setFromBuffer(buf, Integer.class);
+            Set<Long> v = ICorfuPayload.setFromBuffer(buf, Long.class);
             writeMapBuilder.put(k, v);
         }
+
         writeConflictParams = writeMapBuilder.build();
+
+        poisonedStreams = ICorfuPayload.setFromBuffer(buf, UUID.class);
     }
 
     /**
@@ -122,6 +133,8 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
             ICorfuPayload.serialize(buf, x.getKey());
             ICorfuPayload.serialize(buf, x.getValue());
         });
+
+        ICorfuPayload.serialize(buf, poisonedStreams);
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -15,7 +15,7 @@ public class TransactionAbortedException extends RuntimeException {
     TxResolutionInfo txResolutionInfo;
 
     @Getter
-    Integer conflictKey;
+    Long conflictKey;
 
     /**
      * Constructor.
@@ -25,7 +25,7 @@ public class TransactionAbortedException extends RuntimeException {
      */
     public TransactionAbortedException(
             TxResolutionInfo txResolutionInfo,
-            Integer conflictKey, AbortCause abortCause) {
+            Long conflictKey, AbortCause abortCause) {
         super("TX ABORT "
                 + " | Snapshot Time = " + txResolutionInfo.getSnapshotTimestamp()
                 + " | Transaction ID = " + txResolutionInfo.getTXid()

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -247,7 +247,7 @@ public abstract class AbstractTransactionalContext implements
      *
      * @return A set of longs representing all the conflict params
      */
-    Map<UUID, Set<Integer>> collectWriteConflictParams() {
+    Map<UUID, Set<Long>> collectWriteConflictParams() {
         return getWriteSetInfo().getWriteSetConflicts();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -259,7 +259,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
      * @param computeConflictSet  conflict set used to check whether transaction can commit
      * @return  the commit address
      */
-    public long getConflictSetAndCommit(Supplier<Map<UUID, Set<Integer>>>
+    public long getConflictSetAndCommit(Supplier<Map<UUID, Set<Long>>>
                                        computeConflictSet) {
 
         if (TransactionalContext.isInNestedTransaction()) {
@@ -305,7 +305,8 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                         new TxResolutionInfo(getTransactionID(),
                                 getSnapshotTimestamp(),
                                 computeConflictSet.get(),
-                                collectWriteConflictParams())
+                                collectWriteConflictParams(),
+                                getWriteSetInfo().getPoisonedStreams())
                 );
 
         log.trace("Commit[{}] Acquire address {}", this, address);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/ReadSetInfo.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/ReadSetInfo.java
@@ -17,7 +17,7 @@ import lombok.Getter;
 class ReadSetInfo {
     // fine-grained conflict information regarding accessed-objects;
     // captures values passed using @conflict annotations in @corfuObject
-    Map<UUID, Set<Integer>> readSetConflicts = new HashMap<>();
+    Map<UUID, Set<Long>> readSetConflicts = new HashMap<>();
 
     public void mergeInto(ReadSetInfo other) {
         other.getReadSetConflicts().forEach((streamId, cset) -> {
@@ -30,12 +30,12 @@ class ReadSetInfo {
             return;
         }
 
-        Set<Integer> streamConflicts = getConflictSet(streamId);
+        Set<Long> streamConflicts = getConflictSet(streamId);
         Arrays.asList(conflictObjects).stream()
-                .forEach(V -> streamConflicts.add(Integer.valueOf(V.hashCode())));
+                .forEach(V -> streamConflicts.add(Long.valueOf(V.hashCode())));
     }
 
-    public Set<Integer> getConflictSet(UUID streamId) {
+    public Set<Long> getConflictSet(UUID streamId) {
         return getReadSetConflicts().computeIfAbsent(streamId, u -> {
             return new HashSet<>();
         });


### PR DESCRIPTION
This PR partially addresses #753 and reduces the number of
false conflicts. 

It introduces a two-level conflict map, the first level
maps stream ids to a new per-stream data class. The 
per-stream data class contains a map of conflict parameters
(which now can be longs) to addresses, as well as a
single long which represents a minimum "poisoned" value.

The implementation still uses a Java hashCode, (32 bits),
but this is much improved over the previous implementation
which attempted to squeeze the stream ID and a java hashCode
of the conflict param into 32 bits. In order to use a
longer hash code, we'll need to find a generic way to
generate a long hashCode from an object without serializing
it.

Poisoned streams are streams affected by operations with
fine-grained conflict information, for example, operations
such as clear(). Previously, these operations would
not conflict at all, when they should have conflicted with
all operations.