### PR TITLE
Fixing intermittent test failures

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -14,7 +14,7 @@ public abstract class AbstractServer {
 
     @Getter
     @Setter
-    boolean shutdown;
+    volatile boolean shutdown;
 
     public AbstractServer() {
         shutdown = false;

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -284,14 +284,8 @@ public class ClusterReconfigIT extends AbstractIT {
         corfuRuntime.getRouter("localhost:9000").getClient(BaseClient.class).restart()
                 .get();
 
-        corfuRuntime = createDefaultRuntime();
-        // The shutdown and restart can take an unknown amount of time and there is a chance that
-        // the newer runtime may also connect to the older corfu server (before restart).
-        // Hence the while loop.
-        while (corfuRuntime.getLayoutView().getLayout().getEpoch() != (l.getEpoch() + 1)) {
-            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
-            corfuRuntime = createDefaultRuntime();
-        }
+        restartServer(corfuRuntime, DEFAULT_ENDPOINT);
+
         assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(l.getEpoch() + 1);
         assertThat(shutdownCorfuServer(corfuServer)).isTrue();
     }

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -282,7 +282,7 @@ public class ServerRestartIT extends AbstractIT {
             }
 
             return true;
-        },CLIENT_DELAY_POST_SHUTDOWN, TimeUnit.MILLISECONDS);
+        }, CLIENT_DELAY_POST_SHUTDOWN, TimeUnit.MILLISECONDS);
         offline.shutdown();
 
         Thread.sleep(CORFU_SERVER_DOWN_TIME);
@@ -438,10 +438,8 @@ public class ServerRestartIT extends AbstractIT {
         final int newMapBStreamTail = 19;
         final int newGlobalTail = 19;
 
-        assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
+        restartServer(corfuRuntime, DEFAULT_ENDPOINT);
 
-        corfuServerProcess = runCorfuServer();
-        corfuRuntime = createDefaultRuntime();
         TokenResponse tokenResponseA = corfuRuntime
                 .getSequencerView()
                 .nextToken(Collections.singleton(streamNameA), 1);


### PR DESCRIPTION
## Overview

Description: Fixes 3 intermittent test failures:
Shutdown Exceptions in sequencerTailsRecoveryTest and restartTest. Fixed by rechecking client connection after restart.
Time out in testTlsUpdateServerTrust. Fixed by stopping the existing the client and restarting it after trust reload.

Why should this be merged: Fixes broken tests.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
