### PR TITLE
AddressSpaceView Initialization Bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -279,8 +279,6 @@ public class CorfuRuntime {
         nodeRouters = new ConcurrentHashMap<>();
         retryRate = 5;
 
-        getAddressSpaceView().setMetrics(metrics != null
-                ? metrics : CorfuRuntime.getDefaultMetrics());
         synchronized (metrics) {
             if (metrics.getNames().isEmpty()) {
 //                MetricsUtils.addJvmMetrics(metrics, mp);

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -67,10 +67,7 @@ public class AddressSpaceView extends AbstractView {
      */
     public AddressSpaceView(@Nonnull final CorfuRuntime runtime) {
         super(runtime);
-    }
-
-    public void setMetrics(MetricRegistry metrics) {
-
+        MetricRegistry metrics = runtime.getMetrics();
         final String pfx = String.format("%s0x%x.cache.", runtime.getMpASV(), this.hashCode());
         metrics.register(pfx + "cache-size", (Gauge<Long>) readCache::estimatedSize);
         metrics.register(pfx + "evictions", (Gauge<Long>) () -> readCache.stats().evictionCount());
@@ -78,6 +75,7 @@ public class AddressSpaceView extends AbstractView {
         metrics.register(pfx + "hits", (Gauge<Long>) () -> readCache.stats().hitCount());
         metrics.register(pfx + "misses", (Gauge<Long>) () -> readCache.stats().missCount());
     }
+
 
     /**
      * Reset all in-memory caches.

--- a/runtime/src/main/resources/logback.xml
+++ b/runtime/src/main/resources/logback.xml
@@ -1,31 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-
-    <appender name="MetricsRollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/var/log/corfu-metrics.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>/var/log/corfu-metrics.%i.log</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>10</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
-
-        <encoder>
-            <pattern>%d %highlight(%-5level) - %msg%n %ex{short}</pattern>
-        </encoder>
-    </appender>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{short}</pattern>
         </encoder>
     </appender>
-
-    <logger name="org.corfudb.metricsdata" level="INFO" additivity="false">
-        <appender-ref ref="MetricsRollingFile" />
-    </logger>
 
     <root level="ERROR">
         <appender-ref ref="STDOUT"/>

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -11,6 +11,21 @@
             <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{3}</pattern>
         </encoder>
     </appender>
+    <appender name="MetricsRollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/tmp/log/corfu-metrics.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/var/log/corfu-metrics.%i.log</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>10</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>100MB</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d %highlight(%-5level) - %msg%n %ex{short}</pattern>
+        </encoder>
+    </appender>
 
     <!-- Control logging levels for individual components here. -->
     <logger name="org.corfudb.runtime.object" level="TRACE"/>
@@ -20,8 +35,14 @@
     <logger name="io.netty.util.internal" level="INFO"/>
     <logger name="io.netty.buffer" level="INFO"/>
 
-    <root level="TRACE">
+    <logger name="org.corfudb.metricsdata" level="INFO">
+        <!--<appender-ref ref="MetricsRollingFile" />-->
+    </logger>
+
+
+    <root level="INFO">
         <!--<appender-ref ref="FILE" />-->
         <!--<appender-ref ref="STDOUT" />-->
+        <!--<appender-ref ref="MetricsRollingFile" />-->
     </root>
 </configuration>


### PR DESCRIPTION
The current initialization order of the AddressSpaceView causes
the cache configuration by the runtime to be ignored. This patch
fixes this order so that the numCacheEntries config is picked up
by the cache.