### PR TITLE
Reporting Corfu metrics to MBeans

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
@@ -2,6 +2,7 @@ package org.corfudb.util;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.MetricSet;
@@ -13,6 +14,7 @@ import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 import com.codahale.metrics.jvm.ThreadStatesGaugeSet;
 import com.github.benmanes.caffeine.cache.Cache;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.slf4j.LoggerFactory;
 
@@ -25,46 +27,54 @@ public class MetricsUtils {
     private static final MetricSet metricsJVMGC = new GarbageCollectorMetricSet();
     private static final MetricSet metricsJVMMem = new MemoryUsageGaugeSet();
     private static final MetricSet metricsJVMThread = new ThreadStatesGaugeSet();
+    public static final String ADDRESS_SPACE_METRIC_PREFIX = "corfu.runtime.as-view";
+    public static final String PROPERTY_METRICS_COLLECTION = "corfu.metrics.collection";
+    public static final String PROPERTY_JMX_REPORTING = "corfu.metrics.jmxreporting";
+    public static final String PROPERTY_LOG_INTERVAL = "corfu.metrics.log.interval";
 
-    private static int interval;
+    private static int metricsLogInterval;
     @Getter
     private static boolean metricsCollectionEnabled = false;
-    private static boolean metricsReportingEnabled = false;
+    private static boolean metricsJmxReportingEnabled = false;
+    private static boolean metricsSlf4jReportingEnabled = false;
     private static String mpTrigger = "filter-trigger"; // internal use only
 
     /**
      * Load metrics properties.
      *
-     * <p>The expected properties in this properties file are:
+     * <p>The expected properties from vm system properties are:
      * <ul>
-     * <li> interval: Integer taken from vm metricsInterval property
-     * for the reporting interval for CSV output
+     * <li> metricsCollectionEnabled: Boolean taken from vm corfu.metrics.collection
+     * property to enable the collection
+     * <li> metricsJmxReportingEnabled: Boolean taken from vm corfu.metrics.jmxreporting
+     * property to enable jmx reporting of metrics
+     * <li> metricsLogInterval: Integer taken from vm corfu.metrics.log.interval
+     * property for enabling and setting the intervals of reporting to log output
      * </ul>
      *
-     * <p>This function will be called to set the value of interval for
-     * reporting. The value of interval is used as an indicator for setting
-     * the metrics behavior. Positive values enable collection and reporting at
-     * provided interval in seconds. Zero indicated only metrics collection.
-     * Negative values disable both collection and reporting.
+     * <p>This function will be called to set the value of metricsCollectionEnabled,
+     * metricsJmxReportingEnabled, and metricsLogInterval for reporting. The value
+     * of metricsCollectionEnabled represents the expected collection status.
+     * Slf4j reporting is enabled if metricsLogInterval is set to a positive integer
+     * representing emission intervals in seconds.
+     * Jmx reporting is enabled if metricsJmxReportingEnabled is set to {@code true}.
      */
     private static void loadVmProperties() {
         try {
-            interval = Integer.valueOf(System.getProperty("metricsInterval"));
+            metricsCollectionEnabled = Boolean.valueOf(System.getProperty(PROPERTY_METRICS_COLLECTION));
+            metricsJmxReportingEnabled = Boolean.valueOf(System.getProperty(PROPERTY_JMX_REPORTING));
+            metricsLogInterval = Integer.valueOf(System.getProperty(PROPERTY_LOG_INTERVAL));
+            metricsSlf4jReportingEnabled = metricsLogInterval > 0 ? true : false;
         } catch (NumberFormatException e) {
-            log.error("Extracting metricsInterval VM property failed. " +
-                    "Metrics collection and reporting will be disabled");
-            interval = -1;
+            log.warn("Extracting metricsInterval VM property failed. " +
+                    "Reporting to corfu metrics log is disabled");
+            metricsSlf4jReportingEnabled = false;
         }
 
-        if (interval > 0) {
-            metricsCollectionEnabled = true;
-            metricsReportingEnabled = true;
-        } else if (interval == 0) {
-            metricsCollectionEnabled = true;
-            metricsReportingEnabled = false;
-        } else {
-            metricsCollectionEnabled= false;
-            metricsReportingEnabled = false;
+        if (!metricsCollectionEnabled) {
+            metricsJmxReportingEnabled = false;
+            metricsSlf4jReportingEnabled = false;
+            log.info("Corfu metrics collection and reporting is disabled");
         }
     }
 
@@ -75,42 +85,63 @@ public class MetricsUtils {
      * @param metrics Metric Registry
      * @return True if metricsReportingSetup() function has been called earlier
      */
-    public static boolean isMetricsReportingSetUp(MetricRegistry metrics) {
+    public static boolean isMetricsReportingSetUp(@NonNull MetricRegistry metrics) {
         return metrics.getNames().contains(mpTrigger);
     }
 
     /**
-     * Start metrics reporting via the Dropwizard 'CsvReporter' file writer.
-     * Reporting can be turned on and off via the properties file described
-     * in loadVmProperties()'s docs.  The report interval and report
-     * directory cannot be altered at runtime.
+     * Start metrics reporting via the Dropwizard 'Slf4jReporter' and
+     * 'JmxReporter'. Reporting can be turned on and off via the system
+     * properties described in loadVmProperties()'s docs.
+     * The report interval and report directory cannot be altered at runtime.
      *
      * @param metrics Metrics registry
      */
-    public static void metricsReportingSetup(MetricRegistry metrics) {
+    public static void metricsReportingSetup(@NonNull MetricRegistry metrics) {
         metrics.counter(mpTrigger);
         loadVmProperties();
 
-        if (metricsReportingEnabled) {
-            MetricFilter f = (name, metric) -> {
-                if (name.equals(mpTrigger)) {
-                    loadVmProperties();
-                    return false;
-                }
-                return metricsReportingEnabled;
-            };
-
-            Slf4jReporter reporter1 = Slf4jReporter.forRegistry(metrics)
-                    .convertRatesTo(TimeUnit.SECONDS)
-                    .convertDurationsTo(TimeUnit.MILLISECONDS)
-                    .outputTo(LoggerFactory.getLogger("org.corfudb.metricsdata"))
-                    .filter(f)
-                    .build();
-            reporter1.start(interval, TimeUnit.SECONDS);
+        if (metricsCollectionEnabled) {
+            setupSlf4jReporting(metrics);
+            setupJmxReporting(metrics);
         }
     }
 
-    public static void addCacheGauges(MetricRegistry metrics, String name, Cache cache) {
+    // If enabled, setup jmx reporting
+    private static void setupJmxReporting(MetricRegistry metrics) {
+        if (!metricsJmxReportingEnabled) return;
+
+        // This filters noisy addressSpace metrics to have a clean JMX reporting
+        MetricFilter addressSpaceFilter = (name, metric) ->
+                !name.contains(ADDRESS_SPACE_METRIC_PREFIX);
+
+        JmxReporter jmxReporter = JmxReporter.forRegistry(metrics)
+                .convertDurationsTo(TimeUnit.MICROSECONDS)
+                .convertRatesTo(TimeUnit.SECONDS)
+                .inDomain("corfu.metrics")
+                .filter(addressSpaceFilter)
+                .build();
+        jmxReporter.start();
+    }
+
+    // If enabled, setup slf4j reporting
+    private static void setupSlf4jReporting(MetricRegistry metrics) {
+        if (!metricsSlf4jReportingEnabled) return;
+
+        MetricFilter mpTriggerFilter = (name, metric) -> !name.equals(mpTrigger);
+
+        Slf4jReporter slf4jReporter = Slf4jReporter.forRegistry(metrics)
+                .convertDurationsTo(TimeUnit.MICROSECONDS)
+                .convertRatesTo(TimeUnit.SECONDS)
+                .outputTo(LoggerFactory.getLogger("org.corfudb.metricsdata"))
+                .filter(mpTriggerFilter)
+                .build();
+        slf4jReporter.start(metricsLogInterval, TimeUnit.SECONDS);
+    }
+
+    public static void addCacheGauges(@NonNull MetricRegistry metrics,
+                                      @NonNull String name,
+                                      @NonNull Cache cache) {
         try {
             metrics.register(name + "cache-size", (Gauge<Long>) () -> cache.estimatedSize());
             metrics.register(name + "evictions", (Gauge<Long>) () -> cache.stats().evictionCount());
@@ -122,8 +153,7 @@ public class MetricsUtils {
         }
     }
 
-
-    public static void addJvmMetrics(MetricRegistry metrics, String pfx) {
+    public static void addJvmMetrics(@NonNull MetricRegistry metrics, String pfx) {
         try {
             metrics.register(pfx + "jvm.gc", metricsJVMGC);
             metrics.register(pfx + "jvm.memory", metricsJVMMem);
@@ -134,11 +164,11 @@ public class MetricsUtils {
         }
     }
 
-    public static Timer.Context getConditionalContext(Timer t) {
+    public static Timer.Context getConditionalContext(@NonNull Timer t) {
         return getConditionalContext(metricsCollectionEnabled, t);
     }
 
-    public static Timer.Context getConditionalContext(boolean enabled, Timer t) {
+    public static Timer.Context getConditionalContext(boolean enabled, @NonNull Timer t) {
         return enabled ? t.time() : null;
     }
 
@@ -148,7 +178,7 @@ public class MetricsUtils {
         }
     }
 
-    public static void incConditionalCounter(boolean enabled, Counter counter, long amount) {
+    public static void incConditionalCounter(boolean enabled, @NonNull Counter counter, long amount) {
         if (enabled) {
             counter.inc(amount);
         }


### PR DESCRIPTION
## Overview
Description:
This PR adds the ability of reporting the currently collected metrics to MBeans. In addition some refactoring is done to improve the clarity of metrics utility.

Why should this be merged: 
- Reported metrics to MBeans can be conveniently examined and monitored live using the tools conforming to JMX api such as jConsole and jVisualVM which are already bundled with standard JDK. This enables both users and developers of Corfu to easily access Corfu metrics.
- In regards to refactoring, the changes are steps toward improving metrics infrastructure to better address the metrics collection and reporting requirement.  

Related issue(s) (if applicable): #1243 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
