### PR TITLE
Improve exception/error handling

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -24,6 +24,7 @@ import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.TrimmedUpcallException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
@@ -391,11 +392,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 MetricsUtils.incConditionalCounter(isMetricsEnabled, counterTxnRetryN, 1);
                 log.debug("Transactional function aborted due to {}, retrying after {} msec",
                         e, sleepTime);
-                try {
-                    Thread.sleep(sleepTime);
-                } catch (InterruptedException ie) {
-                    throw new UnrecoverableCorfuInterruptedError("Interrupted while retrying tx", ie);
-                }
+                Utils.sleepUninterruptibly(sleepTime);
                 sleepTime = min(sleepTime * 2L, maxSleepTime);
                 retries++;
             } catch (Exception e) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.exceptions.NoRollbackException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.object.transactions.WriteSetSMRStream;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.Utils;
@@ -606,7 +607,7 @@ public class VersionLockedObject<T> {
                         entry.setUpcallResult(res);
                     } catch (Exception e) {
                         log.error("Sync[{}] Error: Couldn't execute upcall due to {}", this, e);
-                        throw new RuntimeException(e);
+                        throw new UnrecoverableCorfuError(e);
                     }
                 });
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -28,6 +28,7 @@ import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.util.CFUtils;
 
 import java.util.Comparator;
@@ -229,7 +230,7 @@ public class AddressSpaceView extends AbstractView {
 
         } catch (Exception e) {
             log.error("prefixTrim: Error while calling prefix trimming {}", address, e);
-            return;
+            throw new UnrecoverableCorfuError("Unexpected error while prefix trimming", e);
         }
     }
 
@@ -311,6 +312,8 @@ public class AddressSpaceView extends AbstractView {
                         .readAll(l, batch)));
             } catch (Exception e) {
                 log.error("cacheFetch: Couldn't read addresses {}", batch, e);
+                throw new UnrecoverableCorfuError(
+                    "Unexpected error during cacheFetch", e);
             }
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -20,6 +20,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.object.CorfuCompileWrapperBuilder;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
@@ -178,37 +179,37 @@ public class ObjectsView extends AbstractView {
             return AbstractTransactionalContext.UNCOMMITTED_ADDRESS;
         } else {
             long totalTime = System.currentTimeMillis() - context.getStartTime();
-            log.trace("TXCommit[{}] time={} ms",
+            log.trace("TXEnd[{}] time={} ms",
                     context, totalTime);
             try {
                 return TransactionalContext.getCurrentContext().commitTransaction();
             } catch (TransactionAbortedException e) {
-                log.warn("TXCommit[{}] Exception {}", context, e);
+                log.warn("TXEnd[{}] Aborted Exception {}", context, e);
                 TransactionalContext.getCurrentContext().abortTransaction(e);
                 throw e;
-            } catch (Exception e) {
-                log.warn("TXCommit[{}] Exception {}", context, e);
-                AbortCause abortCause;
-
-                if (e instanceof NetworkException) {
-                    abortCause = AbortCause.NETWORK;
-                } else {
-                    abortCause = AbortCause.UNDEFINED;
-                }
-
+            } catch (NetworkException e) {
+                log.warn("TXEnd[{}] Network Exception {}", context, e);
                 long snapshotTimestamp;
                 try {
                     snapshotTimestamp = context.getSnapshotTimestamp();
                 } catch (NetworkException ne) {
                     snapshotTimestamp = -1L;
                 }
-
                 TxResolutionInfo txInfo = new TxResolutionInfo(context.getTransactionID(),
-                        snapshotTimestamp);
+                    snapshotTimestamp);
                 TransactionAbortedException tae = new TransactionAbortedException(txInfo,
-                        null, null, abortCause, e, context);
+                    null, null, AbortCause.NETWORK, e, context);
                 context.abortTransaction(tae);
                 throw tae;
+
+            } catch (Exception e) {
+               log.error("TXEnd: Unexpected exception", e);
+                TxResolutionInfo txInfo = new TxResolutionInfo(context.getTransactionID(),
+                    -1L);
+                TransactionAbortedException tae = new TransactionAbortedException(txInfo,
+                    null, null, AbortCause.UNDEFINED, e, context);
+                context.abortTransaction(tae);
+                throw new UnrecoverableCorfuError("Unexpected exception during commit", e);
             } finally {
                 TransactionalContext.removeContext();
             }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -179,8 +179,7 @@ public class ObjectsView extends AbstractView {
             return AbstractTransactionalContext.UNCOMMITTED_ADDRESS;
         } else {
             long totalTime = System.currentTimeMillis() - context.getStartTime();
-            log.trace("TXEnd[{}] time={} ms",
-                    context, totalTime);
+            log.trace("TXEnd[{}] time={} ms", context, totalTime);
             try {
                 return TransactionalContext.getCurrentContext().commitTransaction();
             } catch (TransactionAbortedException e) {
@@ -203,7 +202,7 @@ public class ObjectsView extends AbstractView {
                 throw tae;
 
             } catch (Exception e) {
-               log.error("TXEnd: Unexpected exception", e);
+               log.error("TXEnd[{}]: Unexpected exception", context, e);
                 TxResolutionInfo txInfo = new TxResolutionInfo(context.getTransactionID(),
                     -1L);
                 TransactionAbortedException tae = new TransactionAbortedException(txInfo,

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.exceptions.HoleFillRequiredException;
+import org.corfudb.util.Utils;
 
 
 /** A hole filling policy which reads several times,
@@ -43,11 +44,7 @@ public class ReadWaitHoleFillPolicy implements IHoleFillPolicy {
         do {
             // If this is not the first try, sleep before trying again
             if (tryNum != 0) {
-                try {
-                    Thread.sleep(waitMs);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+                Utils.sleepUninterruptibly(waitMs);
             }
             // Try the read
             ILogData data = peekFunction.apply(address);


### PR DESCRIPTION
## Overview

Description: This PR improves error and exception handling by throwing ```UnrecoverableCorfuError``` whenever an unexpected exception is caught, and sleeping using the ```Utils.sleepUninterruptibly``` helper, which throws a ```UnrecoverableCorfuInterruptedError``` when interrupted.

Why should this be merged: This PR addresses several cases where catching all ```Exception``` types masked errors which should have been passed on to the application. In particular, this type of handling was causing ```InterruptedException``` to not shutdown threads on application termination.

Related issue(s) (if applicable): #1033

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
