### PR TITLE
Do not reconstruct tail of empty streams

### DIFF
--- a/runtime/src/main/java/org/corfudb/recovery/FastSmrMapsLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastSmrMapsLoader.java
@@ -30,6 +30,7 @@ import org.corfudb.runtime.view.Address;
 import org.corfudb.util.Utils;
 
 import static org.corfudb.recovery.RecoveryUtils.*;
+import static org.corfudb.runtime.view.Address.isAddress;
 
 /** The FastSmrMapsLoader reconstructs the coalesced state of SMRMaps through sequential log read
  *
@@ -182,7 +183,8 @@ public class FastSmrMapsLoader {
     public void updateStreamTails(long address, ILogData logData) {
         // On checkpoint, we also need to track the stream tail of the checkpoint
         if (isCheckPointEntry(logData)) {
-            if (logData.getCheckpointType() == CheckpointEntry.CheckpointEntryType.END) {
+            if (logData.getCheckpointType() == CheckpointEntry.CheckpointEntryType.END &&
+                    isAddress(getStartAddressOfCheckPoint(logData))) {
                 streamTails.compute(logData.getCheckpointedStreamId(),
                         (uuid, value) -> (value == null) ? getStartAddressOfCheckPoint(logData)
                             : Math.max(value, getStartAddressOfCheckPoint(logData)));


### PR DESCRIPTION
When we do a checkpoint of an empty stream, the start
address of the stream will be -1 (don't exist). When
we reconstruct the tails, if we encounter a checkpoint
of an empty stream, we should not reconstruct its tail.