### PR TITLE
Introduce a conflict data class, replacing the conflict string "hash"

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 
 import io.netty.buffer.ByteBuf;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;


### PR DESCRIPTION
This PR introduces a new conflict data class, which replaces the conflict
"string" hash. Since this class just refers to the conflict byte array by
reference, it should result in significantly lower memory pressure.