### PR TITLE
Cleanup sequencer tx token path

### DIFF
--- a/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
+++ b/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
@@ -43,6 +43,7 @@ import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
 
+import org.corfudb.runtime.object.IConflictFunction;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.ICorfuSMRProxy;
 import org.corfudb.runtime.object.ICorfuSMRUpcallTarget;
@@ -571,6 +572,7 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
         addUndoRecordMap(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
         addUndoMap(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
         addResetSet(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
+        addEntryToConflictMap(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
 
         typeSpecBuilder
                 .addSuperinterfaces(interfacesToAdd);
@@ -918,6 +920,83 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                 .addStatement("return $L", "undoMap" + CORFUSMR_FIELD)
                 .build());
 
+    }
+
+    private void addEntryToConflictMap(TypeSpec.Builder typeSpecBuilder, TypeName originalName,
+                                        Set<TypeName> interfacesToAdd,
+                                        Set<SmrMethodInfo> methodSet) {
+        // Generate the conflict resolver string and associated map.
+        // We only need to resolve conflicts which actually can be
+        // written to as upcalls
+        String conflictResolverString = methodSet.stream()
+                .filter(x -> x.method.getAnnotation(MutatorAccessor.class) != null
+                        || (x.method.getAnnotation(Mutator.class) != null
+                        && !x.method.getAnnotation(Mutator.class).noUpcall()))
+                .map(x -> "\n.put(\"" + getSmrFunctionName(x.method) + "\", "
+                        + "(args) ->  " + (x.hasConflictAnnotations ?
+                        getConflictAnnotationsString("args", x) :
+                            getConflictMethodString("args", x)) + ")")
+                .collect(Collectors.joining());
+
+        FieldSpec conflictResolverMap =
+                FieldSpec.builder(ParameterizedTypeName.get(ClassName.get(Map.class),
+                ClassName.get(String.class),
+                ClassName.get(IConflictFunction.class)), "entryToConflictMap" + CORFUSMR_FIELD,
+                Modifier.PUBLIC, Modifier.FINAL)
+                .initializer("new $T()$L.build()",
+                        ParameterizedTypeName.get(ClassName.get(ImmutableMap.Builder.class),
+                                ClassName.get(String.class),
+                                ClassName.get(IConflictFunction.class)), conflictResolverString)
+                .build();
+
+        typeSpecBuilder.addField(conflictResolverMap);
+
+        typeSpecBuilder.addMethod(MethodSpec.methodBuilder("getCorfuEntryToConflictMap")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get(Map.class),
+                        ClassName.get(String.class),
+                        ClassName.get(IConflictFunction.class)))
+                .addStatement("return $L", "entryToConflictMap" + CORFUSMR_FIELD)
+                .build());
+    }
+
+    private String getConflictAnnotationsString(String paramName, SmrMethodInfo method) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("new Object[] {");
+        boolean firstArg = true;
+        for (int i = 0; i < method.method.getParameters().size(); i++) {
+            if (method.method.getParameters().get(i)
+                    .getAnnotation(ConflictParameter.class) != null) {
+                if (!firstArg) {
+                    sb.append(",");
+                } else {
+                    firstArg = false;
+                }
+                sb.append(paramName).append("[").append(i).append("]");
+            }
+        }
+        sb.append("}");
+        return sb.toString();
+    }
+
+    private String getConflictMethodString(String paramName, SmrMethodInfo method) {
+        if (method.conflictFunction == null) {
+            return "null";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(method.conflictFunction).append("(");
+        for (int i = 0; i < method.method.getParameters().size(); i++) {
+                if (i != 0) {
+                    sb.append(",");
+                }
+                sb.append("(").append(method.method.getParameters()
+                        .get(i).asType())
+                        .append(")").append(paramName)
+                        .append("[").append(i).append("]");
+        }
+        sb.append(")");
+        return sb.toString();
     }
 
     /** Add a conflict field to the method.

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
@@ -33,6 +33,11 @@ public interface ICorfuSMR<T> {
      * @return The undo record map. */
     Map<String, IUndoRecordFunction<T>> getCorfuUndoRecordMap();
 
+    /** Get a map from strings (function names) to conflict functions.
+     * @return The conflict entry map.
+     */
+    Map<String, IConflictFunction> getCorfuEntryToConflictMap();
+
     /** Get a set of strings (function names) which result in a reset
      * of the object.
      * @return  The set of strings that cause a reset on the object.

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
@@ -80,5 +80,12 @@ public interface ICorfuSMRProxy<T> {
      */
     long getVersion();
 
+    /** Given an SMR Entry (with method an arguments), return the
+     * conflict set, or null if there is no conflict set.
+     * @param smrMethod     The method used
+     * @param smrArguments  The arguments to the method.
+     * @return              The conflict set.
+     */
+    Object[] getConflictFromEntry(String smrMethod, Object[] smrArguments);
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -199,96 +198,6 @@ public class SequencerServer extends AbstractServer {
     }
 
     /**
-     * If the request submits a timestamp (a global offset) that is less than one of the
-     * global offsets of a streams specified in the request, then abort; otherwise commit.
-     *
-     * @param txInfo      info provided by corfuRuntime for conflict resolultion:
-     *                    - timestamp : the snapshot (global) offset that this TX reads
-     *                    - conflictSet: conflict set of the txn.
-     *                    if any conflict-param (or stream, if empty) in this set has a later
-     *                    timestamp than the snapshot, abort
-     * @param conflictKey is a return parameter that signals to the consumer which key was
-     *                    responsible for unsuccessful allocation af a token.
-     * @return Returns the type of token reponse based on whether the txn commits, or the abort
-     *     cause.
-     */
-    public TokenType txnCanCommit(TxResolutionInfo txInfo, /** Input. */
-                                  AtomicReference<byte[]> conflictKey /** Output. */,
-                                  AtomicReference<Long> conflictAddress /** Output. */) {
-        log.trace("Commit-req[{}]", txInfo);
-        final long txSnapshotTimestamp = txInfo.getSnapshotTimestamp();
-
-        if (txSnapshotTimestamp < trimMark) {
-            log.debug("ABORT[{}] snapshot-ts[{}] trimMark-ts[{}]", txInfo,
-                    txSnapshotTimestamp, trimMark);
-            return TokenType.TX_ABORT_SEQ_TRIM;
-        }
-
-        AtomicReference<TokenType> response = new AtomicReference<>(TokenType.NORMAL);
-
-        for (Map.Entry<UUID, Set<byte[]>> entry : txInfo.getConflictSet().entrySet()) {
-            if (response.get() != TokenType.NORMAL) {
-                break;
-            }
-
-            // if conflict-parameters are present, check for conflict based on conflict-parameter
-            // updates
-            Set<byte[]> conflictParamSet = entry.getValue();
-            if (conflictParamSet != null && conflictParamSet.size() > 0) {
-                // for each key pair, check for conflict;
-                // if not present, check against the wildcard
-                for (byte[] conflictParam : conflictParamSet) {
-
-                    String conflictKeyHash = getConflictHashCode(entry.getKey(),
-                            conflictParam);
-                    Long v = conflictToGlobalTailCache.getIfPresent(conflictKeyHash);
-
-                    log.trace("Commit-ck[{}] conflict-key[{}](ts={})", txInfo, conflictParam, v);
-
-                    if (v != null && v > txSnapshotTimestamp) {
-                        log.debug("ABORT[{}] conflict-key[{}](ts={})", txInfo, conflictParam, v);
-                        conflictKey.set(conflictParam);
-                        response.set(TokenType.TX_ABORT_CONFLICT_KEY);
-                        break;
-                    }
-
-                    if (txSnapshotTimestamp < maxConflictWildcard) {
-                        log.debug("ABORT[{}] snapshot-ts[{}] WILDCARD ts=[{}]",
-                                txInfo, txSnapshotTimestamp, maxConflictWildcard);
-                        response.set(TX_ABORT_SEQ_OVERFLOW);
-                        break;
-                    }
-
-                    if (v == null && maxConflictWildcard > txSnapshotTimestamp) {
-                        log.warn("ABORT[{}] conflict-key[{}](WILDCARD ts={})", txInfo,
-                                conflictParam,
-                                maxConflictWildcard);
-                        conflictAddress.set(maxConflictWildcard);
-                        conflictKey.set(conflictParam);
-                        response.set(TokenType.TX_ABORT_CONFLICT_KEY);
-                    }
-                }
-            } else { // otherwise, check for conflict based on streams updates
-                UUID streamId = entry.getKey();
-                streamTailToGlobalTailMap.compute(streamId, (k, v) -> {
-                    if (v == null) {
-                        return null;
-                    }
-                    if (v > txSnapshotTimestamp) {
-                        log.debug("ABORT[{}] conflict-stream[{}](ts={})",
-                                txInfo, Utils.toReadableId(streamId), v);
-                        conflictAddress.set(v);
-                        response.set(TokenType.TX_ABORT_CONFLICT_STREAM);
-                    }
-                    return v;
-                });
-            }
-        }
-
-        return response.get();
-    }
-
-    /**
      * Service a query request.
      *
      * <p>This returns information about the tail of the
@@ -456,11 +365,12 @@ public class SequencerServer extends AbstractServer {
     }
 
     /**
-     * this method serves token-requests for transaction-commit entries.
+     * This method serves token-requests for transaction-commit entries.
      *
-     * <p>it checks if the transaction can commit.
-     * - if the transction must abort,
-     * then a 'error token' containing an Address.ABORTED address is returned.
+     * <p>It checks if the transaction can commit.
+     * - if the transaction must abort,
+     * then an abort token type is returned, with the address which caused the abort
+     * as the token, as well as the conflict key, if present.
      * - if the transaction may commit,
      * then a normal allocation of log position(s) is pursued.
      *
@@ -472,28 +382,75 @@ public class SequencerServer extends AbstractServer {
                                ChannelHandlerContext ctx, IServerRouter r) {
         final long serverEpoch = r.getServerEpoch();
         final TokenRequest req = msg.getPayload();
+        final TxResolutionInfo txInfo = req.getTxnResolution();
+        final long txSnapshotTimestamp = txInfo.getSnapshotTimestamp();
 
-        // Since Java does not allow an easy way for a function to return multiple values, this
-        // variable is passed to the consumer that will use it to indicate to us if/what key was
-        // responsible for an aborted transaction.
-        AtomicReference<byte[]> conflictKey = new AtomicReference(TokenResponse.NO_CONFLICT_KEY);
-        AtomicReference<Long> conflictAddress = new AtomicReference<>(Address.ABORTED);
-
-        // in the TK_TX request type, the sequencer is utilized for transaction conflict-resolution.
-        // Token allocation is conditioned on commit.
-        // First, we check if the transaction can commit.
-        TokenType tokenType = txnCanCommit(req.getTxnResolution(), conflictKey, conflictAddress);
-        if (tokenType != TokenType.NORMAL) {
-            // If the txn aborts, then DO NOT hand out a token.
-            Token token = new Token(conflictAddress.get(), serverEpoch);
-            r.sendResponse(ctx, msg, CorfuMsgType.TOKEN_RES.payloadMsg(new TokenResponse(tokenType,
-                    conflictKey.get(), token, Collections.emptyMap())));
+        if (txSnapshotTimestamp < trimMark) {
+            log.debug("ABORT[{}] snapshot-ts[{}] trimMark-ts[{}]", txInfo,
+                    txSnapshotTimestamp, trimMark);
+            r.sendResponse(ctx, msg,
+                    CorfuMsgType.TOKEN_RES.payloadMsg(
+                            new TokenResponse(TokenType.TX_ABORT_SEQ_TRIM, trimMark, serverEpoch)));
             return;
+        }
+
+        // Iterate over all of the streams in the conflict set
+        for (Map.Entry<UUID, Set<byte[]>> entry : txInfo.getConflictSet().entrySet()) {
+            final Set<byte[]> conflictParamSet = entry.getValue();
+            final UUID streamId = entry.getKey();
+
+            // if conflict-parameters are present, check for conflict
+            // based on conflict-parameter updates
+            if (conflictParamSet != null && conflictParamSet.size() > 0) {
+                // for each key pair, check for conflict;
+                // if not present, check against the wildcard
+                for (byte[] conflictParam : conflictParamSet) {
+                    final String conflictKeyHash = getConflictHashCode(streamId, conflictParam);
+                    final Long conflictTail = conflictToGlobalTailCache
+                            .getIfPresent(conflictKeyHash);
+
+
+                    if (txSnapshotTimestamp < maxConflictWildcard) {
+                        log.debug("ABORT[{}] snapshot-ts[{}] WILDCARD ts=[{}]",
+                                txInfo, txSnapshotTimestamp, maxConflictWildcard);
+                        r.sendResponse(ctx, msg,
+                                CorfuMsgType.TOKEN_RES.payloadMsg(
+                                        new TokenResponse(TokenType.TX_ABORT_SEQ_OVERFLOW,
+                                                conflictParam, Address.ABORTED, serverEpoch)));
+                        return;
+                    }
+
+                    if (conflictTail != null
+                            && (conflictTail > txSnapshotTimestamp)) {
+                        log.debug("handleTxToken: ABORT[{}] conflict-key[{}](ts={})", txInfo,
+                                conflictParam,
+                                conflictTail);
+                        r.sendResponse(ctx, msg,
+                                CorfuMsgType.TOKEN_RES.payloadMsg(
+                                        new TokenResponse(TokenType.TX_ABORT_CONFLICT_KEY,
+                                                conflictParam, conflictTail, serverEpoch)));
+                        return;
+                    }
+                    log.trace("handleTxToken: OK[{}] conflict-key[{}](ts={})", txInfo,
+                            conflictParam, conflictTail);
+                }
+            } else { // otherwise, check for conflict based on streams updates
+                final Long streamTail = streamTailToGlobalTailMap.get(streamId);
+                if (streamTail > txSnapshotTimestamp) {
+                    log.debug("handleTxToken: ABORT[{}] conflict-stream[{}](ts={})",
+                            txInfo, Utils.toReadableId(streamId), streamTail);
+                    r.sendResponse(ctx, msg,
+                            CorfuMsgType.TOKEN_RES.payloadMsg(
+                                    new TokenResponse(TokenType.TX_ABORT_CONFLICT_STREAM,
+                                            streamTail, serverEpoch)));
+                    return;
+                }
+            }
         }
 
         // if we get here, this means the transaction can commit.
         // handleAllocation() does the actual allocation of log position(s)
-        // and returns the reponse
+        // and returns the response
         handleAllocation(msg, ctx, r);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -409,7 +409,6 @@ public class SequencerServer extends AbstractServer {
                     final Long conflictTail = conflictToGlobalTailCache
                             .getIfPresent(conflictKeyHash);
 
-
                     if (txSnapshotTimestamp < maxConflictWildcard) {
                         log.debug("ABORT[{}] snapshot-ts[{}] WILDCARD ts=[{}]",
                                 txInfo, txSnapshotTimestamp, maxConflictWildcard);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -32,6 +32,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
         this.backpointerMap = backpointerMap;
     }
 
+
     /** the cause/type of response. */
     final TokenType respType;
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -17,6 +17,7 @@ import lombok.Data;
 public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
 
     public static byte[] NO_CONFLICT_KEY = new byte[]{};
+    public static UUID EMPTY_UUID = new UUID(0L, 0L);
 
     /**
      * Constructor for TokenResponse.
@@ -30,6 +31,24 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
         conflictKey = NO_CONFLICT_KEY;
         token = new Token(tokenValue, epoch);
         this.backpointerMap = backpointerMap;
+        this.conflictStream = EMPTY_UUID;
+    }
+
+    public TokenResponse(TokenType type, long address, long epoch) {
+        respType = type;
+        conflictKey = NO_CONFLICT_KEY;
+        token = new Token(address, epoch);
+        this.backpointerMap = Collections.emptyMap();
+        this.conflictStream = EMPTY_UUID;
+    }
+
+    public TokenResponse(TokenType type, byte[] conflictKey, UUID conflictStream,
+                         long address, long epoch) {
+        respType = type;
+        this.conflictKey = conflictKey;
+        this.conflictStream = conflictStream;
+        token = new Token(address, epoch);
+        this.backpointerMap = Collections.emptyMap();
     }
 
 
@@ -40,6 +59,9 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
      * In case there is a conflict, signal to the client which key was responsible for the conflict.
      */
     final byte[] conflictKey;
+
+    /** The stream that caused the conflict if type is abort. */
+    final UUID conflictStream;
 
     /** The current token,
      * or overload with "cause address" in case token request is denied. */
@@ -55,35 +77,34 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
      */
     public TokenResponse(ByteBuf buf) {
         respType = TokenType.values()[ICorfuPayload.fromBuffer(buf, Byte.class)];
-        conflictKey = ICorfuPayload.fromBuffer(buf, byte[].class);
         Long tokenValue = ICorfuPayload.fromBuffer(buf, Long.class);
         Long epoch = ICorfuPayload.fromBuffer(buf, Long.class);
         token = new Token(tokenValue, epoch);
-        backpointerMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
+
+        if (respType.isAborted()) {
+            conflictKey = ICorfuPayload.fromBuffer(buf, byte[].class);
+            conflictStream = ICorfuPayload.fromBuffer(buf, UUID.class);
+            backpointerMap = Collections.emptyMap();
+        } else {
+            conflictKey = NO_CONFLICT_KEY;
+            conflictStream = EMPTY_UUID;
+            backpointerMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
+        }
     }
 
-
-    public TokenResponse(TokenType type, long address, long epoch) {
-        respType = type;
-        conflictKey = NO_CONFLICT_KEY;
-        token = new Token(address, epoch);
-        this.backpointerMap = Collections.emptyMap();
-    }
-
-    public TokenResponse(TokenType type, byte[] conflictKey, long address, long epoch) {
-        respType = type;
-        this.conflictKey = conflictKey;
-        token = new Token(address, epoch);
-        this.backpointerMap = Collections.emptyMap();
-    }
-    
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, respType);
-        ICorfuPayload.serialize(buf, conflictKey);
+
         ICorfuPayload.serialize(buf, token.getTokenValue());
         ICorfuPayload.serialize(buf, token.getEpoch());
-        ICorfuPayload.serialize(buf, backpointerMap);
+
+        if (respType.isAborted()) {
+            ICorfuPayload.serialize(buf, conflictKey);
+            ICorfuPayload.serialize(buf, conflictStream);
+        } else {
+            ICorfuPayload.serialize(buf, backpointerMap);
+        }
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
@@ -37,6 +37,11 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
     @Getter
     final Map<UUID, Set<byte[]>>  writeConflictParams;
 
+    /** A map of streams which have been validated for transactional commit,
+        with the addresses they have been validated up to. */
+    @Getter
+    final Map<UUID, Long> validatedStreams;
+
     /**
      * Constructor for TxResolutionInfo.
      *
@@ -48,6 +53,7 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
         this.snapshotTimestamp = snapshotTimestamp;
         this.conflictSet = Collections.emptyMap();
         this.writeConflictParams = Collections.emptyMap();
+        this.validatedStreams = Collections.emptyMap();
     }
 
     /**
@@ -64,7 +70,29 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
         this.snapshotTimestamp = snapshotTimestamp;
         this.conflictSet = conflictMap;
         this.writeConflictParams = writeConflictParams;
+        this.validatedStreams = Collections.emptyMap();
     }
+
+    /**
+     * Constructor for TxResolutionInfo.
+     *
+     * @param txId transaction identifier
+     * @param snapshotTimestamp transaction snapshot timestamp
+     * @param conflictMap map of conflict parameters, arranged by stream IDs
+     * @param writeConflictParams map of write conflict parameters, arranged by stream IDs
+     * @param validatedMap  map of streams which have been validated for transactional commit,
+     *                      with the addresses they have been validated up to.
+     */
+    public TxResolutionInfo(UUID txId, long snapshotTimestamp, Map<UUID, Set<byte[]>>
+            conflictMap, Map<UUID, Set<byte[]>> writeConflictParams,
+                            Map<UUID, Long> validatedMap) {
+        this.TXid = txId;
+        this.snapshotTimestamp = snapshotTimestamp;
+        this.conflictSet = conflictMap;
+        this.writeConflictParams = writeConflictParams;
+        this.validatedStreams = validatedMap;
+    }
+
 
     /**
      * fast, specialized deserialization constructor, from a ByteBuf to this object
@@ -100,6 +128,8 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
         }
 
         writeConflictParams = writeMapBuilder.build();
+
+        this.validatedStreams = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
     }
 
     /**
@@ -125,6 +155,8 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
             ICorfuPayload.serialize(buf, x.getKey());
             ICorfuPayload.serialize(buf, x.getValue());
         });
+
+        ICorfuPayload.serialize(buf, validatedStreams);
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -3,9 +3,12 @@ package org.corfudb.runtime.exceptions;
 import java.util.UUID;
 
 import lombok.Getter;
+import lombok.Setter;
+
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
 import org.corfudb.util.Utils;
+import org.corfudb.runtime.view.Address;
 
 /**
  * Created by mwei on 1/11/16.
@@ -29,6 +32,17 @@ public class TransactionAbortedException extends RuntimeException {
 
     @Getter
     AbstractTransactionalContext context;
+
+    /** True, if it is known that this abort was not caused by a false conflict. */
+    @Getter
+    @Setter
+    boolean precise = false;
+
+    /** If available, the address where the conflict was detected,
+     *  otherwise, Address.NON_EXIST.
+     */
+    @Getter
+    long conflictAddress = Address.NON_EXIST;
 
     /**
      * Constructor.
@@ -61,6 +75,15 @@ public class TransactionAbortedException extends RuntimeException {
         this.cause = cause;
         this.conflictStream = conflictStream;
         this.context = context;
+    }
+
+    public TransactionAbortedException(TxResolutionInfo txResolutionInfo,
+                                       byte[] conflictKey, UUID conflictStream,
+                                       AbortCause abortCause, Throwable cause,
+                                       long conflictAddress, AbstractTransactionalContext context) {
+        this(txResolutionInfo, conflictKey, conflictStream,
+                abortCause, cause, context);
+        this.conflictAddress = conflictAddress;
     }
 
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -90,6 +90,12 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
     @Getter
     ISerializer serializer;
 
+    /** A map from method names to their corresponding conflict
+     * functions.
+     */
+    @Getter
+    Map<String, IConflictFunction> conflictFunctionMap;
+
     /**
      * The arguments this proxy was created with.
      */
@@ -129,6 +135,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                              Map<String, ICorfuSMRUpcallTarget<T>> upcallTargetMap,
                              Map<String, IUndoFunction<T>> undoTargetMap,
                              Map<String, IUndoRecordFunction<T>> undoRecordTargetMap,
+                             Map<String, IConflictFunction> conflictFunctionMap,
                              Set<String> resetSet
     ) {
         this.rt = rt;
@@ -136,6 +143,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         this.type = type;
         this.args = args;
         this.serializer = serializer;
+        this.conflictFunctionMap = conflictFunctionMap;
 
         underlyingObject = new VersionLockedObject<T>(this::getNewInstance,
                 new StreamViewSMRAdapter(rt, rt.getStreamsView().get(streamID)),
@@ -424,6 +432,12 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
     public long getVersion() {
         return access(o -> underlyingObject.getVersionUnsafe(),
                 null);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Object[] getConflictFromEntry(String smrMethod, Object[] smrArguments) {
+        return getConflictFunctionMap().get(smrMethod).getConflictSet(smrArguments);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -64,6 +64,7 @@ public class CorfuCompileWrapperBuilder {
                 wrapperObject.getCorfuSMRUpcallMap(),
                 wrapperObject.getCorfuUndoMap(),
                 wrapperObject.getCorfuUndoRecordMap(),
+                wrapperObject.getCorfuEntryToConflictMap(),
                 wrapperObject.getCorfuResetSet()));
 
         if (wrapperObject instanceof ICorfuSMRProxyWrapper) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/ConflictSetInfo.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/ConflictSetInfo.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -26,6 +27,12 @@ public class ConflictSetInfo {
     /** Get a hash for the object, given a proxy. */
     public static byte[] generateHashFromObject(ICorfuSMRProxyInternal p, Object o) {
         return p.getSerializer().hash(o);
+    }
+
+    public Optional<ICorfuSMRProxyInternal> getProxy(UUID stream) {
+        return conflicts.keySet().stream()
+                .filter(p -> p.getStreamID().equals(stream))
+                .findFirst();
     }
 
     /** Get the hashed conflict set.

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionBuilder.java
@@ -29,6 +29,25 @@ public class TransactionBuilder {
      */
     public long snapshot = -1L;
 
+
+    /** Require precise conflict detection.
+     *
+     * <p>If set to false, transaction conflict resolution
+     * will rely on the sequencer, which may abort due
+     * to hash collisions.
+     *
+     * <p>If set to true, transaction conflict resolution
+     * will first attempt to resolve using the sequencer
+     * and if the sequencer requests an abort, then we
+     * will retry by reading the log manually. If a true
+     * conflict exists, then we will abort, otherwise
+     * we will reattempt to commit the transaction using
+     * the manually resolved information. Setting
+     * this value to true has significant performance
+     * implications on an abort.
+     */
+    public boolean preciseConflicts = false;
+
     public TransactionBuilder(CorfuRuntime runtime) {
         this.runtime = runtime;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -32,7 +32,7 @@ public class WriteAfterWriteTransactionalContext
     public long commitTransaction() throws TransactionAbortedException {
         log.debug("TX[{}] request write-write commit", this);
 
-        return getConflictSetAndCommit(getWriteSetInfo());
+        return doCommit(getWriteSetInfo());
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetInfo.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetInfo.java
@@ -25,16 +25,12 @@ public class WriteSetInfo extends ConflictSetInfo {
     /** The actual updates to mutated objects. */
     MultiObjectSMREntry writeSet = new MultiObjectSMREntry();
 
+
     public long add(ICorfuSMRProxyInternal proxy, SMREntry updateEntry, Object[] conflictObjects) {
-        synchronized (getRootContext().getTransactionID()) {
-
-            // add the SMRentry to the list of updates for this stream
-            writeSet.addTo(proxy.getStreamID(), updateEntry);
-
-            super.add(proxy, conflictObjects);
-
-            return writeSet.getSMRUpdates(proxy.getStreamID()).size() - 1;
-        }
+        super.add(proxy, conflictObjects);
+        affectedStreams.add(proxy.getStreamID());
+        writeSet.addTo(proxy.getStreamID(), updateEntry);
+        return writeSet.getSMRUpdates(proxy.getStreamID()).size() - 1;
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -115,13 +115,19 @@ public class StreamsView extends AbstractView {
                 throw new TransactionAbortedException(
                         conflictInfo,
                         tokenResponse.getConflictKey(),
+                        tokenResponse.getConflictStream(),
                         AbortCause.CONFLICT,
+                        null,
+                        tokenResponse.getTokenValue(),
                         TransactionalContext.getCurrentContext());
                 case TX_ABORT_CONFLICT_STREAM:
                 throw new TransactionAbortedException(
                         conflictInfo,
                         tokenResponse.getConflictKey(),
+                        tokenResponse.getConflictStream(),
                         AbortCause.CONFLICT,
+                        null,
+                        tokenResponse.getTokenValue(),
                         TransactionalContext.getCurrentContext());
                 case TX_ABORT_NEWSEQ:
                 throw new TransactionAbortedException(
@@ -174,6 +180,7 @@ public class StreamsView extends AbstractView {
                 // eventually be deprecated since these are no longer used)
                 tokenResponse = new TokenResponse(
                         temp.getRespType(), tokenResponse.getConflictKey(),
+                        tokenResponse.getConflictStream(),
                         temp.getToken(), temp.getBackpointerMap());
 
             } catch (StaleTokenException se) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -424,7 +424,8 @@ public abstract class AbstractQueuedStreamView extends
          * */
         @Override
         void seek(long globalAddress) {
-            if (Address.nonAddress(globalAddress)) {
+            if (globalAddress != Address.maxNonAddress() &&
+                    Address.nonAddress(globalAddress)) {
                 throw new IllegalArgumentException("globalAddress must"
                         + " be >= Address.maxNonAddress()");
             }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -1,5 +1,7 @@
 package org.corfudb.runtime.object.transactions;
 
+import org.corfudb.annotations.CorfuObject;
+import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
@@ -10,11 +12,15 @@ import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
 import java.nio.ByteBuffer;
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
 
 import lombok.AllArgsConstructor;
@@ -63,13 +69,13 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
                 .collect(Collectors.toList()))
                 .contains(TEST_0, TEST_4);
 
-        // in optimistic mode, assert that the conflict set does NOT contain TEST_2, TEST_3
+        // in optimistic mode, assert that the conflict set does NOT contain TEST_1 - TEST_3
         assertThat(TransactionalContext.getCurrentContext()
                 .getReadSetInfo()
                 .getConflicts().values().stream()
                 .flatMap(x -> x.stream())
                 .collect(Collectors.toList()))
-                .doesNotContain(TEST_2, TEST_3, TEST_5);
+                .doesNotContain(TEST_1, TEST_2, TEST_3);
 
         getRuntime().getObjectsView().TXAbort();
     }
@@ -612,13 +618,15 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
         Map<String, String> m1 = rt.getObjectsView()
                 .build()
                 .setStreamName("test-1")
-                .setTypeToken(new TypeToken<SMRMap<String,String>>() {})
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {
+                })
                 .open();
 
         Map<String, String> m2 = rt.getObjectsView()
                 .build()
                 .setStreamName("test-2")
-                .setTypeToken(new TypeToken<SMRMap<String,String>>() {})
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {
+                })
                 .open();
 
         t1(() -> rt.getObjectsView().TXBegin());
@@ -626,7 +634,517 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
         t1(() -> m1.put("azusavnj", "1"));
         t2(() -> m2.put("ajkenmbb", "2"));
         t1(() -> rt.getObjectsView().TXEnd());
-        t2(() -> rt.getObjectsView().TXEnd())
+        t2(() -> rt.getObjectsView().TXEnd());
+    }
+
+    /** Check that precise conflicts do not abort when
+     * two conflict keys collide.
+     */
+    @Test
+    public void preciseFalseConflictsDoNotAbort() {
+        String k1 = "Aa";
+        String k2 = "BB";
+
+        // Make sure these two keys collide.
+        assertThat(k1.hashCode())
+                .isEqualTo(k2.hashCode());
+
+        // Start two transactions, where k1 and k2
+        // are written to.
+        t1(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t1(() -> put(k1, "a"));
+
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t2(() -> put(k2, "a"));
+
+        t1(() -> TXEnd());
+
+        // The second transaction would normally abort,
+        // Even though k1 != k2. However, under precise
+        // conflicts, there should be no abort.
+        t2(() -> TXEnd())
+            .assertDoesNotThrow(TransactionAbortedException.class);
+    }
+
+
+
+    /** Check that precise conflicts do not abort when
+     * two conflict keys collide and the causing operation
+     * is a mutator only.
+     */
+    @Test
+    public void preciseFalseConflictsMutatorDoNotAbort() {
+        String k1 = "Aa";
+        String k2 = "BB";
+
+        // Make sure these two keys collide.
+        assertThat(k1.hashCode())
+                .isEqualTo(k2.hashCode());
+
+        // Start two transactions, where k1 and k2
+        // are written to.
+        t1(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t1(() -> getMap().remove(k1));
+
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t2(() -> put(k2, "a"));
+
+        t1(() -> TXEnd());
+
+        // The second transaction would normally abort,
+        // Even though k1 != k2. However, under precise
+        // conflicts, there should be no abort.
+        t2(() -> TXEnd())
+                .assertDoesNotThrow(TransactionAbortedException.class);
+    }
+
+    /** Check that precise conflicts do abort
+     * when an entry (such as a clear), which
+     * conflicts with all updates is inserted.
+     */
+    @Test
+    public void preciseTrueConflictAllAborts() {
+        String k1 = "A";
+        String k2 = "A";
+
+        // Insert something initially into the map
+        put(k1, "a");
+
+        t1(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        // TX1 will clear the map
+        // TODO: Until poisoning is implemented, this operation
+        // TODO: conflicts when we -scan- the log, but not when
+        // TODO: the sequencer is deciding aborts, since "clear"
+        // TODO: is not added to the conflict set. We add clear
+        // TODO: falsely to the conflict set by inserting k1.
+        t1(() -> put(k1, "a"));
+        t1(() -> getMap().clear());
+
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t2(() -> put(k2, "a"));
+
+        t1(() -> TXEnd());
+        t2(() -> TXEnd())
+            .assertThrows()
+            .isInstanceOf(TransactionAbortedException.class);
+    }
+
+    /** Check that precise conflicts do abort
+     * when two conflict keys collide.
+     */
+    @Test
+    public void preciseTrueConflictAllAbort() {
+        // Here, k1 == k2, so the transaction should
+        // abort.
+        String k1 = "A";
+        String k2 = "A";
+
+        t1(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t1(() -> put(k1, "a"));
+
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t2(() -> put(k2, "a"));
+
+        t1(() -> TXEnd());
+        t2(() -> TXEnd())
+                .assertThrows()
+                .isInstanceOf(TransactionAbortedException.class);
+    }
+
+    /** Check that precise conflicts do not abort when
+     * two conflict keys collide.
+     *
+     * Here, k1 and k2 collide, as well as k3 and k4.
+     */
+    @Test
+    public void preciseMultiFalseConflictsDoNotAbort() {
+        String k1 = "Aa";
+        String k2 = "BB";
+        String k3 = "AaAaAa";
+        String k4 = "BBBBBB";
+
+        // Make sure these two key sets collide.
+        assertThat(k1.hashCode())
+                .isEqualTo(k2.hashCode());
+
+        assertThat(k3.hashCode())
+                .isEqualTo(k4.hashCode());
+
+        // Start two transactions, where k1-k4
+        // are written to.
+        t1(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t1(() -> put(k1, "a"));
+        t1(() -> put(k3, "a"));
+
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t2(() -> put(k2, "a"));
+        t2(() -> put(k4, "a"));
+
+        t1(() -> TXEnd());
+
+        // The second transaction would normally abort,
+        // Even though k1 != k2 and k3 != k4. However, under precise
+        // conflicts, there should be no abort.
+        t2(() -> TXEnd())
+                .assertDoesNotThrow(TransactionAbortedException.class);
+    }
+
+
+    /** Check that precise conflicts do not abort when
+     * two conflict keys from two different maps collide.
+     *
+     * Here, k1 and k2 collide, as well as k3 and k4.
+     */
+    @Test
+    public void preciseMultiStreamFalseConflictsDoNotAbort() {
+        String k1 = "Aa";
+        String k2 = "BB";
+        String k3 = "AaAaAa";
+        String k4 = "BBBBBB";
+
+        Map<String, String> map1 = getRuntime()
+                .getObjectsView().build()
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
+                .setStreamName("map1")
+                .open();
+
+        Map<String, String> map2 = getRuntime()
+                .getObjectsView().build()
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
+                .setStreamName("map2")
+                .open();
+
+        // Make sure these two key sets collide.
+        assertThat(k1.hashCode())
+                .isEqualTo(k2.hashCode());
+
+        assertThat(k3.hashCode())
+                .isEqualTo(k4.hashCode());
+
+        // Start two transactions, where k1-k4
+        // are written to on two maps.
+        t1(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t1(() -> map1.put(k1, "a"));
+        t1(() -> map2.put(k3, "a"));
+
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t2(() -> map1.put(k2, "a"));
+        t2(() -> map2.put(k4, "a"));
+
+        t1(() -> TXEnd());
+
+        // The second transaction would normally abort,
+        // Even though k1 != k2 and k3 != k4. However, under precise
+        // conflicts, there should be no abort.
+        t2(() -> TXEnd())
+                .assertDoesNotThrow(TransactionAbortedException.class);
+    }
+
+
+    /** Check that precise conflicts do not abort when
+     * two conflict keys from two different maps collide.
+     *
+     * The two colliding pairs are written in two different
+     * transactions, so they result in two entries written
+     * to the log.
+     *
+     * Here, k1 and k2 collide, as well as k3 and k4.
+     */
+    @Test
+    public void preciseMultiStreamMultiWriteDoNotAbort() {
+        String k1 = "Aa";
+        String k2 = "BB";
+        String k3 = "AaAaAa";
+        String k4 = "BBBBBB";
+
+        Map<String, String> map1 = getRuntime()
+                .getObjectsView().build()
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
+                .setStreamName("map1")
+                .open();
+
+        Map<String, String> map2 = getRuntime()
+                .getObjectsView().build()
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
+                .setStreamName("map2")
+                .open();
+
+        // Make sure these two key sets collide.
+        assertThat(k1.hashCode())
+                .isEqualTo(k2.hashCode());
+
+        assertThat(k3.hashCode())
+                .isEqualTo(k4.hashCode());
+
+        // Start three transactions, where k1-k4
+        // are written to on two maps.
+        // T1 modifies k1 which falsely conflicts
+        // with k2.
+        t1(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t1(() -> map1.put(k1, "a"));
+
+        // T2 modifies k3 which falsely conflicts
+        // with k4.
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t2(() -> map2.put(k3, "a"));
+
+        t3(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t3(() -> map1.put(k2, "a"));
+        t3(() -> map2.put(k4, "a"));
+
+        t1(() -> TXEnd());
+        t2(() -> TXEnd());
+
+        // The third transaction would normally abort,
+        // Even though k1 != k2 and k3 != k4. However, under precise
+        // conflicts, there should be no abort.
+        t3(() -> TXEnd())
+                .assertDoesNotThrow(TransactionAbortedException.class);
+    }
+
+    /** Check that precise conflicts do not abort
+     * due to a hole fill.
+     */
+    @Test
+    public void preciseFalseConflictDueToHoleFill() {
+        // Here, k1 == k2, so the transaction would
+        // normally abort, but we will hole fill tx1
+        // so it fails
+
+        String k1 = "A";
+        String k2 = "A";
+        UUID mapId = CorfuRuntime.getStreamID("test stream");
+
+        Map<UUID, Set<byte[]>> conflictMap = ImmutableMap.<UUID, Set<byte[]>>builder()
+                .put(mapId, Collections.singleton(Serializers.CORFU.hash(k1)))
+                .build();
+
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t2(() -> put(k2, "a"));
+
+        // To simulate a failed transaction,
+        // we will manually update the counter
+        // on the sequencer.
+        getRuntime().getSequencerView()
+                .nextToken(Collections.singleton(mapId),1,
+                        new TxResolutionInfo(mapId, 0L,
+                                conflictMap, conflictMap));
+
+        // Reading address 0L before it gets
+        // written will insert a hole without
+        // contacting the sequencer.
+
+        getRuntime()
+                .getAddressSpaceView()
+                .read(0L);
+
+        t2(() -> TXEnd())
+                .assertDoesNotThrow(TransactionAbortedException.class);
+    }
+
+
+    /** Check that precise conflicts do not abort when
+     * two conflict keys collide.
+     */
+    @Test
+    public void preciseFalseConflictsMixedWithHoleFillDoNotAbort() {
+        String k1 = "Aa";
+        String k2 = "BB";
+
+        // Make sure these two keys collide.
+        assertThat(k1.hashCode())
+                .isEqualTo(k2.hashCode());
+
+        UUID mapId = CorfuRuntime.getStreamID("test stream");
+
+        Map<UUID, Set<byte[]>> conflictMap = ImmutableMap.<UUID, Set<byte[]>>builder()
+                .put(mapId, Collections.singleton(Serializers.CORFU.hash(k2)))
+                .build();
+
+        // Start two transactions, where k1 and k2
+        // are written to.
+        t1(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t1(() -> put(k1, "a"));
+
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t2(() -> put(k2, "a"));
+
+        t1(() -> TXEnd());
+
+        // To simulate a failed transaction T3 that should have,
+        // been at address 2 and conflicted with T2
+        // we will manually update the counter
+        // on the sequencer.
+        getRuntime().getSequencerView()
+                .nextToken(Collections.singleton(mapId),1,
+                        new TxResolutionInfo(mapId, 0L,
+                                conflictMap, conflictMap));
+
+        // Reading address 1L before it gets
+        // written will insert a hole without
+        // contacting the sequencer.
+        getRuntime()
+                .getAddressSpaceView()
+                .read(1L);
+
+        // The second transaction would normally abort,
+        // Even though k1 != k2. However, under precise
+        // conflicts, there should be no abort.
+        t2(() -> TXEnd())
+                .assertDoesNotThrow(TransactionAbortedException.class);
+    }
+
+    /** Check that precise conflicts do not abort
+     * when not conflicting with a non-transactional
+     * update.
+     */
+    @Test
+    public void preciseNonTxConflictsDoNotAbort() {
+        // Here, k1 != k2, so the transaction should
+        // not abort.
+        String k1 = "Aa";
+        String k2 = "BB";
+
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t1(() -> put(k1, "a"));
+
+        t2(() -> put(k2, "a"));
+
+        t2(() -> TXEnd())
+                .assertDoesNotThrow(TransactionAbortedException.class);
+    }
+
+    /** Check that precise conflicts do not abort
+     * when not conflicting with a non-transactional
+     * update.
+     */
+    @Test
+    public void preciseConflictAllAborts() {
+        String k1 = "Aa";
+        String k2 = "BB";
+
+        Map<String, String> map2 = getRuntime()
+                .getObjectsView().build()
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
+                .setStreamName("map2")
+                .open();
+
+        // Start two transactions, where k1 and k2
+        // are written to.
+        t1(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t1(() -> map2.put(k1, "a"));
+
+        t2(() -> getRuntime()
+                .getObjectsView()
+                .TXBuild()
+                .setPreciseConflicts(true)
+                .begin());
+
+        t2(() -> map2.size());
+        t2(() -> getMap().remove("z"));
+
+        t1(() -> TXEnd());
+        t2(() -> TXEnd())
                 .assertDoesNotThrow(TransactionAbortedException.class);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -7,12 +7,14 @@ import org.corfudb.infrastructure.LogUnitServerAssertions;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.protocols.wireprotocol.*;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.OverwriteException;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Created by mwei on 2/1/16.
@@ -159,7 +161,75 @@ public class AddressSpaceViewTest extends AbstractViewTest {
 
         assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
-        assertThat(m.get(ADDRESS_1).isHole());
-        assertThat(m.get(ADDRESS_2).isHole());
+        assertThat(m.get(ADDRESS_1).isHole()).isTrue();
+        assertThat(m.get(ADDRESS_2).isHole()).isTrue();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void holeFillOverwriteIsNotCached()
+            throws Exception {
+        CorfuRuntime r = getRuntime()
+                .setCacheDisabled(false)
+                .connect();
+
+        byte[] testPayload = "hello world".getBytes();
+
+        final long ADDRESS_0 = 0;
+        final long ADDRESS_1 = 1;
+
+        Token token = new Token(ADDRESS_0, r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(token, testPayload);
+
+        assertThat(r.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
+                .isEqualTo("hello world".getBytes());
+
+        Range range = Range.closed(ADDRESS_0, ADDRESS_1);
+        ContiguousSet<Long> addresses = ContiguousSet.create(range, DiscreteDomain.longs());
+
+        Map<Long, ILogData> m = r.getAddressSpaceView().cacheFetch(addresses);
+
+        assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
+                .isEqualTo("hello world".getBytes());
+
+        Token tokenHoleFilled = new Token(ADDRESS_1, r.getLayoutView().getLayout().getEpoch());
+        assertThatThrownBy(() ->
+                r.getAddressSpaceView().write(tokenHoleFilled, testPayload))
+                .isInstanceOf(OverwriteException.class);
+
+        assertThat(m.get(ADDRESS_1).isHole()).isTrue();
+    }
+
+    @SuppressWarnings("unchecked")
+    public void holeFillOverwriteReadIsNotCached()
+            throws Exception {
+        CorfuRuntime r = getRuntime()
+                .setCacheDisabled(false)
+                .connect();
+
+        byte[] testPayload = "hello world".getBytes();
+
+        final long ADDRESS_0 = 0;
+        final long ADDRESS_1 = 1;
+
+        Token token = new Token(ADDRESS_0, r.getLayoutView().getLayout().getEpoch());
+        r.getAddressSpaceView().write(token, testPayload);
+
+        assertThat(r.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
+                .isEqualTo("hello world".getBytes());
+
+        Range range = Range.closed(ADDRESS_0, ADDRESS_1);
+        ContiguousSet<Long> addresses = ContiguousSet.create(range, DiscreteDomain.longs());
+
+        Map<Long, ILogData> m = r.getAddressSpaceView().cacheFetch(addresses);
+
+        assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
+                .isEqualTo("hello world".getBytes());
+
+        Token tokenHoleFilled = new Token(ADDRESS_1, r.getLayoutView().getLayout().getEpoch());
+        assertThatThrownBy(() ->
+                r.getAddressSpaceView().write(tokenHoleFilled, testPayload))
+                .isInstanceOf(OverwriteException.class);
+
+        assertThat(m.get(ADDRESS_1).isHole()).isTrue();
     }
 }

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -15,7 +15,7 @@
     <!-- Control logging levels for individual components here. -->
     <logger name="org.corfudb.runtime.object" level="TRACE"/>
     <logger name="org.corfudb.runtime.clients" level="INFO"/>
-    <logger name="org.corfudb.infrastructure" level="INFO"/>
+    <logger name="org.corfudb.infrastructure" level="TRACE"/>
     <logger name="io.netty.util" level="INFO"/>
     <logger name="io.netty.util.internal" level="INFO"/>
     <logger name="io.netty.buffer" level="INFO"/>


### PR DESCRIPTION
This PR cleans up the sequencer transactional token allocation path,
and adds additional information for debug purposes.

1. If the transaction is aborted, the address of the conflict is
returned if possible

2. A new token type, TX_ABORT_CONFLICT_STREAM used when a tx is aborted
due to a stream update is added to diffrentiate against TX_ABORT_CONFLICT_KEY, 
which is used when an abort was due to fine-grained conflict information in use.

3. The txCanCommit method is removed and inserted into handleTxToken,
removing unnecessary AtomicReferences being generated just to pass variables,
since handleTxToken only needs to check if a tx can commit, and tx commit
checks are not performed elsewhwre in the code.