### PR TITLE
Eliminate expensive typetoken resolve call

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -189,7 +189,27 @@ public interface IMetadata {
         final int type;
         @Getter
         final TypeToken<?> componentType;
+        @Getter
+        final Class[] typeParameters;
+        @Getter
+        final Class<?> rawType;
 
+        LogUnitMetadataType(int type, TypeToken<?> componentType) {
+            this.type = type;
+            this.componentType = componentType;
+
+            this.rawType = componentType.getRawType();
+            if (rawType.isAssignableFrom(Map.class)) {
+                typeParameters =  new Class[] {componentType.resolveType(
+                    Map.class.getTypeParameters()[0]).getRawType(),
+                    componentType.resolveType(Map.class.getTypeParameters()[1]).getRawType()};
+            } else if (rawType.isAssignableFrom(Set.class)) {
+                typeParameters =  new Class[] {componentType.resolveType(
+                    Set.class.getTypeParameters()[0]).getRawType()};
+            } else {
+                typeParameters =  new Class[0];
+            }
+        }
         public byte asByte() {
             return (byte) type;
         }
@@ -199,6 +219,8 @@ public interface IMetadata {
                         .collect(Collectors.toMap(LogUnitMetadataType::asByte,
                                 Function.identity()));
     }
+
+
 
     @Value
     @AllArgsConstructor

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ITypedEnum.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ITypedEnum.java
@@ -9,6 +9,8 @@ import io.netty.buffer.ByteBuf;
 public interface ITypedEnum<T extends Enum<T>> extends ICorfuPayload<T>  {
 
     TypeToken<?> getComponentType();
+    Class[] getTypeParameters();
+    Class<?> getRawType();
 
     byte asByte();
 


### PR DESCRIPTION
This PR addresses an issue where ICorfuPayload's enumMapFromBuffer
was using a expensive resolve call from the typetoken in order
to determine the type parameters of a map that could be held
in the data. The type information in ITypedEnum is now
determined when the enum is constructed.