### PR TITLE
CorfuTable can modify the indexer at runtime

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -33,6 +33,19 @@ public class CorfuTableTest extends AbstractViewTest {
                 = (i, s) -> s.map(entry -> entry.getValue());
     }
 
+    @RequiredArgsConstructor
+    enum OtherStringIndexer implements CorfuTable.IndexSpecification<String, String, String, String> {
+        BY_LAST_LETTER((k, v) -> Collections.singleton(Character.toString(v.charAt(v.length()-1))));
+        ;
+
+        @Getter
+        final CorfuTable.IndexFunction<String, String, String> indexFunction;
+
+        @Getter
+        final CorfuTable.ProjectionFunction<String, String, String, String> projectionFunction
+                = (i, s) -> s.map(entry -> entry.getValue());
+    }
+
     @Test
     @SuppressWarnings("unchecked")
     public void canReadFromEachIndex() {
@@ -96,4 +109,92 @@ public class CorfuTableTest extends AbstractViewTest {
                                  MapEntry.entry("k2", "ab"),
                                  MapEntry.entry("k3", "b"));
     }
+
+    /**
+     * Create a CorfuTable without index and add an indexer
+     * post-creation (CorfuTable already have entries).
+     */
+    @Test
+    public void canSetIndexIfNoneSoFar() {
+        CorfuTable<String, String, CorfuTable.NoSecondaryIndex, Void>
+                corfuTable = getDefaultRuntime().getObjectsView().build()
+                .setType(CorfuTable.class)
+                .setStreamName("test")
+                .open();
+
+        corfuTable.put("k1", "a");
+        corfuTable.put("k2", "ab");
+        corfuTable.put("k3", "b");
+
+        CorfuTable<String, String, StringIndexers, String>
+                corfuTableWithIndex = getDefaultRuntime().getObjectsView().build()
+                .setType(CorfuTable.class)
+                .setArguments(StringIndexers.class)
+                .setStreamName("test")
+                .open();
+
+        assertThat(corfuTableWithIndex.get("k1")).isEqualTo("a");
+        assertThat(corfuTableWithIndex.get("k2")).isEqualTo("ab");
+        assertThat(corfuTableWithIndex.get("k3")).isEqualTo("b");
+
+        assertThat(corfuTableWithIndex.getByIndex(StringIndexers.BY_FIRST_LETTER, "a"))
+                .containsExactly("a", "ab");
+
+        assertThat(corfuTableWithIndex.getByIndex(StringIndexers.BY_VALUE, "ab"))
+                .containsExactly("ab");
+
+    }
+
+    /**
+     * Replace the existing indexer with another one.
+     */
+    @Test
+    public void canSetNewIndex() {
+        CorfuTable<String, String, StringIndexers, String>
+                corfuTable = getDefaultRuntime().getObjectsView().build()
+                .setType(CorfuTable.class)
+                .setArguments(StringIndexers.class)
+                .setStreamName("test")
+                .open();
+
+        corfuTable.put("k1", "a");
+        corfuTable.put("k2", "ab");
+        corfuTable.put("k3", "b");
+
+        assertThat(corfuTable.getByIndex(StringIndexers.BY_FIRST_LETTER, "a"))
+                .containsExactly("a", "ab");
+
+
+        CorfuTable<String, String, OtherStringIndexer, String>
+                corfuTableWithIndex = getDefaultRuntime().getObjectsView().build()
+                .setType(CorfuTable.class)
+                .setArguments(OtherStringIndexer.class)
+                .setStreamName("test")
+                .open();
+
+        assertThat(corfuTableWithIndex.getByIndex(OtherStringIndexer.BY_LAST_LETTER, "b"))
+                .containsExactly("ab", "b");
+    }
+
+    /**
+     * Remove an entry also update indices
+     */
+    @Test
+    public void doUpdateIndicesOnRemove() throws Exception {
+        CorfuTable<String, String, StringIndexers, String>
+                corfuTable = getDefaultRuntime().getObjectsView().build()
+                .setType(CorfuTable.class)
+                .setArguments(StringIndexers.class)
+                .setStreamName("test")
+                .open();
+
+        corfuTable.put("k1", "a");
+        corfuTable.put("k2", "ab");
+        corfuTable.put("k3", "b");
+        corfuTable.remove("k2");
+
+        assertThat(corfuTable.getByIndex(StringIndexers.BY_FIRST_LETTER, "a"))
+                .containsExactly("a");
+    }
+
 }

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -89,7 +89,7 @@ public class SMRMapTest extends AbstractViewTest {
         // ScanAndFilterByEntry
         Predicate<Map.Entry<String, String>> valuePredicate =
                 p -> p.getValue().equals("CorfuServer");
-        Collection<Map.Entry<String, String>> filteredMap = ((CorfuTable)corfuInstancesMap)
+        Collection<Map.Entry<String, String>> filteredMap = ((SMRMap)corfuInstancesMap)
                 .scanAndFilterByEntry(valuePredicate);
 
         assertThat(filteredMap.size()).isEqualTo(2);
@@ -99,7 +99,7 @@ public class SMRMapTest extends AbstractViewTest {
         }
 
         // ScanAndFilter (Deprecated Method)
-        List<String> corfuServerList = ((CorfuTable)corfuInstancesMap)
+        List<String> corfuServerList = ((SMRMap)corfuInstancesMap)
                 .scanAndFilter(p -> p.equals("CorfuServer"));
 
         assertThat(corfuServerList.size()).isEqualTo(2);


### PR DESCRIPTION
Main change is that we can modify the indexer of an existing
CorfuTable. This enable FastObjectLoader to reload the maps in
memory and postpone the computation of the index at instatiation
time. Also include minor fixes.