### PR TITLE
Fix stack trace print during TlsUtilsTest

### DIFF
--- a/test/src/test/java/org/corfudb/security/tls/TlsUtilsTest.java
+++ b/test/src/test/java/org/corfudb/security/tls/TlsUtilsTest.java
@@ -51,8 +51,6 @@ public class TlsUtilsTest {
         try {
             TlsUtils.openKeyStore(KEY_STORE_FILE, "fake password");
         } catch (SSLException e) {
-            System.out.println(e.getCause());
-            e.printStackTrace();
             assertEquals("Keystore was tampered with, or password was incorrect",
                     e.getCause().getMessage());
         }


### PR DESCRIPTION
## Overview

Description: This PR fixes an issue where TlsUtilsTest prints stack traces even though the tests pass.

Why should this be merged: Tests should not print stack traces - this PR resolves the issue with the test.

Related issue(s) (if applicable): #1063

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
