### PR TITLE
Remove log unit while handling failures

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/ConservativeFailureHandlerPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ConservativeFailureHandlerPolicy.java
@@ -34,6 +34,7 @@ public class ConservativeFailureHandlerPolicy implements IFailureHandlerPolicy {
         LayoutBuilder layoutBuilder = new LayoutBuilder(originalLayout);
         Layout newLayout = layoutBuilder
                 .assignResponsiveSequencerAsPrimary(failedNodes)
+                .removeLogunitServers(failedNodes)
                 .removeUnResponsiveServers(healedNodes)
                 .addUnresponsiveServers(failedNodes)
                 .build();


### PR DESCRIPTION
## Overview

Description: Removes log unit while handling failures.

Why should this be merged: Without this the chain still contains a failed node which blocks all subsequent writes.

Related issue(s) (if applicable): Resolves #1036 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
