### PR TITLE
Debian build for gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,4 +225,3 @@ target
 .gradletasknamecache
 .gradle/
 build/
-bin/


### PR DESCRIPTION
This PR introduces debian support for Gradle, which may
not be working due to change from -shaded to -all.

It also generates an uberjar, which includes
all dependencies.