### PR TITLE
ArithmeticException Fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
@@ -87,7 +87,7 @@ public abstract class WorkflowRequest {
     private void waitForWorkflow(@Nonnull UUID workflow, @Nonnull ManagementClient client,
                                  @Nonnull Duration timeout, @Nonnull Duration pollPeriod)
             throws TimeoutException {
-        long tries = timeout.getSeconds() / pollPeriod.getSeconds();
+        long tries = timeout.toNanos() / pollPeriod.toNanos();
         for (long x = 0; x < tries; x++) {
             if (!client.queryRequest(workflow).isActive()) {
                 return;

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -34,7 +34,7 @@ public class WorkflowIT extends AbstractIT {
     }
 
     final Duration timeout = Duration.ofMinutes(5);
-    final Duration pollPeriod = Duration.ofSeconds(5);
+    final Duration pollPeriod = Duration.ofMillis(50);
     final int workflowNumRetry = 3;
 
     @Test


### PR DESCRIPTION
## Overview
Avoid rounding to zero by using the smallest time unit when
calculating number of times to poll in waitForWorkflow.

Why should this be merged: 
Fixes #1200


## Checklist (Definition of Done):
- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
