### PR TITLE
Use Netty MessageToMessage Encoder/Decoder

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -378,7 +378,10 @@ public class CorfuServer {
         Runtime.getRuntime().addShutdownHook(
                 shutdownThread);
 
+        final NettyCorfuMessageDecoder decoder = new NettyCorfuMessageDecoder();
+        final NettyCorfuMessageEncoder encoder = new NettyCorfuMessageEncoder();
         try {
+
             ServerBootstrap b = new ServerBootstrap();
             b.group(bossGroup, workerGroup)
                     .channel(NioServerSocketChannel.class)
@@ -407,8 +410,8 @@ public class CorfuServer {
                                 ch.pipeline().addLast("sasl/plain-text", new
                                         PlainTextSaslNettyServer());
                             }
-                            ch.pipeline().addLast(ee, new NettyCorfuMessageDecoder());
-                            ch.pipeline().addLast(ee, new NettyCorfuMessageEncoder());
+                            ch.pipeline().addLast(ee, decoder);
+                            ch.pipeline().addLast(ee, encoder);
                             ch.pipeline().addLast(ee, router);
                         }
                     });

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageDecoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageDecoder.java
@@ -2,11 +2,15 @@ package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandler;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
+import io.netty.handler.codec.MessageToMessageDecoder;
 import java.util.List;
 
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -14,24 +18,14 @@ import lombok.extern.slf4j.Slf4j;
  * Created by mwei on 10/1/15.
  */
 @Slf4j
-public class NettyCorfuMessageDecoder extends ByteToMessageDecoder {
+@Sharable
+public class NettyCorfuMessageDecoder extends MessageToMessageDecoder<ByteBuf> {
 
-    @Override
-    protected void decode(ChannelHandlerContext channelHandlerContext, ByteBuf byteBuf,
-                          List<Object> list) throws Exception {
+
+    protected void decode(@Nonnull ChannelHandlerContext channelHandlerContext,
+                          @Nonnull ByteBuf byteBuf,
+                          @Nonnull List<Object> list) throws Exception {
         list.add(CorfuMsg.deserialize(byteBuf));
     }
 
-    @Override
-    protected void decodeLast(ChannelHandlerContext ctx, ByteBuf in,
-                              List<Object> out) throws Exception {
-        //log.info("Netty channel handler context goes inactive, received out size is {}",
-        // (out == null) ? null : out.size());
-
-        if (in != Unpooled.EMPTY_BUFFER) {
-            this.decode(ctx, in, out);
-        }
-        // ignore the Netty generated {@link EmptyByteBuf empty ByteBuf message} when channel
-        // handler goes inactive (typically happened after each received burst of batch of messages)
-    }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageDecoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageDecoder.java
@@ -7,6 +7,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandler;
 import io.netty.handler.codec.ByteToMessageDecoder;
 
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import java.util.List;
 
@@ -18,14 +19,17 @@ import lombok.extern.slf4j.Slf4j;
  * Created by mwei on 10/1/15.
  */
 @Slf4j
-@Sharable
-public class NettyCorfuMessageDecoder extends MessageToMessageDecoder<ByteBuf> {
+public class NettyCorfuMessageDecoder extends LengthFieldBasedFrameDecoder {
 
-    /** {@inheritDoc} */
-    protected void decode(@Nonnull ChannelHandlerContext channelHandlerContext,
-                          @Nonnull ByteBuf byteBuf,
-                          @Nonnull List<Object> list) throws Exception {
-        list.add(CorfuMsg.deserialize(byteBuf));
+    public NettyCorfuMessageDecoder() {
+        super(Integer.MAX_VALUE, 0, 4,
+            0, 4);
+    }
+
+    @Override
+    protected Object decode(ChannelHandlerContext ctx, ByteBuf in) throws Exception {
+        ByteBuf buf = (ByteBuf) super.decode(ctx, in);
+        return buf == null ? null : CorfuMsg.deserialize(buf);
     }
 
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageDecoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageDecoder.java
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 @Sharable
 public class NettyCorfuMessageDecoder extends MessageToMessageDecoder<ByteBuf> {
 
-
+    /** {@inheritDoc} */
     protected void decode(@Nonnull ChannelHandlerContext channelHandlerContext,
                           @Nonnull ByteBuf byteBuf,
                           @Nonnull List<Object> list) throws Exception {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
@@ -21,6 +21,7 @@ public class NettyCorfuMessageEncoder extends MessageToMessageEncoder<CorfuMsg> 
 
     private final LongAccumulator maxValue = new LongAccumulator(Math::max, Long.MIN_VALUE);
 
+    /** {@inheritDoc} */
     @Override
     protected void encode(
         @Nonnull ChannelHandlerContext ctx,

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
@@ -3,7 +3,6 @@ package org.corfudb.protocols.wireprotocol;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.MessageToByteEncoder;
 
 import io.netty.handler.codec.MessageToMessageEncoder;
 import java.util.List;
@@ -11,7 +10,6 @@ import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.atomic.LongAccumulator;
-import java.util.function.LongBinaryOperator;
 
 /**
  * Created by mwei on 10/1/15.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
@@ -1,9 +1,13 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler.Sharable;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.MessageToByteEncoder;
 
+import io.netty.handler.codec.MessageToMessageEncoder;
+import java.util.List;
+import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.concurrent.atomic.LongAccumulator;
@@ -13,27 +17,31 @@ import java.util.function.LongBinaryOperator;
  * Created by mwei on 10/1/15.
  */
 @Slf4j
-public class NettyCorfuMessageEncoder extends MessageToByteEncoder<CorfuMsg> {
+@Sharable
+public class NettyCorfuMessageEncoder extends MessageToMessageEncoder<CorfuMsg> {
 
 
-    final LongAccumulator maxValue = new LongAccumulator(Math::max, Long.MIN_VALUE);
+    private final LongAccumulator maxValue = new LongAccumulator(Math::max, Long.MIN_VALUE);
 
     @Override
-    protected void encode(ChannelHandlerContext channelHandlerContext,
-                          CorfuMsg corfuMsg,
-                          ByteBuf byteBuf) throws Exception {
+    protected void encode(
+        @Nonnull ChannelHandlerContext ctx,
+        @Nonnull CorfuMsg corfuMsg,
+        @Nonnull List<Object> list) throws Exception {
+        // Nice if the size could be known
+        final ByteBuf buffer = ctx.alloc().directBuffer();
         try {
-            corfuMsg.serialize(byteBuf);
-            if(log.isDebugEnabled()) {
+            corfuMsg.serialize(buffer);
+            if (log.isDebugEnabled()) {
                 long prev = maxValue.get();
-                maxValue.accumulate(byteBuf.readableBytes());
+                maxValue.accumulate(buffer.readableBytes());
                 long curr = maxValue.get();
                 // The max value has been updated.
                 if (prev < curr) {
                     log.debug("encode: New max write buffer found {}", curr);
                 }
             }
-
+            list.add(buffer);
         } catch (Exception e) {
             log.error("encode: Error during serialization!", e);
         }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -192,9 +192,6 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
     /** The encoder to use to encode Corfu messages. */
     private static final NettyCorfuMessageEncoder ENCODER = new NettyCorfuMessageEncoder();
 
-    /** The decoder for decoding Corfu messages. */
-    private static final NettyCorfuMessageDecoder DECODER = new NettyCorfuMessageDecoder();
-
     /**
      * Creates a new NettyClientRouter connected to the specified endpoint.
      *
@@ -400,16 +397,16 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                         ch.pipeline().addLast("ssl", sslContext.newHandler(ch.alloc()));
                     }
                     ch.pipeline().addLast(new LengthFieldPrepender(4));
-                    ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE,
-                            0, 4, 0,
-                            4));
                     if (saslPlainTextEnabled) {
+                        ChannelHandler decoder = new LengthFieldBasedFrameDecoder
+                            (Integer.MAX_VALUE, 0, 4, 0, 4);
+                        ch.pipeline().addLast(decoder);
                         PlainTextSaslNettyClient saslNettyClient =
                                 SaslUtils.enableSaslPlainText(saslPlainTextUsernameFile,
-                                        saslPlainTextPasswordFile);
+                                        saslPlainTextPasswordFile, decoder);
                         ch.pipeline().addLast("sasl/plain-text", saslNettyClient);
                     }
-                    ch.pipeline().addLast(ee, DECODER);
+                    ch.pipeline().addLast(ee, new NettyCorfuMessageDecoder());
                     ch.pipeline().addLast(ee, ENCODER);
                     ch.pipeline().addLast(ee, router);
                 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -189,6 +189,12 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
 
     private String saslPlainTextPasswordFile;
 
+    /** The encoder to use to encode Corfu messages. */
+    private static final NettyCorfuMessageEncoder ENCODER = new NettyCorfuMessageEncoder();
+
+    /** The decoder for decoding Corfu messages. */
+    private static final NettyCorfuMessageDecoder DECODER = new NettyCorfuMessageDecoder();
+
     /**
      * Creates a new NettyClientRouter connected to the specified endpoint.
      *
@@ -403,8 +409,8 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                                         saslPlainTextPasswordFile);
                         ch.pipeline().addLast("sasl/plain-text", saslNettyClient);
                     }
-                    ch.pipeline().addLast(ee, new NettyCorfuMessageDecoder());
-                    ch.pipeline().addLast(ee, new NettyCorfuMessageEncoder());
+                    ch.pipeline().addLast(ee, DECODER);
+                    ch.pipeline().addLast(ee, ENCODER);
                     ch.pipeline().addLast(ee, router);
                 }
             });

--- a/runtime/src/main/java/org/corfudb/security/sasl/SaslUtils.java
+++ b/runtime/src/main/java/org/corfudb/security/sasl/SaslUtils.java
@@ -1,5 +1,6 @@
 package org.corfudb.security.sasl;
 
+import io.netty.channel.ChannelHandler;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -20,7 +21,7 @@ public class SaslUtils {
      * @return PlainTextSaslNettyClient or RuntimeException on error
      */
     public static PlainTextSaslNettyClient enableSaslPlainText(
-            String usernameFile, String passwordFile) {
+            String usernameFile, String passwordFile, ChannelHandler decoder) {
         if (usernameFile == null) {
             throw new RuntimeException("Invalid username file");
         }
@@ -50,7 +51,7 @@ public class SaslUtils {
         PlainTextSaslNettyClient saslNettyClient = null;
 
         try {
-            saslNettyClient = new PlainTextSaslNettyClient(username, password);
+            saslNettyClient = new PlainTextSaslNettyClient(username, password, decoder);
         } catch (SaslException se) {
             throw new RuntimeException("Could not create a SASL Plain Text Netty client"
                     + se.getClass().getSimpleName(), se);

--- a/runtime/src/main/java/org/corfudb/security/sasl/plaintext/PlainTextSaslNettyServer.java
+++ b/runtime/src/main/java/org/corfudb/security/sasl/plaintext/PlainTextSaslNettyServer.java
@@ -1,6 +1,7 @@
 package org.corfudb.security.sasl.plaintext;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 
@@ -25,12 +26,15 @@ public class PlainTextSaslNettyServer extends SimpleChannelInboundHandler<ByteBu
 
     private final String mechanisms = "PLAIN";
 
+    private final ChannelHandler decoder;
     static {
         PlainTextSaslServerProvider.initialize();
     }
 
-    public PlainTextSaslNettyServer() throws SaslException {
-        saslServer = Sasl.createSaslServer(mechanisms, "plain", null, null, null);
+    public PlainTextSaslNettyServer(ChannelHandler decoder) throws SaslException {
+        this.decoder = decoder;
+        saslServer = Sasl.createSaslServer(mechanisms, "plain",
+            null, null, null);
     }
 
     @Override
@@ -51,6 +55,7 @@ public class PlainTextSaslNettyServer extends SimpleChannelInboundHandler<ByteBu
 
         if (saslServer.isComplete()) {
             ctx.pipeline().remove(this);
+            ctx.pipeline().remove(decoder);
         }
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableMap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -477,9 +478,11 @@ public class NettyCommTest extends AbstractCorfuTest {
                                 ch.pipeline().addLast("ssl", new SslHandler(engine));
                             }
                             ch.pipeline().addLast(new LengthFieldPrepender(FRAME_SIZE));
-                            ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, FRAME_SIZE, 0, FRAME_SIZE));
                             if (saslPlainTextAuthEnabled) {
-                                ch.pipeline().addLast("sasl/plain-text", new PlainTextSaslNettyServer());
+                                ChannelHandler decoder = new LengthFieldBasedFrameDecoder
+                                    (Integer.MAX_VALUE, 0, FRAME_SIZE, 0, FRAME_SIZE);
+                                ch.pipeline().addLast(decoder);
+                                ch.pipeline().addLast("sasl/plain-text", new PlainTextSaslNettyServer(decoder));
                             }
                             ch.pipeline().addLast(ee, new NettyCorfuMessageDecoder());
                             ch.pipeline().addLast(ee, new NettyCorfuMessageEncoder());


### PR DESCRIPTION
## Overview

Description: Previously, Netty MessageToByte and ByteToMessage encoders/decoders were used to encode/decode Corfu messages. Since our messages are framed by the LengthField encoder/decoder, there is no need for extra state logic to determine how many messages there are, and this enables these channels to be implemented as sharable, which should reduce overhead in the Netty pipeline.

Why should this be merged: Relatively simple and low risk change to the Netty pipeline which should reduce overhead and slightly improve performance.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
