### PR TITLE
Regenerate CorfuTable indexes if failed

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -106,6 +106,28 @@ public class CorfuTableTest extends AbstractViewTest {
                                  MapEntry.entry("k3", "b"));
     }
 
+    /** Make sure we can still read on the index even if it was
+     *  never present.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadWithFailedIndex() {
+        CorfuTable<String, String, StringIndexers, String>
+            corfuTable = getDefaultRuntime().getObjectsView().build()
+            .setTypeToken(
+                new TypeToken<CorfuTable<String, String,
+                    StringIndexers, String>>() {})
+            .setStreamName("test")
+            .open();
+
+        corfuTable.put("k1", "a");
+        corfuTable.put("k2", "ab");
+        corfuTable.put("k3", "b");
+
+        assertThat(corfuTable.getByIndex(StringIndexers.BY_FIRST_LETTER, "a"))
+            .containsExactly("a", "ab");
+    }
+
     /**
      * Create a CorfuTable without index and add an indexer
      * post-creation (CorfuTable already have entries).


### PR DESCRIPTION
## Overview

Description: This PR regenerates CorfuTable indexes if they have failed, building on top of #1088. This allows queries after the failed index to have the same performance as if the indexes were present the whole time.

Why should this be merged: This PR builds on top of #1088, improving performance on subsequent queries when the index fails.

Related issue(s) (if applicable): Fixes #1087


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
