### PR TITLE
Support EPoll/KQueue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
-            <version>4.1.10.Final</version>
+            <version>4.1.18.Final</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -162,6 +162,14 @@
     </dependencies>
 
     <build>
+
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.5.0.Final</version>
+            </extension>
+        </extensions>
 
         <pluginManagement>
             <plugins>

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -30,6 +30,8 @@ public class ServerContextBuilder {
     String truststore = "";
     String truststorePasswordFile = "";
 
+    String implementation = "auto";
+
     String cacheSizeHeapRatio = "0.5";
     String address = "test";
     int port = 9000;
@@ -71,6 +73,7 @@ public class ServerContextBuilder {
                  .put("--truststore", truststore)
                  .put("--truststore-password-file", truststorePasswordFile)
                  .put("--enable-sasl-plain-text-auth", saslPlainTextAuth)
+                 .put("--implementation", implementation)
                  .put("<port>", port);
         ServerContext sc = new ServerContext(builder.build());
         sc.setServerRouter(serverRouter);

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -30,7 +30,7 @@ public class ServerContextBuilder {
     String truststore = "";
     String truststorePasswordFile = "";
 
-    String implementation = "auto";
+    String implementation = "nio";
 
     String cacheSizeHeapRatio = "0.5";
     String address = "test";

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -544,7 +544,7 @@ public class NettyCommTest extends AbstractCorfuTest {
             workerGroup = CorfuServer.getWorkerGroup(serverContext);
             f = CorfuServer.startAndListen(bossGroup,
                                             workerGroup,
-                                            NioServerSocketChannel.class,
+                                            CorfuServer.getServerChannelType(serverContext),
                                             b -> CorfuServer.configureBootstrapOptions(
                                                 serverContext, b),
                                             serverContext,


### PR DESCRIPTION
## Overview

Description: This PR builds on top of #1061 to support Epoll/Kqueue server channel types. 

Why should this be merged: This relatively simple addition on top of #1061 allows the use of native Netty transports, which should be more performant than the default NIO channel type. In addition, this change paves the way to use the built-in Local channel type, which will allow us to use Netty for all tests.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
