### PR TITLE
Fix issue where upcall result is sometimes consumed

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/IStateMachineStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/IStateMachineStream.java
@@ -129,9 +129,12 @@ public interface IStateMachineStream {
      * a previous call to {@link #append(String, Object[], Object[], boolean)} with the
      * {@code keepEntry} flag set to true.
      *
+     * <p> If no upcall result is yet present, {@code null} is returned.
+     *
      * @param address           An address provided by a previous call to
      *                          {@link #append(String, Object[], Object[], boolean)}
-     * @return                  The state machine entry appended to the given address.
+     * @return                  The state machine entry appended to the given address, or
+     *                          {@code null}, if not upcall result is present.
      */
     @Nullable IStateMachineOp consumeEntry(long address);
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/LinearizableStateMachineStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/LinearizableStateMachineStream.java
@@ -22,6 +22,7 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.UnrecoverableCorfuException;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.serializer.ISerializer;
@@ -244,7 +245,7 @@ public class LinearizableStateMachineStream implements IStateMachineStream {
     public IStateMachineOp consumeEntry(long address) {
         Optional<IStateMachineOp> op = entryMap.get(address);
         if (op == null) {
-            throw new RuntimeException("Requested to consume entry " + address
+            throw new UnrecoverableCorfuException("Requested to consume entry " + address
                     + " but never requested to save!");
         }
         if (op.isPresent() && op.get().isUpcallResultPresent()) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/LinearizableStateMachineStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/LinearizableStateMachineStream.java
@@ -247,7 +247,7 @@ public class LinearizableStateMachineStream implements IStateMachineStream {
             throw new RuntimeException("Requested to consume entry " + address
                     + " but never requested to save!");
         }
-        if (op.isPresent()) {
+        if (op.isPresent() && op.get().isUpcallResultPresent()) {
             entryMap.remove(address);
             return op.get();
         }

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionedObjectManager.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionedObjectManager.java
@@ -121,7 +121,7 @@ public class VersionedObjectManager<T> implements IObjectManager<T> {
             IStateMachineOp entry = stream.consumeEntry(address);
 
             // If there is no upcall present, we must obtain it (via syncing).
-            if (entry == null || !entry.isUpcallResultPresent()) {
+            if (entry == null) {
                 // If the object is write-locked, this means some other thread is syncing
                 // the object forward. This might have our update, so we wait until the write
                 // lock is removed.
@@ -129,10 +129,8 @@ public class VersionedObjectManager<T> implements IObjectManager<T> {
                     // We don't have a way to "park" or wait for the lock yet,
                     // so we will spin.
                     for (int i = 0; i < 1000000; i++) {
-                        if (entry == null) {
-                            entry = stream.consumeEntry(address);
-                        }
-                        if (entry != null && entry.isUpcallResultPresent()) {
+                        entry = stream.consumeEntry(address);
+                        if (entry != null) {
                             return (R) entry.getUpcallResult();
                         }
                         if (!lock.isWriteLocked()) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractOptimisticStateMachineStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractOptimisticStateMachineStream.java
@@ -135,8 +135,9 @@ public abstract class AbstractOptimisticStateMachineStream extends
      */
     @Override
     public IStateMachineOp consumeEntry(long address) {
-        return writerContext.getWriteSet().getWriteSet()
+        IStateMachineOp op = writerContext.getWriteSet().getWriteSet()
                 .getSMRUpdates(parent.getId()).get((int) address);
+        return op.isUpcallResultPresent() ? op : null;
     }
 
     @Override


### PR DESCRIPTION
This PR addresses an issue where versionedObjectManager would call
consumeEntry multiple times because an upcall was not present.

However, consumeEntry removes the entry from the entry map, 
which caused the second call to return a runtime exception. 

This PR changes the behavior of consumeEntry to only return
an entry is an upcall is present, and modifies VersionedObjectManager
to expect this new behavior.