### PR TITLE
VLO Simplification

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -196,9 +196,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
 
         // Perform underlying access
         try {
-            return underlyingObject.access(o -> o.getVersionUnsafe() >= timestamp
-                            && !o.isOptimisticallyModifiedUnsafe(),
-                    o -> o.syncObjectUnsafe(timestamp),
+            return underlyingObject.access(o -> o.syncObjectUnsafe(timestamp),
                     o -> accessMethod.access(o));
         } catch (TrimmedException te) {
             log.warn("Access[{}] Encountered Trim, reset and retry", this);

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -25,19 +24,19 @@ import org.corfudb.util.Utils;
  * The VersionLockedObject maintains a versioned object which is
  * backed by an ISMRStream, and is optionally backed by an additional
  * optimistic update stream.
- *
+ * <p>
  * <p>Users of the VersionLockedObject cannot access the versioned object
  * directly, rather they use the access() and update() methods to
  * read and manipulate the object.
- *
+ * <p>
  * <p>access() and update() allow the user to provide functions to execute
  * under locks. These functions execute various "unsafe" methods provided
  * by this object which inspect and manipulate the object state.
- *
+ * <p>
  * <p>syncObjectUnsafe() enables the user to bring the object to a given version,
  * and the VersionLockedObject manages any sync or rollback of updates
  * necessary.
- *
+ * <p>
  * <p>Created by mwei on 11/13/16.
  */
 @Slf4j
@@ -65,14 +64,6 @@ public class VersionLockedObject<T> {
      * requested.
      */
     final Map<Long, Object> upcallResults;
-
-
-    /**
-     * A lock, which controls access to modifications to
-     * the object. Any access to unsafe methods should
-     * obtain the lock.
-     */
-    private final StampedLock lock;
 
     /**
      * The stream view this object is backed by.
@@ -137,92 +128,30 @@ public class VersionLockedObject<T> {
         this.object = newObjectFn.get();
         this.pendingUpcalls = ConcurrentHashMap.newKeySet();
         this.upcallResults = new ConcurrentHashMap<>();
-
-        lock = new StampedLock();
     }
 
     /**
-     * Access the internal state of the object, trying first to optimistically access
-     * the object, then obtaining a write lock the optimistic access fails.
-     *
-     * <p>If the directAccessCheckFunction returns true, then we execute the accessFunction
-     * without running updateFunction. If false, we execute the updateFunction to
-     * allow the user to modify the state of the object before calling accessFunction.
-     *
-     * <p>directAccessCheckFunction is executed under an optimistic read lock. Read-only
-     * unsafe operations are permitted.
-     *
+     * Access the internal state of the object.
+     * <p>
      * <p>updateFunction is executed under a write lock. Both read and write unsafe operations
      * are permitted.
-     *
+     * <p>
      * <p>accessFunction is accessed either under a read lock or write lock depending on
      * whether an update was necessary or not.
      *
-     * @param directAccessCheckFunction A function which returns True if the object can be
-     *                                  accessed without being updated.
-     * @param updateFunction            A function which is executed when direct access
-     *                                  is not allowed and the object must be updated.
-     * @param accessFunction            A function which allows the user to directly access
-     *                                  the object while locked in the state enforced by
-     *                                  either the directAccessCheckFunction or updateFunction.
-     * @param <R>                       The type of the access function return.
+     * @param updateFunction A function which is executed when direct access
+     *                       is not allowed and the object must be updated.
+     * @param accessFunction A function which allows the user to directly access
+     *                       the object while locked in the state enforced by
+     *                       either the directAccessCheckFunction or updateFunction.
+     * @param <R>            The type of the access function return.
      * @return Returns the access function.
      */
-    public <R> R access(Function<VersionLockedObject<T>, Boolean> directAccessCheckFunction,
-                        Consumer<VersionLockedObject<T>> updateFunction,
-                        Function<T, R> accessFunction) {
-        // First, we try to do an optimistic read on the object, in case it
-        // meets the conditions for direct access.
-        long ts = lock.tryOptimisticRead();
-        if (ts != 0) {
-            try {
-            if (directAccessCheckFunction.apply(this)) {
-                log.trace("Access [{}] Direct (optimistic-read) access at {}",
-                        this, getVersionUnsafe());
-                    R ret = accessFunction.apply(object);
-                    if (lock.validate(ts)) {
-                        return ret;
-                    }
-                }
-            } catch (Exception e) {
-                // If we have an exception, we didn't get a chance to validate the the lock.
-                // If it's still valid, then we should re-throw the exception since it was
-                // on a correct view of the object.
-                if (lock.validate(ts)) {
-                    throw e;
-                }
-                // Otherwise, it is not on a correct view of the object (the object was
-                // modified) and we should try again by upgrading the lock.
-                log.warn("Access [{}] Direct (optimistic-read) exception, upgrading lock",
-                        this);
-            }
-        }
-        // Next, we just upgrade to a full write lock if the optimistic
-        // read fails, since it means that the state of the object was
-        // updated.
-        try {
-            // Attempt an upgrade
-            ts = lock.tryConvertToWriteLock(ts);
-            // Upgrade failed, try conversion again
-            if (ts == 0) {
-                ts = lock.writeLock();
-            }
-            // Check if direct access is possible (unlikely).
-            if (directAccessCheckFunction.apply(this)) {
-                log.trace("Access [{}] Direct (writelock) access at {}", this, getVersionUnsafe());
-                R ret = accessFunction.apply(object);
-                if (lock.validate(ts)) {
-                    return ret;
-                }
-            }
-            // If not, perform the update operations
-            updateFunction.accept(this);
-            log.trace("Access [{}] Updated (writelock) access at {}", this, getVersionUnsafe());
-            return accessFunction.apply(object);
-            // And perform the access
-        } finally {
-            lock.unlock(ts);
-        }
+    public synchronized <R> R access(Consumer<VersionLockedObject<T>> updateFunction,
+                                     Function<T, R> accessFunction) {
+        updateFunction.accept(this);
+        log.trace("Access [{}] Updated (writelock) access at {}", this, getVersionUnsafe());
+        return accessFunction.apply(object);
     }
 
     /**
@@ -232,22 +161,15 @@ public class VersionLockedObject<T> {
      * @param <R>            The type of the return of the updateFunction.
      * @return The return value of the update function.
      */
-    public <R> R update(Function<VersionLockedObject<T>, R> updateFunction) {
-        long ts = 0;
-        try {
-            ts = lock.writeLock();
-            log.trace("Update[{}] (writelock)", this);
-            return updateFunction.apply(this);
-        } finally {
-            lock.unlock(ts);
-        }
+    public synchronized <R> R update(Function<VersionLockedObject<T>, R> updateFunction) {
+        return updateFunction.apply(this);
     }
 
     /**
      * Roll the object back to the supplied version if possible.
      * This function may roll back to a point prior to the requested version.
      * Otherwise, throws a NoRollbackException.
-     *
+     * <p>
      * <p>Unsafe, requires that the caller has acquired a write lock.
      *
      * @param rollbackVersion The version to rollback to.
@@ -431,7 +353,7 @@ public class VersionLockedObject<T> {
 
     /**
      * Generate the summary string for this version locked object.
-     *
+     * <p>
      * <p>The format of this string is [type]@[version][+]
      * (where + is the optimistic flag)
      *
@@ -577,7 +499,7 @@ public class VersionLockedObject<T> {
      * applied until the current tail of the stream. If Address.OPTIMISTIC
      * is given, updates will be applied to the end of the stream, and
      * upcall results will be stored in the resulting entries.
-     *
+     * <p>
      * <p>When the stream is trimmed, this exception is passed up to the caller,
      * unless the timestamp was Address.MAX, in which the entire object is
      * reset and re-try the sync, which should pick up any checkpoint that
@@ -627,7 +549,8 @@ public class VersionLockedObject<T> {
         }
     }
 
-    /** Apply an SMREntry to the version object, while
+    /**
+     * Apply an SMREntry to the version object, while
      * doing bookkeeping for the underlying stream.
      *
      * @param entry

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -66,12 +66,6 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
      * Access within optimistic transactional context is implemented
      * in via proxy.access() as follows:
      *
-     * <p>1. First, we try to grab a read-lock on the proxy, and hope to "catch" the proxy in the
-     * snapshot version. If this succeeds, we invoke the corfu-object access method, and
-     * un-grab the read-lock.
-     *
-     * <p>2. Otherwise, we grab a write-lock on the proxy and bring it to the correct
-     * version
      * - Inside proxy.setAsOptimisticStream, if there are currently optimistic
      * updates on the proxy, we roll them back.  Then, we set this
      * transactional context as the proxy's new optimistic context.
@@ -94,22 +88,6 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         return proxy
                 .getUnderlyingObject()
                 .access(o -> {
-                            WriteSetSMRStream stream = o.getOptimisticStreamUnsafe();
-
-                            // Obtain the stream position as when transaction context last
-                            // remembered it.
-                            long streamReadPosition = getKnownStreamPosition()
-                                    .getOrDefault(proxy.getStreamID(), getSnapshotTimestamp());
-
-                            return (
-                                    (stream == null || stream.isStreamCurrentContextThreadCurrentContext())
-                                    && (stream != null && getWriteSetEntrySize(proxy.getStreamID()) == stream.pos() + 1
-                                       || (getWriteSetEntrySize(proxy.getStreamID()) == 0 /* No updates. */
-                                          && o.getVersionUnsafe() == streamReadPosition) /* Match timestamp. */
-                                    )
-                            );
-                        },
-                        o -> {
                             // inside syncObjectUnsafe, depending on the object
                             // version, we may need to undo or redo
                             // committed changes, or apply forward committed changes.

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -46,10 +46,7 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
         // In snapshot transactions, there are no conflicts.
         // Hence, we do not need to add this access to a conflict set
         // do not add: addToReadSet(proxy, conflictObject);
-        return proxy.getUnderlyingObject().access(o -> o.getVersionUnsafe()
-                        == getSnapshotTimestamp()
-                        && !o.isOptimisticallyModifiedUnsafe(),
-                o -> {
+        return proxy.getUnderlyingObject().access(o -> {
                     syncWithRetryUnsafe(o, getSnapshotTimestamp(), proxy, null);
                 },
                 o -> accessFunction.access(o));


### PR DESCRIPTION
Removed the stamped lock from the version locked object and replaced
it with synchronized.

## Overview

Description:
Using stamped lock to allow multiple readers to the same snapshot is an optimization, but the
performance benefits are not clear. We shall see if this PR impacts performance and decide whether this patch improves readability via removing unnecessary code or not.

Why should this be merged: 
This is one patch in a series of many upcoming patches that attempts to improve the VLOs readability, robustness and hopefully performance.  Reducing complexity is also a motivating factor. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
