### PR TITLE
Fix object creation performance regression #1192

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -3,6 +3,8 @@ package org.corfudb.runtime.view;
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
@@ -59,6 +61,11 @@ public abstract class AbstractView {
         return layoutHelper(function, false);
     }
 
+    /**
+     * Maintains reference of the RuntimeLayout which gets invalidated if the AbstractView
+     * encounters a newer layout. (with a greater epoch)
+     */
+    private AtomicReference<RuntimeLayout> runtimeLayout = new AtomicReference<>();
 
     /**
      * Helper function for view to retrieve layouts.
@@ -86,7 +93,13 @@ public abstract class AbstractView {
         final Duration retryRate = runtime.getParameters().getConnectionRetryRate();
         while (true) {
             try {
-                return function.apply(new RuntimeLayout(runtime.layout.get(), runtime));
+                final Layout layout = runtime.layout.get();
+                return function.apply(runtimeLayout.updateAndGet(rLayout -> {
+                    if (rLayout == null || rLayout.getLayout().getEpoch() != layout.getEpoch()) {
+                        return new RuntimeLayout(layout, runtime);
+                    }
+                    return rLayout;
+                }));
             } catch (RuntimeException re) {
                 if (re.getCause() instanceof TimeoutException) {
                     log.warn("Timeout executing remote call, invalidating view and retrying in {}s",

--- a/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
@@ -44,12 +44,11 @@ public class RuntimeLayout {
     private final CorfuRuntime runtime;
 
     /**
-     * Defensive constructor since we can create a Layout from a JSON file.
-     * JSON deserialize is forced through this constructor.
+     * Constructor taking a reference of the layout to stamp the clients.
      */
     public RuntimeLayout(@Nonnull Layout layout, @Nonnull CorfuRuntime corfuRuntime) {
 
-        this.layout = new Layout(layout);
+        this.layout = layout;
         this.runtime = corfuRuntime;
     }
 


### PR DESCRIPTION
## Overview

Description:
Fixing performance. Instead of creating deep copies of the layout, reusing the layout reference in the RuntimeLayout constructor.
In the AbstractView, we now keep an atomic reference of the RuntimeLayout used and create new only if there is an epoch change. 

Why should this be merged: Fixes performance drop introduced by #1192 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
