### PR TITLE
Added Integrity Checks

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/DataStoreTest.java
@@ -2,12 +2,20 @@ package org.corfudb.infrastructure;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.util.UUID;
 
 import org.corfudb.AbstractCorfuTest;
+import org.corfudb.infrastructure.log.StreamLogFiles;
+import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.junit.Test;
 
+import javax.xml.crypto.Data;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Created by mdhawan on 7/29/16.
@@ -26,6 +34,30 @@ public class DataStoreTest extends AbstractCorfuTest {
 
         dataStore.put(String.class, "test", "key", "NEW_VALUE");
         assertThat(dataStore.get(String.class, "test", "key")).isEqualTo("NEW_VALUE");
+    }
+
+    @Test
+    public void testDataCorruption() throws IOException {
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+        DataStore dataStore = new DataStore(new ImmutableMap.Builder<String, Object>()
+                .put("--log-path", serviceDir)
+                .build());
+        String value = UUID.randomUUID().toString();
+        dataStore.put(String.class, "test", "key", value);
+
+        String fileName = PARAMETERS.TEST_TEMP_DIR + File.separator + "test_key" + DataStore.EXTENSION;
+        RandomAccessFile file1 = new RandomAccessFile(fileName , "rw");
+
+        file1.seek(value.length() / 2);
+        file1.writeShort(0);
+        file1.close();
+
+        //Simulate a restart of data store
+        final DataStore dataStore2 = new DataStore(new ImmutableMap.Builder<String, Object>()
+                .put("--log-path", serviceDir)
+                .build());
+        assertThatThrownBy(() -> dataStore2.get(String.class, "test", "key"))
+                .isInstanceOf(DataCorruptionException.class);
     }
 
     @Test


### PR DESCRIPTION
## Overview
Added integrity checks on the local data store, now partial writes
are not possible and data corruption is detectable.


Why should this be merged: 
Partially addresses #1187

## Checklist (Definition of Done):
- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [x] Public API has Javadoc
