### PR TITLE
Paxos on current layout members

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -92,7 +92,7 @@ public class LayoutServer extends AbstractServer {
         this.opts = serverContext.getServerConfig();
         this.serverContext = serverContext;
 
-        if ((Boolean) opts.get("--single")) {
+        if (getCurrentLayout() == null && (Boolean) opts.get("--single")) {
             getSingleNodeLayout();
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -30,6 +30,7 @@ import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.clients.NettyClientRouter;
 import org.corfudb.runtime.clients.SequencerClient;
+import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.view.AddressSpaceView;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.LayoutView;
@@ -505,8 +506,8 @@ public class CorfuRuntime {
                         // If the layout we got has a smaller epoch than the router,
                         // we discard it.
                         if (l.getEpoch() < router.getEpoch()) {
-                            log.warn("fetchLayout: Received a layout with epoch {} from server {}:{}" +
-                                            " smaller than router epoch {}, discarded.",
+                            log.warn("fetchLayout: Received a layout with epoch {} from server "
+                                            + "{}:{} smaller than router epoch {}, discarded.",
                                     l.getEpoch(), router.getHost(),
                                     router.getPort(), router.getEpoch());
                             continue;
@@ -525,8 +526,15 @@ public class CorfuRuntime {
                         // it is acceptable (at least the code on 10/13/2016 does not have issues)
                         // but setEpoch of routers needs to be synchronized as those variables are
                         // not local.
-                        l.getAllServers().stream().map(getRouterFunction).forEach(x ->
-                                x.setEpoch(l.getEpoch()));
+                        try {
+                            l.getAllServers().stream().map(getRouterFunction).forEach(x ->
+                                    x.setEpoch(l.getEpoch()));
+                        } catch (NetworkException ne) {
+                            // We have already received the layout and there is no need to keep client waiting.
+                            // NOTE: This is true assuming this happens only at router creation.
+                            // If not we also have to take care of setting the latest epoch on Client Router.
+                            log.warn("fetchLayout: Error getting router : {}", ne);
+                        }
                         layoutServers = l.getLayoutServers();
                         layout = layoutFuture;
                         //FIXME Synchronization END
@@ -537,7 +545,8 @@ public class CorfuRuntime {
                         log.warn("Tried to get layout from {} but failed with exception:", s, e);
                     }
                 }
-                log.warn("Couldn't connect to any up-to-date layout servers, retrying in {}s.", retryRate);
+                log.warn("Couldn't connect to any up-to-date layout servers, retrying in {}s.",
+                        retryRate);
                 try {
                     Thread.sleep(retryRate * 1000);
                 } catch (InterruptedException e) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -14,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.wireprotocol.LayoutPrepareResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.LayoutClient;
+import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
@@ -45,7 +47,7 @@ public class LayoutView extends AbstractView {
      * @return The number of nodes required for a quorum.
      */
     public int getQuorumNumber() {
-        return (int) (getCurrentLayout().getLayoutClientStream().count() / 2) + 1;
+        return (getLayout().getLayoutServers().size() / 2) + 1;
     }
 
     /**
@@ -68,10 +70,15 @@ public class LayoutView extends AbstractView {
             throws QuorumUnreachableException, OutrankedException, WrongEpochException {
         // Note this step is done because we have added the layout to the Epoch.
         long epoch = layout.getEpoch();
-        Layout layoutToPropose = layout;
+        Layout currentLayout = getLayout();
+        if (currentLayout.getEpoch() != epoch - 1) {
+            log.error("Runtime layout has epoch {} but expected {} to move to epoch {}",
+                    currentLayout.getEpoch(), epoch - 1, epoch);
+            throw new WrongEpochException(epoch - 1);
+        }
         //phase 1: prepare with a given rank.
-        Layout alreadyProposedLayout = prepare(epoch, rank, layout);
-        layoutToPropose = alreadyProposedLayout != null ? alreadyProposedLayout : layout;
+        Layout alreadyProposedLayout = prepare(epoch, rank);
+        Layout layoutToPropose = alreadyProposedLayout != null ? alreadyProposedLayout : layout;
         // For some reason, the alreadyProposedLayout sometimes doesn't have a runtime
         // we need to remove runtime from the layout, but for now, let's manually take
         // it from the original layout.
@@ -84,7 +91,6 @@ public class LayoutView extends AbstractView {
 
     /**
      * Sends prepare to the current layout and can proceed only if it is accepted by a quorum.
-     * // TODO Gets stuck if quorum is not achieved. Figure out if this is the correct solution.
      *
      * @param rank The rank for the proposed layout.
      * @return layout
@@ -94,18 +100,31 @@ public class LayoutView extends AbstractView {
      * @throws WrongEpochException wrong epoch number.
      */
     @SuppressWarnings("unchecked")
-    public Layout prepare(long epoch, long rank, Layout layout)
+    public Layout prepare(long epoch, long rank)
             throws QuorumUnreachableException, OutrankedException, WrongEpochException {
 
-        CompletableFuture<LayoutPrepareResponse>[] prepareList = layout.getLayoutClientStream()
-                .map(x -> x.prepare(epoch, rank))
+        CompletableFuture<LayoutPrepareResponse>[] prepareList = getLayout().getLayoutServers()
+                .stream()
+                .map(x -> {
+                    CompletableFuture<LayoutPrepareResponse> cf = new CompletableFuture<>();
+                    try {
+                        // Connection to router can cause network exception too.
+                        LayoutClient layoutClient = runtime.getRouter(x)
+                                .getClient(LayoutClient.class);
+                        cf = layoutClient.prepare(epoch, rank);
+                    } catch (Exception e) {
+                        cf.completeExceptionally(e);
+                    }
+                    return cf;
+                })
                 .toArray(CompletableFuture[]::new);
         LayoutPrepareResponse[] acceptList;
         long timeouts = 0L;
+        long wrongEpochRejected = 0L;
         while (true) {
             // do we still have enough for a quorum?
             if (prepareList.length < getQuorumNumber()) {
-                log.debug("Quorum unreachable, remaining={}, required={}", prepareList,
+                log.debug("prepare: Quorum unreachable, remaining={}, required={}", prepareList,
                         getQuorumNumber());
                 throw new QuorumUnreachableException(prepareList.length, getQuorumNumber());
             }
@@ -113,9 +132,12 @@ public class LayoutView extends AbstractView {
             // wait for someone to complete.
             try {
                 CFUtils.getUninterruptibly(CompletableFuture.anyOf(prepareList),
-                        OutrankedException.class, TimeoutException.class);
-            } catch (TimeoutException te) {
+                        OutrankedException.class, TimeoutException.class, NetworkException.class,
+                        WrongEpochException.class);
+            } catch (TimeoutException | NetworkException e) {
                 timeouts++;
+            } catch (WrongEpochException we) {
+                wrongEpochRejected++;
             }
 
             // remove errors.
@@ -128,8 +150,9 @@ public class LayoutView extends AbstractView {
                     .filter(x -> x != null)
                     .toArray(LayoutPrepareResponse[]::new);
 
-            log.debug("Successful responses={}, needed={}, timeouts={}", acceptList.length,
-                    getQuorumNumber(), timeouts);
+            log.debug("prepare: Successful responses={}, needed={}, timeouts={}, "
+                            + "wrongEpochRejected={}",
+                    acceptList.length, getQuorumNumber(), timeouts, wrongEpochRejected);
 
             if (acceptList.length >= getQuorumNumber()) {
                 break;
@@ -145,7 +168,6 @@ public class LayoutView extends AbstractView {
 
     /**
      * Proposes new layout to all the servers in the current layout.
-     * // TODO Gets stuck if quorum is not achieved. Figure out if this is the correct solution.
      *
      * @throws QuorumUnreachableException Thrown if responses not received from a majority of
      *                                    layout servers.
@@ -154,15 +176,27 @@ public class LayoutView extends AbstractView {
     @SuppressWarnings("unchecked")
     public Layout propose(long epoch, long rank, Layout layout)
             throws QuorumUnreachableException, OutrankedException {
-        CompletableFuture<Boolean>[] proposeList = layout.getLayoutClientStream()
-                .map(x -> x.propose(epoch, rank, layout))
+        CompletableFuture<Boolean>[] proposeList = getLayout().getLayoutServers().stream()
+                .map(x -> {
+                    CompletableFuture<Boolean> cf = new CompletableFuture<>();
+                    try {
+                        // Connection to router can cause network exception too.
+                        LayoutClient layoutClient = runtime.getRouter(x)
+                                .getClient(LayoutClient.class);
+                        cf =  layoutClient.propose(epoch, rank, layout);
+                    } catch (NetworkException e) {
+                        cf.completeExceptionally(e);
+                    }
+                    return cf;
+                })
                 .toArray(CompletableFuture[]::new);
 
         long timeouts = 0L;
+        long wrongEpochRejected = 0L;
         while (true) {
             // do we still have enough for a quorum?
             if (proposeList.length < getQuorumNumber()) {
-                log.debug("Quorum unreachable, remaining={}, required={}", proposeList,
+                log.debug("propose: Quorum unreachable, remaining={}, required={}", proposeList,
                         getQuorumNumber());
                 throw new QuorumUnreachableException(proposeList.length, getQuorumNumber());
             }
@@ -170,9 +204,12 @@ public class LayoutView extends AbstractView {
             // wait for someone to complete.
             try {
                 CFUtils.getUninterruptibly(CompletableFuture.anyOf(proposeList),
-                        OutrankedException.class, TimeoutException.class);
-            } catch (TimeoutException te) {
+                        OutrankedException.class, TimeoutException.class, NetworkException.class,
+                        WrongEpochException.class);
+            } catch (TimeoutException | NetworkException e) {
                 timeouts++;
+            } catch (WrongEpochException we) {
+                wrongEpochRejected++;
             }
 
             // remove errors.
@@ -183,11 +220,12 @@ public class LayoutView extends AbstractView {
             // count successes.
             long count = stream(proposeList)
                     .map(x -> x.getNow(false))
-                    .filter(x -> true)
+                    .filter(x -> x)
                     .count();
 
-            log.debug("Successful responses={}, needed={}, timeouts={}", count, getQuorumNumber(),
-                    timeouts);
+            log.debug("propose: Successful responses={}, needed={}, timeouts={}, "
+                            + "wrongEpochRejected={}",
+                    count, getQuorumNumber(), timeouts, wrongEpochRejected);
 
             if (count >= getQuorumNumber()) {
                 break;
@@ -206,10 +244,22 @@ public class LayoutView extends AbstractView {
      *
      * @throws WrongEpochException wrong epoch number.
      */
+    @SuppressWarnings("unchecked")
     public void committed(long epoch, Layout layout)
             throws WrongEpochException {
-        CompletableFuture<Boolean>[] commitList = layout.getLayoutClientStream()
-                .map(x -> x.committed(epoch, layout))
+        CompletableFuture<Boolean>[] commitList = layout.getLayoutServers().stream()
+                .map(x -> {
+                    CompletableFuture<Boolean> cf = new CompletableFuture<>();
+                    try {
+                        // Connection to router can cause network exception too.
+                        LayoutClient layoutClient = runtime.getRouter(x)
+                                .getClient(LayoutClient.class);
+                        cf = layoutClient.committed(epoch, layout);
+                    } catch (NetworkException e) {
+                        cf.completeExceptionally(e);
+                    }
+                    return cf;
+                })
                 .toArray(CompletableFuture[]::new);
 
         int timeouts = 0;
@@ -218,12 +268,12 @@ public class LayoutView extends AbstractView {
             // wait for someone to complete.
             try {
                 CFUtils.getUninterruptibly(CompletableFuture.anyOf(commitList),
-                        WrongEpochException.class, TimeoutException.class);
-            } catch (TimeoutException te) {
+                        WrongEpochException.class, TimeoutException.class, NetworkException.class);
+            } catch (TimeoutException | NetworkException e) {
                 timeouts++;
             }
             responses++;
-            log.debug("Successful responses={}, timeouts={}", responses, timeouts);
+            log.debug("committed: Successful responses={}, timeouts={}", responses, timeouts);
         }
     }
 }

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -41,7 +41,8 @@ public class SealIT extends AbstractIT{
          *   3. Propose the new layout by driving paxos.
          */
 
-        Layout currentLayout = cr1.getLayoutView().getCurrentLayout();
+        Layout currentLayout = (Layout) cr1.getLayoutView().getCurrentLayout().clone();
+        currentLayout.setRuntime(cr1);
         /* 1 */
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
         /* 2 */

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -102,7 +102,8 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         getManagementServer(SERVERS.PORT_2).shutdown();
 
         // Seal
-        Layout currentLayout = rt.getLayoutView().getCurrentLayout();
+        Layout currentLayout = (Layout) rt.getLayoutView().getCurrentLayout().clone();
+        currentLayout.setRuntime(rt);
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
         currentLayout.moveServersToEpoch();
 


### PR DESCRIPTION
### Prepare and Propose on the members of the current layout.
- Now sending prepare and propose messages to members of the current layout only and NOT members of the proposed layout.

### Handle wrong epoch exception
- Apart from the Timeout Exception also handle wrong epoch exception for the case where a layout server may be left behind and may reject the prepare or propose message.

### Fix Network Exceptions
- Fixes a few unhandled network exceptions in the consensus and the seal phase. This unblocks the testing-framework fault tests effort.

### getQuorumNumber
- Changed from getLayoutClientStream.count -> getLayoutServers.size
- getLayoutClientStream attempts to create client routers to connect to the endpoints which can result in unhandled network exceptions causing reconfiguration to abort.