### PR TITLE
Custom type initialization fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -382,7 +382,7 @@ public class FastObjectLoader {
             // Create an Object only for non-checkpoints
 
             // If it is a special type, create it with the object builder
-            if (objectType != defaultObjectsType) {
+            if (customTypeStreams.containsKey(streamId)) {
                 createObjectIfNotExist(customTypeStreams.get(streamId), serializer);
             }
             else {

--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -779,10 +779,16 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         CorfuRuntime recreatedRuntime = new CorfuRuntime(getDefaultConfigurationString())
                 .connect();
 
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap(originalTable);
+        long cpAddress = mcw.appendCheckpoints(originalRuntime, "author");
+        Helpers.trim(originalRuntime, cpAddress);
+
+
         FastObjectLoader fsmr = new FastObjectLoader(recreatedRuntime);
         fsmr.addIndexerToCorfuTableStream("test",
                 CorfuTableTest.StringIndexers.class);
-
+        fsmr.setDefaultObjectsType(CorfuTable.class);
         fsmr.loadMaps();
 
         Helpers.assertThatMapIsBuilt(originalRuntime, recreatedRuntime, "test", originalTable, CorfuTable.class);


### PR DESCRIPTION
## Overview
Ensure that custom types are built correctly in the FastLoader.

When passing customType objects to the fastloader, upon creation of the tables, it checks if it needs to reconstruct the table using the custom object loader or using the default one. The check used to be if the custom constructor is different than the default constructor.

Since now the default type used in MP is CorfuTable, when we were passing a custom constructor that happens to also be of CorfuTable type, we would just used the default type. Because of this, we were losing the indexer passed in the custom object builder.

This change the condition for constructing a table with the custom object builder. If the stream ID is in customTypes, we will reconstruct the table with the custom object builder.

Why should this be merged: 
This is a critical issue, that impact recreation of maps with indexer. It has a very low impact (low risk bugwise) and was tested on a live real system (MP)


- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
