### PR TITLE
Fixing intermittently failing killAndHealNode

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/HealingDetectorTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/HealingDetectorTest.java
@@ -54,6 +54,7 @@ public class HealingDetectorTest extends AbstractViewTest {
 
         healingDetector = new HealingDetector();
         healingDetector.setDetectionPeriodDuration(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+        healingDetector.setInterIterationInterval(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -94,15 +94,12 @@ public class ManagementViewTest extends AbstractViewTest {
         bootstrapAllServers(l);
         getManagementServer(SERVERS.PORT_0).shutdown();
 
-        CorfuRuntime corfuRuntime = new CorfuRuntime();
-        l.getLayoutServers().forEach(corfuRuntime::addLayoutServer);
-        corfuRuntime.connect();
+        CorfuRuntime corfuRuntime = getRuntime(l).connect();
 
         // Set aggressive timeouts.
         setAggressiveTimeouts(l, corfuRuntime,
-                getManagementServer(SERVERS.PORT_0).getManagementAgent().getCorfuRuntime(),
                 getManagementServer(SERVERS.PORT_1).getManagementAgent().getCorfuRuntime());
-        setAggressiveDetectorTimeouts(SERVERS.PORT_0, SERVERS.PORT_1);
+        setAggressiveDetectorTimeouts(SERVERS.PORT_1);
 
         failureDetected.acquire();
 
@@ -163,9 +160,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .build();
         bootstrapAllServers(l);
 
-        CorfuRuntime corfuRuntime = new CorfuRuntime();
-        l.getLayoutServers().forEach(corfuRuntime::addLayoutServer);
-        corfuRuntime.connect();
+        CorfuRuntime corfuRuntime = getRuntime(l).connect();
 
         // Setting aggressive timeouts
         setAggressiveTimeouts(l, corfuRuntime,
@@ -198,12 +193,14 @@ public class ManagementViewTest extends AbstractViewTest {
                     .getFailureDetector();
             failureDetector.setInitPeriodDuration(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
             failureDetector.setPeriodDelta(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            failureDetector.setMaxPeriodDuration(PARAMETERS.TIMEOUT_SHORT.toMillis());
+            failureDetector.setMaxPeriodDuration(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            failureDetector.setInterIterationInterval(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
 
             HealingDetector healingDetector = (HealingDetector) getManagementServer(port)
                     .getManagementAgent()
                     .getHealingDetector();
             healingDetector.setDetectionPeriodDuration(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            healingDetector.setInterIterationInterval(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         });
     }
 
@@ -783,6 +780,7 @@ public class ManagementViewTest extends AbstractViewTest {
     public void unblockSealedCluster() throws Exception {
         CorfuRuntime corfuRuntime = getDefaultRuntime();
         Layout l = new Layout(corfuRuntime.getLayoutView().getLayout());
+        setAggressiveDetectorTimeouts(SERVERS.PORT_0);
 
         CFUtils.within(
                 CompletableFuture.allOf(


### PR DESCRIPTION
## Overview

Description:
Fixing intermittently failing killAndHealNode IT.
Reducing waiting times on unit tests.

Why should this be merged: 
Fixes intermittent failures.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
