### PR TITLE
Ignore Trimming Trimmed Addresses

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -12,12 +12,15 @@ import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * This class implements the StreamLog interface using a Java hash map.
  * The stream log is only stored in-memory and not persisted.
  * This should only be used for testing.
  * Created by maithem on 7/21/16.
  */
+@Slf4j
 public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressSpace {
 
     private final AtomicLong globalTail = new AtomicLong(0L);
@@ -59,10 +62,11 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
 
     @Override
     public synchronized void prefixTrim(long address) {
-        if(isTrimmed(address)){
-            throw new TrimmedException();
+        if (isTrimmed(address)) {
+            log.warn("prefixTrim: Ignoring repeated trim {}", address);
+        } else {
+            startingAddress = address + 1;
         }
-        startingAddress = address + 1;
     }
 
     @Override
@@ -71,7 +75,9 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
     }
 
     @Override
-    public long getTrimMark() { return startingAddress; }
+    public long getTrimMark() {
+        return startingAddress;
+    }
 
     private void throwLogUnitExceptionsIfNecessary(long address, LogData entry) {
         if (entry.getRank() == null) {
@@ -89,7 +95,7 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
 
     @Override
     public LogData read(long address) {
-        if(isTrimmed(address)){
+        if (isTrimmed(address)) {
             return LogData.TRIMMED;
         }
         if (trimmed.contains(address)) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -213,7 +213,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     @Override
     public void prefixTrim(long address) {
         if (address < startingAddress) {
-            throw new TrimmedException();
+            log.warn("prefixTrim: Ignoring repeated trim {}", address);
         } else {
             // TODO(Maithem): Although this operation is persisted to disk,
             // the startingAddress can be lost even after the method has completed.

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -416,8 +416,8 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         }
 
         // Try to trim an address that is less than the new starting address
-        assertThatThrownBy(() -> log.prefixTrim(trimAddress))
-                .isInstanceOf(TrimmedException.class);
+        // This shouldn't throw an exception
+        log.prefixTrim(trimAddress);
 
         long trimmedExceptions = 0;
 

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -506,16 +506,11 @@ public class CheckpointTest extends AbstractObjectTest {
     @Test
     public void prefixTrimTwiceAtSameAddress() throws Exception {
         final int mapSize = 5;
-        ThrowableAssert.ThrowingCallable trim = () -> getMyRuntime().getAddressSpaceView().prefixTrim(2);
-
         populateMaps(mapSize);
-        try {
-            trim.call();
-        } catch (Throwable t) {
-            throw new Exception("First trim call shouldn't fail");
-        }
-        // Trim again in exactly the same place should fail
-        assertThatThrownBy(trim).hasCauseInstanceOf(ExecutionException.class);
+
+        // Trim again in exactly the same place shouldn't fail
+        getMyRuntime().getAddressSpaceView().prefixTrim(2);
+        getMyRuntime().getAddressSpaceView().prefixTrim(2);
 
         // GC twice at the same place should be fine.
         getMyRuntime().getAddressSpaceView().gc();


### PR DESCRIPTION
This patch changes the behavior of prefixTrim, instead of throwing
an exception on prefix trimming a trimmed address, it just ignores
the request.