### PR TITLE
Do not validate epoch on client msg reception

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -44,7 +44,6 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.ShutdownException;
-import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.security.sasl.SaslUtils;
@@ -558,7 +557,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      * @param msg The incoming message to validate.
      * @return True, if the clientID is correct, but false otherwise.
      */
-    private boolean validateClientID(CorfuMsg msg) {
+    private boolean validateClientId(CorfuMsg msg) {
         // Check if the message is intended for us. If not, drop the message.
         if (!msg.getClientID().equals(parameters.getClientId())) {
             log.warn("Incoming message intended for client {}, our id is {}, dropping!",
@@ -577,7 +576,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                 // The message was unregistered, we are dropping it.
                 log.warn("Received unregistered message {}, dropping", m);
             } else {
-                if (validateClientID(m)) {
+                if (validateClientId(m)) {
                     // Route the message to the handler.
                     if (log.isTraceEnabled()) {
                         log.trace("Message routed to {}: {}",

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -553,27 +553,16 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
     }
 
     /**
-     * Validate the epoch of a CorfuMsg, and send a WRONG_EPOCH response if
-     * the server is in the wrong epoch. Ignored if the message type is reset (which
-     * is valid in any epoch).
+     * Validate the clientID of a CorfuMsg.
      *
      * @param msg The incoming message to validate.
-     * @param ctx The context of the channel handler.
-     * @return True, if the epoch is correct, but false otherwise.
+     * @return True, if the clientID is correct, but false otherwise.
      */
-    private boolean validateEpoch(CorfuMsg msg, ChannelHandlerContext ctx) {
+    private boolean validateClientID(CorfuMsg msg) {
         // Check if the message is intended for us. If not, drop the message.
         if (!msg.getClientID().equals(parameters.getClientId())) {
             log.warn("Incoming message intended for client {}, our id is {}, dropping!",
-                msg.getClientID(), parameters.getClientId());
-            return false;
-        }
-        // Check if the message is in the right epoch.
-        if (!msg.getMsgType().ignoreEpoch && msg.getEpoch() != epoch) {
-            log.trace("Incoming message with wrong epoch, got {}, expected {}, message was: {}",
-                msg.getEpoch(), epoch, msg);
-            /* If this message was pending a completion, complete it with an error. */
-            completeExceptionally(msg.getRequestID(), new WrongEpochException(msg.getEpoch()));
+                    msg.getClientID(), parameters.getClientId());
             return false;
         }
         return true;
@@ -588,11 +577,11 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                 // The message was unregistered, we are dropping it.
                 log.warn("Received unregistered message {}, dropping", m);
             } else {
-                if (validateEpoch(m, ctx)) {
+                if (validateClientID(m)) {
                     // Route the message to the handler.
                     if (log.isTraceEnabled()) {
                         log.trace("Message routed to {}: {}",
-                            handler.getClass().getSimpleName(), m);
+                                handler.getClass().getSimpleName(), m);
                     }
                     handler.handleMessage(m, ctx);
                 }

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -11,7 +11,6 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.NetworkException;
-import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.util.CFUtils;
 
 import java.time.Duration;
@@ -142,7 +141,7 @@ public class TestClientRouter implements IClientRouter {
     private void handleMessage(Object o) {
         if (o instanceof CorfuMsg) {
             CorfuMsg m = (CorfuMsg) o;
-            if (validateClientID(m)) {
+            if (validateClientId(m)) {
                 IClient handler = handlerMap.get(m.getMsgType());
                 handler.handleMessage(m, null);
             }
@@ -284,7 +283,7 @@ public class TestClientRouter implements IClientRouter {
      * @param msg The incoming message to validate.
      * @return True, if the clientID is correct, but false otherwise.
      */
-    private boolean validateClientID(CorfuMsg msg) {
+    private boolean validateClientId(CorfuMsg msg) {
         // Check if the message is intended for us. If not, drop the message.
         if (!msg.getClientID().equals(clientID)) {
             log.warn("Incoming message intended for client {}, our id is {}, dropping!",


### PR DESCRIPTION
## Overview

Description: A client does not need to validate the epoch of the response message on reception from the server.

### Scenario:
Server epoch: 1
Client epoch: 0
The client sends a write message stamped with epoch 0. The server rejects this and sends back a WrongEpochException message stamped with epoch 1. The client on reception, validates the epoch and rejects this message and throws a WrongEpochException with expected epoch as 0. Whereas,  the expected epoch should be 1.

Why should this be merged: Avoid redundant check.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
