### PR TITLE
Persist logging after server reboot (#773)

### DIFF
--- a/debian/src/deb/init.d/corfu-server
+++ b/debian/src/deb/init.d/corfu-server
@@ -30,7 +30,7 @@ case "$1" in
     start)
         log_daemon_msg "Starting $ROLENAME on port $PORT"
         if start-stop-daemon --start --quiet  --background --make-pidfile --oknodo --pidfile $PIDFILE \
-        --startas /bin/bash -- -c "exec $PREFIX/corfu_server $OPTS > $LOGFILE 2>&1"; then
+        --startas /bin/bash -- -c "exec $PREFIX/corfu_server $OPTS >> $LOGFILE 2>&1"; then
             log_end_msg 0
         else
             log_end_msg 1
@@ -55,7 +55,7 @@ case "$1" in
         case $RET in
             0)
                 if start-stop-daemon --start --quiet  --background --make-pidfile --oknodo --pidfile $PIDFILE \
-                --startas /bin/bash -- -c "exec $PREFIX/corfu_server $OPTS > $LOGFILE 2>&1"; then
+                --startas /bin/bash -- -c "exec $PREFIX/corfu_server $OPTS >> $LOGFILE 2>&1"; then
                     log_end_msg 0
                 else
                     log_end_msg 1

--- a/runtime/src/main/resources/logback.xml
+++ b/runtime/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{short}</pattern>
+            <pattern>%d %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{short}</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Ref: #781

- Avoid erase logging file when server is started or restarted
- Include date in logback to help debugging