### PR TITLE
Release referenced message object in NettyServerRouter

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.util.ReferenceCountUtil;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -148,6 +149,9 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
             }
         } catch (Exception e) {
             log.error("Exception during read!", e);
+        } finally {
+            // Releasing referenced counted objects passed to the handler.
+            ReferenceCountUtil.release(msg);
         }
     }
 


### PR DESCRIPTION
Releasing referenced message object held by NettyServerRouter.