### PR TITLE
replaceAll fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -524,7 +524,7 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
             v = function.apply(k, v);
 
             try {
-                entry.setValue(v);
+                insert(k, v);
             } catch (IllegalStateException ise) {
                 // this usually means the entry is no longer in the map.
                 throw new ConcurrentModificationException(ise);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
@@ -244,7 +244,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
             v = function.apply(k, v);
 
             try {
-                entry.setValue(v);
+                blindPut(k, v);
             } catch (IllegalStateException ise) {
                 // this usually means the entry is no longer in the map.
                 throw new ConcurrentModificationException(ise);


### PR DESCRIPTION
per @annym's comment, replaceAll had a bug where it was trying to update the entry,
but the entry was coming from a immutable set, therefore no update to the mapping
would occur, and replaceAll would do nothing.

This PR fixes that bug by forcing an update on the map. This is broken in
CorfuTable and SMRMap.