### PR TITLE
Add logical time expiry policy to AddressSpaceView's Caffeine cache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>
             <artifactId>caffeine</artifactId>
-            <version>2.4.0</version>
+            <version>2.5.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -122,6 +122,7 @@ public class CorfuRuntime {
     /**
      * Sets expireAfterAccess and expireAfterWrite in seconds.
      */
+    @Deprecated
     @Getter
     @Setter
     public long cacheExpiryTime = Long.MAX_VALUE;

--- a/runtime/src/main/java/org/corfudb/util/LogicalTicker.java
+++ b/runtime/src/main/java/org/corfudb/util/LogicalTicker.java
@@ -1,0 +1,58 @@
+package org.corfudb.util;
+
+import com.github.benmanes.caffeine.cache.Expiry;
+import com.github.benmanes.caffeine.cache.Ticker;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.corfudb.protocols.wireprotocol.ILogData;
+
+/**
+ * A Ticker subclass for manipulating Caffeine cache expiry
+ * policy using logical time.
+ */
+
+public class LogicalTicker implements Ticker {
+    AtomicLong time;
+
+    // Caffeine's algorithm assumes fairly "wide" distances between
+    // times, e.g. nanoseconds, see commentary on GitHub PR 801.
+    private static final long scaleFactor = 1_000_000_000;
+
+    public LogicalTicker(AtomicLong time) {
+        this.time = time;
+    }
+
+    @Override
+    public long read() {
+        long time = this.time.get();
+        if (time < 0) {
+            return 0; // Don't report a negative clock
+        } else {
+            return time * scaleFactor;
+        }
+    }
+
+    /** Return an expiry policy based on logical time. */
+    public static Expiry<Long, ILogData> caffeineLogicalExpiryPolicy() {
+        // Use a policy of logical time, where the logical clock advances
+        // each time that we witness a TrimmedException.  The "time" for
+        // a cache entry's expiry is its log address.
+
+        return new Expiry<Long, ILogData>() {
+            public long expireAfterCreate(Long key, ILogData l, long currentTime) {
+                return (key * scaleFactor) - currentTime;
+            }
+
+            public long expireAfterUpdate(Long key, ILogData l,
+                                          long currentTime, long currentDuration) {
+                return (key * scaleFactor) - currentTime;
+            }
+
+            public long expireAfterRead(Long key, ILogData l,
+                                        long currentTime, long currentDuration) {
+                return (key * scaleFactor) - currentTime;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #790

Add a custom Ticker class to AddressSpaceView's Caffeine cache,
based on a notion of logical time specified by global log address.
The clock advances when a TrimmedException is witnessed.  See #790
for discussion.