### PR TITLE
Heal logUnit chain

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/ReconfigurationEventHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/ReconfigurationEventHandler.java
@@ -64,9 +64,11 @@ public class ReconfigurationEventHandler {
 
     /**
      * Takes in the existing layout and a set of healed nodes.
-     * It first generates a new layout by adding the healed nodes to the existing layout.
-     * It then seals the epoch to prevent any client from accessing the stale layout.
-     * Finally we run paxos to update all servers with the new layout.
+     * The LayoutManagementView launches a workflow to heal the specified node. This call is
+     * blocked until the workflow is completed or aborted.
+     * The node is healed and added back to the layout with all components enabled i.e., with its
+     * layout, sequencer and log unit server enabled and as an active participant in the
+     * data replication view.
      *
      * @param currentLayout The current layout
      * @param corfuRuntime  Connected corfu runtime instance
@@ -77,8 +79,9 @@ public class ReconfigurationEventHandler {
                                  CorfuRuntime corfuRuntime,
                                  Set<String> healedServers) {
         try {
-            corfuRuntime.getLayoutManagementView().handleHealing(failureHandlerPolicy,
-                    currentLayout, healedServers);
+            healedServers.forEach(healedServer ->
+                    corfuRuntime.getLayoutManagementView()
+                            .handleHealing(failureHandlerPolicy, currentLayout, healedServer));
             return true;
         } catch (Exception e) {
             log.error("Error: handleHealing: {}", e);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
@@ -40,7 +40,7 @@ public class AddNodeWorkflow implements IWorkflow {
 
     private final AddNodeRequest request;
 
-    private Layout newLayout;
+    protected Layout newLayout;
 
     /**
      * The chunk size (i.e. number of address space entries) that
@@ -77,7 +77,7 @@ public class AddNodeWorkflow implements IWorkflow {
      * Bootstrap the new node to be added to the cluster, or ignore
      * bootstrap if it's already bootstrapped.
      */
-    private class BootstrapNode extends Action {
+    protected class BootstrapNode extends Action {
         @Override
         public String getName() {
             return "BootstrapNode";
@@ -184,7 +184,7 @@ public class AddNodeWorkflow implements IWorkflow {
      * Copies the split segment to the new node, if it
      * is the new node also participates as a logging unit.
      */
-    private class StateTransfer extends Action {
+    protected class StateTransfer extends Action {
         @Override
         public String getName() {
             return "StateTransfer";
@@ -201,7 +201,7 @@ public class AddNodeWorkflow implements IWorkflow {
      * Merges the fragmented segment if the AddNodeToLayout action caused any
      * segments to split
      */
-    private class MergeSegments extends Action {
+    protected class MergeSegments extends Action {
         @Override
         public String getName() {
             return "MergeSegments";

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
@@ -1,0 +1,85 @@
+package org.corfudb.infrastructure.orchestrator.workflows;
+
+import static org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorRequestType.HEAL_NODE;
+
+import java.util.Arrays;
+import java.util.List;
+
+import javax.annotation.Nonnull;
+
+import org.corfudb.infrastructure.orchestrator.Action;
+import org.corfudb.protocols.wireprotocol.orchestrator.AddNodeRequest;
+import org.corfudb.protocols.wireprotocol.orchestrator.HealNodeRequest;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.view.Layout;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * A definition of a workflow that heals an existing unresponsive node back to the cluster.
+ * NOTE: The healing first resets this node, which erases all existing data.
+ * Then, similar to the AddNodeWorkflow, the segment is split, the node is added with all the
+ * data transferred from the existing log unit nodes and finally the segments are merged.
+ *
+ * <p>Created by Zeeshan on 12/8/17.
+ */
+@Slf4j
+public class HealNodeWorkflow extends AddNodeWorkflow {
+
+    private final HealNodeRequest request;
+
+    public HealNodeWorkflow(HealNodeRequest healNodeRequest) {
+        super(new AddNodeRequest(healNodeRequest.getEndpoint()));
+        this.request = healNodeRequest;
+    }
+
+    @Override
+    public String getName() {
+        return HEAL_NODE.toString();
+    }
+
+    @Override
+    public List<Action> getActions() {
+        return Arrays.asList(new ResetNode(),
+                new HealNodeToLayout(),
+                new StateTransfer(),
+                new MergeSegments());
+    }
+
+    class ResetNode extends Action {
+        @Override
+        public String getName() {
+            return "ResetNode";
+        }
+
+        @Override
+        public void impl(@Nonnull CorfuRuntime runtime) throws Exception {
+            runtime.getRouter(request.getEndpoint())
+                    .getClient(LogUnitClient.class)
+                    .resetLogUnit()
+                    .get();
+        }
+    }
+
+
+    /**
+     * This action adds a new node to the layout. If it is also
+     * added as a logunit server, then in addition to adding
+     * the node the address space segment is split at the
+     * tail determined during the layout modification.
+     */
+    class HealNodeToLayout extends Action {
+        @Override
+        public String getName() {
+            return "HealNodeToLayout";
+        }
+
+        @Override
+        public void impl(@Nonnull CorfuRuntime runtime) throws Exception {
+            Layout currentLayout = new Layout(runtime.getLayoutView().getLayout());
+            runtime.getLayoutManagementView().healNode(currentLayout, request.getEndpoint());
+            runtime.invalidateLayout();
+            newLayout = new Layout(runtime.getLayoutView().getLayout());
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/HealNodeRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/HealNodeRequest.java
@@ -1,0 +1,74 @@
+package org.corfudb.protocols.wireprotocol.orchestrator;
+
+import static org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorRequestType.HEAL_NODE;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+import lombok.Getter;
+
+/**
+ * An orchestrator request to heal an existing node to the cluster.
+ *
+ * @author Maithem
+ */
+public class HealNodeRequest implements CreateRequest {
+
+    @Getter
+    public String endpoint;
+
+    @Getter
+    boolean layoutServer;
+
+    @Getter
+    boolean sequencerServer;
+
+    @Getter
+    boolean logUnitServer;
+
+    @Getter
+    int stripeIndex;
+
+    public HealNodeRequest(String endpoint,
+                           boolean layoutServer,
+                           boolean sequencerServer,
+                           boolean logUnitServer,
+                           int stripeIndex) {
+        this.endpoint = endpoint;
+        this.layoutServer = layoutServer;
+        this.sequencerServer = sequencerServer;
+        this.logUnitServer = logUnitServer;
+        this.stripeIndex = stripeIndex;
+    }
+
+    public HealNodeRequest(byte[] buf) {
+        ByteBuffer byteBuffer = ByteBuffer.wrap(buf);
+        int el = byteBuffer.getInt();
+        byte[] eb = new byte[el];
+        byteBuffer.get(eb);
+        endpoint = new String(eb, StandardCharsets.UTF_8);
+        layoutServer = byteBuffer.get() != 0;
+        sequencerServer = byteBuffer.get() != 0;
+        logUnitServer = byteBuffer.get() != 0;
+        stripeIndex = byteBuffer.getInt();
+    }
+
+    @Override
+    public OrchestratorRequestType getType() {
+        return HEAL_NODE;
+    }
+
+    @Override
+    public byte[] getSerialized() {
+        byte[] eb = endpoint.getBytes(StandardCharsets.UTF_8);
+
+        ByteBuffer byteBuffer = ByteBuffer.allocate(4 + eb.length + 3 + 4);
+        byteBuffer.putInt(eb.length);
+        byteBuffer.put(eb);
+        byteBuffer.put((byte) (isLayoutServer() ? 1 : 0));
+        byteBuffer.put((byte) (isSequencerServer() ? 1 : 0));
+        byteBuffer.put((byte) (isLogUnitServer() ? 1 : 0));
+        byteBuffer.putInt(stripeIndex);
+        return byteBuffer.array();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/OrchestratorRequestType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/OrchestratorRequestType.java
@@ -29,7 +29,12 @@ public enum OrchestratorRequestType {
     /**
      * Remove a node from the cluster
      */
-    REMOVE_NODE(2, RemoveNodeRequest::new);
+    REMOVE_NODE(2, RemoveNodeRequest::new),
+
+    /**
+     * Heal an existing node in the cluster
+     */
+    HEAL_NODE(3, HealNodeRequest::new);
 
     @Getter
     public final int type;

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -684,7 +684,7 @@ public class CorfuRuntime {
                 Collections.shuffle(layoutServersCopy);
                 // Iterate through the layout servers, attempting to connect to one
                 for (String s : layoutServersCopy) {
-                    log.info("Trying connection to layout server {}", s);
+                    log.debug("Trying connection to layout server {}", s);
                     try {
                         IClientRouter router = getRouter(s);
                         // Try to get a layout.

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -13,14 +13,16 @@ import lombok.Setter;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
+import org.corfudb.protocols.wireprotocol.DetectorMsg;
 import org.corfudb.protocols.wireprotocol.orchestrator.AddNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
+import org.corfudb.protocols.wireprotocol.orchestrator.HealNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorMsg;
 import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.QueryRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.QueryResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.RemoveNodeRequest;
-import org.corfudb.protocols.wireprotocol.DetectorMsg;
+
 import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.NoBootstrapException;
 import org.corfudb.runtime.view.Layout;
@@ -130,6 +132,34 @@ public class ManagementClient implements IClient {
         CompletableFuture<OrchestratorResponse> resp = router.sendMessageAndGetCompletable(CorfuMsgType
                 .ORCHESTRATOR_REQUEST
                 .payloadMsg(req));
+        return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp).getResponse();
+    }
+
+    /**
+     * Creates a workflow request to heal a node.
+     *
+     * @param endpoint          Endpoint of the node to be healed.
+     * @param isLayoutServer    True if the node to be healed is a layout server.
+     * @param isSequencerServer True if the node to be healed is a sequencer server.
+     * @param isLogUnitServer   True if the node to be healed is a logunit server.
+     * @param stripeIndex       Stripe index of the node if it is a logunit server.
+     * @return CreateWorkflowResponse which gives the workflowId.
+     */
+    public CreateWorkflowResponse healNodeRequest(@Nonnull String endpoint,
+                                                  boolean isLayoutServer,
+                                                  boolean isSequencerServer,
+                                                  boolean isLogUnitServer,
+                                                  int stripeIndex) {
+        OrchestratorMsg req = new OrchestratorMsg(
+                new HealNodeRequest(endpoint,
+                        isLayoutServer,
+                        isSequencerServer,
+                        isLogUnitServer,
+                        stripeIndex));
+        CompletableFuture<OrchestratorResponse> resp =
+                router.sendMessageAndGetCompletable(CorfuMsgType
+                        .ORCHESTRATOR_REQUEST
+                        .payloadMsg(req));
         return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp).getResponse();
     }
 

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -305,7 +305,6 @@ public class ClusterReconfigIT extends AbstractIT {
             throws Exception {
 
         // Set up cluster of 3 nodes.
-        // Set up cluster of 3 nodes.
         final int PORT_0 = 9000;
         final int PORT_1 = 9001;
         final int PORT_2 = 9002;
@@ -313,9 +312,9 @@ public class ClusterReconfigIT extends AbstractIT {
         Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
         Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
         List<Process> corfuServers = Arrays.asList(corfuServer_1, corfuServer_2, corfuServer_3);
-        Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
         final Layout layout = get3NodeLayout();
-        bootstrapCluster(layout);
+        final int retries = 3;
+        BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
         // Create map and set up daemon writer thread.
         CorfuRuntime runtime = createDefaultRuntime();
@@ -424,6 +423,104 @@ public class ClusterReconfigIT extends AbstractIT {
 
         CorfuRuntime corfuRuntime = createDefaultRuntime();
         assertThat(corfuRuntime.getLayoutView().getLayout().equals(layout)).isTrue();
+
+        shutdownCorfuServer(corfuServer_1);
+        shutdownCorfuServer(corfuServer_2);
+        shutdownCorfuServer(corfuServer_3);
+    }
+
+    /**
+     * Starts with 3 nodes on ports 0, 1 and 2.
+     * A daemon thread is started for random writes in the background.
+     * First the node on port 0 is killed. The test then waits for the cluster to stabilize and
+     * assert that data operations still go through.
+     * Now, the same node is revived and waits for the node to be healed and merged back into the
+     * cluster.
+     * Finally the data on all the 3 nodes is verified.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void killAndHealNode() throws Exception {
+
+        // Set up cluster of 3 nodes.
+        final int PORT_0 = 9000;
+        final int PORT_1 = 9001;
+        final int PORT_2 = 9002;
+        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
+        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        final Layout layout = get3NodeLayout();
+        final int retries = 3;
+        BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
+
+        // Create map and set up daemon writer thread.
+        CorfuRuntime runtime = createDefaultRuntime();
+        CorfuTable table = runtime.getObjectsView()
+                .build()
+                .setType(CorfuTable.class)
+                .setStreamName("test")
+                .open();
+        final String data = createStringOfSize(1_000);
+        Random r = getRandomNumberGenerator();
+        final AtomicBoolean moreDataToBeWritten = new AtomicBoolean(true);
+        Thread t = startDaemonWriter(runtime, r, table, data, moreDataToBeWritten);
+
+        // Some preliminary writes into the corfu table.
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+            runtime.getObjectsView().TXBegin();
+            table.put(Integer.toString(r.nextInt()), data);
+            runtime.getObjectsView().TXEnd();
+        }
+
+        // Killing killNode.
+        assertThat(shutdownCorfuServer(corfuServer_1)).isTrue();
+
+        // We wait for failure to be detected and the cluster to stabilize by waiting for the epoch
+        // to increment.
+        runtime.invalidateLayout();
+        Layout refreshedLayout = runtime.getLayoutView().getLayout();
+        while (refreshedLayout.getEpoch() == layout.getEpoch()) {
+            runtime.invalidateLayout();
+            refreshedLayout = runtime.getLayoutView().getLayout();
+            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
+        }
+
+        // Ensure writes still going through.
+        // Fail test if write fails.
+        boolean writeAfterKillNode = false;
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
+            try {
+                runtime.getObjectsView().TXBegin();
+                table.put(Integer.toString(r.nextInt()), data);
+                runtime.getObjectsView().TXEnd();
+                writeAfterKillNode = true;
+                break;
+            } catch (TransactionAbortedException tae) {
+                // A transaction aborted exception is expected during
+                // some reconfiguration cases.
+                tae.printStackTrace();
+            }
+            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
+        }
+        assertThat(writeAfterKillNode).isTrue();
+
+        corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        runtime.invalidateLayout();
+        refreshedLayout = runtime.getLayoutView().getLayout();
+        final long epochAfterKillNode = 1L;
+        while (refreshedLayout.getEpoch() == epochAfterKillNode) {
+            runtime.invalidateLayout();
+            refreshedLayout = runtime.getLayoutView().getLayout();
+            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
+        }
+
+
+        // Stop the daemon thread.
+        moreDataToBeWritten.set(false);
+        t.join();
+
+        verifyData(runtime);
 
         shutdownCorfuServer(corfuServer_1);
         shutdownCorfuServer(corfuServer_2);

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -122,21 +122,25 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
                 .simulateDisconnectedEndpoint();
     }
 
-    /** Function for obtaining a router, given a runtime and an endpoint.
+    /**
+     * Function for obtaining a router, given a runtime and an endpoint.
      *
-     * @param runtime       The CorfuRuntime to obtain a router for.
-     * @param endpoint      An endpoint string for the router.
+     * @param runtime  The CorfuRuntime to obtain a router for.
+     * @param endpoint An endpoint string for the router.
      * @return
      */
     protected IClientRouter getRouterFunction(CorfuRuntime runtime, String endpoint) {
         runtimeRouterMap.putIfAbsent(runtime, new ConcurrentHashMap<>());
-        if (!endpoint.startsWith("test:")) {
+        if (!endpoint.startsWith("test:") && !endpoint.startsWith("tcp://test")) {
             throw new RuntimeException("Unsupported endpoint in test: " + endpoint);
         }
         return runtimeRouterMap.get(runtime).computeIfAbsent(endpoint,
                 x -> {
+                    String serverName = endpoint.startsWith("tcp://test") ?
+                            endpoint.substring(endpoint.indexOf("test"), endpoint.length() - 1)
+                            : endpoint;
                     TestClientRouter tcn =
-                            new TestClientRouter(testServerMap.get(endpoint).getServerRouter());
+                            new TestClientRouter(testServerMap.get(serverName).getServerRouter());
                     tcn.addClient(new BaseClient())
                             .addClient(new SequencerClient())
                             .addClient(new LayoutClient())

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -834,11 +834,12 @@ public class ManagementViewTest extends AbstractViewTest {
         bootstrapAllServers(l);
         CorfuRuntime corfuRuntime = getRuntime(l).connect();
 
+        getManagementServer(SERVERS.PORT_1).shutdown();
+        getManagementServer(SERVERS.PORT_2).shutdown();
+
         setAggressiveTimeouts(l, corfuRuntime,
-                getManagementServer(SERVERS.PORT_0).getManagementAgent().getCorfuRuntime(),
-                getManagementServer(SERVERS.PORT_1).getManagementAgent().getCorfuRuntime(),
-                getManagementServer(SERVERS.PORT_2).getManagementAgent().getCorfuRuntime());
-        setAggressiveDetectorTimeouts(SERVERS.PORT_0, SERVERS.PORT_1, SERVERS.PORT_2);
+                getManagementServer(SERVERS.PORT_0).getManagementAgent().getCorfuRuntime());
+        setAggressiveDetectorTimeouts(SERVERS.PORT_0);
 
         addServerRule(SERVERS.PORT_2, new TestRule().always().drop());
 
@@ -852,11 +853,11 @@ public class ManagementViewTest extends AbstractViewTest {
                 .containsExactly(SERVERS.ENDPOINT_2);
 
         clearServerRules(SERVERS.PORT_2);
-        while (corfuRuntime.getLayoutView().getLayout().getEpoch() == newEpoch) {
+        final long finalEpoch = 4L;
+        while (corfuRuntime.getLayoutView().getLayout().getEpoch() != finalEpoch) {
             Thread.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
             corfuRuntime.invalidateLayout();
         }
-        final long finalEpoch = 3L;
         assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(finalEpoch);
         assertThat(corfuRuntime.getLayoutView().getLayout().getUnresponsiveServers()).isEmpty();
     }


### PR DESCRIPTION
## Overview

Description: Healing a node with all components - Layout, Sequencer and Log unit Servers.
On healing detection, the management agent launches an orchestrator request spawning the healing workflow.
The healing is carried out in the following actions:
1. Reset logunits - First we need to clear all existing data on this node. This is carried out by a logunit only reset.
2. Heal node - The node is then added back to the layout. If it contains a logunit then the segment is split before adding it into the chain.
3. State transfer and merge - If a logunit component is present then state transfer is carried out followed by merging the segments.

Why should this be merged: Currently we cannot heal a log unit.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
