### PR TITLE
Remove Redundant Delimiter

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -401,7 +401,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         Types.Metadata metadata = Types.Metadata.parseFrom(metaDataBuf.array());
         final int fileOffset = Integer.BYTES + METADATA_SIZE + metadata.getLength() + 20;
         final int CORRUPT_BYTES = 0xFFFF;
-        file.seek(fileOffset); // File header + delimiter
+        file.seek(fileOffset); // Skip file header
         file.writeInt(CORRUPT_BYTES);
         file.close();
 


### PR DESCRIPTION
## Overview
Removed a redundant delimiter in the log file format.

Why should this be merged: Enhances log file format.

Related issue(s) (if applicable): addresses #978


## Checklist (Definition of Done):
- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
