### PR TITLE
Batch sequencer view implementation

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -407,13 +407,11 @@ public class SequencerServer extends AbstractServer {
                     });
                 }
 
-                info.getWriteConflictParams().entrySet()
-                    .stream()
-                    .forEach(txEntry ->
-                        txEntry.getValue().stream().forEach(conflictParam ->
+                info.getWriteConflictParams()
+                    .forEach((id, params) ->
+                        params.forEach(conflictParam ->
                             conflictToGlobalTailCache.put(
-                                getConflictHashCode(txEntry
-                                    .getKey(), conflictParam),
+                                getConflictHashCode(id, conflictParam),
                                 currentTail)));
                 conditionalTokens.add(new BackpointerToken(currentTail, backPointerMap.build()));
             }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/BatchTokenRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/BatchTokenRequest.java
@@ -1,0 +1,33 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class BatchTokenRequest implements ICorfuPayload<BatchTokenRequest> {
+
+    @Getter
+    final UUID[] readStreams;
+
+    @Getter
+    final List<UUID[]> unconditionalTokenRequests;
+
+    @Getter
+    final List<TxResolutionInfo> conditionalTokenRequests;
+
+    public BatchTokenRequest(ByteBuf buf) {
+        readStreams = ICorfuPayload.arrayFromBuffer(buf, UUID.class);
+        unconditionalTokenRequests = ICorfuPayload.listFromBuffer(buf, UUID[].class);
+        conditionalTokenRequests = ICorfuPayload.listFromBuffer(buf, TxResolutionInfo.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, readStreams);
+        ICorfuPayload.serialize(buf, unconditionalTokenRequests);
+        ICorfuPayload.serialize(buf, conditionalTokenRequests);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/BatchTokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/BatchTokenResponse.java
@@ -1,0 +1,64 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class BatchTokenResponse implements ICorfuPayload<BatchTokenResponse> {
+
+    @Getter
+    final Map<UUID, Long> addressMap;
+
+    @Getter
+    final long globalTail;
+
+    @Getter
+    final long epoch;
+
+    @RequiredArgsConstructor
+    public static class BackpointerToken implements ICorfuPayload<BackpointerToken> {
+        @Getter
+        public final long token;
+
+        @Getter
+        public final Map<UUID, Long> backpointerMap;
+
+        public BackpointerToken (ByteBuf buf) {
+            token = ICorfuPayload.fromBuffer(buf, long.class);
+            backpointerMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, long.class);
+        }
+
+        @Override
+        public void doSerialize(ByteBuf buf) {
+            ICorfuPayload.serialize(buf, token);
+            ICorfuPayload.serialize(buf, backpointerMap);
+        }
+    }
+
+    @Getter
+    final List<BackpointerToken> unconditionalTokens;
+
+    @Getter
+    final List<BackpointerToken> conditionalTokens;
+
+    public BatchTokenResponse(ByteBuf buf) {
+        globalTail = ICorfuPayload.fromBuffer(buf, long.class);
+        epoch = ICorfuPayload.fromBuffer(buf, long.class);
+        addressMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
+        unconditionalTokens = ICorfuPayload.listFromBuffer(buf, BackpointerToken.class);
+        conditionalTokens = ICorfuPayload.listFromBuffer(buf, BackpointerToken.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, globalTail);
+        ICorfuPayload.serialize(buf, epoch);
+        ICorfuPayload.serialize(buf, addressMap);
+        ICorfuPayload.serialize(buf, unconditionalTokens);
+        ICorfuPayload.serialize(buf, conditionalTokens);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -47,6 +47,8 @@ public enum CorfuMsgType {
     LAYOUT_NOBOOTSTRAP(19, TypeToken.of(CorfuMsg.class), true),
 
     // Sequencer Messages
+    TOKEN_BATCH_REQ(23, new TypeToken<CorfuPayloadMsg<BatchTokenRequest>>() {}),
+    TOKEN_BATCH_RES(24, new TypeToken<CorfuPayloadMsg<BatchTokenResponse>>() {}),
     TOKEN_REQ(25, new TypeToken<CorfuPayloadMsg<TokenRequest>>(){}),
     TOKEN_RES(26, new TypeToken<CorfuPayloadMsg<TokenResponse>>(){}),
     BOOTSTRAP_SEQUENCER(27, new TypeToken<CorfuPayloadMsg<SequencerTailsRecoveryMsg>>(){}),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
@@ -35,7 +35,8 @@ public class TxResolutionInfo implements ICorfuPayload<TxResolutionInfo> {
     final Map<UUID, Set<byte[]>> conflictSet;
 
     @Getter
-    final Map<UUID, Set<byte[]>>  writeConflictParams;
+    @Setter
+    Map<UUID, Set<byte[]>>  writeConflictParams;
 
     /**
      * Constructor for TxResolutionInfo.

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -170,6 +170,18 @@ public class CorfuRuntime {
         String passwordFile;
         //endregion
 
+        //region Sequencer Parameters
+        /** Whether or not to batch requests to the sequencer. */
+        @Default boolean batchSequencerRequests = true;
+
+        /** If batching, how many requests to batch. */
+        @Default int batchSequencerRequestCount = 4;
+
+        /** How long to wait before timing out a batch.*/
+        @Default Duration batchSequencerTimeout = Duration.ofMillis(1);
+
+        //endregion
+
         //region Connection parameters
         /**
          * {@link Duration} before requests timeout.
@@ -292,7 +304,9 @@ public class CorfuRuntime {
      * A view of the sequencer server in the Corfu server instance.
      */
     @Getter(lazy = true)
-    private final SequencerView sequencerView = new BatchSequencerView(this);
+    private final SequencerView sequencerView = parameters.isBatchSequencerRequests()
+                                                ? new BatchSequencerView(this) :
+                                                new SequencerView(this);
     /**
      * A view of the address space in the Corfu server instance.
      */

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -52,6 +52,7 @@ import org.corfudb.runtime.view.ManagementView;
 import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.runtime.view.SequencerView;
 import org.corfudb.runtime.view.StreamsView;
+import org.corfudb.runtime.view.BatchSequencerView;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.GitRepositoryState;
 import org.corfudb.util.MetricsUtils;
@@ -291,7 +292,7 @@ public class CorfuRuntime {
      * A view of the sequencer server in the Corfu server instance.
      */
     @Getter(lazy = true)
-    private final SequencerView sequencerView = new SequencerView(this);
+    private final SequencerView sequencerView = new BatchSequencerView(this);
     /**
      * A view of the address space in the Corfu server instance.
      */

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -5,6 +5,10 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.corfudb.protocols.wireprotocol.BatchTokenRequest;
+import org.corfudb.protocols.wireprotocol.BatchTokenResponse;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.SequencerTailsRecoveryMsg;
 import org.corfudb.protocols.wireprotocol.TokenRequest;
@@ -25,6 +29,13 @@ public class SequencerClient extends AbstractClient {
         super(router, epoch);
     }
 
+    public CompletableFuture<TokenResponse> getToken(@Nonnull TokenRequest request) {
+        return sendMessageWithFuture(CorfuMsgType.TOKEN_REQ.payloadMsg(request));
+    }
+
+    public CompletableFuture<BatchTokenResponse> getBatchToken(@Nonnull BatchTokenRequest request) {
+        return sendMessageWithFuture(CorfuMsgType.TOKEN_BATCH_REQ.payloadMsg(request));
+    }
     /**
      * Fetches the next available token from the sequencer.
      *

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerHandler.java
@@ -42,4 +42,10 @@ public class SequencerHandler implements IClient, IHandler<SequencerClient> {
                                               ChannelHandlerContext ctx, IClientRouter r) {
         return msg.getPayload();
     }
+
+    @ClientHandler(type = CorfuMsgType.TOKEN_BATCH_RES)
+    private static Object handleBatchTokenResponse(CorfuPayloadMsg<TokenResponse> msg,
+        ChannelHandlerContext ctx, IClientRouter r) {
+        return msg.getPayload();
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.view;
 
 import java.time.Duration;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -110,8 +111,11 @@ public abstract class AbstractView {
                     log.warn("Server still not ready. Waiting for server to start "
                             + "accepting requests.");
                     Sleep.sleepUninterruptibly(retryRate);
-                } else if (re instanceof WrongEpochException) {
-                    WrongEpochException we = (WrongEpochException) re;
+                } else if (re instanceof WrongEpochException
+                    || (re instanceof CompletionException
+                    && re.getCause() instanceof WrongEpochException)) {
+                    WrongEpochException we = (WrongEpochException)
+                        (re instanceof CompletionException ? re.getCause() : re);
                     log.warn("Got a wrong epoch exception, updating epoch to {} and "
                             + "invalidate view", we.getCorrectEpoch());
                     runtime.invalidateLayout();

--- a/runtime/src/main/java/org/corfudb/runtime/view/BatchSequencerView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/BatchSequencerView.java
@@ -1,0 +1,219 @@
+package org.corfudb.runtime.view;
+
+import com.google.common.collect.MultimapBuilder;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
+import com.google.common.hash.HashCode;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import lombok.Data;
+import org.corfudb.protocols.wireprotocol.BatchTokenRequest;
+import org.corfudb.protocols.wireprotocol.BatchTokenResponse;
+import org.corfudb.protocols.wireprotocol.BatchTokenResponse.BackpointerToken;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.protocols.wireprotocol.TokenType;
+import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+
+public class BatchSequencerView extends SequencerView {
+
+    @Data
+    private static class BatchSequencerOperation {
+
+        final boolean next;
+
+        final TxResolutionInfo info;
+
+        final UUID[] streams;
+
+        final CompletableFuture<TokenResponse> completion = new CompletableFuture<>();
+
+        TokenResponse response = null;
+
+        void completeResponse() {
+            if (response == null) {
+                throw new UnrecoverableCorfuError("Attempted to complete an empty token");
+            }
+            completion.complete(response);
+        }
+    }
+
+    Semaphore s = new Semaphore(0);
+
+    final Deque<BatchSequencerOperation> queue = new ConcurrentLinkedDeque<>();
+
+    final ExecutorService batcher = Executors.newFixedThreadPool(1, new ThreadFactoryBuilder()                                                  .setNameFormat("sequencer-batcher-%d").build());
+
+
+    public BatchSequencerView(CorfuRuntime runtime) {
+        super(runtime);
+        batcher.submit(this::sequencerBatcher);
+    }
+
+    private void sequencerBatcher() {
+        while (!runtime.isShutdown()) {
+            // A list of completed operations
+            List<BatchSequencerOperation> abortedOps = new ArrayList<>();
+            List<BatchSequencerOperation> readOps = new ArrayList<>();
+            List<BatchSequencerOperation> writeOps = new ArrayList<>();
+            List<BatchSequencerOperation> conditionalWriteOps = new ArrayList<>();
+
+            Set<UUID> readStreams = new HashSet<>();
+            List<UUID[]> tokenRequests = new ArrayList<>();
+            List<TxResolutionInfo> conditionalTokenRequests = new ArrayList<>();
+            SetMultimap<UUID, ByteBuffer> conflictMap =
+                MultimapBuilder.hashKeys().hashSetValues().build();
+            try {
+                s.tryAcquire(4, 1, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException ie) {
+                throw new UnrecoverableCorfuInterruptedError(ie);
+            }
+            while (queue.size() > 0) {
+                BatchSequencerOperation op = queue.pollFirst();
+                if (op == null) {
+                    break;
+                }
+                if (op.next) {
+                    if (op.info == null) {
+                        tokenRequests.add(op.streams);
+                        writeOps.add(op);
+                    } else {
+                        boolean isLocallyConflicted = false;
+                        for (Entry<UUID, Set<byte[]>> e : op.info.getConflictSet().entrySet()) {
+                            Set<ByteBuffer> conflictSet = e.getValue().stream()
+                                .map(ByteBuffer::wrap).collect(Collectors.toSet());
+                            Set<ByteBuffer> written = conflictMap.get(e.getKey());
+                            Set<ByteBuffer> conflicts = Sets.intersection(written, conflictSet);
+                            if (!conflicts.isEmpty()) {
+                                isLocallyConflicted = true;
+                                op.response = new TokenResponse(TokenType.TX_ABORT_CONFLICT,
+                                    conflicts.iterator().next().array(),
+                                    new Token(Address.ABORTED,
+                                        0), Collections.emptyMap()
+                                    );
+                                abortedOps.add(op);
+                                break;
+                            } else {
+                                conflictMap.putAll(e.getKey(), conflictSet);
+                            }
+                        }
+                        if (!isLocallyConflicted) {
+                            conditionalTokenRequests.add(op.info);
+                            conditionalWriteOps.add(op);
+                        }
+                    }
+                } else {
+                    // Batch reads
+                    readOps.add(op);
+                    readStreams.addAll(Arrays.asList(op.streams));
+                }
+            }
+
+            if (readOps.size() != 0 || writeOps.size() != 0 || conditionalWriteOps.size() != 0) {
+                BatchTokenRequest r = new BatchTokenRequest(readStreams.toArray(new UUID[0]),
+                    tokenRequests, conditionalTokenRequests);
+                try {
+                    BatchTokenResponse response =
+                        layoutHelper(l -> l.getPrimarySequencerClient().getBatchToken(r).join());
+                    // Handle a batched read
+                    readOps.forEach(op -> {
+                        if (op.streams.length == 0) {
+                            op.response
+                                = new TokenResponse(response.getGlobalTail(),
+                                response.getEpoch(),
+                                Collections.emptyMap());
+                        } else {
+                            op.response
+                                = new TokenResponse(response
+                                .getAddressMap().get(op.streams[0]),
+                                response.getEpoch(), Collections.emptyMap());
+                        }
+                        op.completeResponse();
+                    });
+
+                    for (int i = 0; i < response.getUnconditionalTokens().size(); i++) {
+                        final BackpointerToken token = response.getUnconditionalTokens().get(i);
+                        writeOps.get(i).response = new TokenResponse(token.getToken(),
+                            response.getEpoch(),
+                            token.getBackpointerMap());
+                        writeOps.get(i).completeResponse();
+                    }
+
+                    for (int i = 0; i < response.getConditionalTokens().size(); i++) {
+                        final BackpointerToken token = response.getConditionalTokens().get(i);
+                        if (token.getToken() == Address.ABORTED) {
+                            conditionalWriteOps.get(i).response = new TokenResponse(TokenType.TX_ABORT_CONFLICT,
+                                new byte[0],
+                                new Token(Address.ABORTED,
+                                    0), Collections.emptyMap()
+                            );
+                        } else {
+                            conditionalWriteOps.get(i).response = new TokenResponse(
+                                token.getToken(),
+                                response.getEpoch(),
+                                token.getBackpointerMap());
+                        }
+                        conditionalWriteOps.get(i).completeResponse();
+                    }
+                } catch (CompletionException ce) {
+                    queue.addAll(readOps);
+                    queue.addAll(writeOps);
+                    queue.addAll(conditionalWriteOps);
+                }
+            }
+
+            abortedOps.forEach(BatchSequencerOperation::completeResponse);
+        }
+    }
+
+    private CompletableFuture<TokenResponse> queueBatchOperation(boolean next,
+                                                                 @Nullable  TxResolutionInfo info,
+                                                                 UUID... streams) {
+        if (runtime.isShutdown()) {
+            throw new UnrecoverableCorfuError("Runtime is shutdown");
+        }
+        s.release();
+        BatchSequencerOperation op = new BatchSequencerOperation(next, info, streams);
+        queue.add(op);
+        return op.completion;
+    }
+
+    @Override
+    public TokenResponse nextConditionalToken(@Nullable TxResolutionInfo info, UUID... streams) {
+        return queueBatchOperation(true, info, streams).join();
+    }
+
+    @Override
+    public TokenResponse nextToken(UUID... streams) {
+        return queueBatchOperation(true, null, streams).join();
+    }
+
+    @Override
+    public TokenResponse currentToken(UUID... streams) {
+        return queueBatchOperation(false, null, streams).join();
+    }
+
+
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
@@ -3,9 +3,12 @@ package org.corfudb.runtime.view;
 import java.util.Set;
 import java.util.UUID;
 
+import javax.annotation.Nullable;
+import org.corfudb.protocols.wireprotocol.TokenRequest;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.util.CFUtils;
 
 
@@ -19,6 +22,21 @@ public class SequencerView extends AbstractView {
         super(runtime);
     }
 
+    public TokenResponse nextConditionalToken(@Nullable TxResolutionInfo info, UUID... streams) {
+        return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
+            .getToken(new TokenRequest(true, info, streams))));
+    }
+
+    public TokenResponse nextToken(UUID... streams) {
+        return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
+            .getToken(new TokenRequest(true, null, streams))));
+    }
+
+    public TokenResponse currentToken(UUID... streams) {
+        return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
+            .getToken(new TokenRequest(false, null, streams))));
+    }
+
     /**
      * Return the next token in the sequencer for a particular stream.
      *
@@ -30,16 +48,25 @@ public class SequencerView extends AbstractView {
      * @param numTokens The number of tokens to reserve.
      * @return The first token retrieved.
      */
+    @Deprecated
     public TokenResponse nextToken(Set<UUID> streamIDs, int numTokens) {
-        return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
-                .nextToken(streamIDs, numTokens)));
+        if (numTokens == 0) {
+            return currentToken(streamIDs.toArray(new UUID[0]));
+        } else if (numTokens == 1) {
+            return nextToken(streamIDs.toArray(new UUID[0]));
+        }
+        throw new UnrecoverableCorfuError("numTokens other than 0,1 no longer supported");
     }
 
 
+    @Deprecated
     public TokenResponse nextToken(Set<UUID> streamIDs, int numTokens,
                                    TxResolutionInfo conflictInfo) {
-        return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
-                .nextToken(streamIDs, numTokens, conflictInfo)));
+        if (numTokens != 1) {
+            throw new UnrecoverableCorfuError("numTokens other than 1 no longer supported");
+        }
+
+        return nextConditionalToken(conflictInfo, streamIDs.toArray(new UUID[0]));
     }
 
     public void trimCache(long address) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -97,6 +97,18 @@ public class StreamsView extends AbstractView {
         return get(destination);
     }
 
+    /** Append to multiple streams conditionally.
+     *
+     * @param conflictInfo                  Conflict information for conditional append.
+     * @param object                        The object to append.
+     * @return                              The address the object was appended at.
+     * @throws TransactionAbortedException  If the transaction was aborted by the sequencer.
+     */
+    public long conditionalAppend(@Nonnull TxResolutionInfo conflictInfo,
+                                  @Nonnull Object object) throws TransactionAbortedException {
+        return append(conflictInfo.getWriteConflictParams().keySet(), object, conflictInfo);
+    }
+
     /**
      * Append to multiple streams simultaneously, possibly providing
      * information on how to resolve conflicts.

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime;
 
 import org.corfudb.infrastructure.TestLayoutBuilder;
 
+import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.clients.TestRule;
 import org.corfudb.runtime.exceptions.unrecoverable.SystemUnavailableError;
@@ -235,7 +236,12 @@ public class CorfuRuntimeTest extends AbstractViewTest {
 
         addSingleServer(SERVERS.PORT_0);
 
-        CorfuRuntime runtime = getDefaultRuntime();
+        CorfuRuntime runtime = getNewRuntime(
+            CorfuRuntimeParameters.builder()
+                .batchSequencerRequests(false)
+                .build())
+            .connect();
+
         TimeoutHandler th = new TimeoutHandler(runtime, TIMEOUT_CORFU_RUNTIME_IN_MS);
 
         runtime

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -34,7 +34,7 @@ public class CheckpointTest extends AbstractObjectTest {
 
     void setRuntime() {
         if (myRuntime != null) {
-            myRuntime.shutdown();
+            //myRuntime.shutdown();
         }
         myRuntime = getNewRuntime(getDefaultNode()).connect();
     }

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -743,6 +743,8 @@ public class SMRMapTest extends AbstractViewTest {
 
         // print stats..
         calculateRequestsPerSecond("TPS", numRecords * numThreads, startTime);
+        calculateRequestsPerSecond("GPS", (numRecords * numThreads) -
+            aborts.get(), startTime);
         calculateAbortRate(aborts.get(), numRecords * numThreads);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.object;
 
 import com.google.common.reflect.TypeToken;
+import java.util.UUID;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.SMRMap;
@@ -52,8 +53,10 @@ public class CompileProxyTest extends AbstractViewTest {
         // read will be on a trimmed address
         final int numOfTokens = 10;
         String streamName = "s1";
-        rt.getSequencerView().nextToken(Collections.singleton(CorfuRuntime.getStreamID(streamName)),
-                numOfTokens);
+        UUID streamId = CorfuRuntime.getStreamID(streamName);
+        for (int i = 0; i < numOfTokens; i++) {
+            rt.getSequencerView().nextToken(streamId);
+        }
 
         // Trim all the way up to the tail
         rt.getAddressSpaceView().prefixTrim(numOfTokens);

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
     }
 
     public CorfuRuntime getNewRuntime(@Nonnull NodeLocator node) {
-        CorfuRuntime runtime = getNewRuntime(CorfuRuntimeParameters
+        CorfuRuntime runtime = configureRuntime(CorfuRuntimeParameters
             .builder()
             .build());
         runtime.parseConfigurationString(node.getHost() + ":" + node.getPort());
@@ -108,6 +108,14 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
     }
 
     public CorfuRuntime getNewRuntime(@Nonnull CorfuRuntimeParameters parameters) {
+        CorfuRuntime runtime = configureRuntime(parameters);
+        runtime.parseConfigurationString(getDefaultNode().getHost()
+            + ":"
+            + getDefaultNode().getPort());
+        return runtime;
+    }
+
+    private CorfuRuntime configureRuntime(@Nonnull CorfuRuntimeParameters parameters) {
         parameters.setNettyEventLoop(NETTY_EVENT_LOOP);
         return CorfuRuntime.fromParameters(parameters);
     }
@@ -123,6 +131,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
     public void simulateEndpointDisconnected(CorfuRuntime runtime) {
         ((TestClientRouter) runtime.getRouter(getDefaultEndpoint()))
                 .simulateDisconnectedEndpoint();
+        testServerMap.values().forEach(s -> s.layoutServer.shutdown());
     }
 
     /**

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -40,7 +40,7 @@
     </logger>
 
 
-    <root level="INFO">
+    <root level="DEBUG">
         <!--<appender-ref ref="FILE" />-->
         <!--<appender-ref ref="STDOUT" />-->
         <!--<appender-ref ref="MetricsRollingFile" />-->


### PR DESCRIPTION
## Overview

Description: This PR is a WIP which implements a batch sequencer view, which batches requests to the sequencer. For single-threaded workloads this may result in slightly higher latency and reduced performance, but should greatly improve the performance of multi-threaded workloads.

For multi-threaded workloads, the sequencer view waits for a configurable minimum batch size or a timeout to batch. This allows us to control the rate of requests to the sequencer and maximize the pay off of batching. In addition, the sequencer view performs local conflict resolution when possible, aborting conflicting transactions locally if possible (conflicting transactions within the same batch.

Why should this be merged: Improved overall performance


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
