### PR TITLE
LogData has now an id (clientId/ThreadId)

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -35,6 +35,12 @@ message LogEntry {
     optional int64 checkpointedStreamId_least_significant = 14;
     //  Tail of the stream at the time of taking the checkpoint snapshot.
     optional int64 checkpointedStreamStartLogAddress = 15;
+
+    // ClientId is the Corfu runtime id that created this LogEntry
+    optional int64 clientId_least_significant = 16;
+    optional int64 clientId_most_significant = 17;
+    // ThreadId is the thread id that created this LogEntry
+    optional int64 threadId = 18;
 }
 
 message LogHeader {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -541,6 +541,17 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         logData.setGlobalAddress(entry.getGlobalAddress());
         logData.setRank(createDataRank(entry));
 
+        if (entry.hasThreadId()) {
+            logData.setThreadId(entry.getThreadId());
+        }
+        if (entry.hasClientIdLeastSignificant() && entry.hasClientIdMostSignificant()){
+            long lsd = entry.getClientIdLeastSignificant();
+            long msd = entry.getClientIdMostSignificant();
+            logData.setClientId(new UUID(msd, lsd));
+        }
+
+
+
         if (entry.hasCheckpointEntryType()) {
             logData.setCheckpointType(CheckpointEntry.CheckpointEntryType
                     .typeMap.get((byte) entry.getCheckpointEntryType().ordinal()));
@@ -832,6 +843,15 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         if (rank.isPresent()) {
             logEntryBuilder.setRank(rank.get());
         }
+
+        if (entry.getClientId() != null && entry.getThreadId() != null) {
+            logEntryBuilder.setClientIdMostSignificant(
+                    entry.getClientId().getMostSignificantBits());
+            logEntryBuilder.setClientIdLeastSignificant(
+                    entry.getClientId().getLeastSignificantBits());
+            logEntryBuilder.setThreadId(entry.getThreadId());
+        }
+
         if (entry.hasCheckpointMetadata()) {
             logEntryBuilder.setCheckpointEntryType(
                     Types.CheckpointEntryType.forNumber(

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -151,4 +151,9 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
             setBackpointerMap(token.getBackpointerMap());
         }
     }
+
+    default void setId(UUID clientId) {
+        setClientId(clientId);
+        setThreadId(Thread.currentThread().getId());
+    }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -101,6 +101,25 @@ public interface IMetadata {
         getMetadataMap().put(LogUnitMetadataType.GLOBAL_ADDRESS, address);
     }
 
+    default void setClientId(UUID clientId) {getMetadataMap().put(LogUnitMetadataType.CLIENT_ID, clientId); }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    default UUID getClientId() {
+            return (UUID) getMetadataMap().getOrDefault(LogUnitMetadataType.CLIENT_ID,
+                    null);
+    }
+
+    default void setThreadId(Long threadId) {getMetadataMap().put(LogUnitMetadataType.THREAD_ID, threadId); }
+
+    @SuppressWarnings("unchecked")
+    @Nullable
+    default Long getThreadId() {
+        return (Long) getMetadataMap().getOrDefault(LogUnitMetadataType.THREAD_ID,
+                null);
+    }
+
+
     /**
      * Get Log's global address (global tail).
      * @return global address
@@ -184,7 +203,9 @@ public interface IMetadata {
         CHECKPOINT_TYPE(6, TypeToken.of(CheckpointEntry.CheckpointEntryType.class)),
         CHECKPOINT_ID(7, TypeToken.of(UUID.class)),
         CHECKPOINTED_STREAM_ID(8, TypeToken.of(UUID.class)),
-        CHECKPOINTED_STREAM_START_LOG_ADDRESS(9, TypeToken.of(Long.class))
+        CHECKPOINTED_STREAM_START_LOG_ADDRESS(9, TypeToken.of(Long.class)),
+        CLIENT_ID(10, TypeToken.of(UUID.class)),
+        THREAD_ID(11, TypeToken.of(Long.class))
         ;
         final int type;
         @Getter

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -226,6 +226,12 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         }
     }
 
+    /**
+     * LogData are considered equals if clientId and threadId are equal.
+     * Here, it means or both of them are null or both of them are the same.
+     * @param o
+     * @return
+     */
     @Override
     public boolean equals(Object o) {
         if (o == this) {
@@ -233,7 +239,17 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         } else if (!(o instanceof LogData)) {
             return false;
         } else {
-            return compareTo((LogData) o) == 0;
+            LogData other = (LogData) o;
+            if (compareTo(other) == 0) {
+                boolean sameClientId = getClientId() == null ? other.getClientId() == null :
+                        getClientId().equals(other.getClientId());
+                boolean sameThreadId = getThreadId() == null ? other.getThreadId() == null :
+                        getThreadId().equals(other.getThreadId());
+
+                return sameClientId && sameThreadId;
+            }
+
+            return false;
         }
     }
 


### PR DESCRIPTION
## Overview

In order to validate that the entry that was persisted is
indeed the entry that the client wrote, we need to add an
id field for the LogData. The id is a compound id of
CorfuRuntime id and thread id.

Why should this be merged: This is a Consistency/Isolation issue that needs to be addressed.

Related issue(s) (if applicable): #1172 


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
