### PR TITLE
Retain Projection Return Type

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -224,7 +224,7 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
      */
     @SuppressWarnings("unchecked")
     @Accessor
-    public @Nonnull Collection<Object> getByIndex(@Nonnull F indexFunction, I index) {
+    public @Nonnull <P> Collection<P> getByIndex(@Nonnull F indexFunction, I index) {
         return getByIndex(indexFunction, indexFunction.getProjectionFunction(), index);
     }
 


### PR DESCRIPTION
Retain the generic return type for getByIndex.