### PR TITLE
 Catchup, replicate and Merge segments

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -51,6 +51,12 @@ public abstract class AbstractServer {
             return;
         }
 
+        if (isShutdown()) {
+            log.warn("Server received {} but is shutdown.", msg.getMsgType().toString());
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
+            return;
+        }
+
         if (!getHandler().handle(msg, ctx, r, isMetricsEnabled)) {
             log.warn("Received unhandled message type {}" , msg.getMsgType());
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/FailureHandlerDispatcher.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/FailureHandlerDispatcher.java
@@ -1,18 +1,11 @@
 package org.corfudb.infrastructure;
 
-import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.corfudb.recovery.FastObjectLoader;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.clients.LogUnitClient;
-import org.corfudb.runtime.exceptions.OutrankedException;
-import org.corfudb.runtime.exceptions.QuorumUnreachableException;
-import org.corfudb.runtime.exceptions.RecoveryException;
+import org.corfudb.runtime.view.IFailureHandlerPolicy;
 import org.corfudb.runtime.view.Layout;
 
 /**
@@ -25,11 +18,6 @@ import org.corfudb.runtime.view.Layout;
 public class FailureHandlerDispatcher {
 
     /**
-     * Rank used to update layout.
-     */
-    private volatile long prepareRank = 1;
-
-    /**
      * Recover cluster from layout.
      *
      * @param recoveryLayout Layout to use to recover
@@ -39,41 +27,7 @@ public class FailureHandlerDispatcher {
     public boolean recoverCluster(Layout recoveryLayout, CorfuRuntime corfuRuntime) {
 
         try {
-            // Seals and increments the epoch.
-            recoveryLayout.setRuntime(corfuRuntime);
-            sealEpoch(recoveryLayout);
-
-            // Attempts to update all the layout servers with the modified layout.
-            while (true) {
-                try {
-                    corfuRuntime.getLayoutView().updateLayout(recoveryLayout, prepareRank);
-                    prepareRank++;
-                } catch (OutrankedException oe) {
-                    // Update rank since outranked.
-                    log.error("Retrying layout update with higher rank: {}", oe);
-                    // Update rank to be able to outrank other competition and complete paxos.
-                    prepareRank = oe.getNewRank() + 1;
-                    continue;
-                }
-                break;
-            }
-
-            // Check if our proposed layout got selected and committed.
-            corfuRuntime.invalidateLayout();
-            if (corfuRuntime.getLayoutView().getLayout().equals(recoveryLayout)) {
-                log.info("Layout Recovered = {}", recoveryLayout);
-            } else {
-                log.warn("Layout recovered with a different layout = {}",
-                        corfuRuntime.getLayoutView().getLayout());
-            }
-
-            //TODO: Since sequencer reset is moved after paxos. Make sure the runtime has the latest
-            //TODO: layout view and latest client router epoch. (Use quorum layout fetch.)
-            //TODO: Handle condition if primary sequencer is not marked ready, reset fails.
-            // Reconfigure servers if required
-            // Primary sequencer would already be in a not-ready state since its in recovery.
-            reconfigureServers(corfuRuntime, recoveryLayout, recoveryLayout, true);
-
+            corfuRuntime.getLayoutManagementView().recoverCluster(recoveryLayout);
         } catch (Exception e) {
             log.error("Error: recovery: {}", e);
             return false;
@@ -93,153 +47,11 @@ public class FailureHandlerDispatcher {
      */
     public void dispatchHandler(IFailureHandlerPolicy failureHandlerPolicy, Layout currentLayout,
                                 CorfuRuntime corfuRuntime, Set<String> failedServers) {
-
         try {
-
-            // Generates a new layout by removing the failed nodes from the existing layout
-            Layout newLayout = failureHandlerPolicy.generateLayout(currentLayout, corfuRuntime,
-                    failedServers);
-
-            // Seals and increments the epoch.
-            currentLayout.setRuntime(corfuRuntime);
-            sealEpoch(currentLayout);
-
-            // Attempts to update all the layout servers with the modified layout.
-            try {
-                corfuRuntime.getLayoutView().updateLayout(newLayout, prepareRank);
-                prepareRank++;
-            } catch (OutrankedException oe) {
-                // Update rank since outranked.
-                log.error("Conflict in updating layout by failureHandlerDispatcher: {}", oe);
-                // Update rank to be able to outrank other competition and complete paxos.
-                prepareRank = oe.getNewRank() + 1;
-            }
-
-            // Check if our proposed layout got selected and committed.
-            corfuRuntime.invalidateLayout();
-            if (corfuRuntime.getLayoutView().getLayout().equals(newLayout)) {
-                log.info("Failed node removed. New Layout committed = {}", newLayout);
-            } else {
-                log.warn("Layout recovered with a different layout = {}",
-                        corfuRuntime.getLayoutView().getLayout());
-            }
-
-            //TODO: Since sequencer reset is moved after paxos. Make sure the runtime has the latest
-            //TODO: layout view and latest client router epoch. (Use quorum layout fetch.)
-            //TODO: Handle condition if primary sequencer is not marked ready, reset fails.
-            // Reconfigure servers if required
-            reconfigureServers(corfuRuntime, currentLayout, newLayout, false);
-
+            corfuRuntime.getLayoutManagementView().handleFailure(failureHandlerPolicy,
+                    currentLayout, failedServers);
         } catch (Exception e) {
             log.error("Error: dispatchHandler: {}", e);
-        }
-    }
-
-    /**
-     * Seals the epoch.
-     * Set local epoch and then attempt to move all servers to new epoch
-     *
-     * @param layout Layout to be sealed
-     */
-    private void sealEpoch(Layout layout) throws QuorumUnreachableException {
-        layout.setEpoch(layout.getEpoch() + 1);
-        layout.moveServersToEpoch();
-    }
-
-    /**
-     * Reconfigures the servers in the new layout if reconfiguration required.
-     *
-     * @param runtime          Runtime to reconfigure new servers.
-     * @param originalLayout   Current layout to get the latest state of servers.
-     * @param newLayout        New Layout to be reconfigured.
-     * @param forceReconfigure Flag to force reconfiguration.
-     */
-    private void reconfigureServers(CorfuRuntime runtime, Layout originalLayout, Layout
-            newLayout, boolean forceReconfigure)
-            throws ExecutionException {
-
-        // Reconfigure the primary Sequencer Server if changed.
-        reconfigureSequencerServers(runtime, originalLayout, newLayout, forceReconfigure);
-
-        // TODO: Reconfigure log units if new log unit added.
-    }
-
-    /**
-     * Reconfigures the sequencer.
-     * If the primary sequencer has changed in the new layout,
-     * the global tail of the log units are queried and used to set
-     * the initial token of the new primary sequencer.
-     *
-     * @param runtime          Runtime to reconfigure new servers.
-     * @param originalLayout   Current layout to get the latest state of servers.
-     * @param newLayout        New Layout to be reconfigured.
-     * @param forceReconfigure Flag to force reconfiguration.
-     */
-    private void reconfigureSequencerServers(CorfuRuntime runtime, Layout originalLayout, Layout
-            newLayout, boolean forceReconfigure)
-            throws ExecutionException {
-
-        // Reconfigure Primary Sequencer if required
-        if (forceReconfigure
-                || !originalLayout.getSequencers().get(0).equals(newLayout.getSequencers()
-                .get(0))) {
-            long maxTokenRequested = 0;
-            for (Layout.LayoutSegment segment : originalLayout.getSegments()) {
-                // Query the tail of every log unit in every stripe.
-                for (Layout.LayoutStripe stripe : segment.getStripes()) {
-                    for (String logServer : stripe.getLogServers()) {
-                        try {
-                            long tail = runtime.getRouter(logServer).getClient(LogUnitClient
-                                    .class).getTail().get();
-                            if (tail != 0) {
-                                maxTokenRequested = maxTokenRequested > tail ? maxTokenRequested
-                                        : tail;
-                            }
-                        } catch (Exception e) {
-                            log.error("Exception while fetching log unit tail : {}", e);
-                        }
-                    }
-                }
-            }
-
-            try {
-
-                FastObjectLoader fastObjectLoader = new FastObjectLoader(runtime);
-                fastObjectLoader.setRecoverSequencerMode(true);
-                fastObjectLoader.setLoadInCache(false);
-
-                // FastSMRLoader sets the logHead based on trim mark.
-                fastObjectLoader.setLogTail(maxTokenRequested);
-                fastObjectLoader.loadMaps();
-                Map<UUID, Long> streamTails = fastObjectLoader.getStreamTails();
-                verifyStreamTailsMap(streamTails);
-
-                // Configuring the new sequencer.
-                boolean sequencerBootstrapResult = newLayout.getSequencer(0)
-                        .bootstrap(maxTokenRequested + 1, streamTails,
-                                newLayout.getEpoch()).get();
-                if (sequencerBootstrapResult) {
-                    log.info("Sequencer bootstrap successful.");
-                } else {
-                    log.warn("Sequencer bootstrap failed. Already bootstrapped.");
-                }
-
-            } catch (InterruptedException e) {
-                log.error("Sequencer bootstrap interrupted : {}", e);
-            }
-        }
-    }
-
-    /**
-     * Verifies whether there are any invalid streamTails.
-     * @param streamTails Stream tails map obtained from the fastSMRLoader.
-     */
-    private void verifyStreamTailsMap(Map<UUID, Long> streamTails) {
-        for (Long value : streamTails.values()) {
-            if (value < 0) {
-                log.error("Stream Tails map verification failed. Map = {}", streamTails);
-                throw new RecoveryException("Invalid stream tails found in map.");
-            }
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -28,6 +28,7 @@ import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.MultipleReadRequest;
+import org.corfudb.protocols.wireprotocol.RawDataMsg;
 import org.corfudb.protocols.wireprotocol.ReadRequest;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.protocols.wireprotocol.TrimRequest;
@@ -286,6 +287,20 @@ public class LogUnitServer extends AbstractServer {
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
     }
 
+    /**
+     * Handles requests for replicating
+     */
+    @ServerHandler(type = CorfuMsgType.RAW_DATA_REPLICATE, opTimer = metricsPrefix + "replicate")
+    private void replicateRawData(CorfuPayloadMsg<RawDataMsg> msg,
+                                  ChannelHandlerContext ctx, IServerRouter r,
+                                  boolean isMetricsEnabled) {
+        Map<Long, LogData> rawDataMap = msg.getPayload().getRawDataMap();
+        for (Long address : rawDataMap.keySet()) {
+            // bypass the cache.
+            batchWriter.write(address, rawDataMap.get(address));
+        }
+        r.sendResponse(ctx, msg, CorfuMsgType.WRITE_OK.msg());
+    }
 
     /**
      * Retrieve the LogUnitEntry from disk, given an address.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -26,6 +26,7 @@ import org.corfudb.protocols.wireprotocol.FailureDetectorMsg;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.clients.SequencerClient;
+import org.corfudb.runtime.view.IFailureHandlerPolicy;
 import org.corfudb.runtime.view.Layout;
 
 /**
@@ -242,7 +243,6 @@ public class ManagementServer extends AbstractServer {
     boolean checkBootstrap(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         if (latestLayout == null && bootstrapEndpoint == null) {
             log.warn("Received message but not bootstrapped! Message={}", msg);
-            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP_ERROR));
             return false;
         }
         return true;
@@ -285,13 +285,10 @@ public class ManagementServer extends AbstractServer {
     public synchronized void initiateFailureHandler(CorfuMsg msg, ChannelHandlerContext ctx,
                                                     IServerRouter r,
                                                     boolean isMetricsEnabled) {
-        if (isShutdown()) {
-            log.warn("Management Server received {} but is shutdown.", msg.getMsgType().toString());
-            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
-            return;
-        }
+
         // This server has not been bootstrapped yet, ignore all requests.
         if (!checkBootstrap(msg, ctx, r)) {
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP_ERROR));
             return;
         }
 
@@ -317,13 +314,10 @@ public class ManagementServer extends AbstractServer {
     public synchronized void handleFailureDetectedMsg(CorfuPayloadMsg<FailureDetectorMsg> msg,
                                                       ChannelHandlerContext ctx, IServerRouter r,
                                                       boolean isMetricsEnabled) {
-        if (isShutdown()) {
-            log.warn("Management Server received {} but is shutdown.", msg.getMsgType().toString());
-            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
-            return;
-        }
+
         // This server has not been bootstrapped yet, ignore all requests.
         if (!checkBootstrap(msg, ctx, r)) {
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP_ERROR));
             return;
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -102,6 +102,7 @@ public class ManagementServer extends AbstractServer {
 
     /**
      * Returns new ManagementServer.
+     *
      * @param serverContext context object providing parameters and objects
      */
     public ManagementServer(ServerContext serverContext) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -8,9 +8,10 @@ import java.util.Map;
 import lombok.Getter;
 import lombok.Setter;
 
+import org.corfudb.runtime.view.ConservativeFailureHandlerPolicy;
+import org.corfudb.runtime.view.IFailureHandlerPolicy;
 import org.corfudb.util.MetricsUtils;
 
-import static org.corfudb.util.MetricsUtils.addJvmMetrics;
 import static org.corfudb.util.MetricsUtils.isMetricsReportingSetUp;
 
 /**

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -89,6 +89,8 @@ public enum CorfuMsgType {
     HEARTBEAT_REQUEST(75, TypeToken.of(CorfuMsg.class), true),
     HEARTBEAT_RESPONSE(76, new TypeToken<CorfuPayloadMsg<byte[]>>(){}, true),
 
+    RAW_DATA_REPLICATE(80, new TypeToken<CorfuPayloadMsg<RawDataMsg>>(){}),
+
     ERROR_SERVER_EXCEPTION(200, new TypeToken<CorfuPayloadMsg<ExceptionMsg>>() {}, true)
     ;
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/MergeSegmentRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/MergeSegmentRequest.java
@@ -1,0 +1,29 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.Layout.LayoutSegment;
+
+/**
+ * Request to merge the given layout segment.
+ */
+@Data
+@AllArgsConstructor
+public class MergeSegmentRequest implements ICorfuPayload<MergeSegmentRequest> {
+
+    private LayoutSegment segment;
+
+    public MergeSegmentRequest(ByteBuf buf) {
+        segment = Layout.getParser().fromJson(ICorfuPayload.fromBuffer(buf, String.class),
+                LayoutSegment.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, Layout.getParser().toJson(segment));
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/RawDataMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/RawDataMsg.java
@@ -1,0 +1,27 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Raw Log Entries map payload.
+ */
+@Data
+@AllArgsConstructor
+public class RawDataMsg implements ICorfuPayload<RawDataMsg> {
+
+    private Map<Long, LogData> rawDataMap;
+
+    public RawDataMsg(ByteBuf buf) {
+        rawDataMap = ICorfuPayload.mapFromBuffer(buf, Long.class, LogData.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, rawDataMap);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -33,6 +33,7 @@ import org.corfudb.runtime.clients.SequencerClient;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.view.AddressSpaceView;
 import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.LayoutManagementView;
 import org.corfudb.runtime.view.LayoutView;
 import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.runtime.view.SequencerView;
@@ -94,6 +95,11 @@ public class CorfuRuntime {
      */
     @Getter(lazy = true)
     private final ObjectsView objectsView = new ObjectsView(this);
+    /**
+     * A view of the Layout Manager to manage reconfigurations of the Corfu Cluster.
+     */
+    @Getter(lazy = true)
+    private final LayoutManagementView layoutManagementView = new LayoutManagementView(this);
     /**
      * A list of known layout servers.
      */

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -27,6 +27,7 @@ import org.corfudb.protocols.wireprotocol.FillHoleRequest;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.MultipleReadRequest;
+import org.corfudb.protocols.wireprotocol.RawDataMsg;
 import org.corfudb.protocols.wireprotocol.ReadRequest;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.protocols.wireprotocol.TrimRequest;
@@ -448,5 +449,16 @@ public class LogUnitClient implements IClient {
                 CorfuRuntime.getMpLUC()
                         + getHost() + ":" + getPort().toString() + "-" + opName);
         return t.time();
+    }
+
+    /**
+     * Sends a request to replicate the addresses for the given rawDataMsg
+     *
+     * @param rawDataMsg RawDataMsg received from the log unit server.
+     * @return Completable future which returns true on success.
+     */
+    public CompletableFuture<Boolean> replicateRawData(RawDataMsg rawDataMsg) {
+        return router.sendMessageAndGetCompletable(CorfuMsgType.RAW_DATA_REPLICATE
+                .payloadMsg(rawDataMsg));
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ConservativeFailureHandlerPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ConservativeFailureHandlerPolicy.java
@@ -1,20 +1,20 @@
-package org.corfudb.infrastructure;
+package org.corfudb.runtime.view;
 
 import java.util.Set;
 
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.LayoutModificationException;
-import org.corfudb.runtime.view.Layout;
 
 /**
- * Handles the failures.
+ * Conserves the failures.
  *
  * <p>Created by zlokhandwala on 11/21/16.
  */
-public class PurgeFailurePolicy implements IFailureHandlerPolicy {
+public class ConservativeFailureHandlerPolicy implements IFailureHandlerPolicy {
 
     /**
-     * Modifies the layout by removing/purging the set failed nodes.
+     * Modifies the layout by marking the failed nodes as unresponsive but still keeping them in
+     * the layout.
      *
      * @param originalLayout Original Layout which needs to be modified.
      * @param corfuRuntime   Connected runtime to attach to the new layout.
@@ -24,14 +24,14 @@ public class PurgeFailurePolicy implements IFailureHandlerPolicy {
      * @throws CloneNotSupportedException  Clone not supported for layout.
      */
     @Override
-    public Layout generateLayout(Layout originalLayout, CorfuRuntime corfuRuntime, Set<String>
-            failedNodes)
+    public Layout generateLayout(Layout originalLayout, CorfuRuntime corfuRuntime,
+                                 Set<String> failedNodes)
             throws LayoutModificationException, CloneNotSupportedException {
-        LayoutWorkflowManager layoutManager = new LayoutWorkflowManager(originalLayout);
-        Layout newLayout = layoutManager
-                .removeLayoutServers(failedNodes)
-                .removeSequencerServers(failedNodes)
-                .removeLogunitServers(failedNodes)
+        LayoutBuilder layoutBuilder = new LayoutBuilder(originalLayout);
+        Layout newLayout = layoutBuilder
+                .assignResponsiveSequencerAsPrimary(failedNodes)
+                .clearUnResponsiveServers()
+                .addUnresponsiveServers(failedNodes)
                 .build();
         newLayout.setRuntime(corfuRuntime);
         newLayout.setEpoch(newLayout.getEpoch() + 1);

--- a/runtime/src/main/java/org/corfudb/runtime/view/IFailureHandlerPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/IFailureHandlerPolicy.java
@@ -1,4 +1,4 @@
-package org.corfudb.infrastructure;
+package org.corfudb.runtime.view;
 
 import java.util.Set;
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -51,6 +51,7 @@ public class Layout implements Cloneable {
     /**
      * A Gson parser.
      */
+    @Getter
     static final Gson parser = new GsonBuilder()
             .registerTypeAdapter(Layout.class, new LayoutDeserializer())
             .create();

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutBuilder.java
@@ -1,4 +1,4 @@
-package org.corfudb.infrastructure;
+package org.corfudb.runtime.view;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -7,7 +7,8 @@ import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.runtime.exceptions.LayoutModificationException;
-import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.Layout.LayoutSegment;
+import org.corfudb.runtime.view.Layout.LayoutStripe;
 
 /**
  * Allows us to make modifications to a layout.
@@ -15,7 +16,7 @@ import org.corfudb.runtime.view.Layout;
  * <p>Created by zlokhandwala on 10/12/16.
  */
 @Slf4j
-public class LayoutWorkflowManager {
+public class LayoutBuilder {
 
     /**
      * Updated layout.
@@ -31,21 +32,30 @@ public class LayoutWorkflowManager {
      *
      * @param layout Base layout to be modified.
      */
-    public LayoutWorkflowManager(Layout layout) throws CloneNotSupportedException {
+    public LayoutBuilder(Layout layout) throws CloneNotSupportedException {
         this.layout = (Layout) layout.clone();
         this.epoch = layout.getEpoch();
+    }
+
+    /**
+     * Clears the existing unrsponsive servers.
+     *
+     * @return
+     */
+    public LayoutBuilder clearUnResponsiveServers() {
+        layout.getUnresponsiveServers().clear();
+        return this;
     }
 
     /**
      * Adds unresponsive servers in the list.
      *
      * @param endpoints Endpoints to be added.
-     * @return updated LayoutWorkflowManager including unresponsive servers
+     * @return updated LayoutBuilder including unresponsive servers
      */
-    public LayoutWorkflowManager addUnresponsiveServers(Set<String> endpoints) {
+    public LayoutBuilder addUnresponsiveServers(Set<String> endpoints) {
         List<String> unresponsiveServers = layout.getUnresponsiveServers();
-        unresponsiveServers.clear();
-        endpoints.forEach(unresponsiveServers::add);
+        unresponsiveServers.addAll(endpoints);
         return this;
     }
 
@@ -56,7 +66,7 @@ public class LayoutWorkflowManager {
      * @return Workflow manager
      * @throws LayoutModificationException If attempt to remove all layout servers.
      */
-    public LayoutWorkflowManager removeLayoutServer(String endpoint)
+    public LayoutBuilder removeLayoutServer(String endpoint)
             throws LayoutModificationException {
 
         List<String> layoutServers = layout.getLayoutServers();
@@ -80,7 +90,7 @@ public class LayoutWorkflowManager {
      * @return Workflow manager
      * @throws LayoutModificationException If attempt to remove all layout servers.
      */
-    public LayoutWorkflowManager removeLayoutServers(Set<String> endpoints)
+    public LayoutBuilder removeLayoutServers(Set<String> endpoints)
             throws LayoutModificationException {
 
         // Not making changes in the original list in case of exceptions.
@@ -102,14 +112,111 @@ public class LayoutWorkflowManager {
     }
 
     /**
+     * Adds a new layout server.
+     *
+     * @param endpoint Endpoint to be added.
+     * @return this.
+     */
+    public LayoutBuilder addLayoutServer(String endpoint) {
+        layout.getLayoutServers().add(endpoint);
+        return this;
+    }
+
+    /**
+     * Adds a new sequencer server.
+     *
+     * @param endpoint Endpoint to be added.
+     * @return this.
+     */
+    public LayoutBuilder addSequencerServer(String endpoint) {
+        layout.getSequencers().add(endpoint);
+        return this;
+    }
+
+    /**
+     * Adds a new logunit server.
+     * The latest open segment (which has its end address as infinity) is now closed at address
+     * 'globalLogTail'.
+     * A new segment is open, starting at 'globalLogTail' ending at infinity for all new writes.
+     * This new segment contains the new logunit server to be added in the specified stripe.
+     *
+     * @param stripeIndex        stripe index where new endpoint should be added.
+     * @param globalLogTail      Global log tail to split segment.
+     * @param newLogunitEndpoint Endpoint to be added.
+     * @return this.
+     */
+    public LayoutBuilder addLogunitServer(int stripeIndex, long globalLogTail,
+                                          String newLogunitEndpoint) {
+        List<LayoutSegment> layoutSegmentList = layout.getSegments();
+        LayoutSegment segmentToSplit = layoutSegmentList.remove(layoutSegmentList.size() - 1);
+
+        // Close the existing segment with the provided globalLogTail.
+        LayoutSegment closedSegment = new LayoutSegment(segmentToSplit.getReplicationMode(),
+                segmentToSplit.getStart(),
+                globalLogTail + 1,
+                segmentToSplit.getStripes());
+
+        List<String> logunitServerList = new ArrayList<>();
+        logunitServerList.addAll(segmentToSplit.getStripes()
+                .get(stripeIndex)
+                .getLogServers());
+        logunitServerList.add(newLogunitEndpoint);
+
+        // Create new stripe list with the new logunit server added.
+        LayoutStripe newStripe = new LayoutStripe(logunitServerList);
+        List<LayoutStripe> newStripeList = new ArrayList<>();
+        newStripeList.addAll(segmentToSplit.getStripes());
+        newStripeList.remove(stripeIndex);
+        newStripeList.add(stripeIndex, newStripe);
+
+        LayoutSegment openSegment = new LayoutSegment(segmentToSplit.getReplicationMode(),
+                globalLogTail + 1,
+                segmentToSplit.getEnd(),
+                newStripeList);
+        layoutSegmentList.add(layoutSegmentList.size(), closedSegment);
+        layoutSegmentList.add(layoutSegmentList.size(), openSegment);
+        return this;
+    }
+
+    /**
+     * Merges the specified segment and the segment before this.
+     *
+     * @param segmentIndex Segment to merge.
+     * @return this.
+     * @throws LayoutModificationException
+     */
+    public LayoutBuilder mergePreviousSegment(int segmentIndex)
+            throws LayoutModificationException {
+        if (segmentIndex < 1) {
+            throw new LayoutModificationException("No segments to merge.");
+        }
+
+        List<LayoutSegment> layoutSegmentList = layout.getSegments();
+        if (layoutSegmentList.get(segmentIndex).start
+                != layoutSegmentList.get(segmentIndex - 1).start) {
+            throw new LayoutModificationException("Cannot merge disjoint segments.");
+        }
+
+        LayoutSegment mergedSegment = new LayoutSegment(layoutSegmentList.get(segmentIndex)
+                .getReplicationMode(),
+                layoutSegmentList.get(segmentIndex - 1).getStart(),
+                layoutSegmentList.get(segmentIndex).getEnd(),
+                layoutSegmentList.get(segmentIndex).getStripes());
+        layoutSegmentList.remove(segmentIndex);
+        layoutSegmentList.remove(segmentIndex - 1);
+        layoutSegmentList.add(segmentIndex - 1, mergedSegment);
+        return this;
+    }
+
+    /**
      * Moves a responsive server to the top of the sequencer server list.
      * If all have failed, throws exception.
      *
      * @param endpoints Failed endpoints.
-     * @return LayoutWorkflowManager
+     * @return LayoutBuilder
      * @throws LayoutModificationException throws if no working sequencer left.
      */
-    public LayoutWorkflowManager moveResponsiveSequencerToTop(Set<String> endpoints)
+    public LayoutBuilder assignResponsiveSequencerAsPrimary(Set<String> endpoints)
             throws LayoutModificationException {
 
         List<String> modifiedSequencerServers = new ArrayList<>(layout.getSequencers());
@@ -132,7 +239,7 @@ public class LayoutWorkflowManager {
      * @return Workflow manager
      * @throws LayoutModificationException Cannot remove the only sequencer server.
      */
-    public LayoutWorkflowManager removeSequencerServer(String endpoint)
+    public LayoutBuilder removeSequencerServer(String endpoint)
             throws LayoutModificationException {
 
         List<String> sequencerServers = layout.getSequencers();
@@ -155,7 +262,7 @@ public class LayoutWorkflowManager {
      * @return Workflow manager
      * @throws LayoutModificationException Cannot remove the only sequencer server.
      */
-    public LayoutWorkflowManager removeSequencerServers(Set<String> endpoints)
+    public LayoutBuilder removeSequencerServers(Set<String> endpoints)
             throws LayoutModificationException {
 
         // Not making changes in the original list in case of exceptions.
@@ -183,12 +290,12 @@ public class LayoutWorkflowManager {
      * @return Workflow manager
      * @throws LayoutModificationException Cannot remove non-replicated logunit
      */
-    public LayoutWorkflowManager removeLogunitServer(String endpoint)
+    public LayoutBuilder removeLogunitServer(String endpoint)
             throws LayoutModificationException {
 
-        List<Layout.LayoutSegment> layoutSegments = layout.getSegments();
-        for (Layout.LayoutSegment layoutSegment : layoutSegments) {
-            for (Layout.LayoutStripe layoutStripe : layoutSegment.getStripes()) {
+        List<LayoutSegment> layoutSegments = layout.getSegments();
+        for (LayoutSegment layoutSegment : layoutSegments) {
+            for (LayoutStripe layoutStripe : layoutSegment.getStripes()) {
 
                 List<String> loguintServers = layoutStripe.getLogServers();
 
@@ -217,15 +324,15 @@ public class LayoutWorkflowManager {
      * @return Workflow manager
      * @throws LayoutModificationException Cannot remove non-replicated logunit
      */
-    public LayoutWorkflowManager removeLogunitServers(Set<String> endpoints)
+    public LayoutBuilder removeLogunitServers(Set<String> endpoints)
             throws LayoutModificationException {
 
         // Not making changes in the original list in case of exceptions.
         // Copy the list so that we can have an atomic result and no partial removals
-        List<Layout.LayoutSegment> modifiedLayoutSegments = new ArrayList<>(layout.getSegments());
+        List<LayoutSegment> modifiedLayoutSegments = new ArrayList<>(layout.getSegments());
 
-        for (Layout.LayoutSegment layoutSegment : modifiedLayoutSegments) {
-            for (Layout.LayoutStripe layoutStripe : layoutSegment.getStripes()) {
+        for (LayoutSegment layoutSegment : modifiedLayoutSegments) {
+            for (LayoutStripe layoutStripe : layoutSegment.getStripes()) {
 
                 List<String> loguintServers = layoutStripe.getLogServers();
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -1,0 +1,331 @@
+package org.corfudb.runtime.view;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import org.corfudb.recovery.FastObjectLoader;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.IClientRouter;
+import org.corfudb.runtime.clients.LayoutClient;
+import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.clients.ManagementClient;
+import org.corfudb.runtime.exceptions.LayoutModificationException;
+import org.corfudb.runtime.exceptions.OutrankedException;
+import org.corfudb.runtime.exceptions.QuorumUnreachableException;
+import org.corfudb.runtime.exceptions.RecoveryException;
+
+/**
+ * A view of the Layout Manager to manage reconfigurations of the Corfu Cluster.
+ *
+ * <p>Created by zlokhandwala on 11/1/17.</p>
+ */
+@Slf4j
+public class LayoutManagementView extends AbstractView {
+
+    public LayoutManagementView(@NonNull CorfuRuntime runtime) {
+        super(runtime);
+    }
+
+    private volatile long prepareRank = 1L;
+
+    /**
+     * Recover cluster from layout.
+     *
+     * @param recoveryLayout Layout to use to recover
+     * @return True if the cluster was recovered, False otherwise
+     */
+    public void recoverCluster(Layout recoveryLayout)
+            throws QuorumUnreachableException, OutrankedException, InterruptedException,
+            ExecutionException, LayoutModificationException, CloneNotSupportedException {
+
+        Layout newLayout = (Layout) recoveryLayout.clone();
+        newLayout.setEpoch(recoveryLayout.getEpoch() + 1);
+        newLayout.setRuntime(runtime);
+        runLayoutReconfiguration(recoveryLayout, newLayout, true);
+    }
+
+    /**
+     * Takes in the existing layout and a set of failed nodes.
+     * It first generates a new layout by removing the failed nodes from the existing layout.
+     * It then seals the epoch to prevent any client from accessing the stale layout.
+     * Finally we run paxos to update all servers with the new layout.
+     *
+     * @param currentLayout The current layout
+     * @param failedServers Set of failed server addresses
+     */
+    public void handleFailure(IFailureHandlerPolicy failureHandlerPolicy, Layout currentLayout,
+                              Set<String> failedServers)
+            throws QuorumUnreachableException, OutrankedException, InterruptedException,
+            ExecutionException, LayoutModificationException, CloneNotSupportedException {
+
+        // Generates a new layout by removing the failed nodes from the existing layout
+        Layout newLayout = failureHandlerPolicy.generateLayout(currentLayout, runtime,
+                failedServers);
+        runLayoutReconfiguration(currentLayout, newLayout, false);
+    }
+
+
+    /**
+     * Bootstraps the new node with the current layout.
+     *
+     * @param endpoint New node endpoint.
+     * @throws InterruptedException       if bootstrapping interrupted.
+     * @throws ExecutionException         if bootstrapping fails.
+     * @throws CloneNotSupportedException if layout clone fails.
+     */
+    public void bootstrapNewNode(String endpoint)
+            throws InterruptedException, ExecutionException, CloneNotSupportedException {
+
+        // Bootstrap the to-be added node with the old layout.
+        IClientRouter newEndpointRouter = runtime.getRouter(endpoint);
+        Layout layout = (Layout) runtime.getLayoutView().getLayout().clone();
+        // Ignoring call result as the call returns ACK or throws an exception.
+        newEndpointRouter.getClient(LayoutClient.class)
+                .bootstrapLayout(layout).get();
+        newEndpointRouter.getClient(ManagementClient.class)
+                .bootstrapManagement(layout).get();
+        newEndpointRouter.getClient(ManagementClient.class)
+                .initiateFailureHandler().get();
+
+        log.info("bootstrapNewNode: New node {} bootstrapped.", endpoint);
+    }
+
+    /**
+     * Adds a new node to the existing layout.
+     *
+     * @param currentLayout        Current layout.
+     * @param endpoint             New endpoint to be added.
+     * @param isLayoutServer       is a layout server
+     * @param isSequencerServer    is a sequencer server
+     * @param isLogUnitServer      is a log unit server
+     * @param isUnresponsiveServer is an unresponsive server
+     * @param logUnitStripeIndex   stripe index to be added into if its a log unit.
+     * @throws CloneNotSupportedException if layout clone fails.
+     * @throws QuorumUnreachableException if seal or consensus cannot be achieved.
+     * @throws OutrankedException         if consensus outranked.
+     * @throws InterruptedException       if fetching global tail interrupted.
+     * @throws ExecutionException         if fetching global tail failed.
+     */
+    public void addNode(Layout currentLayout,
+                        String endpoint,
+                        boolean isLayoutServer,
+                        boolean isSequencerServer,
+                        boolean isLogUnitServer,
+                        boolean isUnresponsiveServer,
+                        int logUnitStripeIndex)
+            throws CloneNotSupportedException, QuorumUnreachableException, OutrankedException,
+            InterruptedException, ExecutionException {
+
+        currentLayout.setRuntime(runtime);
+        sealEpoch(currentLayout);
+
+        LayoutBuilder layoutBuilder = new LayoutBuilder(currentLayout);
+        if (isLayoutServer) {
+            layoutBuilder.addLayoutServer(endpoint);
+        }
+        if (isSequencerServer) {
+            layoutBuilder.addSequencerServer(endpoint);
+        }
+        if (isLogUnitServer) {
+            layoutBuilder.addLogunitServer(logUnitStripeIndex, getMaxGlobalTail(currentLayout),
+                    endpoint);
+        }
+        if (isUnresponsiveServer) {
+            layoutBuilder.addUnresponsiveServers(Collections.singleton(endpoint));
+        }
+        Layout newLayout = layoutBuilder.build();
+        newLayout.setRuntime(runtime);
+
+        attemptConsensus(newLayout);
+
+        try {
+            // Add node is successful even if reconfigure sequencer fails.
+            // TODO: Optimize this by retrying or submitting a workflow to retry.
+            reconfigureSequencerServers(currentLayout, newLayout, true);
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Bootstrapping sequencer failed due to exception : ", e);
+        }
+    }
+
+    /**
+     * Runs the layout reconfiguration process.
+     * Seals the layout.
+     * Runs paxos.
+     * During paxos if in recovery mode, we increment rank until committed on same epoch.
+     * If not in recovery, we fail with outrankedException.
+     * The new committed layout is then verified by invalidating the runtime.
+     * Finally we reconfigure the servers (bootstrapping sequencer.)
+     *
+     * @param currentLayout          Layout which needs to be sealed.
+     * @param newLayout              New layout to be committed.
+     * @param forceSequencerRecovery Flag. True if want to force sequencer recovery.
+     */
+    private void runLayoutReconfiguration(Layout currentLayout, Layout newLayout,
+                                          final boolean forceSequencerRecovery)
+            throws QuorumUnreachableException, OutrankedException, InterruptedException,
+            ExecutionException {
+
+        // Seals the incremented epoch (Assumes newLayout epoch = currentLayout epoch + 1).
+        currentLayout.setRuntime(runtime);
+        sealEpoch(currentLayout);
+
+        attemptConsensus(newLayout);
+
+        //TODO: Since sequencer reset is moved after paxos. Make sure the runtime has the latest
+        //TODO: layout view and latest client router epoch. (Use quorum layout fetch.)
+        //TODO: Handle condition if primary sequencer is not marked ready, reset fails.
+        // Reconfigure servers if required
+        // Primary sequencer would be in a not-ready state if its in recovery mode.
+        reconfigureSequencerServers(currentLayout, newLayout, forceSequencerRecovery);
+    }
+
+    /**
+     * Seals the epoch.
+     *
+     * @param layout Layout to be sealed
+     */
+    private void sealEpoch(Layout layout) throws QuorumUnreachableException {
+        layout.setEpoch(layout.getEpoch() + 1);
+        layout.moveServersToEpoch();
+    }
+
+    /**
+     * Attempt consensus.
+     *
+     * @param layout Layout to propose.
+     * @throws OutrankedException         if consensus is outranked.
+     * @throws QuorumUnreachableException if consensus could not be achieved.
+     */
+    private void attemptConsensus(Layout layout)
+            throws OutrankedException, QuorumUnreachableException {
+        // Attempts to update all the layout servers with the modified layout.
+        try {
+            runtime.getLayoutView().updateLayout(layout, prepareRank);
+            prepareRank = 1L;
+        } catch (OutrankedException oe) {
+            // Update rank since outranked.
+            log.error("Conflict in updating layout by failureHandlerDispatcher: {}", oe);
+            // Update rank to be able to outrank other competition and complete paxos.
+            prepareRank = oe.getNewRank() + 1;
+            throw oe;
+        }
+
+        // Check if our proposed layout got selected and committed.
+        runtime.invalidateLayout();
+        if (runtime.getLayoutView().getLayout().equals(layout)) {
+            log.info("New Layout Committed = {}", layout);
+        } else {
+            log.warn("Runtime recovered with a different layout = {}",
+                    runtime.getLayoutView().getLayout());
+        }
+    }
+
+    /**
+     * Fetches the max global log tail from the log unit cluster. This depends on the mode of
+     * replication being used.
+     * CHAIN: Block on fetch of global log tail from the head log unitin every stripe.
+     * QUORUM: Block on fetch of global log tail from a majority in every stripe.
+     *
+     * @param layout Current layout.
+     * @return The max global log tail obtained from the log unit servers.
+     */
+    private long getMaxGlobalTail(Layout layout)
+            throws ExecutionException, InterruptedException {
+        long maxTokenRequested = 0;
+        for (Layout.LayoutSegment segment : layout.getSegments()) {
+
+            // Query the tail of every log unit in every stripe.
+            if (segment.getReplicationMode().equals(Layout.ReplicationMode.CHAIN_REPLICATION)) {
+                for (Layout.LayoutStripe stripe : segment.getStripes()) {
+                    maxTokenRequested = Math.max(maxTokenRequested, runtime.getRouter(stripe
+                            .getLogServers().get(0))
+                            .getClient(LogUnitClient.class).getTail().get());
+                }
+            } else if (segment.getReplicationMode()
+                    .equals(Layout.ReplicationMode.QUORUM_REPLICATION)) {
+                for (Layout.LayoutStripe stripe : segment.getStripes()) {
+                    CompletableFuture<Long>[] completableFutures = stripe.getLogServers()
+                            .stream()
+                            .map(s -> runtime.getRouter(s).getClient(LogUnitClient.class)
+                                    .getTail())
+                            .toArray(CompletableFuture[]::new);
+                    QuorumFuturesFactory.CompositeFuture<Long> quorumFuture =
+                            QuorumFuturesFactory.getQuorumFuture(Comparator.naturalOrder(),
+                                    completableFutures);
+                    maxTokenRequested = Math.max(maxTokenRequested, quorumFuture.get());
+                }
+            }
+        }
+        return maxTokenRequested;
+    }
+
+    /**
+     * Reconfigures the sequencer.
+     * If the primary sequencer has changed in the new layout,
+     * the global tail of the log units are queried and used to set
+     * the initial token of the new primary sequencer.
+     *
+     * @param originalLayout   Current layout to get the latest state of servers.
+     * @param newLayout        New Layout to be reconfigured.
+     * @param forceReconfigure Flag to force reconfiguration.
+     */
+    private void reconfigureSequencerServers(Layout originalLayout, Layout
+            newLayout, boolean forceReconfigure)
+            throws InterruptedException, ExecutionException {
+
+        long maxTokenRequested = 0L;
+        Map<UUID, Long> streamTails = Collections.emptyMap();
+
+        // Reconfigure Primary Sequencer if required
+        if (forceReconfigure
+                || !originalLayout.getSequencers().get(0).equals(newLayout.getSequencers()
+                .get(0))) {
+            maxTokenRequested = getMaxGlobalTail(originalLayout);
+
+            FastObjectLoader fastObjectLoader = new FastObjectLoader(runtime);
+            fastObjectLoader.setRecoverSequencerMode(true);
+            fastObjectLoader.setLoadInCache(false);
+
+            // FastSMRLoader sets the logHead based on trim mark.
+            fastObjectLoader.setLogTail(maxTokenRequested);
+            fastObjectLoader.loadMaps();
+            streamTails = fastObjectLoader.getStreamTails();
+            verifyStreamTailsMap(streamTails);
+
+            // Incrementing the maxTokenRequested value for sequencer reset.
+            maxTokenRequested++;
+        }
+
+        // Configuring the new sequencer.
+        boolean sequencerBootstrapResult = newLayout.getSequencer(0)
+                .bootstrap(maxTokenRequested, streamTails, newLayout.getEpoch()).get();
+        if (sequencerBootstrapResult) {
+            log.info("Sequencer bootstrap successful.");
+        } else {
+            log.warn("Sequencer bootstrap failed. Already bootstrapped.");
+        }
+
+    }
+
+    /**
+     * Verifies whether there are any invalid streamTails.
+     *
+     * @param streamTails Stream tails map obtained from the fastSMRLoader.
+     */
+    private void verifyStreamTailsMap(Map<UUID, Long> streamTails) {
+        for (Long value : streamTails.values()) {
+            if (value < 0) {
+                log.error("Stream Tails map verification failed. Map = {}", streamTails);
+                throw new RecoveryException("Invalid stream tails found in map.");
+            }
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/PurgeFailurePolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/PurgeFailurePolicy.java
@@ -1,21 +1,19 @@
-package org.corfudb.infrastructure;
+package org.corfudb.runtime.view;
 
 import java.util.Set;
 
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.LayoutModificationException;
-import org.corfudb.runtime.view.Layout;
 
 /**
- * Conserves the failures.
+ * Handles the failures.
  *
  * <p>Created by zlokhandwala on 11/21/16.
  */
-public class ConservativeFailureHandlerPolicy implements IFailureHandlerPolicy {
+public class PurgeFailurePolicy implements IFailureHandlerPolicy {
 
     /**
-     * Modifies the layout by marking the failed nodes as unresponsive but still keeping them in
-     * the layout.
+     * Modifies the layout by removing/purging the set failed nodes.
      *
      * @param originalLayout Original Layout which needs to be modified.
      * @param corfuRuntime   Connected runtime to attach to the new layout.
@@ -25,13 +23,14 @@ public class ConservativeFailureHandlerPolicy implements IFailureHandlerPolicy {
      * @throws CloneNotSupportedException  Clone not supported for layout.
      */
     @Override
-    public Layout generateLayout(Layout originalLayout, CorfuRuntime corfuRuntime,
-                                 Set<String> failedNodes)
+    public Layout generateLayout(Layout originalLayout, CorfuRuntime corfuRuntime, Set<String>
+            failedNodes)
             throws LayoutModificationException, CloneNotSupportedException {
-        LayoutWorkflowManager layoutManager = new LayoutWorkflowManager(originalLayout);
-        Layout newLayout = layoutManager
-                .moveResponsiveSequencerToTop(failedNodes)
-                .addUnresponsiveServers(failedNodes)
+        LayoutBuilder layoutBuilder = new LayoutBuilder(originalLayout);
+        Layout newLayout = layoutBuilder
+                .removeLayoutServers(failedNodes)
+                .removeSequencerServers(failedNodes)
+                .removeLogunitServers(failedNodes)
                 .build();
         newLayout.setRuntime(corfuRuntime);
         newLayout.setEpoch(newLayout.getEpoch() + 1);

--- a/test/src/test/java/org/corfudb/infrastructure/FailureHandlerDispatcherTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/FailureHandlerDispatcherTest.java
@@ -2,7 +2,9 @@ package org.corfudb.infrastructure;
 
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.IFailureHandlerPolicy;
 import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.PurgeFailurePolicy;
 import org.junit.Test;
 
 import java.util.HashSet;

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutBuilderTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutBuilderTest.java
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.runtime.exceptions.LayoutModificationException;
 import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.LayoutBuilder;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -17,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Created by zlokhandwala on 10/26/16.
  */
-public class LayoutWorkflowManagerTest extends AbstractCorfuTest {
+public class LayoutBuilderTest extends AbstractCorfuTest {
 
     final int SERVER_ENTRY_3 = 3;
     final int SERVER_ENTRY_4 = 4;
@@ -61,7 +62,7 @@ public class LayoutWorkflowManagerTest extends AbstractCorfuTest {
         allNodes.add(TestLayoutBuilder.getEndpoint(SERVERS.PORT_4));
 
         Set<String> failedNodes = new HashSet<String>();
-        LayoutWorkflowManager layoutWorkflowManager = new LayoutWorkflowManager(originalLayout);
+        LayoutBuilder layoutBuilder = new LayoutBuilder(originalLayout);
 
         //Preparing failed nodes set.
         failedNodes.addAll(allNodes);
@@ -73,17 +74,17 @@ public class LayoutWorkflowManagerTest extends AbstractCorfuTest {
 
         // Deleting all Layout Servers
         assertThatThrownBy(() ->
-                layoutWorkflowManager.removeLayoutServers(failedNodes).build()
+                layoutBuilder.removeLayoutServers(failedNodes).build()
         ).isInstanceOf(LayoutModificationException.class);
 
         //Deleting all Sequencer Servers
         assertThatThrownBy(() ->
-                layoutWorkflowManager.removeSequencerServers(failedNodes).build()
+                layoutBuilder.removeSequencerServers(failedNodes).build()
         ).isInstanceOf(LayoutModificationException.class);
 
         //Deleting all Log unit Servers
         assertThatThrownBy(() ->
-                layoutWorkflowManager.removeLogunitServers(failedNodes).build()
+                layoutBuilder.removeLogunitServers(failedNodes).build()
         ).isInstanceOf(LayoutModificationException.class);
 
         // Deleting all nodes in one stripe
@@ -91,7 +92,7 @@ public class LayoutWorkflowManagerTest extends AbstractCorfuTest {
         failedNodes.add(allNodes.get(0));
         failedNodes.add(allNodes.get(2));
         assertThatThrownBy(() ->
-                layoutWorkflowManager.removeLogunitServers(failedNodes).build()
+                layoutBuilder.removeLogunitServers(failedNodes).build()
         ).isInstanceOf(LayoutModificationException.class);
 
 
@@ -123,7 +124,7 @@ public class LayoutWorkflowManagerTest extends AbstractCorfuTest {
         failedNodes.add(allNodes.get(0));
         failedNodes.add(allNodes.get(SERVER_ENTRY_4));
 
-        Layout actualLayout = layoutWorkflowManager.removeLayoutServers(failedNodes)
+        Layout actualLayout = layoutBuilder.removeLayoutServers(failedNodes)
                 .removeLogunitServers(failedNodes)
                 .removeSequencerServers(failedNodes)
                 .build();
@@ -149,30 +150,90 @@ public class LayoutWorkflowManagerTest extends AbstractCorfuTest {
                 .build();
 
         // Remove SERVERS.PORT_1 & SERVERS.PORT_2 from layout server
-        layoutWorkflowManager.removeLayoutServer(allNodes.get(1));
-        layoutWorkflowManager.removeLayoutServer(allNodes.get(2));
+        layoutBuilder.removeLayoutServer(allNodes.get(1));
+        layoutBuilder.removeLayoutServer(allNodes.get(2));
         // No effect on removing removed node
-        layoutWorkflowManager.removeLayoutServer(allNodes.get(2));
+        layoutBuilder.removeLayoutServer(allNodes.get(2));
         // Remove SERVERS.PORT_3 from layout server should throw error.
         assertThatThrownBy(() ->
-                layoutWorkflowManager.removeLayoutServer(allNodes.get(SERVER_ENTRY_3))
+                layoutBuilder.removeLayoutServer(allNodes.get(SERVER_ENTRY_3))
         ).isInstanceOf(LayoutModificationException.class);
         // Remove SERVERS.PORT_1 from sequencers
-        layoutWorkflowManager.removeSequencerServer(allNodes.get(1));
+        layoutBuilder.removeSequencerServer(allNodes.get(1));
         // No effect on removing removed node
-        layoutWorkflowManager.removeSequencerServer(allNodes.get(1));
+        layoutBuilder.removeSequencerServer(allNodes.get(1));
         // Remove SERVERS.PORT_2 from sequencer server should throw error.
         assertThatThrownBy(() ->
-                layoutWorkflowManager.removeSequencerServer(allNodes.get(2))
+                layoutBuilder.removeSequencerServer(allNodes.get(2))
         ).isInstanceOf(LayoutModificationException.class);
         // Remove SERVERS.PORT_1 from logunits
-        layoutWorkflowManager.removeLogunitServer(allNodes.get(1));
+        layoutBuilder.removeLogunitServer(allNodes.get(1));
         // No effect on removing removed node
-        layoutWorkflowManager.removeLogunitServer(allNodes.get(1));
+        layoutBuilder.removeLogunitServer(allNodes.get(1));
         // Remove SERVERS.PORT_2 from logunit server should throw error.
         assertThatThrownBy(() ->
-                layoutWorkflowManager.removeLogunitServer(allNodes.get(2))
+                layoutBuilder.removeLogunitServer(allNodes.get(2))
         ).isInstanceOf(LayoutModificationException.class);
-        assertThat(layoutWorkflowManager.build()).isEqualTo(expectedLayout);
+        assertThat(layoutBuilder.build()).isEqualTo(expectedLayout);
+    }
+
+    /**
+     * Tests the modification of the layout by the addition of new nodes.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void checkAdditionOfNodes() throws Exception {
+
+        Layout originalLayout = new TestLayoutBuilder()
+                .setEpoch(1L)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_0)
+                .buildSegment()
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addToSegment()
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_1)
+                .addToSegment()
+                .addToLayout()
+                .build();
+
+        LayoutBuilder layoutBuilder = new LayoutBuilder(originalLayout);
+
+        final long globalLogTail = 50L;
+        layoutBuilder.addLayoutServer(SERVERS.ENDPOINT_1);
+        layoutBuilder.addSequencerServer(SERVERS.ENDPOINT_2);
+        layoutBuilder.addLogunitServer(1, globalLogTail, SERVERS.ENDPOINT_3);
+
+        // Expected layout
+        Layout expectedLayout = new TestLayoutBuilder()
+                .setEpoch(1L)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_2)
+                .buildSegment()
+                .setEnd(globalLogTail + 1)
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addToSegment()
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_1)
+                .addToSegment()
+                .addToLayout()
+                .buildSegment()
+                .setStart(globalLogTail + 1)
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addToSegment()
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_1)
+                .addLogUnit(SERVERS.PORT_3)
+                .addToSegment()
+                .addToLayout()
+                .build();
+
+        assertThat(layoutBuilder.build()).isEqualTo(expectedLayout);
     }
 }


### PR DESCRIPTION
### Workflow: Merge segment

This workflow is executed only if the new node to be added is going to be a log unit server.
Steps of these workflow are dependent on the type of replication protocol being used. The current implementation strongly assumes Chain replication only. Abstraction to support other replication modes might be missing.
Comprises of 3 steps:
- Step 1: Catch-up segment.
  - This step fetches a list of all known addresses from the existing head and tail of the chain.
  - The diff of all the addresses between these 2 sets is calculated.
  - A read is performed (on the tail) for all the missing addresses (diff set) which forces hole fills.

- Step 2: Segment replication
  - At the source (any node in the existing chain as all nodes have the same state after catch-up) the 
    files are copied into a buffer and sent to the destination node. (No lock or snapshot is taken on 
    the file being copied)
  - At the destination, the file is opened by a temporary segment handler and copied to the existing 
    file to preserve existing data.

- Step 3: Merge Segment
  - The layout is now reconfigured to merge the last 2 segments.