### PR TITLE
Fix LogData getSizeEstimate

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -7,6 +7,7 @@ import java.util.EnumMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.LogEntry;
@@ -16,6 +17,7 @@ import org.corfudb.util.serializer.Serializers;
 /**
  * Created by mwei on 8/15/16.
  */
+@Slf4j
 public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
 
     public static final LogData EMPTY = new LogData(DataType.EMPTY);
@@ -29,6 +31,8 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
     byte[] data;
 
     private ByteBuf serializedCache = null;
+
+    private int lastKnownSize = 0;
 
     private final transient AtomicReference<Object> payload = new AtomicReference<>();
 
@@ -80,6 +84,7 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         if (serializedCache == null) {
             serializedCache = Unpooled.buffer();
             doSerializeInternal(serializedCache);
+            lastKnownSize = serializedCache.array().length;
         } else {
             serializedCache.retain();
         }
@@ -89,7 +94,11 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
     public int getSizeEstimate() {
         if (data != null) {
             return data.length;
+        } else if (lastKnownSize != 0) {
+            return lastKnownSize;
         }
+        log.warn("getSizeEstimate: LogData size estimate is defaulting to 1,"
+                + " this might cause leaks in the cache!");
         return 1;
     }
 


### PR DESCRIPTION
This patch maintains the size of a LogData instance as it changes
and gets serialized multiple times.