### PR TITLE
Fix channel race

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -376,9 +376,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
     private void channelConnectionFutureHandler(@Nonnull ChannelFuture future,
                                                 @Nonnull Bootstrap bootstrap) {
         if (future.isSuccess()) {
-            // When the channel connection succeeds, set this channel as active
-            channel = future.channel();
-            // And register a future to reconnect in case we get disconnected
+            // Register a future to reconnect in case we get disconnected
             addReconnectionOnCloseFuture(channel, bootstrap);
             log.info("connectAsync[{}]: Channel connected.", node);
         } else {
@@ -497,15 +495,6 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      * @param message The message to send.
      */
     public void sendMessage(ChannelHandlerContext ctx, CorfuMsg message) {
-        ChannelHandlerContext outContext = context;
-        if (ctx == null) {
-            if (context == null) {
-                // if the router's context is not set, return a failure
-                log.warn("Attempting to send on a channel that is not ready.");
-                return;
-            }
-            outContext = context;
-        }
         // Get the next request ID.
         final long thisRequest = requestID.getAndIncrement();
         // Set the base fields for this message.
@@ -513,7 +502,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         message.setRequestID(thisRequest);
         message.setEpoch(epoch);
         // Write this message out on the channel.
-        outContext.writeAndFlush(message, outContext.voidPromise());
+        channel.writeAndFlush(message, channel.voidPromise());
         log.trace("Sent one-way message: {}", message);
     }
 
@@ -623,23 +612,11 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
     }
 
     @Override
-    public void channelRegistered(ChannelHandlerContext ctx) throws Exception {
-        context = ctx;
-        log.debug("Registered new channel {}", ctx);
-    }
-
-    @Override
-    public void channelUnregistered(ChannelHandlerContext ctx) throws Exception {
-        super.channelUnregistered(ctx);
-        context = null;
-        log.debug("Unregistered channel {}", ctx);
-    }
-
-    @Override
     public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
         if (evt.equals(ClientHandshakeEvent.CONNECTED)) {
             // Handshake successful. Complete the connection future to allow
             // clients to proceed.
+            channel = ctx.channel();
             connectionFuture.complete(null);
         } else if (evt.equals(ClientHandshakeEvent.FAILED) && connectionFuture.isDone()) {
             // Handshake failed. If the current completion future is complete,

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -130,14 +130,11 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      * The clients registered to this router.
      */
     public List<IClient> clientList;
+
     /**
      * The outstanding requests on this router.
      */
     public Map<Long, CompletableFuture> outstandingRequests;
-    /**
-     * The currently registered channel context.
-     */
-    public ChannelHandlerContext context;
 
     /**
      * The currently registered channel.

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -374,7 +374,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                                                 @Nonnull Bootstrap bootstrap) {
         if (future.isSuccess()) {
             // Register a future to reconnect in case we get disconnected
-            addReconnectionOnCloseFuture(channel, bootstrap);
+            addReconnectionOnCloseFuture(future.channel(), bootstrap);
             log.info("connectAsync[{}]: Channel connected.", node);
         } else {
             // Otherwise, the connection failed. If we're not shutdown, try reconnecting after

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -139,7 +139,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
     /**
      * The currently registered channel.
      */
-    public volatile Channel channel = null;
+    private volatile Channel channel = null;
 
     /**
      * The {@link EventLoopGroup} for this router which services requests.


### PR DESCRIPTION
## Overview

Description: When a channel is connected, there is a race in NettyClientRouter between when the channel is connected and when the completionFuture for the channel is fulfilled. As a result, a client can call sendMessageAndGetCompletableFuture() and encounter a NullPointerException if the channel is set after the completionFuture is fulfilled.

This PR also removes a deprecated ChannelHandlerContext that was being passed around, which is also vulnerable to the same race.

Why should this be merged: Resolves a NPE bug in NettyClientRouter.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
