### PR TITLE
Kill node fix and IT

### DIFF
--- a/checks.xml
+++ b/checks.xml
@@ -48,6 +48,7 @@
 
         <module name="RegexpSinglelineJava">
             <!-- Check for e.printStackTrace().-->
+            <property name="id" value="printStackTrace"/>
             <property name="severity" value="error"/>
             <property name="format" value="\.printStackTrace\(\)"/>
             <property name="message" value="Using printStackTrace() is forbidden. Rethrow or handle the exception."/>

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -79,7 +79,7 @@ public class ServerRestartIT extends AbstractIT {
         final Random randomSeed = new Random();
         final long SEED = randomSeed.nextLong();
         // Keep this print at all times to reproduce any failed test.
-        System.out.println("SEED = " + Long.toHexString(SEED));
+        testStatus += "SEED=" + Long.toHexString(SEED);
         return new Random(SEED);
     }
 
@@ -140,7 +140,6 @@ public class ServerRestartIT extends AbstractIT {
 
             for (int i = 0; i < ITERATIONS; i++) {
 
-                System.out.println("Iteration #" + i);
                 boolean serverRestart = rand.nextInt(TOTAL_PERCENTAGE) < SERVER_RESTART_PERCENTAGE;
                 boolean clientRestart = rand.nextInt(TOTAL_PERCENTAGE) < CLIENT_RESTART_PERCENTAGE;
 

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -48,7 +48,7 @@ public class WorkflowIT extends AbstractIT {
         final int n1Port = 9000;
 
         // Start node one and populate it with data
-        new CorfuServerRunner()
+        Process server_1 = new CorfuServerRunner()
                 .setHost(host)
                 .setPort(n1Port)
                 .setSingle(true)
@@ -69,7 +69,7 @@ public class WorkflowIT extends AbstractIT {
 
         // Add a second node
         final int n2Port = 9001;
-        new CorfuServerRunner()
+        Process server_2 = new CorfuServerRunner()
                 .setSingle(false)
                 .setHost(host)
                 .setPort(n2Port)
@@ -106,7 +106,7 @@ public class WorkflowIT extends AbstractIT {
         // Add a third node after compaction
 
         final int n3Port = 9002;
-        new CorfuServerRunner()
+        Process server_3 = new CorfuServerRunner()
                 .setSingle(false)
                 .setHost(host)
                 .setPort(n3Port)
@@ -131,6 +131,10 @@ public class WorkflowIT extends AbstractIT {
             String v = (String) table.get(String.valueOf(x));
             assertThat(v).isEqualTo(String.valueOf(x));
         }
+
+        shutdownCorfuServer(server_1);
+        shutdownCorfuServer(server_2);
+        shutdownCorfuServer(server_3);
     }
 
     void waitForWorkflow(UUID id, CorfuRuntime rt, int port) throws Exception {


### PR DESCRIPTION
## Overview

Description: Fixes the kill node scenario and introduces an IT to test the same.
Issue: Writes blocked when a node containing a logunit and the primary sequencer crashes.
Fix: The maxGlobalTail fetch relied on fetching the tail from the crashed server. This caused failure in bootstrapping the new sequencer. So no new writes could get through.
Now the maxGlobalTail relies on fetching the global tail from the head of the chain of the new proposed layout. This ensures availability of the server and successfully bootstraps the sequencer.

Why should this be merged: Fixes kill node scenario and cleans up IT.

Related issue(s) (if applicable): Fixes #1074 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
