### PR TITLE
Rename getEpochedClient to getRuntimeLayout

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -247,7 +247,7 @@ public class ManagementAgent {
     private void bootstrapPrimarySequencerServer() {
         try {
             Layout layout = serverContext.getManagementLayout();
-            boolean bootstrapResult = getCorfuRuntime().getLayoutView().getEpochedClient(layout)
+            boolean bootstrapResult = getCorfuRuntime().getLayoutView().getRuntimeLayout(layout)
                     .getPrimarySequencerClient()
                     .bootstrap(0L, Collections.emptyMap(), layout.getEpoch())
                     .get();
@@ -383,7 +383,7 @@ public class ManagementAgent {
                     try {
                         log.info("Attempting to heal nodes in poll report: {}", pollReport);
                         Layout layout = serverContext.getManagementLayout();
-                        corfuRuntime.getLayoutView().getEpochedClient(layout)
+                        corfuRuntime.getLayoutView().getRuntimeLayout(layout)
                                 .getManagementClient(getLocalEndpoint())
                                 .handleHealing(pollReport.getPollEpoch(),
                                         pollReport.getHealingNodes())
@@ -488,7 +488,7 @@ public class ManagementAgent {
                 log.info("Detected changes in node responsiveness: Failed:{}, pollReport:{}",
                         failedNodes, pollReport);
                 Layout layout = serverContext.getManagementLayout();
-                getCorfuRuntime().getLayoutView().getEpochedClient(layout)
+                getCorfuRuntime().getLayoutView().getRuntimeLayout(layout)
                         .getManagementClient(getLocalEndpoint())
                         .handleFailure(pollReport.getPollEpoch(), failedNodes).get();
             }
@@ -518,7 +518,7 @@ public class ManagementAgent {
             for (String layoutServer : layout.getLayoutServers()) {
                 CompletableFuture<Layout> completableFuture = new CompletableFuture<>();
                 try {
-                    completableFuture = getCorfuRuntime().getLayoutView().getEpochedClient(layout)
+                    completableFuture = getCorfuRuntime().getLayoutView().getRuntimeLayout(layout)
                             .getLayoutClient(layoutServer)
                             .getLayout();
                 } catch (Exception e) {
@@ -546,7 +546,7 @@ public class ManagementAgent {
 
             // Re-seal all servers with the latestLayout epoch.
             // This has no effect on up-to-date servers. Only the trailing servers are caught up.
-            getCorfuRuntime().getLayoutView().getEpochedClient(layout).moveServersToEpoch();
+            getCorfuRuntime().getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
 
             // Check if any layout server has a stale layout.
             // If yes patch it (commit) with the latestLayout (received from quorum).
@@ -613,7 +613,7 @@ public class ManagementAgent {
                 // Committing this layout directly to the trailing layout servers.
                 // This is safe because this layout is acquired by a quorum fetch which confirms
                 // that there was a consensus on this layout and has been committed to a quorum.
-                boolean result = getCorfuRuntime().getLayoutView().getEpochedClient(latestLayout)
+                boolean result = getCorfuRuntime().getLayoutView().getRuntimeLayout(latestLayout)
                         .getLayoutClient(layoutServer)
                         .committed(latestLayout.getEpoch(), latestLayout).get();
                 if (result) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
@@ -164,7 +164,7 @@ public class AddNodeWorkflow implements IWorkflow {
 
             for (String endpoint : endpoints) {
                 // Write segment chunk to the new logunit
-                boolean transferSuccess = runtime.getLayoutView().getEpochedClient(newLayout)
+                boolean transferSuccess = runtime.getLayoutView().getRuntimeLayout(newLayout)
                         .getLogUnitClient(endpoint)
                         .writeRange(entries).get();
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
@@ -61,7 +61,7 @@ public class HealNodeWorkflow extends AddNodeWorkflow {
             runtime.invalidateLayout();
             Layout layout = new Layout(runtime.getLayoutView().getLayout());
             if (layout.getUnresponsiveServers().contains(request.getEndpoint())) {
-                runtime.getLayoutView().getEpochedClient(layout)
+                runtime.getLayoutView().getRuntimeLayout(layout)
                         .getLogUnitClient(request.getEndpoint())
                         .resetLogUnit()
                         .get();

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -727,7 +727,7 @@ public class CorfuRuntime {
             Layout currentLayout = CFUtils.getUninterruptibly(layout);
             List<CompletableFuture<VersionInfo>> versions =
                     currentLayout.getLayoutServers()
-                        .stream().map(s -> getLayoutView().getEpochedClient().getBaseClient(s))
+                        .stream().map(s -> getLayoutView().getRuntimeLayout().getBaseClient(s))
                         .map(BaseClient::getVersionInfo)
                         .collect(Collectors.toList());
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -85,10 +85,10 @@ public class LayoutManagementView extends AbstractView {
         // Bootstrap the to-be added node with the old layout.
         Layout layout = new Layout(runtime.getLayoutView().getLayout());
         // Ignoring call result as the call returns ACK or throws an exception.
-        CFUtils.getUninterruptibly(runtime.getLayoutView().getEpochedClient(layout)
+        CFUtils.getUninterruptibly(runtime.getLayoutView().getRuntimeLayout(layout)
                 .getLayoutClient(endpoint)
                 .bootstrapLayout(layout));
-        CFUtils.getUninterruptibly(runtime.getLayoutView().getEpochedClient(layout)
+        CFUtils.getUninterruptibly(runtime.getLayoutView().getRuntimeLayout(layout)
                 .getManagementClient(endpoint)
                 .bootstrapManagement(layout));
 
@@ -332,7 +332,7 @@ public class LayoutManagementView extends AbstractView {
      */
     private void sealEpoch(Layout layout) throws QuorumUnreachableException {
         layout.setEpoch(layout.getEpoch() + 1);
-        runtime.getLayoutView().getEpochedClient(layout).moveServersToEpoch();
+        runtime.getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
     }
 
     /**
@@ -387,7 +387,7 @@ public class LayoutManagementView extends AbstractView {
             for (Layout.LayoutStripe stripe : segment.getStripes()) {
                 maxTokenRequested = Math.max(maxTokenRequested,
                         CFUtils.getUninterruptibly(
-                                runtime.getLayoutView().getEpochedClient(layout)
+                                runtime.getLayoutView().getRuntimeLayout(layout)
                                         .getLogUnitClient(stripe.getLogServers().get(0))
                                         .getTail()));
 
@@ -397,7 +397,7 @@ public class LayoutManagementView extends AbstractView {
             for (Layout.LayoutStripe stripe : segment.getStripes()) {
                 CompletableFuture<Long>[] completableFutures = stripe.getLogServers()
                         .stream()
-                        .map(s -> runtime.getLayoutView().getEpochedClient(layout)
+                        .map(s -> runtime.getLayoutView().getRuntimeLayout(layout)
                                 .getLogUnitClient(s).getTail())
                         .toArray(CompletableFuture[]::new);
                 QuorumFuturesFactory.CompositeFuture<Long> quorumFuture =
@@ -451,7 +451,7 @@ public class LayoutManagementView extends AbstractView {
 
         // Configuring the new sequencer.
         boolean sequencerBootstrapResult = CFUtils.getUninterruptibly(
-                runtime.getLayoutView().getEpochedClient(newLayout)
+                runtime.getLayoutView().getRuntimeLayout(newLayout)
                         .getPrimarySequencerClient()
                         .bootstrap(maxTokenRequested, streamTails, newLayout.getEpoch()));
         if (sequencerBootstrapResult) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -38,11 +38,11 @@ public class LayoutView extends AbstractView {
         return layoutHelper(RuntimeLayout::getLayout);
     }
 
-    public RuntimeLayout getEpochedClient() {
+    public RuntimeLayout getRuntimeLayout() {
         return layoutHelper(l -> l);
     }
 
-    public RuntimeLayout getEpochedClient(@Nonnull Layout layout) {
+    public RuntimeLayout getRuntimeLayout(@Nonnull Layout layout) {
         return new RuntimeLayout(layout, runtime);
     }
 
@@ -121,7 +121,7 @@ public class LayoutView extends AbstractView {
                     CompletableFuture<LayoutPrepareResponse> cf = new CompletableFuture<>();
                     try {
                         // Connection to router can cause network exception too.
-                        cf = getEpochedClient().getLayoutClient(x).prepare(epoch, rank);
+                        cf = getRuntimeLayout().getLayoutClient(x).prepare(epoch, rank);
                     } catch (Exception e) {
                         cf.completeExceptionally(e);
                     }
@@ -210,7 +210,7 @@ public class LayoutView extends AbstractView {
                     CompletableFuture<Boolean> cf = new CompletableFuture<>();
                     try {
                         // Connection to router can cause network exception too.
-                        cf = getEpochedClient().getLayoutClient(x).propose(epoch, rank, layout);
+                        cf = getRuntimeLayout().getLayoutClient(x).propose(epoch, rank, layout);
                     } catch (NetworkException e) {
                         cf.completeExceptionally(e);
                     }
@@ -294,9 +294,9 @@ public class LayoutView extends AbstractView {
                     try {
                         // Connection to router can cause network exception too.
                         if (force) {
-                            cf = getEpochedClient(layout).getLayoutClient(x).force(layout);
+                            cf = getRuntimeLayout(layout).getLayoutClient(x).force(layout);
                         } else {
-                            cf = getEpochedClient(layout).getLayoutClient(x).committed(epoch, layout);
+                            cf = getRuntimeLayout(layout).getLayoutClient(x).committed(epoch, layout);
                         }
                     } catch (NetworkException e) {
                         cf.completeExceptionally(e);

--- a/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
@@ -43,6 +43,6 @@ public class SequencerView extends AbstractView {
     }
 
     public void trimCache(long address) {
-        runtime.getLayoutView().getEpochedClient().getPrimarySequencerClient().trimCache(address);
+        runtime.getLayoutView().getRuntimeLayout().getPrimarySequencerClient().trimCache(address);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
@@ -63,7 +63,7 @@ public abstract class WorkflowRequest {
             throw new WorkflowException("getOrchestrator: no available orchestrators " + layout);
         }
 
-        return runtime.getLayoutView().getEpochedClient(layout)
+        return runtime.getLayoutView().getRuntimeLayout(layout)
                 .getManagementClient(activeLayoutServers.get(0));
     }
 

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -141,7 +141,7 @@ public class AbstractIT extends AbstractCorfuTest {
 
     public void restartServer(CorfuRuntime corfuRuntime, String endpoint) {
         corfuRuntime.invalidateLayout();
-        RuntimeLayout runtimeLayout = corfuRuntime.getLayoutView().getEpochedClient();
+        RuntimeLayout runtimeLayout = corfuRuntime.getLayoutView().getRuntimeLayout();
         try {
             runtimeLayout.getBaseClient(endpoint).restart().get();
         } catch (ExecutionException | InterruptedException e) {

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -230,7 +230,7 @@ public class ClusterReconfigIT extends AbstractIT {
      */
     private Map<Long, LogData> getAllData(CorfuRuntime corfuRuntime,
                                           String endpoint, long end) throws Exception {
-        ReadResponse readResponse = corfuRuntime.getLayoutView().getEpochedClient()
+        ReadResponse readResponse = corfuRuntime.getLayoutView().getRuntimeLayout()
                 .getLogUnitClient(endpoint)
                 .read(Range.closed(0L, end)).get();
         return readResponse.getAddresses();
@@ -246,7 +246,7 @@ public class ClusterReconfigIT extends AbstractIT {
     private Layout incrementClusterEpoch(CorfuRuntime corfuRuntime) throws Exception {
         Layout l = new Layout(corfuRuntime.getLayoutView().getLayout());
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getEpochedClient(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
         corfuRuntime.getLayoutView().updateLayout(l, 1L);
         corfuRuntime.invalidateLayout();
         assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(1L);
@@ -269,7 +269,7 @@ public class ClusterReconfigIT extends AbstractIT {
 
         CorfuRuntime corfuRuntime = createDefaultRuntime();
         incrementClusterEpoch(corfuRuntime);
-        corfuRuntime.getLayoutView().getEpochedClient().getBaseClient("localhost:9000")
+        corfuRuntime.getLayoutView().getRuntimeLayout().getBaseClient("localhost:9000")
                 .reset().get();
 
         corfuRuntime = createDefaultRuntime();
@@ -304,7 +304,7 @@ public class ClusterReconfigIT extends AbstractIT {
 
         CorfuRuntime corfuRuntime = createDefaultRuntime();
         Layout l = incrementClusterEpoch(corfuRuntime);
-        corfuRuntime.getLayoutView().getEpochedClient(l).getBaseClient("localhost:9000")
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).getBaseClient("localhost:9000")
                 .restart().get();
 
         restartServer(corfuRuntime, DEFAULT_ENDPOINT);

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -44,14 +44,14 @@ public class SealIT extends AbstractIT{
         /* 1 */
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
         /* 2 */
-        cr1.getLayoutView().getEpochedClient(currentLayout).moveServersToEpoch();
+        cr1.getLayoutView().getRuntimeLayout(currentLayout).moveServersToEpoch();
         /* 3 */
         cr1.getLayoutView().updateLayout(currentLayout, 0);
 
         cr1.invalidateLayout();
         cr1.getLayoutView().getLayout();
 
-        cr1.getLayoutView().getEpochedClient()
+        cr1.getLayoutView().getRuntimeLayout()
                 .getSequencerClient(corfuSingleNodeHost + ":" + corfuSingleNodePort)
                 .bootstrap(1L, Collections.emptyMap(), currentLayout.getEpoch())
                 .get();

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -576,7 +576,7 @@ public class ServerRestartIT extends AbstractIT {
             }
 
             SequencerClient sequencerClient = corfuRuntime
-                    .getLayoutView().getEpochedClient()
+                    .getLayoutView().getRuntimeLayout()
                     .getSequencerClient(corfuSingleNodeHost + ":" + corfuSingleNodePort);
 
             TokenResponse expectedTokenResponseA = sequencerClient
@@ -600,7 +600,7 @@ public class ServerRestartIT extends AbstractIT {
             corfuRuntime = createDefaultRuntime();
 
             sequencerClient = corfuRuntime
-                    .getLayoutView().getEpochedClient()
+                    .getLayoutView().getRuntimeLayout()
                     .getSequencerClient(corfuSingleNodeHost + ":" + corfuSingleNodePort);
 
             // check tail recovery after restart

--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -181,9 +181,9 @@ public class FastObjectLoaderTest extends AbstractViewTest {
     public void canReadHoles() throws Exception {
         populateMaps(1, getDefaultRuntime(), CorfuTable.class, true,2);
 
-        LogUnitClient luc = getDefaultRuntime().getLayoutView().getEpochedClient()
+        LogUnitClient luc = getDefaultRuntime().getLayoutView().getRuntimeLayout()
                 .getLogUnitClient(getDefaultConfigurationString());
-        SequencerClient seq = getDefaultRuntime().getLayoutView().getEpochedClient()
+        SequencerClient seq = getDefaultRuntime().getLayoutView().getRuntimeLayout()
                 .getSequencerClient(getDefaultConfigurationString());
 
         seq.nextToken(null, 1);
@@ -400,9 +400,9 @@ public class FastObjectLoaderTest extends AbstractViewTest {
     public void canReadRankOnlyEntries() throws Exception {
         populateMaps(1, getDefaultRuntime(), CorfuTable.class, true, 2);
 
-        LogUnitClient luc = getDefaultRuntime().getLayoutView().getEpochedClient()
+        LogUnitClient luc = getDefaultRuntime().getLayoutView().getRuntimeLayout()
                 .getLogUnitClient(getDefaultConfigurationString());
-        SequencerClient seq = getDefaultRuntime().getLayoutView().getEpochedClient()
+        SequencerClient seq = getDefaultRuntime().getLayoutView().getRuntimeLayout()
                 .getSequencerClient(getDefaultConfigurationString());
 
         long address = seq.nextToken(Collections.emptySet(),1).get().getTokenValue();

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -55,7 +55,7 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         });
 
         scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LARGE, (v) -> {
-            assertThat(rt.getLayoutView().getEpochedClient().getRuntime()).isEqualTo(rt);
+            assertThat(rt.getLayoutView().getRuntimeLayout().getRuntime()).isEqualTo(rt);
         });
 
         executeScheduled(PARAMETERS.CONCURRENCY_TWO, PARAMETERS.TIMEOUT_LONG);
@@ -129,7 +129,7 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         // Seal
         Layout currentLayout = new Layout(rt.getLayoutView().getCurrentLayout());
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
-        rt.getLayoutView().getEpochedClient(currentLayout).moveServersToEpoch();
+        rt.getLayoutView().getRuntimeLayout(currentLayout).moveServersToEpoch();
 
         // Server2 is sealed but will not be able to commit the layout.
         addClientRule(rt, SERVERS.ENDPOINT_2,
@@ -183,14 +183,14 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         sv.append("testPayload".getBytes());
 
         l.setEpoch(l.getEpoch() + 1);
-        runtime.getLayoutView().getEpochedClient(l).moveServersToEpoch();
+        runtime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
 
         // We need to be sure that the layout is invalidated before proceeding
         // This is what would trigger the wrong epoch exception in the consequent read.
         runtime.invalidateLayout();
 
         LogUnitClient luc = runtime
-                .getLayoutView().getEpochedClient().getLogUnitClient(SERVERS.ENDPOINT_0);
+                .getLayoutView().getRuntimeLayout().getLogUnitClient(SERVERS.ENDPOINT_0);
 
         assertThatThrownBy(() -> luc.read(0).get())
                 .isInstanceOf(ExecutionException.class)

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
@@ -79,7 +79,7 @@ public class StreamTest extends AbstractTransactionsTest {
         final long trimMark = getRuntime().getParameters().getWriteRetry() - 1;
         final String key = "key";
         final String val = "val";
-        LogUnitClient lu = getRuntime().getLayoutView().getEpochedClient()
+        LogUnitClient lu = getRuntime().getLayoutView().getRuntimeLayout()
                 .getLogUnitClient(getDefaultConfigurationString());
         lu.prefixTrim(trimMark).get();
         TXBegin();

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutSealTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutSealTest.java
@@ -27,7 +27,7 @@ public class LayoutSealTest extends AbstractViewTest {
      * @param replicationMode Replication view to set all segments in the layout with.
      * @return  Built layout with a connected runtime.
      */
-    public RuntimeLayout getEpochedClient(Layout.ReplicationMode replicationMode) {
+    public RuntimeLayout getRuntimeLayout(Layout.ReplicationMode replicationMode) {
         addServer(SERVERS.PORT_0);
         addServer(SERVERS.PORT_1);
         addServer(SERVERS.PORT_2);
@@ -55,7 +55,7 @@ public class LayoutSealTest extends AbstractViewTest {
                 .build();
         bootstrapAllServers(l);
         CorfuRuntime corfuRuntime = getRuntime(l).connect();
-        RuntimeLayout runtimeLayout = corfuRuntime.getLayoutView().getEpochedClient(l);
+        RuntimeLayout runtimeLayout = corfuRuntime.getLayoutView().getRuntimeLayout(l);
         setAggressiveTimeouts(runtimeLayout);
 
         getManagementServer(SERVERS.PORT_0).shutdown();
@@ -121,7 +121,7 @@ public class LayoutSealTest extends AbstractViewTest {
      */
     @Test
     public void successfulChainSeal() {
-        RuntimeLayout runtimeLayout = getEpochedClient(Layout.ReplicationMode.CHAIN_REPLICATION);
+        RuntimeLayout runtimeLayout = getRuntimeLayout(Layout.ReplicationMode.CHAIN_REPLICATION);
         Layout l = runtimeLayout.getLayout();
         l.setEpoch(l.getEpoch() + 1);
         try {
@@ -143,7 +143,7 @@ public class LayoutSealTest extends AbstractViewTest {
      */
     @Test
     public void failingChainSeal() {
-        RuntimeLayout runtimeLayout = getEpochedClient(Layout.ReplicationMode.CHAIN_REPLICATION);
+        RuntimeLayout runtimeLayout = getRuntimeLayout(Layout.ReplicationMode.CHAIN_REPLICATION);
         Layout l = runtimeLayout.getLayout();
 
         addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_1, new TestRule().drop().always());
@@ -164,7 +164,7 @@ public class LayoutSealTest extends AbstractViewTest {
      */
     @Test
     public void successfulQuorumSeal() {
-        RuntimeLayout runtimeLayout = getEpochedClient(Layout.ReplicationMode.QUORUM_REPLICATION);
+        RuntimeLayout runtimeLayout = getRuntimeLayout(Layout.ReplicationMode.QUORUM_REPLICATION);
         Layout l = runtimeLayout.getLayout();
         l.setEpoch(l.getEpoch() + 1);
         try {
@@ -186,7 +186,7 @@ public class LayoutSealTest extends AbstractViewTest {
      */
     @Test
     public void failingQuorumSeal() {
-        RuntimeLayout runtimeLayout = getEpochedClient(Layout.ReplicationMode.QUORUM_REPLICATION);
+        RuntimeLayout runtimeLayout = getRuntimeLayout(Layout.ReplicationMode.QUORUM_REPLICATION);
         Layout l = runtimeLayout.getLayout();
 
         addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_3,

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -69,7 +69,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .addToLayout()
                 .setClusterId(r.clusterId)
                 .build();
-        r.getLayoutView().getEpochedClient(l).moveServersToEpoch();
+        r.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
         r.getLayoutView().updateLayout(l, 1L);
         r.invalidateLayout();
         assertThat(r.getLayoutView().getLayout().epoch)
@@ -94,7 +94,7 @@ public class LayoutViewTest extends AbstractViewTest {
             .addToLayout()
             .setClusterId(UUID.nameUUIDFromBytes("wrong cluster".getBytes()))
             .build();
-        r.getLayoutView().getEpochedClient(l).moveServersToEpoch();
+        r.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
         r.invalidateLayout();
         assertThatThrownBy(() -> r.getLayoutView().updateLayout(l, 1L))
             .isInstanceOf(WrongClusterException.class);
@@ -203,11 +203,11 @@ public class LayoutViewTest extends AbstractViewTest {
                         .build();
                 //TODO need to figure out if we can move to
                 //update layout
-                corfuRuntime.getLayoutView().getEpochedClient(newLayout).moveServersToEpoch();
+                corfuRuntime.getLayoutView().getRuntimeLayout(newLayout).moveServersToEpoch();
 
                 corfuRuntime.getLayoutView().updateLayout(newLayout, newLayout.getEpoch());
                 corfuRuntime.invalidateLayout();
-                corfuRuntime.getLayoutView().getEpochedClient()
+                corfuRuntime.getLayoutView().getRuntimeLayout()
                         .getSequencerClient(SERVERS.ENDPOINT_0)
                         .bootstrap(0L, Collections.emptyMap(), newLayout.getEpoch()).get();
                 log.debug("layout updated new layout {}", corfuRuntime.getLayoutView().getLayout());
@@ -280,7 +280,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .build();
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getEpochedClient(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
         corfuRuntime.getLayoutView().updateLayout(newLayout, 1L);
 
         assertThat(getLayoutServer(SERVERS.PORT_0).getCurrentLayout()).isEqualTo(newLayout);
@@ -343,7 +343,7 @@ public class LayoutViewTest extends AbstractViewTest {
         // Keep old layout untouched for assertion
         Layout oldLayout = new Layout(l);
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getEpochedClient(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
 
         // We receive responses from PORT_0 and PORT_2
         corfuRuntime.getLayoutView().updateLayout(newLayout, 1L);
@@ -464,7 +464,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .build();
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getEpochedClient(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
 
         // STEP 1
         final long rank1 = 1L;
@@ -588,7 +588,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .build();
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime1.getLayoutView().getEpochedClient(l).moveServersToEpoch();
+        corfuRuntime1.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
 
         Semaphore proposeLock = new Semaphore(0);
         ExecutorService executorService = Executors.newSingleThreadExecutor();

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -714,7 +714,7 @@ public class ManagementViewTest extends AbstractViewTest {
                             // There is a failure but the BOOTSTRAP_SEQUENCER message has not yet been
                             // sent. So if we request a token now, we should be denied as the
                             // server is sealed and we get a WrongEpochException.
-                            corfuRuntime.getLayoutView().getEpochedClient(layout)
+                            corfuRuntime.getLayoutView().getRuntimeLayout(layout)
                                     .getSequencerClient(SERVERS.ENDPOINT_1)
                                     .nextToken(Collections.singleton(CorfuRuntime
                                             .getStreamID("testStream")), 1).get();
@@ -744,7 +744,7 @@ public class ManagementViewTest extends AbstractViewTest {
         // Seal
         Layout newLayout = new Layout(l);
         newLayout.setEpoch(newLayout.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getEpochedClient(newLayout).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(newLayout).moveServersToEpoch();
         assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(l.getEpoch());
     }
 
@@ -755,7 +755,7 @@ public class ManagementViewTest extends AbstractViewTest {
 
         addClientRule(corfuRuntime, SERVERS.ENDPOINT_0, new TestRule().always().drop());
         layout.setEpoch(2L);
-        corfuRuntime.getLayoutView().getEpochedClient(layout).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
         corfuRuntime.getLayoutView().updateLayout(layout, 1L);
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
@@ -789,7 +789,7 @@ public class ManagementViewTest extends AbstractViewTest {
         ).join();
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getEpochedClient(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
             Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
@@ -933,7 +933,7 @@ public class ManagementViewTest extends AbstractViewTest {
 
     private Map<Long, LogData> getAllNonEmptyData(CorfuRuntime corfuRuntime,
                                                   String endpoint, long end) throws Exception {
-        ReadResponse readResponse = corfuRuntime.getLayoutView().getEpochedClient()
+        ReadResponse readResponse = corfuRuntime.getLayoutView().getRuntimeLayout()
                 .getLogUnitClient(endpoint)
                 .read(Range.closed(0L, end)).get();
         return readResponse.getAddresses().entrySet()

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
@@ -22,7 +22,7 @@ public class QuorumReplicationStreamViewTest extends StreamViewTest {
         r.setCacheDisabled(true);
         r.getLayoutView().committed(1L, newLayout);
         r.invalidateLayout();
-        r.getLayoutView().getEpochedClient(newLayout).getPrimarySequencerClient()
+        r.getLayoutView().getRuntimeLayout(newLayout).getPrimarySequencerClient()
                 .bootstrap(0L, Collections.emptyMap(), 1L).get();
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocolTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocolTest.java
@@ -49,7 +49,7 @@ public abstract class AbstractReplicationProtocolTest extends AbstractViewTest {
         //begin tests
         final CorfuRuntime r = getDefaultRuntime();
         final IReplicationProtocol rp = getProtocol();
-        final RuntimeLayout runtimeLayout = r.getLayoutView().getEpochedClient();
+        final RuntimeLayout runtimeLayout = r.getLayoutView().getRuntimeLayout();
 
         LogData data = getLogData(0, "hello world".getBytes());
         rp.write(runtimeLayout, data);
@@ -75,7 +75,7 @@ public abstract class AbstractReplicationProtocolTest extends AbstractViewTest {
         //begin tests
         final CorfuRuntime r = getDefaultRuntime();
         final IReplicationProtocol rp = getProtocol();
-        final RuntimeLayout runtimeLayout = r.getLayoutView().getEpochedClient();
+        final RuntimeLayout runtimeLayout = r.getLayoutView().getRuntimeLayout();
 
         ILogData read = rp.read(runtimeLayout, 0);
 
@@ -101,7 +101,7 @@ public abstract class AbstractReplicationProtocolTest extends AbstractViewTest {
         //begin tests
         final CorfuRuntime r = getDefaultRuntime();
         final IReplicationProtocol rp = getProtocol();
-        final RuntimeLayout runtimeLayout = r.getLayoutView().getEpochedClient();
+        final RuntimeLayout runtimeLayout = r.getLayoutView().getRuntimeLayout();
 
         LogData d1 = getLogData(0, "1".getBytes());
         LogData d2 = getLogData(0, "2".getBytes());

--- a/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
@@ -59,7 +59,7 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
         //begin tests
         final CorfuRuntime r = getDefaultRuntime();
         final IReplicationProtocol rp = getProtocol();
-        final RuntimeLayout runtimeLayout = r.getLayoutView().getEpochedClient();
+        final RuntimeLayout runtimeLayout = r.getLayoutView().getRuntimeLayout();
 
         LogData failedWrite = getLogData(0, "failed".getBytes());
         LogData incompleteWrite = getLogData(0, "incomplete".getBytes());
@@ -91,7 +91,7 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
         //begin tests
         final CorfuRuntime r = getDefaultRuntime();
         final IReplicationProtocol rp = getProtocol();
-        final RuntimeLayout runtimeLayout = r.getLayoutView().getEpochedClient();
+        final RuntimeLayout runtimeLayout = r.getLayoutView().getRuntimeLayout();
 
         LogData incompleteWrite = getLogData(0, "incomplete".getBytes());
 
@@ -112,7 +112,7 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
         layout.setEpoch(layout.getEpoch() + 1);
         layout.getLayoutServers().add(endpoint);
         layout.getSegment(0L).getStripes().get(0).getLogServers().remove(endpoint);
-        corfuRuntime.getLayoutView().getEpochedClient(layout).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
         corfuRuntime.getLayoutView().updateLayout(layout, 1L);
     }
 
@@ -130,7 +130,7 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
         setupNodes();
         final CorfuRuntime r = getDefaultRuntime();
         Layout layout = new Layout(r.getLayoutView().getLayout());
-        RuntimeLayout runtimeLayout = r.getLayoutView().getEpochedClient();
+        RuntimeLayout runtimeLayout = r.getLayoutView().getRuntimeLayout();
         final IReplicationProtocol rp = getProtocol();
 
         LogData incompleteWrite = getLogData(0, "incomplete".getBytes());
@@ -140,11 +140,11 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
         removeLogunit(layout, SERVERS.ENDPOINT_2);
         r.invalidateLayout();
         r.getLayoutView().getLayout();
-        runtimeLayout = r.getLayoutView().getEpochedClient();
+        runtimeLayout = r.getLayoutView().getRuntimeLayout();
 
         try {
             // Trigger hole fill.
-            rp.read(r.getLayoutView().getEpochedClient(layout), 0L);
+            rp.read(r.getLayoutView().getRuntimeLayout(layout), 0L);
             fail("No wrong epoch on write.");
         } catch (WrongEpochException we) {
             assertThat(we.getCorrectEpoch()).isEqualTo(1L);


### PR DESCRIPTION
## Overview

Description: Renames the getEpochedClient to getRuntimeLayout

Why should this be merged: The method fetches the RuntimeLayout. Hence should be named accordingly.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
