### PR TITLE
Move seal epoch to Base Server

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -442,7 +442,6 @@ public class LayoutServerTest extends AbstractServerTest {
     public void testReboot() throws Exception {
         String serviceDir = PARAMETERS.TEST_TEMP_DIR;
         LayoutServer s1 = getDefaultServer(serviceDir);
-        setServer(s1);
 
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         final long NEW_EPOCH = 99L;
@@ -460,7 +459,6 @@ public class LayoutServerTest extends AbstractServerTest {
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             LayoutServer s2 = getDefaultServer(serviceDir);
-            setServer(s2);
             commitReturnsAck(s2, i, NEW_EPOCH + 1);
             s2.shutdown();
         }
@@ -493,8 +491,15 @@ public class LayoutServerTest extends AbstractServerTest {
     }
 
     private LayoutServer getDefaultServer(String serviceDir) {
-        LayoutServer s1 = new LayoutServer(new ServerContextBuilder().setSingle(false).setMemory(false).setLogPath(serviceDir).setServerRouter(getRouter()).build());
+        ServerContext sc = new ServerContextBuilder()
+                .setSingle(false)
+                .setMemory(false)
+                .setLogPath(serviceDir)
+                .setServerRouter(getRouter())
+                .build();
+        LayoutServer s1 = new LayoutServer(sc);
         setServer(s1);
+        getRouter().addServer(new BaseServer(sc));
         return s1;
     }
 


### PR DESCRIPTION
## Overview

Description: Moves the seal functionality to the Base Server from the Layout Server.

Why should this be merged: This allows corfu servers with log unit component to function independent of a layout server.

Related issue(s) (if applicable): Fixes #1012


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
