### PR TITLE
Layout migration

### DIFF
--- a/migration/src/main/java/org/corfudb/migration/LogFormat1to2.java
+++ b/migration/src/main/java/org/corfudb/migration/LogFormat1to2.java
@@ -23,7 +23,7 @@ import static com.google.common.collect.Sets.newHashSet;
 
 /**
  * This migration tool will migrate the local data store files and the log segment files
- * fro, version 1 to 2. This migration will include remove an extra delimiter (i.e. redundant magic byte)
+ * from version 1 to 2. This migration will include remove an extra delimiter (i.e. redundant magic byte)
  * and add a new field to the metadata type. As a result, checksums will be recomputed.
  *
  * To run this tool, execute the following steps:
@@ -46,15 +46,36 @@ public class LogFormat1to2 {
             .build()
             .getSerializedSize();
 
+    /**
+     * Data-store files responsible for layout recovery.
+     */
+    private static final Set<String> layoutStateRecoveryFiles = newHashSet("LAYOUT_CURRENT",
+            "MANAGEMENT_LAYOUT");
+
+    /**
+     * Migrates the log segments and data store files.
+     *
+     * @param args Accepts the arguments in the following order,
+     *             dir:         CorfuDB data directory,
+     *             oldEndpoint: Old address the server was binding to,
+     *             newEndpoint: New address to which the server will bind to.
+     * @throws Exception if migration fails.
+     */
     public static void main(String[] args) throws Exception {
-        if (args.length < 1) {
-            throw new IllegalArgumentException("CorfuDB data directory not specified!");
+        if (args.length < 3) {
+            throw new IllegalArgumentException("Expected parameters: CorfuDB data directory,"
+                    + "old endpoint and new endpoint");
         }
 
         String corfuDir = args[0];
+        String oldEndpoint = args[1];
+        String newEndpoint = args[2];
 
-        // migrate log segments and localdata store files
+        // migrate log segments
         migrateLUData(corfuDir);
+        // Transform the layout state local datastore files.
+        modifyBindingIpAddress(corfuDir, oldEndpoint, newEndpoint);
+        // migrate data-store files.
         migrateLocalDatastore(corfuDir);
     }
 
@@ -98,6 +119,26 @@ public class LogFormat1to2 {
         Files.write(destPath, buffer.array(), StandardOpenOption.CREATE,
                 StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
         Files.delete(srcPath);
+    }
+
+
+    public static void modifyBindingIpAddress(String dirStr,
+                                              String oldEndpoint,
+                                              String newEndpoint) throws IOException {
+        File dir = new File(dirStr);
+        File[] layoutStateFiles = dir.listFiles(
+                (dir1, name) -> layoutStateRecoveryFiles.stream().anyMatch(name::endsWith));
+
+        for (File file : layoutStateFiles) {
+            Path path = Paths.get(file.getAbsolutePath());
+            byte[] bytes = Files.readAllBytes(path);
+            String data = new String(bytes);
+            bytes = data.replace(oldEndpoint, newEndpoint).getBytes();
+            ByteBuffer buffer = ByteBuffer.allocate(bytes.length);
+            buffer.put(bytes);
+            Files.write(path, buffer.array(), StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
+        }
     }
 
     public static void migrateLUData(String dir) throws IOException {


### PR DESCRIPTION
## Overview

Description: Introduction of network interface binding by #1209 allows the user to bind to a specific IP address. To support migration from version 0.1.1, we should transform the layout configuration files (LAYOUT_CURRENT and MANAGEMENT_LAYOUT) so that they replace the old ip:port with the new binding ip:port.

Why should this be merged: To allow the user to migrate from 0.1.1 to the latest build.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
