### PR TITLE
Stale token bug fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/StaleTokenException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/StaleTokenException.java
@@ -1,0 +1,22 @@
+package org.corfudb.runtime.exceptions;
+
+import lombok.Getter;
+
+/**
+ * The exception is thrown internally by the runtime
+ * if the following race happens:
+ * a token is obtained from sequencer at epoch x,
+ * then reconfiguration happens and a new layout with epoch x+k is installed,
+ * finally the action with epoch x resumes.
+ *
+ * Created by dmalkhi on 7/21/17.
+ */
+public class StaleTokenException extends RuntimeException {
+    @Getter
+    private final long correctEpoch;
+
+    public StaleTokenException(long correctEpoch) {
+        super("Stale token epoch. [expected=" + correctEpoch + "]");
+        this.correctEpoch = correctEpoch;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -96,7 +96,6 @@ public abstract class AbstractView {
                     WrongEpochException we = (WrongEpochException) re;
                     log.warn("Got a wrong epoch exception, updating epoch to {} and "
                             + "invalidate view", we.getCorrectEpoch());
-                    Long newEpoch = (we.getCorrectEpoch());
                     runtime.invalidateLayout();
                 } else {
                     throw re;

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -23,6 +23,7 @@ import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.util.CFUtils;
@@ -106,7 +107,7 @@ public class AddressSpaceView extends AbstractView {
             // epoch as the layout we are about to write
             // to.
             if (token.getEpoch() != l.getEpoch()) {
-                throw new WrongEpochException(l.getEpoch());
+                throw new StaleTokenException(l.getEpoch());
             }
 
             // Set the data to use the token

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -16,6 +16,7 @@ import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.Address;
@@ -107,6 +108,18 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                 tokenResponse = runtime.getSequencerView()
                         .nextToken(Collections.singleton(id),
                              1);
+            } catch (StaleTokenException te) {
+                log.trace("Token grew stale occurred at {}", tokenResponse);
+                if (deacquisitionCallback != null && !deacquisitionCallback.apply(tokenResponse)) {
+                        log.debug("Deacquisition requested abort");
+                        return -1L;
+                }
+                // Request a new token, informing the sequencer we were
+                // overwritten.
+                tokenResponse = runtime.getSequencerView()
+                        .nextToken(Collections.singleton(id),
+                                1);
+
             }
         }
     }

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -1,17 +1,29 @@
 package org.corfudb.integration;
 
+import org.assertj.core.api.ThrowableAssert;
+import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.MultiCheckpointWriter;
+import org.corfudb.runtime.clients.LayoutClient;
+import org.corfudb.runtime.clients.ManagementClient;
+import org.corfudb.runtime.clients.NettyClientRouter;
 import org.corfudb.runtime.clients.SequencerClient;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.util.CFUtils;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.exceptions.*;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.FileOutputStream;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -19,16 +31,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests the recovery of the Corfu instance.
@@ -458,6 +464,213 @@ public class ServerRestartIT extends AbstractIT {
         assertThat(tokenResponseB.getToken().getTokenValue()).isEqualTo(newGlobalTail + 2);
         assertThat(tokenResponseB.getBackpointerMap().get(streamNameB))
                 .isEqualTo(newMapBStreamTail);
+
+        assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
+
+    }
+
+    /**
+     * If a tokenResponse is received in the previous epoch,
+     * a write should discard the tokenResponse and throw an exception.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void discardTokenReceivedInPreviousEpoch() throws Exception {
+        final int timeToWaitInSeconds = 3;
+
+        Process corfuServerProcess = runCorfuServer();
+        final CorfuRuntime corfuRuntime = createDefaultRuntime();
+
+        // wait for this server long enough to start (by requesting token service)
+        TokenResponse firsttr = corfuRuntime.getSequencerView().nextToken(Collections.emptySet(),
+                1);
+
+        assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
+
+        corfuServerProcess = runCorfuServer();
+
+        corfuRuntime.invalidateLayout();
+        TokenResponse tr = corfuRuntime.getSequencerView().nextToken(Collections.emptySet(), 1);
+
+        assertThat(tr.getEpoch())
+                .isEqualTo(1);
+
+        // Force the token response to have epoch = 0, to simulate a request received in previous epoch
+        TokenResponse mockTr = new TokenResponse(tr.getToken().getTokenValue(), tr.getEpoch() - 1, Collections.emptyMap());
+
+        byte[] testPayload = "hello world".getBytes();
+
+        // Should succeed. internally, it will refresh the token.
+        CompletableFuture cf = CFUtils.within(CompletableFuture.supplyAsync(() -> {
+            corfuRuntime.getAddressSpaceView().write(mockTr, testPayload);
+            return true;
+        }), Duration.ofSeconds(timeToWaitInSeconds));
+
+        try {
+            cf.get();
+        } catch (Exception e) {
+            assertThat(e.getCause()).isNotInstanceOf(TimeoutException.class);
+            assertThat(e.getCause()).isInstanceOf(StaleTokenException.class);
+        }
+
+        assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
+    }
+
+    /**
+     * loop that randomizes a combination of the following activities:
+     * (i) map put()s
+     * (ii) checkpoint/trim
+     * (iii) leaving holes behind
+     * (iv) server shutdown/restart
+     *
+     * @throws Exception
+     */
+
+  public void sequencerTailsRecoveryLoopTest() throws Exception {
+
+        Process corfuServerProcess = runCorfuServer();
+        final int mapSize = 10;
+        UUID streamNameA = CorfuRuntime.getStreamID("mapA");
+        UUID streamNameB = CorfuRuntime.getStreamID("mapB");
+
+        long mapAStreamTail = -1;
+        long mapBStreamTail = -1;
+        long globalTail = -1;
+
+        CorfuRuntime corfuRuntime = createDefaultRuntime();
+        Random rand = new Random(PARAMETERS.SEED);
+
+        for (int r = 0; r < PARAMETERS.NUM_ITERATIONS_LOW; r++) {
+
+            Map<String, Integer> mapA = createMap(corfuRuntime, "mapA");
+            Map<String, Integer> mapB = createMap(corfuRuntime, "mapB");
+
+            // activity (i): map put()'s
+            boolean updateMaps = rand.nextBoolean();
+
+            if (updateMaps) {
+                System.out.println(r + "..do update maps");
+                for (int i = 0; i < mapSize; i++) {
+                    mapA.put(Integer.toString(i), i);
+                }
+                for (int i = 0; i < mapSize; i++) {
+                    mapB.put(Integer.toString(i), i);
+                }
+                mapAStreamTail = globalTail + mapSize;
+                mapBStreamTail = globalTail + 2 * mapSize;
+                globalTail += 2 * mapSize;
+            } else {
+                System.out.println(r + "..no map updates");
+            }
+
+            // activity (ii): log checkpoint and trim
+            boolean doCkpoint = rand.nextBoolean();
+
+            if (doCkpoint) {
+                // checkpoint and trim
+                MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
+                mcw1.addMap((SMRMap) mapA);
+                mcw1.addMap((SMRMap) mapB);
+                long checkpointAddress = mcw1.appendCheckpoints(corfuRuntime, "dahlia");
+
+                // Trim the log
+                corfuRuntime.getAddressSpaceView().prefixTrim(checkpointAddress - 1);
+                corfuRuntime.getAddressSpaceView().gc();
+                corfuRuntime.getAddressSpaceView().invalidateServerCaches();
+                corfuRuntime.getAddressSpaceView().invalidateClientCache();
+
+                System.out.println(r + "..ckpoint and trimmed @" + checkpointAddress);
+            } else {
+                System.out.println(r + "..no checkpoint/trim");
+            }
+
+            TokenResponse expectedTokenResponseA = corfuRuntime
+                    .getRouter(corfuSingleNodeHost + ":" + corfuSingleNodePort)
+                    .getClient(SequencerClient.class)
+                    .nextToken(Collections.singleton(streamNameA), 0)
+                    .get();
+
+            TokenResponse expectedTokenResponseB = corfuRuntime
+                    .getRouter(corfuSingleNodeHost + ":" + corfuSingleNodePort)
+                    .getClient(SequencerClient.class)
+                    .nextToken(Collections.singleton(streamNameB), 0)
+                    .get();
+
+
+            TokenResponse expectedGlobalTailResponse = corfuRuntime
+                    .getRouter(corfuSingleNodeHost + ":" + corfuSingleNodePort)
+                    .getClient(SequencerClient.class)
+                    .nextToken(Collections.emptySet(), 0)
+                    .get();
+
+
+            // activity (iii) shutdown and restart
+            corfuRuntime.shutdown();
+            assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
+
+            corfuServerProcess = runCorfuServer();
+            corfuRuntime = createDefaultRuntime();
+
+            // check tail recovery after restart
+            TokenResponse tokenResponseA = corfuRuntime
+                    .getRouter(corfuSingleNodeHost + ":" + corfuSingleNodePort)
+                    .getClient(SequencerClient.class)
+                    .nextToken(Collections.singleton(streamNameA), 1)
+                    .get();
+
+            TokenResponse tokenResponseB = corfuRuntime
+                    .getRouter(corfuSingleNodeHost + ":" + corfuSingleNodePort)
+                    .getClient(SequencerClient.class)
+                    .nextToken(Collections.singleton(streamNameB), 1)
+                    .get();
+
+            assertThat(tokenResponseA.getTokenValue()).isEqualTo(expectedGlobalTailResponse
+                    .getTokenValue()+1);
+            assertThat(tokenResponseA.getBackpointerMap().get(streamNameA))
+                    .isEqualTo(expectedTokenResponseA.getTokenValue());
+
+            assertThat(tokenResponseB.getTokenValue()).isEqualTo(expectedGlobalTailResponse
+                    .getTokenValue()+2);
+            assertThat(tokenResponseB.getBackpointerMap().get(streamNameB))
+                    .isEqualTo(expectedTokenResponseB.getTokenValue());
+
+            // activity (iv): leave holes behind
+            // this is done by having another shutdown/restart, so the token above becomes stale
+
+            boolean restartwithHoles = true; // rand.nextBoolean();
+
+            if (restartwithHoles) {
+                corfuRuntime.shutdown();
+                assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
+
+                corfuServerProcess = runCorfuServer();
+                corfuRuntime = createDefaultRuntime();
+                System.out.println(r + "..restart with holes");
+                // in this scenario, the globalTail is left unchanged from before,
+                // because we restart without ever having writes use the tokens
+            } else {
+                System.out.println(r + ".. no holes left");
+                globalTail = tokenResponseB.getTokenValue();
+            }
+
+            // these writes should throw a StaleTokenException if we restarted
+            try {
+                corfuRuntime.getAddressSpaceView()
+                        .write(tokenResponseA.getToken(), "fixed string".getBytes());
+            } catch (StaleTokenException se) {
+                assertThat(restartwithHoles).isTrue();
+            }
+
+            try {
+                corfuRuntime.getAddressSpaceView()
+                        .write(tokenResponseB.getToken(), "fixed string".getBytes());
+            } catch (StaleTokenException se) {
+                assertThat(restartwithHoles).isTrue();
+            }
+
+            System.out.println(r + "completed..@" + globalTail);
+        }
 
         assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
 


### PR DESCRIPTION
This branch exposes a bug on sequencer epoch change (#865): 
AddressSpaceView.write() may be handed a token with a stale epoch, and it will then loop forever trying to get the token and the layout to be the same epoch.

The fix is to throw a new exception type, staleTokenException, and let the streams layer decide if and how to obtain a new token. This depends on who invokes AddressSpaceView.write() : 
* on a regular stream write, simply discard the old token and grab a new one
* on a transactions write, throw a transactionAborted exception, because the conflict parameters on the sequencer may be messed up
* on a multi-stream COW, simply discard the old token and grab a new one.