### PR TITLE
ScanAndFilter to Filter by Map.Entries

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.collections;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
@@ -70,14 +71,29 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     /**
      * Returns a filtered {@link List} view of the values contained in this map.
      * This method has a memory/CPU advantage over the map iterators as no deep copy
-     * is actually performed. 
+     * is actually performed.
      *
      * @param p java predicate (function to evaluate)
-     * @return a view of the values contained in this map meeting the predicate condition.   
+     * @return a view of the values contained in this map meeting the predicate condition.
      */
+    @Deprecated
     @Accessor
     public List<V> scanAndFilter(Predicate<? super V> p) {
         return super.values().parallelStream().filter(p).collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a {@link Map} filtered by entries (keys and/or values).
+     * This method has a memory/CPU advantage over the map iterators as no deep copy
+     * is actually performed.
+     *
+     * @param entryPredicate java predicate (function to evaluate)
+     * @return a view of the entries contained in this map meeting the predicate condition.
+     */
+    @Accessor
+    public Map<K, V> scanAndFilterByEntry(Predicate<? super Map.Entry<K, V>> entryPredicate) {
+        return super.entrySet().parallelStream().filter(entryPredicate).collect(Collectors
+                .toMap(p -> p.getKey(), p -> p.getValue()));
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -1,18 +1,9 @@
 package org.corfudb.runtime.collections;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
-import lombok.Data;
-import lombok.Getter;
-import lombok.ToString;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.object.ICorfuSMR;
-import org.corfudb.runtime.view.AbstractViewTest;
-import org.corfudb.runtime.view.ObjectOpenOptions;
-import org.corfudb.util.serializer.Serializers;
-import org.junit.Before;
-import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
@@ -22,10 +13,21 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
 import java.util.stream.IntStream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import lombok.Data;
+import lombok.Getter;
+import lombok.ToString;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.object.ICorfuSMR;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.ObjectOpenOptions;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Created by mwei on 1/7/16.
@@ -82,6 +84,18 @@ public class SMRMapTest extends AbstractViewTest {
                 .isNull();
         assertThat(corfuInstancesMap.put("d", "CorfuServer"))
                 .isNull();
+
+        // ScanAndFilterByEntry
+        Predicate<Map.Entry<String, String>> valuePredicate = p -> p.getValue().equals("CorfuServer");
+        Map<String, String> filteredMap = ((SMRMap)corfuInstancesMap).scanAndFilterByEntry(valuePredicate);
+
+        assertThat(filteredMap.size()).isEqualTo(2);
+
+        for(String corfuInstance : filteredMap.values()) {
+            assertThat(corfuInstance).isEqualTo("CorfuServer");
+        }
+
+        // ScanAndFilter (Deprecated Method)
         List<String> corfuServerList = ((SMRMap)corfuInstancesMap).scanAndFilter(p -> p.equals("CorfuServer"));
 
         assertThat(corfuServerList.size()).isEqualTo(2);


### PR DESCRIPTION
Modifying scanAndFilter method for SMRMaps to filter on map.entries
(keys and/or values) instead of values ONLY (as initial implementation).

This will provide a more generic interface to suit different types of
queries.