### PR TITLE
Memory mapped read/address-space implementation

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -53,6 +53,23 @@ message LogEntry {
     optional int64 checkpointedStreamStartLogAddress = 15;
 }
 
+message LogEntryMetadataOnly {
+    optional DataType data_type = 1;
+    // don't deserialize bytes
+    optional int64 global_address = 3;
+    repeated string	streams = 6;
+    map<string, int64> logical_addresses = 7;
+    map<string, int64> backpointers = 8;
+    optional DataRank rank = 9;
+    optional CheckpointEntryType checkpointEntryType = 10;
+    optional int64 checkpointId_most_significant = 11;
+    optional int64 checkpointId_least_significant = 12;
+    optional int64 checkpointedStreamId_most_significant = 13;
+    optional int64 checkpointedStreamId_least_significant = 14;
+    //  Tail of the stream at the time of taking the checkpoint snapshot.
+    optional int64 checkpointedStreamStartLogAddress = 15;
+}
+
 message LogHeader {
     optional int32 version = 1;
     optional bool verify_checksum = 2;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -323,8 +323,8 @@ public class LogUnitServer extends AbstractServer {
      *     the read() and append(). Any address that cannot be retrieved should be returned as
      *     unwritten (null).
      */
-    public synchronized ILogData handleRetrieval(long address) {
-        LogData entry = streamLog.read(address);
+    public ILogData handleRetrieval(long address) {
+        ILogData entry = streamLog.read(address);
         log.trace("Retrieved[{} : {}]", address, entry);
         return entry;
     }

--- a/runtime/src/main/java/org/corfudb/util/AutoCleanableMappedByteBuf.java
+++ b/runtime/src/main/java/org/corfudb/util/AutoCleanableMappedByteBuf.java
@@ -1,0 +1,53 @@
+package org.corfudb.util;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.nio.MappedByteBuffer;
+import javax.annotation.Nonnull;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import sun.misc.Cleaner;
+import sun.nio.ch.DirectBuffer;
+
+/** {@link this} wraps around a {@link MappedByteBuffer}, implementing the
+ *  {@link java.lang.AutoCloseable} interface which enables a {@link MappedByteBuffer} to be
+ *  automatically cleaned via a try-resources block.
+ *
+ *  <p>Once the buffer is closed it should no longer be used.
+ */
+@Slf4j
+public class AutoCleanableMappedByteBuf implements AutoCloseable {
+
+    /** The {@link java.nio.MappedByteBuffer} being wrapped. */
+    @Getter
+    private final MappedByteBuffer buffer;
+
+    /** A {@link ByteBuf} which wraps the {@link MappedByteBuffer}. */
+    @Getter
+    private final ByteBuf byteBuf;
+
+    /** Construct a new {@link AutoCleanableMappedByteBuf}.
+     *
+     * @param buffer    The {@link MappedByteBuffer} to wrap.
+     */
+    public AutoCleanableMappedByteBuf(@Nonnull MappedByteBuffer buffer) {
+        this.buffer = buffer;
+        this.byteBuf = Unpooled.wrappedBuffer(buffer);
+    }
+
+    /** {@inheritDoc}
+     *
+     * @throws UnsupportedOperationException    If the buffer could not be auto-cleaned.
+     */
+    @Override
+    public void close() {
+        try {
+            Cleaner c = ((DirectBuffer) buffer).cleaner();
+            if (c != null) {
+                 c.clean();
+            }
+        } catch (Exception ex) {
+            throw new UnsupportedOperationException("Failed to autoclean buffer", ex);
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/util/MappedByteBufInputStream.java
+++ b/runtime/src/main/java/org/corfudb/util/MappedByteBufInputStream.java
@@ -1,0 +1,246 @@
+package org.corfudb.util;
+
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileChannel.MapMode;
+import javax.annotation.Nonnull;
+
+/** This class provides an {@link ByteBuf} view over a memory-mapped file. It automatically
+ *  allocates a memory mapped buffer over a {@link FileChannel} given at construction time,
+ *  and creates new mappings as necessary during stream traversal. The mapping(s) are released
+ *  when the stream is closed and during stream traversal when they are no longer necessary.
+ *
+ */
+public class MappedByteBufInputStream extends InputStream implements AutoCloseable {
+
+    /** The underlying {@link FileChannel} to map. */
+    private final FileChannel fc;
+
+    /** The position to start the stream from. */
+    private final long startPosition;
+
+    /** The total length of the stream. */
+    private final long totalLength;
+
+    /** The current mapped buffer. Updated as the stream is traversed. */
+    private AutoCleanableMappedByteBuf buffer;
+
+    /** The current position in the stream. Updated as the stream is traversed. */
+    private long currentPosition;
+
+    /** Generate a new {@link MappedByteBufInputStream} over the entire file.
+     *
+     * @param fc                The FileChannel to map the stream over.
+     * @throws IOException      If the stream cannot be mapped.
+     */
+    public MappedByteBufInputStream(@Nonnull FileChannel fc)
+            throws IOException {
+        this(fc, fc.size());
+    }
+
+    /** Generate a new {@link MappedByteBufInputStream} over a file length.
+     *
+     * @param fc                The FileChannel to map the stream over.
+     * @param length            The length of the file to map.
+     * @throws IOException      If the stream cannot be mapped.
+     */
+    public MappedByteBufInputStream(@Nonnull FileChannel fc, long length)
+            throws IOException {
+        this(fc, 0, length);
+    }
+
+    /** Generate a new {@link MappedByteBufInputStream} over a file length and start position.
+     *
+     * @param fc                The FileChannel to map the stream over.
+     * @param position          The position to start at.
+     * @param length            The length of the file to map.
+     * @throws IOException      If the stream cannot be mapped.
+     */
+    public MappedByteBufInputStream(@Nonnull FileChannel fc, long position, long length)
+            throws IOException {
+        this.fc = fc;
+        this.startPosition = position;
+        this.totalLength = length;
+        reset();
+    }
+
+    /** Update {@code buffer} with the given position and length.
+     *
+     * @param position          The position the buffer should be mapped to in the file.
+     * @param length            The length of the mapping, which must be < 2GB.
+     * @throws IOException      If an I/O exception was encountered during mapping.
+     */
+    private void getNewBuffer(long position, int length) throws IOException {
+        if (buffer != null) {
+            buffer.close();
+        }
+        buffer = new AutoCleanableMappedByteBuf(fc.map(MapMode.READ_ONLY, position, length));
+    }
+
+    /** Ensure that the current buffer has {@code size} bytes available to read, possibly updating
+     *  {@code buffer} if necessary.
+     *
+     *  <p>If {@code size} bytes are not available to read, the current {@code buffer} is guaranteed
+     *  to contain all remaining bytes in the stream.
+     *
+     * @param size               The number of bytes to ensure are readable.
+     * @return                   True, if the the buffer contains all the data, False otherwise.
+     */
+    private boolean ensureReadable(int size)
+            throws IOException {
+        if (size > availableInBuffer()) {
+            // Not enough data in the current buffer. Remap the buffer.
+            getNewBuffer(currentPosition, (int) Math.min(Integer.MAX_VALUE, availableBytes()));
+        }
+
+        if (size > availableBytes()) {
+            currentPosition = startPosition + totalLength - 1;
+            return false;
+        }
+
+        currentPosition += size;
+        return true;
+    }
+
+    /** Return a limited version of this {@link MappedByteBufInputStream} which only returns
+     * {@code limit} bytes.
+     *
+     * @param limit             The number of bytes to limit to.
+     * @return                  An {@link InputStream} which only permits reading up to the
+     *                          given number of bytes.
+     */
+    public InputStream limited(int limit) {
+        return ByteStreams.limit(this, limit);
+    }
+
+    /** Get the position of the reader into this stream.
+     *
+     * @return                  The position of this stream, in bytes.
+     */
+    public long position() {
+        return currentPosition;
+    }
+
+    /** Get how many bytes are available to be consumed via read calls.
+     *
+     * <p>Due to limitations of {@link InputStream}, this method is limited to
+     * {@link Integer.MAX_VALUE}. To retrieve the actual number of bytes, call
+     * {@link this#availableBytes()}.
+     *
+     * @return                  The number of bytes available to be consumed.
+     */
+    public int available() {
+        return (int) Math.min(Integer.MAX_VALUE, availableBytes());
+    }
+
+    /** Get how many bytes are available to be consumed via read calls.
+     *
+     * @return                  The number of bytes available to be consumed.
+     */
+    public long availableBytes() {
+        return totalLength - (currentPosition - startPosition);
+    }
+
+    /** Get how many bytes are available in the current {@link buffer}.
+     *
+     * @return                  The number of bytes available in the current buffer.
+     */
+    private int availableInBuffer() {
+        if (buffer == null) {
+            return 0;
+        }
+        return buffer.getByteBuf().writerIndex() - buffer.getByteBuf().readerIndex();
+    }
+
+    /** Skip the given number of bytes.
+     *
+     * @param bytes             The number of bytes to skip.
+     */
+    public long skipBytes(long bytes)
+            throws IOException {
+        if (bytes == 0) {
+            return 0;
+        } else if (bytes < 0) {
+            throw new IllegalArgumentException("Must skip positive bytes!");
+        }
+
+        long skipped = Math.min(bytes, availableBytes());
+        currentPosition += skipped;
+
+        if (availableInBuffer() >= skipped) {
+            // All the skipped bytes are available in the buffer, so just move
+            // the buffer index
+            buffer.getByteBuf().readerIndex(buffer.getByteBuf().readerIndex() + (int) bytes);
+        } else {
+            // Otherwise, we need to get a new buffer
+            getNewBuffer(currentPosition, (int) Math.min(Integer.MAX_VALUE, availableBytes()));
+        }
+        return skipped;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (!ensureReadable(1)) {
+            return -1;
+        }
+        return buffer.getByteBuf().readByte() & 255;
+    }
+
+    @Override
+    public int read(@Nonnull byte[] b, int off, int len) throws IOException {
+        if (!ensureReadable(len)) {
+            // check if anything is available in the current buffer
+            int available = availableInBuffer();
+            if (available > 0) {
+                buffer.getByteBuf().readBytes(b, off, available);
+                return available;
+            } else {
+                // Nothing is available.
+                return -1;
+            }
+        } else {
+            buffer.getByteBuf().readBytes(b, off, len);
+            return len;
+        }
+    }
+
+    @Override
+    public void reset() throws IOException {
+        int thisSegmentLength = (int) Math.min(Integer.MAX_VALUE, totalLength);
+        getNewBuffer(startPosition, thisSegmentLength);
+        currentPosition = startPosition;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public long skip(long bytes) throws IOException {
+        return skipBytes(bytes);
+    }
+
+    /** Read a {@link short}
+     *
+     * @return  The next {@link short}.
+     */
+    public short readShort() throws IOException {
+        if (!ensureReadable(Short.BYTES)) {
+            throw new IndexOutOfBoundsException();
+        }
+        return buffer.getByteBuf().readShort();
+    }
+
+    /** {@inheritDoc}
+     *
+     *  <Pp>Also closes the underlying {@link AutoCleanableMappedByteBuf}.
+     */
+    @Override
+    public void close() {
+        buffer.close();
+        buffer = null;
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -520,7 +520,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
     public void testGetGlobalTail() {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
 
-        assertThat(log.getGlobalTail()).isEqualTo(0);
+        assertThat(log.getGlobalTail()).isEqualTo(-1L);
 
         // Write to multiple segments
         final int segments = 3;
@@ -689,7 +689,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
                 s -> assertThat(new File(s).length()).isEqualTo(0L));
 
         final int expectedFilesAfterReset = 3;
-        final long globalTailAfterReset = 0L;
+        final long globalTailAfterReset = -1L;
         final long trimMarkAfterReset = 0L;
         assertThat(logsDir.list()).hasSize(expectedFilesAfterReset);
         assertThat(log.getGlobalTail()).isEqualTo(globalTailAfterReset);


### PR DESCRIPTION
## Overview

Description: This PR replaces the implementation of read and readAddressSpace with versions that used MemoryMappedByteBuffers, instead of allocating and reading into a secondary byte buffer, then constructing the protobuf. A new inputstream (MappedByteBufInputStream) which automatically allocates a buffer and maintains a view over a file channel, is introduced, which allows the log unit to read over a file in a memory-mapped fashion. Verification in StreamLogFiles has been merged into StreamLogFiles::scanLogAndPerformAction. This change unifies code which needs to scan over an entire log file. I've tested the PR on a 6GB log file.

Why should this be merged: Issue #986 reported that a Corfu server is unable to startup with a . large log file (>800MB) due to heap space. Usually this shouldn't be a issue since log files are limited to 10k entries each, but the server does not place a limit to how large each entry is, so this could result in an unstartable Corfu server if large entries were written (for example, checkpoints of ~100KB per entry). This was due to StreamLogFiles::readAddressSpace and StreamLogFiles::getGlobalAdddressTail requiring twice as much memory as the file to read it. It should also significantly reduce memory pressure during startup. Unfortunately, generating a memory mapping for each read is also likely to be potentially costly, #940 may help, but transferring a FileRegion (instead of converting into a protobuf) should be preferred.

Related issue(s) (if applicable): Fixes #1048, #986, related to #940 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
