### PR TITLE
Describe the Node ID format

### DIFF
--- a/docs/NODE_FORMAT.md
+++ b/docs/NODE_FORMAT.md
@@ -4,7 +4,7 @@ This document describes the format of Corfu node locators, which are used to ref
 
 Corfu node locators consist of the following components:
 
-- ``<protocol>``: The protocol that used by the node. Currently, only ``tcp`` is supported.
+- ``<protocol>``: The protocol that is used by the node. Currently, only ``tcp`` is supported.
 - ``<host-name>``: The host name the node can be reached at. This can be a DNS name, an IPv4 address or an IPv6 address.
 If an IPv6 address is provided, it must be delimited by brackets (``[<ipv6-host-name>]``).
 - ``<port>``: The port the node is providing the Corfu service on.

--- a/docs/NODE_FORMAT.md
+++ b/docs/NODE_FORMAT.md
@@ -1,0 +1,36 @@
+## Corfu Node IDs
+
+This document describes the format of Corfu node identifiers (node IDs), which are used to refer to unique Corfu instances.
+Node Ids provide an extra layer of reliability in the case of a server or network reconfiguration. For example, a DNS error
+could point a Corfu client at an incorrect node. This could lead a client to read an update from the wrong system, or believe
+that it has committed an update when it is not committed. Node IDs prevent this issue by assigning each node a unique 128-bit
+identifier at startup. When clients connect to a Corfu node, they verify that the correct Node ID is presented by the node
+before interacting with it.
+
+Node IDs consist of the following components:
+
+- ``<protocol>``: The protocol that used by the node. Currently, only ``tcp`` is supported.
+- ``<host-name>``: The host name the node can be reached at. This can be a DNS name, an IPv4 address or an IPv6 address.
+If an IPv6 address is provided, it must be delimited by brackets (``[<ipv6-host-name>]``).
+- ``<port>``: The port the node is providing the Corfu service on.
+- ``<id>``: A 128-bit unique identifier for the node. This parameter is optional, andd if not provided, the identifier will not
+be checked at connection time.
+- ``<options>``: A list of options required when connecting to the node, in ``<option-name>=<option-value>`` format. Used for
+settings such as TLS.
+
+Node IDs may be provided in a human readable format. The format of a human-readable node-id is as follows:
+
+(``<protocol>``://)``<host-name>``:``<port>``(/``<id>``)(?``<options>``)
+
+If (``<protocol>``://) is omitted, it is assumed that the protocol is ``tcp``.
+
+If (/``<id>``) is omitted, no identifier checking will be done.
+
+If (?``<options>``) are omittedd, no options will be usedd to connect to the server instance. 
+
+
+``<id>`` is in base64 url-safe (RFC 4648) 
+
+For example, a node using the ``tcp`` protocol at ``10.0.0.1`` on port ``9000`` with node id ``fZPF5eGIScaq9m1DabhaCQ`` and no
+options would use the string:
+``tcp://10.0.0.1:9000/fZPF5eGIScaq9m1DabhaCQ``

--- a/docs/NODE_FORMAT.md
+++ b/docs/NODE_FORMAT.md
@@ -1,16 +1,11 @@
-## Corfu Node IDs
+## Corfu Node Locators
 
-This document describes the format of Corfu node identifiers (node IDs), which are used to refer to unique Corfu instances.
-Node Ids provide an extra layer of reliability in the case of a server or network reconfiguration. For example, a DNS error
-could point a Corfu client at an incorrect node. This could lead a client to read an update from the wrong system, or believe
-that it has committed an update when it is not committed. Node IDs prevent this issue by assigning each node a unique 128-bit
-identifier at startup. When clients connect to a Corfu node, they verify that the correct Node ID is presented by the node
-before interacting with it.
+This document describes the format of Corfu node locators, which are used to refer to locate and connect to Corfu instances in a similar manner to URIs. Corfu node locators include a node identifer, which provides an extra layer of reliability in the case of a server or network reconfiguration. For example, a DNS error could point a Corfu client at an incorrect node. This could lead a client to read an update from the wrong system, or believe that it has committed an update when it is not committed. Node identifiers prevent this issue by assigning each node a unique 128-bit identifier at startup. When clients connect to a Corfu node, they verify that the correct node identifer is presented by the node before interacting with it.
 
-Node IDs consist of the following components:
+Corfu node locators consist of the following components:
 
 - ``<protocol>``: The protocol that used by the node. Currently, only ``tcp`` is supported.
-- ``<host-name>``: The host name the node can be reached at. This can be a DNS name, an IPv4 address or an IPv6 anress.
+- ``<host-name>``: The host name the node can be reached at. This can be a DNS name, an IPv4 address or an IPv6 address.
 If an IPv6 address is provided, it must be delimited by brackets (``[<ipv6-host-name>]``).
 - ``<port>``: The port the node is providing the Corfu service on.
 - ``<id>``: A 128-bit unique identifier for the node. This parameter is optional, and if not provided, the identifier will not
@@ -18,7 +13,7 @@ be checked at connection time.
 - ``<options>``: A list of options required when connecting to the node, in ``<option-name>=<option-value>`` format. Used for
 settings such as TLS.
 
-Node IDs may be provided in a human readable format. The format of a human-readable node-id is as follows:
+Node locators may be provided in a human readable format. The format of a human-readable node locator is as follows:
 
 (``<protocol>``://)``<host-name>``:``<port>``(/``<id>``)(?``<options>``)
 

--- a/docs/NODE_FORMAT.md
+++ b/docs/NODE_FORMAT.md
@@ -10,10 +10,10 @@ before interacting with it.
 Node IDs consist of the following components:
 
 - ``<protocol>``: The protocol that used by the node. Currently, only ``tcp`` is supported.
-- ``<host-name>``: The host name the node can be reached at. This can be a DNS name, an IPv4 address or an IPv6 address.
+- ``<host-name>``: The host name the node can be reached at. This can be a DNS name, an IPv4 address or an IPv6 anress.
 If an IPv6 address is provided, it must be delimited by brackets (``[<ipv6-host-name>]``).
 - ``<port>``: The port the node is providing the Corfu service on.
-- ``<id>``: A 128-bit unique identifier for the node. This parameter is optional, andd if not provided, the identifier will not
+- ``<id>``: A 128-bit unique identifier for the node. This parameter is optional, and if not provided, the identifier will not
 be checked at connection time.
 - ``<options>``: A list of options required when connecting to the node, in ``<option-name>=<option-value>`` format. Used for
 settings such as TLS.
@@ -26,10 +26,10 @@ If (``<protocol>``://) is omitted, it is assumed that the protocol is ``tcp``.
 
 If (/``<id>``) is omitted, no identifier checking will be done.
 
-If (?``<options>``) are omittedd, no options will be usedd to connect to the server instance. 
+If (?``<options>``) are omitted, no options will be used to connect to the server instance. 
 
 
-``<id>`` is in base64 url-safe (RFC 4648) 
+``<id>`` is in base64 url-safe (RFC 4648) format.
 
 For example, a node using the ``tcp`` protocol at ``10.0.0.1`` on port ``9000`` with node id ``fZPF5eGIScaq9m1DabhaCQ`` and no
 options would use the string:


### PR DESCRIPTION
## Overview

Description: This documentation only PR describes the format of Node IDs in Corfu.

Why should this be merged: This simple PR describes only the Node ID format and does not contain code. It is required to safely enable all the clustering features in Corfu.

Related issue(s) (if applicable): Partially addresses #1051


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
