### PR TITLE
Optimize case when no conflict resolution is necesssary

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -382,6 +382,13 @@ public class SequencerServer extends AbstractServer {
         final TxResolutionInfo txInfo = req.getTxnResolution();
         final long txSnapshotTimestamp = txInfo.getSnapshotTimestamp();
 
+        // If the tx has no snapshot (conflict-free) then issue the tokens.
+        if (txSnapshotTimestamp == Address.NO_SNAPSHOT) {
+            log.debug("handleTxToken[{}]: Conflict-free TX");
+            handleAllocation(msg, ctx, r);
+            return;
+        }
+
         if (txSnapshotTimestamp < trimMark) {
             log.debug("ABORT[{}] snapshot-ts[{}] trimMark-ts[{}]", txInfo,
                     txSnapshotTimestamp, trimMark);


### PR DESCRIPTION
When no conflict resolution is neccessary, the conflict set
does not need to be hashed, and the sequencer does not
need to resolve conflicts. This PR enables the sequencer
to handle conflict-free transactions.