### PR TITLE
Eliminate getUpcallResult, use primitive maps in stream

### DIFF
--- a/annotations/src/main/java/org/corfudb/runtime/object/IObjectManager.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/IObjectManager.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.object;
 
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 /** Interface for a manager, which manages an object.
@@ -45,17 +46,8 @@ public interface IObjectManager<T> {
      * @param conflictObject
      * @return
      */
-    long logUpdate(String smrUpdateFunction, boolean keepUpcallResult,
+    Object logUpdate(String smrUpdateFunction, boolean keepUpcallResult,
                        Object[] conflictObject, Object... args);
-
-    /** Get the result of an upcall.
-     *
-     * @param address
-     * @param conflictObject
-     * @param <R>
-     * @return
-     */
-    <R> R getUpcallResult(long address, Object[] conflictObject);
 
     /** Access the state of an object.
      *

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -64,6 +64,15 @@
             <artifactId>metrics-jvm</artifactId>
             <version>3.1.0</version>
         </dependency>
+      <dependency>
+        <groupId>org.eclipse.collections</groupId>
+        <artifactId>eclipse-collections-api</artifactId>
+        <version>9.0.0</version>
+      </dependency>
+        <dependency>
+            <groupId>org.eclipse.collections</groupId>
+            <artifactId>eclipse-collections</artifactId>
+            <version>9.0.0</version>
+        </dependency>
     </dependencies>
-
 </project>

--- a/runtime/src/main/java/org/corfudb/recovery/FastLoadedStateMachineStream.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastLoadedStateMachineStream.java
@@ -5,6 +5,8 @@ import com.google.common.collect.Streams;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -45,6 +47,11 @@ public class FastLoadedStateMachineStream implements IStateMachineStream {
         @Override
         public <T> T apply(ICorfuWrapper<T> wrapper, T object) {
             return originalOp.apply(wrapper, object);
+        }
+
+        @Override
+        public void setUpcallConsumer(@Nonnull Consumer<Object> consumer) {
+            originalOp.setUpcallConsumer(consumer);
         }
 
         IStateMachineOp getUndoOperation() {
@@ -107,14 +114,16 @@ public class FastLoadedStateMachineStream implements IStateMachineStream {
     }
 
     @Override
-    public long append(@Nonnull String smrMethod, @Nonnull Object[] smrArguments, Object[] conflictObjects, boolean keepEntry) {
-        return parent.append(smrMethod, smrArguments, conflictObjects, keepEntry);
+    public CompletableFuture<Object> append(@Nonnull String smrMethod,
+                                            @Nonnull Object[] smrArguments,
+                            Object[] conflictObjects, boolean returnUpcall) {
+        return parent.append(smrMethod, smrArguments, conflictObjects, returnUpcall);
     }
 
     @Override
     @Nullable
-    public IStateMachineOp consumeEntry(long address) {
-        return parent.consumeEntry(address);
+    public Object getUpcallResult(long address) {
+        return parent.getUpcallResult(address);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/recovery/FastLoadedStateMachineStream.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastLoadedStateMachineStream.java
@@ -120,12 +120,6 @@ public class FastLoadedStateMachineStream implements IStateMachineStream {
         return parent.append(smrMethod, smrArguments, conflictObjects, returnUpcall);
     }
 
-    @Override
-    @Nullable
-    public Object getUpcallResult(long address) {
-        return parent.getUpcallResult(address);
-    }
-
     /**
      * Return the parent, which is null, since this stream must be the new root
      * @return  The parent stream, which is null.

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedUpcallException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedUpcallException.java
@@ -9,8 +9,8 @@ package org.corfudb.runtime.exceptions;
  */
 public class TrimmedUpcallException extends TrimmedException {
 
-    public TrimmedUpcallException(long address) {
-        super("Attempted to get upcall result @" + address
+    public TrimmedUpcallException() {
+        super("Attempted to get upcall result"
                 + " but it was trimmed before we could read it");
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/IStateMachineOp.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/IStateMachineOp.java
@@ -1,6 +1,9 @@
 package org.corfudb.runtime.object;
 
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.corfudb.runtime.exceptions.UnrecoverableCorfuException;
 
 /** Represents an operation that can be applied to a state machine object. An operation may bring
  *  an object to a new state, or it may revert an object to a prior state.
@@ -17,15 +20,10 @@ public interface IStateMachineOp {
      */
     <T> T apply(ICorfuWrapper<T> wrapper, T object);
 
-    /** Get the upcall result which was saved when this operation was applied. Will only
-     * be present if the operation was applied and resulted in an upcall, otherwise a runtime
-     * {@link IllegalStateException} will be thrown. Callers can check if a result was present
-     * by calling {@link #isUpcallResultPresent()}.
-     *
-     * @return  An upcall result, if it was present.
-     */
-    default Object getUpcallResult() {
-        throw new IllegalStateException("Requested an upcall result but none present!");
+
+    default void setUpcallConsumer(@Nonnull Consumer<Object> consumer) {
+        throw new UnrecoverableCorfuException("Attempted to set an upcall consumer for an op that "
+            + "does not support it!");
     }
 
     /** Get the list of conflicts that this operation produces, if available.
@@ -38,14 +36,6 @@ public interface IStateMachineOp {
      */
     default @Nullable <T> Object[] getConflicts(ICorfuWrapper<T> wrapper) {
         return null;
-    }
-
-    /** Return whether or not an upcall result is present.
-     *
-     * @return  True, if an upcall result is present, otherwise false.
-     */
-    default boolean isUpcallResultPresent() {
-        return false;
     }
 
     /** Return the address this operation is located at. There may be multiple operations located

--- a/runtime/src/main/java/org/corfudb/runtime/object/IStateMachineStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/IStateMachineStream.java
@@ -125,19 +125,6 @@ public interface IStateMachineStream {
                 @Nullable Object[] conflictObjects,
                 boolean returnUpcall);
 
-    /** Consumes a state machine entry, returning the state machine operation at the given address.
-     * Typically used to obtain the result of an upcall. This address must have been provided by
-     * a previous call to {@link #append(String, Object[], Object[], boolean)} with the
-     * {@code keepEntry} flag set to true.
-     *
-     * <p> If no upcall result is yet present, {@code null} is returned.
-     *
-     * @param address           An address provided by a previous call to
-     *                          {@link #append(String, Object[], Object[], boolean)}
-     * @return                  The state machine entry appended to the given address, or
-     *                          {@code null}, if not upcall result is present.
-     */
-    @Nullable Object getUpcallResult(long address);
 
     /** Get the parent stream of this stream, if present, or null if the stream has no parent.
      *

--- a/runtime/src/main/java/org/corfudb/runtime/object/LinearizableStateMachineStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/LinearizableStateMachineStream.java
@@ -3,11 +3,10 @@ package org.corfudb.runtime.object;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Spliterator;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -25,7 +24,11 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.UnrecoverableCorfuException;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.IStreamView;
+import org.corfudb.util.CFUtils;
 import org.corfudb.util.serializer.ISerializer;
+import org.eclipse.collections.api.map.primitive.MutableLongObjectMap;
+import org.eclipse.collections.impl.map.mutable.primitive.LongObjectHashMap;
+import org.eclipse.collections.impl.map.mutable.primitive.SynchronizedLongObjectMap;
 
 /**
  * An implementation of a state machine stream which has linearizable semantics over
@@ -53,9 +56,10 @@ public class LinearizableStateMachineStream implements IStateMachineStream {
     private final ISerializer serializer;
 
     /** A map which keeps track of entries which have been requested to be saved for calls to
-     * {@link #consumeEntry(long)}.
+     * {@link #getUpcallResult(long)}.
      */
-    final Map<Long, Optional<IStateMachineOp>> entryMap = new ConcurrentHashMap<>();
+    final MutableLongObjectMap<CompletableFuture<Object>> entryMap =
+        new SynchronizedLongObjectMap<>(new LongObjectHashMap<>());
 
     /** Generate a new linearizable state machine stream from a streamview.
      *
@@ -207,10 +211,11 @@ public class LinearizableStateMachineStream implements IStateMachineStream {
                     .map(this::dataAndCheckpointMapper)
                     .flatMap(List::stream)
                     .map(x -> {
-                        if (entryMap.containsKey(x.getAddress())) {
-                            entryMap.put(x.getAddress(), Optional.of(x));
+                        CompletableFuture<Object> cf = entryMap.get(x.getAddress());
+                        if (cf != null) {
+                            x.setUpcallConsumer(cf::complete);
                         }
-                        return (IStateMachineOp) x;
+                        return x;
                     });
         }
     }
@@ -219,22 +224,25 @@ public class LinearizableStateMachineStream implements IStateMachineStream {
      * {@inheritDoc}
      */
     @Override
-    public long append(@Nonnull String smrMethod,
+    public CompletableFuture<Object> append(@Nonnull String smrMethod,
                        @Nonnull Object[] smrArguments,
                        @Nullable Object[] conflictObjects,
-                       final boolean saveEntry) {
+                       final boolean returnUpcall) {
         SMREntry entry = new SMREntry(smrMethod, smrArguments, serializer);
-        return streamView.append(entry, t -> {
-            if (saveEntry) {
-                entryMap.put(t.getTokenValue(), Optional.empty());
-            }
-            return true;
-        }, t -> {
-            if (saveEntry) {
-                entryMap.remove(t.getTokenValue());
-            }
+        if (returnUpcall) {
+            CompletableFuture<Object> cf = new CompletableFuture<>();
+            streamView.append(entry, t -> {
+                entryMap.put(t.getTokenValue(), cf);
                 return true;
-         });
+            }, t -> {
+                entryMap.remove(t.getTokenValue());
+                return true;
+            });
+            return cf;
+        } else {
+            streamView.append(entry, t -> true, t -> true);
+            return null;
+        }
     }
 
     /**
@@ -242,17 +250,17 @@ public class LinearizableStateMachineStream implements IStateMachineStream {
      */
     @Override
     @Nullable
-    public IStateMachineOp consumeEntry(long address) {
-        Optional<IStateMachineOp> op = entryMap.get(address);
+    public Object getUpcallResult(long address) {
+        CompletableFuture<Object> op = entryMap.get(address);
         if (op == null) {
             throw new UnrecoverableCorfuException("Requested to consume entry " + address
                     + " but never requested to save!");
         }
-        if (op.isPresent() && op.get().isUpcallResultPresent()) {
+        if (op.isDone()) {
             entryMap.remove(address);
-            return op.get();
+            return CFUtils.getUninterruptibly(op);
         }
-        return null;
+        throw new IllegalStateException("Upcall result unavailable (address=" + address  + ")");
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/LinearizableStateMachineStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/LinearizableStateMachineStream.java
@@ -249,24 +249,6 @@ public class LinearizableStateMachineStream implements IStateMachineStream {
      * {@inheritDoc}
      */
     @Override
-    @Nullable
-    public Object getUpcallResult(long address) {
-        CompletableFuture<Object> op = entryMap.get(address);
-        if (op == null) {
-            throw new UnrecoverableCorfuException("Requested to consume entry " + address
-                    + " but never requested to save!");
-        }
-        if (op.isDone()) {
-            entryMap.remove(address);
-            return CFUtils.getUninterruptibly(op);
-        }
-        throw new IllegalStateException("Upcall result unavailable (address=" + address  + ")");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public UUID getId() {
         return streamView.getId();
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionedObjectManager.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionedObjectManager.java
@@ -115,6 +115,10 @@ public class VersionedObjectManager<T> implements IObjectManager<T> {
             }
             try {
                 ts = lock.writeLock();
+                // Possibly completed by another thread.
+                if (result.isDone()) {
+                    return result.join();
+                }
                 switchToActiveStreamUnsafe();
                 // Potentially pick up other updates.
                 syncObjectUnsafe(Address.MAX, conflictObject);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractOptimisticStateMachineStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractOptimisticStateMachineStream.java
@@ -139,14 +139,6 @@ public abstract class AbstractOptimisticStateMachineStream extends
         return null;
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Object getUpcallResult(long address) {
-        return null;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransaction.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransaction.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.object.transactions;
 
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
@@ -111,9 +112,9 @@ public class SnapshotTransaction extends AbstractTransaction {
          * Unsupported operation.
          */
         @Override
-        public long append(@Nonnull String smrMethod,
+        public CompletableFuture<Object> append(@Nonnull String smrMethod,
                            @Nonnull Object[] smrArguments,
-                           @Nullable Object[] conflictObjects, boolean keepEntry) {
+                           @Nullable Object[] conflictObjects, boolean returnUpcall) {
             throw new UnsupportedOperationException("Snapshot stream doesn't support append");
         }
 
@@ -123,7 +124,7 @@ public class SnapshotTransaction extends AbstractTransaction {
          */
         @Override
         @Nullable
-        public IStateMachineOp consumeEntry(long address) {
+        public Object getUpcallResult(long address) {
             throw new UnsupportedOperationException("Snapshot stream cannot keep entries");
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransaction.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransaction.java
@@ -120,16 +120,6 @@ public class SnapshotTransaction extends AbstractTransaction {
 
         /**
          * {@inheritDoc}
-         * Unsupported operation.
-         */
-        @Override
-        @Nullable
-        public Object getUpcallResult(long address) {
-            throw new UnsupportedOperationException("Snapshot stream cannot keep entries");
-        }
-
-        /**
-         * {@inheritDoc}
          */
         @Override
         public UUID getId() {

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransaction.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransaction.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.object.transactions;
 
+import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -38,11 +39,11 @@ public class WriteAfterWriteTransaction
 
         /** {@inheritDoc} */
         @Override
-        public long append(@Nonnull String smrMethod,
+        public CompletableFuture<Object> append(@Nonnull String smrMethod,
                            @Nonnull Object[] smrArguments,
-                           @Nullable Object[] conflictObjects, boolean keepEntry) {
+                           @Nullable Object[] conflictObjects, boolean returnUpcall) {
             writerContext.getConflictSet().add(manager, conflictObjects);
-            return super.append(smrMethod, smrArguments, conflictObjects, keepEntry);
+            return super.append(smrMethod, smrArguments, conflictObjects, returnUpcall);
         }
 
 


### PR DESCRIPTION
This PR eliminates the use of getUpcallResult by passing the
result as an optional CompletableFuture to logUpdate, instead
of returning the address.

In addition, primitive maps are now used to keep track of
upcalls that need to be saved, and upcalls are only saved
when requested.