### PR TITLE
Clear Node

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -920,6 +920,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             sh.getWriteChannel().write(allRecordsBuf);
             channelsToSync.add(sh.getWriteChannel());
             syncTailSegment(entries.get(entries.size() - 1).getGlobalAddress());
+            log.info("writeRecords: entries {}", entries);
         }
 
         return recordsMap;
@@ -1062,6 +1063,8 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                 segTwoEntries.add(curr);
             }
         }
+
+        log.debug("append: segment entries one {} two {}", segOneEntries, segTwoEntries);
 
         try {
             if (!segOneEntries.isEmpty()) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -66,7 +66,7 @@ public enum CorfuMsgType {
     FLUSH_CACHE(44, TypeToken.of(CorfuMsg.class), true),
     TRIM_MARK_REQUEST(45, TypeToken.of(CorfuMsg.class), true),
     TRIM_MARK_RESPONSE(46, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
-    RESET_LOGUNIT(47, TypeToken.of(CorfuMsg.class)),
+    RESET_LOGUNIT(47, TypeToken.of(CorfuMsg.class), true),
 
     WRITE_OK(50, TypeToken.of(CorfuMsg.class)),
     ERROR_TRIMMED(51, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -137,6 +137,9 @@ public class LayoutManagementView extends AbstractView {
         if (isLogUnitServer) {
             layoutBuilder.addLogunitServer(logUnitStripeIndex, getMaxGlobalTail(currentLayout),
                     endpoint);
+            // Clear the state of the logging on the endpoint to be added
+            CFUtils.getUninterruptibly(runtime.getRouter(endpoint)
+                    .getClient(LogUnitClient.class).resetLogUnit());
         }
         if (isUnresponsiveServer) {
             layoutBuilder.addUnresponsiveServers(Collections.singleton(endpoint));
@@ -146,9 +149,9 @@ public class LayoutManagementView extends AbstractView {
 
         attemptConsensus(newLayout);
 
-            // Add node is successful even if reconfigure sequencer fails.
-            // TODO: Optimize this by retrying or submitting a workflow to retry.
-            reconfigureSequencerServers(currentLayout, newLayout, false);
+        // Add node is successful even if reconfigure sequencer fails.
+        // TODO: Optimize this by retrying or submitting a workflow to retry.
+        reconfigureSequencerServers(currentLayout, newLayout, false);
 
     }
     


### PR DESCRIPTION
## Overview
Description:
When the add node workflow runs, it should clear the state of the
endpoint that it is trying to add.

Why should this be merged: 
This PR fixes a bug in the add node workflow. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc

  