### PR TITLE
Handle case when sonar env vars are not available

### DIFF
--- a/.travis_scripts/verify.sh
+++ b/.travis_scripts/verify.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
     ./mvnw verify -Dmaven.javadoc.skip=true -Dtest.travisBuild=true  sonar:sonar \
         -Dsonar.analysis.mode=preview \
         -Dsonar.host.url=https://sonarqube.com \
@@ -10,6 +10,9 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
         -Dsonar.organization=corfudb \
         -Dsonar.login=$SONAR_TOKEN
 else
+     if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
+     echo "Not submitting sonar status to github because this is an external PR"
+     fi
     ./mvnw verify -Dmaven.javadoc.skip=true -Dsonar.host.url=https://sonarqube.com \
         -Dsonar.organization=corfudb -Dsonar.login=$SONAR_TOKEN -Dtest.travisBuild=true sonar:sonar
 fi


### PR DESCRIPTION
This PR addresses the case when encrypted env variables
are unavailable in travis due to an external PR (from a fork).