### PR TITLE
Reset logunit server

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -302,6 +302,18 @@ public class LogUnitServer extends AbstractServer {
     }
 
     /**
+     * Resets the log unit server.
+     * Warning: Clears all data.
+     */
+    @ServerHandler(type = CorfuMsgType.RESET_LOGUNIT, opTimer = metricsPrefix + "resetLogUnit")
+    private void resetLogUnit(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r,
+                           boolean isMetricsEnabled) {
+        streamLog.reset();
+        dataCache.invalidateAll();
+        r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
+    }
+
+    /**
      * Retrieve the LogUnitEntry from disk, given an address.
      *
      * @param address The address to retrieve the entry from.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -151,4 +151,14 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
             }
         }
     }
+
+    @Override
+    public void reset() {
+        startingAddress = 0;
+        globalTail.set(0L);
+        // Clear the trimmed addresses record.
+        trimmed.clear();
+        // Clearing all data from the cache.
+        logCache.clear();
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -81,4 +81,9 @@ public interface StreamLog {
      * @param address  address to release
      */
     void release(long address, LogData entry);
+
+    /**
+     * Clears all data and resets all segment handlers.
+     */
+    void reset();
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -64,6 +64,7 @@ public enum CorfuMsgType {
     FLUSH_CACHE(44, TypeToken.of(CorfuMsg.class), true),
     TRIM_MARK_REQUEST(45, TypeToken.of(CorfuMsg.class), true),
     TRIM_MARK_RESPONSE(46, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
+    RESET_LOGUNIT(47, TypeToken.of(CorfuMsg.class)),
 
     WRITE_OK(50, TypeToken.of(CorfuMsg.class)),
     ERROR_TRIMMED(51, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -475,4 +475,11 @@ public class LogUnitClient implements IClient {
         return router.sendMessageAndGetCompletable(CorfuMsgType.RANGE_WRITE
                 .payloadMsg(new RangeWriteMsg(range)));
     }
+
+    /**
+     * Send a reset request.
+     */
+    public CompletableFuture<Boolean> resetLogUnit() {
+        return router.sendMessageAndGetCompletable(CorfuMsgType.RESET_LOGUNIT.msg());
+    }
 }


### PR DESCRIPTION
## Overview

Description: Resets the log unit server by clearing all data and persisted state.

Why should this be merged: This is a requirement to heal failed nodes.
The healing nodes need to be added back to the chain and this can only be done once the state
on the log unit server on the healing node is reset.

## Checklist (Definition of Done):
- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
