### PR TITLE
Separate endpoint migration to different class

### DIFF
--- a/migration/src/main/java/org/corfudb/migration/EndpointMigration.java
+++ b/migration/src/main/java/org/corfudb/migration/EndpointMigration.java
@@ -1,0 +1,89 @@
+package org.corfudb.migration;
+
+import static com.google.common.collect.Sets.newHashSet;
+import static org.corfudb.migration.LogFormat1to2.getChecksum;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Set;
+
+/**
+ * Endpoint migration tool modifies the layout datastore files to replace a particular endpoint.
+ * To maintain consistency this should be run on all nodes of the cluster replacing the required
+ * endpoint.
+ * NOTE: The Corfu Server should NOT be running when this tool is run to avoid disruption.
+ *
+ * <p>Created by zlokhandwala on 3/4/18.
+ */
+public class EndpointMigration {
+
+    /**
+     * Data-store files responsible for layout recovery.
+     */
+    private static final Set<String> layoutStateRecoveryFiles =
+            newHashSet("LAYOUT_CURRENT", "MANAGEMENT_LAYOUT");
+
+    /**
+     * Modifies the endpoint in the layout datastore files.
+     *
+     * @param args Accepts the arguments in the following order,
+     *             dir:         CorfuDB data directory,
+     *             oldEndpoint: Old address the server was binding to,
+     *             newEndpoint: New address to which the server will bind to.
+     * @throws Exception if migration fails.
+     */
+    public static void main(String[] args) throws Exception {
+        if (args.length < 3) {
+            throw new IllegalArgumentException("Expected parameters: CorfuDB data directory,"
+                    + "old endpoint and new endpoint");
+        }
+
+        String corfuDir = args[0];
+        String oldEndpoint = args[1];
+        String newEndpoint = args[2];
+
+        // Transform the layout state local datastore files.
+        modifyBindingIpAddress(corfuDir, oldEndpoint, newEndpoint);
+    }
+
+    /**
+     * Modifies the ip address in the layout files.
+     *
+     * @param dirStr      Directory path
+     * @param oldEndpoint Old endpoint to be replaced.
+     * @param newEndpoint New endpoint.
+     */
+    static void modifyBindingIpAddress(String dirStr,
+                                       String oldEndpoint,
+                                       String newEndpoint) throws IOException {
+        File dir = new File(dirStr);
+        File[] layoutStateFiles = dir.listFiles(
+                (dir1, name) -> layoutStateRecoveryFiles.stream().anyMatch(name::startsWith));
+
+        if (layoutStateFiles != null) {
+            for (File file : layoutStateFiles) {
+                Path path = Paths.get(file.getAbsolutePath());
+
+                byte[] bytes = Files.readAllBytes(path);
+                // Skip the first 4 checksum bytes.
+                byte[] dataBytes = Arrays.copyOfRange(bytes, Integer.BYTES, bytes.length);
+
+                String data = new String(dataBytes);
+                data = data.replace(oldEndpoint, newEndpoint);
+                dataBytes = data.getBytes();
+                ByteBuffer buffer = ByteBuffer.allocate(dataBytes.length + Integer.BYTES);
+                buffer.putInt(getChecksum(data.getBytes()));
+                buffer.put(data.replace(oldEndpoint, newEndpoint).getBytes());
+
+                Files.write(path, buffer.array(), StandardOpenOption.CREATE,
+                        StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
+            }
+        }
+    }
+}

--- a/migration/src/main/java/org/corfudb/migration/LogFormat1to2.java
+++ b/migration/src/main/java/org/corfudb/migration/LogFormat1to2.java
@@ -20,6 +20,7 @@ import java.util.EnumSet;
 import java.util.Set;
 
 import static com.google.common.collect.Sets.newHashSet;
+import static org.corfudb.migration.EndpointMigration.modifyBindingIpAddress;
 
 /**
  * This migration tool will migrate the local data store files and the log segment files
@@ -47,12 +48,6 @@ public class LogFormat1to2 {
             .getSerializedSize();
 
     /**
-     * Data-store files responsible for layout recovery.
-     */
-    private static final Set<String> layoutStateRecoveryFiles = newHashSet("LAYOUT_CURRENT",
-            "MANAGEMENT_LAYOUT");
-
-    /**
      * Migrates the log segments and data store files.
      *
      * @param args Accepts the arguments in the following order,
@@ -73,10 +68,10 @@ public class LogFormat1to2 {
 
         // migrate log segments
         migrateLUData(corfuDir);
-        // Transform the layout state local datastore files.
-        modifyBindingIpAddress(corfuDir, oldEndpoint, newEndpoint);
         // migrate data-store files.
         migrateLocalDatastore(corfuDir);
+        // Transform the layout state local datastore files.
+        modifyBindingIpAddress(corfuDir, oldEndpoint, newEndpoint);
     }
 
     public static void migrateLocalDatastore(String dirStr) throws IOException {
@@ -119,26 +114,6 @@ public class LogFormat1to2 {
         Files.write(destPath, buffer.array(), StandardOpenOption.CREATE,
                 StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
         Files.delete(srcPath);
-    }
-
-
-    public static void modifyBindingIpAddress(String dirStr,
-                                              String oldEndpoint,
-                                              String newEndpoint) throws IOException {
-        File dir = new File(dirStr);
-        File[] layoutStateFiles = dir.listFiles(
-                (dir1, name) -> layoutStateRecoveryFiles.stream().anyMatch(name::endsWith));
-
-        for (File file : layoutStateFiles) {
-            Path path = Paths.get(file.getAbsolutePath());
-            byte[] bytes = Files.readAllBytes(path);
-            String data = new String(bytes);
-            bytes = data.replace(oldEndpoint, newEndpoint).getBytes();
-            ByteBuffer buffer = ByteBuffer.allocate(bytes.length);
-            buffer.put(bytes);
-            Files.write(path, buffer.array(), StandardOpenOption.CREATE,
-                    StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
-        }
     }
 
     public static void migrateLUData(String dir) throws IOException {


### PR DESCRIPTION
## Overview

Description: Separate the endpoint migration to a standalone tool. Allow users to modify the endpoint in the layout files. However, to use this the tool, the user first needs to shut down the server.

Why should this be merged: To allow users to modify the endpoint in the layout files.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
