### PR TITLE
Sequencer reset after paxos & protected by ready/not-ready state

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -27,7 +27,10 @@ public abstract class AbstractServer {
      */
     public abstract CorfuMsgHandler getHandler();
 
-    public abstract boolean isServerReady();
+    public boolean isServerReadyToHandleMsg(CorfuMsg msg) {
+        // Overridden in sequencer to mark ready/not-ready state.
+        return true;
+    }
 
     /**
      * Handle a incoming Netty message.
@@ -42,7 +45,7 @@ public abstract class AbstractServer {
         }
         boolean isMetricsEnabled = MetricsUtils.isMetricsCollectionEnabled();
 
-        if (!this.isServerReady()) {
+        if (!this.isServerReadyToHandleMsg(msg)) {
             log.warn("Received message {} but Server not ready." , msg.getMsgType());
             r.sendResponse(ctx, msg, CorfuMsgType.NOT_READY.msg());
             return;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -75,9 +75,4 @@ public class BaseServer extends AbstractServer {
         Utils.sleepUninterruptibly(500); // Sleep, to make sure that all channels are flushed...
         System.exit(100);
     }
-
-    @Override
-    public boolean isServerReady() {
-        return true;
-    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -271,8 +271,6 @@ public class CorfuServer {
 
         // Create a common Server Context for all servers to access.
         serverContext = new ServerContext(opts, router);
-        // All servers wait for startup trigger from Management Server.
-        serverContext.setReady(false);
 
         // Add each role to the router.
         addSequencer();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/FailureHandlerDispatcher.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/FailureHandlerDispatcher.java
@@ -36,20 +36,12 @@ public class FailureHandlerDispatcher {
      * @param corfuRuntime   Connected runtime
      * @return True if the cluster was recovered, False otherwise
      */
-    public boolean recoverCluster(ServerContext serverContext, Layout recoveryLayout,
-                                  CorfuRuntime corfuRuntime) {
+    public boolean recoverCluster(Layout recoveryLayout, CorfuRuntime corfuRuntime) {
 
         try {
             // Seals and increments the epoch.
             recoveryLayout.setRuntime(corfuRuntime);
             sealEpoch(recoveryLayout);
-            log.info("After seal: {}", recoveryLayout.asJSONString());
-
-            // Mark all components on node as ready after sealing.
-            serverContext.setReady(true);
-
-            // Reconfigure servers if required
-            reconfigureServers(corfuRuntime, recoveryLayout, recoveryLayout, true);
 
             // Attempts to update all the layout servers with the modified layout.
             while (true) {
@@ -70,7 +62,18 @@ public class FailureHandlerDispatcher {
             corfuRuntime.invalidateLayout();
             if (corfuRuntime.getLayoutView().getLayout().equals(recoveryLayout)) {
                 log.info("Layout Recovered = {}", recoveryLayout);
+            } else {
+                log.warn("Layout recovered with a different layout = {}",
+                        corfuRuntime.getLayoutView().getLayout());
             }
+
+            //TODO: Since sequencer reset is moved after paxos. Make sure the runtime has the latest
+            //TODO: layout view and latest client router epoch. (Use quorum layout fetch.)
+            //TODO: Handle condition if primary sequencer is not marked ready, reset fails.
+            // Reconfigure servers if required
+            // Primary sequencer would already be in a not-ready state since its in recovery.
+            reconfigureServers(corfuRuntime, recoveryLayout, recoveryLayout, true);
+
         } catch (Exception e) {
             log.error("Error: recovery: {}", e);
             return false;
@@ -101,9 +104,6 @@ public class FailureHandlerDispatcher {
             currentLayout.setRuntime(corfuRuntime);
             sealEpoch(currentLayout);
 
-            // Reconfigure servers if required
-            reconfigureServers(corfuRuntime, currentLayout, newLayout, false);
-
             // Attempts to update all the layout servers with the modified layout.
             try {
                 corfuRuntime.getLayoutView().updateLayout(newLayout, prepareRank);
@@ -119,7 +119,17 @@ public class FailureHandlerDispatcher {
             corfuRuntime.invalidateLayout();
             if (corfuRuntime.getLayoutView().getLayout().equals(newLayout)) {
                 log.info("Failed node removed. New Layout committed = {}", newLayout);
+            } else {
+                log.warn("Layout recovered with a different layout = {}",
+                        corfuRuntime.getLayoutView().getLayout());
             }
+
+            //TODO: Since sequencer reset is moved after paxos. Make sure the runtime has the latest
+            //TODO: layout view and latest client router epoch. (Use quorum layout fetch.)
+            //TODO: Handle condition if primary sequencer is not marked ready, reset fails.
+            // Reconfigure servers if required
+            reconfigureServers(corfuRuntime, currentLayout, newLayout, false);
+
         } catch (Exception e) {
             log.error("Error: dispatchHandler: {}", e);
         }
@@ -205,9 +215,17 @@ public class FailureHandlerDispatcher {
                 verifyStreamTailsMap(streamTails);
 
                 // Configuring the new sequencer.
-                newLayout.getSequencer(0).reset(maxTokenRequested + 1, streamTails).get();
+                boolean sequencerBootstrapResult = newLayout.getSequencer(0)
+                        .bootstrap(maxTokenRequested + 1, streamTails,
+                                newLayout.getEpoch()).get();
+                if (sequencerBootstrapResult) {
+                    log.info("Sequencer bootstrap successful.");
+                } else {
+                    log.warn("Sequencer bootstrap failed. Already bootstrapped.");
+                }
+
             } catch (InterruptedException e) {
-                log.error("Sequencer Reset interrupted : {}", e);
+                log.error("Sequencer bootstrap interrupted : {}", e);
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -81,11 +81,6 @@ public class LayoutServer extends AbstractServer {
     private CorfuMsgHandler handler = new CorfuMsgHandler()
             .generateHandlers(MethodHandles.lookup(), this);
 
-    @Override
-    public boolean isServerReady() {
-        return true;
-    }
-
     private static final String metricsPrefix = "corfu.server.layout.";
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -101,19 +101,11 @@ public class LogUnitServer extends AbstractServer {
 
     private static final String metricsPrefix = "corfu.server.logunit.";
 
-    private final ServerContext serverContext;
-
-    @Override
-    public boolean isServerReady() {
-        return serverContext.isReady();
-    }
-
     /**
      * Returns a new LogUnitServer.
      * @param serverContext context object providing settings and objects
      */
     public LogUnitServer(ServerContext serverContext) {
-        this.serverContext = serverContext;
         this.opts = serverContext.getServerConfig();
         double cacheSizeHeapRatio = Double.parseDouble((String) opts.get("--cache-heap-ratio"));
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -62,17 +62,12 @@ public class ServerContext {
     @Getter
     public static final MetricRegistry metrics = new MetricRegistry();
 
-    @Getter
-    @Setter
-    private volatile boolean ready;
-
     /**
      * Returns a new ServerContext.
      * @param serverConfig map of configuration strings to objects
      * @param serverRouter server router
      */
     public ServerContext(Map<String, Object> serverConfig, IServerRouter serverRouter) {
-        this.ready = true;
         this.serverConfig = serverConfig;
         this.dataStore = new DataStore(serverConfig);
         this.serverRouter = serverRouter;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -47,7 +47,7 @@ public enum CorfuMsgType {
     // Sequencer Messages
     TOKEN_REQ(20, new TypeToken<CorfuPayloadMsg<TokenRequest>>(){}),
     TOKEN_RES(21, new TypeToken<CorfuPayloadMsg<TokenResponse>>(){}),
-    RESET_SEQUENCER(22, new TypeToken<CorfuPayloadMsg<SequencerTailsRecoveryMsg>>(){}),
+    BOOTSTRAP_SEQUENCER(22, new TypeToken<CorfuPayloadMsg<SequencerTailsRecoveryMsg>>(){}),
 
     // Logging Unit Messages
     WRITE(30, new TypeToken<CorfuPayloadMsg<WriteRequest>>() {}),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/SequencerTailsRecoveryMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/SequencerTailsRecoveryMsg.java
@@ -16,10 +16,12 @@ public class SequencerTailsRecoveryMsg implements ICorfuPayload<SequencerTailsRe
 
     private Long globalTail;
     private Map<UUID, Long> streamTails;
+    private Long readyStateEpoch;
 
     public SequencerTailsRecoveryMsg(ByteBuf buf) {
         globalTail = ICorfuPayload.fromBuffer(buf, Long.class);
         streamTails = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
+        readyStateEpoch = ICorfuPayload.fromBuffer(buf, Long.class);
     }
 
     @Override
@@ -27,6 +29,7 @@ public class SequencerTailsRecoveryMsg implements ICorfuPayload<SequencerTailsRe
 
         ICorfuPayload.serialize(buf, globalTail);
         ICorfuPayload.serialize(buf, streamTails);
+        ICorfuPayload.serialize(buf, readyStateEpoch);
     }
 }
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -71,8 +71,10 @@ public class SequencerClient implements IClient {
      * @param initialToken Token Number which the sequencer starts distributing.
      * @return A CompletableFuture which completes once the sequencer is reset.
      */
-    public CompletableFuture<Boolean> reset(Long initialToken, Map<UUID, Long> sequencerTails) {
-        return router.sendMessageAndGetCompletable(CorfuMsgType.RESET_SEQUENCER
-                .payloadMsg(new SequencerTailsRecoveryMsg(initialToken, sequencerTails)));
+    public CompletableFuture<Boolean> bootstrap(Long initialToken, Map<UUID, Long> sequencerTails,
+                                            Long readyStateEpoch) {
+        return router.sendMessageAndGetCompletable(CorfuMsgType.BOOTSTRAP_SEQUENCER
+                .payloadMsg(new SequencerTailsRecoveryMsg(initialToken, sequencerTails,
+                        readyStateEpoch)));
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure;
 
 import org.corfudb.protocols.wireprotocol.*;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -19,10 +20,17 @@ public class SequencerServerTest extends AbstractServerTest {
         super();
     }
 
+    SequencerServer server;
+
     @Override
     public AbstractServer getDefaultServer() {
-        return new
-                SequencerServer(ServerContextBuilder.emptyContext());
+        server = new SequencerServer(ServerContextBuilder.emptyContext());
+        return server;
+    }
+
+    @Before
+    public void bootstrapSequencer() {
+        server.setReadyStateEpoch(0L);
     }
 
     @Test
@@ -193,8 +201,10 @@ public class SequencerServerTest extends AbstractServerTest {
         tailMap.put(streamB, newTailB);
         tailMap.put(streamC, newTailC);
 
-        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.RESET_SEQUENCER,
-                new SequencerTailsRecoveryMsg(globalTail + 2, tailMap)));
+        // Modifying the readyStateEpoch to simulate sequencer reset.
+        server.setReadyStateEpoch(-1L);
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.BOOTSTRAP_SEQUENCER,
+                new SequencerTailsRecoveryMsg(globalTail + 2, tailMap, 0L)));
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(0L, Collections.singleton(streamA))));

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -14,6 +14,7 @@ import java.io.*;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -211,9 +212,12 @@ public class AbstractIT extends AbstractCorfuTest {
         private InputStream inputStream;
         private String logfile;
 
-        public StreamGobbler(InputStream inputStream, String logfile) {
+        public StreamGobbler(InputStream inputStream, String logfile) throws IOException {
             this.inputStream = inputStream;
             this.logfile = logfile;
+            if (Files.notExists(Paths.get(logfile))) {
+                Files.createFile(Paths.get(logfile));
+            }
         }
 
         @Override
@@ -221,7 +225,10 @@ public class AbstractIT extends AbstractCorfuTest {
             new BufferedReader(new InputStreamReader(inputStream)).lines()
                     .forEach((x) -> {
                                 try {
-                                    Files.write(Paths.get(logfile), x.getBytes());
+                                    Files.write(Paths.get(logfile), x.getBytes(),
+                                            StandardOpenOption.APPEND);
+                                    Files.write(Paths.get(logfile), "\n".getBytes(),
+                                            StandardOpenOption.APPEND);
                                 } catch (Exception e) {
                                     e.printStackTrace();
                                 }
@@ -236,7 +243,7 @@ public class AbstractIT extends AbstractCorfuTest {
     public static class CorfuServerRunner {
 
         private boolean single = true;
-        private String logLevel = "TRACE";
+        private String logLevel = "INFO";
         private String host = DEFAULT_HOST;
         private int port = DEFAULT_PORT;
         private String managementBootstrap = null;

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -1,10 +1,12 @@
 package org.corfudb.integration;
 
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.SequencerClient;
 import org.corfudb.runtime.view.Layout;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -46,6 +48,14 @@ public class SealIT extends AbstractIT{
         currentLayout.moveServersToEpoch();
         /* 3 */
         cr1.getLayoutView().updateLayout(currentLayout, 0);
+
+        cr1.invalidateLayout();
+        cr1.layout.get();
+
+        cr1.getRouter(corfuSingleNodeHost + ":" + corfuSingleNodePort)
+                .getClient(SequencerClient.class)
+                .bootstrap(1L, Collections.EMPTY_MAP, currentLayout.getEpoch())
+                .get();
 
 
         /* Now cr2 is still stuck in the previous epoch. The next time it will ask for a token,

--- a/test/src/test/java/org/corfudb/runtime/clients/SequencerClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/SequencerClientTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import org.corfudb.infrastructure.AbstractServer;
 import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
@@ -32,6 +33,11 @@ public class SequencerClientTest extends AbstractClientTest {
         return new ImmutableSet.Builder<IClient>()
                 .add(client)
                 .build();
+    }
+
+    @Before
+    public void bootstrapSequencer() {
+        client.bootstrap(0L, Collections.EMPTY_MAP, 0L);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapEntrySetTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapEntrySetTest.java
@@ -6,6 +6,7 @@ import org.corfudb.runtime.object.transactions.AbstractTransactionsTest;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -77,7 +78,9 @@ public class SMRMapEntrySetTest extends AbstractTransactionsTest {
         CountDownLatch l1 = new CountDownLatch(1);
         CountDownLatch l2 = new CountDownLatch(1);
         CountDownLatch l3 = new CountDownLatch(1);
-        CountDownLatch l4 = new CountDownLatch(1);
+
+        // Block until sequencer operational.
+        r.getSequencerView().nextToken(Collections.EMPTY_SET, 0);
 
         // first thread: create and manipulate map
         scheduleConcurrently(t -> {

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -6,6 +6,7 @@ import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.junit.Test;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -274,6 +275,9 @@ public class CompileProxyTest extends AbstractViewTest {
                 .open();
         int concurrency = PARAMETERS.CONCURRENCY_LOTS;
 
+        // Blocking until sequencer becomes functional.
+        getDefaultRuntime().getSequencerView().nextToken(Collections.EMPTY_SET, 0);
+
         // schedule 'concurrency' number of threads,
         // each one put()'s a key with its thread index
 
@@ -338,7 +342,10 @@ public class CompileProxyTest extends AbstractViewTest {
 
         int concurrency = PARAMETERS.CONCURRENCY_LOTS;
 
-        // set up 'concurrency' number of threads that concurrency update sharedCorfuCompound, each to a differen value
+        // Block until sequencer operational.
+        getDefaultRuntime().getSequencerView().nextToken(Collections.EMPTY_SET, 0);
+
+        // set up 'concurrency' number of threads that concurrency update sharedCorfuCompound, each to a different value
         scheduleConcurrently(concurrency, t -> {
             sharedCorfuCompound.set(sharedCorfuCompound.new Inner("A"+t, "B"+t), t);
         });

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -14,6 +14,7 @@ import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.infrastructure.TestServerRouter;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.LayoutBootstrapRequest;
+import org.corfudb.protocols.wireprotocol.SequencerTailsRecoveryMsg;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.BaseClient;
 import org.corfudb.runtime.clients.IClientRouter;
@@ -26,6 +27,7 @@ import org.corfudb.runtime.clients.TestRule;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
@@ -238,6 +240,10 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
                             .handleMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST.payloadMsg(l),
                                     null, e.getValue().serverRouter);
                 });
+        TestServer primarySequencerNode = testServerMap.get(l.getSequencers().get(0));
+        primarySequencerNode.sequencerServer
+                .handleMessage(CorfuMsgType.BOOTSTRAP_SEQUENCER.payloadMsg(new SequencerTailsRecoveryMsg(0L,
+                        Collections.EMPTY_MAP, l.getEpoch())), null, primarySequencerNode.serverRouter);
     }
 
     /** Get a default CorfuRuntime. The default CorfuRuntime is connected to a single-node

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -18,7 +18,6 @@ import org.corfudb.runtime.clients.TestRule;
 import org.corfudb.runtime.collections.ISMRMap;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Test;
 
@@ -26,7 +25,9 @@ import java.util.Collections;
 import java.util.Map;
 
 import java.util.UUID;
-import java.util.concurrent.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
@@ -78,7 +79,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .setEpoch(1L)
                 .addLayoutServer(SERVERS.PORT_0)
                 .addLayoutServer(SERVERS.PORT_1)
-                .addSequencer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_1)
                 .buildSegment()
                 .buildStripe()
                 .addLogUnit(SERVERS.PORT_0)
@@ -413,6 +414,10 @@ public class ManagementViewTest extends AbstractViewTest {
 
         induceSequencerFailureAndWait();
 
+        // Block until new sequencer reaches READY state.
+        getCorfuRuntime().getSequencerView().nextToken(
+                Collections.singleton(CorfuRuntime.getStreamID("streamA")),
+                0);
         // verify that a failover sequencer was started with the correct starting-tail
         //
         assertThat(getSequencer(SERVERS.PORT_0).getGlobalLogTail().get()).isEqualTo(beforeFailure);
@@ -711,9 +716,9 @@ public class ManagementViewTest extends AbstractViewTest {
         getManagementServer(SERVERS.PORT_2).shutdown();
         addClientRule(getManagementServer(SERVERS.PORT_0).getCorfuRuntime(),
                 new TestRule().matches(msg -> {
-                    if (msg.getMsgType().equals(CorfuMsgType.RESET_SEQUENCER)) {
+                    if (msg.getMsgType().equals(CorfuMsgType.BOOTSTRAP_SEQUENCER)) {
                         try {
-                            // There is a failure but the RESET_SEQUENCER message has not yet been
+                            // There is a failure but the BOOTSTRAP_SEQUENCER message has not yet been
                             // sent. So if we request a token now, we should be denied as the
                             // server is sealed and we get a WrongEpochException.
                             corfuRuntime
@@ -736,9 +741,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .isTrue();
 
         // We should be able to request a token now.
-        corfuRuntime.getRouter(SERVERS.ENDPOINT_0).getClient(SequencerClient.class)
-                .nextToken(Collections.singleton(CorfuRuntime
-                        .getStreamID("testStream")), 1).get();
-
+        corfuRuntime.getSequencerView().nextToken(Collections.singleton(CorfuRuntime
+                .getStreamID("testStream")), 1);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
@@ -1,9 +1,12 @@
 package org.corfudb.runtime.view;
 
+import org.corfudb.runtime.clients.SequencerClient;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertNotNull;
+
+import java.util.Collections;
 
 /**
  * Created by kspirov
@@ -13,13 +16,16 @@ public class QuorumReplicationStreamViewTest extends StreamViewTest {
     @Override
     public void setRuntime() throws Exception {
         r = getDefaultRuntime().connect();
-        // First commit a layout that uses Replex
+        // First commit a layout that uses Quorum Replication
         Layout newLayout = r.layout.get();
         newLayout.getSegment(0L).setReplicationMode(Layout.ReplicationMode.QUORUM_REPLICATION);
         newLayout.setEpoch(1);
         r.setCacheDisabled(true);
         r.getLayoutView().committed(1L, newLayout);
         r.invalidateLayout();
+        r.layout.get();
+        r.getRouter(newLayout.sequencers.get(0)).getClient(SequencerClient.class).bootstrap(
+                0L, Collections.EMPTY_MAP, 1L).get();
     }
 
 


### PR DESCRIPTION
Sequencer returns NOT_READY Exception if it is NOT_READY state and receives any message other than the SEQUENCER_RESET message (Marks server as READY).
The sequence of operations is as follows:
- Seal
- If primary sequencer has changed, mark all sequencers as NOT_READY.
- Run paxos
- Reset sequencers using stream tails from fastLoader. (The reset call marks the sequencer as ready.)

Possible race condition:
Since SET_NOT_READY message is epoch UNAWARE, the following scenario can occur:
ManagementServers 1 & 2 are trying to reset sequencer 3. 1 sends SET_NOT_READY but doesn't receive a response so aborts. 2 sends the SET_NOT_READY, receives response proceeds and succeeds with reconfiguration. 3 now receives 1's SET_NOT_READY and accepts it. Who should detect and mark 3 as READY now?