### PR TITLE
getRouter Race

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/PeriodicPollPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/PeriodicPollPolicy.java
@@ -102,7 +102,7 @@ public class PeriodicPollPolicy implements IFailureDetectorPolicy {
                     historyStatus.put(allServers[i], true);  // Assume it's up until we think it
                     // isn't.
                 }
-                historyRouters[i] = corfuRuntime.getRouterFunction.apply(allServers[i]);
+                historyRouters[i] = corfuRuntime.getRouter(allServers[i]);
                 historyPollFailures[i] = 0;
                 historyPollEpochExceptions[i] = 0;
             }


### PR DESCRIPTION
Fixed a race in the getRouter method.

## Overview

Description:
This patch synchronizes the creation of node routers. This PR is needed to fix random WrongEpochException failures.  

Why should this be merged: 
Fixes https://github.com/CorfuDB/CorfuDB/issues/1114


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
