### PR TITLE
Add cause description for TX Aborted Exceptions

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
@@ -12,5 +12,6 @@ public enum AbortCause {
     USER,
     NETWORK,
     TRIM, /** Aborted because an access to this snapshot resulted in a trim exception. */
+    UNSUPPORTED,
     UNDEFINED;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -17,6 +17,9 @@ public class TransactionAbortedException extends RuntimeException {
     @Getter
     Long conflictKey;
 
+    @Getter
+    Throwable cause;
+
     /**
      * Constructor.
      * @param txResolutionInfo transaction information
@@ -26,6 +29,12 @@ public class TransactionAbortedException extends RuntimeException {
     public TransactionAbortedException(
             TxResolutionInfo txResolutionInfo,
             Long conflictKey, AbortCause abortCause) {
+        this(txResolutionInfo, conflictKey, abortCause, null);
+    }
+
+    public TransactionAbortedException(
+            TxResolutionInfo txResolutionInfo,
+            Long conflictKey, AbortCause abortCause, Throwable cause) {
         super("TX ABORT "
                 + " | Snapshot Time = " + txResolutionInfo.getSnapshotTimestamp()
                 + " | Transaction ID = " + txResolutionInfo.getTXid()
@@ -34,6 +43,8 @@ public class TransactionAbortedException extends RuntimeException {
         this.txResolutionInfo = txResolutionInfo;
         this.conflictKey = conflictKey;
         this.abortCause = abortCause;
+        this.cause = cause;
+
     }
 
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -121,7 +121,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                                         new TransactionAbortedException(
                                                 new TxResolutionInfo(getTransactionID(),
                                                         getSnapshotTimestamp()), null,
-                                                AbortCause.TRIM);
+                                                AbortCause.TRIM, te);
                                 abortTransaction(tae);
                                 throw tae;
                             }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -59,7 +59,7 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
                         TransactionAbortedException tae =
                                 new TransactionAbortedException(
                                         new TxResolutionInfo(getTransactionID(),
-                                                getSnapshotTimestamp()), null, AbortCause.TRIM);
+                                                getSnapshotTimestamp()), null, AbortCause.TRIM, te);
                         abortTransaction(tae);
                         throw tae;
                     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -208,7 +208,7 @@ public class ObjectsView extends AbstractView {
                 TxResolutionInfo txInfo = new TxResolutionInfo(context.getTransactionID(),
                         snapshotTimestamp);
                 TransactionAbortedException tae = new TransactionAbortedException(txInfo, null,
-                        abortCause);
+                        abortCause, e);
                 context.abortTransaction(tae);
                 throw tae;
             } finally {

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -200,7 +200,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             // range, terminate.
             if (queue.contains(currentAddress)) {
                 log.trace("FollowBackpointers[{}] Terminate due to {} "
-                        + "already in queue", currentAddress);
+                        + "already in queue", this, currentAddress);
                 return entryAdded;
             }
             backpointerCount++;
@@ -210,6 +210,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             try {
                 d = read(currentAddress);
             } catch (TrimmedException e) {
+                log.warn("FollowBackpointers[{}] Trimmed Exception {}", this, e);
                 if (options.ignoreTrimmed) {
                     return entryAdded;
                 } else {
@@ -336,7 +337,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             } catch (TrimmedException te) {
                 // If we reached a trim and didn't hit a checkpoint, this might be okay,
                 // if the stream was created recently and no checkpoint exists yet.
-                log.trace("Read_Fill_Queue[{}] Trim encountered and no checkpoint detected.", this);
+                log.warn("Read_Fill_Queue[{}] Trim encountered and no checkpoint detected.", this);
             }
         }
 

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTXConcurrencyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTXConcurrencyTest.java
@@ -1,13 +1,13 @@
 package org.corfudb.runtime.object.transactions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.reflect.TypeToken;
-import org.corfudb.runtime.collections.SMRMap;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.corfudb.runtime.collections.SMRMap;
+import org.junit.Test;
 
 /**
  * Created by dalia on 12/8/16.


### PR DESCRIPTION
- Adding descriptive cause to TransactionAbortedException in order to have more information of the cause of the transaction abort.
- Adding new abortCause = 'Unsupported' for UnsupportedOperationException
  types raised whenever an operation is not supported (e.g, attempting to do a write operation --logUpdate--- in the context of a Snapshot Transaction).