### PR TITLE
Enable CorfuTable getByIndex if index is missing

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -269,9 +269,10 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
             // will be re-built on every query.
             log.error("getByIndexAndFilter: Attempted getByIndexAndFilter without indexing");
             entryStream = mainMap.entrySet().parallelStream()
-                .filter(x ->
-                    indexFunction.getIndexFunction().generateIndex(x.getKey(), x.getValue())
-                                    .equals(index));
+                .filter(x -> indexFunction.getIndexFunction()
+                        .generateIndex(x.getKey(), x.getValue())
+                        .stream()
+                        .anyMatch(index::equals));
         } else {
             Map<I, Map<K, V>> secondaryMap = indexMap.get(indexFunction);
             if (secondaryMap != null) {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -261,7 +261,9 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
                                  I index) {
         Stream<Map.Entry<K,V>> entryStream;
 
-        if (indexFunctions.isEmpty()) {
+        Map<I, Map<K, V>> secondaryMap = indexMap.get(indexFunction);
+
+        if (indexFunctions.isEmpty() || secondaryMap == null) {
             // If there are no index functions, use the entire map
             // Note that this is an ERROR - Currently, the index should be present if an index
             // is used for a query. If you see the error message below, you should debug
@@ -274,20 +276,11 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
                         .stream()
                         .anyMatch(index::equals));
         } else {
-            Map<I, Map<K, V>> secondaryMap = indexMap.get(indexFunction);
-            if (secondaryMap != null) {
-                // Otherwise, use the secondary index that was generated.
-                if (secondaryMap.get(index) != null) {
-                    entryStream = secondaryMap.get(index).entrySet().stream();
-                } else {
-                    entryStream = Stream.empty();
-                }
+            // Otherwise, use the secondary index that was generated.
+            if (secondaryMap.get(index) != null) {
+                entryStream = secondaryMap.get(index).entrySet().stream();
             } else {
-                // For some reason the function is not present (maybe someone passed the
-                // wrong function).
-                log.error("getByIndexAndFilter: Attempted to read from a index function which"
-                        + "is not available, falling back to no secondary index");
-                entryStream = mainMap.entrySet().parallelStream();
+                entryStream = Stream.empty();
             }
         }
 

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -106,6 +106,26 @@ public class CorfuTableTest extends AbstractViewTest {
                                  MapEntry.entry("k3", "b"));
     }
 
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadWithFailedIndex() {
+        CorfuTable<String, String, StringIndexers, String>
+            corfuTable = getDefaultRuntime().getObjectsView().build()
+            .setTypeToken(
+                new TypeToken<CorfuTable<String, String,
+                    StringIndexers, String>>() {})
+            .setStreamName("test")
+            .open();
+
+        corfuTable.put("k1", "a");
+        corfuTable.put("k2", "ab");
+        corfuTable.put("k3", "b");
+
+        assertThat(corfuTable.getByIndex(StringIndexers.BY_FIRST_LETTER, "a"))
+            .containsExactly("a", "ab");
+    }
+
     /**
      * Create a CorfuTable without index and add an indexer
      * post-creation (CorfuTable already have entries).

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -106,7 +106,9 @@ public class CorfuTableTest extends AbstractViewTest {
                                  MapEntry.entry("k3", "b"));
     }
 
-
+    /** Make sure we can still read on the index even if it was
+     *  never present.
+     */
     @Test
     @SuppressWarnings("unchecked")
     public void canReadWithFailedIndex() {


### PR DESCRIPTION
## Overview

Description: Previously, CorfuTable index methods would incorrectly retrieve the entire table if the index was missing (for example getByIndex would always return the whole table). This PR corrects the problem by dynamically recalculating the index if the index is missing, returning as if the table was retrieved by index.

Why should this be merged: This PR fixes an issue where erroneous data could be returned to the user.

Related issue(s) (if applicable): Fixes #1087.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
