### PR TITLE
Change default serializer

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
@@ -45,7 +45,7 @@ public class ObjectBuilder<T> implements IObjectBuilder<T> {
     String streamName;
 
     @Setter
-    ISerializer serializer = Serializers.JSON;
+    ISerializer serializer = Serializers.JAVA;
 
     @Setter
     Set<ObjectOpenOptions> options = EnumSet.noneOf(ObjectOpenOptions.class);


### PR DESCRIPTION
## Overview

Description: This PR switches the default serializer from JSON to JAVA

Why should this be merged: This PR should not be merged yet. It is for evaluating the performance effect of switching the serializer.

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
