### PR TITLE
Optimisitic TX RPC Call out of the lock

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -196,7 +196,7 @@ public class VersionLockedObject<T> {
                     }
                 }
             } catch (Exception e) {
-                // If we have an exception, we didn't get a chance to validate the the lock.
+                // If we have an exception, we didn't get a chance to validate the lock.
                 // If it's still valid, then we should re-throw the exception since it was
                 // on a correct view of the object.
                 if (lock.validate(ts)) {


### PR DESCRIPTION
To avoid waiting for RPC calls to be executed under the VLO lock,
snapshot timestamp can be obtained right before acquiring the lock.

## Overview

Description: Get Snapshot Timestamp before the lock is acquired. This typically represents a single RPC call per transaction, therefore, the performance gains are higher for smaller transactions. 

Why should this be merged: depending on the workload pattern we have found performance improvements of up to 44%. Performance outperforms as the transaction size decreases and the number of threads in the client increases. This percentage (44%) was found for the case of Single Write Transactions and 40 client threads. We have also tested this thoroughly on Rishi's System and not found any regression. 

Related issue(s) (if applicable): #1207


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [ ] Public API has Javadoc
