### PR TITLE
Fixing Correctness report

### DIFF
--- a/generator/src/main/java/org/corfudb/generator/operations/OptimisticTxOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/OptimisticTxOperation.java
@@ -3,6 +3,7 @@ package org.corfudb.generator.operations;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.generator.Correctness;
 import org.corfudb.generator.State;
+import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.Address;
 
@@ -50,6 +51,11 @@ public class OptimisticTxOperation extends Operation {
             }
 
         } catch (TransactionAbortedException tae) {
+            // TX aborted because of conflict is a successful operation regarding
+            // Liveness status.
+            if (tae.getAbortCause() == AbortCause.CONFLICT) {
+                state.setLastSuccessfulWriteOperationTimestamp(System.currentTimeMillis());
+            }
             Correctness.recordTransactionMarkers(false, shortName, Correctness.TX_ABORTED);
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -194,7 +194,6 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                         .nextToken(Collections.singleton(streamID), 0).getToken()
                         .getTokenValue();
         log.debug("Access[{}] conflictObj={} version={}", this, conflictObject, timestamp);
-        correctnessLogger.trace("Version, {}", timestamp);
 
         // Perform underlying access
         try {


### PR DESCRIPTION
## Overview
The version of a non-transactional access needs
to be reported from within the lock. Because of
specific timing (and optimization) we might access
the object to a later version than the timestamp
we linearized this access against.

Why should this be merged: 
Stop reporting false positive in consistency correctness verification.


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
