### PR TITLE
Fix Orchestrator Query

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -27,7 +27,7 @@ enum OrchestratorResponseType {
     // The status of a workflow
     WORKFLOW_STATUS = 0;
     // Id of a created workflow
-    WORKFLOW_ID = 1;
+    WORKFLOW_CREATE = 1;
 }
 
 message DataRank {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/CreateWorkflowResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/CreateWorkflowResponse.java
@@ -6,29 +6,29 @@ import org.corfudb.format.Types.OrchestratorResponseType;
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
-import static org.corfudb.format.Types.OrchestratorResponseType.WORKFLOW_ID;
+import static org.corfudb.format.Types.OrchestratorResponseType.WORKFLOW_CREATE;
 
 /**
- * AddNodeResponse returns the UUID of the add node workflow that was requested.
+ * CreateWorkflowResponse returns the UUID of a created workflow.
  * @author Maithem
  */
-public class AddNodeResponse implements Response {
+public class CreateWorkflowResponse implements Response {
 
     @Getter
     public UUID workflowId;
 
-    public AddNodeResponse(UUID workflowId) {
+    public CreateWorkflowResponse(UUID workflowId) {
         this.workflowId = workflowId;
     }
 
-    public AddNodeResponse(byte[] buf) {
+    public CreateWorkflowResponse(byte[] buf) {
         ByteBuffer bytes = ByteBuffer.wrap(buf);
         this.workflowId = new UUID(bytes.getLong(), bytes.getLong());
     }
 
     @Override
     public OrchestratorResponseType getType() {
-        return WORKFLOW_ID;
+        return WORKFLOW_CREATE;
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/OrchestratorResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/OrchestratorResponse.java
@@ -40,8 +40,8 @@ public class OrchestratorResponse implements ICorfuPayload<OrchestratorResponse>
         switch (type) {
             case WORKFLOW_STATUS:
                 return new QueryResponse(payload);
-            case WORKFLOW_ID:
-                return new AddNodeResponse(payload);
+            case WORKFLOW_CREATE:
+                return new CreateWorkflowResponse(payload);
             default:
                 throw new IllegalStateException("mapResponse: Unknown Type");
         }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -14,7 +14,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.FailureDetectorMsg;
 import org.corfudb.protocols.wireprotocol.orchestrator.AddNodeRequest;
-import org.corfudb.protocols.wireprotocol.orchestrator.AddNodeResponse;
+import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.QueryRequest;
@@ -115,12 +115,12 @@ public class ManagementClient implements IClient {
         return router.sendMessageAndGetCompletable(CorfuMsgType.HEARTBEAT_REQUEST.msg());
     }
 
-    public AddNodeResponse addNodeRequest(String endpoint) throws Exception {
+    public CreateWorkflowResponse addNodeRequest(String endpoint) throws Exception {
         OrchestratorRequest req = new OrchestratorRequest(new AddNodeRequest(endpoint));
         CompletableFuture<OrchestratorResponse> resp = router.sendMessageAndGetCompletable(CorfuMsgType
                 .ORCHESTRATOR_REQUEST
                 .payloadMsg(req));
-        return (AddNodeResponse) resp.get().getResponse();
+        return (CreateWorkflowResponse) resp.get().getResponse();
     }
 
     public QueryResponse queryRequest(UUID workflowId) throws Exception {

--- a/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/ManagementClientTest.java
@@ -3,14 +3,11 @@ package org.corfudb.runtime.clients;
 import com.google.common.collect.ImmutableSet;
 import org.corfudb.format.Types.NodeMetrics;
 import org.corfudb.infrastructure.*;
-import org.corfudb.protocols.wireprotocol.orchestrator.AddNodeResponse;
-import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.QueryResponse;
 import org.junit.After;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -78,13 +75,6 @@ public class ManagementClientTest extends AbstractClientTest {
         assertThatThrownBy(() ->
                 client.bootstrapManagement(TestLayoutBuilder.single(SERVERS.PORT_0)).get())
                 .isInstanceOf(ExecutionException.class);
-    }
-
-    @Test
-    public void addNodeWorkflowRPCTest() throws Exception {
-        // Verify that a workflow id is generated for ID node.
-        AddNodeResponse resp = client.addNodeRequest("localhost:9000");
-        assertThat(resp.getWorkflowId()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
Properly add/remove workflow ids when tracking workflows.

## Overview

Description:

This PR fixes a bug introduced in #940. Workflows were being added by a different key than they were being removed, as a consequence querying a workflow's id would always return "active" even if the workflow wasn't running.

Why should this be merged: 
Fixes CI on master.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
