### PR TITLE
TransactionAbortedException String

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -51,9 +51,9 @@ public class TransactionAbortedException extends RuntimeException {
                 + " | Conflict Key = " + conflictKey
                 + " | Conflict Stream = " + conflictStream
                 + " | Cause = " + abortCause
-                + " | Time = " + context == null ? "Unknown" :
+                + " | Time = " + (context == null ? "Unknown" :
                 System.currentTimeMillis() -
-                context.getStartTime() + " ms");
+                context.getStartTime()) + " ms");
         this.txResolutionInfo = txResolutionInfo;
         this.conflictKey = conflictKey;
         this.abortCause = abortCause;


### PR DESCRIPTION
Fixed the string message that is created during the construction
of the exception.