### PR TITLE
Release data buffer only after deserialization

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -67,7 +67,6 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
             }
         }
 
-        data = null;
         return value;
     }
 


### PR DESCRIPTION
Fixing NullPointerException.
Race condition where Thread 1 sets data to null, while another Thread 2, which has acquired the lock tries to get data.length resulting in a NullPointerException.
Release data buffer only after deserialization.