### PR TITLE
Fix Client Leak

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -117,7 +117,7 @@ public class CorfuRuntime {
      */
     @Getter
     @Setter
-    public long maxCacheSize = 4_000_000_000L;
+    public long numCacheEntries = 5000;
 
     /**
      * The number of times to retry on a retriable TrimException within during a tranasaction

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -43,8 +43,7 @@ public class AddressSpaceView extends AbstractView {
      * A cache for read results.
      */
     final LoadingCache<Long, ILogData> readCache = Caffeine.<Long, ILogData>newBuilder()
-            .<Long, ILogData>weigher((k, v) -> v.getSizeEstimate())
-            .maximumWeight(runtime.getMaxCacheSize())
+            .maximumSize(runtime.getNumCacheEntries())
             .expireAfterAccess(runtime.getCacheExpiryTime(), TimeUnit.SECONDS)
             .expireAfterWrite(runtime.getCacheExpiryTime(), TimeUnit.SECONDS)
             .recordStats()


### PR DESCRIPTION
On a write request, the client puts entries in the cache before
they are serialized, this results in incorrectly calculating the
object's size when it enters the cache, as a result client
leaks memory through admitting more entries into the cache.