### PR TITLE
Fix router deadlock

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
@@ -34,6 +34,11 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
     private final Queue<CorfuMsg> messages = new ArrayDeque();
     private static final String READ_TIMEOUT_HANDLER = "readTimeoutHandler";
 
+    public enum ClientHandshakeEvent {
+        CONNECTED,
+        FAILED
+    }
+
 
     /**
      * Creates a new ClientHandshakeHandler which will handle the handshake between the
@@ -64,7 +69,7 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
      */
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object m)
-            throws Exception {
+        throws Exception {
 
         if (this.handshakeState.failed()) {
             // if handshake has already failed, return
@@ -81,13 +86,13 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
         CorfuPayloadMsg<HandshakeResponse> handshakeResponse;
 
         try {
-           handshakeResponse = (CorfuPayloadMsg<HandshakeResponse>) m;
+            handshakeResponse = (CorfuPayloadMsg<HandshakeResponse>) m;
             log.info("channelRead: Handshake Response received. Removing " + READ_TIMEOUT_HANDLER +
-                    " from pipeline.");
+                " from pipeline.");
             ctx.pipeline().remove(READ_TIMEOUT_HANDLER);
         } catch (ClassCastException e) {
             log.warn("channelRead: Non-handshake message received by handshake handler. Send upstream only " +
-                    "if handshake succeeded.");
+                "if handshake succeeded.");
             if (this.handshakeState.completed()) {
                 // Only send upstream if handshake is complete.
                 super.channelRead(ctx, m);
@@ -115,7 +120,7 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
             // 'nodeId', instead server's id is 'serverId'
             log.error("channelRead: Handshake validation failed. Server node id mismatch.");
             log.debug("channelRead: Client opened socket to server {" + this.nodeId
-                    + "} instead, connected to: {" + serverId + "}");
+                + "} instead, connected to: {" + serverId + "}");
             this.fireHandshakeFailed(ctx);
             return;
         }
@@ -123,7 +128,7 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
         log.info("channelRead: Handshake succeeded. Server Corfu Version: {" + corfuVersion + "}");
         // Flush messages in queue
         log.debug("channelRead: There are {" + this.messages.size() + "} messages in queue to " +
-                "be flushed.");
+            "be flushed.");
         for (CorfuMsg message : this.messages) {
             ctx.writeAndFlush(message);
         }
@@ -131,7 +136,7 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
         // Remove this handler from the pipeline; handshake is completed.
         log.info("channelRead: Removing handshake handler from pipeline.");
         ctx.pipeline().remove(this);
-        this.fireHandshakeSucceeded();
+        this.fireHandshakeSucceeded(ctx);
     }
 
     /**
@@ -142,12 +147,12 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
      */
     @Override
     public void channelActive(ChannelHandlerContext ctx)
-            throws Exception {
+        throws Exception {
         log.info("channelActive: Outgoing connection established to: " + ctx.channel().remoteAddress());
 
         // Write the handshake & add a timeout listener.
         CorfuMsg handshake = CorfuMsgType.HANDSHAKE_INITIATE
-                .payloadMsg(new HandshakeMsg(this.clientId, this.nodeId));
+            .payloadMsg(new HandshakeMsg(this.clientId, this.nodeId));
 
         log.info("channelActive: Initiate handshake. Send handshake message.");
         ctx.writeAndFlush(handshake);
@@ -178,7 +183,7 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
      */
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx,
-                                java.lang.Throwable cause) throws Exception {
+        java.lang.Throwable cause) throws Exception {
         log.error("exceptionCaught: Exception {} caught.", cause.getClass().getSimpleName(), cause);
         if (cause instanceof ReadTimeoutException) {
             // Handshake has failed or completed. If none is True, handshake timed out.
@@ -191,13 +196,13 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
                 // If handshake did not complete nor failed, it timed out.
                 // Force failure.
                 log.error("exceptionCaught: Handshake timeout checker: timed out." +
-                        " Close Connection.");
+                    " Close Connection.");
                 this.handshakeState.set(true, false);
                 ctx.channel().close();
             } else {
                 // Handshake completed successfully,
                 log.debug("exceptionCaught: Handshake timeout checker: discarded " +
-                        "(handshake OK)");
+                    "(handshake OK)");
             }
         }
         if (ctx.channel().isOpen()) {
@@ -217,7 +222,7 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
      */
     @Override
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
-            throws Exception {
+        throws Exception {
         if (this.handshakeState.failed()) {
             return;
         }
@@ -242,14 +247,18 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
     private void fireHandshakeFailed(ChannelHandlerContext ctx) {
         this.handshakeState.set(true, true);
         log.error("fireHandshakeFailed: Handshake Failed. Close Channel.");
+        // Let downstream handlers know the handshake failed
+        ctx.fireUserEventTriggered(ClientHandshakeEvent.FAILED);
         ctx.channel().close();
     }
 
     /**
      * Signal handshake as succeeded.
      */
-    private void fireHandshakeSucceeded() {
+    private void fireHandshakeSucceeded(ChannelHandlerContext ctx) {
         this.handshakeState.set(false, true);
+        // Let downstream handlers know the handshake succeeded.
+        ctx.fireUserEventTriggered(ClientHandshakeEvent.CONNECTED);
     }
 }
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
@@ -34,9 +34,12 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
     private final Queue<CorfuMsg> messages = new ArrayDeque();
     private static final String READ_TIMEOUT_HANDLER = "readTimeoutHandler";
 
+    /** Events that the handshaker sends to downstream handlers.
+     *
+     */
     public enum ClientHandshakeEvent {
-        CONNECTED,
-        FAILED
+        CONNECTED,  /* Connection succeeded. */
+        FAILED      /* Handshake failed. */
     }
 
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -407,7 +407,7 @@ public class CorfuRuntime {
             ? (address) -> overrideGetRouterFunction.apply(this, address) : (address) ->
                 nodeRouters.compute(address, (k, r) -> {
                     final NettyClientRouter router = (NettyClientRouter) r;
-                    if (router != null && router.getConnected()) {
+                    if (router != null) {
                         // Return an existing router if we already have one and it is connected.
                         return router;
                     } else {
@@ -422,8 +422,7 @@ public class CorfuRuntime {
                                 .addClient(new SequencerClient())
                                 .addClient(new LogUnitClient().setMetricRegistry(metrics != null
                                     ? metrics : CorfuRuntime.getDefaultMetrics()))
-                                .addClient(new ManagementClient())
-                                .start();
+                                .addClient(new ManagementClient());
                         } catch (Exception e) {
                             log.warn("Error connecting to router", e);
                             throw e;

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -641,13 +641,11 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
             // Handshake successful. Complete the connection future to allow
             // clients to proceed.
             connectionFuture.complete(null);
-        } else if (evt.equals(ClientHandshakeEvent.FAILED)) {
+        } else if (evt.equals(ClientHandshakeEvent.FAILED) && connectionFuture.isDone()) {
             // Handshake failed. If the current completion future is complete,
             // create a new one to unset it, causing future requests
             // to wait.
-            if (connectionFuture.isDone()) {
-                connectionFuture = new CompletableFuture<>();
-            }
+            connectionFuture = new CompletableFuture<>();
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -3,7 +3,6 @@ package org.corfudb.runtime.clients;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.channel.Channel;
@@ -15,11 +14,9 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.DefaultChannelPromise;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.VoidChannelPromise;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslContext;
-
 import io.netty.util.concurrent.GlobalEventExecutor;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -27,21 +24,16 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
-
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLException;
-
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-
-import org.corfudb.comm.ChannelImplementation;
 import org.corfudb.protocols.wireprotocol.ClientHandshakeHandler;
 import org.corfudb.protocols.wireprotocol.ClientHandshakeHandler.ClientHandshakeEvent;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
@@ -52,17 +44,15 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.ShutdownException;
+import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
-
-import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.security.sasl.SaslUtils;
 import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyClient;
 import org.corfudb.security.tls.SslContextConstructor;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.NodeLocator;
-import org.corfudb.util.NodeLocator.Protocol;
 import org.corfudb.util.Sleep;
 
 
@@ -74,7 +64,7 @@ import org.corfudb.util.Sleep;
 @Slf4j
 @ChannelHandler.Sharable
 public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
-    implements IClientRouter {
+        implements IClientRouter {
 
     /**
      * Metrics: meter (counter), histogram.
@@ -90,7 +80,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
     public long epoch;
 
     /**
-     * We should never set epoch backwards
+     * We should never set epoch backwards.
      *
      * @param epoch
      */
@@ -292,12 +282,14 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
             .findFirst().get();
     }
 
-    @Override
-    @Deprecated
     /**
+     * {@inheritDoc}.
+     *
      * @deprecated The router automatically starts now, so this function call is no
      *             longer necessary
      */
+    @Override
+    @Deprecated
     public synchronized void start() {
         // Do nothing, legacy call
     }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -330,7 +330,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      * @param bootstrap     The channel bootstrap to use
      */
     private void addReconnectionOnCloseFuture(@Nonnull Channel channel,
-        @Nonnull Bootstrap bootstrap) {
+            @Nonnull Bootstrap bootstrap) {
         channel.closeFuture().addListener((r) -> {
             log.info("addReconnectionOnCloseFuture[{}]: disconnected", node);
             // Remove the current completion future, forcing clients to wait for reconnection.

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -377,6 +377,8 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                     log.info("connectAsync[{}]: Channel connection failed, reconnecting...", node);
                     Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
                     // Call connect, which will retry the call again.
+                    // Note that this is not recursive, because it is called in the
+                    // context of the handler future.
                     connectAsync(b);
                 }
             }

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -468,12 +468,7 @@ public class NettyCommTest extends AbstractCorfuTest {
                 .tsPasswordFile("src/test/resources/security/reload/password")
                 .build());
 
-        clientRouter.addClient(new BaseClient());
-        clientRouter.start();
-
         assertThat(clientRouter.getClient(BaseClient.class).pingSync()).isFalse();
-
-        clientRouter.stop();
 
 
         if (replaceClientTrust) {
@@ -482,7 +477,7 @@ public class NettyCommTest extends AbstractCorfuTest {
             Files.copy(serverTrustWithClient.toPath(), serverTrustFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         }
 
-        clientRouter.start();
+        clientRouter.getConnectionFuture().join();
         assertThat(clientRouter.getClient(BaseClient.class).pingSync()).isTrue();
         clientRouter.stop();
 


### PR DESCRIPTION
## Overview

Description: This PR changes the behavior of NettyClientRouter so that the a created router is automatically started, and that stopping a router automatically shuts it down. This prevents a deadlock cycle that could occur due to retry holding the monitor lock on the router.

Why should this be merged: Fixes deadlock bug, needed for reconfiguration to be robust.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
