### PR TITLE
Use same CorfuRuntimeParameters

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -6,13 +6,15 @@ import java.time.Duration;
 import java.util.Map;
 
 import java.util.UUID;
-import javax.annotation.Nonnull;
+
 import lombok.Getter;
 import lombok.Setter;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.management.IFailureDetectorPolicy;
 import org.corfudb.infrastructure.management.PeriodicPollPolicy;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.ConservativeFailureHandlerPolicy;
 import org.corfudb.runtime.view.IFailureHandlerPolicy;
@@ -100,6 +102,18 @@ public class ServerContext {
         }
     }
 
+    public CorfuRuntimeParameters getDefaultRuntimeParameters() {
+        return CorfuRuntime.CorfuRuntimeParameters.builder()
+                .tlsEnabled((Boolean) serverConfig.get("--enable-tls"))
+                .keyStore((String) serverConfig.get("--keystore"))
+                .ksPasswordFile((String) serverConfig.get("--keystore-password-file"))
+                .trustStore((String) serverConfig.get("--truststore"))
+                .tsPasswordFile((String) serverConfig.get("--truststore-password-file"))
+                .saslPlainTextEnabled((Boolean) serverConfig.get("--enable-sasl-plain-text-auth"))
+                .usernameFile((String) serverConfig.get("--sasl-plain-text-username-file"))
+                .passwordFile((String) serverConfig.get("--sasl-plain-text-password-file"))
+                .build();
+    }
 
     /** Generate a Node Id if not present.
      *


### PR DESCRIPTION
## Overview
The Orchestrator creates a new runtime for each workflow, this PR
makes the orchestrator use the same CorfuRuntimeParameters as the
management server's runtime. As a result, the security and auth
settings are carried over.

Related issue(s) (if applicable): #1106

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
