### PR TITLE
Add node equality check

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/NodeLocator.java
+++ b/runtime/src/main/java/org/corfudb/util/NodeLocator.java
@@ -142,9 +142,9 @@ public class NodeLocator implements Serializable {
         if (otherNode.getNodeId() != null && otherNode.getNodeId().equals(getNodeId())) {
             return true;
         } else {
-            // Otherwise, the other node must not have a node ID set
+            // Otherwise, the both node IDs must not be set
             // and must match by host and port.
-            return otherNode.getNodeId() == null
+            return !(otherNode.getNodeId() == null && getNodeId() != null)
                 && otherNode.getHost().equals(getHost())
                 && otherNode.getPort() == getPort();
         }

--- a/runtime/src/main/java/org/corfudb/util/NodeLocator.java
+++ b/runtime/src/main/java/org/corfudb/util/NodeLocator.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Singular;
@@ -121,5 +122,31 @@ public class NodeLocator implements Serializable {
         }
 
         return sb.toString();
+    }
+
+
+    /** Returns true if the provided string points to the same node.
+     *
+     * <p>A string points to the same node as this {@link NodeLocator} if
+     * it has the same node ID, or it has no node ID and points to the same
+     * host and port.
+     *
+     * @param nodeString    The string to check.
+     * @return              True, if the string points to the node referenced by this {@link this}.
+     * @throws IllegalArgumentException     If the provided string cannot be parsed as a
+     *                                      {@link NodeLocator}.
+     */
+    public boolean isSameNode(@Nonnull String nodeString) {
+        NodeLocator otherNode = NodeLocator.parseString(nodeString);
+        // The nodes are the same if their Node IDs are the same.
+        if (otherNode.getNodeId() != null && otherNode.getNodeId().equals(getNodeId())) {
+            return true;
+        } else {
+            // Otherwise, the other node must not have a node ID set
+            // and must match by host and port.
+            return otherNode.getNodeId() == null
+                && otherNode.getHost().equals(getHost())
+                && otherNode.getPort() == getPort();
+        }
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/utils/NodeLocatorTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/NodeLocatorTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.UUID;
+import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.NodeLocator.Protocol;
@@ -74,6 +75,48 @@ public class NodeLocatorTest extends AbstractViewTest {
 
         assertThat(locator)
             .isEqualToComparingFieldByField(parsed);
+    }
+
+    @Test
+    public void testLegacyStringIsEqual() {
+        NodeLocator locator = NodeLocator.builder()
+            .host("localhost")
+            .port(1)
+            .nodeId(null)
+            .build();
+
+        assertThat(locator.isSameNode("localhost:1"))
+            .isTrue();
+    }
+
+    @Test
+    public void testStringWithoutIdIsEqual() {
+        NodeLocator locator = NodeLocator.builder()
+            .host("localhost")
+            .port(1)
+            .nodeId(null)
+            .build();
+
+        assertThat(locator.isSameNode(locator.toString()))
+            .isTrue();
+    }
+
+    @Test
+    public void testStringWithIdIsEqual() {
+        NodeLocator locator = NodeLocator.builder()
+            .host("localhost")
+            .port(1)
+            .nodeId(null)
+            .build();
+
+        NodeLocator locatorWithId = NodeLocator.builder()
+            .host("localhost")
+            .port(1)
+            .nodeId(UUID.nameUUIDFromBytes("test".getBytes()))
+            .build();
+
+        assertThat(locator.isSameNode(locatorWithId.toString()))
+            .isTrue();
     }
 
 }


### PR DESCRIPTION
## Overview

Description: In the layout, we use strings which can have different forms. For example the node at localhost on port 9000 with id a could be represented in the layout as "localhost:9000", "tcp://localhost:9000" or "tcp://localhost:9000/a" depending on how the layout was created. This PR adds a method to NodeLocator which allows a client to check for equality between a node locator and a wide number of strings.

Why should this be merged:  Needed for clustering to perform correct checks on the layout.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
