### PR TITLE
Block layout commit until completion

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/FailureHandlerDispatcher.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/FailureHandlerDispatcher.java
@@ -115,6 +115,7 @@ public class FailureHandlerDispatcher {
         }
 
         // Check if our proposed layout got selected and committed.
+        corfuRuntime.getLayoutView().getLayout();
         corfuRuntime.invalidateLayout();
         if (corfuRuntime.getLayoutView().getLayout().equals(newLayout)) {
             log.info("New Layout committed = {}", newLayout);

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -298,6 +298,10 @@ public class LayoutView extends AbstractView {
                 timeouts++;
             }
             responses++;
+            commitList = Arrays.stream(commitList)
+                    .filter(x -> !x.isCompletedExceptionally())
+                    .toArray(CompletableFuture[]::new);
+
             log.debug("committed: Successful responses={}, timeouts={}", responses, timeouts);
         }
     }


### PR DESCRIPTION
Fixing kill/remove node scenario.

Committed phase after paxos should block until responses from all nodes have been received.

Currently we hit the following scenario where the failures are not removed while iterating in the while loop and the same response is accounted for multiple iterations. After exit, when we poll for the layout we can still get the old layout as the new one has not been committed yet.