### PR TITLE
Prevent NetworkException from causing a double-write

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/unrecoverable/SystemUnavailableError.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/unrecoverable/SystemUnavailableError.java
@@ -1,0 +1,11 @@
+package org.corfudb.runtime.exceptions.unrecoverable;
+
+/**
+ * Created by rmichoud on 10/31/17.
+ */
+public class SystemUnavailableError extends UnrecoverableCorfuError {
+    public SystemUnavailableError(String reason) {
+        super(reason);
+    }
+
+}

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.exceptions.unrecoverable.SystemUnavailableError;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.Layout;
@@ -24,6 +25,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  */
 public class CorfuRuntimeTest extends AbstractViewTest {
     static final int TIME_TO_WAIT_FOR_LAYOUT_IN_SEC = 5;
+    static final long TIMEOUT_CORFU_RUNTIME_IN_MS = 500;
+
+
 
     @Test
     public void checkValidLayout() throws Exception {
@@ -172,5 +176,61 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         assertThatThrownBy(() ->luc.read(0).get())
                 .isInstanceOf(ExecutionException.class)
                 .hasRootCauseInstanceOf(WrongEpochException.class);
+    }
+
+    /**
+     * Implement a SystemUnavailable systemDownHandler that stops the runtime after a certain timeout.
+     *
+     * The correct behaviour for this systemDownHandler is that, once the router is disconnected during the whole timeout,
+     * a SystemUnavailableError is thrown and the runtime is shutdown.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void customNetworkExceptionHandler() throws Exception {
+        class TimeoutHandler {
+            CorfuRuntime rt;
+            long maxTimeout;
+            ThreadLocal<Long> localTimeStart = new ThreadLocal<>();
+
+            TimeoutHandler(CorfuRuntime rt, long maxTimeout) {
+                this.rt = rt;
+                this.maxTimeout = maxTimeout;
+            }
+
+            void startTimeout() {
+                localTimeStart.set(System.currentTimeMillis());
+            }
+
+            void checkIfTimeout() {
+                if (System.currentTimeMillis() - localTimeStart.get() > maxTimeout) {
+                    stopRuntimeAndThrowException();
+                }
+            }
+
+            void stopRuntimeAndThrowException() {
+                rt.stop();
+                throw new SystemUnavailableError("Timeout " + maxTimeout + " elapsed");
+            }
+        }
+
+        addSingleServer(SERVERS.PORT_0);
+
+        CorfuRuntime runtime = getDefaultRuntime();
+        TimeoutHandler th = new TimeoutHandler(runtime, TIMEOUT_CORFU_RUNTIME_IN_MS);
+
+        runtime
+                .registerBeforeRpcHandler(() -> th.startTimeout())
+                .registerSystemDownHandler(() -> th.checkIfTimeout())
+                .connect();
+
+        IStreamView sv = runtime.getStreamsView().get(CorfuRuntime.getStreamID("test"));
+        sv.append("testPayload".getBytes());
+
+        simulateEndpointDisconnected(runtime);
+
+        assertThatThrownBy(() -> sv.append("testPayload".getBytes())).
+                isInstanceOf(SystemUnavailableError.class);
+
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
@@ -10,6 +10,7 @@ import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.AppendException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Test;
 

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -82,6 +82,11 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
         runtime.getParameters().setHoleFillRetry(0);
     }
 
+    public void simulateEndpointDisconnected(CorfuRuntime runtime) {
+        ((TestClientRouter) runtime.getRouter(getDefaultEndpoint()))
+                .simulateDisconnectedEndpoint();
+    }
+
     /** Function for obtaining a router, given a runtime and an endpoint.
      *
      * @param runtime       The CorfuRuntime to obtain a router for.


### PR DESCRIPTION
The Runtime has a settable timeout for how long it will wait for
an unavailable system. If we are not able to progress (due to NetworkExcpetion)
during the timeout, the handler provided by the client (or default handler,
that shutdown the Runtime) will be triggered.

Fixes #974 