### PR TITLE
Add cluster Id support

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -6,6 +6,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -100,6 +101,7 @@ public class LayoutServer extends AbstractServer {
     private void getSingleNodeLayout() {
         String localAddress = opts.get("--address") + ":" + opts.get("<port>");
         setCurrentLayout(new Layout(
+                UUID.randomUUID(),
                 Collections.singletonList(localAddress),
                 Collections.singletonList(localAddress),
                 Collections.singletonList(new LayoutSegment(

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutWorkflowManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutWorkflowManager.java
@@ -255,6 +255,7 @@ public class LayoutWorkflowManager {
      */
     public Layout build() {
         return new Layout(
+                layout.getClusterId(),
                 layout.getLayoutServers(),
                 layout.getSequencers(),
                 layout.getSegments(),

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -7,6 +7,7 @@ import io.netty.channel.ChannelHandlerContext;
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -122,6 +123,7 @@ public class ManagementServer extends AbstractServer {
             String localAddress = opts.get("--address") + ":" + opts.get("<port>");
 
             Layout singleLayout = new Layout(
+                    UUID.randomUUID(),
                     Collections.singletonList(localAddress),
                     Collections.singletonList(localAddress),
                     Collections.singletonList(new Layout.LayoutSegment(

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -74,6 +74,12 @@ public class Layout implements Cloneable {
      */
     @Getter
     List<String> unresponsiveServers;
+
+    /** A unique identifier for the "cluster". Stays constant through the lifetime
+     *  of the layout (through epoch changes). */
+    @Getter
+    UUID clusterId;
+
     /**
      * The epoch of this layout.
      */
@@ -92,10 +98,12 @@ public class Layout implements Cloneable {
      * Defensive constructor since we can create a Layout from a JSON file.
      * JSON deserialize is forced through this constructor.
      */
-    public Layout(@NonNull List<String> layoutServers, @NonNull List<String> sequencers,
+    public Layout(@Nonnull UUID clusterId,
+                  @NonNull List<String> layoutServers, @NonNull List<String> sequencers,
                   @NonNull List<LayoutSegment> segments, @NonNull List<String> unresponsiveServers,
                   long epoch) {
 
+        this.clusterId = clusterId;
         this.layoutServers = layoutServers;
         this.sequencers = sequencers;
         this.segments = segments;
@@ -120,9 +128,12 @@ public class Layout implements Cloneable {
         }
     }
 
-    public Layout(List<String> layoutServers, List<String> sequencers, List<LayoutSegment> segments,
+    public Layout(@Nonnull UUID clusterId,
+                  @Nonnull List<String> layoutServers,
+                  @Nonnull List<String> sequencers,
+                  @Nonnull List<LayoutSegment> segments,
                   long epoch) {
-        this(layoutServers, sequencers, segments, new ArrayList<String>(), epoch);
+        this(clusterId, layoutServers, sequencers, segments, new ArrayList<String>(), epoch);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutDeserializer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutDeserializer.java
@@ -31,7 +31,9 @@ public class LayoutDeserializer implements JsonDeserializer {
 
         /* Similar to a copy constructor. This constructor holds all the validation for
         constructing a layout. */
-        Layout safeLayout = new Layout(unsafeLayout.layoutServers, unsafeLayout.sequencers,
+        Layout safeLayout = new Layout(
+                unsafeLayout.clusterId,
+                unsafeLayout.layoutServers, unsafeLayout.sequencers,
                 unsafeLayout.segments, unsafeLayout.unresponsiveServers, unsafeLayout.epoch);
 
         return safeLayout;


### PR DESCRIPTION
This PR adds a cluster ID field, which should remain consistent
during reconfigurations.

It does not add verification of this field, which is left
for a future PR.