### PR TITLE
Introduce Node Id on the client side.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -43,6 +43,7 @@ import org.corfudb.runtime.view.StreamsView;
 
 import org.corfudb.util.GitRepositoryState;
 import org.corfudb.util.MetricsUtils;
+import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Version;
 
 /**
@@ -290,14 +291,13 @@ public class CorfuRuntime {
                 if (nodeRouters.containsKey(address)) {
                     return nodeRouters.get(address);
                 }
-                // Parse the string in host:port format.
-                String host = address.split(":")[0];
-                Integer port = Integer.parseInt(address.split(":")[1]);
+
+                NodeLocator node = NodeLocator.parseString(address);
                 // Generate a new router, start it and add it to the table.
-                NettyClientRouter router = new NettyClientRouter(host, port,
+                NettyClientRouter router = new NettyClientRouter(node,
                         tlsEnabled, keyStore, ksPasswordFile, trustStore, tsPasswordFile,
                         saslPlainTextEnabled, usernameFile, passwordFile);
-                log.debug("Connecting to new router {}:{}", host, port);
+                log.debug("Connecting to new router {}", node);
                 try {
                     router.addClient(new LayoutClient())
                             .addClient(new SequencerClient())

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/NetworkException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/NetworkException.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.exceptions;
 
 import lombok.Getter;
+import org.corfudb.util.NodeLocator;
 
 /**
  * Created by mwei on 12/14/15.
@@ -8,15 +9,16 @@ import lombok.Getter;
 public class NetworkException extends RuntimeException {
 
     @Getter
-    String endpoint;
+    NodeLocator node;
 
-    public NetworkException(String message, String endpoint) {
-        super(message + " [endpoint=" + endpoint + "]");
-        this.endpoint = endpoint;
+
+    public NetworkException(String message, NodeLocator node) {
+        super(message + " [endpoint=" + node.toString() + "]");
+        this.node = node;
     }
 
-    public NetworkException(String message, String endpoint, Throwable cause) {
-        super(message + " [endpoint=" + endpoint + "]", cause);
-        this.endpoint = endpoint;
+    public NetworkException(String message, NodeLocator node, Throwable cause) {
+        super(message + " [endpoint=" + node.toString() + "]", cause);
+        this.node = node;
     }
 }

--- a/runtime/src/main/java/org/corfudb/util/NodeLocator.java
+++ b/runtime/src/main/java/org/corfudb/util/NodeLocator.java
@@ -54,7 +54,7 @@ public class NodeLocator {
 
             final URI url = new URI(toParse);
 
-            // Get the proto from the enum
+            // Get the protocol from the enum
             Protocol proto = Protocol.valueOf(url.getScheme().toUpperCase());
 
             // Host/port are as in a URL
@@ -74,7 +74,7 @@ public class NodeLocator {
             if (url.getQuery() == null || url.getQuery().equals("")) {
                 options = Collections.emptyMap();
             } else {
-                String[] query = url.getQuery().split("\\&");
+                String[] query = url.getQuery().split("&");
                 options = Arrays.stream(query)
                     .map(keyValue -> keyValue.split("="))
                     .collect(Collectors.toMap(kv -> kv[0], kv -> kv[1]));

--- a/runtime/src/main/java/org/corfudb/util/NodeLocator.java
+++ b/runtime/src/main/java/org/corfudb/util/NodeLocator.java
@@ -1,0 +1,120 @@
+package org.corfudb.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Singular;
+
+/** {@link NodeLocator}s represent locators for Corfu nodes.
+ *
+ *  <p>A detailed document regarding their contents and format can be found in docs/NODE_FORMAT.md
+ *
+ */
+@Data
+@Builder
+public class NodeLocator {
+
+    /** Represents protocols for Corfu nodes. */
+    public enum Protocol {
+        TCP     /** Default TCP-based protocol. */
+    }
+
+    /** The protocol to use. */
+    @Builder.Default private Protocol protocol = Protocol.TCP;
+
+    /** The host the node is located on. */
+    final String host;
+
+    /** The port number on the host the node is located on. */
+    final int port;
+
+    /** The ID of the node. Can be null if node id matching is not requested. */
+    @Builder.Default private UUID nodeId = null;
+
+    /** A map of options. */
+    @Singular final Map<String, String> options;
+
+    /** Parse a node locator string.
+     *
+     * @param toParse   The string to parse.
+     * @return          A {@link NodeLocator} which represents the string.
+     */
+    public static NodeLocator parseString(String toParse) {
+        try {
+            // Fix a "legacy" node locator, which doesn't have a protocol.
+            if (!toParse.contains("://")) {
+                toParse = "tcp://" + toParse;
+            }
+
+            final URI url = new URI(toParse);
+
+            // Get the proto from the enum
+            Protocol proto = Protocol.valueOf(url.getScheme().toUpperCase());
+
+            // Host/port are as in a URL
+            String host = url.getHost();
+            int port = url.getPort();
+
+            // Node ID is from the path, if present.
+            UUID nodeId;
+            if (url.getPath().equals("")) {
+                nodeId = null;
+            } else {
+                nodeId = UuidUtils.fromBase64(url.getPath().replaceFirst("/", ""));
+            }
+
+            // Options map is from the query, if present.
+            Map<String, String> options;
+            if (url.getQuery() == null || url.getQuery().equals("")) {
+                options = Collections.emptyMap();
+            } else {
+                String[] query = url.getQuery().split("\\&");
+                options = Arrays.stream(query)
+                    .map(keyValue -> keyValue.split("="))
+                    .collect(Collectors.toMap(kv -> kv[0], kv -> kv[1]));
+            }
+
+            return NodeLocator.builder()
+                            .protocol(proto)
+                            .host(host)
+                            .port(port)
+                            .nodeId(nodeId)
+                            .options(options)
+                            .build();
+
+        } catch (URISyntaxException m) {
+            throw new IllegalArgumentException(m);
+        }
+    }
+
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder()
+                .append(protocol.toString().toLowerCase())
+                .append("://")
+                .append(host)
+                .append(":")
+                .append(port)
+                .append("/");
+
+        if (nodeId != null) {
+            sb.append(UuidUtils.asBase64(nodeId));
+        }
+
+        if (!options.isEmpty()) {
+            sb.append("?");
+            sb.append(options.entrySet().stream()
+                    .map(e -> e.getKey() + "=" + e.getValue())
+                    .collect(Collectors.joining("&")));
+        }
+
+        return sb.toString();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/util/UuidUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/UuidUtils.java
@@ -5,7 +5,7 @@ import java.nio.ByteBuffer;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 
-/** A collection of utilities to manage and maniupulate UUIDs. */
+/** A collection of utilities to manage and manipulate UUIDs. */
 public class UuidUtils {
 
     /** Generate a base64 URL-safe string from a given UUID.

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -18,6 +18,7 @@ import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.CFUtils;
+import org.corfudb.util.NodeLocator;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -287,7 +288,11 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         // Note: This does not simulate NetworkException while message transfer or connection.
         CorfuRuntime.overrideGetRouterFunction = (corfuRuntime, endpoint) -> {
             if (failedNode.get() != null && endpoint.equals(failedNode.get())) {
-                throw new NetworkException("Test server not responding : ", endpoint);
+                throw new NetworkException("Test server not responding : ",
+                    NodeLocator.builder()
+                        .host(endpoint.split(":")[0])
+                        .port(Integer.parseInt(endpoint.split(":")[1]))
+                        .build());
             }
             if (!endpoint.startsWith("test:")) {
                 throw new RuntimeException("Unsupported endpoint in test: " + endpoint);

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -33,6 +33,7 @@ import org.corfudb.protocols.wireprotocol.NettyCorfuMessageEncoder;
 import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyServer;
 import org.corfudb.security.tls.SslContextConstructor;
 import org.corfudb.security.tls.TlsUtils;
+import org.corfudb.util.NodeLocator;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -116,7 +117,8 @@ public class NettyCommTest extends AbstractCorfuTest {
                 return d;
             },
             (port) -> {
-                return new NettyClientRouter("localhost", port,
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
                     true,
                     "src/test/resources/security/r1.jks",
                     "src/test/resources/security/storepass",
@@ -148,7 +150,8 @@ public class NettyCommTest extends AbstractCorfuTest {
                 return d;
             },
             (port) -> {
-                return new NettyClientRouter("localhost", port,
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
                     true,
                     "src/test/resources/security/r1.jks",
                     "src/test/resources/security/storepass",
@@ -180,7 +183,8 @@ public class NettyCommTest extends AbstractCorfuTest {
                 return d;
             },
             (port) -> {
-                return new NettyClientRouter("localhost", port,
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
                     true,
                     "src/test/resources/security/r1.jks",
                     "src/test/resources/security/storepass",
@@ -212,7 +216,8 @@ public class NettyCommTest extends AbstractCorfuTest {
                 return d;
             },
             (port) -> {
-                return new NettyClientRouter("localhost", port,
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
                     true,
                     "src/test/resources/security/r2.jks",
                     "src/test/resources/security/storepass",
@@ -244,7 +249,8 @@ public class NettyCommTest extends AbstractCorfuTest {
                 return d;
             },
             (port) -> {
-                return new NettyClientRouter("localhost", port,
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
                     true,
                     "src/test/resources/security/r2.jks",
                     "src/test/resources/security/storepass",
@@ -279,7 +285,8 @@ public class NettyCommTest extends AbstractCorfuTest {
                 return d;
             },
             (port) -> {
-                return new NettyClientRouter("localhost", port,
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
                     true,
                     "src/test/resources/security/r1.jks",
                     "src/test/resources/security/storepass",
@@ -316,7 +323,8 @@ public class NettyCommTest extends AbstractCorfuTest {
                 return d;
             },
             (port) -> {
-                return new NettyClientRouter("localhost", port,
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
                     true,
                     "src/test/resources/security/r1.jks",
                     "src/test/resources/security/storepass",
@@ -383,7 +391,8 @@ public class NettyCommTest extends AbstractCorfuTest {
         serverData.bootstrapServer();
 
 
-        NettyClientRouter clientRouter = new NettyClientRouter("localhost", port,
+        NettyClientRouter clientRouter = new NettyClientRouter(
+            NodeLocator.builder().host("localhost").port(port).build(),
                 true,
                 "src/test/resources/security/reload/client_key.jks",
                 "src/test/resources/security/reload/password",

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import org.corfudb.util.NodeLocator;
 
 import static org.corfudb.AbstractCorfuTest.PARAMETERS;
 
@@ -204,7 +205,9 @@ public class TestClientRouter implements IClientRouter {
         // Simulate a "disconnected endpoint"
         if (!connected) {
             log.trace("Disconnected endpoint " + host + ":" + port);
-            throw new NetworkException("Disconnected endpoint", host + ":" + port);
+            throw new NetworkException("Disconnected endpoint", NodeLocator.builder()
+                                                                    .host(host)
+                                                                    .port(port).build());
         }
 
         // Get the next request ID.

--- a/test/src/test/java/org/corfudb/runtime/utils/NodeLocatorTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/NodeLocatorTest.java
@@ -43,12 +43,13 @@ public class NodeLocatorTest extends AbstractViewTest {
                                         .host("localhost")
                                         .port(1)
                                         .nodeId(UUID.nameUUIDFromBytes("test".getBytes()))
-                                        .options(ImmutableMap.<String,String>builder()
-                                                            .put("test", "test2").build())
+                                        .option("test1", "test2")
+                                        .option("test2", "test3")
                                         .protocol(Protocol.TCP)
                                         .build();
         NodeLocator parsed = NodeLocator.parseString(locator.toString());
 
+        System.out.println(locator.toString());
         assertThat(locator)
             .isEqualTo(parsed);
 

--- a/test/src/test/java/org/corfudb/runtime/utils/NodeLocatorTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/NodeLocatorTest.java
@@ -1,0 +1,59 @@
+package org.corfudb.runtime.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.UUID;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.util.NodeLocator;
+import org.corfudb.util.NodeLocator.Protocol;
+import org.junit.Test;
+
+public class NodeLocatorTest extends AbstractViewTest {
+
+    @Test
+    public void invalidNodeThrowsException() {
+        assertThatThrownBy(() -> NodeLocator.parseString("invalid{}"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    /** Tests that a legacy (without protocol) node parses correctly. **/
+    @Test
+    public void legacyNodeParses() {
+        final int PORT_NUM = 3000;
+        NodeLocator locator = NodeLocator.parseString("10.0.0.1:3000");
+
+        assertThat(locator.getHost())
+            .isEqualTo("10.0.0.1");
+
+        assertThat(locator.getPort())
+            .isEqualTo(PORT_NUM);
+
+        assertThat(locator.getNodeId())
+            .isNull();
+
+        assertThat(locator.getProtocol())
+            .isEqualTo(Protocol.TCP);
+    }
+
+    @Test
+    public void nodeCanBeConvertedBackAndForth() {
+        NodeLocator locator = NodeLocator.builder()
+                                        .host("localhost")
+                                        .port(1)
+                                        .nodeId(UUID.nameUUIDFromBytes("test".getBytes()))
+                                        .options(ImmutableMap.<String,String>builder()
+                                                            .put("test", "test2").build())
+                                        .protocol(Protocol.TCP)
+                                        .build();
+        NodeLocator parsed = NodeLocator.parseString(locator.toString());
+
+        assertThat(locator)
+            .isEqualTo(parsed);
+
+        assertThat(locator)
+            .isEqualToComparingFieldByField(parsed);
+    }
+
+}


### PR DESCRIPTION
## Overview

Description:This PR introduces a NodeLocator class, which enables the Node ID to be accessed from the client side. The format of NodeLocators are described in PR #1069. A layout with a properly formatted NodeID string will be propagated to the server.

Why should this be merged: This PR is required to fully support clustering, and to prevent clients from connecting to nodes with incorrect state.

Related issue(s) (if applicable): Partially fixes #1051. What's left is to have layouts to be generated with the correct node id during bootstrap.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
