### PR TITLE
Implement Netty message-to-message encoders/decoder

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageDecoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageDecoder.java
@@ -2,11 +2,15 @@ package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
+import io.netty.handler.codec.MessageToMessageDecoder;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -14,24 +18,14 @@ import lombok.extern.slf4j.Slf4j;
  * Created by mwei on 10/1/15.
  */
 @Slf4j
-public class NettyCorfuMessageDecoder extends ByteToMessageDecoder {
+@Sharable
+public class NettyCorfuMessageDecoder extends MessageToMessageDecoder<ByteBuf> {
 
-    @Override
-    protected void decode(ChannelHandlerContext channelHandlerContext, ByteBuf byteBuf,
-                          List<Object> list) throws Exception {
+
+    protected void decode(@Nonnull ChannelHandlerContext channelHandlerContext,
+                          @Nonnull ByteBuf byteBuf,
+                          @Nonnull List<Object> list) throws Exception {
         list.add(CorfuMsg.deserialize(byteBuf));
     }
 
-    @Override
-    protected void decodeLast(ChannelHandlerContext ctx, ByteBuf in,
-                              List<Object> out) throws Exception {
-        //log.info("Netty channel handler context goes inactive, received out size is {}",
-        // (out == null) ? null : out.size());
-
-        if (in != Unpooled.EMPTY_BUFFER) {
-            this.decode(ctx, in, out);
-        }
-        // ignore the Netty generated {@link EmptyByteBuf empty ByteBuf message} when channel
-        // handler goes inactive (typically happened after each received burst of batch of messages)
-    }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
@@ -1,23 +1,32 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
 
+import io.netty.handler.codec.MessageToMessageEncoder;
+import java.util.List;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * Created by mwei on 10/1/15.
  */
 @Slf4j
-public class NettyCorfuMessageEncoder extends MessageToByteEncoder<CorfuMsg> {
+@Sharable
+public class NettyCorfuMessageEncoder extends MessageToMessageEncoder<CorfuMsg> {
 
     @Override
-    protected void encode(ChannelHandlerContext channelHandlerContext,
-                          CorfuMsg corfuMsg,
-                          ByteBuf byteBuf) throws Exception {
+    protected void encode(
+        @Nonnull ChannelHandlerContext ctx,
+        @Nonnull CorfuMsg corfuMsg,
+        @Nonnull List<Object> list) throws Exception {
+        // Nice if the size could be known
+        final ByteBuf buffer = ctx.alloc().directBuffer();
         try {
-            corfuMsg.serialize(byteBuf);
+            corfuMsg.serialize(buffer);
+            list.add(buffer);
         } catch (Exception e) {
             log.error("Error during serialization!", e);
         }


### PR DESCRIPTION
This PR converts the ByteToMessage/MessageToByte encoder/decoders
to MessageToMessage encoder/decoders. Since our messages are
framed by the LengthField encoder/decoder, there is no need
for extra state logic to determine how many messages there are,
and this enables these channels to be implemented as sharable.