### PR TITLE
Fix stateTransfer and mergeSegment

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
@@ -128,8 +128,8 @@ public class AddNodeWorkflow implements IWorkflow {
     }
 
     /**
-     * Transfer an address segment from a cluster to a set of specified nodes. The epoch shouldn't
-     * change during the segment transfer.
+     * Transfer an address segment from a cluster to a set of specified nodes.
+     * There are no cluster reconfigurations, hence no epoch change side effects.
      *
      * @param endpoints destination nodes
      * @param runtime   The runtime to read the segment from

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
@@ -225,7 +225,8 @@ public class AddNodeWorkflow implements IWorkflow {
                 runtime.invalidateLayout();
                 newLayout = runtime.getLayoutView().getLayout();
             } else {
-                throw new RuntimeException("Node to be added marked unresponsive.");
+                throw new RuntimeException("RestoreRedundancy: "
+                        + "Node to be added marked unresponsive.");
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
@@ -1,30 +1,34 @@
 package org.corfudb.infrastructure.orchestrator.workflows;
 
+import static org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorRequestType.ADD_NODE;
+
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
 import org.corfudb.infrastructure.orchestrator.Action;
 import org.corfudb.infrastructure.orchestrator.IWorkflow;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.orchestrator.AddNodeRequest;
-import org.corfudb.protocols.wireprotocol.orchestrator.Request;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.view.Layout;
-
-import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import javax.annotation.concurrent.NotThreadSafe;
-
-import static org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorRequestType.ADD_NODE;
 
 /**
  * A definition of a workflow that adds a new node to the cluster. This workflow
@@ -64,8 +68,7 @@ public class AddNodeWorkflow implements IWorkflow {
         this.request = request;
         actions = ImmutableList.of(new BootstrapNode(),
                 new AddNodeToLayout(),
-                new StateTransfer(),
-                new MergeSegments());
+                new RestoreRedundancy());
     }
 
     @Override
@@ -121,21 +124,19 @@ public class AddNodeWorkflow implements IWorkflow {
 
             runtime.invalidateLayout();
             newLayout = new Layout(runtime.getLayoutView().getLayout());
-            return;
-
         }
     }
 
     /**
-     * Transfer an address segment from a cluster to a new node. The epoch shouldn't change
-     * during the segment transfer.
+     * Transfer an address segment from a cluster to a set of specified nodes. The epoch shouldn't
+     * change during the segment transfer.
      *
-     * @param endpoint destination node
-     * @param runtime  The runtime to read the segment from
-     * @param segment  segment to transfer
+     * @param endpoints destination nodes
+     * @param runtime   The runtime to read the segment from
+     * @param segment   segment to transfer
      */
-    private void stateTransfer(String endpoint, CorfuRuntime runtime,
-                       Layout.LayoutSegment segment) throws Exception {
+    protected void stateTransfer(Set<String> endpoints, CorfuRuntime runtime,
+                                 Layout.LayoutSegment segment) throws Exception {
 
         long trimMark = runtime.getAddressSpaceView().getTrimMark();
         if (trimMark > segment.getEnd()) {
@@ -162,54 +163,70 @@ public class AddNodeWorkflow implements IWorkflow {
                 entries.add((LogData) dataMap.get(x));
             }
 
-            // Write segment chunk to the new logunit
-            boolean transferSuccess = runtime
-                    .getRouter(endpoint)
-                    .getClient(LogUnitClient.class)
-                    .writeRange(entries).get();
+            for (String endpoint : endpoints) {
+                // Write segment chunk to the new logunit
+                boolean transferSuccess = runtime
+                        .getRouter(endpoint)
+                        .getClient(LogUnitClient.class)
+                        .writeRange(entries).get();
 
-            if (!transferSuccess) {
-                log.error("stateTransfer: Failed to transfer {}-{} to {}", CHUNK_SIZE,
-                        chunkEnd, endpoint);
-                throw new IllegalStateException("Failed to transfer!");
+                if (!transferSuccess) {
+                    log.error("stateTransfer: Failed to transfer {}-{} to {}", CHUNK_SIZE,
+                            chunkEnd, endpoint);
+                    throw new IllegalStateException("Failed to transfer!");
+                }
+
+                log.info("stateTransfer: Transferred address chunk [{}, {}] to {}",
+                        chunkStart, chunkEnd, endpoint);
             }
-
-            log.info("stateTransfer: Transferred address chunk [{}, {}]",
-                    chunkStart, chunkEnd);
         }
     }
 
 
     /**
-     * Copies the split segment to the new node, if it
-     * is the new node also participates as a logging unit.
+     * The new server is caught up with all data.
+     * This server is then added to all the segments to mark it open to all reads and writes.
      */
-    protected class StateTransfer extends Action {
+    protected class RestoreRedundancy extends Action {
+        @Nonnull
         @Override
         public String getName() {
-            return "StateTransfer";
+            return "RestoreRedundancy";
         }
 
         @Override
         public void impl(@Nonnull CorfuRuntime runtime) throws Exception {
-            // Transfer the replicated segment to the new node
-            stateTransfer(request.getEndpoint(), runtime, newLayout.getSegment(0));
-        }
-    }
+            runtime.invalidateLayout();
+            newLayout = runtime.getLayoutView().getLayout();
 
-    /**
-     * Merges the fragmented segment if the AddNodeToLayout action caused any
-     * segments to split
-     */
-    protected class MergeSegments extends Action {
-        @Override
-        public String getName() {
-            return "MergeSegments";
-        }
+            // A newly added node can be marked as unresponsive by the fault detector by the
+            // time this action is executed. There are 2 cases following this:
 
-        @Override
-        public void impl(@Nonnull CorfuRuntime runtime) throws Exception {
-            runtime.getLayoutManagementView().mergeSegments(newLayout);
+            // Case 1. The node remains unresponsive.
+            //      State transfer fails.
+            // Case 2. The node is marked responsive again.
+            //      In this case, the node was removed from all segments and was wiped clean.
+            //      So either the healing workflow or the add node workflow will attempt
+            //      to catchup the new node.
+            if (newLayout.getAllActiveServers().contains(request.endpoint)) {
+                // Transfer only till the second last segment as the last segment is unbounded.
+                // The new server is already a part of the last segment. This is based on an
+                // assumption that the newly added node is not removed from the layout.
+                for (int i = 0; i < newLayout.getSegments().size() - 1; i++) {
+                    stateTransfer(Collections.singleton(request.getEndpoint()),
+                            runtime,
+                            newLayout.getSegments().get(i));
+                }
+
+                final int stripeIndex = 0;
+                runtime.getLayoutManagementView()
+                        .addLogUnitReplica(
+                                new Layout(newLayout), request.getEndpoint(), stripeIndex);
+                runtime.invalidateLayout();
+                newLayout = runtime.getLayoutView().getLayout();
+            } else {
+                throw new RuntimeException("Node to be added marked unresponsive.");
+            }
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
@@ -115,14 +115,8 @@ public class HealNodeWorkflow extends AddNodeWorkflow {
                 // Get the set of servers present in the second segment but not in the first
                 // segment.
                 Set<String> lowRedundancyServers = Sets.difference(
-                        newLayout.getSegments().get(1)
-                                .getStripes().stream()
-                                .flatMap(layoutStripe -> layoutStripe.getLogServers().stream())
-                                .collect(Collectors.toSet()),
-                        newLayout.getSegments().get(0)
-                                .getStripes().stream()
-                                .flatMap(layoutStripe -> layoutStripe.getLogServers().stream())
-                                .collect(Collectors.toSet()));
+                        newLayout.getSegments().get(1).getAllLogServers(),
+                        newLayout.getSegments().get(0).getAllLogServers());
                 // Transfer the replicated segment to the difference set calculated above.
                 stateTransfer(lowRedundancyServers, runtime, newLayout.getSegments().get(0));
                 runtime.getLayoutManagementView().mergeSegments(new Layout(newLayout));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
@@ -2,8 +2,12 @@ package org.corfudb.infrastructure.orchestrator.workflows;
 
 import static org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorRequestType.HEAL_NODE;
 
+import com.google.common.collect.Sets;
+
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
@@ -42,8 +46,7 @@ public class HealNodeWorkflow extends AddNodeWorkflow {
     public List<Action> getActions() {
         return Arrays.asList(new ResetNode(),
                 new HealNodeToLayout(),
-                new StateTransfer(),
-                new MergeSegments());
+                new RestoreRedundancyAndMergeSegments());
     }
 
     /**
@@ -87,6 +90,41 @@ public class HealNodeWorkflow extends AddNodeWorkflow {
             runtime.getLayoutManagementView().healNode(currentLayout, request.getEndpoint());
             runtime.invalidateLayout();
             newLayout = new Layout(runtime.getLayoutView().getLayout());
+        }
+    }
+
+    /**
+     * This action attempts to restore redundancy for all servers across all segments
+     * starting from the oldest segment. It then collapses the segments once the set of
+     * servers in the 2 oldest subsequent segments are equal.
+     */
+    class RestoreRedundancyAndMergeSegments extends Action {
+        @Nonnull
+        @Override
+        public String getName() {
+            return "RestoreRedundancyAndMergeSegments";
+        }
+
+        @Override
+        public void impl(@Nonnull CorfuRuntime runtime) throws Exception {
+            while (newLayout.getSegments().size() > 1) {
+
+                // Catchup all servers.
+                Set<String> lowRedundancyServers = Sets.difference(
+                        newLayout.getSegments().get(1)
+                                .getStripes().stream()
+                                .flatMap(layoutStripe -> layoutStripe.getLogServers().stream())
+                                .collect(Collectors.toSet()),
+                        newLayout.getSegments().get(0)
+                                .getStripes().stream()
+                                .flatMap(layoutStripe -> layoutStripe.getLogServers().stream())
+                                .collect(Collectors.toSet()));
+                // Transfer the replicated segment to any new nodes node
+                stateTransfer(lowRedundancyServers, runtime, newLayout.getSegments().get(0));
+                runtime.getLayoutManagementView().mergeSegments(new Layout(newLayout));
+                runtime.invalidateLayout();
+                newLayout = runtime.getLayoutView().getLayout();
+            }
         }
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -556,6 +556,17 @@ public class Layout {
         public int getNumberOfStripes() {
             return stripes.size();
         }
+
+        /**
+         * Get all servers from all stripes present in this segment.
+         *
+         * @return Set of log unit servers.
+         */
+        public Set<String> getAllLogServers() {
+            return this.getStripes().stream()
+                    .flatMap(layoutStripe -> layoutStripe.getLogServers().stream())
+                    .collect(Collectors.toSet());
+        }
     }
 
     @Data

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -149,8 +149,8 @@ public class Layout {
      * @param endpoint the endpoint to return all the segments for
      * @return a set of segments that contain the endpoint
      */
-    public Set<LayoutSegment> getSegmentsForEndpoint(@Nonnull String endpoint) {
-        Set<LayoutSegment> res = new HashSet<>();
+    public List<LayoutSegment> getSegmentsForEndpoint(@Nonnull String endpoint) {
+        List<LayoutSegment> res = new ArrayList<>();
 
         for (LayoutSegment segment : getSegments()) {
             for (LayoutStripe stripe : segment.getStripes()) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutBuilder.java
@@ -213,6 +213,24 @@ public class LayoutBuilder {
     }
 
     /**
+     * Add a log unit server to a specific stripe in a specific segment.
+     *
+     * @param endpoint     Endpoint to add to the log unit list.
+     * @param segmentIndex Segment to which the log unit is to be added.
+     * @param stripeIndex  Stripe to which the log unit is to be added.
+     * @return this.
+     */
+    public LayoutBuilder addLogunitServerToSegment(String endpoint,
+                                                   int segmentIndex,
+                                                   int stripeIndex) {
+        LayoutStripe stripe = layout.getSegments().get(segmentIndex).getStripes().get(stripeIndex);
+        if (!stripe.getLogServers().contains(endpoint)) {
+            stripe.getLogServers().add(endpoint);
+        }
+        return this;
+    }
+
+    /**
      * Merges the specified segment and the segment before this.
      * No addition or removal of stripes are allowed.
      * Only 1 log unit server addition/removal allowed between segments.

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -222,6 +222,9 @@ public class LayoutManagementView extends AbstractView {
 
     /**
      * Add the log unit to the segment to increase redundancy. This is preceded by state transfer.
+     * Adds the specified log unit to the stripe in all segments, increments the epoch and
+     * proposes the new layout. This method is idempotent - adds the new log unit to each segment
+     * only once.
      *
      * @param currentLayout Current layout.
      * @param endpoint      Endpoint to be added to the segment.

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nonnull;
+
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -21,8 +23,6 @@ import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.RecoveryException;
 import org.corfudb.util.CFUtils;
-
-import javax.annotation.Nonnull;
 
 /**
  * A view of the Layout Manager to manage reconfigurations of the Corfu Cluster.
@@ -65,7 +65,7 @@ public class LayoutManagementView extends AbstractView {
     public void handleFailure(IReconfigurationHandlerPolicy failureHandlerPolicy,
                               Layout currentLayout,
                               Set<String> failedServers)
-            throws QuorumUnreachableException, OutrankedException, LayoutModificationException {
+            throws OutrankedException, LayoutModificationException {
 
         // Generates a new layout by removing the failed nodes from the existing layout
         Layout newLayout = failureHandlerPolicy
@@ -109,11 +109,10 @@ public class LayoutManagementView extends AbstractView {
      * @param isLogUnitServer      is a log unit server
      * @param isUnresponsiveServer is an unresponsive server
      * @param logUnitStripeIndex   stripe index to be added into if its a log unit.
-     * @throws QuorumUnreachableException if seal or consensus cannot be achieved.
-     * @throws OutrankedException         if consensus outranked.
+     * @throws OutrankedException if consensus outranked.
      */
-    public void addNode(Layout currentLayout,
-                        String endpoint,
+    public void addNode(@Nonnull Layout currentLayout,
+                        @Nonnull String endpoint,
                         boolean isLayoutServer,
                         boolean isSequencerServer,
                         boolean isLogUnitServer,
@@ -162,7 +161,7 @@ public class LayoutManagementView extends AbstractView {
      *
      * @param currentLayout Current layout.
      * @param endpoint      New endpoint to be added.
-     * @throws OutrankedException         if consensus outranked.
+     * @throws OutrankedException if consensus outranked.
      */
     public void healNode(Layout currentLayout, String endpoint) throws OutrankedException {
 
@@ -196,12 +195,9 @@ public class LayoutManagementView extends AbstractView {
      * Attempts to merge the last 2 segments.
      *
      * @param currentLayout Current layout
-     * @return True if merge successful, else False.
-     * @throws QuorumUnreachableException if seal or consensus could not be achieved.
-     * @throws OutrankedException         if consensus is outranked.
+     * @throws OutrankedException if consensus is outranked.
      */
-    public boolean mergeSegments(Layout currentLayout)
-            throws QuorumUnreachableException, OutrankedException {
+    public void mergeSegments(Layout currentLayout) throws OutrankedException {
 
         Layout newLayout;
         if (currentLayout.getSegments().size() > 1) {
@@ -213,7 +209,7 @@ public class LayoutManagementView extends AbstractView {
 
             LayoutBuilder layoutBuilder = new LayoutBuilder(currentLayout);
             newLayout = layoutBuilder
-                    .mergePreviousSegment(currentLayout.getSegments().size() - 1)
+                    .mergePreviousSegment(1)
                     .build();
             newLayout.setRuntime(runtime);
             attemptConsensus(newLayout);
@@ -222,14 +218,42 @@ public class LayoutManagementView extends AbstractView {
             newLayout = currentLayout;
         }
         reconfigureSequencerServers(currentLayout, newLayout, false);
-        return true;
+    }
+
+    /**
+     * Add the log unit to the segment to increase redundancy. This is preceded by state transfer.
+     *
+     * @param currentLayout Current layout.
+     * @param endpoint      Endpoint to be added to the segment.
+     * @param stripeIndex   Stripe index.
+     * @throws OutrankedException if consensus is outranked.
+     */
+    public void addLogUnitReplica(@Nonnull Layout currentLayout,
+                                  @Nonnull String endpoint,
+                                  int stripeIndex) throws OutrankedException {
+        boolean isTaskDone = currentLayout.getSegments().stream()
+                .map(layoutSegment -> layoutSegment.getStripes().get(stripeIndex))
+                .allMatch(layoutStripe -> layoutStripe.getLogServers().contains(endpoint));
+
+        if (!isTaskDone) {
+            LayoutBuilder builder = new LayoutBuilder(currentLayout);
+            for (int i = 0; i < currentLayout.getSegments().size(); i++) {
+                builder.addLogunitServerToSegment(endpoint, i, stripeIndex);
+            }
+            Layout newLayout = builder.setEpoch(currentLayout.getEpoch() + 1).build();
+            newLayout.setRuntime(runtime);
+            runLayoutReconfiguration(currentLayout, newLayout, false);
+        } else {
+            log.info("addLogUnitReplica: Ignoring task because {} present in all segments in {}",
+                    endpoint, currentLayout);
+        }
     }
 
     /**
      * Best effort attempt to removes a node from the layout.
      *
      * @param currentLayout the layout to remove the node from
-     * @param endpoint the node to remove
+     * @param endpoint      the node to remove
      */
     public void removeNode(@Nonnull Layout currentLayout,
                            @Nonnull String endpoint) throws OutrankedException {
@@ -295,12 +319,11 @@ public class LayoutManagementView extends AbstractView {
      * @param currentLayout          Layout which needs to be sealed.
      * @param newLayout              New layout to be committed.
      * @param forceSequencerRecovery Flag. True if want to force sequencer recovery.
-     * @throws QuorumUnreachableException if seal or consensus could not be achieved.
-     * @throws OutrankedException         if consensus is outranked.
+     * @throws OutrankedException if consensus is outranked.
      */
     private void runLayoutReconfiguration(Layout currentLayout, Layout newLayout,
                                           final boolean forceSequencerRecovery)
-            throws QuorumUnreachableException, OutrankedException {
+            throws OutrankedException {
 
         // Seals the incremented epoch (Assumes newLayout epoch = currentLayout epoch + 1).
         currentLayout.setRuntime(runtime);
@@ -330,11 +353,10 @@ public class LayoutManagementView extends AbstractView {
      * Attempt consensus.
      *
      * @param layout Layout to propose.
-     * @throws OutrankedException         if consensus is outranked.
-     * @throws QuorumUnreachableException if consensus could not be achieved.
+     * @throws OutrankedException if consensus is outranked.
      */
     private void attemptConsensus(Layout layout)
-            throws OutrankedException, QuorumUnreachableException {
+            throws OutrankedException {
         // Attempts to update all the layout servers with the modified layout.
         try {
             runtime.getLayoutView().updateLayout(layout, prepareRank);

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/AddNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/AddNode.java
@@ -44,8 +44,9 @@ public class AddNode extends WorkflowRequest {
         // Verify that the node has been added and that the address space isn't
         // segmented
         return runtime.getLayoutView().getLayout()
-                .getAllServers().contains(nodeForWorkflow) &&
-                layout.getSegmentsForEndpoint(nodeForWorkflow).size() == 1;
+                .getAllServers().contains(nodeForWorkflow)
+                && layout.getSegmentsForEndpoint(nodeForWorkflow).size()
+                == layout.getSegments().size();
     }
 
     @Override


### PR DESCRIPTION
## Overview

Description:
Addressing the following issues. #1178 
Modifying the add node workflow to replace the state transfer and merge segment Actions with the RestoreRedundancy Action.
This action takes the new endpoint to be added and restores its redundancy across all segments.
This is done by transferring the state of each of these segments to the new node. The end result is that now the new node is added as a part of all these segments. (Side effect: 1 epoch change.)
Note: After an add node, there will be multiple segments. The merging of segments will now only be handled by the Heal node workflow.

Modifying the heal node workflow to replace the state transfer and merge segment Actions with the RestoreRedundancyAndMergeSegments Action.
This action attempts to merge all the existing segments. In order to do so it finds out the incomplete logunit servers (logunits which are not present in all segments), transfers the required state so that all log units have the same data and finally merges the segments 2 at a time starting from the oldest.
(Side effect: To merge n segments, we have n-1 epoch increments.)

Why should this be merged: 

Related issue(s) (if applicable): Fixes #1178  


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
