### PR TITLE
Make conflict and write set public

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/ConflictSetInfo.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/ConflictSetInfo.java
@@ -22,7 +22,7 @@ import net.openhft.hashing.LongHashFunction;
  * transaction execution.
  */
 @Getter
-class ConflictSetInfo {
+public class ConflictSetInfo {
 
 
     /** Set of objects this conflict set conflicts with. */

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetInfo.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetInfo.java
@@ -17,7 +17,7 @@ import static org.corfudb.runtime.object.transactions.TransactionalContext.getRo
  * transaction execution.
  */
 @Getter
-class WriteSetInfo extends ConflictSetInfo {
+public class WriteSetInfo extends ConflictSetInfo {
 
     /** The set of mutated objects. */
     Set<UUID> affectedStreams = new HashSet<>();


### PR DESCRIPTION
This PR makes the conflict and write set classes publicly accessible so the methods can
be accessed by external applications.