### PR TITLE
Performance Improve to scanAndFilter Method

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.collections;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
@@ -16,6 +17,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+
 import org.corfudb.annotations.Accessor;
 import org.corfudb.annotations.CorfuObject;
 import org.corfudb.annotations.TransactionalMethod;
@@ -76,14 +78,13 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
      * @param p java predicate (function to evaluate)
      * @return a view of the values contained in this map meeting the predicate condition.
      */
-    @Deprecated
     @Accessor
     public List<V> scanAndFilter(Predicate<? super V> p) {
         return super.values().parallelStream().filter(p).collect(Collectors.toList());
     }
 
     /**
-     * Returns a {@link Map} filtered by entries (keys and/or values).
+     * Returns a {@link Collection} filtered by entries (keys and/or values).
      * This method has a memory/CPU advantage over the map iterators as no deep copy
      * is actually performed.
      *
@@ -91,9 +92,10 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
      * @return a view of the entries contained in this map meeting the predicate condition.
      */
     @Accessor
-    public Map<K, V> scanAndFilterByEntry(Predicate<? super Map.Entry<K, V>> entryPredicate) {
+    public Collection<Map.Entry<K, V>> scanAndFilterByEntry(Predicate<? super Map.Entry<K, V>>
+                                                                        entryPredicate) {
         return super.entrySet().parallelStream().filter(entryPredicate).collect(Collectors
-                .toMap(p -> p.getKey(), p -> p.getValue()));
+                .toCollection(ArrayList::new));
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -86,13 +87,15 @@ public class SMRMapTest extends AbstractViewTest {
                 .isNull();
 
         // ScanAndFilterByEntry
-        Predicate<Map.Entry<String, String>> valuePredicate = p -> p.getValue().equals("CorfuServer");
-        Map<String, String> filteredMap = ((SMRMap)corfuInstancesMap).scanAndFilterByEntry(valuePredicate);
+        Predicate<Map.Entry<String, String>> valuePredicate =
+                p -> p.getValue().equals("CorfuServer");
+        Collection<Map.Entry<String, String>> filteredMap = ((SMRMap)corfuInstancesMap)
+                .scanAndFilterByEntry(valuePredicate);
 
         assertThat(filteredMap.size()).isEqualTo(2);
 
-        for(String corfuInstance : filteredMap.values()) {
-            assertThat(corfuInstance).isEqualTo("CorfuServer");
+        for(Map.Entry<String, String> corfuInstance : filteredMap) {
+            assertThat(corfuInstance.getValue()).isEqualTo("CorfuServer");
         }
 
         // ScanAndFilter (Deprecated Method)


### PR DESCRIPTION
- Returning Collection of map entries over maps, because of verified performance improve. 

- No deprecation of old scanAndFilter, both methods add value to clients---depending on usage.