### PR TITLE
Removed usage of commons-lang package

### DIFF
--- a/runtime/src/main/java/org/corfudb/security/tls/TlsUtils.java
+++ b/runtime/src/main/java/org/corfudb/security/tls/TlsUtils.java
@@ -12,7 +12,6 @@ import java.security.cert.CertificateException;
 import javax.net.ssl.SSLException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Utilities for common options parsing and session configuration for
@@ -78,15 +77,15 @@ public class TlsUtils {
      *      Wraps the IOException.
      */
     public static String getKeyStorePassword(String passwordFilePath) throws SSLException {
-        if (!StringUtils.isEmpty(passwordFilePath)) {
-            try {
-                return (new String(Files.readAllBytes(Paths.get(passwordFilePath)))).trim();
-            } catch (IOException e) {
-                String errorMessage = "Unable to read password file " + passwordFilePath + ".";
-                log.error(errorMessage, e);
-                throw new SSLException(errorMessage, e);
-            }
+        if (passwordFilePath == null || passwordFilePath.isEmpty()) {
+            return "";
         }
-        return "";
+        try {
+            return (new String(Files.readAllBytes(Paths.get(passwordFilePath)))).trim();
+        } catch (IOException e) {
+            String errorMessage = "Unable to read password file " + passwordFilePath + ".";
+            log.error(errorMessage, e);
+            throw new SSLException(errorMessage, e);
+        }
     }
 }


### PR DESCRIPTION
## Overview

Description:
Removes usage of common-lang package from TlsUtils.
This commons-lang package is used by findbugs-maven-plugin dependency, which has the scope of provided (hence commons-lang also has the scope of provided), meaning it should be provided, but it's not actually provided when we use corfu anywhere.

Why should this be merged: 
Needed for TLS, otherwise it's broken.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
