### PR TITLE
Fastloader has an api to provide indexer for specific streams

### DIFF
--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -29,6 +29,7 @@ import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.object.CorfuCompileProxy;
@@ -141,6 +142,18 @@ public class FastObjectLoader {
 
     public void addCustomTypeStream(UUID streamId, ObjectBuilder ob) {
         customTypeStreams.put(streamId, ob);
+    }
+
+    /**
+     * Add an indexer to a stream (that backs a CorfuTable)
+     * @param streamName
+     * @param indexer
+     */
+    public void addIndexerToCorfuTableStream(String streamName, Class<?> indexer) {
+        UUID streamId = CorfuRuntime.getStreamID(streamName);
+        ObjectBuilder ob = new ObjectBuilder(runtime).setType(CorfuTable.class)
+                .setArguments(indexer).setStreamID(streamId);
+        addCustomTypeStream(streamId, ob);
     }
 
     private Class getStreamType(UUID streamId) {

--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -755,6 +755,12 @@ public class FastObjectLoaderTest extends AbstractViewTest {
 
     }
 
+    /**
+     * Here we providing and indexer to the FastLoader. After reconstruction, we open the map
+     * without specifying the indexer, but we are still able to use the indexer.
+     *
+     * @throws Exception
+     */
     @Test
     public void canRecreateCorfuTableWithIndex() throws Exception {
         CorfuRuntime originalRuntime = getDefaultRuntime();
@@ -774,19 +780,16 @@ public class FastObjectLoaderTest extends AbstractViewTest {
                 .connect();
 
         FastObjectLoader fsmr = new FastObjectLoader(recreatedRuntime);
-        ObjectBuilder ob = new ObjectBuilder(recreatedRuntime).setType(CorfuTable.class)
-                .setArguments(CorfuTableTest.StringIndexers.class)
-                .setStreamID(CorfuRuntime.getStreamID("test"));
-        fsmr.addCustomTypeStream(CorfuRuntime.getStreamID("test"), ob);
+        fsmr.addIndexerToCorfuTableStream("test",
+                CorfuTableTest.StringIndexers.class);
 
         fsmr.loadMaps();
 
         Helpers.assertThatMapIsBuilt(originalRuntime, recreatedRuntime, "test", originalTable, CorfuTable.class);
 
-
+        // Recreating the table without explicitly providing the indexer
         CorfuTable recreatedTable = recreatedRuntime.getObjectsView().build()
                 .setType(CorfuTable.class)
-                .setArguments(CorfuTableTest.StringIndexers.class)
                 .setStreamName("test")
                 .open();
 


### PR DESCRIPTION
## Overview

Description: Fastloader has an api to provide indexer for specific streams

Why should this be merged: Decrease MP exposure to race conditions.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
