### PR TITLE
Sequencer Ready API

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -51,6 +51,7 @@ public enum CorfuMsgType {
     TOKEN_RES(21, new TypeToken<CorfuPayloadMsg<TokenResponse>>(){}),
     BOOTSTRAP_SEQUENCER(22, new TypeToken<CorfuPayloadMsg<SequencerTailsRecoveryMsg>>(){}),
     SEQUENCER_TRIM_REQ(23, new TypeToken<CorfuPayloadMsg<Long>>() {}),
+    SEQUENCER_STATUS_REQ(24, TypeToken.of(CorfuMsg.class)),
 
     // Logging Unit Messages
     WRITE(30, new TypeToken<CorfuPayloadMsg<WriteRequest>>() {}),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -47,6 +47,32 @@ public class SequencerClient implements IClient {
         return msg.getPayload();
     }
 
+    /**
+     * Handle an ACK response from the server.
+     *
+     * @param msg The ping request message
+     * @param ctx The context the message was sent under
+     * @param r   A reference to the router
+     * @return Always True, since the ACK message was successful.
+     */
+    @ClientHandler(type = CorfuMsgType.ACK)
+    private static Object handleAck(CorfuMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
+        return true;
+    }
+
+    /**
+     * Handle a NACK response from the server.
+     *
+     * @param msg The ping request message
+     * @param ctx The context the message was sent under
+     * @param r   A reference to the router
+     * @return Always True, since the ACK message was successful.
+     */
+    @ClientHandler(type = CorfuMsgType.NACK)
+    private static Object handleNack(CorfuMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
+        return false;
+    }
+
     public CompletableFuture<TokenResponse> nextToken(Set<UUID> streamIDs, long numTokens) {
         return router.sendMessageAndGetCompletable(
                 CorfuMsgType.TOKEN_REQ.payloadMsg(new TokenRequest(numTokens, streamIDs)));
@@ -83,5 +109,9 @@ public class SequencerClient implements IClient {
         return router.sendMessageAndGetCompletable(CorfuMsgType.BOOTSTRAP_SEQUENCER
                 .payloadMsg(new SequencerTailsRecoveryMsg(initialToken, sequencerTails,
                         readyStateEpoch)));
+    }
+
+    public CompletableFuture<Boolean> isReady() {
+        return router.sendMessageAndGetCompletable(new CorfuMsg(CorfuMsgType.SEQUENCER_STATUS_REQ));
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -16,6 +16,7 @@ import org.corfudb.runtime.clients.IClientRouter;
 import org.corfudb.runtime.clients.LayoutClient;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.clients.ManagementClient;
+import org.corfudb.runtime.clients.SequencerClient;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.RecoveryException;
@@ -307,8 +308,9 @@ public class LayoutManagementView extends AbstractView {
 
         // Reconfigure Primary Sequencer if required
         if (forceReconfigure
-                || !originalLayout.getSequencers().get(0).equals(newLayout.getSequencers()
-                .get(0))) {
+                || !originalLayout.getSequencers().get(0).equals(newLayout.getSequencers().get(0))
+                || !CFUtils.getUninterruptibly(runtime.getRouter(originalLayout
+                .getSequencers().get(0)).getClient(SequencerClient.class).isReady())) {
             maxTokenRequested = getMaxGlobalTail(originalLayout);
 
             FastObjectLoader fastObjectLoader = new FastObjectLoader(runtime);

--- a/test/src/test/java/org/corfudb/runtime/clients/SequencerClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/SequencerClientTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import org.corfudb.infrastructure.AbstractServer;
 import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.CorfuRuntime;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,6 +45,16 @@ public class SequencerClientTest extends AbstractClientTest {
     public void canGetAToken()
             throws Exception {
         client.nextToken(Collections.<UUID>emptySet(), 1).get();
+    }
+
+    @Test
+    public void sequencerReadyStatusTest() throws Exception {
+        Boolean isReady = client.isReady().get();
+        assertThat(isReady).isTrue();
+        client.bootstrap(0L, Collections.EMPTY_MAP, 1L);
+        isReady = client.isReady().get();
+        assertThat(isReady).isFalse();
+
     }
 
     @Test


### PR DESCRIPTION
## Overview

Description:
The reconfigureSequencerServers doesn't consider the sequencer's status when it makes a decision without to push out configurations or not. This PR adds changes the logic to conisder the sequencer status by retrieving the status of the leading sequencer and checking if its not ready, in that case it will force push a configuration. 

Why should this be merged: 
Required for all workflows. While workflows execute the chances of failure are high, if a workflow changes the layout, but fails before the sequencer is configured problem the system freezes. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
