### PR TITLE
Set proper exception log levels for fast-tracking

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
@@ -88,7 +88,7 @@ public class MultiCheckpointWriter {
                         checkpointLogAddresses.addAll(addresses);
                         break;
                     } catch (TransactionAbortedException ae) {
-                        log.trace("appendCheckpoints: checkpoint map {} "
+                        log.warn("appendCheckpoints: checkpoint map {} "
                                         + "TransactionAbortedException, retry",
                                 Utils.toReadableID(map.getCorfuStreamID()));
                         // Don't break!

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -44,7 +44,7 @@ public class BaseClient implements IClient {
         try {
             return ping().get();
         } catch (Exception e) {
-            log.trace("Ping failed due to exception", e);
+            log.error("Ping failed due to exception", e);
             return false;
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -391,7 +391,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                     // shutdown EventLoopGroup
                     workerGroup.shutdownGracefully().sync();
                 } catch (InterruptedException ie) {
-                    log.trace("workerGroup shutdown interrupted : {}", ie);
+                    log.warn("workerGroup shutdown interrupted : {}", ie);
                 }
                 throw new NetworkException(e.getClass().getSimpleName()
                         + " connecting to endpoint failed", host + ":" + port, e);
@@ -429,7 +429,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                     } catch (Exception ex) {
                         MetricsUtils.incConditionalCounter(isEnabled,
                                 counterConnectFailed, 1);
-                        log.trace("Exception while reconnecting, retry in {} ms", timeoutRetry);
+                        log.warn("Exception while reconnecting, retry in {} ms", timeoutRetry);
                         Thread.sleep(timeoutRetry);
                     }
                 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -161,7 +161,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 return TransactionalContext.getCurrentContext()
                         .access(this, accessMethod, conflictObject);
             } catch (Exception e) {
-                log.debug("Access[{}] Exception: {}", this, e);
+                log.warn("Access[{}] Exception: {}", this, e);
                 this.abortTransaction(e);
             }
         }
@@ -180,7 +180,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                     o -> o.syncObjectUnsafe(timestamp),
                     o -> accessMethod.access(o));
         } catch (TrimmedException te) {
-            log.debug("Access[{}] Encountered Trim, reset and retry", this);
+            log.warn("Access[{}] Encountered Trim, reset and retry", this);
             // We encountered a TRIM during sync, reset the object
             underlyingObject.update(o -> {
                 o.resetUnsafe();
@@ -213,7 +213,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 return TransactionalContext.getCurrentContext()
                         .logUpdate(this, entry, conflictObject);
             } catch (Exception e) {
-                log.debug("Update[{}] Exception: {}", this, e);
+                log.warn("Update[{}] Exception: {}", this, e);
                 this.abortTransaction(e);
             }
         }
@@ -265,7 +265,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 return (R) TransactionalContext.getCurrentContext()
                         .getUpcallResult(this, timestamp, conflictObject);
             } catch (Exception e) {
-                log.debug("UpcallResult[{}] Exception: {}", this, e);
+                log.warn("UpcallResult[{}] Exception: {}", this, e);
                 this.abortTransaction(e);
             }
         }
@@ -344,6 +344,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 // retrying a nested transaction indefinitely (this could go on forever).
                 // If this is part of an outer transaction abort and remove from context.
                 // Re-throw exception to client.
+                log.warn("TXExecute[{}] Abort with exception {}", this, e);
                 if (e.getAbortCause() == AbortCause.NETWORK) {
                     if (TransactionalContext.getCurrentContext() != null) {
                         TransactionalContext.getCurrentContext().abortTransaction(e);
@@ -367,7 +368,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 sleepTime = min(sleepTime * 2L, maxSleepTime);
                 retries++;
             } catch (Exception e) {
-                log.debug("TXExecute[{}] Abort with Exception: {}", this, e);
+                log.warn("TXExecute[{}] Abort with Exception: {}", this, e);
                 this.abortTransaction(e);
             }
         }

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -194,7 +194,7 @@ public class VersionLockedObject<T> {
                     }
                     // Otherwise, it is not on a correct view of the object (the object was
                     // modified) and we should try again by upgrading the lock.
-                    log.trace("Access [{}] Direct (optimistic-read) exception, upgrading lock",
+                    log.warn("Access [{}] Direct (optimistic-read) exception, upgrading lock",
                             this);
                 }
             }
@@ -292,6 +292,7 @@ public class VersionLockedObject<T> {
                     try {
                         rollbackObjectUnsafe(timestamp);
                     } catch (NoRollbackException nre) {
+                        log.warn("SyncObjectUnsafe[{}] failed {}", this, nre);
                         resetUnsafe();
                     }
                 }
@@ -320,6 +321,7 @@ public class VersionLockedObject<T> {
                         return;
                     }
                 } catch (NoRollbackException nre) {
+                    log.warn("OptimisticRollback[{}] failed {}", this, nre);
                     resetUnsafe();
                 }
             }
@@ -617,7 +619,7 @@ public class VersionLockedObject<T> {
                     Address.NEVER_READ);
             log.trace("OptimisticRollback[{}] complete", this);
         } catch (NoRollbackException nre) {
-            log.debug("OptimisticRollback[{}] failed", this);
+            log.warn("OptimisticRollback[{}] failed", this);
             resetUnsafe();
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -185,10 +185,11 @@ public class ObjectsView extends AbstractView {
             try {
                 return TransactionalContext.getCurrentContext().commitTransaction();
             } catch (TransactionAbortedException e) {
+                log.warn("TXCommit[{}] Exception {}", context, e);
                 TransactionalContext.getCurrentContext().abortTransaction(e);
                 throw e;
             } catch (Exception e) {
-                log.trace("TXCommit[{}] Exception {}", context, e);
+                log.warn("TXCommit[{}] Exception {}", context, e);
                 AbortCause abortCause;
 
                 if (e instanceof NetworkException) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -79,7 +79,7 @@ public class StreamsView extends AbstractView {
                 runtime.getAddressSpaceView().write(cowToken, entry);
                 written = true;
             } catch (OverwriteException oe) {
-                log.debug("hole fill during COW entry append, retrying...");
+                log.warn("hole fill during COW entry append, retrying...");
             }
         }
         return get(destination);
@@ -131,7 +131,7 @@ public class StreamsView extends AbstractView {
                 return tokenResponse.getTokenValue();
             } catch (OverwriteException oe) {
                 // We were overwritten, get a new token and try again.
-                log.trace("Overwrite[{}]: streams {}", tokenResponse.getTokenValue(),
+                log.warn("Overwrite[{}]: streams {}", tokenResponse.getTokenValue(),
                         streamIDs.stream().map(Utils::toReadableID).collect(Collectors.toSet()));
 
                 TokenResponse temp;


### PR DESCRIPTION
Changing log level to warn/error for exception handling. We are missing out on relevant/critical information when certain exceptions are raised.