### PR TITLE
Increase logging for NoRollbackException and TransactionExceptions

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/NoRollbackException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/NoRollbackException.java
@@ -7,12 +7,22 @@ import org.corfudb.protocols.logprotocol.SMREntry;
  */
 public class NoRollbackException extends RuntimeException {
 
-    public NoRollbackException() {
-        super("Can't roll back due to non-undoable exception");
+    public NoRollbackException(long rollbackVersion) {
+        super("Can't roll back due to non-undoable exception "
+                + " but need "
+                + rollbackVersion + " so can't undo");
     }
 
-    public NoRollbackException(SMREntry entry) {
-        super("Can't roll back due to " + entry.getSMRMethod() + "@"
-                + entry.getEntry().getGlobalAddress());
+    public NoRollbackException(long address, long rollbackVersion) {
+        super("Could only roll back to " + address + " but need "
+                + rollbackVersion + " so can't undo");
+    }
+
+    public NoRollbackException(SMREntry entry, long address, long rollbackVersion) {
+        super("Can't roll back due to " + entry.getSMRMethod()
+                + "@"
+                + address
+                + " but need "
+                + rollbackVersion + " so can't undo");
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/NoRollbackException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/NoRollbackException.java
@@ -1,5 +1,7 @@
 package org.corfudb.runtime.exceptions;
 
+import java.util.Optional;
+
 import org.corfudb.protocols.logprotocol.SMREntry;
 
 /**
@@ -18,8 +20,10 @@ public class NoRollbackException extends RuntimeException {
                 + rollbackVersion + " so can't undo");
     }
 
-    public NoRollbackException(SMREntry entry, long address, long rollbackVersion) {
-        super("Can't roll back due to " + entry.getSMRMethod()
+    public NoRollbackException(Optional<SMREntry> entry, long address, long rollbackVersion) {
+        super("Can't roll back due to " +
+                (entry.isPresent() ?
+                entry.get().getSMRMethod() : "Unknown Entry")
                 + "@"
                 + address
                 + " but need "

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -1,7 +1,10 @@
 package org.corfudb.runtime.exceptions;
 
+import java.util.UUID;
+
 import lombok.Getter;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
+import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
 
 /**
  * Created by mwei on 1/11/16.
@@ -18,6 +21,9 @@ public class TransactionAbortedException extends RuntimeException {
     Integer conflictKey;
 
     @Getter
+    UUID conflictStream;
+
+    @Getter
     Throwable cause;
 
     /**
@@ -28,22 +34,28 @@ public class TransactionAbortedException extends RuntimeException {
      */
     public TransactionAbortedException(
             TxResolutionInfo txResolutionInfo,
-            Integer conflictKey, AbortCause abortCause) {
-        this(txResolutionInfo, conflictKey, abortCause, null);
+            Integer conflictKey, AbortCause abortCause, AbstractTransactionalContext context) {
+        this(txResolutionInfo, conflictKey, null, abortCause, null, context);
     }
 
     public TransactionAbortedException(
             TxResolutionInfo txResolutionInfo,
-            Integer conflictKey, AbortCause abortCause, Throwable cause) {
+            Integer conflictKey, UUID conflictStream,
+            AbortCause abortCause, Throwable cause, AbstractTransactionalContext context) {
         super("TX ABORT "
                 + " | Snapshot Time = " + txResolutionInfo.getSnapshotTimestamp()
                 + " | Transaction ID = " + txResolutionInfo.getTXid()
                 + " | Conflict Key = " + conflictKey
-                + " | Cause = " + abortCause);
+                + " | Conflict Stream = " + conflictStream
+                + " | Cause = " + abortCause
+                + " | Time = " + context == null ? "Unknown" :
+                System.currentTimeMillis() -
+                context.getStartTime() + " ms");
         this.txResolutionInfo = txResolutionInfo;
         this.conflictKey = conflictKey;
         this.abortCause = abortCause;
         this.cause = cause;
+        this.conflictStream = conflictStream;
 
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -26,6 +26,9 @@ public class TransactionAbortedException extends RuntimeException {
     @Getter
     Throwable cause;
 
+    @Getter
+    AbstractTransactionalContext context;
+
     /**
      * Constructor.
      * @param txResolutionInfo transaction information
@@ -56,7 +59,7 @@ public class TransactionAbortedException extends RuntimeException {
         this.abortCause = abortCause;
         this.cause = cause;
         this.conflictStream = conflictStream;
-
+        this.context = context;
     }
 
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -470,7 +470,8 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
 
             TxResolutionInfo txInfo = new TxResolutionInfo(
                     context.getTransactionID(), snapshotTimestamp);
-            tae = new TransactionAbortedException(txInfo, null, abortCause, e);
+            tae = new TransactionAbortedException(txInfo, null, getStreamID(),
+                    abortCause, e, context);
             context.abortTransaction(tae);
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -557,12 +557,7 @@ public class VersionLockedObject<T> {
                 }
             } else {
                 Optional<SMREntry> entry = entries.stream().findFirst();
-                if (entry.isPresent()) {
-                    throw new NoRollbackException(entry.get(), stream.pos(), rollbackVersion);
-                }
-                else {
-                    throw new NoRollbackException(rollbackVersion);
-                }
+                throw new NoRollbackException(entry, stream.pos(), rollbackVersion);
             }
 
             entries = stream.previous();

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -5,6 +5,7 @@ import io.netty.util.internal.ConcurrentSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -292,7 +293,7 @@ public class VersionLockedObject<T> {
                     try {
                         rollbackObjectUnsafe(timestamp);
                     } catch (NoRollbackException nre) {
-                        log.warn("SyncObjectUnsafe[{}] failed {}", this, nre);
+                        log.warn("SyncObjectUnsafe[{}] to {} failed {}", this, timestamp, nre);
                         resetUnsafe();
                     }
                 }
@@ -321,7 +322,7 @@ public class VersionLockedObject<T> {
                         return;
                     }
                 } catch (NoRollbackException nre) {
-                    log.warn("OptimisticRollback[{}] failed {}", this, nre);
+                    log.warn("OptimisticRollback[{}] to {} failed {}", this, timestamp, nre);
                     resetUnsafe();
                 }
             }
@@ -555,7 +556,13 @@ public class VersionLockedObject<T> {
                     applyUndoRecordUnsafe(it.previous());
                 }
             } else {
-                throw new NoRollbackException();
+                Optional<SMREntry> entry = entries.stream().findFirst();
+                if (entry.isPresent()) {
+                    throw new NoRollbackException(entry.get(), stream.pos(), rollbackVersion);
+                }
+                else {
+                    throw new NoRollbackException(rollbackVersion);
+                }
             }
 
             entries = stream.previous();
@@ -565,7 +572,7 @@ public class VersionLockedObject<T> {
             }
         }
 
-        throw new NoRollbackException();
+        throw new NoRollbackException(stream.pos(), rollbackVersion);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import lombok.Getter;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
@@ -44,6 +45,7 @@ import org.corfudb.util.Utils;
  * <p>Created by mwei on 4/4/16.
  */
 @Slf4j
+@ToString
 public abstract class AbstractTransactionalContext implements
         Comparable<AbstractTransactionalContext> {
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -84,7 +84,6 @@ public abstract class AbstractTransactionalContext implements
     public final TransactionBuilder builder;
 
     /**
-     * TODO remove this!
      * The start time of the context.
      */
     @Getter
@@ -127,7 +126,6 @@ public abstract class AbstractTransactionalContext implements
         transactionID = UUID.randomUUID();
         this.builder = builder;
 
-        // TODO remove this
         startTime = System.currentTimeMillis();
 
         parentContext = TransactionalContext.getCurrentContext();

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -121,7 +121,8 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                                         new TransactionAbortedException(
                                                 new TxResolutionInfo(getTransactionID(),
                                                         getSnapshotTimestamp()), null,
-                                                AbortCause.TRIM, te);
+                                                        proxy.getStreamID(),
+                                                AbortCause.TRIM, te, this);
                                 abortTransaction(tae);
                                 throw tae;
                             }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -59,7 +59,9 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
                         TransactionAbortedException tae =
                                 new TransactionAbortedException(
                                         new TxResolutionInfo(getTransactionID(),
-                                                getSnapshotTimestamp()), null, AbortCause.TRIM, te);
+                                                getSnapshotTimestamp()), null,
+                                                proxy.getStreamID(),
+                                                AbortCause.TRIM, te, this);
                         abortTransaction(tae);
                         throw tae;
                     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -146,7 +146,7 @@ public class ObjectsView extends AbstractView {
             TxResolutionInfo txInfo = new TxResolutionInfo(
                     context.getTransactionID(), context.getSnapshotTimestamp());
             context.abortTransaction(new TransactionAbortedException(
-                    txInfo, null, AbortCause.USER));
+                    txInfo, null, AbortCause.USER, context));
             TransactionalContext.removeContext();
         }
     }
@@ -177,11 +177,9 @@ public class ObjectsView extends AbstractView {
             log.warn("Attempted to end a transaction, but no transaction active!");
             return AbstractTransactionalContext.UNCOMMITTED_ADDRESS;
         } else {
-            // TODO remove this, doesn't belong here!
             long totalTime = System.currentTimeMillis() - context.getStartTime();
             log.trace("TXCommit[{}] time={} ms",
                     context, totalTime);
-            // TODO up to here
             try {
                 return TransactionalContext.getCurrentContext().commitTransaction();
             } catch (TransactionAbortedException e) {
@@ -207,8 +205,8 @@ public class ObjectsView extends AbstractView {
 
                 TxResolutionInfo txInfo = new TxResolutionInfo(context.getTransactionID(),
                         snapshotTimestamp);
-                TransactionAbortedException tae = new TransactionAbortedException(txInfo, null,
-                        abortCause, e);
+                TransactionAbortedException tae = new TransactionAbortedException(txInfo,
+                        null, null, abortCause, e, context);
                 context.abortTransaction(tae);
                 throw tae;
             } finally {

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -18,6 +18,8 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.Utils;
 
@@ -112,7 +114,8 @@ public class StreamsView extends AbstractView {
                 throw new TransactionAbortedException(
                         conflictInfo,
                         tokenResponse.getConflictKey(),
-                        AbortCause.CONFLICT
+                        AbortCause.CONFLICT,
+                        TransactionalContext.getCurrentContext()
                 );
             }
 
@@ -120,7 +123,8 @@ public class StreamsView extends AbstractView {
                 throw new TransactionAbortedException(
                         conflictInfo,
                         tokenResponse.getConflictKey(),
-                        AbortCause.NEW_SEQUENCER
+                        AbortCause.NEW_SEQUENCER,
+                        TransactionalContext.getCurrentContext()
                 );
             }
 


### PR DESCRIPTION
This PR introduces additional logging, for TransactionAbortedException
the id of the stream is added whenever possible, for NoRollbackException
the cause of the failed undo is added to the exception message.
1