### PR TITLE
Init test groups outside of AbstractCorfuTest

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/concurrent/SingletonResource.java
+++ b/runtime/src/main/java/org/corfudb/util/concurrent/SingletonResource.java
@@ -1,0 +1,102 @@
+package org.corfudb.util.concurrent;
+
+import java.util.concurrent.locks.StampedLock;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.annotation.Nonnull;
+
+/** Utility class which implements a singleton resource pattern.
+ *
+ *  <p>A {@link SingletonResource} is a common resource pattern where the first thread that
+ *  needs to use a resource instantiates it. Subsequent threads should re-use the resource
+ *  instantiated by the first thread. The {@link SingletonResource#cleanup(Consumer)} allows
+ *  the developer to release resources if the resource has been instantiated (doing nothing
+ *  if no thread ever created the resource in the first place).
+ *
+ * @param <T>   The type of resource this {@link SingletonResource} holds.
+ */
+public class SingletonResource<T> {
+
+    /** The resource to be held. */
+    private T resource;
+
+    /** A generator which provides the resource. */
+    private final Supplier<T> generator;
+
+    /** A stamped lock which controls access to the resource. */
+    private final StampedLock lock;
+
+    /** Factory method with similar semantics as a {@link ThreadLocal}.
+     *
+     * @param generator     A method to be called when a new {@link R} is needed.
+     * @param <R>           The type of the resource to be provided.
+     * @return              A new {@link SingletonResource}.
+     */
+    public static <R> SingletonResource<R> withInitial(@Nonnull Supplier<R> generator) {
+        return new SingletonResource<>(generator);
+    }
+
+    /** Generate a new {@link SingletonResource}.
+     *
+     * @param generator     A method to be called when a new {@link T} is needed.
+     */
+    private SingletonResource(Supplier<T> generator) {
+        lock = new StampedLock();
+        this.generator = generator;
+
+    }
+
+    /** Get the resource, potentially generating it by calling the {@code generator} if necessary.
+     *
+     * @return  The resource provided by this {@link SingletonResource}.
+     */
+    public T get() {
+        long ts = lock.tryOptimisticRead();
+        if (ts != 0 && resource != null && lock.validate(ts)) {
+            // If the optimistic read succeeds and the resource
+            // is present, return it.
+            return resource;
+        } else {
+            // Otherwise, grab a read lock (this should be rare)
+            try {
+                ts = lock.readLock();
+                // The resource was present, so return it.
+                if (resource != null) {
+                    return resource;
+                } else {
+                    // Otherwise attempt to grab a write lock so we can initialize
+                    // the resource.
+                    ts = lock.tryConvertToWriteLock(ts);
+                    // Upgrading the read lock failed, so unlock and relock
+                    if (ts == 0) {
+                        lock.unlock(ts);
+                        ts = lock.writeLock();
+                    }
+                    resource = generator.get();
+                    return resource;
+                }
+            } finally {
+                lock.unlock(ts);
+            }
+        }
+    }
+
+    /** Cleanup the resource if it has been generated. Otherwise does nothing.
+     *
+     * @param cleaner   A {@link Consumer} which is provided the resource to perform cleanup
+     *                  actions.
+     */
+    public void cleanup(@Nonnull Consumer<T> cleaner) {
+        long ts = lock.writeLock();
+        try {
+            if (resource != null) {
+                // Perform cleanup actions and release the resource
+                cleaner.accept(resource);
+            }
+            resource = null;
+        } finally {
+            lock.unlock(ts);
+        }
+    }
+
+}

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -3,7 +3,7 @@ package org.corfudb.infrastructure;
 import com.google.common.collect.ImmutableMap;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import org.corfudb.AbstractCorfuTest;
+import org.corfudb.test.concurrent.TestThreadGroups;
 
 /**
  * Created by mwei on 6/29/16.
@@ -90,18 +90,9 @@ public class ServerContextBuilder {
 
         // Provide the server with event loop groups
         if (implementation.equals("local")) {
-            if (AbstractCorfuTest.NETTY_CLIENT_GROUP != null) {
-                builder
-                    .put("client", AbstractCorfuTest.NETTY_CLIENT_GROUP);
-            }
-            if (AbstractCorfuTest.NETTY_BOSS_GROUP != null) {
-                builder
-                .put("boss", AbstractCorfuTest.NETTY_BOSS_GROUP);
-            }
-            if (AbstractCorfuTest.NETTY_WORKER_GROUP != null) {
-                builder
-                .put("worker", AbstractCorfuTest.NETTY_WORKER_GROUP);
-            }
+            builder.put("client", TestThreadGroups.NETTY_CLIENT_GROUP.get());
+            builder.put("boss", TestThreadGroups.NETTY_BOSS_GROUP.get());
+            builder.put("worker", TestThreadGroups.NETTY_CLIENT_GROUP.get());
         }
         ServerContext sc = new ServerContext(builder.build());
         sc.setServerRouter(serverRouter);

--- a/test/src/test/java/org/corfudb/test/concurrent/TestThreadGroups.java
+++ b/test/src/test/java/org/corfudb/test/concurrent/TestThreadGroups.java
@@ -1,0 +1,63 @@
+package org.corfudb.test.concurrent;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import javax.annotation.Nonnull;
+import org.corfudb.util.concurrent.SingletonResource;
+
+public class TestThreadGroups {
+
+    /**
+     * Netty "boss" thread group which is reused in tests.
+     */
+    public static SingletonResource<EventLoopGroup> NETTY_BOSS_GROUP =
+        SingletonResource.withInitial(() ->
+            getEventLoopGroup(1, "boss-%d"));
+
+    /**
+     * Netty "worker" thread group which is reused in tests.
+     */
+    public static SingletonResource<EventLoopGroup> NETTY_WORKER_GROUP =
+        SingletonResource.withInitial(() ->
+            getEventLoopGroup(getTestThreadCount(), "worker-%d"));
+
+    /**
+     * Netty "client" thread group which is reused in tests.
+     */
+    public static SingletonResource<EventLoopGroup> NETTY_CLIENT_GROUP =
+        SingletonResource.withInitial(() ->
+            getEventLoopGroup(getTestThreadCount(), "client-%d"));
+
+
+    /**
+     * Gracefully shutdown the event loop groups.
+     */
+    public static void shutdownThreadGroups() {
+        NETTY_BOSS_GROUP.cleanup(EventLoopGroup::shutdownGracefully);
+        NETTY_WORKER_GROUP.cleanup(EventLoopGroup::shutdownGracefully);
+        NETTY_CLIENT_GROUP.cleanup(EventLoopGroup::shutdownGracefully);
+    }
+
+    /**
+     * Get the number of threads to be used in a test.
+     * @return  The number of threads to use.
+     */
+    private static int getTestThreadCount(){
+        return Runtime.getRuntime().availableProcessors() * 2;
+    }
+
+    /** Get an {@link io.netty.channel.EventLoopGroup} for Netty.
+     *
+     * @param numThreads    The number of threads in the {@link EventLoopGroup}.
+     * @param nameFormat    A format string for the threads in the {@link EventLoopGroup}
+     * @return              The {@link EventLoopGroup} generated.
+     */
+    private static EventLoopGroup getEventLoopGroup(int numThreads, @Nonnull String nameFormat) {
+        return new DefaultEventLoopGroup(numThreads,
+            new ThreadFactoryBuilder()
+                .setNameFormat(nameFormat)
+                .setDaemon(true)
+                .build());
+    }
+}

--- a/test/src/test/java/org/corfudb/test/logging/MemoryAppender.java
+++ b/test/src/test/java/org/corfudb/test/logging/MemoryAppender.java
@@ -1,4 +1,4 @@
-package org.corfudb.test;
+package org.corfudb.test.logging;
 
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
 import ch.qos.logback.core.encoder.Encoder;

--- a/test/src/test/java/org/corfudb/test/logging/TestLogger.java
+++ b/test/src/test/java/org/corfudb/test/logging/TestLogger.java
@@ -1,0 +1,38 @@
+package org.corfudb.test.logging;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import org.slf4j.LoggerFactory;
+
+public class TestLogger {
+
+    private MemoryAppender<ILoggingEvent> appender;
+
+    public TestLogger(int elements) {
+
+        LoggerContext lc = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+        PatternLayoutEncoder encoder = new PatternLayoutEncoder();
+        encoder.setContext(lc);
+        encoder.setPattern("%d{HH:mm:ss.SSS} %highlight(%-5level) "
+            + "[%thread] %cyan(%logger{15}) - %msg%n %ex{3}");
+        encoder.start();
+
+        appender = new MemoryAppender<>(elements, encoder);
+        Logger logger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        appender.setContext(lc);
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    public void reset() {
+        appender.reset();
+    }
+
+    public Iterable<byte[]> getEventsAndReset() {
+        return appender.getEventsAndReset();
+    }
+
+}


### PR DESCRIPTION
## Overview

Description: Initialize test thread groups in their own class instead of inside AbstractCorfuTest. This removes the dependency of ServerContextBuilder on AbstractCorfuTest.

Why should this be merged: The ServerContextBuilder, which is used by other test frameworks unnecessarily loads in all of AbstractCorfuTest, which may require conflicting classes. This test framework change fixes that issue.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
