### PR TITLE
CorfuTable getByIndexAndFilter logging

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -263,7 +263,7 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
         if (indexFunctions.isEmpty()) {
             // If there are no index functions, use the entire map
             entryStream = mainMap.entrySet().parallelStream();
-            log.warn("getByIndexAndFilter: Attempted getByIndexAndFilter without indexing");
+            log.debug("getByIndexAndFilter: Attempted getByIndexAndFilter without indexing");
         } else {
             Map<I, Map<K, V>> secondaryMap = indexMap.get(indexFunction);
             if (secondaryMap != null) {


### PR DESCRIPTION
## Overview

Description: Change CorfuTable getByIndexAndFilter logging from WARN to DEBUG.

Why should this be merged: CorfuTable can now be used with a single index only, so emitting a warn message is excessive.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
