### PR TITLE
Fix bug preventing pending upcalls from being cleared

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -349,7 +349,7 @@ public class VersionLockedObject<T> {
                 },
                 t -> {
                     if (saveUpcall) {
-                        pendingUpcalls.remove(t.getToken());
+                        pendingUpcalls.remove(t.getToken().getTokenValue());
                     }
                     return true;
                 });


### PR DESCRIPTION
When sequencer addresses were refactored to type Token, getTokenValue
was not correctly called when removing the address from the upcall list,
so the type inserted (long) did not match the type being removed (Token)
causing the upcall list to never be freed. This patch fixes this bug.