### PR TITLE
Fix Version Object Trim Race

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -120,6 +120,13 @@ public class CorfuRuntime {
     public long maxCacheSize = 4_000_000_000L;
 
     /**
+     * The number of times to retry on a retriable TrimException within during a tranasaction
+     */
+    @Getter
+    @Setter
+    public int trimRetry = 2;
+
+    /**
      * Sets expireAfterAccess and expireAfterWrite in seconds.
      */
     @Getter

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedException.java
@@ -1,15 +1,27 @@
 package org.corfudb.runtime.exceptions;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * This exception is thrown when a client tries to read an address
  * that has been trimmed.
  */
 public class TrimmedException extends LogUnitException {
-    public TrimmedException() {
 
+    /*
+     * This flag determins whether the operation that caused this exception
+     * can retry or not.
+     */
+    @Getter
+    @Setter
+    private boolean retriable = true;
+
+    public TrimmedException() {
     }
 
     public TrimmedException(String message) {
         super(message);
+        retriable = true;
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -50,20 +50,26 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
                         == getSnapshotTimestamp()
                         && !o.isOptimisticallyModifiedUnsafe(),
                 o -> {
-                    try {
-                        o.syncObjectUnsafe(getSnapshotTimestamp());
-                    } catch (TrimmedException te) {
-                        // If a trim is encountered, we must reset the object
-                        o.resetUnsafe();
-                        // and abort the transaction
-                        TransactionAbortedException tae =
-                                new TransactionAbortedException(
-                                        new TxResolutionInfo(getTransactionID(),
-                                                getSnapshotTimestamp()), null,
+                    for (int x = 0; x < this.builder.getRuntime().getTrimRetry(); x++) {
+                        try {
+                            o.syncObjectUnsafe(getSnapshotTimestamp());
+                            break;
+                        } catch (TrimmedException te) {
+                            // If a trim is encountered, we must reset the object
+                            o.resetUnsafe();
+                            if (!te.isRetriable()
+                                    || x == this.builder.getRuntime().getTrimRetry() - 1) {
+                                // abort the transaction
+                                TransactionAbortedException tae =
+                                        new TransactionAbortedException(
+                                                new TxResolutionInfo(getTransactionID(),
+                                                        getSnapshotTimestamp()), null,
                                                 proxy.getStreamID(),
                                                 AbortCause.TRIM, te, this);
-                        abortTransaction(tae);
-                        throw tae;
+                                abortTransaction(tae);
+                                throw tae;
+                            }
+                        }
                     }
                 },
                 o -> accessFunction.access(o));

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -168,10 +168,20 @@ public class AddressSpaceView extends AbstractView {
      * @return A result, which be cached.
      */
     public Map<Long, ILogData> read(Iterable<Long> addresses) {
+        Map<Long, ILogData> addressesMap;
         if (!runtime.isCacheDisabled()) {
-            return readCache.getAll(addresses);
+            addressesMap = readCache.getAll(addresses);
+        } else {
+            addressesMap = this.cacheFetch(addresses);
         }
-        return this.cacheFetch(addresses);
+
+        for (ILogData logData : addressesMap.values()) {
+            if (logData.isTrimmed()) {
+                throw new TrimmedException();
+            }
+        }
+
+        return addressesMap;
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -521,4 +521,56 @@ public class CheckpointTest extends AbstractObjectTest {
         getMyRuntime().getAddressSpaceView().gc();
         getMyRuntime().getAddressSpaceView().gc();
     }
+
+    @Test
+    public void transactionalReadAfterCheckpoint() throws Exception {
+        Map<String, String> testMap = getDefaultRuntime().getObjectsView().build()
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {
+                })
+                .setStreamName("test")
+                .open();
+
+        Map<String, String> testMap2 = getDefaultRuntime().getObjectsView().build()
+                .setTypeToken(new TypeToken<SMRMap<String, String>>() {
+                })
+                .setStreamName("test2")
+                .open();
+
+        // Place entries into the map
+        testMap.put("a", "a");
+        testMap.put("b", "a");
+        testMap.put("c", "a");
+        testMap2.put("a", "c");
+        testMap2.put("b", "c");
+        testMap2.put("c", "c");
+
+        // Insert a checkpoint
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap((SMRMap) testMap);
+        mcw.addMap((SMRMap) testMap2);
+        long checkpointAddress = mcw.appendCheckpoints(getRuntime(), "author");
+
+
+        // TX1: Move object to 1
+        getRuntime().getObjectsView().TXBuild()
+                .setType(TransactionType.SNAPSHOT)
+                .setSnapshot(1)
+                .begin();
+
+        testMap.get("a");
+        getRuntime().getObjectsView().TXEnd();
+
+
+        // Trim the log
+        getRuntime().getAddressSpaceView().prefixTrim(checkpointAddress - 1);
+        getRuntime().getAddressSpaceView().gc();
+        getRuntime().getAddressSpaceView().invalidateServerCaches();
+        getRuntime().getAddressSpaceView().invalidateClientCache();
+
+        // TX2: Read most recent state in TX
+        getRuntime().getObjectsView().TXBegin();
+        testMap.get("a");
+        getRuntime().getObjectsView().TXEnd();
+
+    }
 }


### PR DESCRIPTION
This patch fixes a race when a transaction starts with a time
stamp that is greater than the checkpoint snapshot time, but
then fails with a TrimmedException.