### PR TITLE
Populate LogData Entries

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -191,7 +191,7 @@ public class LogUnitServer extends AbstractServer {
                     l < msg.getPayload().getRange().upperEndpoint() + 1L; l++) {
                 ILogData e = dataCache.get(l);
                 if (e == null) {
-                    rr.put(l, LogData.EMPTY);
+                    rr.put(l, LogData.getEmpty(l));
                 } else {
                     rr.put(l, (LogData) e);
                 }
@@ -212,7 +212,7 @@ public class LogUnitServer extends AbstractServer {
             for (Long l : msg.getPayload().getAddresses()) {
                 ILogData e = dataCache.get(l);
                 if (e == null) {
-                    rr.put(l, LogData.EMPTY);
+                    rr.put(l, LogData.getEmpty(l));
                 } else {
                     rr.put(l, (LogData) e);
                 }
@@ -228,7 +228,8 @@ public class LogUnitServer extends AbstractServer {
                           IServerRouter r,
                           boolean isMetricsEnabled) {
         try {
-            dataCache.put(msg.getPayload().getAddress(), LogData.HOLE);
+            long address = msg.getPayload().getAddress();
+            dataCache.put(address, LogData.getHole(address));
             r.sendResponse(ctx, msg, CorfuMsgType.WRITE_OK.msg());
 
         } catch (OverwriteException e) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -93,10 +93,10 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
     @Override
     public LogData read(long address) {
         if (isTrimmed(address)) {
-            return LogData.TRIMMED;
+            return LogData.getTrimmed(address);
         }
         if (trimmed.contains(address)) {
-            return LogData.TRIMMED;
+            return LogData.getTrimmed(address);
         }
 
         return logCache.get(address);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -983,13 +983,13 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     @Override
     public LogData read(long address) {
         if (isTrimmed(address)) {
-            return LogData.TRIMMED;
+            return LogData.getTrimmed(address);
         }
         SegmentHandle sh = getSegmentHandleForAddress(address);
 
         try {
             if (sh.getPendingTrims().contains(address)) {
-                return LogData.TRIMMED;
+                return LogData.getTrimmed(address);
             }
             return readRecord(sh, address);
         } catch (IOException e) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
@@ -16,9 +16,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum DataType implements ICorfuPayload<DataType> {
     DATA(0, true),
-    EMPTY(1, false),
+    EMPTY(1, true),
     HOLE(2, true),
-    TRIMMED(3, false),
+    TRIMMED(3, true),
     RANK_ONLY(4, true);
 
     final int val;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -20,9 +20,6 @@ import org.corfudb.util.serializer.Serializers;
 @Slf4j
 public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
 
-    public static final LogData EMPTY = new LogData(DataType.EMPTY);
-    public static final LogData HOLE = new LogData(DataType.HOLE);
-    public static final LogData TRIMMED = new LogData(DataType.TRIMMED);
     public static final int NOT_KNOWN = -1;
 
     @Getter
@@ -36,6 +33,24 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
     private int lastKnownSize = NOT_KNOWN;
 
     private final transient AtomicReference<Object> payload = new AtomicReference<>();
+
+    public static LogData getTrimmed(long address) {
+        LogData logData = new LogData(DataType.TRIMMED);
+        logData.setGlobalAddress(address);
+        return logData;
+    }
+
+    public static LogData getHole(long address) {
+        LogData logData = new LogData(DataType.HOLE);
+        logData.setGlobalAddress(address);
+        return logData;
+    }
+
+    public static LogData getEmpty(long address) {
+        LogData logData = new LogData(DataType.EMPTY);
+        logData.setGlobalAddress(address);
+        return logData;
+    }
 
     /**
      * Return the payload.
@@ -208,6 +223,17 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         }
         if (type.isMetadataAware()) {
             ICorfuPayload.serialize(buf, metadataMap);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        } else if (!(o instanceof LogData)) {
+            return false;
+        } else {
+            return compareTo((LogData) o) == 0;
         }
     }
 


### PR DESCRIPTION
This patch populates the global address for all entry types on
reads.