### PR TITLE
Implement Node Id on Server

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -6,6 +6,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -24,8 +25,14 @@ public class BaseServer extends AbstractServer {
 
     /** Options map, if available. */
     @Getter
-    @Setter
-    public Map<String, Object> optionsMap = new HashMap<>();
+    final public Map<String, Object> optionsMap;
+
+    final ServerContext serverContext;
+
+    public BaseServer(@Nonnull ServerContext context) {
+        this.serverContext = context;
+        optionsMap = context.getServerConfig();
+    }
 
     /** Handler for the base server. */
     @Getter
@@ -55,7 +62,8 @@ public class BaseServer extends AbstractServer {
     @ServerHandler(type = CorfuMsgType.VERSION_REQUEST, opTimer = metricsPrefix + "version-request")
     private void getVersion(CorfuMsg msg, ChannelHandlerContext ctx,
                             IServerRouter r, boolean isMetricsEnabled) {
-        VersionInfo vi = new VersionInfo(optionsMap);
+        VersionInfo vi = new VersionInfo(serverContext.getServerConfig(),
+            serverContext.getDataStore().get(String.class, "", ServerContext.NODE_ID));
         r.sendResponse(ctx, msg, new JSONPayloadMsg<>(vi, CorfuMsgType.VERSION_RESPONSE));
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -63,7 +63,7 @@ public class BaseServer extends AbstractServer {
     private void getVersion(CorfuMsg msg, ChannelHandlerContext ctx,
                             IServerRouter r, boolean isMetricsEnabled) {
         VersionInfo vi = new VersionInfo(serverContext.getServerConfig(),
-            serverContext.getDataStore().get(String.class, "", ServerContext.NODE_ID));
+                                         serverContext.getNodeIdBase64());
         r.sendResponse(ctx, msg, new JSONPayloadMsg<>(vi, CorfuMsgType.VERSION_RESPONSE));
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -271,9 +271,6 @@ public class CorfuServer {
         // Create a common Server Context for all servers to access.
         serverContext = new ServerContext(opts, router);
 
-        // Generate a node ID if necessary.
-        generateNodeId(serverContext);
-
         // Add each role to the router.
         router.addServer(new BaseServer(serverContext));
         addSequencer();
@@ -480,22 +477,5 @@ public class CorfuServer {
     public static void addManagementServer() {
         managementServer = new ManagementServer(serverContext);
         router.addServer(managementServer);
-    }
-
-    /** Generate a Node Id if not present.
-     *
-     * @param context   The server context to use.
-     */
-    private static void generateNodeId(@Nonnull ServerContext context) {
-        String currentId = context.getDataStore().get(String.class, "",
-                ServerContext.NODE_ID);
-        if (currentId == null) {
-            String idString = UuidUtils.asBase64(UUID.randomUUID());
-            log.info("No Node Id, setting to new Id={}", idString);
-            context.getDataStore().put(String.class, "", ServerContext.NODE_ID, idString);
-
-        } else {
-            log.info("Node Id = {}", currentId);
-        }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -103,8 +103,6 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
      */
     public NettyServerRouter(Map<String, Object> opts) {
         handlerMap = new ConcurrentHashMap<>();
-        baseServer = new BaseServer();
-        addServer(baseServer);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -38,6 +38,9 @@ public class ServerContext {
     private static final String PREFIX_STARTING_ADDRESS = "STARTING_ADDRESS";
     private static final String KEY_STARTING_ADDRESS = "CURRENT";
 
+    /** The node Id, stored as a base64 string. */
+    public static final String NODE_ID = "NODE_ID";
+
     /**
      * various duration constants.
      */

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/VersionInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/VersionInfo.java
@@ -2,10 +2,9 @@ package org.corfudb.protocols.wireprotocol;
 
 import java.lang.management.ManagementFactory;
 import java.util.Map;
-
-import org.corfudb.runtime.CorfuRuntime;
-
+import javax.annotation.Nonnull;
 import lombok.Getter;
+import org.corfudb.runtime.CorfuRuntime;
 
 /**
  * Created by mwei on 7/27/16.
@@ -26,8 +25,17 @@ public class VersionInfo {
     @Getter
     String version;
 
-    public VersionInfo(Map<String,Object> optionsMap) {
+    @Getter
+    String nodeId;
+
+    /** Create a new version info, using the current options map and node id.
+     *
+     * @param optionsMap    The options map used to start the server.
+     * @param nodeId        The current node id.
+     */
+    public VersionInfo(Map<String,Object> optionsMap, @Nonnull String nodeId) {
         this.optionsMap = optionsMap;
+        this.nodeId = nodeId;
         this.version = CorfuRuntime.getVersionString();
     }
 }

--- a/runtime/src/main/java/org/corfudb/util/UuidUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/UuidUtils.java
@@ -1,0 +1,40 @@
+package org.corfudb.util;
+
+import com.google.common.io.BaseEncoding;
+import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+
+/** A collection of utilities to manage and maniupulate UUIDs. */
+public class UuidUtils {
+
+    /** Generate a base64 URL-safe string from a given UUID.
+     *
+     * @param uuid      The UUID to convert.
+     * @return          A base64 URL-safe string for the UUID.
+     */
+    public static String asBase64(@Nonnull UUID uuid) {
+        ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+        bb.putLong(uuid.getMostSignificantBits());
+        bb.putLong(uuid.getLeastSignificantBits());
+        return BaseEncoding.base64Url().omitPadding().encode(bb.array());
+    }
+
+    /** Generate a UUID from a base64 URL-safe string.
+     *
+     * @param uuidString    The base64 URL-safe string to convert.
+     *
+     * @throws IllegalArgumentException   If decoding fails due to a malformed string.
+     * @return                            A UUID from the string.
+     */
+    public static UUID fromBase64(@Nonnull String uuidString) {
+        ByteBuffer bb = ByteBuffer.wrap(BaseEncoding.base64Url().decode(uuidString));
+        if (bb.remaining() < 16) {
+            throw new IllegalArgumentException("Input too short: must be 16 bytes");
+        } else if (bb.remaining() > 16) {
+            throw new IllegalArgumentException("Input too long: must be 16 bytes");
+        }
+        return new UUID(bb.getLong(), bb.getLong());
+    }
+}

--- a/runtime/src/main/java/org/corfudb/util/UuidUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/UuidUtils.java
@@ -1,7 +1,6 @@
 package org.corfudb.util;
 
 import com.google.common.io.BaseEncoding;
-import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 import javax.annotation.Nonnull;
@@ -25,8 +24,8 @@ public class UuidUtils {
      *
      * @param uuidString    The base64 URL-safe string to convert.
      *
-     * @throws IllegalArgumentException   If decoding fails due to a malformed string.
      * @return                            A UUID from the string.
+     * @throws IllegalArgumentException   If decoding fails due to a malformed string.
      */
     public static UUID fromBase64(@Nonnull String uuidString) {
         ByteBuffer bb = ByteBuffer.wrap(BaseEncoding.base64Url().decode(uuidString));

--- a/test/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
@@ -15,7 +15,7 @@ public class BaseServerTest extends AbstractServerTest {
     @Override
     public AbstractServer getDefaultServer() {
         if (bs == null) {
-            bs = new BaseServer();
+            bs = new BaseServer(ServerContextBuilder.emptyContext());
         }
         return bs;
     }

--- a/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
@@ -32,7 +32,7 @@ public class ManagementServerTest extends AbstractServerTest {
                 .build();
         // Required for management server to fetch layout.
         router.addServer(new LayoutServer(serverContext));
-        router.addServer(new BaseServer());
+        router.addServer(new BaseServer(serverContext));
         // Required to fetch global tails while handling failures.
         router.addServer(new LogUnitServer(serverContext));
         // Required for management server to bootstrap during initialization.

--- a/test/src/test/java/org/corfudb/runtime/clients/BaseClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/BaseClientTest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import com.google.common.collect.ImmutableSet;
 import org.corfudb.infrastructure.AbstractServer;
 import org.corfudb.infrastructure.BaseServer;
+import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.util.CFUtils;
 import org.junit.Test;
 
@@ -18,7 +19,7 @@ public class BaseClientTest extends AbstractClientTest {
     @Override
     Set<AbstractServer> getServersForTest() {
         return new ImmutableSet.Builder<AbstractServer>()
-                .add(new BaseServer())
+                .add(new BaseServer(ServerContextBuilder.emptyContext()))
                 .build();
     }
 

--- a/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
@@ -41,7 +41,7 @@ public class ManagementClientTest extends AbstractClientTest {
                 // Required for management server to be able to bootstrap the sequencer.
                 .add(new SequencerServer(serverContext))
                 .add(new LogUnitServer(serverContext))
-                .add(new BaseServer())
+                .add(new BaseServer(serverContext))
                 .build();
     }
 

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -27,6 +27,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.infrastructure.BaseServer;
 import org.corfudb.infrastructure.NettyServerRouter;
+import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.protocols.wireprotocol.NettyCorfuMessageDecoder;
 import org.corfudb.protocols.wireprotocol.NettyCorfuMessageEncoder;
 import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyServer;
@@ -349,7 +350,7 @@ public class NettyCommTest extends AbstractCorfuTest {
      */
     private void reloadedTrustManagerTestHelper(boolean replaceClientTrust) throws Exception {
         NettyServerRouter serverRouter = new NettyServerRouter(new ImmutableMap.Builder<String, Object>().build());
-        serverRouter.addServer(new BaseServer());
+        serverRouter.addServer(new BaseServer(ServerContextBuilder.emptyContext()));
         int port = findRandomOpenPort();
 
         File clientTrustNoServer = new File("src/test/resources/security/reload/client_trust_no_server.jks");
@@ -417,7 +418,7 @@ public class NettyCommTest extends AbstractCorfuTest {
             throws Exception {
 
         NettyServerRouter nsr = new NettyServerRouter(new ImmutableMap.Builder<String, Object>().build());
-        nsr.addServer(new BaseServer());
+        nsr.addServer(new BaseServer(ServerContextBuilder.emptyContext()));
         int port = findRandomOpenPort();
 
         NettyServerData d = nsdc.createNettyServerData(port);
@@ -498,6 +499,7 @@ public class NettyCommTest extends AbstractCorfuTest {
 
         void bootstrapServer() throws Exception {
             NettyServerRouter nsr = new NettyServerRouter(new ImmutableMap.Builder<String, Object>().build());
+            nsr.addServer(new BaseServer(ServerContextBuilder.emptyContext()));
             bossGroup = new NioEventLoopGroup(1, new ThreadFactory() {
                 final AtomicInteger threadNum = new AtomicInteger(0);
 

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.clients;
 
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.infrastructure.BaseServer;
+import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.infrastructure.TestServerRouter;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.junit.Test;
@@ -19,7 +20,7 @@ public class TestClientRouterTest extends AbstractCorfuTest {
     @Test
     public void testRuleDropsMessages() {
         TestServerRouter tsr = new TestServerRouter();
-        BaseServer bs = new BaseServer();
+        BaseServer bs = new BaseServer(ServerContextBuilder.emptyContext());
         tsr.addServer(bs);
         TestClientRouter tcr = new TestClientRouter(tsr);
 
@@ -40,7 +41,7 @@ public class TestClientRouterTest extends AbstractCorfuTest {
     @Test
     public void onlyDropEpochChangeMessages() {
         TestServerRouter tsr = new TestServerRouter();
-        BaseServer bs = new BaseServer();
+        BaseServer bs = new BaseServer(ServerContextBuilder.emptyContext());
         tsr.addServer(bs);
         TestClientRouter tcr = new TestClientRouter(tsr);
 
@@ -62,7 +63,7 @@ public class TestClientRouterTest extends AbstractCorfuTest {
     @Test
     public void doesNotUpdateEpochBackward() throws Exception {
         TestServerRouter tsr = new TestServerRouter();
-        BaseServer bs = new BaseServer();
+        BaseServer bs = new BaseServer(ServerContextBuilder.emptyContext());
         tsr.addServer(bs);
         TestClientRouter tcr = new TestClientRouter(tsr);
 

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -375,7 +375,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
         TestServer(ServerContext serverContext) {
             this.serverContext = serverContext;
             this.serverRouter = serverContext.getServerRouter();
-            this.baseServer = new BaseServer();
+            this.baseServer = new BaseServer(ServerContextBuilder.emptyContext());
             this.sequencerServer = new SequencerServer(serverContext);
             this.layoutServer = new LayoutServer(serverContext);
             this.logUnitServer = new LogUnitServer(serverContext);

--- a/test/src/test/java/org/corfudb/util/UuidUtilsTest.java
+++ b/test/src/test/java/org/corfudb/util/UuidUtilsTest.java
@@ -1,0 +1,45 @@
+package org.corfudb.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+import org.junit.Test;
+
+public class UuidUtilsTest {
+
+    /** Test that a UUID can be converted back and forth between base64 and UUID. */
+    @Test
+    public void base64StringEqualsUuid() {
+        final UUID testId = UUID.nameUUIDFromBytes("test".getBytes());
+        final String base64 = UuidUtils.asBase64(testId);
+
+        assertThat(UuidUtils.fromBase64(base64))
+            .isEqualTo(testId);
+    }
+
+    /** Test that a invalid string throws {@link java.lang.IllegalArgumentException}. */
+    @Test
+    public void nonBase64StringThrowsException() {
+        assertThatThrownBy(() -> UuidUtils.fromBase64("!!!!!!!!!!!"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /** Test that a short base64 string, which is insufficient (< 16 bytes) to reconstruct
+     *  an UUID throws an exception.
+     */
+    @Test
+    public void shortBase64StringThrowsException() {
+        assertThatThrownBy(() -> UuidUtils.fromBase64("AAAA"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /** Test that a long base64 string, which is too long (> 16 bytes) to reconstruct
+     *  an UUID throws an exception.
+     */
+    @Test
+    public void longBase64StringThrowsException() {
+        assertThatThrownBy(() -> UuidUtils.fromBase64("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
## Overview

Description: This PR introduces a node Id field, which is generated on first start and stored in the data store. The node Id is a 128-bit UUID which is represented as a Base64 URL-safe string. The planned use of a base64 string is to append it to a server url, in the form ```<host>:<port>:<node-id>```, which will enable the node id to be checked at connection time during a handshake to be implemented in the future. Currently, the Node Id can be retrieved in using a versionRequest call to a server, and the server can retrieve the node Id from a serverContext.

Why should this be merged: This PR makes it possible to disambiguate servers which have failed, but restarted at the same IP address, eliminating configuration errors from allowing clients to connect to incorrect servers.

Related issue(s) (if applicable): Fixes #1050 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
