### PR TITLE
Refactor CorfuServer so that code can be reused in tests

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -23,15 +23,10 @@ import org.corfudb.util.Utils;
 @Slf4j
 public class BaseServer extends AbstractServer {
 
-    /** Options map, if available. */
-    @Getter
-    final public Map<String, Object> optionsMap;
-
     final ServerContext serverContext;
 
     public BaseServer(@Nonnull ServerContext context) {
         this.serverContext = context;
-        optionsMap = context.getServerConfig();
     }
 
     /** Handler for the base server. */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -291,7 +291,7 @@ public class CorfuServer {
     /** A functional interface for receiving and configuring a {@link ServerBootstrap}.
      */
     @FunctionalInterface
-    interface BootstrapConfigurer {
+    public interface BootstrapConfigurer {
 
         /** Configure a {@link ServerBootstrap}.
          *

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -177,7 +177,7 @@ public class LayoutServer extends AbstractServer {
             log.info("handleMessageLayoutBootstrap: Bootstrap with new layout={}, {}",
                     msg.getPayload().getLayout(), msg);
             setCurrentLayout(msg.getPayload().getLayout());
-            serverContext.setServerEpoch(getCurrentLayout().getEpoch());
+            serverContext.setServerEpoch(getCurrentLayout().getEpoch(), r);
             //send a response that the bootstrap was successful.
             r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
         } else {
@@ -207,7 +207,8 @@ public class LayoutServer extends AbstractServer {
         if (msg.getPayload() >= serverEpoch) {
             log.info("handleMessageSetEpoch: Received SET_EPOCH, moving to new epoch {}",
                     msg.getPayload());
-            setServerEpoch(msg.getPayload());
+            serverContext.setServerEpoch(msg.getPayload(), r);
+            r.setServerEpoch(msg.getPayload());
             r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
         } else {
             log.debug("handleMessageSetEpoch: Rejected SET_EPOCH current={}, requested={}",
@@ -364,7 +365,7 @@ public class LayoutServer extends AbstractServer {
         }
 
         setCurrentLayout(commitLayout);
-        setServerEpoch(msg.getPayload().getEpoch());
+        serverContext.setServerEpoch(msg.getPayload().getEpoch(), r);
         r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
     }
 
@@ -407,10 +408,6 @@ public class LayoutServer extends AbstractServer {
     public void setLayoutInHistory(Layout layout) {
         serverContext.getDataStore().put(Layout.class, PREFIX_LAYOUTS, String.valueOf(layout
                 .getEpoch()), layout);
-    }
-
-    private void setServerEpoch(long serverEpoch) {
-        serverContext.setServerEpoch(serverEpoch);
     }
 
     private long getServerEpoch() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -100,7 +100,7 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
     @Getter
     final List<AbstractServer> servers;
 
-    /** Construct an new {@link NettyServerRouter}.
+    /** Construct a new {@link NettyServerRouter}.
      *
      * @param servers   A list of {@link AbstractServer}s this router will route
      *                  messages for.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -4,8 +4,9 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
+import java.util.EnumMap;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
@@ -86,9 +87,7 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
     /**
      * This map stores the mapping from message type to netty server handler.
      */
-    Map<CorfuMsgType, AbstractServer> handlerMap;
-
-    BaseServer baseServer;
+    private final Map<CorfuMsgType, AbstractServer> handlerMap;
 
     /**
      * The epoch of this router. This is managed by the base server implementation.
@@ -97,39 +96,32 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
     @Setter
     long serverEpoch;
 
-    /**
-     * Returns a new NettyServerRouter.
-     * @param opts map of options (FIXME: unused)
-     */
-    public NettyServerRouter(Map<String, Object> opts) {
-        handlerMap = new ConcurrentHashMap<>();
-    }
+    /** The {@link AbstractServer}s this {@link NettyServerRouter} routes messages for. */
+    @Getter
+    final List<AbstractServer> servers;
 
-    /**
-     * Add a new netty server handler to the router.
+    /** Construct an new {@link NettyServerRouter}.
      *
-     * @param server The server to add.
+     * @param servers   A list of {@link AbstractServer}s this router will route
+     *                  messages for.
      */
-    public void addServer(AbstractServer server) {
-        // Iterate through all types of CorfuMsgType, registering the handler
-        server.getHandler().getHandledTypes()
-                .forEach(x -> {
-                    handlerMap.put(x, server);
-                    log.trace("Registered {} to handle messages of type {}", server, x);
-                });
+    public NettyServerRouter(List<AbstractServer> servers) {
+        this.servers = servers;
+        handlerMap = new EnumMap<>(CorfuMsgType.class);
+        servers.forEach(server -> server.getHandler().getHandledTypes()
+            .forEach(x -> handlerMap.put(x, server)));
     }
 
     /**
-     * Remove a server from the router.
-     * @param server  server to remove
+     * {@inheritDoc}
+     *
+     * @deprecated This operation is no longer supported. The router will only route messages for
+     * servers provided at construction time.
      */
-    public void removeServer(AbstractServer server) {
-        // Iterate through all types of CorfuMsgType, un-registering the handler
-        server.getHandler().getHandledTypes()
-                .forEach(x -> {
-                    handlerMap.remove(x, server);
-                    log.trace("Un-Registered {} to handle messages of type {}", server, x);
-                });
+    @Override
+    @Deprecated
+    public void addServer(AbstractServer server) {
+        throw new UnsupportedOperationException("No longer supported");
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -60,6 +60,7 @@ public class ServerContext {
     private final DataStore dataStore;
 
     @Getter
+    @Setter
     private IServerRouter serverRouter;
 
     @Getter
@@ -76,9 +77,8 @@ public class ServerContext {
     /**
      * Returns a new ServerContext.
      * @param serverConfig map of configuration strings to objects
-     * @param serverRouter server router
      */
-    public ServerContext(Map<String, Object> serverConfig, IServerRouter serverRouter) {
+    public ServerContext(Map<String, Object> serverConfig) {
         this.serverConfig = serverConfig;
         this.dataStore = new DataStore(serverConfig);
         generateNodeId();
@@ -128,6 +128,18 @@ public class ServerContext {
         return getDataStore().get(String.class, "", ServerContext.NODE_ID);
     }
 
+    /** Get a field from the server configuration map.
+     *
+     * @param type          The type of the field.
+     * @param optionName    The name of the option to retrieve.
+     * @param <T>           The type of the field to return.
+     * @return              The field with the give option name.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getServerConfig(Class<T> type, String optionName) {
+        return (T) getServerConfig().get(optionName);
+    }
+
     /**
      * The epoch of this router. This is managed by the base server implementation.
      */
@@ -140,11 +152,9 @@ public class ServerContext {
      * Set the serverRouter epoch.
      * @param serverEpoch the epoch to set
      */
-    public void setServerEpoch(long serverEpoch) {
+    public void setServerEpoch(long serverEpoch, IServerRouter r) {
         dataStore.put(Long.class, PREFIX_EPOCH, KEY_EPOCH, serverEpoch);
-        // Set the epoch in the router as well.
-        //TODO need to figure out if we can remove this redundancy
-        serverRouter.setServerEpoch(serverEpoch);
+        r.setServerEpoch(serverEpoch);
     }
 
     public long getTailSegment() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -82,7 +82,6 @@ public class ServerContext {
         this.serverConfig = serverConfig;
         this.dataStore = new DataStore(serverConfig);
         generateNodeId();
-        this.serverRouter = serverRouter;
         this.failureDetectorPolicy = new PeriodicPollPolicy();
         this.failureHandlerPolicy = new ConservativeFailureHandlerPolicy();
 

--- a/logReader/src/test/java/org/corfudb/logReader/logReaderTest.java
+++ b/logReader/src/test/java/org/corfudb/logReader/logReaderTest.java
@@ -35,7 +35,7 @@ public class logReaderTest {
         configs.put("--log-path", LOG_BASE_PATH);
         configs.put("--no-verify", false);
         configs .put("--cache-heap-ratio", "0.5");
-        return new ServerContext(configs, null);
+        return new ServerContext(configs);
     }
 
     @Before

--- a/test/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
@@ -15,7 +15,7 @@ public class BaseServerTest extends AbstractServerTest {
     @Override
     public AbstractServer getDefaultServer() {
         if (bs == null) {
-            bs = new BaseServer(ServerContextBuilder.emptyContext());
+            bs = new BaseServer(ServerContextBuilder.defaultTestContext(0));
         }
         return bs;
     }

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -36,7 +36,7 @@ public class ServerContextBuilder {
     String seqCache = "1000";
     String managementBootstrapEndpoint = null;
     IServerRouter serverRouter;
-    int numThreads = 0;
+    String numThreads = "0";
 
     public ServerContextBuilder() {
 

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -19,13 +19,24 @@ public class ServerContextBuilder {
     boolean memory = true;
     String logPath = null;
     boolean noVerify = false;
+
     boolean tlsEnabled = false;
+    boolean tlsMutualAuthEnabled = false;
+    String tlsProtocols = "";
+    String tlsCiphers = "";
+    String keystore = "";
+    String keystorePasswordFile = "";
+    boolean saslPlainTextAuth = false;
+    String truststore = "";
+    String truststorePasswordFile = "";
+
     String cacheSizeHeapRatio = "0.5";
     String address = "test";
     int port = 9000;
     String seqCache = "1000";
     String managementBootstrapEndpoint = null;
     IServerRouter serverRouter;
+    int numThreads = 0;
 
     public ServerContextBuilder() {
 
@@ -37,6 +48,7 @@ public class ServerContextBuilder {
                 .put("--initial-token", initialToken)
                 .put("--single", single)
                 .put("--memory", memory)
+                .put("--Threads", numThreads)
                 .put("--sequencer-cache-size", seqCache);
         if (logPath != null) {
          builder.put("--log-path", logPath);
@@ -49,12 +61,29 @@ public class ServerContextBuilder {
                  .put("--address", address)
                  .put("--cache-heap-ratio", cacheSizeHeapRatio)
                  .put("--enable-tls", tlsEnabled)
+                 .put("--enable-tls-mutual-auth", tlsMutualAuthEnabled)
+                 .put("--tls-protocols", tlsProtocols)
+                 .put("--tls-ciphers", tlsCiphers)
+                 .put("--keystore", keystore)
+                 .put("--keystore-password-file", keystorePasswordFile)
+                 .put("--truststore", truststore)
+                 .put("--truststore-password-file", truststorePasswordFile)
+                 .put("--enable-sasl-plain-text-auth", saslPlainTextAuth)
                  .put("<port>", port);
-        return new ServerContext(builder.build(), serverRouter);
+        ServerContext sc = new ServerContext(builder.build());
+        sc.setServerRouter(serverRouter);
+        return sc;
     }
 
-    public static ServerContext defaultContext(int port) {
-        return new ServerContextBuilder().setPort(port).build();
+    /** Create a test context at a given port with the default settings.
+     *
+     * @param port  The port to use.
+     * @return      A {@link ServerContext} with a {@link TestServerRouter} installed.
+     */
+    public static ServerContext defaultTestContext(int port) {
+        ServerContext sc = new ServerContextBuilder().setPort(port).build();
+        sc.setServerRouter(new TestServerRouter());
+        return sc;
     }
 
     public static ServerContext emptyContext() {

--- a/test/src/test/java/org/corfudb/runtime/clients/BaseClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/BaseClientTest.java
@@ -19,7 +19,7 @@ public class BaseClientTest extends AbstractClientTest {
     @Override
     Set<AbstractServer> getServersForTest() {
         return new ImmutableSet.Builder<AbstractServer>()
-                .add(new BaseServer(ServerContextBuilder.emptyContext()))
+                .add(new BaseServer(ServerContextBuilder.defaultTestContext(0)))
                 .build();
     }
 

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyClientRouterTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyClientRouterTest.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.clients;
 
+import org.corfudb.infrastructure.ServerContextBuilder;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,7 +14,7 @@ public class NettyClientRouterTest extends NettyCommTest {
 
         runWithBaseServer(
                 (port) -> {
-                    return new NettyServerData(port);
+                    return new NettyServerData(ServerContextBuilder.defaultTestContext(port));
                 },
                 (port) -> {
                     return new NettyClientRouter("localhost", port);

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
@@ -20,7 +20,7 @@ public class TestClientRouterTest extends AbstractCorfuTest {
     @Test
     public void testRuleDropsMessages() {
         TestServerRouter tsr = new TestServerRouter();
-        BaseServer bs = new BaseServer(ServerContextBuilder.emptyContext());
+        BaseServer bs = new BaseServer(ServerContextBuilder.defaultTestContext(0));
         tsr.addServer(bs);
         TestClientRouter tcr = new TestClientRouter(tsr);
 
@@ -41,7 +41,7 @@ public class TestClientRouterTest extends AbstractCorfuTest {
     @Test
     public void onlyDropEpochChangeMessages() {
         TestServerRouter tsr = new TestServerRouter();
-        BaseServer bs = new BaseServer(ServerContextBuilder.emptyContext());
+        BaseServer bs = new BaseServer(ServerContextBuilder.defaultTestContext(0));
         tsr.addServer(bs);
         TestClientRouter tcr = new TestClientRouter(tsr);
 
@@ -63,7 +63,7 @@ public class TestClientRouterTest extends AbstractCorfuTest {
     @Test
     public void doesNotUpdateEpochBackward() throws Exception {
         TestServerRouter tsr = new TestServerRouter();
-        BaseServer bs = new BaseServer(ServerContextBuilder.emptyContext());
+        BaseServer bs = new BaseServer(ServerContextBuilder.defaultTestContext(0));
         tsr.addServer(bs);
         TestClientRouter tcr = new TestClientRouter(tsr);
 

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -141,7 +141,9 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
      * @param config    The configuration to use for the server.
      */
     public void addServer(int port, Map<String, Object> config) {
-        addServer(port, new ServerContext(config, new TestServerRouter(port)));
+        ServerContext sc = new ServerContext(config);
+        sc.setServerRouter(new TestServerRouter(port));
+        addServer(port, sc);
     }
 
     /**
@@ -383,13 +385,17 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
 
         TestServer(Map<String, Object> optsMap)
         {
-            this(new ServerContext(optsMap, new TestServerRouter()));
+            this(new ServerContext(optsMap));
+            serverContext.setServerRouter(new TestServerRouter());
         }
 
         TestServer(ServerContext serverContext) {
             this.serverContext = serverContext;
             this.serverRouter = serverContext.getServerRouter();
-            this.baseServer = new BaseServer(ServerContextBuilder.emptyContext());
+            if (serverRouter == null) {
+                serverRouter = new TestServerRouter();
+            }
+            this.baseServer = new BaseServer(serverContext);
             this.sequencerServer = new SequencerServer(serverContext);
             this.layoutServer = new LayoutServer(serverContext);
             this.logUnitServer = new LogUnitServer(serverContext);
@@ -404,7 +410,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
 
         TestServer(int port)
         {
-            this(ServerContextBuilder.defaultContext(port).getServerConfig());
+            this(ServerContextBuilder.defaultTestContext(port).getServerConfig());
         }
 
         void addToTest(int port, AbstractViewTest test) {


### PR DESCRIPTION
## Overview
Description: This PR refactors CorfuServer so that code for instantiating the server and binding to a port can be reused in tests.

Why should this be merged: Previously, most CorfuServer code was untested because it required running from CorfuServer's ```main``` function. This resulted in a lot of code duplication in tests, and ultimately led to the test code deviating from the CorfuServer code. This change consolidates the test code (especially in ```NettyCommTest```) into CorfuServer, and the test code now re-uses the CorfuServer code. This change should increase coverage significantly and pave the way towards actually using Netty during tests instead of the simulated TestRouter framework.

## Checklist (Definition of Done):
- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
