### PR TITLE
add bulk hole fill response, needed for bulk hole fill

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -20,7 +20,10 @@ import org.corfudb.util.Utils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -246,20 +249,24 @@ public class AddressSpaceView extends AbstractView {
     }
 
     /**
-     * Fetch an address for insertion into the cache.
+     * Fetch a collection of addresses for insertion into the cache.
      *
-     * @param addresses An address to read from.
-     * @return A result to be cached. If the readresult is empty,
-     * This entry will be scheduled to self invalidate.
+     * @param addresses collection of addresses to read from.
+     * @return A result to be cached
      */
     private @Nonnull Map<Long, ILogData> cacheFetch(Iterable<Long> addresses) {
-        return StreamSupport.stream(addresses.spliterator(), true)
-                .map(address -> layoutHelper(l ->
-                        l.getReplicationMode(address).getReplicationProtocol(runtime)
-                        .read(l, address)))
-                .collect(Collectors.toMap(ILogData::getGlobalAddress, r -> r));
-    }
+        //turn the addresses into Set for now to satisfy signature requirement down the line
+        Set<Long> readAddresses = new TreeSet<>();
+        Iterator<Long> iterator = addresses.iterator();
+        while(iterator.hasNext()){
+            readAddresses.add(iterator.next());
+        }
 
+        //doesn't handle the case where some address have a different replication mode
+        return layoutHelper(l -> l.getReplicationMode(readAddresses.iterator().next())
+                .getReplicationProtocol(runtime)
+                .readAll(l, readAddresses));
+    }
 
     /**
      * Explicitly fetch a given address, bypassing the cache.

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 /**
  * Created by mwei on 4/6/17.
@@ -89,10 +90,10 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
                 .read(null, range)).getReadSet();
 
         //in case of a hole, do a normal read and use its hole fill policy
-        Map<Long, ILogData> returnResult = new HashMap<>();
+        Map<Long, ILogData> returnResult = new TreeMap<>();
         for (Map.Entry<Long, LogData> entry: logResult.entrySet()){
             ILogData value = entry.getValue();
-            if (value == null){
+            if (value == null || value.isEmpty()){
                 value = read(layout, entry.getKey());
             }
 


### PR DESCRIPTION
Part of Issue #749

Modify the hole fill to take in a list of addresses.

LogData.HOLE has a null rank, if processed in StreamLogWithRankedAddressSpace::assertAppendPermittedUnsafe(), there would be a NullPointerException. There's no other place that throws DataOutrankedException, ValueAdoptedException.

QuorumReplicationProtocol doesn't even use this function, it just does a normal write. Why don't we have a uniform procedure for both?