### PR TITLE
Collection sync

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -29,7 +29,7 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
 
     // map from stream-ID to a list of updates encapsulated as MultiSMREntry
     @Getter
-    public Map<UUID, MultiSMREntry> entryMap = new HashMap<>();
+    public Map<UUID, MultiSMREntry> entryMap = Collections.synchronizedMap(new HashMap<>());
 
     public MultiObjectSMREntry() {
         this.type = LogEntryType.MULTIOBJSMR;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -6,9 +6,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
+import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.ILogData;
@@ -18,7 +18,7 @@ import org.corfudb.util.serializer.Serializers;
 
 
 /**
- * A log entry structure which contains a collection of multiSMREntries,
+ * A log entry sturcture which contains a collection of multiSMRentries,
  * each one contains a list of updates for one object.
  */
 @Deprecated // TODO: Add replacement method that conforms to style
@@ -28,11 +28,11 @@ import org.corfudb.util.serializer.Serializers;
 public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
 
     // map from stream-ID to a list of updates encapsulated as MultiSMREntry
-    private Map<UUID, MultiSMREntry> entryMap;
+    @Getter
+    public Map<UUID, MultiSMREntry> entryMap = new HashMap<>();
 
     public MultiObjectSMREntry() {
         this.type = LogEntryType.MULTIOBJSMR;
-        entryMap = new HashMap<>();
     }
 
     public MultiObjectSMREntry(Map<UUID, MultiSMREntry> entryMap) {
@@ -45,39 +45,11 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
      * @param streamID StreamID
      * @return the MultiSMREntry corresponding to streamId
      */
-    synchronized private MultiSMREntry getStreamEntry(UUID streamID) {
-        return entryMap.computeIfAbsent(streamID, u -> {
+    protected MultiSMREntry getStreamEntry(UUID streamID) {
+        return getEntryMap().computeIfAbsent(streamID, u -> {
                     return new MultiSMREntry();
                 }
         );
-    }
-
-    /**
-     * Return the set of affected streams.
-     * @return Set of UUIDs
-     */
-    synchronized public Set<UUID> getAffectedStreams() {
-        return entryMap.keySet();
-    }
-
-    /**
-     * Checks if the entry map is empty.
-     * @return true if empty
-     */
-    synchronized public boolean isEmpty() {
-        return entryMap.isEmpty();
-    }
-
-    /**
-     * Return the set of entries that belong to this object.
-     * @return set of entries
-     */
-    synchronized public Set<Map.Entry<UUID, MultiSMREntry>> getEntries()  {
-        return entryMap.entrySet();
-    }
-
-    synchronized public MultiSMREntry getMultiSMREntry(UUID uuid) {
-        return entryMap.get(uuid);
     }
 
     /**
@@ -85,7 +57,7 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
      * @param streamID StreamID
      * @param updateEntry SMREntry to add
      */
-    synchronized public void addTo(UUID streamID, SMREntry updateEntry) {
+    public void addTo(UUID streamID, SMREntry updateEntry) {
         getStreamEntry(streamID).addTo(updateEntry);
     }
 
@@ -94,12 +66,12 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
      * merging is done object-by-object
      * @param other Object to merge.
      */
-    synchronized public void mergeInto(MultiObjectSMREntry other) {
+    public void mergeInto(MultiObjectSMREntry other) {
         if (other == null) {
             return;
         }
 
-        other.entryMap.forEach((streamID, multiSmrEntry) -> {
+        other.getEntryMap().forEach((streamID, multiSmrEntry) -> {
             getStreamEntry(streamID).mergeInto(multiSmrEntry);
         });
     }
@@ -110,7 +82,7 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
      * @param b The remaining buffer.
      */
     @Override
-    synchronized void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
+    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
         super.deserializeBuffer(b, rt);
 
         short numUpdates = b.readShort();
@@ -123,10 +95,10 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
     }
 
     @Override
-    synchronized public void serialize(ByteBuf b) {
+    public void serialize(ByteBuf b) {
         super.serialize(b);
         b.writeShort(entryMap.size());
-        entryMap.entrySet()
+        entryMap.entrySet().stream()
                 .forEach(x -> {
                     b.writeLong(x.getKey().getMostSignificantBits());
                     b.writeLong(x.getKey().getLeastSignificantBits());
@@ -140,7 +112,7 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
      * @return an empty list if object has no updates; a list of updates if exists
      */
     @Override
-    synchronized public List<SMREntry> getSMRUpdates(UUID id) {
+    public List<SMREntry> getSMRUpdates(UUID id) {
         MultiSMREntry entry = entryMap.get(id);
         return entryMap.get(id) == null ? Collections.emptyList() :
                 entry.getUpdates();
@@ -150,9 +122,9 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
      * {@inheritDoc}
      */
     @Override
-    synchronized public void setEntry(ILogData entry) {
+    public void setEntry(ILogData entry) {
         super.setEntry(entry);
-        this.entryMap.values().forEach(x -> {
+        this.getEntryMap().values().forEach(x -> {
             x.setEntry(entry);
         });
     }

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
@@ -3,6 +3,7 @@ package org.corfudb.protocols.logprotocol;
 import io.netty.buffer.ByteBuf;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -28,7 +29,7 @@ import org.corfudb.util.serializer.Serializers;
 public class MultiSMREntry extends LogEntry implements ISMRConsumable {
 
     @Getter
-    List<SMREntry> updates = new ArrayList<>();
+    List<SMREntry> updates = Collections.synchronizedList(new ArrayList<>());
 
     public MultiSMREntry() {
         this.type = LogEntryType.MULTISMR;

--- a/runtime/src/main/java/org/corfudb/recovery/FastSmrMapsLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastSmrMapsLoader.java
@@ -251,9 +251,9 @@ public class FastSmrMapsLoader {
 
     private void updateCorfuObjectWithMultiObjSmrEntry(LogEntry logEntry, long globalAddress) {
         MultiObjectSMREntry multiObjectLogEntry = (MultiObjectSMREntry) logEntry;
-        multiObjectLogEntry.getEntries().forEach((multiSmrEntry) -> {
-            multiSmrEntry.getValue().getSMRUpdates(multiSmrEntry.getKey()).forEach((smrEntry) -> {
-                applySmrEntryToStream(multiSmrEntry.getKey(), smrEntry, globalAddress);
+        multiObjectLogEntry.getEntryMap().forEach((streamId, multiSmrEntry) -> {
+            multiSmrEntry.getSMRUpdates(streamId).forEach((smrEntry) -> {
+                applySmrEntryToStream(streamId, smrEntry, globalAddress);
             });
         });
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -249,14 +249,14 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
 
         // If the write set is empty, we're done and just return
         // NOWRITE_ADDRESS.
-        if (getWriteSetInfo().getWriteSet().isEmpty()) {
+        if (getWriteSetInfo().getWriteSet().getEntryMap().isEmpty()) {
             log.trace("Commit[{}] Read-only commit (no write)", this);
             return NOWRITE_ADDRESS;
         }
 
         // Write to the transaction stream if transaction logging is enabled
-        Set<UUID> affectedStreams = new HashSet<>(getWriteSetInfo()
-                .getWriteSet().getAffectedStreams());
+        Set<UUID> affectedStreams = new HashSet<>(getWriteSetInfo().getWriteSet()
+                .getEntryMap().keySet());
         if (this.builder.runtime.getObjectsView().isTransactionLogging()) {
             affectedStreams.add(TRANSACTION_STREAM_ID);
         }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -167,11 +167,10 @@ public class WriteSetSMRStream implements ISMRStream {
         if (Address.nonAddress(currentContextPos)) {
             currentContextPos = -1;
         }
-
         return Collections.singletonList(contexts
                 .get(currentContext)
                 .getWriteSetEntryList(id)
-                .get((int) (currentContextPos)));
+                .get((int)(currentContextPos)));
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -457,9 +457,9 @@ public class Utils {
                 log.info("--------------------------");
             } else if (le.getType() == LogEntry.LogEntryType.MULTIOBJSMR) {
                 log.info("printLogAnatomy: Number of Streams: " + logData.getStreams().size());
-                ((MultiObjectSMREntry)le).getEntries().forEach((multiSmrEntry) -> {
+                ((MultiObjectSMREntry)le).getEntryMap().forEach((stream, multiSmrEntry) -> {
                     log.info("printLogAnatomy: Number of Entries: " + multiSmrEntry
-                            .getValue().getSMRUpdates(multiSmrEntry.getKey()));
+                            .getSMRUpdates(stream).size());
                 });
                 log.info("--------------------------");
             }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
@@ -59,8 +59,8 @@ public class WriteAfterWriteTransactionContextTest extends AbstractTransactionCo
 
         MultiObjectSMREntry tx1 = (MultiObjectSMREntry)txns.get(0).getLogEntry
             (getRuntime());
-        assertThat(tx1.getEntries().size()).isEqualTo(1);
-        MultiSMREntry entryMap = tx1.getEntries().iterator()
+        assertThat(tx1.getEntryMap().size()).isEqualTo(1);
+        MultiSMREntry entryMap = tx1.getEntryMap().entrySet().iterator()
                                                         .next().getValue();
         assertThat(entryMap).isNotNull();
         assertThat(entryMap.getUpdates().size()).isEqualTo(1);

--- a/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -149,7 +149,7 @@ public class ObjectsViewTest extends AbstractViewTest {
 
         MultiObjectSMREntry tx1 = (MultiObjectSMREntry)txns.get(0).getLogEntry
                 (getRuntime());
-        MultiSMREntry entryMap = tx1.getMultiSMREntry(CorfuRuntime.getStreamID(mapA));
+        MultiSMREntry entryMap = tx1.getEntryMap().get(CorfuRuntime.getStreamID(mapA));
         assertThat(entryMap).isNotNull();
 
         assertThat(entryMap.getUpdates().size()).isEqualTo(1);


### PR DESCRIPTION
Use synchronized collections for MultiObjectSMREntry and
MultiSMREntry. This fixes a race condition, where while a thread
is writing another thread can observe stale reads.