### PR TITLE
Return DataType.TRIMMED

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -38,9 +38,7 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
 
     @Override
     public synchronized void append(long address, LogData entry) {
-        try {
-            checkRange(address);
-        } catch (TrimmedException e) {
+        if(isTrimmed(address)) {
             throw new OverwriteException();
         }
 
@@ -54,15 +52,18 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
                 ? entry.getGlobalAddress() : maxTail);
     }
 
-    private void checkRange(long address) {
+    private boolean isTrimmed(long address) {
         if (address < startingAddress) {
-            throw new TrimmedException();
+            return true;
         }
+        return false;
     }
 
     @Override
     public synchronized void prefixTrim(long address) {
-        checkRange(address);
+        if(isTrimmed(address)){
+            throw new TrimmedException();
+        }
         startingAddress = address + 1;
     }
 
@@ -90,9 +91,11 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
 
     @Override
     public LogData read(long address) {
-        checkRange(address);
+        if(isTrimmed(address)){
+            return LogData.TRIMMED;
+        }
         if (trimmed.contains(address)) {
-            throw new TrimmedException();
+            return LogData.TRIMMED;
         }
 
         return logCache.get(address);

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
@@ -17,6 +17,7 @@ import java.util.function.Consumer;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.tools.ant.filters.TokenFilter;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
@@ -27,6 +28,7 @@ import org.corfudb.runtime.exceptions.HoleFillRequiredException;
 import org.corfudb.runtime.exceptions.LogUnitException;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
+import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.ValueAdoptedException;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.QuorumFuturesFactory;
@@ -274,6 +276,9 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
         public int compare(ReadResponse o1, ReadResponse o2) {
             LogData ld1 = o1.getReadSet().get(logPosition);
             LogData ld2 = o2.getReadSet().get(logPosition);
+            if(ld1.isTrimmed() || ld2.isTrimmed()) {
+                throw new TrimmedException();
+            }
             IMetadata.DataRank rank1 = ld1.getRank();
             IMetadata.DataRank rank2 = ld2.getRank();
             if (rank1 == null) {


### PR DESCRIPTION
Instead of throwing an exception on reading trimmed addresses,
this changes makes the logging unit return a trimmed entry.

This patch implements the aforementioned semantics for the
in-memory mode logging unit.