### PR TITLE
Avoid Access During CP

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
 
+import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.ConcurrentModificationException;
@@ -34,6 +35,7 @@ import org.corfudb.annotations.DontInstrument;
 import org.corfudb.annotations.Mutator;
 import org.corfudb.annotations.MutatorAccessor;
 import org.corfudb.annotations.TransactionalMethod;
+import org.corfudb.util.ImmuableListSetWrapper;
 
 /** The CorfuTable implements a simple key-value store.
  *
@@ -480,11 +482,19 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
         return ImmutableList.copyOf(mainMap.values());
     }
 
-    /** {@inheritDoc} */
+    /**
+     * Makes a shallow copy of the map (i.e. all map entries), but not the
+     * key/values (i.e only the mappings are copied).
+     **/
     @Override
     @Accessor
     public @Nonnull Set<Entry<K, V>> entrySet() {
-        return ImmutableSet.copyOf(mainMap.entrySet());
+        List<Entry<K, V>> copy = new ArrayList<>(mainMap.size());
+        for (Map.Entry<K, V> entry : mainMap.entrySet()) {
+            copy.add(new AbstractMap.SimpleImmutableEntry<>(entry.getKey(),
+                    entry.getValue()));
+        }
+        return new ImmuableListSetWrapper<>(copy);
     }
 
     /** {@inheritDoc} */

--- a/runtime/src/main/java/org/corfudb/util/ImmuableListSetWrapper.java
+++ b/runtime/src/main/java/org/corfudb/util/ImmuableListSetWrapper.java
@@ -1,0 +1,116 @@
+package org.corfudb.util;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * An immutable set implementation that is backed by a list. This type is useful when
+ * we have lists that we know conform to the set constraints, but creating the set is
+ * too expensive.
+ *
+ */
+
+public class ImmuableListSetWrapper<E> implements Set<E> {
+    final List<E> internalList;
+
+    public ImmuableListSetWrapper(@Nonnull List<E> internalList) {
+        this.internalList = internalList;
+    }
+
+    @Override
+    public int size() {
+        return internalList.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return internalList.isEmpty();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return internalList.contains(o);
+    }
+
+    @Override
+    public Iterator<E> iterator() {
+        return internalList.iterator();
+    }
+
+    @Override
+    public void forEach(Consumer<? super E> action) {
+        internalList.forEach(action);
+    }
+
+    @Override
+    public Object[] toArray() {
+        return internalList.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return internalList.toArray(a);
+    }
+
+    @Override
+    public boolean add(E e) {
+        throw new UnsupportedOperationException("Immutable set can't add");
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        throw new UnsupportedOperationException("Immutable set can't remove");
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return internalList.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        throw new UnsupportedOperationException("Immutable set can't add");
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Immutable set can't remove");
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        throw new UnsupportedOperationException("Immutable set can't remove");
+    }
+
+    @Override
+    public boolean removeIf(Predicate<? super E> filter) {
+        throw new UnsupportedOperationException("Immutable set can't remove");
+    }
+
+    @Override
+    public void clear() {
+        throw new UnsupportedOperationException("Immutable set can't clear");
+    }
+
+    @Override
+    public Spliterator<E> spliterator() {
+        return internalList.spliterator();
+    }
+
+    @Override
+    public Stream<E> stream() {
+        return internalList.stream();
+    }
+
+    @Override
+    public Stream<E> parallelStream() {
+        return internalList.stream();
+    }
+}


### PR DESCRIPTION
## Overview
On very large maps the checkpointing thread competes with other threads
that try to access the VLO as a result response times can be on the
magnitude of hours.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
