### PR TITLE
Don't generate an exception for each RPC

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/CFUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/CFUtils.java
@@ -93,6 +93,9 @@ public class CFUtils {
                 RuntimeException.class, RuntimeException.class);
     }
 
+    /** A static timeout exception that we complete futures exceptionally with. */
+    static final TimeoutException TIMEOUT_EXCEPTION = new TimeoutException();
+
     /**
      * Generates a completable future which times out.
      * inspired by NoBlogDefFound: http://www.nurkiewicz.com/2014/12/asynchronous-timeouts-with.html
@@ -103,11 +106,8 @@ public class CFUtils {
      */
     public static <T> CompletableFuture<T> failAfter(Duration duration) {
         final CompletableFuture<T> promise = new CompletableFuture<>();
-        scheduler.schedule(() -> {
-            final TimeoutException ex = new TimeoutException("Timeout after "
-                    + duration.toMillis() + " ms");
-            return promise.completeExceptionally(ex);
-        }, duration.toMillis(), TimeUnit.MILLISECONDS);
+        scheduler.schedule(() -> promise.completeExceptionally(TIMEOUT_EXCEPTION),
+                                        duration.toMillis(), TimeUnit.MILLISECONDS);
         return promise;
     }
 


### PR DESCRIPTION
## Overview

Description: This PR changes the behavior of the ```CFUtils::failAfter``` function to not generate a new exception (and stack trace). Instead, it uses a statically generated exception. This statically generated exception does not have useful stack trace information (but arguably, the dynamically generated exception did not either).

Why should this be merged: Currently, every RPC generates this exception and string whether or not it times out, which is significant time overhead to generate the stack trace (via ```fillInStackTrace```). This benchmark: https://shipilev.net/blog/2014/exceptional-performance/ places the cost of the exception at 10-100ns/op depending on stack depth. While that might be too small to affect our benchmarks directly currently (we probably have a lot of other overheads), it is needless performance overhead that is eliminated by a very minor change.

Related issue(s) (if applicable): #1056 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
