### PR TITLE
Fix sequencer recovery with fastSMRLoader

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -32,7 +32,9 @@ message LogEntry {
     optional int64 checkpointId_most_significant = 11;
     optional int64 checkpointId_least_significant = 12;
     optional int64 checkpointedStreamId_most_significant = 13;
-    optional int64 checkpointedStreamdId_least_significant = 14;
+    optional int64 checkpointedStreamId_least_significant = 14;
+    //  Tail of the stream at the time of taking the checkpoint snapshot.
+    optional int64 checkpointedStreamStartLogAddress = 15;
 }
 
 message LogHeader {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -579,11 +579,14 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
 
             logData.setCheckpointId(checkpointId);
 
-            lsd = entry.getCheckpointedStreamdIdLeastSignificant();
+            lsd = entry.getCheckpointedStreamIdLeastSignificant();
             msd = entry.getCheckpointedStreamIdMostSignificant();
             UUID streamId = new UUID(msd, lsd);
 
             logData.setCheckpointedStreamId(streamId);
+
+            logData.setCheckpointedStreamStartLogAddress(
+                    entry.getCheckpointedStreamStartLogAddress());
         }
 
         return logData;
@@ -870,10 +873,12 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                     entry.getCheckpointId().getMostSignificantBits());
             logEntryBuilder.setCheckpointIdLeastSignificant(
                     entry.getCheckpointId().getLeastSignificantBits());
-            logEntryBuilder.setCheckpointedStreamdIdLeastSignificant(
+            logEntryBuilder.setCheckpointedStreamIdLeastSignificant(
                     entry.getCheckpointedStreamId().getLeastSignificantBits());
             logEntryBuilder.setCheckpointedStreamIdMostSignificant(
                     entry.getCheckpointedStreamId().getMostSignificantBits());
+            logEntryBuilder.setCheckpointedStreamStartLogAddress(
+                    entry.getCheckpointedStreamStartLogAddress());
         }
 
         return logEntryBuilder.build();

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -21,8 +21,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
+import org.corfudb.runtime.view.Address;
 
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_ID;
+import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_START_LOG_ADDRESS;
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_ID;
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_TYPE;
 
@@ -160,6 +162,19 @@ public interface IMetadata {
         getMetadataMap().put(CHECKPOINTED_STREAM_ID, Id);
     }
 
+    /**
+     * Returns the tail of the checkpointed stream at the time of taking the checkpoint snapshot.
+     */
+    default Long getCheckpointedStreamStartLogAddress() {
+        return (Long) getMetadataMap()
+                .getOrDefault(LogUnitMetadataType.CHECKPOINTED_STREAM_START_LOG_ADDRESS,
+                        Address.NO_BACKPOINTER);
+    }
+
+    default void setCheckpointedStreamStartLogAddress(Long startLogAddress) {
+        getMetadataMap().put(CHECKPOINTED_STREAM_START_LOG_ADDRESS, startLogAddress);
+    }
+
     @RequiredArgsConstructor
     public enum LogUnitMetadataType implements ITypedEnum {
         RANK(1, TypeToken.of(DataRank.class)),
@@ -168,7 +183,8 @@ public interface IMetadata {
         COMMIT(5, TypeToken.of(Boolean.class)),
         CHECKPOINT_TYPE(6, TypeToken.of(CheckpointEntry.CheckpointEntryType.class)),
         CHECKPOINT_ID(7, TypeToken.of(UUID.class)),
-        CHECKPOINTED_STREAM_ID(8, TypeToken.of(UUID.class))
+        CHECKPOINTED_STREAM_ID(8, TypeToken.of(UUID.class)),
+        CHECKPOINTED_STREAM_START_LOG_ADDRESS(9, TypeToken.of(Long.class))
         ;
         final int type;
         @Getter

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -150,6 +150,9 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
                 setCheckpointType(cp.getCpType());
                 setCheckpointId(cp.getCheckpointId());
                 setCheckpointedStreamId(cp.getStreamId());
+                setCheckpointedStreamStartLogAddress(
+                        Long.parseLong(cp.getDict()
+                                .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)));
             }
         }
     }

--- a/runtime/src/main/java/org/corfudb/recovery/FastSmrMapsLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastSmrMapsLoader.java
@@ -9,9 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.function.BiConsumer;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -104,9 +102,10 @@ public class FastSmrMapsLoader {
     @Getter
     private int numberOfAttempt = NUMBER_OF_ATTEMPT;
 
-    private boolean logContainsCheckpoints = false;
     private int retryIteration = 0;
     private long nextRead;
+
+    private List<Future> futureList;
 
     public FastSmrMapsLoader(@Nonnull final CorfuRuntime corfuRuntime) {
         this.runtime = corfuRuntime;
@@ -129,15 +128,15 @@ public class FastSmrMapsLoader {
     private void summonNecromancer() {
         necromancer = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
                 .setNameFormat("necromancer-%d").build());
+        futureList = new ArrayList<>();
     }
 
     private void invokeNecromancer(Map<Long, ILogData> logDataMap, BiConsumer<Long, ILogData> resurrectionSpell) {
-        necromancer.execute(() -> {
+        futureList.add(necromancer.submit(() -> {
             logDataMap.forEach((address, logData) -> {
                 resurrectionSpell.accept(address, logData);
             });
-
-        });
+        }));
     }
 
     private void killNecromancer() {
@@ -148,6 +147,14 @@ public class FastSmrMapsLoader {
             String msg = "Necromancer is taking too long to load the maps. Gave up.";
             log.error(msg);
             fail(msg);
+        }
+        for (Future future : futureList) {
+            try {
+                future.get();
+            } catch (ExecutionException | InterruptedException e) {
+                log.error("Error in invokingNecromancer task : {}", e);
+                fail("FastSMRLoader recovery failed.");
+            }
         }
     }
 
@@ -175,14 +182,13 @@ public class FastSmrMapsLoader {
     public void updateStreamTails(long address, ILogData logData) {
         // On checkpoint, we also need to track the stream tail of the checkpoint
         if (isCheckPointEntry(logData)) {
-            // Need to deserialize
-            CheckpointEntry checkpointEntry = (CheckpointEntry) logData.getLogEntry(runtime);
-            if (checkpointEntry.getCpType() == CheckpointEntry.CheckpointEntryType.END) {
-                streamTails.put(checkpointEntry.getStreamId(), getStartAddressOfCheckPoint(checkpointEntry));
+            if (logData.getCheckpointType() == CheckpointEntry.CheckpointEntryType.END) {
+                streamTails.put(logData.getCheckpointedStreamId(),
+                        getStartAddressOfCheckPoint(logData));
             }
         }
         for (UUID streamId : logData.getStreams()) {
-                streamTails.put(streamId, address);
+            streamTails.put(streamId, address);
         }
     }
 
@@ -399,7 +405,7 @@ public class FastSmrMapsLoader {
         try {
             CheckpointEntry logEntry = (CheckpointEntry) deserializeLogData(runtime, logData);
             long snapshotAddress = getSnapShotAddressOfCheckPoint(logEntry);
-            long startAddress = getStartAddressOfCheckPoint(logEntry);
+            long startAddress = getStartAddressOfCheckPoint(logData);
 
             streamMeta.addCheckPoint(new CheckPoint(checkPointId)
                     .addAddress(address)
@@ -408,8 +414,8 @@ public class FastSmrMapsLoader {
                     .setStarted(true));
 
         } catch (Exception e) {
-            log.error("findCheckpointsInLogAddress[address = {}]: " +
-                    "Couldn't get the snapshotAddress", e);
+            log.error("findCheckpointsInLogAddress[address = {}]: "
+                    + "Couldn't get the snapshotAddress", e);
             fail("Couldn't get the snapshotAddress at address " + address);
         }
     }

--- a/runtime/src/main/java/org/corfudb/recovery/RecoveryUtils.java
+++ b/runtime/src/main/java/org/corfudb/recovery/RecoveryUtils.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Range;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.object.CorfuCompileProxy;
@@ -34,8 +35,8 @@ public class RecoveryUtils {
         return Long.parseLong(logEntry.getDict().get(SNAPSHOT_ADDRESS));
     }
 
-    static long getStartAddressOfCheckPoint(CheckpointEntry logEntry) {
-        return Long.parseLong(logEntry.getDict().get(START_LOG_ADDRESS));
+    static long getStartAddressOfCheckPoint(ILogData logData) {
+        return logData.getCheckpointedStreamStartLogAddress();
     }
 
     /** Create a new object SMRMap as recipient of SMRUpdates (if doesn't exist yet)

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -48,7 +48,6 @@ public class CheckpointWriter {
      */
     @Getter
     @SuppressWarnings("checkstyle:abbreviation")
-    private UUID checkpointID;
     private UUID streamId;
     private String author;
     @Getter

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -172,8 +172,7 @@ public abstract class AbstractTransactionalContext implements
      * @param <T>            The type of the proxy's underlying object.
      * @return The address the update was written at.
      */
-    public abstract <T> long logUpdate(ICorfuSMRProxyInternal<T> proxy,
-                                       SMREntry updateEntry,
+    public abstract <T> long logUpdate(ICorfuSMRProxyInternal<T> proxy, SMREntry updateEntry,
                                        Object[] conflictObject);
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -636,7 +636,7 @@ public class ManagementViewTest extends AbstractViewTest {
      * <p>
      * Index  :  0  1  2  3  |          | 4  5  6  7  8
      * Stream :  A  B  A  B  | failover | A  C  A  B  B
-     * B.P    : -1 -1  0  1  |          | 2  X  4  3  7
+     * B.P    : -1 -1  0  1  |          | 2 -1  4  3  7
      * <p>
      * -1 : New StreamID so empty backpointers
      *  X : (null) Unknown backpointers as this is a failed-over sequencer.


### PR DESCRIPTION
This patch moves important data for checkpoint entries from the payload into the metadata map. This is neaded because when the corfu server restart, it may not be able to deserialize the payload.