### PR TITLE
Reset and restart without wrapper script

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -22,9 +22,6 @@ public class BaseServer extends AbstractServer {
 
     final ServerContext serverContext;
 
-    private static final int RESET_ERROR_CODE = 100;
-    private static final int RESTART_ERROR_CODE = 200;
-
     public BaseServer(@Nonnull ServerContext context) {
         this.serverContext = context;
     }
@@ -92,10 +89,10 @@ public class BaseServer extends AbstractServer {
      * @param r     The server router.
      */
     @ServerHandler(type = CorfuMsgType.RESET)
-    private static void doReset(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+    private void doReset(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         log.warn("Remote reset requested from client " + msg.getClientID());
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
-        System.exit(RESET_ERROR_CODE);
+        CorfuServer.restartServer(serverContext, true);
     }
 
     /** Restart the JVM. This mechanism leverages that corfu_server runs in a bash script
@@ -107,9 +104,9 @@ public class BaseServer extends AbstractServer {
      * @param r     The server router.
      */
     @ServerHandler(type = CorfuMsgType.RESTART)
-    private static void doRestart(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+    private void doRestart(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         log.warn("Remote restart requested from client " + msg.getClientID());
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
-        System.exit(RESTART_ERROR_CODE);
+        CorfuServer.restartServer(serverContext, false);
     }
 }

--- a/scripts/corfu_server.sh
+++ b/scripts/corfu_server.sh
@@ -47,25 +47,4 @@ else
       byteman=""
 fi
 
-LOG_PATH=""
-# These are the possible options/flags which can be passed to the CorfuServer. The trailing ":" signifies that the flag
-# accepts a variable (eg. filename or log directory path, etc)
-while getopts "l:ma:nsd:t:c:p:M:eu:f:r:w:bgo:j:k:T:i:H:I:x:z:" opt; do
-  case ${opt} in
-    l ) LOG_PATH=${OPTARG};;
-    ? ) ;;
-  esac
-done
-
-while true; do
-    "$JAVA" -cp "$CLASSPATH" $JVMFLAGS $byteman org.corfudb.infrastructure.CorfuServer $*
-    RETURN_CODE=$?
-
-    if [ $RETURN_CODE -ne 100 ] && [ $RETURN_CODE -ne 200 ]; then
-        break
-    fi
-
-    if [ "$LOG_PATH" != "" ] && [ $RETURN_CODE -eq 100 ]; then
-        rm -r $LOG_PATH/*
-    fi
-done
+"$JAVA" -cp "$CLASSPATH" $JVMFLAGS $byteman org.corfudb.infrastructure.CorfuServer $*


### PR DESCRIPTION
## Overview
Description: Base server now triggers a cleanup and reset asynchronously using a thread in the CorfuServer. This removes the dependency on the wrapper script.

Why should this be merged: Apps do not need to depend on the script.

Related issue(s) (if applicable): #1193 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
