### PR TITLE
Batch Size set to '1' performance test

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -29,7 +29,7 @@ import org.corfudb.runtime.exceptions.TrimmedException;
 @Slf4j
 public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
 
-    static final int BATCH_SIZE = 50;
+    static final int BATCH_SIZE = 1;
     private StreamLog streamLog;
     private BlockingQueue<BatchWriterOperation> operationsQueue;
     final ExecutorService writerService = Executors


### PR DESCRIPTION
With this change we want to assess performance for a batch size of 1.
This PR will trigger the performance benchmark for testing.