### PR TITLE
Cleanup message handler and metrics

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -6,7 +6,6 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
-import org.corfudb.util.MetricsUtils;
 
 /**
  * Created by mwei on 12/4/15.
@@ -25,35 +24,11 @@ public abstract class AbstractServer {
     /** Get the message handler for this instance.
      * @return  A message handler.
      */
-    public abstract CorfuMsgHandler getHandler();
+    public abstract CorfuMsgHandler getMsgHandler();
 
     public boolean isServerReadyToHandleMsg(CorfuMsg msg) {
         // Overridden in sequencer to mark ready/not-ready state.
         return true;
-    }
-
-    /**
-     * Handle a incoming Netty message.
-     *
-     * @param msg An incoming message.
-     * @param ctx The channel handler context.
-     * @param r   The router that took in the message.
-     */
-    public void handleMessage(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
-        if (isShutdown()) {
-            return;
-        }
-        boolean isMetricsEnabled = MetricsUtils.isMetricsCollectionEnabled();
-
-        if (!this.isServerReadyToHandleMsg(msg)) {
-            log.warn("Received message {} but Server not ready." , msg.getMsgType());
-            r.sendResponse(ctx, msg, CorfuMsgType.NOT_READY.msg());
-            return;
-        }
-
-        if (!getHandler().handle(msg, ctx, r, isMetricsEnabled)) {
-            log.warn("Received unhandled message type {}" , msg.getMsgType());
-        }
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -29,10 +29,8 @@ public class BaseServer extends AbstractServer {
 
     /** Handler for the base server. */
     @Getter
-    private final CorfuMsgHandler handler = new CorfuMsgHandler()
-            .generateHandlers(MethodHandles.lookup(), this);
-
-    private static final String metricsPrefix = "corfu.server.base.";
+    private final CorfuMsgHandler msgHandler = CorfuMsgHandler
+            .generateHandler(MethodHandles.lookup(), this);
 
     /** Respond to a ping message.
      *
@@ -40,9 +38,8 @@ public class BaseServer extends AbstractServer {
      * @param ctx   The channel context
      * @param r     The server router.
      */
-    @ServerHandler(type = CorfuMsgType.PING, opTimer = metricsPrefix + "ping")
-    private static void ping(CorfuMsg msg, ChannelHandlerContext ctx,
-                             IServerRouter r, boolean isMetricsEnabled) {
+    @ServerHandler(type = CorfuMsgType.PING)
+    private static void ping(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         r.sendResponse(ctx, msg, CorfuMsgType.PONG.msg());
     }
 
@@ -52,9 +49,8 @@ public class BaseServer extends AbstractServer {
      * @param ctx   The channel context
      * @param r     The server router.
      */
-    @ServerHandler(type = CorfuMsgType.VERSION_REQUEST, opTimer = metricsPrefix + "version-request")
-    private void getVersion(CorfuMsg msg, ChannelHandlerContext ctx,
-                            IServerRouter r, boolean isMetricsEnabled) {
+    @ServerHandler(type = CorfuMsgType.VERSION_REQUEST)
+    private void getVersion(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         VersionInfo vi = new VersionInfo(optionsMap);
         r.sendResponse(ctx, msg, new JSONPayloadMsg<>(vi, CorfuMsgType.VERSION_RESPONSE));
     }
@@ -68,8 +64,7 @@ public class BaseServer extends AbstractServer {
      * @param r     The server router.
      */
     @ServerHandler(type = CorfuMsgType.RESET)
-    private static void doReset(CorfuMsg msg, ChannelHandlerContext ctx,
-                                IServerRouter r, boolean isMetricsEnabled) {
+    private static void doReset(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         log.warn("Remote reset requested from client " + msg.getClientID());
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
         Utils.sleepUninterruptibly(500); // Sleep, to make sure that all channels are flushed...

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
@@ -1,43 +1,54 @@
 package org.corfudb.infrastructure;
 
 import com.codahale.metrics.Timer;
-
 import io.netty.channel.ChannelHandlerContext;
-import lombok.extern.slf4j.Slf4j;
-
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
+import javax.annotation.Nonnull;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.ExceptionMsg;
+import org.corfudb.runtime.exceptions.UnrecoverableCorfuException;
 import org.corfudb.util.MetricsUtils;
 
 /**
- * This class simplifies writing switch(msg.getType()) statements.
+ * This class implements message handlers for {@link AbstractServer} implementations.
+ * Servers define methods with signatures which follow the signature of the {@link Handler}
+ * functional interface, and generate a handler using the {@link this#generateHandler(MethodHandles.Lookup, AbstractServer)} method.
  *
  * <p>For maximum performance, make the handlers static whenever possible.
+ * Handlers should be as short as possible (not block), since handler threads come from a
+ * shared pool used by all servers. Blocking operations should be offloaded to I/O threads.
  *
  * <p>Created by mwei on 7/26/16.
  */
 @Slf4j
 public class CorfuMsgHandler {
 
+    /**
+     * A functional interface for server message handlers. Server message handlers should
+     * be fast and not block. If a handler blocks for an extended period of time, it will
+     * exhaust the server's thread pool. I/O and other long operations should be handled
+     * on another thread.
+     */
     @FunctionalInterface
-    interface Handler<T extends CorfuMsg> {
-        void handle(T corfuMsg, ChannelHandlerContext ctx, IServerRouter r,
-                    boolean isMetricsEnabled);
+    public interface Handler<T extends CorfuMsg> {
+        void handle(@Nonnull T corfuMsg,
+                    @Nonnull ChannelHandlerContext ctx,
+                    @Nonnull IServerRouter r);
     }
 
     /** The handler map. */
-    private Map<CorfuMsgType, Handler> handlerMap;
+    private Map<CorfuMsgType, Handler<CorfuMsg>> handlerMap;
 
     /** Get the types this handler will handle.
      *
@@ -47,23 +58,18 @@ public class CorfuMsgHandler {
         return handlerMap.keySet();
     }
 
-    /** Construct a new instance of CorfuMsgHandler. */
-    public CorfuMsgHandler() {
-        handlerMap = new ConcurrentHashMap<>();
+    /** Get a handler for a specific message type.
+     *
+     * @param type  The type to retrieve a handler for.
+     * @return      A handler for the requested message type.
+     */
+    public Handler<CorfuMsg> getHandler(CorfuMsgType type) {
+        return handlerMap.get(type);
     }
 
-    /** Add a handler to this message handler.
-     *
-     * @param messageType       The type of CorfuMsg this handler will handle.
-     * @param handler           The handler itself.
-     * @param <T>               A CorfuMsg type.
-     * @return                  This handler, to support chaining.
-     */
-    @SuppressWarnings("unchecked")
-    public <T extends CorfuMsg> CorfuMsgHandler addHandler(CorfuMsgType messageType,
-                                                           Handler<T> handler) {
-        handlerMap.put(messageType, handler);
-        return this;
+    /** Construct a new instance of CorfuMsgHandler. */
+    private CorfuMsgHandler() {
+        handlerMap = new EnumMap<>(CorfuMsgType.class);
     }
 
     /** Handle an incoming CorfuMsg.
@@ -74,96 +80,138 @@ public class CorfuMsgHandler {
      * @return          True, if the message was handled.
      *                  False otherwise.
      */
-    @SuppressWarnings("unchecked")
-    public boolean handle(CorfuMsg message, ChannelHandlerContext ctx, IServerRouter r,
-                          boolean isMetricsEnabled) {
-        if (handlerMap.containsKey(message.getMsgType())) {
+    public boolean handle(@Nonnull CorfuMsg message,
+                          @Nonnull ChannelHandlerContext ctx,
+                          @Nonnull IServerRouter r) {
+        // Get the handler for the message type
+        final Handler<CorfuMsg> handler = handlerMap.get(message.getMsgType());
+        // If present...
+        if (handler != null) {
             try {
-                handlerMap.get(message.getMsgType()).handle(message, ctx, r, isMetricsEnabled);
+                handler.handle(message, ctx, r);
             } catch (Exception ex) {
+                // Log the exception during handling
                 log.error("handle: Unhandled exception processing {} message",
                         message.getMsgType(), ex);
                 r.sendResponse(ctx, message,
                         CorfuMsgType.ERROR_SERVER_EXCEPTION.payloadMsg(new ExceptionMsg(ex)));
             }
-            return true;
+        // Otherwise log the unexpected message.
+        } else {
+            log.error("handle: Unregistered message type {}", message.getMsgType());
         }
-        return false;
+
+        return handler != null;
     }
 
     /** Generate handlers for a particular server.
      *
      * @param caller    The context that is being used. Call MethodHandles.lookup() to obtain.
-     * @param o         The object that implements the server.
-     * @return          new message handler for caller class
+     * @param server    The object that implements the server.
+     * @return          New message handler for caller class
      */
-    public CorfuMsgHandler generateHandlers(final MethodHandles.Lookup caller, final Object o) {
-        Arrays.stream(o.getClass().getDeclaredMethods())
-                .filter(x -> x.isAnnotationPresent(ServerHandler.class))
-                .forEach(x -> {
-                    ServerHandler a = x.getAnnotation(ServerHandler.class);
-
-                    if (!x.getParameterTypes()[0].isAssignableFrom(a.type().messageType
-                            .getRawType())) {
-                        throw new RuntimeException("Incorrect message type, expected "
-                                + a.type().messageType.getRawType() + " but provided "
-                                + x.getParameterTypes()[0]);
-                    }
-                    if (handlerMap.containsKey(a.type())) {
-                        throw new RuntimeException("Handler for " + a.type()
-                                + " already registered!");
-                    }
-                    // convert the method into a Java8 Lambda for maximum execution speed...
-                    try {
-                        Handler h;
-                        if (Modifier.isStatic(x.getModifiers())) {
-                            MethodHandle mh = caller.unreflect(x);
-                            MethodType mt = mh.type().changeParameterType(0, CorfuMsg.class);
-                            h = (Handler) LambdaMetafactory.metafactory(caller,
-                                    "handle", MethodType.methodType(Handler.class),
-                                    mt, mh, mh.type())
-                                    .getTarget().invokeExact();
-
-                        } else {
-                            // instance method, so we need to capture the type.
-                            MethodType mt = MethodType.methodType(x.getReturnType(),
-                                    x.getParameterTypes());
-                            MethodHandle mh = caller.findVirtual(o.getClass(), x.getName(), mt);
-                            MethodType mtGeneric = mh.type().changeParameterType(1, CorfuMsg.class);
-                            h = (Handler) LambdaMetafactory.metafactory(caller,
-                                    "handle", MethodType.methodType(Handler.class, o.getClass()),
-                                    mtGeneric.dropParameterTypes(0,1), mh,
-                                    mh.type().dropParameterTypes(0,1)).getTarget()
-                                    .bindTo(o).invoke();
-                        }
-
-                        // If there is an annotation element for opTimer that is not "", then
-                        // find/create its timer *outside* of the lambda that we create.
-                        // The lambda may be called very frequently, so avoid touching the metrics
-                        // registry on a hot code path.
-                        final Timer t;
-                        if (!a.opTimer().equals("")) {
-                            t = ServerContext.getMetrics().timer(a.opTimer());
-                        } else {
-                            t = null;
-                        }
-                        // Now create the lambda that wraps the lambda-like-thing that's
-                        // stored in 'h' and insert it into the handlerMap.
-                        handlerMap.put(a.type(),
-                                (CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r,
-                                 boolean isMetricsEnabled) -> {
-                                    try (Timer.Context timerCxt
-                                                 = MetricsUtils.getConditionalContext(
-                                            t != null && isMetricsEnabled, t)) {
-                                        h.handle(msg, ctx, r, isMetricsEnabled);
-                                    }
-                            });
-                    } catch (Throwable e) {
-                        log.error("Exception during incoming message handling", e);
-                        throw new RuntimeException(e);
-                    }
-                });
-        return this;
+    public static CorfuMsgHandler generateHandler(@Nonnull final MethodHandles.Lookup caller,
+                                            @Nonnull final AbstractServer server) {
+        CorfuMsgHandler handler = new CorfuMsgHandler();
+        Arrays.stream(server.getClass().getDeclaredMethods())
+            .filter(method -> method.isAnnotationPresent(ServerHandler.class))
+            .forEach(method -> handler.registerMethod(caller, server, method));
+        return handler;
     }
 
+    /** Takes a method annotated with the {@link org.corfudb.infrastructure.ServerHandler}
+     *  annotation, converts it into a lambda, and registers it in the {@code handlerMap}.
+     * @param caller   The context that is being used. Call MethodHandles.lookup() to obtain.
+     * @param server   The object that implements the server.
+     * @param method   The method to be registered. Must be annotated with the
+     *                 {@link ServerHandler} annotation.
+     */
+    @SuppressWarnings("unchecked")
+    private void registerMethod(@Nonnull final MethodHandles.Lookup caller,
+                                 @Nonnull final AbstractServer server,
+                                 @Nonnull final Method method) {
+        final ServerHandler annotation = method.getAnnotation(ServerHandler.class);
+
+        if (!method.getParameterTypes()[0].isAssignableFrom(annotation.type().messageType
+                .getRawType())) {
+            throw new UnrecoverableCorfuException("Incorrect message type, expected "
+                    + annotation.type().messageType.getRawType() + " but provided "
+                    + method.getParameterTypes()[0]);
+        }
+        if (handlerMap.containsKey(annotation.type())) {
+            throw new UnrecoverableCorfuException("Handler for " + annotation.type()
+                    + " already registered!");
+        }
+        // convert the method into a Java8 Lambda for maximum execution speed...
+        try {
+            Handler<CorfuMsg> h;
+            if (Modifier.isStatic(method.getModifiers())) {
+                MethodHandle mh = caller.unreflect(method);
+                MethodType mt = mh.type().changeParameterType(0, CorfuMsg.class);
+                h = (Handler<CorfuMsg>) LambdaMetafactory.metafactory(caller,
+                        "handle", MethodType.methodType(Handler.class),
+                        mt, mh, mh.type())
+                        .getTarget().invokeExact();
+
+            } else {
+                // instance method, so we need to capture the type.
+                MethodType mt = MethodType.methodType(method.getReturnType(),
+                        method.getParameterTypes());
+                MethodHandle mh = caller.findVirtual(server.getClass(), method.getName(), mt);
+                MethodType mtGeneric = mh.type().changeParameterType(1, CorfuMsg.class);
+                h = (Handler<CorfuMsg>) LambdaMetafactory.metafactory(caller,
+                        "handle",
+                        MethodType.methodType(Handler.class, server.getClass()),
+                        mtGeneric.dropParameterTypes(0,1), mh,
+                        mh.type().dropParameterTypes(0,1)).getTarget()
+                        .bindTo(server).invoke();
+            }
+            // Install pre-conditions on handler
+            final Handler<CorfuMsg> handler =
+                    generateConditionalHandler(server, annotation.type(), h);
+            // Install the handler in the map
+            handlerMap.put(annotation.type(), handler);
+        } catch (Throwable e) {
+            log.error("Exception during incoming message handling", e);
+            throw new UnrecoverableCorfuException(e);
+        }
+    }
+
+    private Handler<CorfuMsg> generateConditionalHandler(@Nonnull final AbstractServer server,
+                                                         @Nonnull final CorfuMsgType type,
+                                                         @Nonnull final Handler<CorfuMsg> handler) {
+        if (!MetricsUtils.isMetricsCollectionEnabled()) {
+            // If metrics are disabled, register the handler without instrumentation.
+            return (msg, ctx, r) -> {
+                if (server.isShutdown()) {
+                    return;
+                }
+
+                if (!server.isServerReadyToHandleMsg(msg)) {
+                    r.sendResponse(ctx, msg, CorfuMsgType.NOT_READY.msg());
+                    return;
+                }
+
+                handler.handle(msg, ctx, r);
+            };
+        } else {
+            // Otherwise, generate a timer based on the operation name
+            final Timer timer = ServerContext.getMetrics().timer(type.toString());
+            // And wrap the handler around a new lambda which measures the execution time.
+            return (msg, ctx, r) -> {
+                if (server.isShutdown()) {
+                    return;
+                }
+
+                if (!server.isServerReadyToHandleMsg(msg)) {
+                    r.sendResponse(ctx, msg, CorfuMsgType.NOT_READY.msg());
+                    return;
+                }
+
+                try (Timer.Context context = MetricsUtils.getConditionalContext(timer)) {
+                    handler.handle(msg, ctx, r);
+                }
+            };
+        }
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -78,10 +78,8 @@ public class LayoutServer extends AbstractServer {
      * Handler for this server.
      */
     @Getter
-    private CorfuMsgHandler handler = new CorfuMsgHandler()
-            .generateHandlers(MethodHandles.lookup(), this);
-
-    private static final String metricsPrefix = "corfu.server.layout.";
+    private final CorfuMsgHandler msgHandler = CorfuMsgHandler
+            .generateHandler(MethodHandles.lookup(), this);
 
     /**
      * Returns new LayoutServer for context.
@@ -134,12 +132,10 @@ public class LayoutServer extends AbstractServer {
      * @param msg              corfu message containing LAYOUT_REQUEST
      * @param ctx              netty ChannelHandlerContext
      * @param r                server router
-     * @param isMetricsEnabled True if metrics are enabled, False otherwise
      */
-    @ServerHandler(type = CorfuMsgType.LAYOUT_REQUEST, opTimer = metricsPrefix + "request")
+    @ServerHandler(type = CorfuMsgType.LAYOUT_REQUEST)
     public synchronized void handleMessageLayoutRequest(CorfuPayloadMsg<Long> msg,
-                                                        ChannelHandlerContext ctx, IServerRouter r,
-                                                        boolean isMetricsEnabled) {
+                                                    ChannelHandlerContext ctx, IServerRouter r) {
         if (!checkBootstrap(msg, ctx, r)) {
             return;
         }
@@ -165,11 +161,11 @@ public class LayoutServer extends AbstractServer {
      * @param ctx netty ChannelHandlerContext
      * @param r   server router
      */
-    @ServerHandler(type = CorfuMsgType.LAYOUT_BOOTSTRAP, opTimer = metricsPrefix + "bootstrap")
+    @ServerHandler(type = CorfuMsgType.LAYOUT_BOOTSTRAP)
     public synchronized void handleMessageLayoutBootstrap(CorfuPayloadMsg<LayoutBootstrapRequest>
-                                                                      msg, ChannelHandlerContext
-            ctx, IServerRouter r,
-                                                          boolean isMetricsEnabled) {
+                                                                      msg,
+                                                          ChannelHandlerContext ctx,
+                                                          IServerRouter r) {
         if (getCurrentLayout() == null) {
             log.info("Bootstrap with new layout={}, {}", msg.getPayload().getLayout(), msg);
             setCurrentLayout(msg.getPayload().getLayout());
@@ -191,10 +187,10 @@ public class LayoutServer extends AbstractServer {
      * @param ctx The channel context
      * @param r   The server router.
      */
-    @ServerHandler(type = CorfuMsgType.SET_EPOCH, opTimer = metricsPrefix + "set-epoch")
+    @ServerHandler(type = CorfuMsgType.SET_EPOCH)
     public synchronized void handleMessageSetEpoch(CorfuPayloadMsg<Long> msg,
-                                                   ChannelHandlerContext ctx, IServerRouter r,
-                                                   boolean isMetricsEnabled) {
+                                                   ChannelHandlerContext ctx,
+                                                   IServerRouter r) {
         if (!checkBootstrap(msg, ctx, r)) {
             return;
         }
@@ -219,11 +215,10 @@ public class LayoutServer extends AbstractServer {
      */
     // TODO this can work under a separate lock for this step as it does not change the global
     // components
-    @ServerHandler(type = CorfuMsgType.LAYOUT_PREPARE, opTimer = metricsPrefix + "prepare")
-    public synchronized void handleMessageLayoutPrepare(CorfuPayloadMsg<LayoutPrepareRequest>
-                                                                    msg, ChannelHandlerContext
-            ctx, IServerRouter r,
-                                                        boolean isMetricsEnabled) {
+    @ServerHandler(type = CorfuMsgType.LAYOUT_PREPARE)
+    public synchronized void handleMessageLayoutPrepare(CorfuPayloadMsg<LayoutPrepareRequest> msg,
+                                                        ChannelHandlerContext ctx,
+                                                        IServerRouter r) {
         // Check if the prepare is for the correct epoch
         if (!checkBootstrap(msg, ctx, r)) {
             return;
@@ -263,11 +258,10 @@ public class LayoutServer extends AbstractServer {
      * @param ctx netty ChannelHandlerContext
      * @param r   server router
      */
-    @ServerHandler(type = CorfuMsgType.LAYOUT_PROPOSE, opTimer = metricsPrefix + "propose")
+    @ServerHandler(type = CorfuMsgType.LAYOUT_PROPOSE)
     public synchronized void handleMessageLayoutPropose(CorfuPayloadMsg<LayoutProposeRequest>
                                                                     msg, ChannelHandlerContext
-            ctx, IServerRouter r,
-                                                        boolean isMetricsEnabled) {
+            ctx, IServerRouter r) {
         // Check if the propose is for the correct epoch
         if (!checkBootstrap(msg, ctx, r)) {
             return;
@@ -329,11 +323,10 @@ public class LayoutServer extends AbstractServer {
     // TODO How do we handle holes in history if let in layout commit message. Maybe we have a
     // hole filling process
     // TODO how do reject the older epoch commits, should it be an explicit NACK.
-    @ServerHandler(type = CorfuMsgType.LAYOUT_COMMITTED, opTimer = metricsPrefix + "committed")
+    @ServerHandler(type = CorfuMsgType.LAYOUT_COMMITTED)
     public synchronized void handleMessageLayoutCommit(CorfuPayloadMsg<LayoutCommittedRequest>
                                                                    msg, ChannelHandlerContext
-            ctx, IServerRouter r,
-                                                       boolean isMetricsEnabled) {
+            ctx, IServerRouter r) {
         Layout commitLayout = msg.getPayload().getLayout();
         if (!checkBootstrap(msg, ctx, r)) {
             return;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -51,8 +51,6 @@ public class ManagementServer extends AbstractServer {
     private static final String PREFIX_MANAGEMENT = "MANAGEMENT";
     private static final String KEY_LAYOUT = "LAYOUT";
 
-    private static final String metricsPrefix = "corfu.server.management-server.";
-
     private CorfuRuntime corfuRuntime;
     /**
      * Policy to be used to detect failures.
@@ -199,8 +197,8 @@ public class ManagementServer extends AbstractServer {
      * Handler for the base server.
      */
     @Getter
-    private CorfuMsgHandler handler = new CorfuMsgHandler()
-            .generateHandlers(MethodHandles.lookup(), this);
+    private CorfuMsgHandler msgHandler = CorfuMsgHandler
+            .generateHandler(MethodHandles.lookup(), this);
 
     /**
      * Thread safe updating of layout only if new layout has higher epoch value.
@@ -256,11 +254,9 @@ public class ManagementServer extends AbstractServer {
      * @param ctx netty ChannelHandlerContext
      * @param r   server router
      */
-    @ServerHandler(type = CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST, opTimer = metricsPrefix
-            + "bootstrap-request")
+    @ServerHandler(type = CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST)
     public synchronized void handleManagementBootstrap(CorfuPayloadMsg<Layout> msg,
-                                                       ChannelHandlerContext ctx, IServerRouter r,
-                                                       boolean isMetricsEnabled) {
+                                                       ChannelHandlerContext ctx, IServerRouter r) {
         if (latestLayout != null) {
             // We are already bootstrapped, bootstrap again is not allowed.
             log.warn("Got a request to bootstrap a server which is already bootstrapped, "
@@ -280,11 +276,9 @@ public class ManagementServer extends AbstractServer {
      * @param ctx netty ChannelHandlerContext
      * @param r   server router
      */
-    @ServerHandler(type = CorfuMsgType.MANAGEMENT_START_FAILURE_HANDLER, opTimer = metricsPrefix
-            + "start-failure-handler")
+    @ServerHandler(type = CorfuMsgType.MANAGEMENT_START_FAILURE_HANDLER)
     public synchronized void initiateFailureHandler(CorfuMsg msg, ChannelHandlerContext ctx,
-                                                    IServerRouter r,
-                                                    boolean isMetricsEnabled) {
+                                                    IServerRouter r) {
         if (isShutdown()) {
             log.warn("Management Server received {} but is shutdown.", msg.getMsgType().toString());
             r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
@@ -312,11 +306,9 @@ public class ManagementServer extends AbstractServer {
      * @param ctx netty ChannelHandlerContext
      * @param r   server router
      */
-    @ServerHandler(type = CorfuMsgType.MANAGEMENT_FAILURE_DETECTED, opTimer = metricsPrefix
-            + "failure-detected")
+    @ServerHandler(type = CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)
     public synchronized void handleFailureDetectedMsg(CorfuPayloadMsg<FailureDetectorMsg> msg,
-                                                      ChannelHandlerContext ctx, IServerRouter r,
-                                                      boolean isMetricsEnabled) {
+                                                      ChannelHandlerContext ctx, IServerRouter r) {
         if (isShutdown()) {
             log.warn("Management Server received {} but is shutdown.", msg.getMsgType().toString());
             r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
@@ -347,10 +339,8 @@ public class ManagementServer extends AbstractServer {
      * @param ctx netty ChannelHandlerContext
      * @param r   server router
      */
-    @ServerHandler(type = CorfuMsgType.HEARTBEAT_REQUEST, opTimer = metricsPrefix
-            + "heartbeat-request")
-    public void handleHearbeatRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r,
-                                      boolean isMetricsEnabled) {
+    @ServerHandler(type = CorfuMsgType.HEARTBEAT_REQUEST)
+    public void handleHearbeatRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         // Currently builds a default instance of the model.
         // TODO: Collect metrics from Layout, Sequencer and LogUnit Servers.
         NodeMetrics nodeMetrics = NodeMetrics.getDefaultInstance();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandler.java
@@ -20,10 +20,4 @@ public @interface ServerHandler {
      * @return the type of corfu message
      */
     CorfuMsgType type();
-
-    /**
-     * Returns registry's name of timer to be used for this operation.
-     * @return the timer name
-     */
-    String opTimer() default ""; //
 }

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/UnrecoverableCorfuException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/UnrecoverableCorfuException.java
@@ -11,4 +11,8 @@ public class UnrecoverableCorfuException extends RuntimeException {
     public UnrecoverableCorfuException(String description) {
         super(description);
     }
+
+    public UnrecoverableCorfuException(Throwable innerException) {
+        super(innerException);
+    }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -239,15 +239,19 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
         testServerMap.entrySet().parallelStream()
                 .forEach(e -> {
                     e.getValue().layoutServer
-                            .handleMessage(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(l)),
+                            .getMsgHandler().getHandler(CorfuMsgType.LAYOUT_BOOTSTRAP)
+                            .handle(CorfuMsgType.LAYOUT_BOOTSTRAP
+                                            .payloadMsg(new LayoutBootstrapRequest(l)),
                                     null, e.getValue().serverRouter);
-                    e.getValue().managementServer
-                            .handleMessage(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST.payloadMsg(l),
+                    e.getValue().managementServer.getMsgHandler()
+                            .getHandler(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST)
+                            .handle(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST.payloadMsg(l),
                                     null, e.getValue().serverRouter);
                 });
         TestServer primarySequencerNode = testServerMap.get(l.getSequencers().get(0));
-        primarySequencerNode.sequencerServer
-                .handleMessage(CorfuMsgType.BOOTSTRAP_SEQUENCER.payloadMsg(new SequencerTailsRecoveryMsg(0L,
+        primarySequencerNode.sequencerServer.getMsgHandler()
+                .getHandler(CorfuMsgType.BOOTSTRAP_SEQUENCER)
+                .handle(CorfuMsgType.BOOTSTRAP_SEQUENCER.payloadMsg(new SequencerTailsRecoveryMsg(0L,
                         Collections.EMPTY_MAP, l.getEpoch())), null, primarySequencerNode.serverRouter);
     }
 


### PR DESCRIPTION
This PR cleans up the server message handler and metrics related infrastructure:

- Metrics are no longer exposed to servers. The CorfuMsgHandler class now instruments
messages automatically based on whether metrics are enabled and uses the message 
type as the timer name.

- Handler maps have been changed from being ConcurrentHashMaps to EnumMaps, which
should reduce lookup time.

- Server routers now install a handle to the handler directly, instead of only
a reference to the server. This should reduce a lookup on the server message
handling path.