### PR TITLE
Handshaking

### DIFF
--- a/generator/src/main/java/org/corfudb/generator/LongevityApp.java
+++ b/generator/src/main/java/org/corfudb/generator/LongevityApp.java
@@ -125,8 +125,6 @@ public class LongevityApp {
 
             exitStatus = checkpointHasFinished ? 0 : 1;
             System.exit(exitStatus);
-
-
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -6,10 +6,9 @@ import static org.fusesource.jansi.Ansi.Color.RED;
 import static org.fusesource.jansi.Ansi.Color.WHITE;
 import static org.fusesource.jansi.Ansi.ansi;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
@@ -24,6 +23,7 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
+
 import java.io.File;
 import java.util.List;
 import java.util.Map;
@@ -33,10 +33,13 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLException;
+
 import lombok.extern.slf4j.Slf4j;
+
 import org.corfudb.protocols.wireprotocol.NettyCorfuMessageDecoder;
 import org.corfudb.protocols.wireprotocol.NettyCorfuMessageEncoder;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
@@ -48,6 +51,10 @@ import org.corfudb.util.Version;
 import org.docopt.Docopt;
 import org.fusesource.jansi.AnsiConsole;
 import org.slf4j.LoggerFactory;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+
 
 /**
  * This is the new Corfu server single-process executable.
@@ -78,7 +85,7 @@ public class CorfuServer {
                     + "<ratio>] [-d <level>] [-p <seconds>] [-M <address>:<port>] [-e [-u "
                     + "<keystore> -f <keystore_password_file>] [-r <truststore> -w "
                     + "<truststore_password_file>] [-b] [-g -o <username_file> -j <password_file>] "
-                    + "[-k <seqcache>] [-T <threads>]"
+                    + "[-k <seqcache>] [-T <threads>] [-H <seconds>]                               "
                     + "[-x <ciphers>] [-z <tls-protocols>]] [--agent] <port>\n"
                     + "\n"
                     + "Options:\n"
@@ -108,6 +115,8 @@ public class CorfuServer {
                     + "              If there is no log, then this will be the size of the log unit"
                     + "\n                                                                        "
                     + "                evicted entries will be auto-trimmed. [default: 0.5].\n"
+                    + " -H <seconds>, --HandshakeTimeout=<sceonds>                               "
+                    + "              Handshake timeout in seconds [default: 10].\n               "
                     + " -t <token>, --initial-token=<token>                                      "
                     + "              The first token the sequencer will issue, or -1 to recover\n"
                     + "                                                                          "
@@ -483,6 +492,10 @@ public class CorfuServer {
                 // Transform the framed message into a Corfu message.
                 ch.pipeline().addLast(new NettyCorfuMessageDecoder());
                 ch.pipeline().addLast(new NettyCorfuMessageEncoder());
+                ch.pipeline().addLast(new ServerHandshakeHandler(context.getNodeId(),
+                        Version.getVersionString() + "("
+                                + GitRepositoryState.getRepositoryState().commitIdAbbrev + ")",
+                        context.getServerConfig(Integer.class, "--HandshakeTimeout")));
                 // Route the message to the server class.
                 ch.pipeline().addLast(router);
             }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -495,7 +495,7 @@ public class CorfuServer {
                 ch.pipeline().addLast(new ServerHandshakeHandler(context.getNodeId(),
                         Version.getVersionString() + "("
                                 + GitRepositoryState.getRepositoryState().commitIdAbbrev + ")",
-                        context.getServerConfig(Integer.class, "--HandshakeTimeout")));
+                        context.getServerConfig(String.class, "--HandshakeTimeout")));
                 // Route the message to the server class.
                 ch.pipeline().addLast(router);
             }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandshakeHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandshakeHandler.java
@@ -1,0 +1,254 @@
+package org.corfudb.infrastructure;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.timeout.ReadTimeoutException;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.util.AttributeKey;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.corfudb.protocols.wireprotocol.CorfuMsg;
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
+import org.corfudb.protocols.wireprotocol.HandshakeMsg;
+import org.corfudb.protocols.wireprotocol.HandshakeResponse;
+
+/**
+ * The ServerHandshakeHandler waits for the handshake message, validates and sends
+ * a response to the client. This reply contains its node id and current version of Corfu.
+ *
+ * Created by amartinezman on 12/11/17.
+ */
+@Slf4j
+public class ServerHandshakeHandler extends ChannelDuplexHandler {
+
+    private final UUID nodeId;
+    private final String corfuVersion;
+    private final AtomicBoolean handshakeComplete;
+    private final AtomicBoolean handshakeFailed;
+    private final int timeoutInSeconds;
+    private final Queue<CorfuMsg> messages = new ArrayDeque();
+    private static final  AttributeKey<UUID> clientIdAttrKey = AttributeKey.valueOf("ClientID");
+    private static final String READ_TIMEOUT_HANDLER = "readTimeoutHandler";
+
+
+    /**
+     * Creates a new ServerHandshakeHandler which will handle the handshake--initiated by a client
+     * on the server side.
+     *
+     * @param nodeId Current Server Node Identifier.
+     * @param corfuVersion Version of Corfu in Server Node.
+     */
+    public ServerHandshakeHandler(UUID nodeId, String corfuVersion, int timeoutInSeconds) {
+        this.nodeId = nodeId;
+        this.corfuVersion = corfuVersion;
+        this.timeoutInSeconds = timeoutInSeconds;
+        this.handshakeComplete = new AtomicBoolean(false);
+        this.handshakeFailed = new AtomicBoolean(false);
+    }
+
+    /**
+     * Read data from the Channel.
+     *
+     * @param ctx channel handler context
+     * @param m object received in inbound buffer
+     * @throws Exception
+     */
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object m) throws Exception {
+
+        if (this.handshakeFailed.get()) {
+            return;
+        }
+
+        if (this.handshakeComplete.get()) {
+            // If handshake completed successfully, but still a message came through this handler,
+            // send on to the next handler in order to avoid message loss.
+            super.channelRead(ctx, m);
+            return;
+        }
+
+        CorfuPayloadMsg<HandshakeMsg> handshake;
+
+        try {
+            handshake = (CorfuPayloadMsg<HandshakeMsg>) m;
+            log.debug("channelRead: Handshake Message received. Removing " + READ_TIMEOUT_HANDLER +
+                    " from pipeline.");
+            ctx.pipeline().remove(READ_TIMEOUT_HANDLER);
+        } catch (ClassCastException e) {
+            log.warn("channelRead: Non-handshake message received by handshake handler." +
+                    " Send upstream only if handshake succeeded.");
+            if (this.handshakeComplete.get()) {
+                // Only send upstream if handshake is complete.
+                super.channelRead(ctx, m);
+            } else {
+                // Otherwise, drop message.
+                try {
+                    log.debug("channelRead: Dropping message: " +
+                            ((CorfuMsg) m).getMsgType().name());
+                } catch (Exception ex) {
+                    log.error("channelRead: Message received by Server is not a valid " +
+                            "CorfuMsg type.");
+                }
+            }
+            return;
+        }
+
+        UUID clientId = handshake.getPayload().getClientId();
+        UUID serverId = handshake.getPayload().getServerId();
+
+        // Validate handshake, but first verify if node identifier is set to default (all 0's)
+        // which indicates node id matching is not required.
+        if (serverId.equals(UUID.fromString("00000000-0000-0000-0000-000000000000"))) {
+            log.info("channelRead: node id matching is not requested by client.");
+        } else {
+            if (!serverId.equals(this.nodeId)) {
+                log.error("channelRead: Invalid handshake: this is " + this.nodeId +
+                        " and client is trying to connect to " + serverId);
+                this.fireHandshakeFailed(ctx);
+                return;
+            }
+        }
+
+        // Store clientID as a channel attribute.
+        ctx.channel().attr(clientIdAttrKey).set(clientId);
+        log.info("channelRead: Handshake validated by Server.");
+        log.debug("channelRead: Sending handshake response: Node Id: " + this.nodeId +
+                " Corfu Version: " + this.corfuVersion);
+
+        CorfuMsg handshakeResponse = CorfuMsgType.HANDSHAKE_RESPONSE
+                .payloadMsg(new HandshakeResponse(this.nodeId, this.corfuVersion));
+        ctx.writeAndFlush(handshakeResponse);
+
+        // Flush messages in queue
+        log.debug("channelRead: There are {" + this.messages.size() + "} messages in queue to " +
+                "be flushed.");
+        for (CorfuMsg message : this.messages) {
+            ctx.writeAndFlush(message);
+        }
+
+        // Remove this handler from the pipeline; handshake is completed.
+        log.info("channelRead: Removing handshake handler from pipeline.");
+        ctx.pipeline().remove(this);
+        this.fireHandshakeSucceeded();
+    }
+
+    /**
+     * Channel event that is triggered when a new connected channel is created.
+     *
+     * @param ctx channel handler context
+     * @throws Exception
+     */
+    @Override
+    public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+        log.info("channelActive: Incoming connection established from: " +
+                ctx.channel().remoteAddress() + " Start Read Timeout.");
+        ctx.pipeline().addBefore(ctx.name(), READ_TIMEOUT_HANDLER,
+                new ReadTimeoutHandler(this.timeoutInSeconds));
+    }
+
+    /**
+     * Channel event that is triggered when the channel is closed.
+     *
+     * @param ctx channel handler context
+     * @throws Exception
+     */
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        log.debug("channelInactive: Channel closed.");
+        if (!this.handshakeComplete.get()) {
+            this.fireHandshakeFailed(ctx);
+        }
+    }
+
+    /**
+     * Channel event that is triggered when an exception is caught.
+     *
+     * @param ctx channel handler context
+     * @param cause exception cause
+     * @throws Exception
+     */
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
+            throws Exception {
+        log.error("exceptionCaught: Exception caught: " + cause.getMessage());
+
+        if (cause instanceof ReadTimeoutException) {
+            // Read timeout: no inbound traffic detected in a period of time.
+            if (handshakeFailed.get()) {
+                log.debug("exceptionCaught: Handshake timeout checker: already failed.");
+                return;
+            }
+
+            if (!handshakeComplete.get()) {
+                log.error("exceptionCaught: Handshake timeout checker: timed out. Close Connection.");
+                handshakeFailed.set(true);
+                ctx.channel().close();
+            } else {
+                log.debug("exceptionCaught: Handshake timeout " +
+                        "checker: discarded (handshake OK)");
+            }
+        } else {
+            super.exceptionCaught(ctx, cause);
+        }
+
+        if (ctx.channel().isActive()) {
+            // Closing the channel will trigger handshake failure.
+            ctx.channel().close();
+        } else {
+            // Channel did not open, fire handshake failure.
+            this.fireHandshakeFailed(ctx);
+        }
+    }
+
+    /**
+     * Channel event that is triggered when an outbound handler attempts to write into the channel.
+     *
+     * @param ctx channel handler context
+     * @param msg message written into channel
+     * @param promise channel promise
+     * @throws Exception
+     */
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+            throws Exception {
+        if (this.handshakeFailed.get()) {
+            // If handshake failed, discard messages.
+            return;
+        }
+
+        if (this.handshakeComplete.get()) {
+            log.debug("write: Handshake already completed, not appending corfu message to queue");
+            super.write(ctx, msg, promise);
+        } else {
+            this.messages.offer((CorfuMsg) msg);
+        }
+    }
+
+    /**
+     * Signal handshake as failed.
+     *
+     * @param ctx channel handler context
+     */
+    private void fireHandshakeFailed(ChannelHandlerContext ctx) {
+        this.handshakeComplete.set(true);
+        this.handshakeFailed.set(true);
+        ctx.channel().close();
+    }
+
+    /**
+     * Signal handshake as succeeded.
+     */
+    private void fireHandshakeSucceeded() {
+        this.handshakeComplete.set(true);
+        this.handshakeFailed.set(false);
+    }
+}
+

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandshakeHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandshakeHandler.java
@@ -106,13 +106,11 @@ public class ServerHandshakeHandler extends ChannelDuplexHandler {
         // which indicates node id matching is not required.
         if (serverId.equals(UUID.fromString("00000000-0000-0000-0000-000000000000"))) {
             log.info("channelRead: node id matching is not requested by client.");
-        } else {
-            if (!serverId.equals(this.nodeId)) {
-                log.error("channelRead: Invalid handshake: this is " + this.nodeId +
-                        " and client is trying to connect to " + serverId);
-                this.fireHandshakeFailed(ctx);
-                return;
-            }
+        } else if (!serverId.equals(this.nodeId)) {
+            log.error("channelRead: Invalid handshake: this is " + this.nodeId +
+                    " and client is trying to connect to " + serverId);
+            this.fireHandshakeFailed(ctx);
+            return;
         }
 
         // Store clientID as a channel attribute.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
@@ -1,0 +1,257 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.handler.timeout.ReadTimeoutException;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The ClientHandshakeHandler initiates the handshake upon socket connection.
+ *
+ * - Once the client connects to the server, it sends a handshake message that contains:
+ *         its own id and the (asserted) server's node id.
+ * - The server validates and replies with its node id and current version of Corfu.
+ * - If validation is correct on both sides, message exchange is initiated between client-server,
+ * otherwise, the handshake times out, and either server or client close the connection.
+ *
+ * Created by amartinezman on 12/8/17.
+ */
+@Slf4j
+public class ClientHandshakeHandler extends ChannelDuplexHandler {
+
+    private final UUID clientId;
+    private final UUID nodeId;
+    private final int handshakeTimeout;
+    private final AtomicBoolean handshakeComplete;
+    private final AtomicBoolean handshakeFailed;
+    private final Queue<CorfuMsg> messages = new ArrayDeque();
+    private static final String READ_TIMEOUT_HANDLER = "readTimeoutHandler";
+
+
+    /**
+     * Creates a new ClientHandshakeHandler which will handle the handshake between the
+     * current client and a remote server.
+     *
+     * @param clientId Current Client Identifier.
+     * @param serverId Remote Server Identifier to connect to.
+     */
+    public ClientHandshakeHandler(@NonNull UUID clientId, UUID serverId, int handshakeTimeout) {
+        this.clientId = clientId;
+        if (serverId == null) {
+            // A null identifier, indicates node ID matching is not required. Send a default
+            // (all 0's) UUID to Server, to ignore matching stage during handshake
+            this.nodeId = UUID.fromString("00000000-0000-0000-0000-000000000000");
+        } else {
+            this.nodeId = serverId;
+        }
+        this.handshakeTimeout = handshakeTimeout;
+        this.handshakeComplete = new AtomicBoolean(false);
+        this.handshakeFailed = new AtomicBoolean(false);
+    }
+
+    /**
+     * Read data from the Channel.
+     *
+     * @param ctx channel handler context
+     * @param m object received in inbound buffer
+     * @throws Exception
+     */
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object m)
+            throws Exception {
+
+        if (this.handshakeFailed.get()) {
+            // if handshake has already failed, return
+            return;
+        }
+
+        if (this.handshakeComplete.get()) {
+            // If handshake completed successfully, but still a message came through this handler,
+            // send on to the next handler in order to avoid message loss.
+            super.channelRead(ctx, m);
+            return;
+        }
+
+        CorfuPayloadMsg<HandshakeResponse> handshakeResponse;
+
+        try {
+           handshakeResponse = (CorfuPayloadMsg<HandshakeResponse>) m;
+            log.info("channelRead: Handshake Response received. Removing " + READ_TIMEOUT_HANDLER +
+                    " from pipeline.");
+            ctx.pipeline().remove(READ_TIMEOUT_HANDLER);
+        } catch (ClassCastException e) {
+            log.warn("channelRead: Non-handshake message received by handshake handler. Send upstream only " +
+                    "if handshake succeeded.");
+            if (this.handshakeComplete.get()) {
+                // Only send upstream if handshake is complete.
+                super.channelRead(ctx, m);
+            } else {
+                // Otherwise, drop message.
+                try {
+                    CorfuMsg msg = (CorfuMsg) m;
+                    log.debug("channelRead: Dropping message: " + msg.getMsgType().name());
+                } catch (Exception ex) {
+                    log.error("channelRead: Message received is not a valid CorfuMsg type.");
+                }
+            }
+            return;
+        }
+
+        UUID serverId = handshakeResponse.getPayload().getServerId();
+        String corfuVersion = handshakeResponse.getPayload().getCorfuVersion();
+
+        // Handshake Validation
+        if (!this.nodeId.equals(serverId)) {
+            // Validation failed, client opened a socket to server with id
+            // 'nodeId', instead server's id is 'serverId'
+            log.error("channelRead: Handshake validation failed. Server node id mismatch.");
+            log.debug("channelRead: Client opened socket to server {" + this.nodeId
+                    + "} instead, connected to: {" + serverId + "}");
+            this.fireHandshakeFailed(ctx);
+            return;
+        }
+
+        log.info("channelRead: Handshake succeeded. Server Corfu Version: {" + corfuVersion + "}");
+        // Flush messages in queue
+        log.debug("channelRead: There are {" + this.messages.size() + "} messages in queue to " +
+                "be flushed.");
+        for (CorfuMsg message : this.messages) {
+            ctx.writeAndFlush(message);
+        }
+
+        // Remove this handler from the pipeline; handshake is completed.
+        log.info("channelRead: Removing handshake handler from pipeline.");
+        ctx.pipeline().remove(this);
+        this.fireHandshakeSucceeded();
+    }
+
+    /**
+     * Channel event that is triggered when a new connected channel is created.
+     *
+     * @param ctx channel handler context
+     * @throws Exception
+     */
+    @Override
+    public void channelActive(ChannelHandlerContext ctx)
+            throws Exception {
+        log.info("channelActive: Outgoing connection established to: " + ctx.channel().remoteAddress());
+
+        // Write the handshake & add a timeout listener.
+        CorfuMsg handshake = CorfuMsgType.HANDSHAKE_INITIATE
+                .payloadMsg(new HandshakeMsg(this.clientId, this.nodeId));
+
+        log.info("channelActive: Initiate handshake. Send handshake message.");
+        ctx.writeAndFlush(handshake);
+        log.debug("channelActive: Add " + READ_TIMEOUT_HANDLER + " to channel pipeline.");
+        ctx.pipeline().addBefore(ctx.name(), READ_TIMEOUT_HANDLER, new ReadTimeoutHandler(this.handshakeTimeout));
+    }
+
+    /**
+     * Channel event that is triggered when the channel is closed.
+     *
+     * @param ctx channel handler context
+     * @throws Exception
+     */
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        log.debug("channelInactive: Channel closed.");
+        if (!this.handshakeComplete.get()) {
+            this.fireHandshakeFailed(ctx);
+        }
+    }
+
+    /**
+     * Channel event that is triggered when an exception is caught.
+     *
+     * @param ctx channel handler context
+     * @param cause exception cause
+     * @throws Exception
+     */
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx,
+                                java.lang.Throwable cause) throws Exception {
+        log.error("exceptionCaught: Exception caught.");
+        if (cause instanceof ReadTimeoutException) {
+            // Handshake has failed or completed. If none is True, handshake timed out.
+            if (handshakeFailed.get()) {
+                log.debug("exceptionCaught: Handshake timeout checker: already failed.");
+                return;
+            }
+
+            if (!handshakeComplete.get()) {
+                // If handshake did not complete nor failed, it timed out.
+                // Force failure.
+                log.error("exceptionCaught: Handshake timeout checker: timed out. Close Connection.");
+                handshakeFailed.set(true);
+                ctx.channel().close();
+            } else {
+                // Handshake completed successfully,
+                log.debug("exceptionCaught: Handshake timeout checker: discarded " +
+                        "(handshake OK)");
+            }
+        }
+        if (ctx.channel().isOpen()) {
+            ctx.channel().close();
+        } else {
+            this.fireHandshakeFailed(ctx);
+        }
+    }
+
+    /**
+     * Channel event that is triggered when an outbound handler attempts to write into the channel.
+     *
+     * @param ctx channel handler context
+     * @param msg message written into channel
+     * @param promise channel promise
+     * @throws Exception
+     */
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+            throws Exception {
+        if (this.handshakeFailed.get()) {
+            return;
+        }
+
+        // If the handshake hasn't failed but completed meanwhile and
+        // messages still passed through this handler, then forward
+        // them downwards.
+        if (this.handshakeComplete.get()) {
+            super.write(ctx, msg, promise);
+        } else {
+            // Otherwise, queue messages in order until the handshake
+            // completes.
+            this.messages.offer((CorfuMsg) msg);
+        }
+    }
+
+    /**
+     * Signal handshake as failed.
+     *
+     * @param ctx channel handler context
+     */
+    private void fireHandshakeFailed(ChannelHandlerContext ctx) {
+        this.handshakeComplete.set(true);
+        this.handshakeFailed.set(true);
+        log.error("fireHandshakeFailed: Handshake Failed. Close Channel.");
+        ctx.channel().close();
+    }
+
+    /**
+     * Signal handshake as succeeded.
+     */
+    private void fireHandshakeSucceeded() {
+        this.handshakeComplete.set(true);
+        this.handshakeFailed.set(false);
+    }
+}
+
+

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
@@ -106,8 +106,11 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
         UUID serverId = handshakeResponse.getPayload().getServerId();
         String corfuVersion = handshakeResponse.getPayload().getCorfuVersion();
 
-        // Handshake Validation
-        if (!this.nodeId.equals(serverId)) {
+        // Validate handshake, but first verify if node identifier is set to default (all 0's)
+        // which indicates node id matching is not required.
+        if (this.nodeId.equals(UUID.fromString("00000000-0000-0000-0000-000000000000"))) {
+            log.info("channelRead: node id matching is not requested by client.");
+        } else if (!this.nodeId.equals(serverId)) {
             // Validation failed, client opened a socket to server with id
             // 'nodeId', instead server's id is 'serverId'
             log.error("channelRead: Handshake validation failed. Server node id mismatch.");

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -96,7 +96,11 @@ public enum CorfuMsgType {
     ORCHESTRATOR_RESPONSE(78, new TypeToken<CorfuPayloadMsg<OrchestratorResponse>>() {}),
 
     ERROR_SERVER_EXCEPTION(200, new TypeToken<CorfuPayloadMsg<ExceptionMsg>>() {}, true),
-    ERROR_SHUTDOWN_EXCEPTION(201, TypeToken.of(CorfuMsg.class), true)
+    ERROR_SHUTDOWN_EXCEPTION(201, TypeToken.of(CorfuMsg.class), true),
+
+    // Handshake Messages
+    HANDSHAKE_INITIATE(80, new TypeToken<CorfuPayloadMsg<HandshakeMsg>>() {}, true),
+    HANDSHAKE_RESPONSE(81, new TypeToken<CorfuPayloadMsg<HandshakeResponse>>() {}, true)
     ;
 
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/HandshakeMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/HandshakeMsg.java
@@ -1,0 +1,37 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Message sent to initiate handshake between client and server.
+ *
+ * Created by amartinezman on 12/11/17.
+ */
+@CorfuPayload
+@Data
+@AllArgsConstructor
+public class HandshakeMsg implements ICorfuPayload<HandshakeMsg> {
+    private UUID clientId;
+    private UUID serverId;
+
+    /**
+     * Constructor to generate an initiating Handshake Message Payload.
+     *
+     * @param buf The buffer to deserialize.
+     */
+    public HandshakeMsg(ByteBuf buf) {
+        clientId = ICorfuPayload.fromBuffer(buf, UUID.class);
+        serverId = ICorfuPayload.fromBuffer(buf, UUID.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, clientId);
+        ICorfuPayload.serialize(buf, serverId);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/HandshakeResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/HandshakeResponse.java
@@ -1,0 +1,32 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+/**
+ * Response sent by server in the handshake stage.
+ *
+ * Created by amartinezman on 12/11/17.
+ */
+@CorfuPayload
+@Data
+@AllArgsConstructor
+public class HandshakeResponse implements ICorfuPayload<HandshakeResponse> {
+    private UUID serverId;
+    private String corfuVersion;
+
+    public HandshakeResponse(ByteBuf buf) {
+        serverId = ICorfuPayload.fromBuffer(buf, UUID.class);
+        corfuVersion = ICorfuPayload.fromBuffer(buf, String.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, serverId);
+        ICorfuPayload.serialize(buf, corfuVersion);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/HandshakeState.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/HandshakeState.java
@@ -1,0 +1,53 @@
+package org.corfudb.protocols.wireprotocol;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Created by amartinezman on 12/20/17.
+ */
+public class HandshakeState {
+
+    /** Indicates if the handshake has failed.
+     * - If it fails because of validation, handshakeComplete = true.
+     * - If it fails due to timeout, handshakeComplete = False.
+     * */
+    private final AtomicBoolean handshakeFailed;
+    /** Indicates if the handshake has completed regardless of the result of validation.*/
+    private final AtomicBoolean handshakeComplete;
+
+    /**
+     * Keeps state of the handshake, initiated between client and server.
+     */
+    public HandshakeState() {
+        this.handshakeFailed = new AtomicBoolean(false);
+        this.handshakeComplete = new AtomicBoolean(false);
+    }
+
+    /**
+     * Set Handshake State
+     * @param failed indicates if handshake failed
+     * @param complete indicates if handshake completed between client/server, i.e., did not timeout.
+     */
+    public void set(boolean failed, boolean complete){
+        this.handshakeFailed.set(failed);
+        this.handshakeComplete.set(complete);
+    }
+
+    /**
+     * Get Handshake Failure State
+     * @return true, if failed
+     *         false, otherwise.
+     */
+    public boolean failed(){
+        return this.handshakeFailed.get();
+    }
+
+    /**
+     * Get Handshake Completeness State
+     * @return true, if handshake completed.
+     *         false, if handshake never concluded.
+     */
+    public boolean completed(){
+        return this.handshakeComplete.get();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -109,6 +109,11 @@ public class CorfuRuntime {
         @Default long cacheExpiryTime = Long.MAX_VALUE;
         // endregion
 
+        // region Handshake Parameters
+        /** Sets handshake timeout in seconds. */
+        @Default int handshakeTimeout = 10;
+        // endregion
+
         // region Stream Parameters
         /** Whether or not to disable backpointers. */
         @Default boolean backpointersDisabled = false;
@@ -403,7 +408,7 @@ public class CorfuRuntime {
     }
 
     /**
-     * Get corfy runtime version.
+     * Get corfu runtime version.
      **/
     public static String getVersionString() {
         if (Version.getVersionString().contains("SNAPSHOT")

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Random;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadFactory;
@@ -38,9 +37,12 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLException;
+
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+
+import org.corfudb.protocols.wireprotocol.ClientHandshakeHandler;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.NettyCorfuMessageDecoder;
@@ -50,6 +52,7 @@ import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.security.sasl.SaslUtils;
 import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyClient;
@@ -393,6 +396,8 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                     }
                     ch.pipeline().addLast(ee, new NettyCorfuMessageDecoder());
                     ch.pipeline().addLast(ee, new NettyCorfuMessageEncoder());
+                    ch.pipeline().addLast(ee, new ClientHandshakeHandler(parameters.getClientId(),
+                            node.getNodeId(), parameters.getHandshakeTimeout()));
                     ch.pipeline().addLast(ee, router);
                 }
             });

--- a/runtime/src/main/java/org/corfudb/security/sasl/plaintext/PlainTextSaslNettyClient.java
+++ b/runtime/src/main/java/org/corfudb/security/sasl/plaintext/PlainTextSaslNettyClient.java
@@ -34,7 +34,7 @@ public class PlainTextSaslNettyClient extends ChannelDuplexHandler {
     }
 
     @Override
-    public void channelActive(ChannelHandlerContext ctx) {
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
         byte[] response = new byte[0];
         while (!saslClient.isComplete()) {
             try {
@@ -46,6 +46,7 @@ public class PlainTextSaslNettyClient extends ChannelDuplexHandler {
         }
 
         if (saslClient.isComplete()) {
+            super.channelActive(ctx);
             ByteBuf buf = ctx.alloc().heapBuffer(response.length);
             ByteBuf encoded = buf.writeBytes(response);
             ctx.writeAndFlush(encoded);

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -37,6 +37,7 @@ public class ServerContextBuilder {
     String managementBootstrapEndpoint = null;
     IServerRouter serverRouter;
     String numThreads = "0";
+    String handshakeTimeout = "10";
 
     public ServerContextBuilder() {
 
@@ -49,6 +50,7 @@ public class ServerContextBuilder {
                 .put("--single", single)
                 .put("--memory", memory)
                 .put("--Threads", numThreads)
+                .put("--HandshakeTimeout", handshakeTimeout)
                 .put("--sequencer-cache-size", seqCache);
         if (logPath != null) {
          builder.put("--log-path", logPath);

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -1,16 +1,25 @@
 package org.corfudb.runtime.clients;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+
 import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Collections;
+import java.util.UUID;
+
 import javax.annotation.Nonnull;
+
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.infrastructure.BaseServer;
 import org.corfudb.infrastructure.CorfuServer;
@@ -21,13 +30,7 @@ import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.util.NodeLocator;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.net.ServerSocket;
-
 import org.junit.rules.TemporaryFolder;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by mwei on 3/28/16.
@@ -287,6 +290,71 @@ public class NettyCommTest extends AbstractCorfuTest {
                 assertThat(r.getClient(BaseClient.class).pingSync())
                     .isTrue();
             });
+    }
+
+    @Test
+    public void nettyServerClientHandshakeDefaultId() throws Exception {
+        runWithBaseServer(
+                (port) -> {
+                    return new NettyServerData(ServerContextBuilder.defaultTestContext(port));
+                },
+                (port) -> {
+                    NodeLocator nl = NodeLocator.builder()
+                            .host("localhost")
+                            .port(port)
+                            .nodeId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
+                            .build();
+                    return new NettyClientRouter(nl, CorfuRuntimeParameters.builder().build());
+                },
+                (r, d) -> {
+                    assertThat(r.getClient(BaseClient.class).pingSync())
+                            .isTrue();
+                });
+    }
+
+    UUID nodeId;
+
+    @Test
+    public void nettyServerClientHandshakeMatchIds() throws Exception {
+        runWithBaseServer(
+                (port) -> {
+                    ServerContext sc = ServerContextBuilder
+                            .defaultTestContext(port);
+                    nodeId = sc.getNodeId();
+                    return new NettyServerData(sc);
+                },
+                (port) -> {
+                    NodeLocator nl = NodeLocator.builder()
+                            .host("localhost")
+                            .port(port)
+                            .nodeId(nodeId)
+                            .build();
+                    return new NettyClientRouter(nl, CorfuRuntimeParameters.builder().build());
+                },
+                (r, d) -> {
+                    assertThat(r.getClient(BaseClient.class).pingSync())
+                            .isTrue();
+                });
+    }
+
+    @Test
+    public void nettyServerClientHandshakeMismatchId() throws Exception {
+        runWithBaseServer(
+                (port) -> {
+                    return new NettyServerData(ServerContextBuilder.defaultTestContext(port));
+                },
+                (port) -> {
+                    NodeLocator nl = NodeLocator.builder()
+                            .host("localhost")
+                            .port(port)
+                            .nodeId(UUID.nameUUIDFromBytes("test".getBytes()))
+                            .build();
+                    return new NettyClientRouter(nl, CorfuRuntimeParameters.builder().build());
+                },
+                (r, d) -> {
+                    assertThat(r.getClient(BaseClient.class).pingSync())
+                            .isFalse();
+                });
     }
 
     @Test


### PR DESCRIPTION
## Overview

Description:

An implementation of Corfu client-server handshaking. Overall:
- Upon connection, the client will initiate a handshake.
- Both (server and client) will start a handshake timeout timer.
- The client sends a message that contains its own id and the (asserted) server's id.
- The server validates the handshake message and replies with its own server id
  and corfu version.
- The client makes its own validation and in case of is success,
  message exchange is enabled.
- If any validation fails client/server will close the connection.


Why should this be merged:  This is a Feature Request. The fact that a node is no longer tied to an IP and instead is uniquely identified by a 16Byte Identifier raises the need of actually validating upon connection that we are connected to the right node. 

Related issue(s) (if applicable): #1077 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
