### PR TITLE
Remove usage of Helpers.trim for compatibilty with corfu-0.1.2

### DIFF
--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -1347,7 +1347,11 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(originalTable);
         long cpAddress = mcw.appendCheckpoints(originalRuntime, "author");
-        Helpers.trim(originalRuntime, cpAddress);
+
+        originalRuntime.getAddressSpaceView().prefixTrim(cpAddress - 1);
+        originalRuntime.getAddressSpaceView().gc();
+        originalRuntime.getAddressSpaceView().invalidateServerCaches();
+        originalRuntime.getAddressSpaceView().invalidateClientCache();
 
 
         FastObjectLoader fsmr = new FastObjectLoader(recreatedRuntime);


### PR DESCRIPTION
## Overview
In our corfu-0.1.2 branch of corfu, Helpers class doesn't exist. This will
remove the forward dependency.


Why should this be merged: 
We are breaking corfu-0.1.2 .


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
