### PR TITLE
Persist logging after server reboot (#773)

### DIFF
--- a/runtime/src/main/resources/logback.xml
+++ b/runtime/src/main/resources/logback.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>/var/log/corfu.log</file>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{short}</pattern>
+            <pattern>%d %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{short}</pattern>
         </encoder>
     </appender>
 
     <root level="ERROR">
-        <appender-ref ref="STDOUT"/>
+        <appender-ref ref="FILE"/>
     </root>
 </configuration>


### PR DESCRIPTION
This patch modifies the logback configuration to save corfu
server logging after corfu server is restarted.

In the old configuration, all logging are treated to write to
stdout. Logback will create (and erase) a default logging file
at `/var/log/corfu.9000.log` and put all info there.

In the new configuration, `/var/log/corfu.log` is specified as
the place to hold logging info. By default FileAppender is persistent
after server reboot.

This patch also modifies the format such that date is included.

**Future works**

1. If the amount of logging is big over the time, we need to add a rolling
   policy to handle them.
2. Mac users benefits from colors. But it does harm to users with traditional
   vi, which is probably to be the log reader in a real server. We can discuss
   and see if it is better to remove colors.
3. After this patch, `/var/log/corfu.9000.log` will still be created to hold
   stdout stream. To make it cleaner we should remove `System.out.print` gradually.