### PR TITLE
Reduce unit test execution time from ~750 seconds to ~200 seconds

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -544,12 +544,7 @@ public class ManagementServer extends AbstractServer {
             corfuRuntime.shutdown();
         }
 
-        try {
-            failureDetectorService.awaitTermination(serverContext.SHUTDOWN_TIMER.getSeconds(),
-                    TimeUnit.SECONDS);
-        } catch (InterruptedException ie) {
-            log.debug("failureDetectorService awaitTermination interrupted : {}", ie);
-        }
+        failureDetectorService.shutdownNow();
         log.info("Management Server shutting down.");
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -46,6 +46,9 @@ public class CorfuRuntime {
 
     static final long DEFAULT_BATCH_FOR_FAST_LOADER = 5;
     static final int DEFAULT_TIMEOUT_MINUTES_FAST_LOADING = 30;
+    @Getter
+    @Setter
+    static int defaultRetryMilliseconds = 5000;
 
     @Data
     public static class CorfuRuntimeParameters {
@@ -104,7 +107,7 @@ public class CorfuRuntime {
      */
     public volatile CompletableFuture<Layout> layout;
     /**
-     * The rate in seconds to retry accessing a layout, in case of a failure.
+     * The rate in milliseconds to retry accessing a layout, in case of a failure.
      */
     public int retryRate;
     /**
@@ -257,7 +260,7 @@ public class CorfuRuntime {
     public CorfuRuntime() {
         layoutServers = new ArrayList<>();
         nodeRouters = new ConcurrentHashMap<>();
-        retryRate = 5;
+        retryRate = defaultRetryMilliseconds;
         synchronized (metrics) {
             if (metrics.getNames().isEmpty()) {
                 MetricsUtils.addJvmMetrics(metrics, mp);
@@ -507,9 +510,9 @@ public class CorfuRuntime {
                         log.warn("Tried to get layout from {} but failed with exception:", s, e);
                     }
                 }
-                log.warn("Couldn't connect to any up-to-date layout servers, retrying in {}s.", retryRate);
+                log.warn("Couldn't connect to any up-to-date layout servers, retrying in {}ms.", retryRate);
                 try {
-                    Thread.sleep(retryRate * 1000);
+                    Thread.sleep(retryRate);
                 } catch (InterruptedException e) {
                     e.printStackTrace();
                 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -42,11 +42,11 @@ public abstract class AbstractView {
             try {
                 return runtime.layout.get();
             } catch (Exception ex) {
-                log.warn("Error executing remote call, invalidating view and retrying in {}s",
+                log.warn("Error executing remote call, invalidating view and retrying in {}ms",
                         runtime.retryRate, ex);
                 runtime.invalidateLayout();
                 try {
-                    Thread.sleep(runtime.retryRate * 1000);
+                    Thread.sleep(runtime.retryRate);
                 } catch (InterruptedException ie) {
                     log.warn("Interrupted Exception when getting current layout.", ie);
                 }
@@ -76,11 +76,11 @@ public abstract class AbstractView {
                 return function.apply(runtime.layout.get());
             } catch (RuntimeException re) {
                 if (re.getCause() instanceof TimeoutException) {
-                    log.warn("Timeout executing remote call, invalidating view and retrying in {}s",
+                    log.warn("Timeout executing remote call, invalidating view and retrying in {}ms",
                             runtime.retryRate);
                     runtime.invalidateLayout();
                     try {
-                        Thread.sleep(runtime.retryRate * 1000);
+                        Thread.sleep(runtime.retryRate);
                     } catch (InterruptedException ie) {
                         log.warn("Interrupted Exception in layout helper.", ie);
                     }
@@ -88,7 +88,7 @@ public abstract class AbstractView {
                     log.warn("Server still not ready. Waiting for server to start "
                             + "accepting requests.");
                     try {
-                        Thread.sleep(runtime.retryRate * 1000);
+                        Thread.sleep(runtime.retryRate);
                     } catch (InterruptedException ie) {
                         log.warn("Interrupted Exception in layout helper.", ie);
                     }
@@ -101,11 +101,11 @@ public abstract class AbstractView {
                     throw re;
                 }
             } catch (InterruptedException | ExecutionException ex) {
-                log.warn("Error executing remote call, invalidating view and retrying in {}s",
+                log.warn("Error executing remote call, invalidating view and retrying in {}ms",
                         runtime.retryRate, ex);
                 runtime.invalidateLayout();
                 try {
-                    Thread.sleep(runtime.retryRate * 1000);
+                    Thread.sleep(runtime.retryRate);
                 } catch (InterruptedException ie) {
                     log.warn("Interrupted Exception in layout helper.", ie);
                 }

--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -2,6 +2,7 @@ package org.corfudb;
 
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractThrowableAssert;
+import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.test.DisabledOnTravis;
 import org.fusesource.jansi.Ansi;
 import org.junit.After;
@@ -218,6 +219,13 @@ public class AbstractCorfuTest {
         if (deleteSelf) {
             folder.delete();
         }
+    }
+
+    @Before
+    public void setAggressiveRuntimeRetryRate() {
+        final int time = 25;
+
+        CorfuRuntime.setDefaultRetryMilliseconds(time);
     }
 
     @Before

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -95,7 +95,7 @@ public class CheckpointTest extends AbstractObjectTest {
                 checkpointAddress = mcw1.appendCheckpoints(currentRuntime, author);
 
                 try {
-                    Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
+                    Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
                 } catch (InterruptedException ie) {
                     //
                 }

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -74,6 +74,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
 
     /** Initialize the AbstractViewTest. */
     public AbstractViewTest() {
+        setAggressiveRuntimeRetryRate();
         // Force all new CorfuRuntimes to override the getRouterFn
         CorfuRuntime.overrideGetRouterFunction = this::getRouterFunction;
         runtime = new CorfuRuntime(getDefaultEndpoint());


### PR DESCRIPTION
1. Adjust CorfuRuntime retry timeout units & mutability for unit tests.

Recent changes to the Sequencer have created a race condition that
many unit tests lose: when the Sequencer is in not ready state,
loser tests must loop & wait 5 seconds before resuming.  On average,
100-110 tests are delayed by this wait.  The new timeout is 25 msec.

2. Shut down ManagementServer's thread pool but don't wait for
it to finish before continuing with JUnit's @After cleanup tasks.

3. Use smallest parameter (`TIMEOUT_VERY_SHORT`) for sleep constant
in CheckpointTest.java.