### PR TITLE
Reduce and gz metrics log files size

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -271,7 +271,7 @@ public class CorfuRuntime {
         nodeRouters = new ConcurrentHashMap<>();
         retryRate = 5;
 
-        getAddressSpaceView().setMetrics(metrics != null
+        getAddressSpaceView().setAndRegisterMetrics(metrics != null
                 ? metrics : CorfuRuntime.getDefaultMetrics());
         synchronized (metrics) {
             if (metrics.getNames().isEmpty()) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -69,8 +69,13 @@ public class AddressSpaceView extends AbstractView {
         super(runtime);
     }
 
-    public void setMetrics(MetricRegistry metrics) {
-
+    /**
+     * Sets the MetricRegistry and registers the metrics.
+     * Should be called only once. Multiple attempts to register the metrics
+     * throws IllegalArgumentException.
+     * @param metrics MetricRegistry to be set and registered to.
+     */
+    public void setAndRegisterMetrics(MetricRegistry metrics) {
         final String pfx = String.format("%s0x%x.cache.", runtime.getMpASV(), this.hashCode());
         metrics.register(pfx + "cache-size", (Gauge<Long>) readCache::estimatedSize);
         metrics.register(pfx + "evictions", (Gauge<Long>) () -> readCache.stats().evictionCount());

--- a/runtime/src/main/resources/logback.xml
+++ b/runtime/src/main/resources/logback.xml
@@ -4,12 +4,12 @@
     <appender name="MetricsRollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>/var/log/corfu-metrics.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>/var/log/corfu-metrics.%i.log</fileNamePattern>
+            <fileNamePattern>/var/log/corfu-metrics.%i.log.gz</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>10</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>100MB</maxFileSize>
+            <maxFileSize>10MB</maxFileSize>
         </triggeringPolicy>
 
         <encoder>


### PR DESCRIPTION
### Logback
* Gz metrics log files on rollover similar to MP.
* Reduce the fixed rollover size to 10MB per file.

### setAndRegisterMetrics
* Changed method name and added comments.