### PR TITLE
Serialization Bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -85,9 +85,9 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
     void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
         super.deserializeBuffer(b, rt);
 
-        short numUpdates = b.readShort();
+        int numUpdates = b.readInt();
         entryMap = new HashMap<>();
-        for (short i = 0; i < numUpdates; i++) {
+        for (int i = 0; i < numUpdates; i++) {
             entryMap.put(
                     new UUID(b.readLong(), b.readLong()),
                     ((MultiSMREntry) Serializers.CORFU.deserialize(b, rt)));
@@ -97,7 +97,7 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
     @Override
     public void serialize(ByteBuf b) {
         super.serialize(b);
-        b.writeShort(entryMap.size());
+        b.writeInt(entryMap.size());
         entryMap.entrySet().stream()
                 .forEach(x -> {
                     b.writeLong(x.getKey().getMostSignificantBits());

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
@@ -57,9 +57,9 @@ public class MultiSMREntry extends LogEntry implements ISMRConsumable {
     void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
         super.deserializeBuffer(b, rt);
 
-        short numUpdates = b.readShort();
+        int numUpdates = b.readInt();
         updates = new ArrayList<>();
-        for (short i = 0; i < numUpdates; i++) {
+        for (int i = 0; i < numUpdates; i++) {
             updates.add(
                     (SMREntry) Serializers.CORFU.deserialize(b, rt));
         }
@@ -68,7 +68,7 @@ public class MultiSMREntry extends LogEntry implements ISMRConsumable {
     @Override
     public void serialize(ByteBuf b) {
         super.serialize(b);
-        b.writeShort(updates.size());
+        b.writeInt(updates.size());
         updates.stream()
                 .forEach(x -> Serializers.CORFU.serialize(x, b));
     }


### PR DESCRIPTION
Maps were being serialized/deserialized incorrectly because their
sizes was being casted from an int to a short. As a consequence,
transactions can successfully commit data, but fail to read them
back.