### PR TITLE
Set Max Write Limit

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -82,6 +82,11 @@ public class CorfuRuntime {
         @Default boolean optimisticUndoDisabled = false;
 
         /**
+         * Max size for a write request.
+         */
+        @Default int maxWriteSize = 0;
+
+        /**
          * Use fast loader to restore objects on connection.
          *
          * <p>If using this utility, you need to be sure that no one

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -31,6 +31,7 @@ import org.corfudb.protocols.wireprotocol.TrimRequest;
 import org.corfudb.protocols.wireprotocol.WriteMode;
 import org.corfudb.protocols.wireprotocol.WriteRequest;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.WriteSizeException;
 import org.corfudb.util.serializer.Serializers;
 
 
@@ -59,6 +60,13 @@ public class LogUnitClient extends AbstractClient {
 
     public LogUnitClient setMetricRegistry(@NonNull MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
+        return this;
+    }
+
+    int maxWrite;
+
+    public LogUnitClient setMaxWrite(int limit) {
+        this.maxWrite = limit;
         return this;
     }
 
@@ -91,6 +99,7 @@ public class LogUnitClient extends AbstractClient {
         wr.setRank(rank);
         wr.setBackpointerMap(backpointerMap);
         wr.setGlobalAddress(address);
+        checkWriteSize(wr.getData());
         CompletableFuture<Boolean> cf = sendMessageWithFuture(CorfuMsgType.WRITE.payloadMsg(wr));
         return cf.thenApply(x -> {
             context.stop();
@@ -106,7 +115,19 @@ public class LogUnitClient extends AbstractClient {
      *     write completes.
      */
     public CompletableFuture<Boolean> write(ILogData payload) {
+        checkWriteSize(payload);
         return sendMessageWithFuture(CorfuMsgType.WRITE.payloadMsg(new WriteRequest(payload)));
+    }
+
+    /**
+     * Verify that max payload is enforced if a limit is confugred
+     *
+     * @param ld the LogData to check
+     */
+    private void checkWriteSize(ILogData ld) {
+        if (maxWrite != 0 && ld.getSizeEstimate() > maxWrite) {
+            throw new WriteSizeException(ld.getSizeEstimate(), maxWrite);
+        }
     }
 
     /**
@@ -128,6 +149,7 @@ public class LogUnitClient extends AbstractClient {
         WriteRequest wr = new WriteRequest(WriteMode.NORMAL, type, null, payload);
         wr.setRank(rank);
         wr.setGlobalAddress(address);
+        checkWriteSize(wr.getData());
         CompletableFuture<Boolean> cf = sendMessageWithFuture(CorfuMsgType.WRITE.payloadMsg(wr));
         return cf.thenApply(x -> {
             context.stop();

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/WriteSizeException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/WriteSizeException.java
@@ -1,0 +1,11 @@
+package org.corfudb.runtime.exceptions;
+
+/**
+ * An exception that is thrown when a write tries to write more than
+ * the max write limit.
+ */
+public class WriteSizeException extends RuntimeException {
+    public WriteSizeException(int size, int max) {
+        super("Trying to write " + size + " bytes but max write limit is " + max + " bytes");
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
@@ -146,7 +146,8 @@ public class RuntimeLayout {
     public LogUnitClient getLogUnitClient(String endpoint) {
         return ((LogUnitClient) getClient(LogUnitClient.class, endpoint))
                 .setMetricRegistry(getRuntime().getMetrics() != null
-                        ? getRuntime().getMetrics() : CorfuRuntime.getDefaultMetrics());
+                        ? getRuntime().getMetrics() : CorfuRuntime.getDefaultMetrics())
+                .setMaxWrite(getRuntime().getParameters().getMaxWriteSize());
     }
 
     public ManagementClient getManagementClient(String endpoint) {


### PR DESCRIPTION
## Overview
Added the ability to enforce a max write limit for the client.

Related Issue: #928

Why should this be merged: 
For some applications clients would like to set a max write limit. This PR will reject writes greater than the limit if its configured. 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
