### PR TITLE
LayoutBuilder Default Constructor

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -98,6 +98,18 @@ public class Layout {
     UUID clusterId;
 
     /**
+     * Default Constructor, creates an empty layout
+     */
+    public Layout() {
+        this.layoutServers = new ArrayList<>();
+        this.sequencers = new ArrayList<>();
+        this.segments = new ArrayList<>();
+        this.unresponsiveServers = new ArrayList<>();
+        this.epoch = -1;
+        this.clusterId = null;
+    }
+
+    /**
      * Defensive constructor since we can create a Layout from a JSON file.
      * JSON deserialize is forced through this constructor.
      */

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutBuilder.java
@@ -14,6 +14,8 @@ import org.corfudb.runtime.exceptions.LayoutModificationException;
 import org.corfudb.runtime.view.Layout.LayoutSegment;
 import org.corfudb.runtime.view.Layout.LayoutStripe;
 
+import javax.annotation.Nonnull;
+
 /**
  * Allows us to make modifications to a layout.
  *
@@ -39,6 +41,33 @@ public class LayoutBuilder {
     public LayoutBuilder(Layout layout) {
         this.layout = new Layout(layout);
         this.epoch = layout.getEpoch();
+    }
+
+    /**
+     * Default Constructor, creates an empty layout
+     */
+    public LayoutBuilder() {
+        this.layout = new Layout();
+    }
+
+    /**
+     * Set the epoch.
+     * @param epoch The epoch to set
+     * @return a layout builder that has this epoch
+     */
+    public LayoutBuilder setEpoch(long epoch) {
+        this.epoch = epoch;
+        return this;
+    }
+
+    /**
+     * Sets the cluster ID.
+     * @param id the cluster id to set in this layout.
+     * @return A layout that has id as the cluster id. 
+     */
+    public LayoutBuilder setClusterId(@Nonnull UUID id) {
+        this.layout.setClusterId(id);
+        return this;
     }
 
     /**
@@ -141,6 +170,16 @@ public class LayoutBuilder {
      */
     public LayoutBuilder addSequencerServer(String endpoint) {
         layout.getSequencers().add(endpoint);
+        return this;
+    }
+
+    /**
+     * Adds a segment to the current layout
+     * @param segment the segment to be added
+     * @return a layout builder that contains segment
+     */
+    public LayoutBuilder addSegment(LayoutSegment segment) {
+        layout.getSegments().add(segment);
         return this;
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutBuilderTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutBuilderTest.java
@@ -8,9 +8,11 @@ import org.corfudb.runtime.view.LayoutBuilder;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -22,6 +24,37 @@ public class LayoutBuilderTest extends AbstractCorfuTest {
 
     final int SERVER_ENTRY_3 = 3;
     final int SERVER_ENTRY_4 = 4;
+
+    @Test
+    public void emptyLayoutBuilderWithSingleNode() {
+        final long epoch = 2;
+        UUID clusterId = new UUID(0, 0);
+        final long startingAddress = 0;
+        final int segment = 0;
+        final int stripeIndex = 0;
+        final long tail = 100;
+        Layout.LayoutStripe stripe = new Layout
+                .LayoutStripe(Collections.singletonList(SERVERS.ENDPOINT_0));
+
+        Layout layout = new LayoutBuilder()
+                .setEpoch(epoch)
+                .setClusterId(clusterId)
+                .addLayoutServer(SERVERS.ENDPOINT_0)
+                .addSequencerServer(SERVERS.ENDPOINT_0)
+                .addSegment(new Layout.LayoutSegment(Layout.ReplicationMode.CHAIN_REPLICATION,
+                        startingAddress, tail, Collections.singletonList(stripe)))
+                .build();
+
+        assertThat(layout.getEpoch()).isEqualTo(epoch);
+        assertThat(layout.getClusterId()).isEqualTo(clusterId);
+        assertThat(layout.getSequencers()).containsExactly(SERVERS.ENDPOINT_0);
+        assertThat(layout.getLayoutServers()).containsExactly(SERVERS.ENDPOINT_0);
+        assertThat(layout.getSegments()).hasSize(1);
+        assertThat(layout.getSegments().get(segment).getReplicationMode())
+                .isEqualTo(Layout.ReplicationMode.CHAIN_REPLICATION);
+        assertThat(layout.getSegments().get(segment).getStripes()
+                .get(stripeIndex).getLogServers()).containsExactly(SERVERS.ENDPOINT_0);
+    }
 
     /**
      * Tests the Layout Workflow manager by removing nodes.

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutTest.java
@@ -33,7 +33,7 @@ public class LayoutTest {
         Layout shouldYieldException = Layout.fromJSONString(JSONEmptyLayout);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void shouldNotDeserializeMissingRequiredFieldLayout()
             throws Exception{
 


### PR DESCRIPTION
Enable the LayoutBuilder to build a layout from an empty layout.

## Overview
Enable the LayoutBuilder to build a layout from an empty layout.

Why should this be merged: 
Some test cases create a layout from scratch, so creating an LayoutBuilder with an empty layout will simplify code. 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
