### PR TITLE
Fix Version Object Trim Race

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedException.java
@@ -1,10 +1,22 @@
 package org.corfudb.runtime.exceptions;
 
+import lombok.Getter;
+import lombok.Setter;
+import org.corfudb.runtime.view.Address;
+
 /**
  * This exception is thrown when a client tries to read an address
  * that has been trimmed.
  */
 public class TrimmedException extends LogUnitException {
+    @Getter
+    @Setter
+    long address = Address.NON_ADDRESS;
+
+    @Getter
+    @Setter
+    long snapshot = Address.NON_ADDRESS;
+
     public TrimmedException() {
 
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -98,6 +98,10 @@ public abstract class AbstractTransactionalContext implements
     private final long snapshotTimestamp = obtainSnapshotTimestamp();
 
 
+    @Getter
+    private volatile int retry = 0;
+
+
     /**
      * The address that the transaction was committed at.
      */
@@ -133,6 +137,10 @@ public abstract class AbstractTransactionalContext implements
         parentContext = TransactionalContext.getCurrentContext();
 
         AbstractTransactionalContext.log.debug("TXBegin[{}]", this);
+    }
+
+    public synchronized void incrementRetry() {
+        retry++;
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -154,7 +154,9 @@ public class AddressSpaceView extends AbstractView {
                 throw new RuntimeException("Unexpected return of empty data at address "
                         + address + " on read");
             } else if (data.isTrimmed()) {
-                throw new TrimmedException();
+                TrimmedException te = new TrimmedException();
+                te.setAddress(address);
+                throw te;
             }
             return data;
         }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -120,13 +120,13 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
      *
      * */
     @Override
-    protected ILogData read(final long address) {
+    protected ILogData readImpl(final long address) {
         return runtime.getAddressSpaceView().read(address);
     }
 
     @Nonnull
     @Override
-    protected List<ILogData> readAll(@Nonnull List<Long> addresses) {
+    protected List<ILogData> readAllImpl(@Nonnull List<Long> addresses) {
         Map<Long, ILogData> dataMap =
                 runtime.getAddressSpaceView().read(addresses);
         return addresses.stream()
@@ -311,7 +311,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
      * {@inheritDoc}
      */
     @Override
-    protected boolean fillReadQueue(final long maxGlobal,
+    protected boolean fillReadQueueImpl(final long maxGlobal,
                                  final QueuedStreamContext context) {
         log.trace("Read_Fill_Queue[{}] Max: {}, Current: {}, Resolved: {} - {}", this,
                 maxGlobal, context.globalPointer, context.maxResolution, context.minResolution);


### PR DESCRIPTION
This patch fixes a race when a transaction starts with a time
stamp that is greater than the trim mark, but then fails with
a TrimmedException.