### PR TITLE
CorfuRuntimeParameters Bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -336,7 +336,7 @@ public class CorfuRuntime {
         this.parameters = parameters;
         layoutServers = new ArrayList<>();
         layoutServers.addAll(this.parameters.getLayoutServers().stream()
-                                .map(NodeLocator::toString)
+                                .map(NodeLocator::getConnectionString)
                                 .collect(Collectors.toList()));
         nodeRouters = new ConcurrentHashMap<>();
 

--- a/runtime/src/main/java/org/corfudb/util/NodeLocator.java
+++ b/runtime/src/main/java/org/corfudb/util/NodeLocator.java
@@ -37,6 +37,10 @@ public class NodeLocator implements Serializable {
 
     /** The port number on the host the node is located on. */
     final int port;
+    
+    public String getConnectionString() {
+        return host + ":" + port;
+    }
 
     /** The ID of the node. Can be null if node id matching is not requested. */
     @Builder.Default private UUID nodeId = null;

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -121,6 +121,16 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         return l;
     }
 
+    @Test
+    public void connectWithCorfuRuntimeParameters() throws Exception {
+        CorfuRuntime.CorfuRuntimeParameters parameters = CorfuRuntime.CorfuRuntimeParameters.builder()
+                .layoutServer(NodeLocator.parseString(getEndpoint(SERVERS.PORT_0)))
+                .build();
+        CorfuRuntime rt = CorfuRuntime.fromParameters(parameters).connect();
+        rt.invalidateLayout();
+        assertThat(rt.getLayoutView().getLayout()).isEqualTo(get3NodeLayout());
+    }
+
     /**
      * Ensures that we will not accept a Layout that is obsolete.
      *


### PR DESCRIPTION
## Overview

Description:
This PR fixes a bug in the runtime parameters where layout servers
cannot be set through the builder, as a result CorfuRuntime.connect()
hangs indefinitely.

Why should this be merged: 
Fixes a bug where the constructor can't consume CorfuRuntimeParameters with layout servers. 

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
