### PR TITLE
Fetch KnownAddressSet from LogUnit

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -26,6 +26,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.KnownAddressSetRequest;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.MultipleReadRequest;
 import org.corfudb.protocols.wireprotocol.ReadRequest;
@@ -284,6 +285,20 @@ public class LogUnitServer extends AbstractServer {
             log.error("Encountered error while flushing cache {}", e);
         }
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
+    }
+
+    /**
+     * Returns a set of all known addresses for the range provided by the start and end addresses.
+     */
+    @ServerHandler(type = CorfuMsgType.KNOWN_ADDRESS_REQUEST, opTimer = metricsPrefix
+            + "knownAddressRequest")
+    private void getKnownAddresses(CorfuPayloadMsg<KnownAddressSetRequest> msg,
+                                   ChannelHandlerContext ctx, IServerRouter r,
+                                   boolean isMetricsEnabled) {
+        KnownAddressSetRequest request = msg.getPayload();
+        r.sendResponse(ctx, msg, CorfuMsgType.KNOWN_ADDRESS_RESPONSE
+                .payloadMsg(streamLog.getKnownAddressesInRange(request.getStartAddress(),
+                        request.getEndAddress())));
     }
 
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -1,15 +1,16 @@
 package org.corfudb.infrastructure.log;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.exceptions.OverwriteException;
-
-import lombok.extern.slf4j.Slf4j;
 
 /**
  * This class implements the StreamLog interface using a Java hash map.
@@ -136,5 +137,17 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
                 trimmed.remove(address);
             }
         }
+    }
+
+    @Override
+    public Set<Long> getKnownAddressesInRange(long startAddress, long endAddress) {
+
+        Set<Long> knownAddresses = new HashSet<>();
+        for (long address = startAddress; address <= endAddress; address++) {
+            if (logCache.containsKey(address)) {
+                knownAddresses.add(address);
+            }
+        }
+        return knownAddresses;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.log;
 
 import java.io.IOException;
+import java.util.Set;
 
 import org.corfudb.protocols.wireprotocol.LogData;
 
@@ -71,4 +72,12 @@ public interface StreamLog {
      * @param address  address to release
      */
     void release(long address, LogData entry);
+
+    /**
+     * Fetches a set of all known addresses in the given range.
+     * @param startAddress start of range address
+     * @param endAddress end of range address
+     * @return set of known addresses by the log unit server.
+     */
+    Set<Long> getKnownAddressesInRange(long startAddress, long endAddress);
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/AddNodeRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/AddNodeRequest.java
@@ -1,0 +1,38 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Request to add a new node.
+ */
+@Data
+@AllArgsConstructor
+public class AddNodeRequest implements ICorfuPayload<AddNodeRequest> {
+
+    private String endpoint;
+    private boolean isLayoutServer;
+    private boolean isSequencerServer;
+    private boolean isLogUnitServer;
+    private boolean isUnresponsiveServer;
+    private int logUnitStripeIndex;
+
+    public AddNodeRequest(ByteBuf buf) {
+        endpoint = ICorfuPayload.fromBuffer(buf, String.class);
+        isLayoutServer = ICorfuPayload.fromBuffer(buf, Boolean.class);
+        isSequencerServer = ICorfuPayload.fromBuffer(buf, Boolean.class);
+        isLogUnitServer = ICorfuPayload.fromBuffer(buf, Boolean.class);
+        isUnresponsiveServer = ICorfuPayload.fromBuffer(buf, Boolean.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, endpoint);
+        ICorfuPayload.serialize(buf, isLayoutServer);
+        ICorfuPayload.serialize(buf, isSequencerServer);
+        ICorfuPayload.serialize(buf, isLogUnitServer);
+        ICorfuPayload.serialize(buf, isUnresponsiveServer);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -88,6 +88,10 @@ public enum CorfuMsgType {
     MANAGEMENT_FAILURE_DETECTED(74, new TypeToken<CorfuPayloadMsg<FailureDetectorMsg>>(){}, true),
     HEARTBEAT_REQUEST(75, TypeToken.of(CorfuMsg.class), true),
     HEARTBEAT_RESPONSE(76, new TypeToken<CorfuPayloadMsg<byte[]>>(){}, true),
+    ADD_NODE_REQUEST(77, new TypeToken<CorfuPayloadMsg<AddNodeRequest>>() {}),
+
+    KNOWN_ADDRESS_REQUEST(81, new TypeToken<CorfuPayloadMsg<KnownAddressSetRequest>>() {}),
+    KNOWN_ADDRESS_RESPONSE(82, new TypeToken<CorfuPayloadMsg<KnownAddressSetResponse>>() {}),
 
     ERROR_SERVER_EXCEPTION(200, new TypeToken<CorfuPayloadMsg<ExceptionMsg>>() {}, true)
     ;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/KnownAddressSetRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/KnownAddressSetRequest.java
@@ -1,0 +1,29 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Request to fetch all known addresses from a log unit server.
+ */
+@Data
+@AllArgsConstructor
+public class KnownAddressSetRequest implements ICorfuPayload<KnownAddressSetRequest> {
+
+    private long startAddress;
+    private long endAddress;
+
+
+    public KnownAddressSetRequest(ByteBuf buf) {
+        startAddress = ICorfuPayload.fromBuffer(buf, Long.class);
+        endAddress = ICorfuPayload.fromBuffer(buf, Long.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, startAddress);
+        ICorfuPayload.serialize(buf, endAddress);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/KnownAddressSetResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/KnownAddressSetResponse.java
@@ -1,0 +1,28 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Response containing all the known addresses from a log unit server.
+ */
+@Data
+@AllArgsConstructor
+public class KnownAddressSetResponse implements ICorfuPayload<KnownAddressSetResponse> {
+
+    private Set<Long> knownAddresses;
+
+
+    public KnownAddressSetResponse(ByteBuf buf) {
+        knownAddresses = ICorfuPayload.setFromBuffer(buf, Long.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, knownAddresses);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -26,6 +26,8 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.FillHoleRequest;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
+import org.corfudb.protocols.wireprotocol.KnownAddressSetRequest;
+import org.corfudb.protocols.wireprotocol.KnownAddressSetResponse;
 import org.corfudb.protocols.wireprotocol.MultipleReadRequest;
 import org.corfudb.protocols.wireprotocol.ReadRequest;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
@@ -241,6 +243,21 @@ public class LogUnitClient implements IClient {
     }
 
     /**
+     * Handle KNOWN_ADDRESS_RESPONSE
+     *
+     * @param msg Incoming Message
+     * @param ctx Context
+     * @param r   Router
+     */
+    @ClientHandler(type = CorfuMsgType.KNOWN_ADDRESS_RESPONSE)
+    private static Object handleKnownAddressSetResponse(CorfuPayloadMsg<KnownAddressSetResponse>
+                                                                msg,
+                                                        ChannelHandlerContext ctx,
+                                                        IClientRouter r) {
+        return msg.getPayload().getKnownAddresses();
+    }
+
+    /**
      * Asynchronously write to the logging unit.
      *
      * @param address        The address to write to.
@@ -448,5 +465,17 @@ public class LogUnitClient implements IClient {
                 CorfuRuntime.getMpLUC()
                         + getHost() + ":" + getPort().toString() + "-" + opName);
         return t.time();
+    }
+
+    /**
+     * Reqeust a set of all known addresses in the specified range.
+     *
+     * @param startAddress Start address
+     * @param endAddress   End Address
+     * @return Completable Future returning the set of addresses known by the log unit server.
+     */
+    public CompletableFuture<Set<Long>> requestKnownAddressSet(long startAddress, long endAddress) {
+        return router.sendMessageAndGetCompletable(CorfuMsgType.KNOWN_ADDRESS_REQUEST.payloadMsg(
+                new KnownAddressSetRequest(startAddress, endAddress)));
     }
 }


### PR DESCRIPTION
API to fetch the set of all known addresses from the log unit server.
This will be used to hole fill to equalize the chain before node catchup and segment replication.
Prerequisite for #971 (Catchup, replicate & merge segments)