### PR TITLE
Fix stream previous/seek calls

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -274,7 +274,7 @@ public abstract class AbstractQueuedStreamView extends
         final QueuedStreamContext context = getCurrentContext();
         final long oldPointer = context.globalPointer;
 
-        log.trace("Previous[{}] max={} min={}", this,
+        log.trace("previous[{}]: max={} min={}", this,
                 context.maxResolution,
                 context.minResolution);
 
@@ -305,7 +305,7 @@ public abstract class AbstractQueuedStreamView extends
             context.globalPointer = oldPointer;
             prevAddress = context
                     .resolvedQueue.lower(context.globalPointer);
-            log.trace("Previous[{}] updated resolved queue {}", this, context.resolvedQueue);
+            log.trace("previous[{}]: updated resolved queue {}", this, context.resolvedQueue);
         }
         // If still null, we're done.
         if (prevAddress == null) {
@@ -313,7 +313,7 @@ public abstract class AbstractQueuedStreamView extends
         }
         // Add the old pointer back into the read queue
         context.readQueue.add(oldPointer);
-        log.trace("Previous[{}] updated read queue {}", this, context.readQueue);
+        log.trace("previous[{}]: updated read queue {}", this, context.readQueue);
         // Update the global pointer
         context.globalPointer = prevAddress;
         return read(prevAddress);

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -307,12 +307,14 @@ public abstract class AbstractQueuedStreamView extends
                     .resolvedQueue.lower(context.globalPointer);
             log.trace("previous[{}]: updated resolved queue {}", this, context.resolvedQueue);
         }
+
+        // Clear the read queue, it may no longer be valid
+        context.readQueue.clear();
+
         // If still null, we're done.
         if (prevAddress == null) {
             return null;
         }
-        // Add the old pointer back into the read queue
-        context.readQueue.add(oldPointer);
         log.trace("previous[{}]: updated read queue {}", this, context.readQueue);
         // Update the global pointer
         context.globalPointer = prevAddress;

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -272,6 +272,8 @@ public abstract class AbstractQueuedStreamView extends
     @Override
     public synchronized ILogData previous() {
         final QueuedStreamContext context = getCurrentContext();
+        final long oldPointer = context.globalPointer;
+
         log.trace("Previous[{}] max={} min={}", this,
                 context.maxResolution,
                 context.minResolution);
@@ -297,20 +299,21 @@ public abstract class AbstractQueuedStreamView extends
                 || prevAddress != null && prevAddress <= context.minResolution) {
             context.globalPointer = prevAddress == null ? Address.NEVER_READ :
                                                 prevAddress - 1L;
-            long oldPointer = context.globalPointer;
+
             remainingUpTo(context.minResolution);
             context.minResolution = Address.NON_ADDRESS;
             context.globalPointer = oldPointer;
             prevAddress = context
                     .resolvedQueue.lower(context.globalPointer);
-            log.trace("Previous[}] updated queue {}", this, context.resolvedQueue);
+            log.trace("Previous[{}] updated resolved queue {}", this, context.resolvedQueue);
         }
         // If still null, we're done.
         if (prevAddress == null) {
             return null;
         }
-        // Add the current pointer back into the read queue
-        context.readQueue.add(context.globalPointer);
+        // Add the old pointer back into the read queue
+        context.readQueue.add(oldPointer);
+        log.trace("Previous[{}] updated read queue {}", this, context.readQueue);
         // Update the global pointer
         context.globalPointer = prevAddress;
         return read(prevAddress);
@@ -423,7 +426,7 @@ public abstract class AbstractQueuedStreamView extends
          * {@inheritDoc}
          * */
         @Override
-        void seek(long globalAddress) {
+        synchronized void seek(long globalAddress) {
             if (Address.nonAddress(globalAddress)) {
                 throw new IllegalArgumentException("globalAddress must"
                         + " be >= Address.maxNonAddress()");

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -235,13 +235,6 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
 
         // Loop until we have reached the stop address.
         while (currentAddress > stopAddress  && Address.isAddress(currentAddress)) {
-            // The queue already contains an address from this
-            // range, terminate.
-            if (queue.contains(currentAddress)) {
-                log.trace("FollowBackpointers[{}] Terminate due to {} "
-                        + "already in queue", this, currentAddress);
-                return entryAdded;
-            }
             backpointerCount++;
 
             // Read the current address

--- a/test/src/test/java/org/corfudb/runtime/view/stream/BackpointerStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/BackpointerStreamViewTest.java
@@ -81,6 +81,9 @@ public class BackpointerStreamViewTest extends AbstractViewTest {
         }
     }
 
+    /** Test if seeking the stream after resetting and then calling previous
+     *  returns the correct entry.
+     */
     @Test
     public void seekSkipTest() {
         CorfuRuntime runtime = getDefaultRuntime();
@@ -93,7 +96,12 @@ public class BackpointerStreamViewTest extends AbstractViewTest {
         sv.append(ENTRY_1);
         sv.append(ENTRY_2);
         sv.reset();
+
+        // This moves the stream pointer so the NEXT read will be 2
+        // (the pointer is at 1).
         sv.seek(2);
+
+        // The previous entry should be ENTRY_0
         assertThat((byte[])sv.previous().getPayload(runtime))
                 .isEqualTo(ENTRY_0);
     }

--- a/test/src/test/java/org/corfudb/runtime/view/stream/BackpointerStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/BackpointerStreamViewTest.java
@@ -81,6 +81,23 @@ public class BackpointerStreamViewTest extends AbstractViewTest {
         }
     }
 
+    @Test
+    public void seekSkipTest() {
+        CorfuRuntime runtime = getDefaultRuntime();
+        IStreamView sv = runtime.getStreamsView().get(CorfuRuntime.getStreamID("streamA"));
+        final byte[] ENTRY_0 = {0};
+        final byte[] ENTRY_1 = {1};
+        final byte[] ENTRY_2 = {2};
+
+        sv.append(ENTRY_0);
+        sv.append(ENTRY_1);
+        sv.append(ENTRY_2);
+        sv.reset();
+        sv.seek(2);
+        assertThat((byte[])sv.previous().getPayload(runtime))
+                .isEqualTo(ENTRY_0);
+    }
+
 
     @Test
     public void moreReadQueueTest() {


### PR DESCRIPTION
A bug in the implementation of previous could result in incorrect data being returned by a stream, if previous is called right after a seek.
This PR fixes this issue and adds a unit test which demonstrates the bug.