### PR TITLE
Object Open Race

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -159,11 +159,12 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
         indexerClass = indexFunctionEnumClass;
         indexFunctions.addAll(EnumSet.allOf(indexFunctionEnumClass));
         indexFunctions.forEach(f -> indexMap.put(f, new HashMap<>()));
+        log.info("CorfuTable: creating CorfuTable with {} as indexer class", indexFunctionEnumClass);
     }
 
     /** Default constructor. Generates a table without any secondary indexes. */
     public CorfuTable() {
-        log.debug("CorfuTable: Creating a table without secondary indexes! Secondary index lookup"
+        log.info("CorfuTable: Creating a table without secondary indexes! Secondary index lookup"
             + " will DEGRADE to a full scan");
     }
 
@@ -284,23 +285,6 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
 
         return projectionFunction.generateProjection(index, entryStream.filter(entryPredicate))
                 .collect(Collectors.toCollection(ArrayList::new));
-    }
-
-
-    /**
-     * Register new index class
-     *
-     * This replaces the current index.
-     *
-     * @param indexFunctionEnumClass
-     */
-    public void registerIndex(Class<F> indexFunctionEnumClass) {
-        indexerClass = indexFunctionEnumClass;
-        indexMap.clear();
-        indexFunctions.clear();
-        indexFunctions.addAll(EnumSet.allOf(indexFunctionEnumClass));
-        indexFunctions.forEach(f -> indexMap.put(f, new HashMap<>()));
-        mainMap.forEach(this::mapSecondaryIndexes);
     }
 
     /** {@inheritDoc} */

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
@@ -61,7 +61,7 @@ public class ObjectBuilder<T> implements IObjectBuilder<T> {
 
     @SuppressWarnings("unchecked")
     public <R> ObjectBuilder<R> setTypeToken(TypeToken<R> typeToken) {
-        this.type = (Class<T>)typeToken.getRawType();
+        this.type = (Class<T>) typeToken.getRawType();
         return (ObjectBuilder<R>) this;
     }
 
@@ -104,45 +104,30 @@ public class ObjectBuilder<T> implements IObjectBuilder<T> {
                         arguments, serializer);
             } else {
                 ObjectsView.ObjectID<T> oid = new ObjectsView.ObjectID(streamID, type);
-                T result = (T) runtime.getObjectsView().objectCache.computeIfAbsent(oid, x -> {
+                return (T) runtime.getObjectsView().objectCache.computeIfAbsent(oid, x -> {
                             try {
-                                return CorfuCompileWrapperBuilder.getWrapper(type, runtime,
+                                T result = CorfuCompileWrapperBuilder.getWrapper(type, runtime,
                                         streamID, arguments, serializer);
+
+                                // Get object serializer to check if we didn't attempt to set another serializer
+                                // to an already existing map
+                                ISerializer objectSerializer = ((CorfuCompileProxy) ((ICorfuSMR) result).
+                                        getCorfuSMRProxy())
+                                        .getSerializer();
+
+                                if (serializer != objectSerializer) {
+                                    log.warn("open: Attempt to open an existing object with a different serializer {}. " +
+                                                    "Object {} opened with original serializer {}.",
+                                            serializer.getClass().getSimpleName(),
+                                            oid,
+                                            objectSerializer.getClass().getSimpleName());
+                                }
+                                return result;
                             } catch (Exception ex) {
                                 throw new UnrecoverableCorfuError(ex);
                             }
                         }
                 );
-                // Get object serializer to check if we didn't attempt to set another serializer
-                // to an already existing map
-                ISerializer objectSerializer = ((CorfuCompileProxy) ((ICorfuSMR) runtime.getObjectsView().
-                        getObjectCache().
-                        get(oid)).
-                        getCorfuSMRProxy())
-                        .getSerializer();
-
-                // FIXME: temporary hack until we have a registry
-                // If current map in cache has no indexer, or there is currently an other one,
-                // this will create and compute the indices.
-                if (result instanceof CorfuTable) {
-                    CorfuTable currentCorfuTable = ((CorfuTable) result);
-                    if (arguments.length > 0) {
-                        // If current map in cache has no indexer, or there is currently an other index
-                        if (!(currentCorfuTable.hasSecondaryIndices()) ||
-                            currentCorfuTable.getIndexerClass() != arguments[0].getClass()){
-                            ((CorfuTable) result).registerIndex((Class) arguments[0]);
-                        }
-                    }
-                }
-
-                if (serializer != objectSerializer) {
-                    log.warn("open: Attempt to open an existing object with a different serializer {}. " +
-                            "Object {} opened with original serializer {}.",
-                            serializer.getClass().getSimpleName(),
-                            oid,
-                            objectSerializer.getClass().getSimpleName());
-                }
-                return result;
             }
         } catch (Exception ex) {
             log.error("Runtime instrumentation no longer supported and no compiled class found"


### PR DESCRIPTION
## Overview

Description:

When an object is opened, it is added to the cache right after
its creation, as a consequence other threads can retreive the object
from the object cache after its creation and before additional
initialization. For example, register index. This patch moves
the extra initialization into an atomic operation (i.e. computeIfAbsent.

Why should this be merged: 
Fixes a race bug in object open

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
