### PR TITLE
CP Empty Maps

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
@@ -72,9 +72,6 @@ public class MultiCheckpointWriter {
         try {
             for (ICorfuSMR<Map> map : maps) {
                 UUID streamId = map.getCorfuStreamID();
-                if (((Map)map).size() == 0) {
-                    continue;
-                }
 
                 while (true) {
                     CheckpointWriter cpw = new CheckpointWriter(rt, streamId, author, (SMRMap) map);

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -61,8 +61,9 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(CorfuRuntime.getStreamID("S1"));
         final int objSize = 100;
         long a1 = sv.append(new byte[objSize]);
-        final long firstAddress = 0L;
-        assertThat(a1).isEqualTo(firstAddress);
+        final long cpEndAddress = 2L;
+        // Verify that the start/end records have been written for empty maps
+        assertThat(a1).isEqualTo(cpEndAddress);
     }
 
     /** First smoke test, steps:
@@ -524,6 +525,49 @@ public class CheckpointSmokeTest extends AbstractViewTest {
             assertThat(m2A.get(keyA)).isEqualTo(i);
             assertThat(m2B.get(keyB)).isEqualTo(i);
         }
+    }
+
+    @Test
+    public void emptyCheckPoint() throws Exception {
+        final String streamA = "streamA";
+        final String streamB = "streamB";
+        Map<String, Long> mA = instantiateMap(streamA);
+        Map<String, Long> mB = instantiateMap(streamB);
+        final String author = "CPWriter";
+        final int iter = 1000;
+
+        for (int x = 0; x < iter; x++) {
+            mA.put(Integer.toString(x), (long) x);
+            mB.put(Integer.toString(x), (long) x);
+        }
+
+        for (String key : mA.keySet()) {
+            mA.remove(key);
+        }
+
+        MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
+        mcw1.addMap((SMRMap) mA);
+        mcw1.addMap((SMRMap) mB);
+        long trimAddress = mcw1.appendCheckpoints(r, author);
+
+        r.getAddressSpaceView().prefixTrim(trimAddress - 1);
+        r.getAddressSpaceView().gc();
+        r.getAddressSpaceView().invalidateServerCaches();
+        r.getAddressSpaceView().invalidateClientCache();
+
+        CorfuRuntime rt2 = new CorfuRuntime(getDefaultEndpoint()).connect();
+
+        Map<String, Long> mA2 = rt2.getObjectsView()
+                .build()
+                .setStreamName(streamA)
+                .setTypeToken(new TypeToken<SMRMap<String, Long>>() {
+                })
+                .setSerializer(serializer)
+                .open();
+
+        rt2.getObjectsView().TXBegin();
+        mA2.put("a", 2l);
+        rt2.getObjectsView().TXEnd();
     }
 }
 


### PR DESCRIPTION
This patch logically revers PR#808 and adds a new test case
which encodes an edge case where accessing an empty map
doesn't cause a StackOverflowException.