### PR TITLE
Retry recovery if failed and reduce testing times

### DIFF
--- a/test/src/test/java/org/corfudb/integration/CmdletIT.java
+++ b/test/src/test/java/org/corfudb/integration/CmdletIT.java
@@ -1,18 +1,11 @@
 package org.corfudb.integration;
 
-import org.corfudb.protocols.wireprotocol.ILogData;
-import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.clients.IClientRouter;
-import org.corfudb.runtime.clients.LayoutClient;
-import org.corfudb.runtime.clients.NettyClientRouter;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.stream.IStreamView;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.BufferedReader;
@@ -30,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * Created by zlokhandwala on 5/8/17.
  */
+@Ignore
 public class CmdletIT extends AbstractIT {
 
     // Using port 9901 to avoid intellij port conflict.
@@ -136,7 +130,6 @@ public class CmdletIT extends AbstractIT {
                 .setLogPath(getCorfuServerLogPath(DEFAULT_HOST, PORT))
                 .getOptionsString();
         String output = runCmdletGetOutput(command);
-        System.out.println(output);
         assertThat(output.contains(expectedLogPath)).isTrue();
         assertThat(output.contains(expectedInitialToken)).isTrue();
         assertThat(output.contains(expectedStartupArgs)).isTrue();

--- a/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
@@ -34,7 +34,10 @@ public class ManagementClientTest extends AbstractClientTest {
         server = new ManagementServer(serverContext);
         return new ImmutableSet.Builder<AbstractServer>()
                 .add(server)
+                // Required for management server to fetch the latest layout and connect runtime.
                 .add(new LayoutServer(serverContext))
+                // Required for management server to be able to bootstrap the sequencer.
+                .add(new SequencerServer(serverContext))
                 .build();
     }
 
@@ -64,7 +67,9 @@ public class ManagementClientTest extends AbstractClientTest {
     public void handleBootstrap()
             throws Exception {
         // Since the servers are started as single nodes thus already bootstrapped.
-        assertThatThrownBy(() -> client.bootstrapManagement(TestLayoutBuilder.single(SERVERS.PORT_0)).get()).isInstanceOf(ExecutionException.class);
+        assertThatThrownBy(() ->
+                client.bootstrapManagement(TestLayoutBuilder.single(SERVERS.PORT_0)).get())
+                .isInstanceOf(ExecutionException.class);
     }
 
     /**


### PR DESCRIPTION
### Retry recovery (ManagementServer)
- Retry node recovery if recovery failed the first time.
- Converting AtomicBoolean to simple boolean.

### Removing redundant sequencer bootstrap retries by the ManagementServer
- The management server retries bootstrapping the sequencer implicitly every second since the flag remains unset until the bootstrap is successful. 
- So explicit retries are not required and I have removed them.

### Reducing ManagementViewTest running time (ManagementViewTest)
- Waiting for management servers to stabilize and realize that the sequencer has been bootstrapped. This makes it quicker for them to detect failures if any and also reduce repeated attempts on bootstrapping the sequencer.

### CmdletIT
- Disabled cmdletIt for now as they are very slow and are not as significant. We can work around later to speed up these tests or run them in parallel.