### PR TITLE
Don't CP Empty Maps

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
@@ -72,6 +72,10 @@ public class MultiCheckpointWriter {
         try {
             for (ICorfuSMR<Map> map : maps) {
                 UUID streamId = map.getCorfuStreamID();
+                if (((Map)map).size() == 0) {
+                    continue;
+                }
+
                 while (true) {
                     CheckpointWriter cpw = new CheckpointWriter(rt, streamId, author, (SMRMap) map);
                     ISerializer serializer =


### PR DESCRIPTION
This patch changes the MultiCheckpointWriter so that it doesn't
generate checkpoint entries for empty maps.