### PR TITLE
Prototype for Corfu global log scanner & replica repair

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
             <scope>provided</scope>
             <type>maven-plugin</type>
         </dependency>
+        <dependency>
+            <groupId>com.breinify</groupId>
+            <artifactId>brein-time-utilities</artifactId>
+            <version>1.6.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -64,6 +64,11 @@
             <artifactId>metrics-jvm</artifactId>
             <version>3.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>com.breinify</groupId>
+            <artifactId>brein-time-utilities</artifactId>
+            <version>1.6.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/runtime/src/main/java/org/corfudb/util/LogIntervalReplicas.java
+++ b/runtime/src/main/java/org/corfudb/util/LogIntervalReplicas.java
@@ -1,0 +1,21 @@
+package org.corfudb.util;
+
+import com.brein.time.timeintervals.intervals.IInterval;
+
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+/**
+ * Store sets of log intervals that are stored by a replica set.
+ */
+
+@AllArgsConstructor
+public class LogIntervalReplicas {
+    @Getter
+    Set<IInterval<Long>> logIntervalSet;
+    @Getter
+    Set<String> replicaSet;
+}

--- a/runtime/src/main/java/org/corfudb/util/RepairScanner.java
+++ b/runtime/src/main/java/org/corfudb/util/RepairScanner.java
@@ -410,7 +410,7 @@ public class RepairScanner {
         BufferedReader reader;
         try {
             // TODO external program review?
-            java.lang.Process p = Runtime.getRuntime().exec("/usr/bin/who am i");
+            java.lang.Process p = Runtime.getRuntime().exec("/usr/bin/who");
             p.waitFor();
 
             reader = new BufferedReader(new InputStreamReader(p.getInputStream()));

--- a/runtime/src/main/java/org/corfudb/util/RepairScanner.java
+++ b/runtime/src/main/java/org/corfudb/util/RepairScanner.java
@@ -1,0 +1,424 @@
+package org.corfudb.util;
+
+import com.brein.time.timeintervals.collections.SetIntervalCollection;
+import com.brein.time.timeintervals.indexes.IntervalTree;
+import com.brein.time.timeintervals.indexes.IntervalTreeBuilder;
+import com.brein.time.timeintervals.intervals.IInterval;
+import com.brein.time.timeintervals.intervals.LongInterval;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.view.Layout;
+
+/**
+ * Corfu global log scanner & replica repair.
+ *
+ * <p>For all intervals in the global Corfu log address space,
+ * the interval is either in a healthy state (as scanned by some
+ * repair worker at an earlier time), or its state is unknown.
+ * A SMRMap called 'globalState' is used to track healthy/unknown
+ * state, in addition to a map of intervals where a worker process
+ * is believed to be working on scanning & repairing data in that
+ * interval.
+ *
+ * <p>A worker processes has an interval size that it prefers to
+ * work with. (No need to use same size interval size with other
+ * workers.)  A worker consults the unknown map and adds an
+ * interval to the working map.  When the quorum repair scan
+ * is complete, a worker removes the interval from working
+ * and adds it to healthy.
+ *
+ * <p>Intervals that sit in the working map for too long are
+ * considered failed and re-eligible to be scanned.  A reliable
+ * detector of worker faults isn't needed: duplicate scans can't
+ * damage Corfu data.
+ *
+ * <p>TODO: Add query of Sequencer's global tail and then add
+ *          missing interval(s) to the unknown map.
+ *
+ * <p>TODO: Implement actual repair of Quorum Replicated data.
+ */
+
+public class RepairScanner {
+    private CorfuRuntime rt;
+    private final String globalStateStreamName = "Repair scanner global state";
+    private Map<Object, Object> globalState;
+    private final Long initTime = System.nanoTime();
+    @Getter
+    private Random random = new Random();
+    @Getter
+    @Setter
+    private long workerTimeoutSeconds = 5 * 60;
+    @Getter
+    @Setter
+    private long batchSize = 5000;
+
+    // Map<IInterval<Long>, Set<String>>
+    private final String keyHealthyMap = "Healthy map";
+    // Map<IInterval<Long>, LogIntervalReplicas>
+    private final String keyUnknownMap = "Unknown map";
+    // Map<String, ScannerWorkStatus>
+    private final String keyWorkingMap = "Working map";
+    // Map<Long, CorfuLayout>
+    private final String keyLayoutMap = "Layout archive map";
+
+    /** New RepairScanner.
+     *
+     * @param rt CorfuRuntime
+     */
+    public RepairScanner(CorfuRuntime rt) {
+        this.rt = rt;
+        globalState = rt.getObjectsView().build()
+                .setStreamName(globalStateStreamName)
+                .setType(SMRMap.class)
+                .open();
+
+        try {
+            rt.getObjectsView().TXBegin();
+            if (getHealthyMap() == null) {
+                globalState.put(keyHealthyMap, new HashMap<IInterval<Long>, Set<String>>());
+            }
+            if (getUnknownMap() == null) {
+                globalState.put(keyUnknownMap, new HashMap<IInterval<Long>, LogIntervalReplicas>());
+            }
+            if (getWorkingMap() == null) {
+                globalState.put(keyWorkingMap, new HashMap<IInterval<Long>, ScannerWorkStatus>());
+            }
+            if (getLayoutMap() == null) {
+                globalState.put(keyWorkingMap, new HashMap<Long, Layout>());
+            }
+
+            rt.getObjectsView().TXEnd();
+        } catch (Exception e) {
+            System.err.printf("TODO: error: %s\n", e);
+        }
+
+    }
+
+    /** Fetch unique replicas from the unknown state map. */
+    public Set<Set<String>> getUnknownState_uniqueReplicas() {
+        Set<Set<String>> x = getUnknownMap().values().stream()
+                .map(lir -> lir.getReplicaSet())
+                .collect(Collectors.toSet());
+        return x;
+    }
+
+    /** Fetch global ranges from the unknown state map. */
+    public Set<IInterval<Long>> getUnknownState_globalRanges(Set<String> replicaSet) {
+        Set<IInterval<Long>> x = getUnknownMap().entrySet().stream()
+                .filter(e -> e.getValue().getReplicaSet().equals(replicaSet))
+                .map(e -> e.getKey())
+                .collect(Collectors.toSet());
+        return x;
+    }
+
+    /**
+     * Find an idle interval to work on.  We direct our search by
+     * first looking at unknown state replica sets, then at an
+     * overall log interval for a replica set, then a specific
+     * log interval that isn't yet being worked on.
+     *
+     * @return Interval to work on, or null
+     *         if there is no work available.
+     */
+
+    public IInterval<Long> findIdleInterval() {
+        // Story: For load balancing reasons, we first want to
+        // chose a replica set at random.
+        Object[] x;
+        Object[] y;
+        Object[] z;
+        int index;
+        Function<Object,Integer> compare = (ignore) -> (random.nextInt(100) < 50) ? -1 : 1;
+
+        x = getUnknownState_uniqueReplicas().stream()
+                .sorted((a,b) -> compare.apply(a)).toArray();
+        for (int ix = 0; ix < x.length; ix++) {
+            Set<String> chosenReplicaSet = (Set<String>) x[ix];
+            // System.err.printf("Candidate replica set = %s\n", chosenReplicaSet);
+            y = getUnknownState_globalRanges(chosenReplicaSet).stream()
+                    .sorted((a,b) -> compare.apply(a)).toArray();
+            for (int iy = 0; iy < y.length; iy++) {
+                IInterval<Long> chosenGlobalInterval = (IInterval<Long>) y[iy];
+                // System.err.printf("Candidate global interval = %s\n", chosenGlobalInterval);
+
+                // Find & delete any working entries that are too old.
+                LocalDateTime tooLate = LocalDateTime.now()
+                        .minus(Duration.ofSeconds(getWorkerTimeoutSeconds()));
+                getWorkingMap().entrySet().stream()
+                        .filter(e -> e.getValue().getUpdateTime().compareTo(tooLate) < 0)
+                        .forEach(e -> {
+                            String workerKey = e.getKey();
+                            System.err.printf("***** worker key %s has expired "
+                                    + "(worker %s tooLate %s), deleting\n",
+                                    workerKey, e.getValue().getUpdateTime(), tooLate);
+                            deleteFromWorkingMap(workerKey);
+                        });
+
+                z = getUnknownMap().get(chosenGlobalInterval).getLogIntervalSet().toArray();
+                for (int iz = 0; iz < z.length; iz++) {
+                    IInterval<Long> workInterval = (IInterval<Long>) z[iz];
+                    // System.err.printf("Candidate work interval = %s\n", workInterval);
+                    IInterval<Long> res = findIdleIntervalInner(workInterval);
+                    if (res != null) {
+                        return res;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Last stage of finding an idle interval. */
+    public IInterval<Long> findIdleIntervalInner(IInterval<Long> candidateWorkInterval) {
+        Long intervalStart = candidateWorkInterval.getNormStart();
+        Long intervalEnd = candidateWorkInterval.getNormEnd();
+        Long incr = getBatchSize() - 1;
+        IInterval<Long> found = null;
+
+        // Build interval tree to help identify intervals that
+        // already have active workers.
+        IntervalTree tree = IntervalTreeBuilder.newBuilder()
+                .usePredefinedType(IntervalTreeBuilder.IntervalType.LONG)
+                .collectIntervals(interval -> new SetIntervalCollection())
+                .build();
+        getWorkingMap().entrySet().stream()
+                .map(e -> e.getValue().getInterval())
+                .forEach(i -> tree.add(i));
+
+        // Search the interval
+        while (intervalStart <= intervalEnd) {
+            Collection<IInterval> c = tree.overlap(new LongInterval(intervalStart,
+                                                                    intervalStart + incr));
+            if (c.isEmpty()) {
+                found = new LongInterval(intervalStart, Long.min(intervalStart + incr,
+                                                                 intervalEnd));
+                // System.err.printf("found %s, break\n", found);
+                break;
+            } else {
+                IInterval<Long> conflict = (IInterval<Long>) c.toArray()[0];
+                if (conflict.getNormStart() == intervalStart) {
+                    intervalStart = conflict.getNormEnd() + 1;
+                    incr = getBatchSize() - 1;
+                } else {
+                    // Keep intervalStart the same, but use a smaller incr and retry.
+                    // There may be *another* overlap, hence the retry.
+                    incr = conflict.getNormStart() - intervalStart - 1;
+                }
+            }
+        }
+        return found;
+    }
+
+    /** Check if worker has aborted. */
+    public boolean workerAborted(String workerId, IInterval<Long> workInterval) {
+        if (getWorkingMap().get(workerId).equals(workerId)) {
+            return deleteFromWorkingMap(workerId);
+        } else {
+            return false;
+        }
+    }
+
+    /** Check for worker success. */
+    public boolean workerSuccess(String workerId, IInterval<Long> workInterval) {
+        if (getWorkingMap().get(workerId) != null) {
+            final IntervalTree tree = IntervalTreeBuilder.newBuilder()
+                    .usePredefinedType(IntervalTreeBuilder.IntervalType.LONG)
+                    .collectIntervals(interval -> new SetIntervalCollection())
+                    .build();
+            getUnknownMap().keySet().stream()
+                    .forEach(interval -> tree.add(interval));
+            IInterval<Long> unknownMapKey =
+                    (IInterval<Long>) tree.overlap(workInterval).toArray()[0];
+
+            LogIntervalReplicas moveVal = getUnknownMap().get(unknownMapKey);
+            if (workInterval.equals(unknownMapKey)) {
+                // 100% overlap.  Nothing to add.
+                // Let the deleteFromWorkingMap() do the rest.
+            } else if (workInterval.getNormStart()
+                       == unknownMapKey.getNormStart()) {
+                IInterval<Long> newKey = new LongInterval(workInterval.getNormEnd() + 1,
+                                                          unknownMapKey.getNormEnd());
+                addToUnknownMap(newKey, moveVal);
+            } else if (workInterval.getNormEnd() == unknownMapKey.getNormEnd()) {
+                IInterval<Long> newKey = new LongInterval(unknownMapKey.getNormStart(),
+                                                          workInterval.getNormStart() - 1);
+                addToUnknownMap(newKey, moveVal);
+            } else {
+                IInterval<Long> beforeKey = new LongInterval(unknownMapKey.getNormStart(),
+                                                             workInterval.getNormStart() - 1);
+                IInterval<Long> afterKey = new LongInterval(workInterval.getNormEnd() + 1,
+                                                            unknownMapKey.getNormEnd());
+                addToUnknownMap(beforeKey, moveVal);
+                addToUnknownMap(afterKey, moveVal);
+            }
+            deleteFromUnknownMap(unknownMapKey);
+            deleteFromWorkingMap(workerId);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+
+    public Map<IInterval<Long>, Set<String>> getHealthyMap() {
+        return (Map<IInterval<Long>, Set<String>>) globalState.get(keyHealthyMap);
+    }
+
+    public Map<IInterval<Long>, LogIntervalReplicas> getUnknownMap() {
+        return (Map<IInterval<Long>, LogIntervalReplicas>) globalState.get(keyUnknownMap);
+    }
+
+    public Map<String, ScannerWorkStatus> getWorkingMap() {
+        return (Map<String, ScannerWorkStatus>) globalState.get(keyWorkingMap);
+    }
+
+    public Map<Long, Layout> getLayoutMap() {
+        return (Map<Long, Layout>) globalState.get(keyLayoutMap);
+    }
+
+    /** Remove interval from the healthy map. */
+    public boolean deleteFromHealthyMap(IInterval<Long> interval) {
+        Map<IInterval<Long>, Set<String>> m = getHealthyMap();
+        if (m.containsKey(interval)) {
+            m.remove(interval);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /** Add interval + replicas to the healthy map. */
+    public boolean addToHealthyMap(IInterval<Long> interval, Set<String> replicas) {
+        Map<IInterval<Long>, Set<String>> m = getHealthyMap();
+        // TODO more safety/sanity checking here, e.g., overlapping conditions
+
+        if (! m.containsKey(interval)) {
+            getHealthyMap().put(interval, replicas);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /** Remove interval from the unknown map. */
+    public boolean deleteFromUnknownMap(IInterval<Long> interval) {
+        Map<IInterval<Long>, LogIntervalReplicas> m = getUnknownMap();
+        if (m.containsKey(interval)) {
+            m.remove(interval);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /** Add interval + LogIntervalReplicas to the unknown map. */
+    public boolean addToUnknownMap(IInterval<Long> interval, LogIntervalReplicas lir) {
+        Map<IInterval<Long>, LogIntervalReplicas> m = getUnknownMap();
+        // TODO more safety/sanity checking here, e.g., overlapping conditions
+
+        if (! m.containsKey(interval)) {
+            m.put(interval, lir);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /** Replace an interval + LogIntervalReplicas from the unknown map. */
+    public boolean replaceUnknownMap(IInterval<Long> interval, LogIntervalReplicas lir) {
+        Map<IInterval<Long>, LogIntervalReplicas> m = getUnknownMap();
+        // TODO more safety/sanity checking here, e.g., overlapping conditions
+
+        if (! m.containsKey(interval)) {
+            return false;
+        } else {
+            m.put(interval, lir);
+            return true;
+        }
+    }
+
+    /** Remove worker from the working map. */
+    public boolean deleteFromWorkingMap(String workerName) {
+        Map<String, ScannerWorkStatus> m = getWorkingMap();
+        if (m.containsKey(workerName)) {
+            m.remove(workerName);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /** Add worker + status to the working map. */
+    public boolean addToWorkingMap(String workerName, ScannerWorkStatus status) {
+        Map<String, ScannerWorkStatus> m = getWorkingMap();
+        // TODO more safety/sanity checking here, e.g., overlapping conditions
+
+        if (! m.containsKey(workerName)) {
+            m.put(workerName, status);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /** Add epoch + layout to the layout map. */
+    public boolean addToLayoutMap(Long epoch, Layout layout) {
+        Map<Long, Layout> m = getLayoutMap();
+        if (! m.containsKey(epoch)) {
+            m.put(epoch, layout);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /** Create a worker task name. */
+    public String myWorkerName() {
+        try {
+            return myWorkerName(java.net.InetAddress.getLocalHost().toString());
+        } catch (UnknownHostException e) {
+            return myWorkerName("unknown host");
+        }
+    }
+
+    /** Create a worker task name. */
+    public String myWorkerName(String host) {
+        String whoAmI = getWhoAmI();
+        String thr = Thread.currentThread().toString();
+        return String.join(",", host, whoAmI, thr,
+                initTime.toString());
+    }
+
+    /** Get /usr/bin/who output from the OS. */
+    public String getWhoAmI() {
+        BufferedReader reader;
+        try {
+            // TODO external program review?
+            java.lang.Process p = Runtime.getRuntime().exec("/usr/bin/who am i");
+            p.waitFor();
+
+            reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String line = reader.readLine();
+            String[] a = line.split(" +");
+            return String.join(":", a[0], a[1]);
+        } catch (Exception e) {
+            return getWhoAmI();
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/util/ScannerWorkStatus.java
+++ b/runtime/src/main/java/org/corfudb/util/ScannerWorkStatus.java
@@ -1,0 +1,29 @@
+package org.corfudb.util;
+
+import com.brein.time.timeintervals.intervals.IInterval;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Store state for individual worker threads as they scan
+ * small intervals of the global log.
+ */
+
+@AllArgsConstructor
+public class ScannerWorkStatus {
+    // String workerName;        // Name for worker, hopefully unique system-wide but not mandatory
+    @Getter
+    LocalDateTime startTime;  // Starting time of the worker
+    @Getter
+    @Setter
+    LocalDateTime updateTime; // Time this record was updated
+    @Getter
+    IInterval<Long> interval; // Interval that we're working on
+    @Getter
+    @Setter
+    long scanCount;           // Total items scanned in this interval
+}

--- a/test/src/test/java/org/corfudb/runtime/concurrent/RepairScannerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/RepairScannerTest.java
@@ -1,0 +1,184 @@
+package org.corfudb.runtime.concurrent;
+
+import com.brein.time.timeintervals.collections.SetIntervalCollection;
+import com.brein.time.timeintervals.indexes.IntervalTree;
+import com.brein.time.timeintervals.indexes.IntervalTreeBuilder;
+import com.brein.time.timeintervals.intervals.IInterval;
+import com.brein.time.timeintervals.intervals.LongInterval;
+import org.corfudb.runtime.object.transactions.AbstractTransactionsTest;
+import org.corfudb.util.LogIntervalReplicas;
+import org.corfudb.util.RepairScanner;
+import org.corfudb.util.ScannerWorkStatus;
+import org.junit.Test;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ *  Basic test suite for RepairScanner.
+ */
+public class RepairScannerTest extends AbstractTransactionsTest {
+
+    @Override
+    public void TXBegin() {
+        OptimisticTXBegin();
+    }
+
+    @Test
+    public void healthyMapTest() throws Exception {
+        final long nine=9L, ninetynine=99L;
+        RepairScanner rs = new RepairScanner(getDefaultRuntime());
+        Set<String> setA = Collections.singleton("host:0");
+        IInterval<Long> bigInterval = new LongInterval(0L, ninetynine);
+        IInterval<Long> smallInterval = new LongInterval(0L, nine);
+        LogIntervalReplicas lirA = new LogIntervalReplicas(
+                Collections.singleton(smallInterval), setA);
+
+        assertThat(rs.getUnknownMap()).isEmpty();
+
+        assertThat(rs.replaceUnknownMap(bigInterval, lirA)).isFalse();
+        assertThat(rs.addToUnknownMap(bigInterval, lirA)).isTrue();
+        assertThat(rs.addToUnknownMap(bigInterval, lirA)).isFalse();
+        assertThat(rs.replaceUnknownMap(bigInterval, lirA)).isTrue();
+
+        assertThat(rs.deleteFromUnknownMap(bigInterval)).isTrue();
+        assertThat(rs.deleteFromUnknownMap(bigInterval)).isFalse();
+    }
+
+    @Test
+    public void unknownMapTest() throws Exception {
+        final long ninetynine=99L;
+        RepairScanner rs = new RepairScanner(getDefaultRuntime());
+        IInterval<Long> intervalA = new LongInterval(0L, ninetynine);
+        Set<String> setA = Collections.singleton("host:0");
+        Set<String> setB = Collections.singleton("host:1");
+
+        assertThat(rs.getHealthyMap()).isEmpty();
+        assertThat(rs.addToHealthyMap(intervalA, setA)).isTrue();
+        assertThat(rs.addToHealthyMap(intervalA, setB)).isFalse();
+        assertThat(rs.deleteFromHealthyMap(intervalA)).isTrue();
+        assertThat(rs.deleteFromHealthyMap(intervalA)).isFalse();
+    }
+
+    @Test
+    public void workingMapTest() throws Exception {
+        final long five=5L;
+        RepairScanner rs = new RepairScanner(getDefaultRuntime());
+        String myName = rs.myWorkerName();
+        ScannerWorkStatus status = new ScannerWorkStatus(
+                LocalDateTime.now(),
+                LocalDateTime.now(),
+                new LongInterval(1L, five),
+                0);
+
+        assertThat(rs.getWorkingMap()).isEmpty();
+        assertThat(rs.addToWorkingMap(myName, status)).isTrue();
+        assertThat(rs.addToWorkingMap(myName, status)).isFalse();
+        assertThat(rs.deleteFromWorkingMap(myName)).isTrue();
+        assertThat(rs.deleteFromWorkingMap(myName)).isFalse();
+    }
+
+    @Test
+    public void workflowTest() throws Exception {
+        final long nineteen = 19L;
+        Random random = new Random();
+        long seed = System.currentTimeMillis();
+        random.setSeed(seed);
+        RepairScanner rs = new RepairScanner(getDefaultRuntime());
+        IInterval<Long> globalInterval = new LongInterval(0L, nineteen);
+        Set<String> setA = new HashSet<>();
+        setA.add("hostA:9000");
+        setA.add("hostB:9000");
+        setA.add("hostC:9000");
+        LogIntervalReplicas unknownState = new LogIntervalReplicas(
+                Collections.singleton(globalInterval), setA);
+
+        // Pretend that we look at a layout and see 0-19 using hostA/B/C.
+        // We've never seen this interval before, so we add this
+        // interval to the unknown map.
+        rs.addToUnknownMap(globalInterval, unknownState);
+
+        // Pretend that there are some active workers that
+        // have already been started.
+        Set<IInterval<Long>> otherActiveWorkers = new HashSet<>();
+        final long four=4L, eleven=11L, twelve=12L;
+        otherActiveWorkers.add(new LongInterval(1L, 2L));
+        otherActiveWorkers.add(new LongInterval(four, four));
+        otherActiveWorkers.add(new LongInterval(eleven, twelve));
+        otherActiveWorkers.forEach(i ->
+                rs.addToWorkingMap("worker" + i.getNormStart().toString(),
+                        new ScannerWorkStatus(LocalDateTime.now(), LocalDateTime.now(), i, 0)));
+
+        final int numThreads = 11, onehundred=100, fifty=50;
+        // Pretend that we have 11 threads that want to do work.
+        // Iterations 9 and beyond will have no work available,
+        // but we'll just test the last iteration.
+        List<IInterval<Long>> ourIntervals = new ArrayList<>();
+        for (int i = 0; i < numThreads; i++) {
+            // Story: Skip past parts of chosenWorkInterval that have
+            // active workers to select a subinterval to work on.
+            IInterval<Long> found = rs.findIdleInterval();
+            // System.err.printf("*** iter %d found = %s\n", i, found);
+            if (found != null) {
+                rs.addToWorkingMap("foo" + found.getNormStart().toString(),
+                        new ScannerWorkStatus(LocalDateTime.now(), LocalDateTime.now(), found, 0));
+                ourIntervals.add(found);
+            }
+            if (i == (numThreads-1)) {
+                assertThat(found).isNull();
+            }
+        }
+
+        // Sanity check: build an interval tree with the ourIntervals (A) intervals
+        // and with the otherActiveWorkers (B) intervals.  For each log address
+        // in globalInterval, that address must overlap with exactly 1 of {A,B}.
+        IntervalTree treeA = IntervalTreeBuilder.newBuilder()
+                .usePredefinedType(IntervalTreeBuilder.IntervalType.LONG)
+                .collectIntervals(interval -> new SetIntervalCollection())
+                .build();
+        IntervalTree treeB = IntervalTreeBuilder.newBuilder()
+                .usePredefinedType(IntervalTreeBuilder.IntervalType.LONG)
+                .collectIntervals(interval -> new SetIntervalCollection())
+                .build();
+        ourIntervals.stream().forEach(i -> treeA.add(i));
+        otherActiveWorkers.stream().forEach(i -> treeB.add(i));
+        for (Long addr = globalInterval.getNormStart(); addr <= globalInterval.getNormEnd(); addr++) {
+            IInterval<Long> addrI = new LongInterval(addr, addr);
+            int sum = treeA.overlap(addrI).size() + treeB.overlap(addrI).size();
+            assertThat(sum).isEqualTo(1);
+        }
+
+        // Simulate completion of the work, updating the
+        // global state as appropriate.  We shuffle-sort the
+        // ourIntervals to help find bugs.
+        try {
+            ourIntervals.stream()
+                    .sorted((a, b) -> random.nextInt(onehundred) < fifty ? -1 : 1)
+                    .forEach(i -> {
+                        String workerKey = (String) rs.getWorkingMap().entrySet().stream()
+                                .filter(e -> e.getValue().getInterval().equals(i))
+                                .map(e -> e.getKey())
+                                .toArray()[0];
+                        boolean success = rs.workerSuccess(workerKey, i);
+                        assertThat(success).describedAs("with seed " + Long.toString(seed)).isTrue();
+                    });
+        } catch (Exception e) {
+            System.err.printf("Error with seed = %d\n", seed);
+            throw e;
+        }
+
+        // Now that all of ourIntervals have simulated doing
+        // successful work and should have cleaned up all
+        // their state, anything else that remains in the
+        // global working list must be the equivalent to the
+        // otherActiveWorkers set.
+        assertThat(rs.getWorkingMap().values().stream()
+                        .map(x -> x.getInterval()).collect(Collectors.toSet()))
+                .isEqualTo(otherActiveWorkers);
+        // System.err.printf("FINAL unknown map keys: %s\n", rs.getUnknownMap().keySet());
+    }
+
+}


### PR DESCRIPTION
For all intervals in the global Corfu log address space,
the interval is either in a healthy state (as scanned by some
repair worker at an earlier time), or its state is unknown.
A SMRMap called 'globalState' is used to track healthy/unknown
state, in addition to a map of intervals where a worker process
is believed to be working on scanning & repairing data in that
interval.

A worker processes has an interval size that it prefers to
work with. (No need to use same size interval size with other
workers.)  A worker consults the unknown map and adds an
interval to the working map.  When the quorum repair scan
is complete, a worker removes the interval from working
and adds it to healthy.

Intervals that sit in the working map for too long are
considered failed and re-eligible to be scanned.  A reliable
detector of worker faults isn't needed: duplicate scans can't
damage Corfu data.