### PR TITLE
Buffer Checkpoints

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/CheckpointData.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/CheckpointData.java
@@ -1,0 +1,41 @@
+package org.corfudb.runtime.view.stream;
+
+import java.util.UUID;
+
+import org.corfudb.runtime.view.Address;
+
+import lombok.Data;
+
+/**
+ * Created by maithem on 7/24/17.
+ */
+@Data
+public class CheckpointData {
+    private UUID id = null;
+    private long startAddr = Address.NEVER_READ;
+    private long endAddr = Address.NEVER_READ;
+    private long numEntries;
+    private long size;
+
+    /** The address the current checkpoint snapshot was taken at.
+     *  The checkpoint guarantees for this stream there are no entries
+     *  between checkpointSuccessStartAddr and checkpointSnapshotAddress.
+     */
+    long snapshotAddress = Address.NEVER_READ;
+
+    public boolean isReady() {
+        return (id != null
+                && startAddr != Address.NEVER_READ
+                && endAddr != Address.NEVER_READ
+                && snapshotAddress != Address.NEVER_READ);
+    }
+
+    public void unset() {
+        startAddr = Address.NEVER_READ;
+        endAddr = Address.NEVER_READ;
+        numEntries = 0;
+        size = 0;
+    }
+
+    public static CheckpointData empty = new CheckpointData();
+}


### PR DESCRIPTION
A Checkpoint should be admitted to the QueuedStreamContext only
when the whole checkpoint has been read. This patch prevents
partial checkpoint from being considered. This is required,
because partial checkpoints can cause a false TrimmedException
to be thrown.