### PR TITLE
Reset Sequencer state during recovery

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/FailureHandlerDispatcher.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/FailureHandlerDispatcher.java
@@ -1,10 +1,13 @@
 package org.corfudb.infrastructure;
 
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.corfudb.recovery.FastSmrMapsLoader;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.exceptions.OutrankedException;
@@ -183,9 +186,20 @@ public class FailureHandlerDispatcher {
                     }
                 }
             }
+
             try {
+
+                FastSmrMapsLoader fastSmrMapsLoader = new FastSmrMapsLoader(runtime);
+                fastSmrMapsLoader.setRecoverSequencerMode(true);
+                fastSmrMapsLoader.setLoadInCache(false);
+
+                // FastSMRLoader sets the logHead based on trim mark.
+                fastSmrMapsLoader.setLogTail(maxTokenRequested);
+                fastSmrMapsLoader.loadMaps();
+                Map<UUID, Long> streamTails = fastSmrMapsLoader.getStreamTails();
+
                 // Configuring the new sequencer.
-                newLayout.getSequencer(0).reset(maxTokenRequested + 1).get();
+                newLayout.getSequencer(0).reset(maxTokenRequested + 1, streamTails).get();
             } catch (InterruptedException e) {
                 log.error("Sequencer Reset interrupted : {}", e);
             }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -46,7 +46,7 @@ public enum CorfuMsgType {
     // Sequencer Messages
     TOKEN_REQ(20, new TypeToken<CorfuPayloadMsg<TokenRequest>>(){}),
     TOKEN_RES(21, new TypeToken<CorfuPayloadMsg<TokenResponse>>(){}),
-    RESET_SEQUENCER(22, new TypeToken<CorfuPayloadMsg<Long>>(){}),
+    RESET_SEQUENCER(22, new TypeToken<CorfuPayloadMsg<SequencerTailsRecoveryMsg>>(){}),
 
     // Logging Unit Messages
     WRITE(30, new TypeToken<CorfuPayloadMsg<WriteRequest>>() {}),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/SequencerTailsRecoveryMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/SequencerTailsRecoveryMsg.java
@@ -1,0 +1,32 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Created by rmichoud on 6/20/17.
+ */
+@Data
+@AllArgsConstructor
+public class SequencerTailsRecoveryMsg implements ICorfuPayload<SequencerTailsRecoveryMsg> {
+
+    private Long globalTail;
+    private Map<UUID, Long> streamTails;
+
+    public SequencerTailsRecoveryMsg(ByteBuf buf) {
+        globalTail = ICorfuPayload.fromBuffer(buf, Long.class);
+        streamTails = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+
+        ICorfuPayload.serialize(buf, globalTail);
+        ICorfuPayload.serialize(buf, streamTails);
+    }
+}
+

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.lang.invoke.MethodHandles;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -11,6 +12,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
+import org.corfudb.protocols.wireprotocol.SequencerTailsRecoveryMsg;
 import org.corfudb.protocols.wireprotocol.TokenRequest;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
@@ -69,8 +71,8 @@ public class SequencerClient implements IClient {
      * @param initialToken Token Number which the sequencer starts distributing.
      * @return A CompletableFuture which completes once the sequencer is reset.
      */
-    public CompletableFuture<Boolean> reset(Long initialToken) {
+    public CompletableFuture<Boolean> reset(Long initialToken, Map<UUID, Long> sequencerTails) {
         return router.sendMessageAndGetCompletable(CorfuMsgType.RESET_SEQUENCER
-                .payloadMsg(initialToken));
+                .payloadMsg(new SequencerTailsRecoveryMsg(initialToken, sequencerTails)));
     }
 }


### PR DESCRIPTION
Reset the Sequencer Server state using the FastSMRLoader during the recovery phase.
Steps:
- Server starts, client connects and performs reads and writes.
- Server shuts down/crashes.
- On recovery all the servers start in "not ready state" (PR #762 )
- The management server then seals the servers, runs reconfiguration with the fastSMRLoader and resets the sequencer with the tails.
- After the paxos round, the data path is open to the clients.