### PR TITLE
Cleanup after node reset.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -220,14 +220,20 @@ public class CorfuServer {
         if (!(Boolean) opts.get("--memory")) {
             File serviceDir = new File((String) opts.get("--log-path"));
 
-            if (!serviceDir.exists()) {
-                if (serviceDir.mkdirs()) {
-                    log.info("Created new service directory at {}.", serviceDir);
-                }
-            } else if (!serviceDir.isDirectory()) {
+            if (!serviceDir.isDirectory()) {
                 log.error("Service directory {} does not point to a directory. Aborting.",
                         serviceDir);
                 throw new RuntimeException("Service directory must be a directory!");
+            } else {
+                String corfuServiceDirPath = serviceDir.getAbsolutePath()
+                        + File.separator
+                        + "corfu";
+                File corfuServiceDir = new File(corfuServiceDirPath);
+                // Update the new path with the dedicated child service directory.
+                opts.put("--log-path", corfuServiceDirPath);
+                if (!corfuServiceDir.exists() && corfuServiceDir.mkdirs()) {
+                    log.info("Created new service directory at {}.", corfuServiceDir);
+                }
             }
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -3,11 +3,8 @@ package org.corfudb.infrastructure;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.lang.invoke.MethodHandles;
-import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
-import java.util.UUID;
 import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.NonNull;
@@ -24,7 +21,6 @@ import org.corfudb.protocols.wireprotocol.LayoutPrepareResponse;
 import org.corfudb.protocols.wireprotocol.LayoutProposeRequest;
 import org.corfudb.protocols.wireprotocol.LayoutProposeResponse;
 import org.corfudb.runtime.view.Layout;
-import org.corfudb.runtime.view.Layout.LayoutSegment;
 
 /**
  * The layout server serves layouts, which are used by clients to find the
@@ -60,12 +56,6 @@ import org.corfudb.runtime.view.Layout.LayoutSegment;
 //TODO Need a janitor to cleanup old phases data and to fill up holes in layout history.
 @Slf4j
 public class LayoutServer extends AbstractServer {
-
-    private static final String PREFIX_PHASE_1 = "PHASE_1";
-    private static final String KEY_SUFFIX_PHASE_1 = "RANK";
-    private static final String PREFIX_PHASE_2 = "PHASE_2";
-    private static final String KEY_SUFFIX_PHASE_2 = "DATA";
-    private static final String PREFIX_LAYOUTS = "LAYOUTS";
 
     /**
      * The options map.
@@ -332,51 +322,27 @@ public class LayoutServer extends AbstractServer {
     }
 
     public Rank getPhase1Rank() {
-        return serverContext.getDataStore().get(Rank.class, PREFIX_PHASE_1, serverContext
-                .getServerEpoch() + KEY_SUFFIX_PHASE_1);
+        return serverContext.getPhase1Rank();
     }
 
     public void setPhase1Rank(Rank rank) {
-        serverContext.getDataStore().put(Rank.class, PREFIX_PHASE_1, serverContext
-                .getServerEpoch() + KEY_SUFFIX_PHASE_1, rank);
+        serverContext.setPhase1Rank(rank);
     }
 
     public Phase2Data getPhase2Data() {
-        return serverContext.getDataStore().get(Phase2Data.class, PREFIX_PHASE_2, serverContext
-                .getServerEpoch() + KEY_SUFFIX_PHASE_2);
+        return serverContext.getPhase2Data();
     }
 
     public void setPhase2Data(Phase2Data phase2Data) {
-        serverContext.getDataStore().put(Phase2Data.class, PREFIX_PHASE_2, serverContext
-                .getServerEpoch() + KEY_SUFFIX_PHASE_2, phase2Data);
+        serverContext.setPhase2Data(phase2Data);
     }
 
     public void setLayoutInHistory(Layout layout) {
-        serverContext.getDataStore().put(Layout.class, PREFIX_LAYOUTS, String.valueOf(layout
-                .getEpoch()), layout);
+        serverContext.setLayoutInHistory(layout);
     }
 
     private long getServerEpoch() {
         return serverContext.getServerEpoch();
-    }
-
-    /**
-     * Returns the layout history.
-     *
-     * @return list of layouts in the history
-     */
-    public List<Layout> getLayoutHistory() {
-        List<Layout> layouts = serverContext.getDataStore().getAll(Layout.class, PREFIX_LAYOUTS);
-        Collections.sort(layouts, (a, b) -> {
-            if (a.getEpoch() > b.getEpoch()) {
-                return 1;
-            } else if (a.getEpoch() < b.getEpoch()) {
-                return -1;
-            } else {
-                return 0;
-            }
-        });
-        return layouts;
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -66,8 +66,8 @@ public class ManagementServer extends AbstractServer {
     private final Map<String, Object> opts;
     private final ServerContext serverContext;
 
-    private static final String PREFIX_MANAGEMENT = "MANAGEMENT";
-    private static final String KEY_LAYOUT = "LAYOUT";
+//    private static final String PREFIX_MANAGEMENT = "MANAGEMENT";
+//    private static final String KEY_LAYOUT = "LAYOUT";
 
     private CorfuRuntime corfuRuntime;
     /**
@@ -132,7 +132,7 @@ public class ManagementServer extends AbstractServer {
         sequencerBootstrappedFuture = new CompletableFuture<>();
 
 
-        safeUpdateLayout(getCurrentLayout());
+        safeUpdateLayout(serverContext.getManagementLayout());
         // If no state was preserved, there is no layout to recover.
         if (latestLayout == null) {
             recovered = true;
@@ -218,29 +218,11 @@ public class ManagementServer extends AbstractServer {
             log.info("safeUpdateLayout: Updating to new layout at epoch {}",
                     latestLayout.getEpoch());
             // Persisting this new updated layout
-            setCurrentLayout(latestLayout);
+            serverContext.setManagementLayout(latestLayout);
         } else {
             log.debug("safeUpdateLayout: Ignoring layout because new epoch {} <= old epoch {}",
                     layout.getEpoch(), latestLayout.getEpoch());
         }
-    }
-
-    /**
-     * Sets the latest layout in the persistent datastore.
-     *
-     * @param layout Layout to be persisted
-     */
-    private void setCurrentLayout(Layout layout) {
-        serverContext.getDataStore().put(Layout.class, PREFIX_MANAGEMENT, KEY_LAYOUT, layout);
-    }
-
-    /**
-     * Fetches the latest layout from the persistent datastore.
-     *
-     * @return The last persisted layout
-     */
-    private Layout getCurrentLayout() {
-        return serverContext.getDataStore().get(Layout.class, PREFIX_MANAGEMENT, KEY_LAYOUT);
     }
 
     private boolean checkBootstrap(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -33,9 +33,6 @@ import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 public class NettyServerRouter extends ChannelInboundHandlerAdapter
         implements IServerRouter {
 
-    public static final String PREFIX_EPOCH = "SERVER_EPOCH";
-    public static final String KEY_EPOCH = "CURRENT";
-
     public static class ServerThreadFactory
             implements ForkJoinPool.ForkJoinWorkerThreadFactory {
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -83,6 +83,7 @@ public enum CorfuMsgType {
     // EXTRA CODES
     LAYOUT_ALREADY_BOOTSTRAP(60, TypeToken.of(CorfuMsg.class), true),
     LAYOUT_PREPARE_ACK(61, new TypeToken<CorfuPayloadMsg<LayoutPrepareResponse>>(){}, true),
+    RESTART(62, TypeToken.of(CorfuMsg.class), true),
 
     // Management Messages
     MANAGEMENT_BOOTSTRAP_REQUEST(70, new TypeToken<CorfuPayloadMsg<Layout>>(){}, true),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -82,13 +82,23 @@ public class BaseClient implements IClient {
 
     /**
      * Reset the endpoint, asynchronously.
+     * WARNING: ALL EXISTING DATA ON THIS NODE WILL BE LOST.
      *
      * @return A completable future which will be completed with True if
      *     the endpoint acks, otherwise False or exceptional completion.
      */
     public CompletableFuture<Boolean> reset() {
-        return router.sendMessageAndGetCompletable(
-                new CorfuMsg(CorfuMsgType.RESET));
+        return router.sendMessageAndGetCompletable(new CorfuMsg(CorfuMsgType.RESET));
+    }
+
+    /**
+     * Restart the endpoint, asynchronously.
+     *
+     * @return A completable future which will be completed with True if
+     *     the endpoint acks, otherwise False or exceptional completion.
+     */
+    public CompletableFuture<Boolean> restart() {
+        return router.sendMessageAndGetCompletable(new CorfuMsg(CorfuMsgType.RESTART));
     }
 
     /**

--- a/scripts/corfu_server.sh
+++ b/scripts/corfu_server.sh
@@ -47,9 +47,25 @@ else
       byteman=""
 fi
 
+LOG_PATH=""
+# These are the possible options/flags which can be passed to the CorfuServer. The trailing ":" signifies that the flag
+# accepts a variable (eg. filename or log directory path, etc)
+while getopts "l:ma:nsd:t:c:p:M:eu:f:r:w:bgo:j:k:T:i:H:I:x:z:" opt; do
+  case ${opt} in
+    l ) LOG_PATH=${OPTARG};;
+    ? ) ;;
+  esac
+done
+
 while true; do
-"$JAVA" -cp "$CLASSPATH" $JVMFLAGS $byteman org.corfudb.infrastructure.CorfuServer $*
-if [ $? -ne 100 ]; then
-break
-fi
+    "$JAVA" -cp "$CLASSPATH" $JVMFLAGS $byteman org.corfudb.infrastructure.CorfuServer $*
+    RETURN_CODE=$?
+
+    if [ $RETURN_CODE -ne 100 ] && [ $RETURN_CODE -ne 200 ]; then
+        break
+    fi
+
+    if [ "$LOG_PATH" != "" ] && [ $RETURN_CODE -eq 100 ]; then
+        rm -r $LOG_PATH/*
+    fi
 done

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -3,12 +3,25 @@ package org.corfudb.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
+import com.google.common.collect.Range;
+
+import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.ReadResponse;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.BaseClient;
+import org.corfudb.runtime.clients.LayoutClient;
+import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.clients.SequencerClient;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.view.Layout;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,6 +56,34 @@ public class ClusterReconfigIT extends AbstractIT {
         return sb.toString();
     }
 
+    private Process runSinglePersistentServer(String address, int port) throws IOException {
+        return new CorfuServerRunner()
+                .setHost(address)
+                .setPort(port)
+                .setLogPath(getCorfuServerLogPath(address, port))
+                .setSingle(true)
+                .runServer();
+    }
+
+    private Process runUnbootstrappedPersistentServer(String address, int port) throws IOException {
+        return new CorfuServerRunner()
+                .setHost(address)
+                .setPort(port)
+                .setLogPath(getCorfuServerLogPath(address, port))
+                .setSingle(false)
+                .runServer();
+    }
+
+    /**
+     * A cluster of one node is started - 9000.
+     * Then a block of data of 15,000 entries is written to the node.
+     * This is to ensure we have at least 1.5 data log files.
+     * A daemon thread is instantiated to randomly put data while add node is executed.
+     * 2 nodes - 9001 and 9002 are added to the cluster.
+     * Finally the epoch and the addition of the 2 nodes in the laout is verified.
+     *
+     * @throws Exception
+     */
     @Test
     public void addNodesTest() throws Exception {
 
@@ -50,26 +91,9 @@ public class ClusterReconfigIT extends AbstractIT {
         final int PORT_1 = 9001;
         final int PORT_2 = 9002;
 
-        Process corfuServer_1 = new CorfuServerRunner()
-                .setHost(corfuSingleNodeHost)
-                .setPort(PORT_0)
-                .setLogPath(getCorfuServerLogPath(corfuSingleNodeHost, PORT_0))
-                .setSingle(true)
-                .runServer();
-
-        Process corfuServer_2 = new CorfuServerRunner()
-                .setHost(corfuSingleNodeHost)
-                .setPort(PORT_1)
-                .setLogPath(getCorfuServerLogPath(corfuSingleNodeHost, PORT_1))
-                .setSingle(false)
-                .runServer();
-
-        Process corfuServer_3 = new CorfuServerRunner()
-                .setHost(corfuSingleNodeHost)
-                .setPort(PORT_2)
-                .setLogPath(getCorfuServerLogPath(corfuSingleNodeHost, PORT_2))
-                .setSingle(false)
-                .runServer();
+        Process corfuServer_1 = runSinglePersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
+        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
 
         CorfuRuntime runtime = createDefaultRuntime();
 
@@ -89,8 +113,9 @@ public class ClusterReconfigIT extends AbstractIT {
             map.put(key, data);
         }
 
+        final AtomicBoolean moreDataToBeWritten = new AtomicBoolean(true);
         Thread t = new Thread(() -> {
-            while (true) {
+            while (moreDataToBeWritten.get()) {
                 assertThatCode(() -> {
                     try {
                         runtime.getObjectsView().TXBegin();
@@ -113,8 +138,132 @@ public class ClusterReconfigIT extends AbstractIT {
         runtime.invalidateLayout();
         assertThat(runtime.getLayoutView().getLayout().getEpoch()).isEqualTo(epochAfter2Adds);
 
+        moreDataToBeWritten.set(false);
+        t.join();
+
+        verifyData(runtime);
+
         shutdownCorfuServer(corfuServer_1);
         shutdownCorfuServer(corfuServer_2);
         shutdownCorfuServer(corfuServer_3);
+    }
+
+    /**
+     * Queries for all the data in the 3 nodes and checks if the data state matches across the
+     * cluster.
+     *
+     * @param corfuRuntime Connected instance of the runtime.
+     * @throws Exception
+     */
+    private void verifyData(CorfuRuntime corfuRuntime) throws Exception {
+
+        TokenResponse tokenResponse = corfuRuntime.getSequencerView()
+                .nextToken(Collections.singleton(CorfuRuntime.getStreamID("test")), 0);
+        long lastAddress = tokenResponse.getTokenValue();
+
+        Map<Long, LogData> map_0 = getAllData(corfuRuntime, "localhost:9000", lastAddress);
+        Map<Long, LogData> map_1 = getAllData(corfuRuntime, "localhost:9001", lastAddress);
+        Map<Long, LogData> map_2 = getAllData(corfuRuntime, "localhost:9002", lastAddress);
+
+        assertThat(map_1.equals(map_0)).isTrue();
+        assertThat(map_2.equals(map_0)).isTrue();
+    }
+
+    /**
+     * Fetches all the data from the node.
+     *
+     * @param corfuRuntime Connected instance of the runtime.
+     * @param endpoint     Endpoint ot query for all the data.
+     * @param end          End address up to which data needs to be fetched.
+     * @return Map of all the addresses contained by the node corresponding to the data stored.
+     * @throws Exception
+     */
+    private Map<Long, LogData> getAllData(CorfuRuntime corfuRuntime,
+                                          String endpoint, long end) throws Exception {
+        ReadResponse readResponse = corfuRuntime.getRouter(endpoint)
+                .getClient(LogUnitClient.class)
+                .read(Range.closed(0L, end))
+                .get();
+        return readResponse.getAddresses();
+    }
+
+    /**
+     * Increments the epoch of the cluster by one. Keeps the remainder of the layout the same.
+     *
+     * @param corfuRuntime Connected runtime instance.
+     * @return Returns the new accepted layout.
+     * @throws Exception
+     */
+    private Layout incrementClusterEpoch(CorfuRuntime corfuRuntime) throws Exception {
+        Layout l = new Layout(corfuRuntime.getLayoutView().getLayout());
+        l.setRuntime(corfuRuntime);
+        l.setEpoch(l.getEpoch() + 1);
+        l.moveServersToEpoch();
+        corfuRuntime.getLayoutView().updateLayout(l, 1L);
+        corfuRuntime.invalidateLayout();
+        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(1L);
+        return l;
+    }
+
+    /**
+     * Starts a corfu server and increments the epoch from 0 to 1.
+     * The server is then reset and the new layout fetch is expected to return a layout with
+     * epoch 0 as all state should have been cleared.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void resetTest() throws Exception {
+
+        final int PORT_0 = 9000;
+
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, PORT_0);
+
+        CorfuRuntime corfuRuntime = createDefaultRuntime();
+        incrementClusterEpoch(corfuRuntime);
+        corfuRuntime.getRouter("localhost:9000").getClient(BaseClient.class).reset().get();
+
+        corfuRuntime = createDefaultRuntime();
+        // The shutdown and reset can take an unknown amount of time and there is a chance that the
+        // newer runtime may also connect to the older corfu server (before reset).
+        // Hence the while loop.
+        while (corfuRuntime.getLayoutView().getLayout().getEpoch() != 0L) {
+            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
+            corfuRuntime = createDefaultRuntime();
+        }
+        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(0L);
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
+    }
+
+    /**
+     * Starts a corfu server and increments the epoch from 0 to 1.
+     * The server is then restarted and the new layout fetch is expected to return a layout with
+     * epoch 2 as the state is not cleared and the restart forces a recovery to increment the
+     * epoch.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void restartTest() throws Exception {
+
+        final int PORT_0 = 9000;
+
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, PORT_0);
+
+        CorfuRuntime corfuRuntime = createDefaultRuntime();
+        Layout l = incrementClusterEpoch(corfuRuntime);
+        corfuRuntime.getRouter("localhost:9000").getClient(BaseClient.class).restart()
+                .get();
+
+        corfuRuntime = createDefaultRuntime();
+        // The shutdown and restart can take an unknown amount of time and there is a chance that
+        // the newer runtime may also connect to the older corfu server (before restart).
+        // Hence the while loop.
+        while (corfuRuntime.getLayoutView().getLayout().getEpoch() != (l.getEpoch() + 1)) {
+            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
+            corfuRuntime = createDefaultRuntime();
+        }
+        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(l.getEpoch() + 1);
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
     }
 }


### PR DESCRIPTION
## Overview

Description: On node reset, all data log files and all meta data is deleted.

Why should this be merged: Required to reset a bootstrapped node before merging it into a different cluster.

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
