### PR TITLE
Cached sequencer view implementation

### DIFF
--- a/annotationProcessor/pom.xml
+++ b/annotationProcessor/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cmdlets/pom.xml
+++ b/cmdlets/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/debian/pom.xml
+++ b/debian/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/format/pom.xml
+++ b/format/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/generator/README.md
+++ b/generator/README.md
@@ -1,0 +1,25 @@
+# Longevity App
+
+The Longevity app is a Corfu application (single Corfu runtime) that spawns a configurable number of threads that will perform CorfuDB operations. While running, the app records all the operations executed along with their result (e.g. Read: map=”mapA”, key=”key1”, value=”value1”, map version = 17).
+
+## Operations
+* Execute Snapshot/Optimistic Transaction (random number of Read/Write/Remove operations)
+* Read (Normal and Transactional)
+* Write (Normal and Transactional)
+* Remove (Normal and transactional)
+* Checkpoint
+* Trim
+
+Checkpoint and Trimming are scheduled at a configurable cyclic interval and the other operations are randomly generated. The key space is configurable with the number of maps and number of keys.
+
+## How to run
+
+usage: longevity
+ -c,--corfu_endpoint <arg>   corfu server to connect to
+ -cp,--checkpoint            enable checkpoint
+ -t,--time_amount <arg>      time amount
+ -u,--time_unit <arg>        time unit (s, m, h)
+
+The required arguments are time_amount and time_unit. Corfu endpoint by default is localhost:9000
+
+

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -17,7 +17,56 @@
             <artifactId>runtime</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.3.1</version>
+        </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version> <!-- version < 3.5.1 has issue with annotation incremental compile-->
+                <configuration>
+                    <compilerVersion>1.8</compilerVersion>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>${project.build.sourceEncoding}</encoding>
+                    <showDeprecation>true</showDeprecation>
+                    <compilerArgs>
+                        <arg>-XDignore.symbol.file</arg>
+                    </compilerArgs>
+                    <fork>true</fork>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.0.0</version>
+
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <outputFile>target/LongevityRun.jar</outputFile>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.corfudb.generator.LongevityRun</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 
 </project>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/generator/src/main/java/org/corfudb/generator/Correctness.java
+++ b/generator/src/main/java/org/corfudb/generator/Correctness.java
@@ -1,0 +1,49 @@
+package org.corfudb.generator;
+
+import ch.qos.logback.classic.Logger;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by rmichoud on 10/9/17.
+ */
+public class Correctness {
+
+    private Correctness() {
+        throw new IllegalStateException("Utility class");
+    }
+
+    private static final String TX_PATTERN = "%s, %s";
+    private static final String TX_PATTERN_VERSION = "%s, %s, %s";
+    public static final String TX_START = "start";
+    public static final String TX_END = "end";
+    public static final String TX_ABORTED = "aborted";
+
+    private static Logger correctnessLogger = (Logger) LoggerFactory.getLogger("correctness");
+
+    public static void recordOperation(String operation, boolean transactionPrefix) {
+        if (transactionPrefix) {
+            String txOperation = "Tx" + operation;
+            correctnessLogger.info("{}, {}", txOperation,
+                    TransactionalContext.getCurrentContext().getSnapshotTimestamp());
+        } else {
+            correctnessLogger.info(operation);
+        }
+    }
+
+    /**
+     * Record a transaction marker operation
+     *
+     *
+     * @param version if we have a version to report
+     * @param fields fields to report
+     */
+    public static void recordTransactionMarkers(boolean version, String... fields) {
+        if (version) {
+            recordOperation(String.format(TX_PATTERN_VERSION, fields[0], fields[1], fields[2]), false);
+        } else {
+            recordOperation(String.format(TX_PATTERN, fields[0], fields[1]), false);
+        }
+    }
+
+}

--- a/generator/src/main/java/org/corfudb/generator/LongevityApp.java
+++ b/generator/src/main/java/org/corfudb/generator/LongevityApp.java
@@ -1,0 +1,165 @@
+package org.corfudb.generator;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.generator.operations.CheckpointOperation;
+import org.corfudb.generator.operations.Operation;
+import org.corfudb.runtime.CorfuRuntime;
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by rmichoud on 7/25/17.
+ */
+
+/**
+ * This Longevity app will stress test corfu using the Load
+ * generator during a given duration.
+ *
+ * I use a blocking queue in order to limit the number of operation
+ * created at any time. Operations as created and consumed as we go.
+ *
+ */
+@Slf4j
+public class LongevityApp {
+    private long durationMs;
+    private boolean checkPoint;
+    BlockingQueue<Operation> operationQueue;
+    CorfuRuntime rt;
+    State state;
+
+    ExecutorService taskProducer;
+    ScheduledExecutorService checkpointer;
+    ExecutorService workers;
+
+    // How much time we live the application hangs once the duration is finished
+    // and the application is hanged
+    static final int APPLICATION_TIMEOUT_IN_MS = 20000;
+
+    static final int QUEUE_CAPACITY = 1000;
+
+    long startTime;
+    int numberThreads;
+
+    public LongevityApp(long durationMs, int numberThreads, String configurationString, boolean checkPoint) {
+        this.durationMs = durationMs;
+        this.checkPoint = checkPoint;
+        this.numberThreads = numberThreads;
+
+        operationQueue = new ArrayBlockingQueue<>(QUEUE_CAPACITY);
+        rt = new CorfuRuntime(configurationString).connect();
+        state = new State(50, 100, rt);
+
+        taskProducer = Executors.newSingleThreadExecutor();
+
+        workers = Executors.newFixedThreadPool(numberThreads);
+        checkpointer = Executors.newScheduledThreadPool(1);
+    }
+
+    /**
+     * Let the workers finish naturally (thanks to the timer) and then kill
+     * the producer and the checkpointer.
+     *
+     * At the end of the duration, we give some margin for the workers to finish their task before shutting
+     * down the thread pool.
+     * If the application is hung (which can happen when something goes wrong) we will still terminate.
+     */
+    private void waitForAppToFinish() {
+        workers.shutdown();
+        try {
+            workers.awaitTermination(durationMs + APPLICATION_TIMEOUT_IN_MS, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            log.error("Operation was stuck", e);
+            Thread.currentThread().interrupt();
+        } finally {
+            taskProducer.shutdownNow();
+            checkpointer.shutdownNow();
+        }
+    }
+
+    /**
+     * Check if we should still execute tasks or if the duration has elapsed.
+     *
+     * @return If we are still within the duration limit
+     */
+    private boolean withinDurationLimit() {
+        return System.currentTimeMillis() - startTime < durationMs;
+    }
+
+    /**
+     * A thread is tasked to indefinitely create operation. Operations are then
+     * put into a blocking queue. The blocking queue serves as a regulator for how
+     * many operations exist at the same time. It allows us to regulate the memory footprint.
+     *
+     * The only way to terminate the producer is to call explicitly a shutdownNow() on
+     * the executorService.
+     */
+    private void runTaskProducer() {
+        taskProducer.execute(() -> {
+            while (true) {
+                Operation current = state.getOperations().getRandomOperation();
+                try {
+                    operationQueue.put(current);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                } catch (Exception e) {
+                    log.error("operation error", e);
+                }
+            }
+        });
+
+    }
+
+    /**
+     * Each workers in the worker pool will consume an operation
+     * from the blocking queue. Once the operation dequeued, it is
+     * executed. This happens while we are within the boundary of the
+     * duration.
+     */
+    private void runTaskConsumers() {
+        // Assign a worker for each thread in the pool
+        for (int i = 0; i < numberThreads; i++) {
+            workers.execute(() -> {
+                while (withinDurationLimit()) {
+                    try {
+                        Operation op = operationQueue.take();
+                        op.execute();
+                    } catch (Exception e) {
+                        log.error("Operation failed with", e);
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     * A thread is tasked with checkpointing activity. This is a cyclic
+     * operation.
+     */
+    private void runCpTrimTask() {
+        Runnable cpTrimTask = () -> {
+            Operation op = new CheckpointOperation(state);
+            op.execute();
+        };
+        checkpointer.scheduleAtFixedRate(cpTrimTask, 30, 20, TimeUnit.SECONDS);
+    }
+
+
+    public void runLongevityTest() {
+        startTime = System.currentTimeMillis();
+
+        if (checkPoint) {
+            runCpTrimTask();
+        }
+
+        runTaskProducer();
+        runTaskConsumers();
+
+        waitForAppToFinish();
+    }
+}

--- a/generator/src/main/java/org/corfudb/generator/LongevityRun.java
+++ b/generator/src/main/java/org/corfudb/generator/LongevityRun.java
@@ -1,0 +1,106 @@
+package org.corfudb.generator;
+
+import java.time.Duration;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import lombok.extern.slf4j.Slf4j;
+
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by rmichoud on 7/27/17.
+ */
+
+/**
+ * This longevity test launcher will set the duration of the test
+ * based on inputs.
+ */
+@Slf4j
+public class LongevityRun {
+    private static final String TIME_UNIT = "time_unit";
+    private static final String TIME_AMOUNT = "time_amount";
+    private static final String CORFU_ENDPOINT = "corfu_endpoint";
+    private static final String CHECKPOINT = "checkpoint";
+
+
+
+    public static void main(String[] args) {
+        Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+        root.setLevel(Level.INFO);
+
+        long longevity;
+
+        Options options = new Options();
+
+        Option amountTime = new Option("t", TIME_AMOUNT, true, "time amount");
+        amountTime.setRequired(true);
+        Option timeUnit = new Option("u", TIME_UNIT, true, "time unit (s, m, h)");
+        timeUnit.setRequired(true);
+        Option corfuEndpoint = new Option("c", CORFU_ENDPOINT, true,
+                "corfu server to connect to");
+        Option checkPointFlag = new Option("cp", CHECKPOINT, false,
+                "enable checkpoint");
+
+        options.addOption(amountTime);
+        options.addOption(timeUnit);
+        options.addOption(corfuEndpoint);
+        options.addOption(checkPointFlag);
+
+
+
+        CommandLineParser parser = new DefaultParser();
+        HelpFormatter formatter = new HelpFormatter();
+        CommandLine cmd;
+
+        try {
+            cmd = parser.parse(options, args);
+            String timeUnitValue = cmd.getOptionValue(TIME_UNIT);
+            if (!timeUnitValue.equals("m") &&
+                    !timeUnitValue.equals("s") &&
+                    !timeUnitValue.equals("h")){
+                throw new ParseException("Time unit should be {s,m,h}");
+            }
+        } catch (ParseException e) {
+            log.info(e.getMessage());
+            formatter.printHelp("longevity", options);
+
+            System.exit(1);
+            return;
+        }
+
+        long amountTimeValue = Long.parseLong(cmd.getOptionValue(TIME_AMOUNT));
+        String timeUnitValue = cmd.getOptionValue(TIME_UNIT);
+
+        String configurationString = cmd.hasOption(CORFU_ENDPOINT) ?
+                cmd.getOptionValue(CORFU_ENDPOINT) : "localhost:9000";
+
+        boolean checkPoint = cmd.hasOption(CHECKPOINT) ?
+                true : false;
+
+        switch (timeUnitValue) {
+            case "s":
+                longevity = Duration.ofSeconds(amountTimeValue).toMillis();
+                break;
+            case "m":
+                longevity = Duration.ofMinutes(amountTimeValue).toMillis();
+                break;
+            case "h":
+                longevity = Duration.ofHours(amountTimeValue).toMillis();
+                break;
+            default:
+                longevity = Duration.ofHours(1).toMillis();
+        }
+
+        LongevityApp la = new LongevityApp(longevity, 10, configurationString, checkPoint);
+        la.runLongevityTest();
+    }
+}

--- a/generator/src/main/java/org/corfudb/generator/distributions/Keys.java
+++ b/generator/src/main/java/org/corfudb/generator/distributions/Keys.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 /**
  * This class implements the distribution of keys that can be inserted
@@ -23,8 +22,8 @@ public class Keys implements DataSet {
 
     @Override
     public void populate() {
-        for (int x = 0; x < numKeys; x++) {
-            mapkeys.add(UUID.randomUUID().toString());
+        for(int x = 0; x < numKeys; x++) {
+            mapkeys.add("key_" + Integer.toString(x));
         }
     }
 

--- a/generator/src/main/java/org/corfudb/generator/distributions/Operations.java
+++ b/generator/src/main/java/org/corfudb/generator/distributions/Operations.java
@@ -20,6 +20,7 @@ import java.util.List;
  */
 public class Operations implements DataSet {
 
+    private State state;
     final List<Operation> allOperations;
 
     public Operations(State state) {
@@ -30,10 +31,17 @@ public class Operations implements DataSet {
                 new SnapshotTxOperation(state),
                 new SleepOperation(state),
                 new RemoveOperation(state));
+//              TODO: Fix nestedTx path to enable it
+//              new NestedTxOperation(state));
+        this.state = state;
     }
 
     public void populate() {
         //no-op
+    }
+
+    public Operation getRandomOperation() {
+        return allOperations.get(state.rand.nextInt(allOperations.size()));
     }
 
     public List<Operation> getDataSet() {

--- a/generator/src/main/java/org/corfudb/generator/distributions/Streams.java
+++ b/generator/src/main/java/org/corfudb/generator/distributions/Streams.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.UUID;
 
 /**
  * This class implements a distribution over the possible streams that
@@ -14,7 +13,7 @@ import java.util.UUID;
  */
 public class Streams implements DataSet {
 
-    final Set<UUID> streamIds;
+    final Set<String> streamIds;
     final int numStreams;
 
     public Streams(int num) {
@@ -25,12 +24,12 @@ public class Streams implements DataSet {
     @Override
     public void populate() {
         for (int x = 0; x < numStreams; x++) {
-            streamIds.add(UUID.randomUUID());
+            streamIds.add("table_" + Integer.toString(x));
         }
     }
 
     @Override
-    public List<UUID> getDataSet() {
+    public List<String> getDataSet() {
         return new ArrayList<>(streamIds);
     }
 }

--- a/generator/src/main/java/org/corfudb/generator/operations/CheckpointOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/CheckpointOperation.java
@@ -1,5 +1,6 @@
 package org.corfudb.generator.operations;
 
+import org.corfudb.generator.Correctness;
 import org.corfudb.generator.State;
 import org.corfudb.runtime.MultiCheckpointWriter;
 
@@ -13,21 +14,30 @@ public class CheckpointOperation extends Operation {
 
     public CheckpointOperation(State state) {
         super(state);
+        shortName = "Checkpoint";
     }
 
     @Override
     public void execute() {
         try {
+
+//            TODO: uncomment when verification supports it
+//            String cpStartRecord = String.format("%s, %s", shortName, "start");
+//            Correctness.recordOperation(cpStartRecord, false);
+
             MultiCheckpointWriter mcw = new MultiCheckpointWriter();
             mcw.addAllMaps(state.getMaps());
             long trimAddress = mcw.appendCheckpoints(state.getRuntime(), "Maithem");
             state.setTrimMark(trimAddress);
-            Thread.sleep(1000 * 30 * 1);
+            Thread.sleep(1000l * 30l * 1l);
             state.getRuntime().getAddressSpaceView().prefixTrim(trimAddress - 1);
             state.getRuntime().getAddressSpaceView().gc();
             state.getRuntime().getAddressSpaceView().invalidateClientCache();
             state.getRuntime().getAddressSpaceView().invalidateServerCaches();
-            System.out.println("CheckpointOperation Completed");
+
+//            TODO: uncomment when verification supports it
+//            String cpStopRecord = String.format("%s, end, %s", shortName, trimAddress);
+//            Correctness.recordOperation(cpStopRecord, false);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/generator/src/main/java/org/corfudb/generator/operations/NestedTxOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/NestedTxOperation.java
@@ -8,46 +8,55 @@ import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import java.util.List;
 
 /**
- * Created by maithem on 7/14/17.
+ * Created by rmichoud on 7/26/17.
  */
 @Slf4j
-public class OptimisticTxOperation extends Operation {
+public class NestedTxOperation extends Operation {
 
-    public OptimisticTxOperation(State state) {
+    private static final int MAX_NEST = 20;
+
+    public NestedTxOperation(State state) {
         super(state);
-        shortName = "TxOpt";
+        shortName = "TxNest";
     }
 
     @Override
     public void execute() {
-        try {
-            Correctness.recordTransactionMarkers(false, shortName, Correctness.TX_START);
-            long timestamp;
-            state.startOptimisticTx();
+        Correctness.recordTransactionMarkers(false, shortName, Correctness.TX_START);
+        state.startOptimisticTx();
 
+        int numNested = state.getOperationCount().sample(1).get(0);
+        int nestedTxToStop = numNested;
+        for (int i = 0; i < numNested && i < MAX_NEST; i++) {
+            try{
+            state.startOptimisticTx();
             int numOperations = state.getOperationCount().sample(1).get(0);
             List<Operation> operations = state.getOperations().sample(numOperations);
 
             for (int x = 0; x < operations.size(); x++) {
-                if (operations.get(x) instanceof OptimisticTxOperation
-                        || operations.get(x) instanceof SnapshotTxOperation
-                        || operations.get(x) instanceof NestedTxOperation)
-                {
+                if (operations.get(x) instanceof OptimisticTxOperation ||
+                        operations.get(x) instanceof SnapshotTxOperation
+            || operations.get(x) instanceof NestedTxOperation) {
                     continue;
                 }
-
                 operations.get(x).execute();
             }
+            } catch (TransactionAbortedException tae) {
+                log.warn("Transaction Aborted", tae);
+                nestedTxToStop--;
+            }
+        }
 
+        for (int i = 0; i < nestedTxToStop; i++) {
+            state.stopTx();
+        }
+        long timestamp;
+        try {
             timestamp = state.stopTx();
-
             Correctness.recordTransactionMarkers(true, shortName, Correctness.TX_END,
                     Long.toString(timestamp));
         } catch (TransactionAbortedException tae) {
             Correctness.recordTransactionMarkers(false, shortName, Correctness.TX_ABORTED);
         }
-
-
-
     }
 }

--- a/generator/src/main/java/org/corfudb/generator/operations/Operation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/Operation.java
@@ -10,6 +10,8 @@ import org.corfudb.generator.State;
  */
 public abstract class Operation {
     protected State state;
+    String shortName;
+
     public Operation(State state) {
         this.state = state;
     }

--- a/generator/src/main/java/org/corfudb/generator/operations/ReadOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/ReadOperation.java
@@ -1,9 +1,12 @@
 package org.corfudb.generator.operations;
 
-import java.util.UUID;
-
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.generator.Correctness;
 import org.corfudb.generator.State;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
+
 
 /**
  * Created by maithem on 7/14/17.
@@ -13,12 +16,24 @@ public class ReadOperation extends Operation {
 
     public ReadOperation(State state) {
         super(state);
+        shortName = "Read";
     }
 
     @Override
     public void execute() {
-        UUID streamID = (UUID) state.getStreams().sample(1).get(0);
+        String streamId = (String) state.getStreams().sample(1).get(0);
         String key = (String) state.getKeys().sample(1).get(0);
-        state.getMap(streamID).get(key);
+        String val = state.getMap(CorfuRuntime.getStreamID(streamId)).get(key);
+
+
+        String correctnessRecord = String.format("%s, %s:%s=%s", shortName, streamId, key, val);
+        Correctness.recordOperation(correctnessRecord, TransactionalContext.isInTransaction());
+
+        // Accessing secondary objects
+        ((CorfuTable)state.getMap((CorfuRuntime.getStreamID(streamId)))).
+                getByIndex(State.StringIndexer.BY_FIRST_CHAR, "a");
+        ((CorfuTable)state.getMap((CorfuRuntime.getStreamID(streamId)))).
+                getByIndex(State.StringIndexer.BY_VALUE, val);
+
     }
 }

--- a/generator/src/main/java/org/corfudb/generator/operations/RemoveOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/RemoveOperation.java
@@ -1,24 +1,31 @@
 package org.corfudb.generator.operations;
 
-import java.util.UUID;
-
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.generator.Correctness;
 import org.corfudb.generator.State;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
 
 /**
  * Created by maithem on 7/14/17.
  */
 @Slf4j
 public class RemoveOperation extends Operation {
-
     public RemoveOperation(State state) {
         super(state);
+        shortName = "Rm";
     }
 
     @Override
     public void execute() {
-        UUID streamID = (UUID) state.getStreams().sample(1).get(0);
-        String key = (String) state.getKeys().sample(1).get(0);
-        state.getMap(streamID).remove(key);
+        // Hack for Transaction writes only
+        if (TransactionalContext.isInTransaction()) {
+            String streamId = (String) state.getStreams().sample(1).get(0);
+            String key = (String) state.getKeys().sample(1).get(0);
+            state.getMap(CorfuRuntime.getStreamID(streamId)).remove(key);
+
+            String correctnessRecord = String.format("%s, %s:%s", shortName, streamId, key);
+            Correctness.recordOperation(correctnessRecord, TransactionalContext.isInTransaction());
+        }
     }
 }

--- a/generator/src/main/java/org/corfudb/generator/operations/SleepOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/SleepOperation.java
@@ -13,6 +13,7 @@ public class SleepOperation extends Operation {
 
     public SleepOperation(State state) {
         super(state);
+        shortName = "Sleep";
     }
 
     @Override
@@ -23,7 +24,9 @@ public class SleepOperation extends Operation {
         try {
             Thread.sleep(sleepTime);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException(e);
+
         }
     }
 }

--- a/generator/src/main/java/org/corfudb/generator/operations/SnapshotTxOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/SnapshotTxOperation.java
@@ -1,8 +1,11 @@
 package org.corfudb.generator.operations;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.generator.Correctness;
 import org.corfudb.generator.State;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -12,31 +15,52 @@ import java.util.Random;
 @Slf4j
 public class SnapshotTxOperation extends Operation {
 
+
     public SnapshotTxOperation(State state) {
         super(state);
+        shortName = "TxSnap";
     }
 
     @Override
     public void execute() {
-        long trimMark = state.getTrimMark();
-        Random rand = new Random();
-        long delta = (long) rand.nextInt(10) + 1;
-        state.startSnapshotTx(trimMark + delta);
+        try {
+            long trimMark = state.getTrimMark();
+            Random rand = new Random();
+            long delta = (long) rand.nextInt(10) + 1;
 
-        int numOperations = state.getOperationCount().sample(1).get(0);
-        List<Operation> operations = state.getOperations().sample(numOperations);
+            // Safety Hack for not having snapshot in the future
 
-        for (int x = 0; x < operations.size(); x++) {
-            if (operations.get(x) instanceof OptimisticTxOperation
-                    || operations.get(x) instanceof SnapshotTxOperation
-                    || operations.get(x) instanceof RemoveOperation
-                    || operations.get(x) instanceof WriteOperation) {
-                continue;
+            long currentMax = state.getRuntime().getSequencerView()
+                    .nextToken(Collections.emptySet(), 0)
+                    .getToken().getTokenValue();
+
+            long snapShotAddress = Long.min(trimMark + delta, currentMax);
+
+            Correctness.recordTransactionMarkers(false, shortName, Correctness.TX_START);
+
+            state.startSnapshotTx(snapShotAddress);
+
+            int numOperations = state.getOperationCount().sample(1).get(0);
+            List<Operation> operations = state.getOperations().sample(numOperations);
+
+            for (int x = 0; x < operations.size(); x++) {
+                if (operations.get(x) instanceof OptimisticTxOperation
+                        || operations.get(x) instanceof SnapshotTxOperation
+                        || operations.get(x) instanceof RemoveOperation
+                        || operations.get(x) instanceof WriteOperation
+                        || operations.get(x) instanceof NestedTxOperation) {
+                    continue;
+                }
+
+                operations.get(x).execute();
             }
 
-            operations.get(x).execute();
+            state.stopTx();
+            Correctness.recordTransactionMarkers(false, shortName, Correctness.TX_END);
+        } catch (TransactionAbortedException tae) {
+            Correctness.recordTransactionMarkers(false, shortName, Correctness.TX_ABORTED);
         }
 
-        state.stopSnapshotTx();
+
     }
 }

--- a/generator/src/main/java/org/corfudb/generator/operations/WriteAfterWriteTxOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/WriteAfterWriteTxOperation.java
@@ -1,0 +1,47 @@
+package org.corfudb.generator.operations;
+
+import org.corfudb.generator.Correctness;
+import org.corfudb.generator.State;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+
+import java.util.List;
+
+/**
+ * Created by rmichoud on 10/6/17.
+ */
+public class WriteAfterWriteTxOperation extends Operation {
+
+    public WriteAfterWriteTxOperation(State state) {
+        super(state);
+        shortName = "TxWaw";
+    }
+
+    @Override
+    public void execute() {
+        Correctness.recordTransactionMarkers(false, shortName, Correctness.TX_START);
+        long timestamp;
+        state.startWriteAfterWriteTx();
+
+        int numOperations = state.getOperationCount().sample(1).get(0);
+        List<Operation> operations = state.getOperations().sample(numOperations);
+
+        for (int x = 0; x < operations.size(); x++) {
+            if (operations.get(x) instanceof org.corfudb.generator.operations.OptimisticTxOperation
+                    || operations.get(x) instanceof SnapshotTxOperation
+                    || operations.get(x) instanceof NestedTxOperation)
+            {
+                continue;
+            }
+
+            operations.get(x).execute();
+        }
+        try {
+            timestamp = state.stopTx();
+            Correctness.recordTransactionMarkers(true, shortName, Correctness.TX_END,
+                    Long.toString(timestamp));
+        } catch (TransactionAbortedException tae) {
+            Correctness.recordTransactionMarkers(false, shortName, Correctness.TX_ABORTED);
+        }
+
+    }
+}

--- a/generator/src/main/java/org/corfudb/generator/operations/WriteOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/WriteOperation.java
@@ -3,7 +3,10 @@ package org.corfudb.generator.operations;
 import java.util.UUID;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.generator.Correctness;
 import org.corfudb.generator.State;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
 
 /**
  * Created by maithem on 7/14/17.
@@ -13,12 +16,21 @@ public class WriteOperation extends Operation {
 
     public WriteOperation(State state) {
         super(state);
+        shortName = "Write";
     }
 
     @Override
     public void execute() {
-        UUID streamID = (UUID) state.getStreams().sample(1).get(0);
-        String key = (String) state.getKeys().sample(1).get(0);
-        state.getMap(streamID).put(key, UUID.randomUUID().toString());
+        // Hack for Transaction writes only
+        if (TransactionalContext.isInTransaction()) {
+            String streamId = (String) state.getStreams().sample(1).get(0);
+
+            String key = (String) state.getKeys().sample(1).get(0);
+            String val = UUID.randomUUID().toString();
+            state.getMap(CorfuRuntime.getStreamID(streamId)).put(key, val);
+
+            String correctnessRecord = String.format("%s, %s:%s=%s", shortName, streamId, key, val);
+            Correctness.recordOperation(correctnessRecord, TransactionalContext.isInTransaction());
+        }
     }
 }

--- a/generator/src/main/resources/logback-test.xml
+++ b/generator/src/main/resources/logback-test.xml
@@ -7,21 +7,35 @@
     </appender>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>${user.home}/corfudb.log</file>
+        <append>false</append>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{3}</pattern>
+        </encoder>
+    </appender>
+    <appender name="CORRECTNESS" class="ch.qos.logback.core.FileAppender">
+        <file>${user.home}/correctness.log</file>
+        <append>false</append>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd_HH:mm:ss.SSS}, [%thread], %msg %n</pattern>
         </encoder>
     </appender>
 
     <!-- Control logging levels for individual components here. -->
     <logger name="org.corfudb.runtime.object" level="TRACE"/>
-    <logger name="org.corfudb.runtime.clients" level="INFO"/>
-    <logger name="org.corfudb.infrastructure" level="INFO"/>
+    <logger name="org.corfudb.runtime.clients" level="TRACE"/>
+    <logger name="org.corfudb.runtime.view" level="TRACE"/>
+    <logger name="org.corfudb.infrastructure" level="TRACE"/>
     <logger name="io.netty.util" level="INFO"/>
     <logger name="io.netty.util.internal" level="INFO"/>
     <logger name="io.netty.buffer" level="INFO"/>
 
+    <!-- Correctness -->
+    <logger name="correctness" level="INFO" additivity="false">
+        <appender-ref ref="CORRECTNESS"/>
+    </logger>
+
     <root level="TRACE">
-        <!--<appender-ref ref="FILE" /-->
+        <!--<appender-ref ref="FILE" />-->
         <!--<appender-ref ref="STDOUT" />-->
     </root>
 </configuration>

--- a/generator/src/main/resources/logback-test.xml
+++ b/generator/src/main/resources/logback-test.xml
@@ -30,7 +30,7 @@
     <logger name="io.netty.buffer" level="INFO"/>
 
     <!-- Correctness -->
-    <logger name="correctness" level="INFO" additivity="false">
+    <logger name="correctness" level="TRACE" additivity="false">
         <appender-ref ref="CORRECTNESS"/>
     </logger>
 

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -4,7 +4,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 
 import com.google.common.collect.ImmutableList;
-
+import com.google.common.collect.ImmutableMap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.ChannelFuture;
@@ -22,6 +22,9 @@ import io.netty.util.concurrent.DefaultEventExecutorGroup;
 import io.netty.util.concurrent.EventExecutorGroup;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -33,7 +36,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import javax.net.ssl.SSLEngine;
-
+import javax.net.ssl.SSLException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -62,7 +65,7 @@ import static org.fusesource.jansi.Ansi.ansi;
  */
 
 @Slf4j
-public class CorfuServer {
+public class CorfuServer implements AutoCloseable {
     /**
      * This string defines the command line arguments,
      * in the docopt DSL (see http://docopt.org) for the executable.
@@ -75,130 +78,116 @@ public class CorfuServer {
      * that each option must be preceded with a space.
      */
     private static final String USAGE =
-            "Corfu Server, the server for the Corfu Infrastructure.\n"
-                    + "\n"
-                    + "Usage:\n"
-                    + "\tcorfu_server (-l <path>|-m) [-ns] [-a <address>] [-t <token>] [-c "
-                    + "<ratio>] [-d <level>] [-p <seconds>] [-M <address>:<port>] [-e [-u "
-                    + "<keystore> -f <keystore_password_file>] [-r <truststore> -w "
-                    + "<truststore_password_file>] [-b] [-g -o <username_file> -j <password_file>] "
-                    + "[-k <seqcache>]"
-                    + "[-x <ciphers>] [-z <tls-protocols>]] <port>\n"
-                    + "\n"
-                    + "Options:\n"
-                    + " -l <path>, --log-path=<path>                                             "
-                    + "              Set the path to the storage file for the log unit.\n"
-                    + " -s, --single                                                             "
-                    + "              Deploy a single-node configuration.\n"
-                    + "                                                                          "
-                    + "              The server will be bootstrapped with a simple one-unit layout."
-                    + "\n -a <address>, --address=<address>                                      "
-                    + "                IP address to advertise to external clients [default: "
-                    + "localhost].\n"
-                    + " -m, --memory                                                             "
-                    + "              Run the unit in-memory (non-persistent).\n"
-                    + "                                                                          "
-                    + "              Data will be lost when the server exits!\n"
-                    + " -c <ratio>, --cache-heap-ratio=<ratio>                                   "
-                    + "              The ratio of jvm max heap size we will use for the the "
-                    + "in-memory cache to serve requests from -\n"
-                    + "                                                                          "
-                    + "              (e.g. ratio = 0.5 means the cache size will be 0.5 * jvm max "
-                    + "heap size\n"
-                    + "                                                                          "
-                    + "              If there is no log, then this will be the size of the log unit"
-                    + "\n                                                                        "
-                    + "                evicted entries will be auto-trimmed. [default: 0.5].\n"
-                    + " -t <token>, --initial-token=<token>                                      "
-                    + "              The first token the sequencer will issue, or -1 to recover\n"
-                    + "                                                                          "
-                    + "              from the log. [default: -1].\n                              "
-                    + "                                                                          "
-                    + " -k <seqcache>, --sequencer-cache-size=<seqcache>                         "
-                    + "               The size of the sequencer's cache. [default: 250000].\n    "
-                    + " -p <seconds>, --compact=<seconds>                                        "
-                    + "              The rate the log unit should compact entries (find the,\n"
-                    + "                                                                          "
-                    + "              contiguous tail) in seconds [default: 60].\n"
-                    + " -d <level>, --log-level=<level>                                          "
-                    + "              Set the logging level, valid levels are: \n"
-                    + "                                                                          "
-                    + "              ERROR,WARN,INFO,DEBUG,TRACE [default: INFO].\n"
-                    + " -M <address>:<port>, --management-server=<address>:<port>                "
-                    + "              Layout endpoint to seed Management Server\n"
-                    + " -n, --no-verify                                                          "
-                    + "              Disable checksum computation and verification.\n"
-                    + " -e, --enable-tls                                                         "
-                    + "              Enable TLS.\n"
-                    + " -u <keystore>, --keystore=<keystore>                                     "
-                    + "              Path to the key store.\n"
-                    + " -f <keystore_password_file>, "
-                    + "--keystore-password-file=<keystore_password_file>         Path to the file "
-                    + "containing the key store password.\n"
-                    + " -b, --enable-tls-mutual-auth                                             "
-                    + "              Enable TLS mutual authentication.\n"
-                    + " -r <truststore>, --truststore=<truststore>                               "
-                    + "              Path to the trust store.\n"
-                    + " -w <truststore_password_file>, "
-                    + "--truststore-password-file=<truststore_password_file>   Path to the file "
-                    + "containing the trust store password.\n"
-                    + " -g, --enable-sasl-plain-text-auth                                        "
-                    + "              Enable SASL Plain Text Authentication.\n"
-                    + " -o <username_file>, --sasl-plain-text-username-file=<username_file>      "
-                    + "              Path to the file containing the username for SASL Plain Text "
-                    + "Authentication.\n"
-                    + " -j <password_file>, --sasl-plain-text-password-file=<password_file>      "
-                    + "              Path to the file containing the password for SASL Plain Text "
-                    + "Authentication.\n"
-                    + " -x <ciphers>, --tls-ciphers=<ciphers>                                    "
-                    + "              Comma separated list of TLS ciphers to use.\n"
-                    + "                                                                          "
-                    + "              [default: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256].\n"
-                    + " -z <tls-protocols>, --tls-protocols=<tls-protocols>                      "
-                    + "              Comma separated list of TLS protocols to use.\n"
-                    + "                                                                          "
-                    + "              [default: TLSv1.1,TLSv1.2].\n"
-                    + " -h, --help                                                               "
-                    + "              Show this screen\n"
-                    + " --version                                                                "
-                    + "              Show version\n";
-    public static boolean serverRunning = false;
-    @Getter
-    private static SequencerServer sequencerServer;
-    @Getter
-    private static LayoutServer layoutServer;
-    @Getter
-    private static LogUnitServer logUnitServer;
-    @Getter
-    private static ManagementServer managementServer;
-    private static NettyServerRouter router;
-    private static ServerContext serverContext;
-    private static SslContext sslContext;
-    private static String[] enabledTlsProtocols;
-    private static String[] enabledTlsCipherSuites;
+        "Corfu Server, the server for the Corfu Infrastructure.\n"
+            + "\n"
+            + "Usage:\n"
+            + "\tcorfu_server (-l <path>|-m) [-ns] [-a <address>|-q <interface-name>] "
+            + "[-t <token>] [-c <ratio>] [-d <level>] [-p <seconds>] [-M <address>:<port>] "
+            + "[-e [-u <keystore> -f <keystore_password_file>] [-r <truststore> -w "
+            + "<truststore_password_file>] [-b] [-g -o <username_file> -j <password_file>] "
+            + "[-k <seqcache>] [-T <threads>] [-i <channel-implementation>] [-H <seconds>] "
+            + "[-I <cluster-id>] [-x <ciphers>] [-z <tls-protocols>]] [-P <prefix>]"
+            + " [--agent] <port>\n"
+            + "\n"
+            + "Options:\n"
+            + " -l <path>, --log-path=<path>                                             "
+            + "              Set the path to the storage file for the log unit.\n"
+            + " -s, --single                                                             "
+            + "              Deploy a single-node configuration.\n"
+            + " -I <cluster-id>, --cluster-id=<cluster-id>"
+            + "              For a single node configuration the cluster id to use in UUID,"
+            + "              base64 format, or auto to randomly generate [default: auto].\n"
+            + " -T <threads>, --Threads=<threads>                                        "
+            + "              Number of corfu server worker threads, or 0 to use 2x the "
+            + "              number of available processors [default: 0].\n"
+            + " -P <prefix> --Prefix=<prefix>"
+            + "              The prefix to use for threads (useful for debugging multiple"
+            + "              servers) [default: ]."
+            + "                                                                          "
+            + "              The server will be bootstrapped with a simple one-unit layout."
+            + "\n -a <address>, --address=<address>                                      "
+            + "                IP address for the server router to bind to and to "
+            + "advertise to external clients.\n"
+            + " -q <interface-name>, --network-interface=<interface-name>                "
+            + "              The name of the network interface.\n"
+            + " -i <channel-implementation>, --implementation <channel-implementation>   "
+            + "              The type of channel to use (auto, nio, epoll, kqueue)"
+            + "[default: nio].\n"
+            + " -m, --memory                                                             "
+            + "              Run the unit in-memory (non-persistent).\n"
+            + "                                                                          "
+            + "              Data will be lost when the server exits!\n"
+            + " -c <ratio>, --cache-heap-ratio=<ratio>                                   "
+            + "              The ratio of jvm max heap size we will use for the the "
+            + "in-memory cache to serve requests from -\n"
+            + "                                                                          "
+            + "              (e.g. ratio = 0.5 means the cache size will be 0.5 * jvm max "
+            + "heap size\n"
+            + "                                                                          "
+            + "              If there is no log, then this will be the size of the log unit"
+            + "\n                                                                        "
+            + "                evicted entries will be auto-trimmed. [default: 0.5].\n"
+            + " -H <seconds>, --HandshakeTimeout=<sceonds>                               "
+            + "              Handshake timeout in seconds [default: 10].\n               "
+            + " -t <token>, --initial-token=<token>                                      "
+            + "              The first token the sequencer will issue, or -1 to recover\n"
+            + "                                                                          "
+            + "              from the log. [default: -1].\n                              "
+            + "                                                                          "
+            + " -k <seqcache>, --sequencer-cache-size=<seqcache>                         "
+            + "               The size of the sequencer's cache. [default: 250000].\n    "
+            + " -p <seconds>, --compact=<seconds>                                        "
+            + "              The rate the log unit should compact entries (find the,\n"
+            + "                                                                          "
+            + "              contiguous tail) in seconds [default: 60].\n"
+            + " -d <level>, --log-level=<level>                                          "
+            + "              Set the logging level, valid levels are: \n"
+            + "                                                                          "
+            + "              ALL,ERROR,WARN,INFO,DEBUG,TRACE,OFF [default: INFO].\n"
+            + " -M <address>:<port>, --management-server=<address>:<port>                "
+            + "              Layout endpoint to seed Management Server\n"
+            + " -n, --no-verify                                                          "
+            + "              Disable checksum computation and verification.\n"
+            + " -e, --enable-tls                                                         "
+            + "              Enable TLS.\n"
+            + " -u <keystore>, --keystore=<keystore>                                     "
+            + "              Path to the key store.\n"
+            + " -f <keystore_password_file>, "
+            + "--keystore-password-file=<keystore_password_file>         Path to the file "
+            + "containing the key store password.\n"
+            + " -b, --enable-tls-mutual-auth                                             "
+            + "              Enable TLS mutual authentication.\n"
+            + " -r <truststore>, --truststore=<truststore>                               "
+            + "              Path to the trust store.\n"
+            + " -w <truststore_password_file>, "
+            + "--truststore-password-file=<truststore_password_file>   Path to the file "
+            + "containing the trust store password.\n"
+            + " -g, --enable-sasl-plain-text-auth                                        "
+            + "              Enable SASL Plain Text Authentication.\n"
+            + " -o <username_file>, --sasl-plain-text-username-file=<username_file>      "
+            + "              Path to the file containing the username for SASL Plain Text "
+            + "Authentication.\n"
+            + " -j <password_file>, --sasl-plain-text-password-file=<password_file>      "
+            + "              Path to the file containing the password for SASL Plain Text "
+            + "Authentication.\n"
+            + " -x <ciphers>, --tls-ciphers=<ciphers>                                    "
+            + "              Comma separated list of TLS ciphers to use.\n"
+            + "                                                                          "
+            + "              [default: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256].\n"
+            + " -z <tls-protocols>, --tls-protocols=<tls-protocols>                      "
+            + "              Comma separated list of TLS protocols to use.\n"
+            + "                                                                          "
+            + "              [default: TLSv1.1,TLSv1.2].\n"
+            + " --agent      Run with byteman agent to enable runtime code injection.\n  "
+            + " -h, --help                                                               "
+            + "              Show this screen\n"
+            + " --version                                                                "
+            + "              Show version\n";
 
-    /**
-     * Print the corfu logo.
-     */
-    public static void printLogo() {
-        System.out.println(ansi().fg(WHITE).a("▄████████  ▄██████▄     ▄████████    ▄████████ ███"
-                + "    █▄").reset());
-        System.out.println(ansi().fg(WHITE).a("███    ███ ███    ███   ███    ███   ███    ███ "
-                + "███    ███").reset());
-        System.out.println(ansi().fg(WHITE).a("███    █▀  ███    ███   ███    ███   ███    █▀  "
-                + "███    ███").reset());
-        System.out.println(ansi().fg(WHITE).a("███        ███    ███  ▄███▄▄▄▄██▀  ▄███▄▄▄     "
-                + "███    ███").reset());
-        System.out.println(ansi().fg(WHITE).a("███        ███    ███ ▀▀███▀▀▀▀▀   ▀▀███▀▀▀     "
-                + "███    ███").reset());
-        System.out.println(ansi().fg(WHITE).a("███    █▄  ███    ███ ▀███████████   ███        "
-                + "███    ███").reset());
-        System.out.println(ansi().fg(WHITE).a("███    ███ ███    ███   ███    ███   ███        "
-                + "███    ███").reset());
-        System.out.println(ansi().fg(WHITE).a("████████▀   ▀██████▀    ███    ███   ███        "
-                + "████████▀").reset());
-        System.out.println(ansi().fg(WHITE).a("                        ███    ███").reset());
-    }
+    private static volatile CorfuServer ACTIVE_SERVER;
+
+    private static volatile boolean SHUTDOWN_SERVER = false;
+    private static volatile boolean CLEANUP_SERVER = false;
 
     /**
      * Main program entry point.
@@ -208,10 +197,9 @@ public class CorfuServer {
         serverRunning = true;
 
         // Parse the options given, using docopt.
-        Map<String, Object> opts =
-                new Docopt(USAGE).withVersion(GitRepositoryState.getRepositoryState().describe)
-                        .parse(args);
-
+        Map<String, Object> opts = new Docopt(USAGE)
+            .withVersion(GitRepositoryState.getRepositoryState().describe)
+            .parse(args);
         // Print a nice welcome message.
         AnsiConsole.systemInstall();
         printLogo();
@@ -251,6 +239,23 @@ public class CorfuServer {
 
         log.debug("Started with arguments: " + opts);
 
+        // Bind to all interfaces only if no address or interface specified by the user.
+        final boolean bindToAllInterfaces;
+        // Fetch the address if given a network interface.
+        if (opts.get("--network-interface") != null) {
+            opts.put("--address",
+                getAddressFromInterfaceName((String) opts.get("--network-interface")));
+            bindToAllInterfaces = false;
+        } else if (opts.get("--address") == null) {
+            // Default the address to localhost and set the bind to all interfaces flag to true,
+            // if the address and interface is not specified.
+            bindToAllInterfaces = true;
+            opts.put("--address", "localhost");
+        } else {
+            // Address is specified by the user.
+            bindToAllInterfaces = false;
+        }
+
         // Create the service directory if it does not exist.
         if (!(Boolean) opts.get("--memory")) {
             File serviceDir = new File((String) opts.get("--log-path"));
@@ -261,35 +266,241 @@ public class CorfuServer {
                 }
             } else if (!serviceDir.isDirectory()) {
                 log.error("Service directory {} does not point to a directory. Aborting.",
-                        serviceDir);
-                throw new RuntimeException("Service directory must be a directory!");
+                    serviceDir);
+                throw new UnrecoverableCorfuError("Service directory must be a directory!");
+            } else {
+                String corfuServiceDirPath = serviceDir.getAbsolutePath()
+                    + File.separator
+                    + "corfu";
+                File corfuServiceDir = new File(corfuServiceDirPath);
+                // Update the new path with the dedicated child service directory.
+                opts.put("--log-path", corfuServiceDirPath);
+                if (!corfuServiceDir.exists() && corfuServiceDir.mkdirs()) {
+                    log.info("Created new service directory at {}.", corfuServiceDir);
+                }
             }
         }
 
-        // Now, we start the Netty router, and have it route to the correct port.
-        router = new NettyServerRouter(opts);
+        // Register shutdown handler
+        Thread shutdownThread = new Thread(CorfuServer::cleanShutdown);
+        shutdownThread.setName("ShutdownThread");
+        Runtime.getRuntime().addShutdownHook(shutdownThread);
 
-        // Create a common Server Context for all servers to access.
-        serverContext = new ServerContext(opts, router);
+        while (!SHUTDOWN_SERVER) {
+            final ServerContext sc = new ServerContext(opts);
+            try (CorfuServer corfuServer = new CorfuServer(sc)) {
+                ACTIVE_SERVER = corfuServer;
+                corfuServer.start().channel().closeFuture().syncUninterruptibly();
+            }
 
-        // Add each role to the router.
-        addSequencer();
-        addLayoutServer();
-        addLogUnit();
-        addManagementServer();
-        router.baseServer.setOptionsMap(opts);
+            if (CLEANUP_SERVER) {
+                log.warn("main: cleanup reqeusted, DELETE server data files");
+                if (!sc.getServerConfig(Boolean.class, "--memory")) {
+                    File serviceDir = new File(sc.getServerConfig(String.class, "--log-path"));
+                    try {
+                        FileUtils.cleanDirectory(serviceDir);
+                    } catch (IOException ioe) {
+                        throw new UnrecoverableCorfuError(ioe);
+                    }
+                }
+                CLEANUP_SERVER = false;
+                log.warn("main: cleanup completed, expect clean startup");
+            }
+        }
 
-        // Setup SSL if needed
-        Boolean tlsEnabled = (Boolean) opts.get("--enable-tls");
-        Boolean tlsMutualAuthEnabled = (Boolean) opts.get("--enable-tls-mutual-auth");
+        log.info("main: Server exiting due to shutdown");
+    }
+
+
+    @Getter
+    private final ServerContext serverContext;
+
+    @Getter
+    private final Map<Class<? extends AbstractServer>, AbstractServer> serverMap;
+
+    @Getter
+    private final NettyServerRouter router;
+
+    private volatile boolean shutdown = false;
+
+    private ChannelFuture bindFuture;
+
+    public CorfuServer(@Nonnull ServerContext serverContext) {
+        this(serverContext,
+            ImmutableMap.<Class<? extends AbstractServer>, AbstractServer>builder()
+                .put(BaseServer.class, new BaseServer(serverContext))
+                .put(SequencerServer.class, new SequencerServer(serverContext))
+                .put(LayoutServer.class, new LayoutServer(serverContext))
+                .put(LogUnitServer.class, new LogUnitServer(serverContext))
+                .put(ManagementServer.class, new ManagementServer(serverContext))
+                .build()
+            );
+    }
+
+    public CorfuServer(@Nonnull ServerContext serverContext,
+                       @Nonnull Map<Class<? extends AbstractServer>, AbstractServer> serverMap) {
+        this.serverContext = serverContext;
+        this.serverMap = serverMap;
+        router = new NettyServerRouter(serverMap.values(), serverContext);
+    }
+
+    public ChannelFuture start() {
+        bindFuture = startAndListen(serverContext.getBossGroup(),
+            serverContext.getWorkerGroup(),
+            b -> configureBootstrapOptions(serverContext, b),
+            serverContext,
+            router,
+            serverContext.getNodeLocator().getBindingSocketAddress());
+
+        return bindFuture.syncUninterruptibly();
+    }
+
+    @Override
+    public synchronized void close() {
+        if (!shutdown) {
+            log.info("close: Shutting down Corfu server and cleaning resources");
+            shutdown = true;
+            serverContext.close();
+            bindFuture.channel().close().syncUninterruptibly();
+
+            // A executor service to create the shutdown threads
+            // plus name the threads correctly.
+            final ExecutorService shutdownService =
+                Executors.newFixedThreadPool(serverMap.size());
+
+            // Turn into a list of futures on the shutdown, returning
+            // generating a log message to inform of the result.
+            CompletableFuture[] shutdownFutures = serverMap.values().stream()
+                .map(s -> CompletableFuture.runAsync(() -> {
+                    try {
+                        Thread.currentThread().setName(s.getClass().getSimpleName()
+                            + "-shutdown");
+                        log.info("close: Shutting down {}",
+                            s.getClass().getSimpleName());
+                        s.shutdown();
+                        log.info("close: Cleanly shutdown {}",
+                            s.getClass().getSimpleName());
+                    } catch (Exception e) {
+                        log.error("close: Failed to cleanly shutdown {}",
+                            s.getClass().getSimpleName(), e);
+                    }
+                }, shutdownService))
+                .toArray(CompletableFuture[]::new);
+
+            CompletableFuture.allOf(shutdownFutures).join();
+            shutdownService.shutdown();
+            router.shutdown();
+            log.info("close: Server shutdown and resources released");
+        } else {
+            log.trace("close: Server already shutdown");
+        }
+    }
+
+    /** Get the requested Corfu server.
+     *
+     * @param serverClass
+     * @param <T>
+     * @return
+     */
+    @SuppressWarnings("unchecked")
+    public @Nonnull <T extends AbstractServer> T getServer(@Nonnull Class<T> serverClass) {
+        T server = (T) serverMap.get(serverClass);
+        if (server == null) {
+            throw new UnrecoverableCorfuError("Server does not exist");
+        }
+        return server;
+    }
+
+    /** A functional interface for receiving and configuring a {@link ServerBootstrap}.
+     */
+    @FunctionalInterface
+    public interface BootstrapConfigurer {
+
+        /** Configure a {@link ServerBootstrap}.
+         *
+         * @param serverBootstrap   The {@link ServerBootstrap} to configure.
+         */
+        void configure(ServerBootstrap serverBootstrap);
+    }
+
+
+    /** Start the Corfu server and bind it to the given {@code port} using the provided
+     * {@code channelType}. It is the callers' responsibility to shutdown the
+     * {@link EventLoopGroup}s. For implementations which listen on multiple ports,
+     * {@link EventLoopGroup}s may be reused.
+     *
+     * @param bossGroup             The "boss" {@link EventLoopGroup} which services incoming
+     *                              connections.
+     * @param workerGroup           The "worker" {@link EventLoopGroup} which services incoming
+     *                              requests.
+     * @param bootstrapConfigurer   A {@link BootstrapConfigurer} which will receive the
+     *                              {@link ServerBootstrap} to set options.
+     * @param context               A {@link ServerContext} which will be used to configure the
+     *                              server.
+     * @param router                A {@link NettyServerRouter} which will process incoming
+     *                              messages.
+     * @param address               The {@link SocketAddress} the {@link ServerChannel}
+     *                              will be created on.
+     * @return                      A {@link ChannelFuture} which can be used to wait for the server
+     *                              to be shutdown.
+     */
+    public ChannelFuture startAndListen(@Nonnull EventLoopGroup bossGroup,
+        @Nonnull EventLoopGroup workerGroup,
+        @Nonnull BootstrapConfigurer bootstrapConfigurer,
+        @Nonnull ServerContext context,
+        @Nonnull NettyServerRouter router,
+        @Nonnull SocketAddress address) {
+
+        ServerBootstrap bootstrap = new ServerBootstrap();
+        bootstrap.group(bossGroup, workerGroup)
+            .channel(context.getChannelImplementation().getServerChannelClass());
+        bootstrapConfigurer.configure(bootstrap);
+
+        bootstrap.childHandler(getServerChannelInitializer(context, router));
+        return bootstrap.bind(address);
+    }
+
+    /** Configure server bootstrap per-channel options, such as TCP options, etc.
+     *
+     * @param context       The {@link ServerContext} to use.
+     * @param bootstrap     The {@link ServerBootstrap} to be configured.
+     */
+    public static void configureBootstrapOptions(@Nonnull ServerContext context,
+        @Nonnull ServerBootstrap bootstrap) {
+        bootstrap.option(ChannelOption.SO_BACKLOG, 100)
+            .childOption(ChannelOption.SO_KEEPALIVE, true)
+            .childOption(ChannelOption.SO_REUSEADDR, true)
+            .childOption(ChannelOption.TCP_NODELAY, true)
+            .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
+    }
+
+
+    /** Obtain a {@link ChannelInitializer} which initializes the channel pipeline
+     *  for a new {@link ServerChannel}.
+     *
+     * @param context   The {@link ServerContext} to use.
+     * @param router    The {@link NettyServerRouter} to initialize the channel with.
+     * @return          A {@link ChannelInitializer} to intialize the channel.
+     */
+    private static ChannelInitializer getServerChannelInitializer(@Nonnull ServerContext context,
+        @Nonnull NettyServerRouter router) {
+        // Security variables
+        final SslContext sslContext;
+        final String[] enabledTlsProtocols;
+        final String[] enabledTlsCipherSuites;
+
+        // Security Initialization
+        Boolean tlsEnabled = context.getServerConfig(Boolean.class, "--enable-tls");
+        Boolean tlsMutualAuthEnabled = context.getServerConfig(Boolean.class,
+            "--enable-tls-mutual-auth");
         if (tlsEnabled) {
             // Get the TLS cipher suites to enable
             String ciphs = (String) opts.get("--tls-ciphers");
             if (ciphs != null) {
                 List<String> ciphers = Pattern.compile(",")
-                        .splitAsStream(ciphs)
-                        .map(String::trim)
-                        .collect(Collectors.toList());
+                    .splitAsStream(ciphs)
+                    .map(String::trim)
+                    .collect(Collectors.toList());
                 enabledTlsCipherSuites = ciphers.toArray(new String[ciphers.size()]);
             }
 
@@ -297,9 +508,9 @@ public class CorfuServer {
             String protos = (String) opts.get("--tls-protocols");
             if (protos != null) {
                 List<String> protocols = Pattern.compile(",")
-                        .splitAsStream(protos)
-                        .map(String::trim)
-                        .collect(Collectors.toList());
+                    .splitAsStream(protos)
+                    .map(String::trim)
+                    .collect(Collectors.toList());
                 enabledTlsProtocols = protocols.toArray(new String[protocols.size()]);
             }
 
@@ -328,21 +539,40 @@ public class CorfuServer {
             }
         }
 
-        Boolean saslPlainTextAuth = (Boolean) opts.get("--enable-sasl-plain-text-auth");
-
-        // Create the event loops responsible for servicing inbound messages.
-        EventLoopGroup bossGroup;
-        EventLoopGroup workerGroup;
-        EventExecutorGroup ee;
-
-        bossGroup = new NioEventLoopGroup(1, new ThreadFactory() {
-            final AtomicInteger threadNum = new AtomicInteger(0);
+        Boolean saslPlainTextAuth = context.getServerConfig(Boolean.class,
+            "--enable-sasl-plain-text-auth");
 
             @Override
-            public Thread newThread(Runnable r) {
-                Thread t = new Thread(r);
-                t.setName("accept-" + threadNum.getAndIncrement());
-                return t;
+            protected void initChannel(@Nonnull Channel ch) throws Exception {
+                // If TLS is enabled, setup the encryption pipeline.
+                if (tlsEnabled) {
+                    SSLEngine engine = sslContext.newEngine(ch.alloc());
+                    engine.setEnabledCipherSuites(enabledTlsCipherSuites);
+                    engine.setEnabledProtocols(enabledTlsProtocols);
+                    if (tlsMutualAuthEnabled) {
+                        engine.setNeedClientAuth(true);
+                    }
+                    ch.pipeline().addLast("ssl", new SslHandler(engine));
+                }
+                // Add/parse a length field
+                ch.pipeline().addLast(new LengthFieldPrepender(4));
+                ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer
+                    .MAX_VALUE, 0, 4,
+                    0, 4));
+                // If SASL authentication is requested, perform a SASL plain-text auth.
+                if (saslPlainTextAuth) {
+                    ch.pipeline().addLast("sasl/plain-text", new
+                        PlainTextSaslNettyServer());
+                }
+                // Transform the framed message into a Corfu message.
+                ch.pipeline().addLast(new NettyCorfuMessageDecoder());
+                ch.pipeline().addLast(new NettyCorfuMessageEncoder());
+                ch.pipeline().addLast(new ServerHandshakeHandler(context.getNodeId(),
+                    Version.getVersionString() + "("
+                        + GitRepositoryState.getRepositoryState().commitIdAbbrev + ")",
+                    context.getServerConfig(String.class, "--HandshakeTimeout")));
+                // Route the message to the server class.
+                ch.pipeline().addLast(router);
             }
         });
 
@@ -361,76 +591,16 @@ public class CorfuServer {
         ee = new DefaultEventExecutorGroup(Runtime.getRuntime().availableProcessors() * 2, new
                 ThreadFactory() {
 
-                    final AtomicInteger threadNum = new AtomicInteger(0);
+        final Map<String, Object> opts = serverContext.getServerConfig();
 
-                    @Override
-                    public Thread newThread(Runnable r) {
-                        Thread t = new Thread(r);
-                        t.setName("event-" + threadNum.getAndIncrement());
-                        return t;
-                    }
-                });
-
-
-        // Register shutdown handler
-        Thread shutdownThread = new Thread(CorfuServer::cleanShutdown);
-        shutdownThread.setName("ShutdownThread");
-        Runtime.getRuntime().addShutdownHook(
-                shutdownThread);
-
-        try {
-            ServerBootstrap b = new ServerBootstrap();
-            b.group(bossGroup, workerGroup)
-                    .channel(NioServerSocketChannel.class)
-                    .option(ChannelOption.SO_BACKLOG, 100)
-                    .childOption(ChannelOption.SO_KEEPALIVE, true)
-                    .childOption(ChannelOption.SO_REUSEADDR, true)
-                    .childOption(ChannelOption.TCP_NODELAY, true)
-                    .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT)
-                    .childHandler(new ChannelInitializer<SocketChannel>() {
-                        @Override
-                        public void initChannel(io.netty.channel.socket.SocketChannel ch) throws
-                                Exception {
-                            if (tlsEnabled) {
-                                SSLEngine engine = sslContext.newEngine(ch.alloc());
-                                engine.setEnabledCipherSuites(enabledTlsCipherSuites);
-                                engine.setEnabledProtocols(enabledTlsProtocols);
-                                if (tlsMutualAuthEnabled) {
-                                    engine.setNeedClientAuth(true);
-                                }
-                                ch.pipeline().addLast("ssl", new SslHandler(engine));
-                            }
-                            ch.pipeline().addLast(new LengthFieldPrepender(4));
-                            ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer
-                                    .MAX_VALUE, 0, 4, 0, 4));
-                            if (saslPlainTextAuth) {
-                                ch.pipeline().addLast("sasl/plain-text", new
-                                        PlainTextSaslNettyServer());
-                            }
-                            ch.pipeline().addLast(ee, new NettyCorfuMessageDecoder());
-                            ch.pipeline().addLast(ee, new NettyCorfuMessageEncoder());
-                            ch.pipeline().addLast(ee, router);
-                        }
-                    });
-            ChannelFuture f = b.bind(port).sync();
-            while (true) {
-                try {
-                    f.channel().closeFuture().sync();
-                } catch (InterruptedException ie) {
-                    System.out.println(ie.getStackTrace());
-                }
-            }
-
-        } catch (InterruptedException ie) {
-            System.out.println(ie.getStackTrace());
-        } catch (Exception ex) {
-            log.error("Corfu server shut down unexpectedly due to exception", ex);
-        } finally {
-            bossGroup.shutdownGracefully();
-            workerGroup.shutdownGracefully();
-            cleanShutdown();
+        if (resetData) {
+            CLEANUP_SERVER = true;
         }
 
+        log.info("RestartServer: Shutting down corfu server");
+        ACTIVE_SERVER.close();
+
+        log.info("RestartServer: Starting corfu server");
     }
 
     /**
@@ -438,39 +608,8 @@ public class CorfuServer {
      */
     public static void cleanShutdown() {
         log.info("CleanShutdown: Starting Cleanup.");
-        // Create a list of servers
-        final List<AbstractServer> servers =
-                ImmutableList.of(sequencerServer,
-                        managementServer,
-                        layoutServer,
-                        logUnitServer);
-
-        // A executor service to create the shutdown threads
-        // plus name the threads correctly.
-        final ExecutorService shutdownService =
-                Executors.newFixedThreadPool(servers.size());
-
-        // Turn into a list of futures on the shutdown, returning
-        // generating a log message to inform of the result.
-        CompletableFuture<Void>[] shutdownFutures = servers.stream()
-                .map(s -> CompletableFuture.runAsync(() -> {
-                    try {
-                        Thread.currentThread().setName(s.getClass().getSimpleName()
-                                + "-shutdown");
-                        log.info("CleanShutdown: Shutting down {}",
-                                s.getClass().getSimpleName());
-                        s.shutdown();
-                        log.info("CleanShutdown: Cleanly shutdown {}",
-                                s.getClass().getSimpleName());
-                    } catch (Exception e) {
-                        log.error("CleanShutdown: Failed to cleanly shutdown {}",
-                                s.getClass().getSimpleName(), e);
-                    }
-                }, shutdownService))
-                .toArray(CompletableFuture[]::new);
-
-        CompletableFuture.allOf(shutdownFutures).join();
-        log.info("CleanShutdown: Shutdown Complete.");
+        SHUTDOWN_SERVER = true;
+        ACTIVE_SERVER.close();
     }
 
     public static void addSequencer() {
@@ -483,13 +622,20 @@ public class CorfuServer {
         router.addServer(layoutServer);
     }
 
-    public static void addLogUnit() {
-        logUnitServer = new LogUnitServer(serverContext);
-        router.addServer(logUnitServer);
-    }
-
-    public static void addManagementServer() {
-        managementServer = new ManagementServer(serverContext);
-        router.addServer(managementServer);
+    /**
+     * Print the welcome message, logo and the arguments.
+     *
+     * @param opts Arguments.
+     */
+    private static void printStartupMsg(Map<String, Object> opts) {
+        printLogo();
+        int port = Integer.parseInt((String) opts.get("<port>"));
+        println(ansi().a("Welcome to ").fg(RED).a("CORFU ").fg(MAGENTA).a("SERVER").reset());
+        println(ansi().a("Version ").a(Version.getVersionString()).a(" (").fg(BLUE)
+            .a(GitRepositoryState.getRepositoryState().commitIdAbbrev).reset().a(")"));
+        println(ansi().a("Serving on port ").fg(WHITE).a(port).reset());
+        println(ansi().a("Service directory: ").fg(WHITE).a(
+            (Boolean) opts.get("--memory") ? "MEMORY mode" :
+                opts.get("--log-path")).reset());
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
@@ -19,6 +19,8 @@ import javax.annotation.Nullable;
 
 import lombok.Getter;
 
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.util.JsonUtils;
 
 /**
@@ -38,6 +40,7 @@ import org.corfudb.util.JsonUtils;
  *
  * <p>Created by mdhawan on 7/27/16.
  */
+@Slf4j
 public class DataStore implements IDataStore {
 
     private final Map<String, Object> opts;
@@ -123,6 +126,7 @@ public class DataStore implements IDataStore {
                         }
                         return new String(Files.readAllBytes(path));
                     } catch (IOException e) {
+                        log.warn("IOException while building datastore", e);
                         throw new RuntimeException(e);
                     }
                 });

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -92,7 +92,7 @@ public class LayoutServer extends AbstractServer {
         this.opts = serverContext.getServerConfig();
         this.serverContext = serverContext;
 
-        if ((Boolean) opts.get("--single")) {
+        if (getCurrentLayout() == null && (Boolean) opts.get("--single")) {
             getSingleNodeLayout();
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -1,0 +1,656 @@
+package org.corfudb.infrastructure;
+
+import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.corfudb.infrastructure.management.IDetector;
+import org.corfudb.infrastructure.management.PollReport;
+import org.corfudb.infrastructure.management.ReconfigurationEventHandler;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.QuorumUnreachableException;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.QuorumFuturesFactory;
+import org.corfudb.util.NodeLocator;
+import org.corfudb.util.Sleep;
+import org.corfudb.util.concurrent.SingletonResource;
+
+/**
+ * Instantiates and performs failure detection and handling asynchronously.
+ *
+ * <p>Failure Detector:
+ * Executes detection policy to detect failed and healed nodes.
+ * It then checks for status of the nodes. If there are failed or healed nodes to be addressed,
+ * this then triggers the respective handler which then responds to these reconfiguration changes
+ * based on a policy.
+ *
+ * <p>Created by zlokhandwala on 1/15/18.
+ */
+@Slf4j
+public class ManagementAgent {
+
+    private final ServerContext serverContext;
+    private final Map<String, Object> opts;
+
+    /**
+     * Detectors to be used to detect failures and healing.
+     */
+    @Getter
+    private IDetector failureDetector;
+    @Getter
+    private IDetector healingDetector;
+    /**
+     * Failure Handler Dispatcher to launch configuration changes or recovery.
+     */
+    @Getter
+    private final ReconfigurationEventHandler reconfigurationEventHandler;
+    /**
+     * Interval in executing the failure detection policy.
+     * In milliseconds.
+     */
+    @Getter
+    private final long policyExecuteInterval = 1000;
+    /**
+     * To dispatch initialization tasks for recovery and sequencer bootstrap.
+     */
+    @Getter
+    private Thread initializationTaskThread;
+    /**
+     * Detection Task Scheduler Service
+     * This service schedules the following tasks every policyExecuteInterval (1 sec):
+     * - Detection of failed nodes.
+     * - Detection of healed nodes.
+     */
+    @Getter
+    private ScheduledExecutorService detectionTasksScheduler;
+    /**
+     * To dispatch tasks for failure or healed nodes detection.
+     */
+    @Getter
+    private ExecutorService detectionTaskWorkers;
+    /**
+     * Future for periodic failure and healed nodes detection task.
+     */
+    private Future failureDetectorFuture = null;
+    private Future healingDetectorFuture = null;
+    private boolean recovered = false;
+
+    private final SingletonResource<CorfuRuntime> runtimeSingletonResource;
+    private final String bootstrapEndpoint;
+
+    private volatile boolean shutdown = false;
+
+    /**
+     * Future which is marked completed if:
+     * If Recovery, recovered successfully
+     * Else, after bootstrapping the primary sequencer successfully.
+     */
+    @Getter
+    private volatile CompletableFuture<Boolean> sequencerBootstrappedFuture;
+
+    /**
+     * Checks and restores if a layout is present in the local datastore to recover from.
+     * Spawns the initialization task which recovers if required, bootstraps sequencer and
+     * schedules detector tasks.
+     *
+     * @param runtimeSingletonResource Singleton resource to fetch runtime.
+     * @param serverContext            Server Context.
+     */
+    ManagementAgent(SingletonResource<CorfuRuntime> runtimeSingletonResource,
+                    ServerContext serverContext) {
+        this.runtimeSingletonResource = runtimeSingletonResource;
+        this.serverContext = serverContext;
+        this.opts = serverContext.getServerConfig();
+
+        bootstrapEndpoint = (opts.get("--management-server") != null)
+                ? opts.get("--management-server").toString() : null;
+
+        sequencerBootstrappedFuture = new CompletableFuture<>();
+
+        // If no state was preserved, there is no layout to recover.
+        if (serverContext.getManagementLayout() == null) {
+            recovered = true;
+        }
+
+        // The management server needs to check both the Layout Server's persisted layout as well
+        // as the Management Server's previously persisted layout. We try to recover from both of
+        // these as the more recent layout (with higher epoch is retained).
+        // When a node does not contain a layout server component and is trying to recover, we
+        // would completely rely on recovering from the management server's persisted layout.
+        // Else in every other case, the layout server is active and will contain the latest layout
+        // (In case of trailing layout server, the management server's persisted layout helps.)
+        serverContext.installSingleNodeLayoutIfAbsent();
+        serverContext.saveManagementLayout(serverContext.getCurrentLayout());
+        serverContext.saveManagementLayout(serverContext.getManagementLayout());
+
+        if (!recovered) {
+            log.info("Attempting to recover. Layout before shutdown: {}",
+                    serverContext.getManagementLayout());
+        }
+
+        this.failureDetector = serverContext.getFailureDetector();
+        this.healingDetector = serverContext.getHealingDetector();
+        this.reconfigurationEventHandler = new ReconfigurationEventHandler();
+
+        final int managementServiceCount = 1;
+        final int detectionWorkersCount = 2;
+
+        this.detectionTasksScheduler = Executors.newScheduledThreadPool(
+                managementServiceCount,
+                new ThreadFactoryBuilder()
+                        .setDaemon(true)
+                        .setNameFormat(serverContext.getThreadPrefix() + "ManagementService")
+                        .build());
+
+        // Creating the detection worker thread pool.
+        // This thread pool is utilized to dispatch detection tasks at regular intervals in the
+        // detectorTaskScheduler.
+        this.detectionTaskWorkers = Executors.newFixedThreadPool(
+                detectionWorkersCount,
+                new ThreadFactoryBuilder()
+                        .setDaemon(true)
+                        .setNameFormat(serverContext.getThreadPrefix() + "DetectionWorker-%d")
+                        .build());
+
+        // Creating the initialization task thread.
+        // This thread pool is utilized to dispatch one time recovery and sequencer bootstrap tasks.
+        // One these tasks finish successfully, they initiate the detection tasks.
+        this.initializationTaskThread = new Thread(this::initializationTask);
+        this.initializationTaskThread.setUncaughtExceptionHandler(
+                (thread, throwable) -> log.error("Error in initialization task: {}", throwable));
+        this.initializationTaskThread.start();
+    }
+
+    /**
+     * Initialization task.
+     * Performs recovery if required.
+     * Bootstraps the primary sequencer if the server has been bootstrapped.
+     * Initiates the failure detection and healing detection tasks.
+     */
+    private void initializationTask() {
+
+        try {
+            while (!shutdown) {
+                if (serverContext.getManagementLayout() == null && bootstrapEndpoint == null) {
+                    log.warn("Management Server waiting to be bootstrapped");
+                    Sleep.MILLISECONDS.sleepRecoverably(policyExecuteInterval);
+                    continue;
+                }
+
+                // Recover if flag is false
+                while (!recovered) {
+                    recovered = runRecoveryReconfiguration();
+                    if (!recovered) {
+                        log.error("detectorTaskScheduler: Recovery failed. Retrying.");
+                        continue;
+                    }
+                    // If recovery succeeds, reconfiguration was successful.
+                    sequencerBootstrappedFuture.complete(true);
+                    log.info("Recovery completed");
+                }
+                break;
+            }
+
+            // Sequencer bootstrap required if this is fresh startup (not recovery).
+            if (!sequencerBootstrappedFuture.isDone()) {
+                bootstrapPrimarySequencerServer();
+            }
+
+            // Initiating periodic task to poll for failures.
+            try {
+                detectionTasksScheduler.scheduleAtFixedRate(
+                        this::detectorTaskScheduler,
+                        0,
+                        policyExecuteInterval,
+                        TimeUnit.MILLISECONDS);
+            } catch (RejectedExecutionException err) {
+                log.error("Error scheduling failure detection task, {}", err);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private String getLocalEndpoint() {
+        return this.opts.get("--address") + ":" + this.opts.get("<port>");
+    }
+
+    /**
+     * Returns a connected instance of the CorfuRuntime.
+     *
+     * @return A connected instance of runtime.
+     */
+    public CorfuRuntime getCorfuRuntime() {
+        return runtimeSingletonResource.get();
+    }
+
+    /**
+     * Bootstraps the primary sequencer on a fresh startup (not recovery).
+     */
+    private void bootstrapPrimarySequencerServer() {
+        try {
+            Layout layout = serverContext.getManagementLayout();
+            boolean bootstrapResult = getCorfuRuntime().getLayoutView().getRuntimeLayout(layout)
+                    .getPrimarySequencerClient()
+                    .bootstrap(0L, Collections.emptyMap(), layout.getEpoch())
+                    .get();
+            sequencerBootstrappedFuture.complete(bootstrapResult);
+            // If false, the sequencer is already bootstrapped with a higher epoch.
+            if (!bootstrapResult) {
+                log.warn("Sequencer already bootstrapped.");
+            } else {
+                log.info("Bootstrapped sequencer server at epoch:{}", layout.getEpoch());
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("Bootstrapping sequencer failed: ", e);
+        }
+    }
+
+    /**
+     * This is called when the management server detects an existing layout in the local datastore
+     * on startup. This requires a recovery from the same layout and attempt to rejoin the cluster.
+     * Recovery is carried out as follows:
+     * - Attempt to run reconfiguration on the cluster from the recovered layout found in the
+     * local data store by incrementing the epoch.
+     * The reconfiguration succeeds if the attempt to reach consensus by re-proposing this
+     * recovery layout with its epoch incremented succeeds.
+     * - If reconfiguration succeeds, the node is added to the layout and recovery was successful.
+     * - If reconfiguration fails, the cluster has moved ahead.
+     * * - This node now cannot force its inclusion into the cluster (it has a stale layout).
+     * * - This node if marked unresponsive will be detected and unmarked by its peers in cluster.
+     * - If multiple nodes are trying to recover, they will retry until they have recovered with
+     * the latest layout previously accepted by the majority.
+     * eg. Consider 3 nodes [Node(Epoch)]:
+     * A(1), B(2), C(2). All 3 nodes crash and attempt to recover at the same time.
+     * Node A should not be able to recover as it will detect a higher epoch in the rest of the
+     * cluster. Hence either node B or C will succeed in recovering the cluster to epoch 3 with
+     * their persisted layout.
+     *
+     * @return True if recovery was successful. False otherwise.
+     */
+    private boolean runRecoveryReconfiguration() {
+        Layout layout = new Layout(serverContext.getManagementLayout());
+        boolean recoveryReconfigurationResult = reconfigurationEventHandler
+                .recoverCluster(layout, getCorfuRuntime());
+        log.info("Recovery reconfiguration attempt result: {}", recoveryReconfigurationResult);
+
+        getCorfuRuntime().invalidateLayout();
+        Layout clusterLayout = getCorfuRuntime().getLayoutView().getLayout();
+
+        log.info("Recovery layout epoch:{}, Cluster epoch: {}",
+                serverContext.getManagementLayout().getEpoch(), clusterLayout.getEpoch());
+        // The cluster has moved ahead. This node should not force any layout. Let the other
+        // members detect that this node has healed and include it in the layout.
+        boolean recoveryResult =
+                clusterLayout.getEpoch() > serverContext.getManagementLayout().getEpoch()
+                        || recoveryReconfigurationResult;
+
+        if (recoveryResult) {
+            sequencerBootstrappedFuture.complete(true);
+        }
+
+        return recoveryResult;
+    }
+
+    /**
+     * Schedules the detection tasks run by detectorTaskScheduler.
+     * It schedules exactly one instance of the following tasks.
+     * - Failure detection tasks.
+     * - Healing detection tasks.
+     */
+    private synchronized void detectorTaskScheduler() {
+
+        CorfuRuntime corfuRuntime = getCorfuRuntime();
+        getCorfuRuntime().invalidateLayout();
+        serverContext.saveManagementLayout(corfuRuntime.getLayoutView().getLayout());
+
+        if (!canHandleReconfigurations()) {
+            return;
+        }
+
+        runFailureDetectorTask();
+
+        runHealingDetectorTask();
+    }
+
+    /**
+     * Checks if this management client is allowed to handle reconfigurations.
+     * - This client is not authorized to trigger reconfigurations if this node is not a part
+     * of the current layout OR it has been marked as unresponsive in the latest layout.
+     * The node is marked responsive by any of the other nodes which can poll and sense this
+     * node's recovery.
+     *
+     * @return True of node is allowed to handle reconfigurations. False otherwise.
+     */
+    private boolean canHandleReconfigurations() {
+
+        // We check for 2 conditions here: If the node is NOT a part of the current layout
+        // or has it been marked as unresponsive. If either is true, it should not
+        // attempt to change layout.
+        Layout layout = serverContext.getManagementLayout();
+        if (layout.getAllServers().stream().noneMatch(serverContext.getNodeLocator()::isSameNode)
+                || layout.getUnresponsiveServers().stream().anyMatch(serverContext.getNodeLocator()::isSameNode)) {
+            log.debug("This Server is not a part of the active layout. "
+                    + "Aborting reconfiguration handling.");
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * This contains the healing mechanism.
+     * - This task is executed in intervals of 1 second (default). This task is blocked until
+     * the management server is bootstrapped and has a connected runtime.
+     * - On every invocation, this task refreshes the runtime to fetch the latest layout and also
+     * updates the local persisted copy of the latest layout
+     * - It then executes the poll using the healingDetector which generates a pollReport at the
+     * end of the round.
+     * - The poll report contains servers that are now responsive and healed.
+     * - The healed servers in the pollReport are then handled based on the healing handler policy.
+     * - The healing handler policy dictates whether the healing node should be added back as a
+     * logUnit node or should only operate as a layout server or a primary/backup sequencer.
+     */
+    private void runHealingDetectorTask() {
+
+        if (healingDetectorFuture == null || healingDetectorFuture.isDone()) {
+            healingDetectorFuture = detectionTaskWorkers.submit(() -> {
+
+                CorfuRuntime corfuRuntime = getCorfuRuntime();
+                PollReport pollReport =
+                        healingDetector.poll(serverContext.getManagementLayout(), corfuRuntime);
+
+                if (!pollReport.getHealingNodes().isEmpty()) {
+
+
+                    try {
+                        log.info("Attempting to heal nodes in poll report: {}", pollReport);
+                        Layout layout = serverContext.getManagementLayout();
+                        corfuRuntime.getLayoutView().getRuntimeLayout(layout)
+                                .getManagementClient(getLocalEndpoint())
+                                .handleHealing(pollReport.getPollEpoch(),
+                                        pollReport.getHealingNodes())
+                                .get();
+                        log.info("Healing nodes successful: {}", pollReport);
+                    } catch (InterruptedException | ExecutionException e) {
+                        log.error("Healing nodes failed: ", e);
+                    }
+                }
+
+            });
+        } else {
+            log.debug("Cannot initiate new healing polling task. Polling in progress.");
+        }
+    }
+
+    /**
+     * This contains the failure detection and handling mechanism.
+     * - This task is executed in intervals of 1 second (default). This task is blocked until
+     * the management server is bootstrapped and has a connected runtime.
+     * - On every invocation, this task refreshes the runtime to fetch the latest layout and also
+     * updates the local persisted copy of the latest layout
+     * - It then executes the poll using the failureDetector which generates a pollReport at the
+     * end of the round.
+     * - The poll report contains servers that are unresponsive and servers whose epochs do not
+     * match the current cluster epoch
+     * - The outOfPhase epoch server errors are corrected by resealing and patching these trailing
+     * layout servers if needed.
+     * - Finally all unresponsive server failures are handled by either removing or marking them
+     * as unresponsive based on a failure handling policy.
+     */
+    private void runFailureDetectorTask() {
+
+        if (failureDetectorFuture == null || failureDetectorFuture.isDone()) {
+            failureDetectorFuture = detectionTaskWorkers.submit(() -> {
+
+                CorfuRuntime corfuRuntime = getCorfuRuntime();
+                // Execute the failure detection poll round.
+                PollReport pollReport =
+                        failureDetector.poll(serverContext.getManagementLayout(), corfuRuntime);
+
+                // Corrects out of phase epoch issues if present in the report. This method
+                // performs re-sealing of all nodes if required and catchup of a layout server to
+                // the current state.
+                correctOutOfPhaseEpochs(pollReport);
+
+                // Analyze the poll report and trigger failure handler if needed.
+                handleFailures(pollReport);
+
+            });
+        } else {
+            log.debug("Cannot initiate new polling task. Polling in progress.");
+        }
+    }
+
+    /**
+     * We check if these servers are the same set of servers which are marked as unresponsive in
+     * the layout.
+     * Check if this new detected failure has already been recognized.
+     *
+     * @param pollReport Report from the polling task
+     * @return Set of nodes which have failed, relative to the latest local copy of the layout.
+     */
+    private Set<String> getNewFailures(PollReport pollReport) {
+        return Sets.difference(
+                pollReport.getFailingNodes(),
+                new HashSet<>(serverContext.getManagementLayout().getUnresponsiveServers()));
+    }
+
+    /**
+     * All Layout servers have been sealed but there is no client to take this forward and fill the
+     * slot by proposing a new layout.
+     * In this case we can pass an empty set to propose the same layout again and fill the layout
+     * slot to un-block the data plane operations.
+     *
+     * @param pollReport Report from the polling task
+     * @return True if latest layout slot is vacant. Else False.
+     */
+    private boolean isCurrentLayoutSlotUnFilled(PollReport pollReport) {
+        boolean result = pollReport.getOutOfPhaseEpochNodes().keySet()
+                .containsAll(serverContext.getManagementLayout().getLayoutServers());
+        if (result) {
+            log.info("Current layout slot is empty. Filling slot with current layout.");
+        }
+        return result;
+    }
+
+    /**
+     * Analyzes the poll report and triggers the failure handler if status change
+     * of node detected.
+     *
+     * @param pollReport Poll report obtained from failure detection policy.
+     */
+    private void handleFailures(PollReport pollReport) {
+        try {
+            Set<String> failedNodes = new HashSet<>(getNewFailures(pollReport));
+
+            // These conditions are mutually exclusive. If there is a failure to be
+            // handled, we don't need to explicitly fix the unfilled layout slot. Else we do.
+            if (!failedNodes.isEmpty() || isCurrentLayoutSlotUnFilled(pollReport)) {
+
+                log.info("Detected changes in node responsiveness: Failed:{}, pollReport:{}",
+                        failedNodes, pollReport);
+                Layout layout = serverContext.getManagementLayout();
+                getCorfuRuntime().getLayoutView().getRuntimeLayout(layout)
+                        .getManagementClient(getLocalEndpoint())
+                        .handleFailure(pollReport.getPollEpoch(), failedNodes).get();
+            }
+
+        } catch (Exception e) {
+            log.error("Exception invoking failure handler : {}", e);
+        }
+    }
+
+    /**
+     * Corrects out of phase epochs by resealing the servers.
+     * This would also need to update trailing layout servers.
+     *
+     * @param pollReport Poll Report from running the failure detection policy.
+     */
+    private void correctOutOfPhaseEpochs(PollReport pollReport) {
+
+        final Map<String, Long> outOfPhaseEpochNodes = pollReport.getOutOfPhaseEpochNodes();
+        if (outOfPhaseEpochNodes.isEmpty()) {
+            return;
+        }
+
+        try {
+            Layout layout = serverContext.getManagementLayout();
+            // Query all layout servers to get quorum Layout.
+            Map<String, CompletableFuture<Layout>> layoutCompletableFutureMap = new HashMap<>();
+            for (String layoutServer : layout.getLayoutServers()) {
+                CompletableFuture<Layout> completableFuture = new CompletableFuture<>();
+                try {
+                    completableFuture = getCorfuRuntime().getLayoutView().getRuntimeLayout(layout)
+                            .getLayoutClient(layoutServer)
+                            .getLayout();
+                } catch (Exception e) {
+                    completableFuture.completeExceptionally(e);
+                }
+                layoutCompletableFutureMap.put(layoutServer, completableFuture);
+            }
+
+            // Retrieve the correct layout from quorum of members to reseal servers.
+            // If we are unable to reach a consensus from a quorum we get an exception and
+            // abort the epoch correction phase.
+            Layout quorumLayout = fetchQuorumLayout(layoutCompletableFutureMap.values()
+                    .toArray(new CompletableFuture[layoutCompletableFutureMap.size()]));
+
+            // Update local layout copy.
+            serverContext.saveManagementLayout(quorumLayout);
+            layout = serverContext.getManagementLayout();
+
+            // In case of a partial seal, a set of servers can be sealed with a higher epoch.
+            // We should be able to detect this and bring the rest of the servers to this epoch.
+            long maxOutOfPhaseEpoch = Collections.max(outOfPhaseEpochNodes.values());
+            if (maxOutOfPhaseEpoch > layout.getEpoch()) {
+                layout.setEpoch(maxOutOfPhaseEpoch);
+            }
+
+            // Re-seal all servers with the latestLayout epoch.
+            // This has no effect on up-to-date servers. Only the trailing servers are caught up.
+            getCorfuRuntime().getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
+
+            // Check if any layout server has a stale layout.
+            // If yes patch it (commit) with the latestLayout (received from quorum).
+            updateTrailingLayoutServers(layoutCompletableFutureMap);
+
+        } catch (QuorumUnreachableException e) {
+            log.error("Error in correcting server epochs: {}", e);
+        }
+    }
+
+    /**
+     * Fetches the updated layout from quorum of layout servers.
+     *
+     * @return quorum agreed layout.
+     * @throws QuorumUnreachableException If unable to receive consensus on layout.
+     */
+    private Layout fetchQuorumLayout(CompletableFuture<Layout>[] completableFutures)
+            throws QuorumUnreachableException {
+
+        QuorumFuturesFactory.CompositeFuture<Layout> quorumFuture = QuorumFuturesFactory
+                .getQuorumFuture(
+                        Comparator.comparing(Layout::asJSONString),
+                        completableFutures);
+        try {
+            return quorumFuture.get();
+        } catch (ExecutionException | InterruptedException e) {
+            if (e.getCause() instanceof QuorumUnreachableException) {
+                throw (QuorumUnreachableException) e.getCause();
+            }
+
+            int reachableServers = (int) Arrays.stream(completableFutures)
+                    .filter(booleanCompletableFuture -> !booleanCompletableFuture
+                            .isCompletedExceptionally()).count();
+            throw new QuorumUnreachableException(reachableServers, completableFutures.length);
+        }
+    }
+
+    /**
+     * Finds all trailing layout servers and patches them with the latest persisted layout
+     * retrieved by quorum.
+     *
+     * @param layoutCompletableFutureMap Map of layout server endpoints to their layout requests.
+     */
+    private void updateTrailingLayoutServers(
+            Map<String, CompletableFuture<Layout>> layoutCompletableFutureMap) {
+
+        // Patch trailing layout servers with latestLayout.
+        Layout latestLayout = serverContext.getManagementLayout();
+        layoutCompletableFutureMap.keySet().forEach(layoutServer -> {
+            Layout layout = null;
+            try {
+                layout = layoutCompletableFutureMap.get(layoutServer).get();
+            } catch (InterruptedException | ExecutionException e) {
+                // Expected wrong epoch exception if layout server fell behind and has stale
+                // layout and server epoch.
+                log.warn("updateTrailingLayoutServers: layout fetch failed: {}", e);
+            }
+
+            // Do nothing if this layout server is updated with the latestLayout.
+            if (layout != null && layout.equals(latestLayout)) {
+                return;
+            }
+            try {
+                // Committing this layout directly to the trailing layout servers.
+                // This is safe because this layout is acquired by a quorum fetch which confirms
+                // that there was a consensus on this layout and has been committed to a quorum.
+                boolean result = getCorfuRuntime().getLayoutView().getRuntimeLayout(latestLayout)
+                        .getLayoutClient(layoutServer)
+                        .committed(latestLayout.getEpoch(), latestLayout).get();
+                if (result) {
+                    log.debug("Layout Server: {} successfully patched with latest layout : {}",
+                            layoutServer, latestLayout);
+                } else {
+                    log.debug("Layout Server: {} patch with latest layout failed : {}",
+                            layoutServer, latestLayout);
+                }
+            } catch (InterruptedException | ExecutionException e) {
+                log.error("Updating layout servers failed due to : {}", e);
+            }
+        });
+    }
+
+    /**
+     * Shutdown the detectorTaskScheduler, workers and initializationTaskThread.
+     */
+    public void shutdown() {
+        // Shutting the fault detector.
+        shutdown = true;
+        detectionTasksScheduler.shutdownNow();
+        detectionTaskWorkers.shutdownNow();
+
+        try {
+            initializationTaskThread.interrupt();
+            initializationTaskThread.join(ServerContext.SHUTDOWN_TIMER.toMillis());
+            detectionTasksScheduler.awaitTermination(ServerContext.SHUTDOWN_TIMER.getSeconds(),
+                    TimeUnit.SECONDS);
+            detectionTaskWorkers.awaitTermination(ServerContext.SHUTDOWN_TIMER.getSeconds(),
+                    TimeUnit.SECONDS);
+        } catch (InterruptedException ie) {
+            log.debug("detectionTaskWorkers awaitTermination interrupted : {}", ie);
+            Thread.currentThread().interrupt();
+        }
+        log.info("Management Agent shutting down.");
+    }
+
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -57,7 +57,7 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
                             exception.getMessage(),
                             exception);
                 } else {
-                    log.warn("onTermination: Thread terminated (completed normally).");
+                    log.debug("onTermination: Thread terminated (completed normally).");
                 }
                 super.onTermination(exception);
             }

--- a/logReader/pom.xml
+++ b/logReader/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.corfudb</groupId>
     <artifactId>corfu</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1.1-SNAPSHOT</version>
 
     <modules>
         <module>infrastructure</module>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/runtime/src/main/java/org/corfudb/comm/ChannelImplementation.java
+++ b/runtime/src/main/java/org/corfudb/comm/ChannelImplementation.java
@@ -1,0 +1,85 @@
+package org.corfudb.comm;
+
+import io.netty.channel.Channel;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.ServerChannel;
+import io.netty.channel.epoll.Epoll;
+import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollServerSocketChannel;
+import io.netty.channel.epoll.EpollSocketChannel;
+import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueServerSocketChannel;
+import io.netty.channel.kqueue.KQueueSocketChannel;
+import io.netty.channel.local.LocalChannel;
+import io.netty.channel.local.LocalServerChannel;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import java.util.concurrent.ThreadFactory;
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.corfudb.util.NodeLocator;
+import org.corfudb.util.NodeLocator.Protocol;
+
+/** An enum representing channel implementation types available to the client. */
+@AllArgsConstructor
+public enum ChannelImplementation {
+    /** Automatically select best channel type (EPOLL/KQUEUE if available, otherwise
+     *  fallback to NIO).
+     */
+    AUTO(Epoll.isAvailable() ? EpollSocketChannel.class :
+        KQueue.isAvailable() ? KQueueSocketChannel.class :
+            NioSocketChannel.class,
+        Epoll.isAvailable() ? EpollServerSocketChannel.class :
+            KQueue.isAvailable() ? KQueueServerSocketChannel.class :
+                NioServerSocketChannel.class,
+        (numThreads, factory) ->
+            Epoll.isAvailable() ? new EpollEventLoopGroup(numThreads, factory) :
+                KQueue.isAvailable() ? new KQueueEventLoopGroup(numThreads, factory) :
+                    new NioEventLoopGroup(numThreads, factory),
+        Protocol.TCP),
+    NIO(NioSocketChannel.class, NioServerSocketChannel.class, NioEventLoopGroup::new,
+        Protocol.TCP),
+    EPOLL(EpollSocketChannel.class, EpollServerSocketChannel.class, EpollEventLoopGroup::new,
+        Protocol.TCP),
+    KQUEUE(KQueueSocketChannel.class, KQueueServerSocketChannel.class, KQueueEventLoopGroup::new,
+        Protocol.TCP),
+    LOCAL(LocalChannel.class, LocalServerChannel.class, DefaultEventLoopGroup::new,
+        Protocol.LOCAL)
+    ;
+
+    /**
+     * The {@link Channel} class used by this implementation.
+     */
+    @Getter
+    final Class<? extends Channel> channelClass;
+
+    /**
+     * The {@link ServerChannel} class used by this implementation.
+     */
+    @Getter
+    final Class<? extends ServerChannel> serverChannelClass;
+
+    /**
+     * Given the number of threads to use, generate a new {@link EventLoopGroup}.
+     */
+    @Getter
+    final EventLoopGroupGenerator generator;
+
+    /**
+     * The protocol for this socket type.
+     */
+    @Getter
+    final NodeLocator.Protocol protocol;
+
+    /**
+     * A functional interface for generating event loops.
+     */
+    @FunctionalInterface
+    public interface EventLoopGroupGenerator {
+        EventLoopGroup generate(int numThreads, @Nonnull ThreadFactory factory);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -60,6 +60,7 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
                         value = actualValue == null ? this.payload : actualValue;
                         this.payload.set(value);
                         copyBuf.release();
+                        lastKnownSize = data.length;
                         data = null;
                     }
                 }
@@ -93,8 +94,9 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
 
     @Override
     public int getSizeEstimate() {
-        if (data != null) {
-            return data.length;
+        byte[] tempData = data;
+        if (tempData != null) {
+            return tempData.length;
         } else if (lastKnownSize != NOT_KNOWN) {
             return lastKnownSize;
         }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -67,7 +67,6 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
             }
         }
 
-        data = null;
         return value;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -279,8 +279,6 @@ public class CorfuRuntime {
         nodeRouters = new ConcurrentHashMap<>();
         retryRate = 5;
 
-        getAddressSpaceView().setMetrics(metrics != null
-                ? metrics : CorfuRuntime.getDefaultMetrics());
         synchronized (metrics) {
             if (metrics.getNames().isEmpty()) {
 //                MetricsUtils.addJvmMetrics(metrics, mp);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -263,7 +263,7 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
         if (indexFunctions.isEmpty()) {
             // If there are no index functions, use the entire map
             entryStream = mainMap.entrySet().parallelStream();
-            log.warn("getByIndexAndFilter: Attempted getByIndexAndFilter without indexing");
+            log.debug("getByIndexAndFilter: Attempted getByIndexAndFilter without indexing");
         } else {
             Map<I, Map<K, V>> secondaryMap = indexMap.get(indexFunction);
             if (secondaryMap != null) {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -163,7 +163,7 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
 
     /** Default constructor. Generates a table without any secondary indexes. */
     public CorfuTable() {
-        log.error("CorfuTable: Creating a table without secondary indexes! Secondary index lookup"
+        log.debug("CorfuTable: Creating a table without secondary indexes! Secondary index lookup"
             + " will DEGRADE to a full scan");
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -159,11 +159,12 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
         indexerClass = indexFunctionEnumClass;
         indexFunctions.addAll(EnumSet.allOf(indexFunctionEnumClass));
         indexFunctions.forEach(f -> indexMap.put(f, new HashMap<>()));
+        log.info("CorfuTable: creating CorfuTable with {} as indexer class", indexFunctionEnumClass);
     }
 
     /** Default constructor. Generates a table without any secondary indexes. */
     public CorfuTable() {
-        log.debug("CorfuTable: Creating a table without secondary indexes! Secondary index lookup"
+        log.info("CorfuTable: Creating a table without secondary indexes! Secondary index lookup"
             + " will DEGRADE to a full scan");
     }
 
@@ -284,23 +285,6 @@ public class CorfuTable<K ,V, F extends Enum<F> & CorfuTable.IndexSpecification,
 
         return projectionFunction.generateProjection(index, entryStream.filter(entryPredicate))
                 .collect(Collectors.toCollection(ArrayList::new));
-    }
-
-
-    /**
-     * Register new index class
-     *
-     * This replaces the current index.
-     *
-     * @param indexFunctionEnumClass
-     */
-    public void registerIndex(Class<F> indexFunctionEnumClass) {
-        indexerClass = indexFunctionEnumClass;
-        indexMap.clear();
-        indexFunctions.clear();
-        indexFunctions.addAll(EnumSet.allOf(indexFunctionEnumClass));
-        indexFunctions.forEach(f -> indexMap.put(f, new HashMap<>()));
-        mainMap.forEach(this::mapSecondaryIndexes);
     }
 
     /** {@inheritDoc} */

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -2,7 +2,6 @@ package org.corfudb.runtime.object;
 
 import static java.lang.Long.min;
 
-import ch.qos.logback.classic.Logger;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
@@ -30,6 +29,7 @@ import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Utils;
 import org.corfudb.util.serializer.ISerializer;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -114,7 +114,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
     /**
      * Correctness Logging
      */
-    private final Logger correctnessLogger = (Logger) LoggerFactory.getLogger("correctness");
+    private final Logger correctnessLogger = LoggerFactory.getLogger("correctness");
 
     /**
      * Creates a CorfuCompileProxy object on a particular stream.
@@ -191,7 +191,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                         .nextToken(Collections.singleton(streamID), 0).getToken()
                         .getTokenValue();
         log.debug("Access[{}] conflictObj={} version={}", this, conflictObject, timestamp);
-        correctnessLogger.info("Version, {}", timestamp);
+        correctnessLogger.trace("Version, {}", timestamp);
 
         // Perform underlying access
         try {
@@ -244,7 +244,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         long address = underlyingObject.logUpdate(smrEntry, keepUpcallResult);
         log.trace("Update[{}] {}@{} ({}) conflictObj={}",
                 this, smrUpdateFunction, address, args, conflictObject);
-        correctnessLogger.info("Version, {}", address);
+        correctnessLogger.trace("Version, {}", address);
         return address;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.object;
 
 import static java.lang.Long.min;
 
+import ch.qos.logback.classic.Logger;
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
@@ -29,6 +30,7 @@ import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Utils;
 import org.corfudb.util.serializer.ISerializer;
+import org.slf4j.LoggerFactory;
 
 /**
  * In the Corfu runtime, on top of a stream,
@@ -110,6 +112,11 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
     private final Counter counterTxnRetryN;
 
     /**
+     * Correctness Logging
+     */
+    private final Logger correctnessLogger = (Logger) LoggerFactory.getLogger("correctness");
+
+    /**
      * Creates a CorfuCompileProxy object on a particular stream.
      *
      * @param rt                  Connected CorfuRuntime instance.
@@ -184,6 +191,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                         .nextToken(Collections.singleton(streamID), 0).getToken()
                         .getTokenValue();
         log.debug("Access[{}] conflictObj={} version={}", this, conflictObject, timestamp);
+        correctnessLogger.info("Version, {}", timestamp);
 
         // Perform underlying access
         try {
@@ -236,6 +244,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         long address = underlyingObject.logUpdate(smrEntry, keepUpcallResult);
         log.trace("Update[{}] {}@{} ({}) conflictObj={}",
                 this, smrUpdateFunction, address, args, conflictObject);
+        correctnessLogger.info("Version, {}", address);
         return address;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -322,7 +322,7 @@ public class VersionLockedObject<T> {
                         return;
                     }
                 } catch (NoRollbackException nre) {
-                    log.warn("OptimisticRollback[{}] to {} failed {}", this, timestamp, nre);
+                    log.warn("Rollback[{}] to {} failed {}", this, timestamp, nre);
                     resetUnsafe();
                 }
             }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -67,10 +67,7 @@ public class AddressSpaceView extends AbstractView {
      */
     public AddressSpaceView(@Nonnull final CorfuRuntime runtime) {
         super(runtime);
-    }
-
-    public void setMetrics(MetricRegistry metrics) {
-
+        MetricRegistry metrics = runtime.getMetrics();
         final String pfx = String.format("%s0x%x.cache.", runtime.getMpASV(), this.hashCode());
         metrics.register(pfx + "cache-size", (Gauge<Long>) readCache::estimatedSize);
         metrics.register(pfx + "evictions", (Gauge<Long>) () -> readCache.stats().evictionCount());
@@ -78,6 +75,7 @@ public class AddressSpaceView extends AbstractView {
         metrics.register(pfx + "hits", (Gauge<Long>) () -> readCache.stats().hitCount());
         metrics.register(pfx + "misses", (Gauge<Long>) () -> readCache.stats().missCount());
     }
+
 
     /**
      * Reset all in-memory caches.

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -14,6 +14,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.wireprotocol.LayoutPrepareResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.LayoutClient;
+import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
@@ -45,7 +47,7 @@ public class LayoutView extends AbstractView {
      * @return The number of nodes required for a quorum.
      */
     public int getQuorumNumber() {
-        return (int) (getCurrentLayout().getLayoutClientStream().count() / 2) + 1;
+        return (getLayout().getLayoutServers().size() / 2) + 1;
     }
 
     /**
@@ -68,10 +70,15 @@ public class LayoutView extends AbstractView {
             throws QuorumUnreachableException, OutrankedException, WrongEpochException {
         // Note this step is done because we have added the layout to the Epoch.
         long epoch = layout.getEpoch();
-        Layout layoutToPropose = layout;
+        Layout currentLayout = getLayout();
+        if (currentLayout.getEpoch() != epoch - 1) {
+            log.error("Runtime layout has epoch {} but expected {} to move to epoch {}",
+                    currentLayout.getEpoch(), epoch - 1, epoch);
+            throw new WrongEpochException(epoch - 1);
+        }
         //phase 1: prepare with a given rank.
-        Layout alreadyProposedLayout = prepare(epoch, rank, layout);
-        layoutToPropose = alreadyProposedLayout != null ? alreadyProposedLayout : layout;
+        Layout alreadyProposedLayout = prepare(epoch, rank);
+        Layout layoutToPropose = alreadyProposedLayout != null ? alreadyProposedLayout : layout;
         // For some reason, the alreadyProposedLayout sometimes doesn't have a runtime
         // we need to remove runtime from the layout, but for now, let's manually take
         // it from the original layout.
@@ -84,7 +91,6 @@ public class LayoutView extends AbstractView {
 
     /**
      * Sends prepare to the current layout and can proceed only if it is accepted by a quorum.
-     * // TODO Gets stuck if quorum is not achieved. Figure out if this is the correct solution.
      *
      * @param rank The rank for the proposed layout.
      * @return layout
@@ -94,18 +100,31 @@ public class LayoutView extends AbstractView {
      * @throws WrongEpochException wrong epoch number.
      */
     @SuppressWarnings("unchecked")
-    public Layout prepare(long epoch, long rank, Layout layout)
+    public Layout prepare(long epoch, long rank)
             throws QuorumUnreachableException, OutrankedException, WrongEpochException {
 
-        CompletableFuture<LayoutPrepareResponse>[] prepareList = layout.getLayoutClientStream()
-                .map(x -> x.prepare(epoch, rank))
+        CompletableFuture<LayoutPrepareResponse>[] prepareList = getLayout().getLayoutServers()
+                .stream()
+                .map(x -> {
+                    CompletableFuture<LayoutPrepareResponse> cf = new CompletableFuture<>();
+                    try {
+                        // Connection to router can cause network exception too.
+                        LayoutClient layoutClient = runtime.getRouter(x)
+                                .getClient(LayoutClient.class);
+                        cf = layoutClient.prepare(epoch, rank);
+                    } catch (Exception e) {
+                        cf.completeExceptionally(e);
+                    }
+                    return cf;
+                })
                 .toArray(CompletableFuture[]::new);
         LayoutPrepareResponse[] acceptList;
         long timeouts = 0L;
+        long wrongEpochRejected = 0L;
         while (true) {
             // do we still have enough for a quorum?
             if (prepareList.length < getQuorumNumber()) {
-                log.debug("Quorum unreachable, remaining={}, required={}", prepareList,
+                log.debug("prepare: Quorum unreachable, remaining={}, required={}", prepareList,
                         getQuorumNumber());
                 throw new QuorumUnreachableException(prepareList.length, getQuorumNumber());
             }
@@ -113,9 +132,12 @@ public class LayoutView extends AbstractView {
             // wait for someone to complete.
             try {
                 CFUtils.getUninterruptibly(CompletableFuture.anyOf(prepareList),
-                        OutrankedException.class, TimeoutException.class);
-            } catch (TimeoutException te) {
+                        OutrankedException.class, TimeoutException.class, NetworkException.class,
+                        WrongEpochException.class);
+            } catch (TimeoutException | NetworkException e) {
                 timeouts++;
+            } catch (WrongEpochException we) {
+                wrongEpochRejected++;
             }
 
             // remove errors.
@@ -128,8 +150,9 @@ public class LayoutView extends AbstractView {
                     .filter(x -> x != null)
                     .toArray(LayoutPrepareResponse[]::new);
 
-            log.debug("Successful responses={}, needed={}, timeouts={}", acceptList.length,
-                    getQuorumNumber(), timeouts);
+            log.debug("prepare: Successful responses={}, needed={}, timeouts={}, "
+                            + "wrongEpochRejected={}",
+                    acceptList.length, getQuorumNumber(), timeouts, wrongEpochRejected);
 
             if (acceptList.length >= getQuorumNumber()) {
                 break;
@@ -145,7 +168,6 @@ public class LayoutView extends AbstractView {
 
     /**
      * Proposes new layout to all the servers in the current layout.
-     * // TODO Gets stuck if quorum is not achieved. Figure out if this is the correct solution.
      *
      * @throws QuorumUnreachableException Thrown if responses not received from a majority of
      *                                    layout servers.
@@ -154,15 +176,27 @@ public class LayoutView extends AbstractView {
     @SuppressWarnings("unchecked")
     public Layout propose(long epoch, long rank, Layout layout)
             throws QuorumUnreachableException, OutrankedException {
-        CompletableFuture<Boolean>[] proposeList = layout.getLayoutClientStream()
-                .map(x -> x.propose(epoch, rank, layout))
+        CompletableFuture<Boolean>[] proposeList = getLayout().getLayoutServers().stream()
+                .map(x -> {
+                    CompletableFuture<Boolean> cf = new CompletableFuture<>();
+                    try {
+                        // Connection to router can cause network exception too.
+                        LayoutClient layoutClient = runtime.getRouter(x)
+                                .getClient(LayoutClient.class);
+                        cf =  layoutClient.propose(epoch, rank, layout);
+                    } catch (NetworkException e) {
+                        cf.completeExceptionally(e);
+                    }
+                    return cf;
+                })
                 .toArray(CompletableFuture[]::new);
 
         long timeouts = 0L;
+        long wrongEpochRejected = 0L;
         while (true) {
             // do we still have enough for a quorum?
             if (proposeList.length < getQuorumNumber()) {
-                log.debug("Quorum unreachable, remaining={}, required={}", proposeList,
+                log.debug("propose: Quorum unreachable, remaining={}, required={}", proposeList,
                         getQuorumNumber());
                 throw new QuorumUnreachableException(proposeList.length, getQuorumNumber());
             }
@@ -170,9 +204,12 @@ public class LayoutView extends AbstractView {
             // wait for someone to complete.
             try {
                 CFUtils.getUninterruptibly(CompletableFuture.anyOf(proposeList),
-                        OutrankedException.class, TimeoutException.class);
-            } catch (TimeoutException te) {
+                        OutrankedException.class, TimeoutException.class, NetworkException.class,
+                        WrongEpochException.class);
+            } catch (TimeoutException | NetworkException e) {
                 timeouts++;
+            } catch (WrongEpochException we) {
+                wrongEpochRejected++;
             }
 
             // remove errors.
@@ -183,11 +220,12 @@ public class LayoutView extends AbstractView {
             // count successes.
             long count = stream(proposeList)
                     .map(x -> x.getNow(false))
-                    .filter(x -> true)
+                    .filter(x -> x)
                     .count();
 
-            log.debug("Successful responses={}, needed={}, timeouts={}", count, getQuorumNumber(),
-                    timeouts);
+            log.debug("propose: Successful responses={}, needed={}, timeouts={}, "
+                            + "wrongEpochRejected={}",
+                    count, getQuorumNumber(), timeouts, wrongEpochRejected);
 
             if (count >= getQuorumNumber()) {
                 break;
@@ -206,10 +244,22 @@ public class LayoutView extends AbstractView {
      *
      * @throws WrongEpochException wrong epoch number.
      */
+    @SuppressWarnings("unchecked")
     public void committed(long epoch, Layout layout)
             throws WrongEpochException {
-        CompletableFuture<Boolean>[] commitList = layout.getLayoutClientStream()
-                .map(x -> x.committed(epoch, layout))
+        CompletableFuture<Boolean>[] commitList = layout.getLayoutServers().stream()
+                .map(x -> {
+                    CompletableFuture<Boolean> cf = new CompletableFuture<>();
+                    try {
+                        // Connection to router can cause network exception too.
+                        LayoutClient layoutClient = runtime.getRouter(x)
+                                .getClient(LayoutClient.class);
+                        cf = layoutClient.committed(epoch, layout);
+                    } catch (NetworkException e) {
+                        cf.completeExceptionally(e);
+                    }
+                    return cf;
+                })
                 .toArray(CompletableFuture[]::new);
 
         int timeouts = 0;
@@ -218,12 +268,12 @@ public class LayoutView extends AbstractView {
             // wait for someone to complete.
             try {
                 CFUtils.getUninterruptibly(CompletableFuture.anyOf(commitList),
-                        WrongEpochException.class, TimeoutException.class);
-            } catch (TimeoutException te) {
+                        WrongEpochException.class, TimeoutException.class, NetworkException.class);
+            } catch (TimeoutException | NetworkException e) {
                 timeouts++;
             }
             responses++;
-            log.debug("Successful responses={}, timeouts={}", responses, timeouts);
+            log.debug("committed: Successful responses={}, timeouts={}", responses, timeouts);
         }
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
@@ -60,7 +60,7 @@ public class ObjectBuilder<T> implements IObjectBuilder<T> {
 
     @SuppressWarnings("unchecked")
     public <R> ObjectBuilder<R> setTypeToken(TypeToken<R> typeToken) {
-        this.type = (Class<T>)typeToken.getRawType();
+        this.type = (Class<T>) typeToken.getRawType();
         return (ObjectBuilder<R>) this;
     }
 
@@ -103,45 +103,30 @@ public class ObjectBuilder<T> implements IObjectBuilder<T> {
                         arguments, serializer);
             } else {
                 ObjectsView.ObjectID<T> oid = new ObjectsView.ObjectID(streamID, type);
-                T result = (T) runtime.getObjectsView().objectCache.computeIfAbsent(oid, x -> {
+                return (T) runtime.getObjectsView().objectCache.computeIfAbsent(oid, x -> {
                             try {
-                                return CorfuCompileWrapperBuilder.getWrapper(type, runtime,
+                                T result = CorfuCompileWrapperBuilder.getWrapper(type, runtime,
                                         streamID, arguments, serializer);
+
+                                // Get object serializer to check if we didn't attempt to set another serializer
+                                // to an already existing map
+                                ISerializer objectSerializer = ((CorfuCompileProxy) ((ICorfuSMR) result).
+                                        getCorfuSMRProxy())
+                                        .getSerializer();
+
+                                if (serializer != objectSerializer) {
+                                    log.warn("open: Attempt to open an existing object with a different serializer {}. " +
+                                                    "Object {} opened with original serializer {}.",
+                                            serializer.getClass().getSimpleName(),
+                                            oid,
+                                            objectSerializer.getClass().getSimpleName());
+                                }
+                                return result;
                             } catch (Exception ex) {
                                 throw new RuntimeException(ex);
                             }
                         }
                 );
-                // Get object serializer to check if we didn't attempt to set another serializer
-                // to an already existing map
-                ISerializer objectSerializer = ((CorfuCompileProxy) ((ICorfuSMR) runtime.getObjectsView().
-                        getObjectCache().
-                        get(oid)).
-                        getCorfuSMRProxy())
-                        .getSerializer();
-
-                // FIXME: temporary hack until we have a registry
-                // If current map in cache has no indexer, or there is currently an other one,
-                // this will create and compute the indices.
-                if (result instanceof CorfuTable) {
-                    CorfuTable currentCorfuTable = ((CorfuTable) result);
-                    if (arguments.length > 0) {
-                        // If current map in cache has no indexer, or there is currently an other index
-                        if (!(currentCorfuTable.hasSecondaryIndices()) ||
-                            currentCorfuTable.getIndexerClass() != arguments[0].getClass()){
-                            ((CorfuTable) result).registerIndex((Class) arguments[0]);
-                        }
-                    }
-                }
-
-                if (serializer != objectSerializer) {
-                    log.warn("open: Attempt to open an existing object with a different serializer {}. " +
-                            "Object {} opened with original serializer {}.",
-                            serializer.getClass().getSimpleName(),
-                            oid,
-                            objectSerializer.getClass().getSimpleName());
-                }
-                return result;
             }
         } catch (Exception ex) {
             log.error("Runtime instrumentation no longer supported and no compiled class found"

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -228,6 +228,8 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                                       final long startAddress,
                                       final long stopAddress,
                                       final Function<ILogData, BackpointerOp> filter) {
+        log.trace("followBackPointers: stmreadId[{}], queue[{}], startAddress[{}], stopAddress[{}]," +
+                "filter[{}]", streamId, queue, startAddress, stopAddress, filter);
         // Whether or not we added entries to the queue.
         boolean entryAdded = false;
         // The current address which we are reading from.
@@ -240,11 +242,12 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             // Read the current address
             ILogData d;
             try {
+                log.trace("followBackPointers: readAddress[{}]", currentAddress);
                 d = read(currentAddress);
             } catch (TrimmedException e) {
                 if (options.ignoreTrimmed) {
-                    log.warn("followBackpointers: Ignoring trimmed exception for address {}," +
-                            " stream {}", currentAddress, id);
+                    log.warn("followBackpointers: Ignoring trimmed exception for address[{}]," +
+                            " stream[{}]", currentAddress, id);
                     return entryAdded;
                 } else {
                     throw e;
@@ -253,10 +256,13 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
 
             // If it contains the stream we are interested in
             if (d.containsStream(streamId)) {
+                log.trace("followBackPointers: address[{}] contains streamId[{}], apply filter", currentAddress,
+                        streamId);
                 // Check whether we should include the address
                 BackpointerOp op = filter.apply(d);
                 if (op == BackpointerOp.INCLUDE
                         || op == BackpointerOp.INCLUDE_STOP) {
+                    log.trace("followBackPointers: Adding backpointer to address[{}] to queue", currentAddress);
                     queue.add(currentAddress);
                     entryAdded = true;
                     // Check if we need to stop
@@ -270,8 +276,11 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             // Now calculate the next address
             // Try using backpointers first
 
+            log.trace("followBackPointers: calculate the next address");
+
             if (!runtime.isBackpointersDisabled() && d.hasBackpointer(streamId)) {
                 long tmp = d.getBackpointer(streamId);
+                log.trace("followBackPointers: backpointer points to {}", tmp);
                 // if backpointer is a valid log address or Address.NON_EXIST
                 // (beginning of the stream), do not single step back on the log
                 if (Address.isAddress(tmp) || tmp == Address.NON_EXIST) {
@@ -283,6 +292,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             if (singleStep) {
                 // backpointers failed, so we're
                 // downgrading to a linear scan
+                log.trace("followBackPointers: downgrading to single step, backpointer failed");
                 currentAddress = currentAddress - 1;
             }
         }
@@ -403,6 +413,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             latestTokenValue = runtime.getSequencerView()
                     .nextToken(Collections.singleton(context.id), 0)
                     .getToken().getTokenValue();
+            log.trace("Read_Fill_Queue[{}] Fetched tail {} from sequencer", this, latestTokenValue);
         }
         // If there is no information on the tail of the stream, return,
         // there is nothing to do

--- a/runtime/src/main/java/org/corfudb/util/NodeLocator.java
+++ b/runtime/src/main/java/org/corfudb/util/NodeLocator.java
@@ -1,0 +1,215 @@
+package org.corfudb.util;
+
+import com.google.common.collect.ImmutableMap;
+import io.netty.channel.local.LocalAddress;
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Singular;
+
+/** {@link NodeLocator}s represent locators for Corfu nodes.
+ *
+ *  <p>A detailed document regarding their contents and format can be found in docs/NODE_FORMAT.md
+ *
+ */
+@Data
+@Builder
+public class NodeLocator implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Represents protocols for Corfu nodes. */
+    @RequiredArgsConstructor
+    public enum Protocol {
+        /**
+         * Default TCP-based protocol.
+         */
+        TCP(l -> new InetSocketAddress(l.getHost(), l.getPort()),
+            l -> {
+                if (l.isBindToAll()) {
+                    return new InetSocketAddress(l.getPort());
+                }
+                return new InetSocketAddress(l.getHost(), l.getPort());
+            }),
+        /**
+         * Local protocol used for testing.
+         */
+        LOCAL(l -> new LocalAddress(l.getHost() + ":" + l.getPort()),
+            l -> new LocalAddress(l.getHost() + ":" + l.getPort()))
+        ;
+
+        /**
+         * Interface for generating socket addresses from {@link NodeLocator}s.
+         */
+        @FunctionalInterface
+        interface SocketAddressGenerator {
+            SocketAddress generate(@Nonnull NodeLocator locator);
+        }
+
+        /**
+         * Generator to get a {@link SocketAddress} to connect to this node.
+         */
+        @Getter
+        final SocketAddressGenerator generator;
+
+        /**
+         * Generator to get a {@link SocketAddress} for binding.
+         */
+        @Getter
+        final SocketAddressGenerator bindingGenerator;
+    }
+
+    /** The protocol to use. */
+    @Builder.Default private Protocol protocol = Protocol.TCP;
+
+    /** The host the node is located on. */
+    final String host;
+
+    /** The port number on the host the node is located on. */
+    final int port;
+
+    /** When generating the binding socket address, whether to bind to all interfaces.
+     *  Only applicable for TCP.
+     */
+    @Getter
+    @Builder.Default private boolean bindToAll = false;
+
+    /** The ID of the node. Can be null if node id matching is not requested. */
+    @Builder.Default private UUID nodeId = null;
+
+    /** A map of options. */
+    @Singular final ImmutableMap<String, String> options;
+
+    /** Parse a node locator string.
+     *
+     * @param toParse   The string to parse.
+     * @return          A {@link NodeLocator} which represents the string.
+     */
+    public static NodeLocator parseString(String toParse) {
+        try {
+            // Fix a "legacy" node locator, which doesn't have a protocol.
+            if (!toParse.contains("://")) {
+                toParse = "tcp://" + toParse;
+            }
+
+            final URI url = new URI(toParse);
+
+            // Get the protocol from the enum
+            Protocol proto = Protocol.valueOf(url.getScheme().toUpperCase());
+
+            // Host/port are as in a URL
+            String host = url.getHost();
+            int port = url.getPort();
+
+            // Node ID is from the path, if present.
+            UUID nodeId;
+            if (url.getPath().equals("") || url.getPath().equals("/")) {
+                // No path, so nodeId is null
+                nodeId = null;
+            } else {
+                nodeId = UuidUtils.fromBase64(url.getPath().replaceFirst("/", ""));
+            }
+
+            // Options map is from the query, if present.
+            Map<String, String> options;
+            if (url.getQuery() == null || url.getQuery().equals("")) {
+                options = Collections.emptyMap();
+            } else {
+                String[] query = url.getQuery().split("&");
+                options = Arrays.stream(query)
+                    .map(keyValue -> keyValue.split("="))
+                    .collect(Collectors.toMap(kv -> kv[0], kv -> kv[1]));
+            }
+
+            return NodeLocator.builder()
+                .protocol(proto)
+                .host(host)
+                .port(port)
+                .nodeId(nodeId)
+                .options(options)
+                .build();
+
+        } catch (URISyntaxException m) {
+            throw new IllegalArgumentException(m);
+        }
+    }
+
+    /** Get a {@link java.net.SocketAddress} for this node, which consists of
+     *  concatenating the host:port components.
+     *
+     * @return  A {@link SocketAddress}.
+     */
+    public SocketAddress getSocketAddress() {
+        return protocol.getGenerator().generate(this);
+    }
+
+    /** Get a {@link SocketAddress} to bind locally to this node, used for serving
+     *  requests at the node.
+     * @return A binding {@link SocketAddress}.
+     */
+    public SocketAddress getBindingSocketAddress() {
+        return protocol.getBindingGenerator().generate(this);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder()
+            .append(protocol.toString().toLowerCase())
+            .append("://")
+            .append(host)
+            .append(":")
+            .append(port)
+            .append("/");
+
+        if (nodeId != null) {
+            sb.append(UuidUtils.asBase64(nodeId));
+        }
+
+        if (!options.isEmpty()) {
+            sb.append("?");
+            sb.append(options.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining("&")));
+        }
+
+        return sb.toString();
+    }
+
+
+    /** Returns true if the provided string points to the same node.
+     *
+     * <p>A string points to the same node as this {@link NodeLocator} if
+     * it has the same node ID, or it has no node ID and points to the same
+     * host and port.
+     *
+     * @param nodeString    The string to check.
+     * @return              True, if the string points to the node referenced by this {@link this}.
+     * @throws IllegalArgumentException     If the provided string cannot be parsed as a
+     *                                      {@link NodeLocator}.
+     */
+    public boolean isSameNode(@Nonnull String nodeString) {
+        NodeLocator otherNode = NodeLocator.parseString(nodeString);
+        // The nodes are the same if their Node IDs are the same.
+        if (otherNode.getNodeId() != null && otherNode.getNodeId().equals(getNodeId())) {
+            return true;
+        } else {
+            // Otherwise, the both node IDs must not be set
+            // and must match by host and port.
+            return !(otherNode.getNodeId() != null && getNodeId() != null)
+                && otherNode.getHost().equals(getHost())
+                && otherNode.getPort() == getPort();
+        }
+    }
+}

--- a/runtime/src/main/resources/logback.xml
+++ b/runtime/src/main/resources/logback.xml
@@ -1,31 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
-
-    <appender name="MetricsRollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>/var/log/corfu-metrics.log</file>
-        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>/var/log/corfu-metrics.%i.log</fileNamePattern>
-            <minIndex>1</minIndex>
-            <maxIndex>10</maxIndex>
-        </rollingPolicy>
-        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>100MB</maxFileSize>
-        </triggeringPolicy>
-
-        <encoder>
-            <pattern>%d %highlight(%-5level) - %msg%n %ex{short}</pattern>
-        </encoder>
-    </appender>
-
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>%d %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{short}</pattern>
         </encoder>
     </appender>
-
-    <logger name="org.corfudb.metricsdata" level="INFO" additivity="false">
-        <appender-ref ref="MetricsRollingFile" />
-    </logger>
 
     <root level="ERROR">
         <appender-ref ref="STDOUT"/>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.corfudb</groupId>
             <artifactId>test</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>corfu</artifactId>
         <groupId>org.corfudb</groupId>
-        <version>0.1-SNAPSHOT</version>
+        <version>0.1.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -30,7 +30,24 @@
             <version>${project.version}</version>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.classic.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.openjdk.jmh</groupId>
+          <artifactId>jmh-core</artifactId>
+          <version>1.20</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
+          <groupId>org.openjdk.jmh</groupId>
+          <artifactId>jmh-generator-annprocess</artifactId>
+          <version>1.20</version>
+          <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -54,7 +54,11 @@ public class ServerContextBuilder {
     }
 
     public static ServerContext defaultContext(int port) {
-        return new ServerContextBuilder().setPort(port).build();
+        ServerContext sc = new ServerContextBuilder().setPort(port)
+            .setAddress("localhost")
+            .setImplementation("auto")
+            .build();
+        return sc;
     }
 
     public static ServerContext emptyContext() {

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -1,0 +1,533 @@
+package org.corfudb.integration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.google.common.collect.Range;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.ReadResponse;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.runtime.BootstrapUtil;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.util.Sleep;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClusterReconfigIT extends AbstractIT {
+
+    private static String corfuSingleNodeHost;
+
+    @Before
+    public void loadProperties() {
+        corfuSingleNodeHost = (String) PROPERTIES.get("corfuSingleNodeHost");
+    }
+
+    private Random getRandomNumberGenerator() {
+        final Random randomSeed = new Random();
+        final long SEED = randomSeed.nextLong();
+        // Keep this print at all times to reproduce any failed test.
+        testStatus += "SEED=" + Long.toHexString(SEED);
+        return new Random(SEED);
+    }
+
+    private Layout get3NodeLayout() throws Exception {
+        return new Layout(
+                new ArrayList<>(
+                        Arrays.asList("localhost:9000", "localhost:9001", "localhost:9002")),
+                new ArrayList<>(
+                        Arrays.asList("localhost:9000", "localhost:9001", "localhost:9002")),
+                Collections.singletonList(new Layout.LayoutSegment(
+                        Layout.ReplicationMode.CHAIN_REPLICATION,
+                        0L,
+                        -1L,
+                        Collections.singletonList(new Layout.LayoutStripe(
+                                Arrays.asList("localhost:9000", "localhost:9001", "localhost:9002")
+                        )))),
+                0L,
+                UUID.randomUUID());
+    }
+
+    /**
+     * Refreshes the layout and waits for a limited time for the refreshed layout to satisfy the
+     * expected epoch verifier.
+     *
+     * @param epochVerifier Predicate to test the refreshed epoch value.
+     * @param corfuRuntime  Runtime.
+     */
+    private void waitForEpochChange(Predicate<Long> epochVerifier, CorfuRuntime corfuRuntime) {
+        corfuRuntime.invalidateLayout();
+        Layout refreshedLayout = corfuRuntime.getLayoutView().getLayout();
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
+            if (epochVerifier.test(refreshedLayout.getEpoch())) {
+                break;
+            }
+            corfuRuntime.invalidateLayout();
+            refreshedLayout = corfuRuntime.getLayoutView().getLayout();
+            Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_SHORT);
+        }
+        assertThat(epochVerifier.test(refreshedLayout.getEpoch())).isTrue();
+    }
+
+    /**
+     * Creates a message of specified size in bytes.
+     *
+     * @param msgSize
+     * @return
+     */
+    private static String createStringOfSize(int msgSize) {
+        StringBuilder sb = new StringBuilder(msgSize);
+        for (int i = 0; i < msgSize; i++) {
+            sb.append('a');
+        }
+        return sb.toString();
+    }
+
+    private Process runSinglePersistentServer(String address, int port) throws IOException {
+        return new CorfuServerRunner()
+                .setHost(address)
+                .setPort(port)
+                .setLogPath(getCorfuServerLogPath(address, port))
+                .setSingle(true)
+                .runServer();
+    }
+
+    private Process runUnbootstrappedPersistentServer(String address, int port) throws IOException {
+        return new CorfuServerRunner()
+                .setHost(address)
+                .setPort(port)
+                .setLogPath(getCorfuServerLogPath(address, port))
+                .setSingle(false)
+                .runServer();
+    }
+
+    private Thread startDaemonWriter(CorfuRuntime runtime, Random r, CorfuTable table,
+                                     String data, AtomicBoolean stopFlag) {
+        Thread t = new Thread(() -> {
+            while (stopFlag.get()) {
+                assertThatCode(() -> {
+                    try {
+                        runtime.getObjectsView().TXBegin();
+                        table.put(Integer.toString(r.nextInt()), data);
+                        runtime.getObjectsView().TXEnd();
+                    } catch (TransactionAbortedException e) {
+                        // A transaction aborted exception is expected during
+                        // some reconfiguration cases.
+                    }
+                }).doesNotThrowAnyException();
+            }
+        });
+        t.setDaemon(true);
+        t.start();
+        return t;
+    }
+
+    /**
+     * A cluster of one node is started - 9000.
+     * Then a block of data of 15,000 entries is written to the node.
+     * This is to ensure we have at least 1.5 data log files.
+     * A daemon thread is instantiated to randomly put data while add node is executed.
+     * 2 nodes - 9001 and 9002 are added to the cluster.
+     * Finally the epoch and the addition of the 2 nodes in the laout is verified.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void addNodesTest() throws Exception {
+        final int PORT_0 = 9000;
+        final int PORT_1 = 9001;
+        final int PORT_2 = 9002;
+        final Duration timeout = Duration.ofMinutes(5);
+        final Duration pollPeriod = Duration.ofSeconds(5);
+        final int workflowNumRetry = 3;
+
+        Process corfuServer_1 = runSinglePersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
+        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+
+        CorfuRuntime runtime = createDefaultRuntime();
+
+        CorfuTable table = runtime.getObjectsView()
+                .build()
+                .setType(CorfuTable.class)
+                .setStreamName("test")
+                .open();
+
+        final String data = createStringOfSize(1_000);
+
+        Random r = getRandomNumberGenerator();
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
+            String key = Long.toString(r.nextLong());
+            table.put(key, data);
+        }
+
+        final AtomicBoolean moreDataToBeWritten = new AtomicBoolean(true);
+        Thread t = startDaemonWriter(runtime, r, table, data, moreDataToBeWritten);
+
+        runtime.getManagementView().addNode("localhost:9001", workflowNumRetry,
+                timeout, pollPeriod);
+        runtime.getManagementView().addNode("localhost:9002", workflowNumRetry,
+                timeout, pollPeriod);
+
+        final long epochAfter2Adds = 4L;
+        runtime.invalidateLayout();
+        assertThat(runtime.getLayoutView().getLayout().getEpoch()).isEqualTo(epochAfter2Adds);
+
+        moreDataToBeWritten.set(false);
+        t.join();
+
+        verifyData(runtime);
+
+        shutdownCorfuServer(corfuServer_1);
+        shutdownCorfuServer(corfuServer_2);
+        shutdownCorfuServer(corfuServer_3);
+    }
+
+    /**
+     * Queries for all the data in the 3 nodes and checks if the data state matches across the
+     * cluster.
+     *
+     * @param corfuRuntime Connected instance of the runtime.
+     * @throws Exception
+     */
+    private void verifyData(CorfuRuntime corfuRuntime) throws Exception {
+
+        TokenResponse tokenResponse = corfuRuntime.getSequencerView()
+                .nextToken(Collections.singleton(CorfuRuntime.getStreamID("test")), 0);
+        long lastAddress = tokenResponse.getTokenValue();
+
+        Map<Long, LogData> map_0 = getAllData(corfuRuntime, "localhost:9000", lastAddress);
+        Map<Long, LogData> map_1 = getAllData(corfuRuntime, "localhost:9001", lastAddress);
+        Map<Long, LogData> map_2 = getAllData(corfuRuntime, "localhost:9002", lastAddress);
+
+        assertThat(map_1.equals(map_0)).isTrue();
+        assertThat(map_2.equals(map_0)).isTrue();
+    }
+
+    /**
+     * Fetches all the data from the node.
+     *
+     * @param corfuRuntime Connected instance of the runtime.
+     * @param endpoint     Endpoint ot query for all the data.
+     * @param end          End address up to which data needs to be fetched.
+     * @return Map of all the addresses contained by the node corresponding to the data stored.
+     * @throws Exception
+     */
+    private Map<Long, LogData> getAllData(CorfuRuntime corfuRuntime,
+                                          String endpoint, long end) throws Exception {
+        ReadResponse readResponse = corfuRuntime.getLayoutView().getRuntimeLayout()
+                .getLogUnitClient(endpoint)
+                .read(Range.closed(0L, end)).get();
+        return readResponse.getAddresses();
+    }
+
+    /**
+     * Increments the epoch of the cluster by one. Keeps the remainder of the layout the same.
+     *
+     * @param corfuRuntime Connected runtime instance.
+     * @return Returns the new accepted layout.
+     * @throws Exception
+     */
+    private Layout incrementClusterEpoch(CorfuRuntime corfuRuntime) throws Exception {
+        Layout l = new Layout(corfuRuntime.getLayoutView().getLayout());
+        l.setEpoch(l.getEpoch() + 1);
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().updateLayout(l, 1L);
+        corfuRuntime.invalidateLayout();
+        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(1L);
+        return l;
+    }
+
+    /**
+     * Starts a corfu server and increments the epoch from 0 to 1.
+     * The server is then reset and the new layout fetch is expected to return a layout with
+     * epoch 0 as all state should have been cleared.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void resetTest() throws Exception {
+
+        final int PORT_0 = 9000;
+
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, PORT_0);
+
+        CorfuRuntime corfuRuntime = createDefaultRuntime();
+        incrementClusterEpoch(corfuRuntime);
+        corfuRuntime.getLayoutView().getRuntimeLayout().getBaseClient("localhost:9000")
+                .reset().get();
+
+        corfuRuntime = createDefaultRuntime();
+        // The shutdown and reset can take an unknown amount of time and there is a chance that the
+        // newer runtime may also connect to the older corfu server (before reset).
+        // Hence the while loop.
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
+            if (corfuRuntime.getLayoutView().getLayout().getEpoch() == 0L) {
+                break;
+            }
+            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
+            corfuRuntime = createDefaultRuntime();
+        }
+        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(0L);
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
+    }
+
+    /**
+     * Starts a corfu server and increments the epoch from 0 to 1.
+     * The server is then restarted and the new layout fetch is expected to return a layout with
+     * epoch 2 or greater (recovery can fail and epoch can increase) as the state is not cleared
+     * and the restart forces a recovery to increment the epoch.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void restartTest() throws Exception {
+
+        final int PORT_0 = 9000;
+
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, PORT_0);
+
+        CorfuRuntime corfuRuntime = createDefaultRuntime();
+        Layout l = incrementClusterEpoch(corfuRuntime);
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).getBaseClient("localhost:9000")
+                .restart().get();
+
+        restartServer(corfuRuntime, l.getLayoutServers().get(0));
+
+        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch())
+                .isGreaterThanOrEqualTo(l.getEpoch() + 1);
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
+    }
+
+    /**
+     * Creates 3 corfu server processes.
+     * Connects a runtime and creates a corfu table to write data.
+     * One of the node is then shutdown/killed. The cluster then stabilizes to the new
+     * epoch by removing the failure from the logunit chain and bootstrapping a backup
+     * sequencer (only if required). After the stabilization is complete, another write is
+     * attempted. The test passes only if this write goes through.
+     *
+     * @param killNode Index of the node to be killed.
+     * @throws Exception
+     */
+    private void killNodeAndVerifyDataPath(int killNode)
+            throws Exception {
+
+        // Set up cluster of 3 nodes.
+        final int PORT_0 = 9000;
+        final int PORT_1 = 9001;
+        final int PORT_2 = 9002;
+        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
+        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        List<Process> corfuServers = Arrays.asList(corfuServer_1, corfuServer_2, corfuServer_3);
+        final Layout layout = get3NodeLayout();
+        final int retries = 3;
+        BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
+
+        // Create map and set up daemon writer thread.
+        CorfuRuntime runtime = createDefaultRuntime();
+        CorfuTable table = runtime.getObjectsView()
+                .build()
+                .setType(CorfuTable.class)
+                .setStreamName("test")
+                .open();
+        final String data = createStringOfSize(1_000);
+        Random r = getRandomNumberGenerator();
+        final AtomicBoolean moreDataToBeWritten = new AtomicBoolean(true);
+        Thread t = startDaemonWriter(runtime, r, table, data, moreDataToBeWritten);
+
+        // Some preliminary writes into the corfu table.
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+            runtime.getObjectsView().TXBegin();
+            table.put(Integer.toString(r.nextInt()), data);
+            runtime.getObjectsView().TXEnd();
+        }
+
+        // Killing killNode.
+        assertThat(shutdownCorfuServer(corfuServers.get(killNode))).isTrue();
+
+        // We wait for failure to be detected and the cluster to stabilize by waiting for the epoch
+        // to increment.
+        waitForEpochChange(refreshedEpoch -> refreshedEpoch > layout.getEpoch(), runtime);
+
+        // Stop the daemon thread.
+        moreDataToBeWritten.set(false);
+        t.join();
+
+        // Ensure writes still going through.
+        // Fail test if write fails.
+        boolean writeAfterKillNode = false;
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
+            try {
+                runtime.getObjectsView().TXBegin();
+                table.put(Integer.toString(r.nextInt()), data);
+                runtime.getObjectsView().TXEnd();
+                writeAfterKillNode = true;
+                break;
+            } catch (TransactionAbortedException tae) {
+                // A transaction aborted exception is expected during
+                // some reconfiguration cases.
+                tae.printStackTrace();
+            }
+            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
+        }
+        assertThat(writeAfterKillNode).isTrue();
+
+        for (int i = 0; i < corfuServers.size(); i++) {
+            if (i == killNode) {
+                continue;
+            }
+            assertThat(shutdownCorfuServer(corfuServers.get(i))).isTrue();
+        }
+    }
+
+    /**
+     * Kill a node containing the head of the log unit chain and the primary sequencer.
+     * Ensures writes go through after kill node and cluster re-stabilization.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void killLogUnitAndPrimarySequencer() throws Exception {
+        killNodeAndVerifyDataPath(0);
+    }
+
+    /**
+     * Kill a node containing one of the log unit chain and the non-primary sequencer.
+     * Ensures writes go through after kill node and cluster re-stabilization.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void killLogUnitAndBackupSequencer() throws Exception {
+        killNodeAndVerifyDataPath(1);
+    }
+
+    /**
+     * Bootstrap cluster of 3 nodes using the BootstrapUtil.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void test3NodeBootstrapUtility() throws Exception {
+
+        // Set up cluster of 3 nodes.
+        final int PORT_0 = 9000;
+        final int PORT_1 = 9001;
+        final int PORT_2 = 9002;
+        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
+        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        final Layout layout = get3NodeLayout();
+
+        final int retries = 3;
+        BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
+
+        CorfuRuntime corfuRuntime = createDefaultRuntime();
+        assertThat(corfuRuntime.getLayoutView().getLayout().equals(layout)).isTrue();
+
+        shutdownCorfuServer(corfuServer_1);
+        shutdownCorfuServer(corfuServer_2);
+        shutdownCorfuServer(corfuServer_3);
+    }
+
+    /**
+     * Starts with 3 nodes on ports 0, 1 and 2.
+     * A daemon thread is started for random writes in the background.
+     * PART 1. Kill node.
+     * First the node on port 0 is killed. The test then waits for the cluster to stabilize and
+     * assert that data operations still go through.
+     * Part 2. Revive node.
+     * Now, the same node is revived and waits for the node to be healed and merged back into the
+     * cluster.
+     * Finally the data on all the 3 nodes is verified.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void killAndHealNode() throws Exception {
+
+        // Set up cluster of 3 nodes.
+        final int PORT_0 = 9000;
+        final int PORT_1 = 9001;
+        final int PORT_2 = 9002;
+        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
+        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        final Layout layout = get3NodeLayout();
+        final int retries = 3;
+        BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
+
+        // Create map and set up daemon writer thread.
+        CorfuRuntime runtime = createDefaultRuntime();
+        CorfuTable table = runtime.getObjectsView()
+                .build()
+                .setType(CorfuTable.class)
+                .setStreamName("test")
+                .open();
+        final String data = createStringOfSize(1_000);
+        Random r = getRandomNumberGenerator();
+
+        // Some preliminary writes into the corfu table.
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+            runtime.getObjectsView().TXBegin();
+            table.put(Integer.toString(r.nextInt()), data);
+            runtime.getObjectsView().TXEnd();
+        }
+
+        // PART 1.
+        // Killing killNode.
+        assertThat(shutdownCorfuServer(corfuServer_1)).isTrue();
+
+        // We wait for failure to be detected and the cluster to stabilize by waiting for the epoch
+        // to increment.
+        waitForEpochChange(refreshedEpoch -> refreshedEpoch > layout.getEpoch(), runtime);
+
+        // Ensure writes still going through. Daemon writer thread does not ensure this.
+        // Fail test if write fails.
+        boolean writeAfterKillNode = false;
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
+            try {
+                runtime.getObjectsView().TXBegin();
+                table.put(Integer.toString(r.nextInt()), data);
+                runtime.getObjectsView().TXEnd();
+                writeAfterKillNode = true;
+                break;
+            } catch (TransactionAbortedException tae) {
+                // A transaction aborted exception is expected during
+                // some reconfiguration cases.
+            }
+            Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_SHORT);
+        }
+        assertThat(writeAfterKillNode).isTrue();
+
+        // PART 2.
+        // Reviving same node.
+        corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        final long epochAfterHealingNode = 3L;
+
+        // Waiting node to be healed and added back to the layout.
+        waitForEpochChange(refreshedEpoch -> refreshedEpoch >= epochAfterHealingNode, runtime);
+        verifyData(runtime);
+
+        shutdownCorfuServer(corfuServer_1);
+        shutdownCorfuServer(corfuServer_2);
+        shutdownCorfuServer(corfuServer_3);
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -41,7 +41,8 @@ public class SealIT extends AbstractIT{
          *   3. Propose the new layout by driving paxos.
          */
 
-        Layout currentLayout = cr1.getLayoutView().getCurrentLayout();
+        Layout currentLayout = (Layout) cr1.getLayoutView().getCurrentLayout().clone();
+        currentLayout.setRuntime(cr1);
         /* 1 */
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
         /* 2 */

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -417,7 +417,8 @@ public class ServerRestartIT extends AbstractIT {
         final int newMapBStreamTail = 19;
         final int newGlobalTail = 19;
 
-        assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
+        restartServer(corfuRuntime, corfuRuntime.getLayoutView()
+            .getLayout().getLayoutServers().get(0));
 
         corfuServerProcess = runCorfuServer();
         corfuRuntime = createDefaultRuntime();

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -102,7 +102,8 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         getManagementServer(SERVERS.PORT_2).shutdown();
 
         // Seal
-        Layout currentLayout = rt.getLayoutView().getCurrentLayout();
+        Layout currentLayout = (Layout) rt.getLayoutView().getCurrentLayout().clone();
+        currentLayout.setRuntime(rt);
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
         currentLayout.moveServersToEpoch();
 

--- a/test/src/test/java/org/corfudb/runtime/clients/AbstractClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/AbstractClientTest.java
@@ -7,6 +7,8 @@ import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.infrastructure.TestServerRouter;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.util.NodeLocator;
+import org.junit.After;
 import org.junit.Before;
 
 import java.util.Map;
@@ -55,6 +57,10 @@ public abstract class AbstractClientTest extends AbstractCorfuTest {
      */
     private IClientRouter getRouterFunction(CorfuRuntime runtime, String endpoint) {
         runtimeRouterMap.putIfAbsent(runtime, new ConcurrentHashMap<>());
+        if (endpoint.startsWith("local://") || endpoint.startsWith("tcp://")) {
+            NodeLocator nl = NodeLocator.parseString(endpoint);
+            endpoint = nl.getHost() + ":" + nl.getPort();
+        }
         if (!endpoint.startsWith("test:")) {
             throw new RuntimeException("Unsupported endpoint in test: " + endpoint);
         }

--- a/test/src/test/java/org/corfudb/runtime/clients/TestChannelContext.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestChannelContext.java
@@ -1,9 +1,17 @@
 package org.corfudb.runtime.clients;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.Unpooled;
-import io.netty.channel.*;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelProgressivePromise;
+import io.netty.channel.ChannelPromise;
 import io.netty.util.Attribute;
 import io.netty.util.AttributeKey;
 import io.netty.util.concurrent.EventExecutor;
@@ -12,6 +20,8 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 
 import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 /**
  * Created by mwei on 7/6/16.
@@ -25,6 +35,10 @@ public class TestChannelContext implements ChannelHandlerContext {
     }
 
     HandleMessageFunction hmf;
+
+    private final static int THREAD_COUNT = 4;
+    private final static ExecutorService msgExecutorService = Executors.newFixedThreadPool(THREAD_COUNT,
+            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("testChannel-%d").build());
 
     public TestChannelContext(HandleMessageFunction hmf) {
         this.hmf = hmf;
@@ -42,7 +56,7 @@ public class TestChannelContext implements ChannelHandlerContext {
             } catch (Exception e) {
                  log.warn("Error during deserialization", e);
             }
-        });
+        }, msgExecutorService);
     }
 
     @Override

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapBenchmark.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapBenchmark.java
@@ -1,0 +1,156 @@
+package org.corfudb.runtime.collections;
+
+import com.google.common.reflect.TypeToken;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.test.benchmark.AbstractCorfuBenchmark;
+import org.corfudb.test.benchmark.CorfuBenchmarkState;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/** A simple benchmark for {@link org.corfudb.runtime.collections.SMRMap} operations.
+ *
+ */
+public class SMRMapBenchmark extends AbstractCorfuBenchmark {
+
+    /** State for simple {@link org.corfudb.runtime.collections.SMRMap} benchmarks.
+     *  Keeps a single map, and a {@link AtomicInteger} which is used as a counter
+     *  to issue new keys.
+     */
+    public static class SMRBenchmarkState extends CorfuBenchmarkState {
+
+        /** A runtime to use during the iteration. */
+        CorfuRuntime rt;
+
+        /** A map to use during each iteration. */
+        Map<Integer, Integer> map;
+
+        /** A counter to be used during each iteration. */
+        AtomicInteger counter;
+
+        /** Initializes a new runtime, map and counter. */
+        @Override
+        public void initializeIteration() {
+            super.initializeIteration();
+
+            rt = getNewRuntime();
+            map = rt.getObjectsView().build()
+                .setStreamName("test")
+                .setTypeToken(new TypeToken<SMRMap<Integer, Integer>>() {})
+                .open();
+            counter = new AtomicInteger();
+        }
+
+        /** Get the next key. */
+        public int getNextKey() {
+            return counter.getAndIncrement();
+        }
+    }
+
+    /** Measure the performance of insert operations. A single operation is performed per trial. */
+    @Benchmark
+    @Warmup(iterations=5)
+    @Measurement(iterations=10)
+    public void insert (SMRBenchmarkState state, Blackhole bh) {
+        state.map.put(state.getNextKey(), 0);
+    }
+
+    /** Measure the performance of insert operations multithreaded. A single operation is performed
+     *  per trial.
+     */
+    @Benchmark
+    @Warmup(iterations=5)
+    @Measurement(iterations=10)
+    @Threads(5)
+    public void insertMultiThreaded (SMRBenchmarkState state, Blackhole bh) {
+        insert(state, bh);
+    }
+
+    /** A more complex benchmark state which initializes 1_000 initial keys in the map,
+     *  which map to 1_000 random other keys in the map.
+     */
+    public static class SMRInitBenchmarkState extends SMRBenchmarkState {
+
+        /** The number of keys in the map. */
+        final int num_keys = 1_000;
+
+        /** A random for generating random numbers. */
+        Random r = new Random();
+
+        /** Initialize the map with {@link SMRInitBenchmarkState#num_keys}, each mapped
+         *  to another key in the map.
+         */
+        @Override
+        public void initializeIteration() {
+            super.initializeIteration();
+
+            IntStream.range(0, num_keys).forEach(i -> map.put(i, r.nextInt(num_keys)));
+        }
+
+        /** Get the next key, which is a random key in the map. */
+        @Override
+        public int getNextKey() {
+            return r.nextInt(num_keys);
+        }
+    }
+
+    /** Measure put/get performance. First get a random key, then insert a random value to another
+     *  key.
+     */
+    @Benchmark
+    @Warmup(iterations=5)
+    @Measurement(iterations=10)
+    public void getThenInsert(SMRInitBenchmarkState state, Blackhole bh) {
+        Integer k = state.map.get(state.getNextKey());
+        state.map.put(state.getNextKey(), k);
+    }
+
+    /** Measure multithreaded put/get performance. First get a random key, then insert a random
+     *  value to another key.
+     */
+    @Benchmark
+    @Warmup(iterations=5)
+    @Measurement(iterations=10)
+    @Threads(5)
+    public void getThenInsertMultithreaded(SMRInitBenchmarkState state, Blackhole bh) {
+        getThenInsert(state, bh);
+    }
+
+    /** Measure transactional put/get performance. Start a transaction and then perform the
+     *  same operations as get then insert: First get a random key, then insert a random value
+     *  to another key.
+     */
+    @Benchmark
+    @Warmup(iterations=5)
+    @Measurement(iterations=10)
+    public void getThenInsertTransactional(SMRInitBenchmarkState state, Blackhole bh) {
+        try {
+            state.rt.getObjectsView().TXBegin();
+            Integer k = state.map.get(state.getNextKey());
+            state.map.put(state.getNextKey(), k);
+            state.rt.getObjectsView().TXEnd();
+        } catch (TransactionAbortedException ignored) {
+            // ignore the abort for benchmark
+        }
+    }
+
+
+    /** Measure multithreaded transactional put/get performance. Start a transaction and then
+     *  perform the same operations as get then insert: First get a random key, then insert a
+     *  random value to another key.
+     */
+    @Benchmark
+    @Warmup(iterations = 5)
+    @Measurement(iterations=10)
+    @Threads(5)
+    public void getThenInsertTransactionalMultithreaded(SMRInitBenchmarkState state, Blackhole bh) {
+        getThenInsertTransactional(state, bh);
+    }
+}

--- a/test/src/test/java/org/corfudb/test/ServerOptionsMap.java
+++ b/test/src/test/java/org/corfudb/test/ServerOptionsMap.java
@@ -1,0 +1,133 @@
+package org.corfudb.test;
+
+import com.google.common.collect.ImmutableMap;
+import io.netty.channel.EventLoopGroup;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Builder.Default;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+
+@Builder
+public class ServerOptionsMap {
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface OptionName {
+        String name();
+    }
+
+    @OptionName(name="initial-token")
+    @Default long initialToken = 0L;
+
+    @OptionName(name="single")
+    @Default boolean single = true;
+
+    @OptionName(name="memory")
+    @Default boolean memory = true;
+
+    @OptionName(name="log-path")
+    @Default String logPath = null;
+
+    @OptionName(name="no-verify")
+    @Default boolean noVerify = false;
+
+    @OptionName(name="enable-tls")
+    @Default boolean tlsEnabled = false;
+
+    @OptionName(name="enable-tls-mutual-auth")
+    @Default boolean tlsMutualAuthEnabled = false;
+
+    @OptionName(name="tls-protocols")
+    @Default String tlsProtocols = "";
+
+    @OptionName(name="tls-ciphers")
+    @Default String tlsCiphers = "";
+
+    @OptionName(name="keystore")
+    @Default String keystore = "";
+
+    @OptionName(name="keystore-password-file")
+    @Default String keystorePasswordFile = "";
+
+    @OptionName(name="enable-sasl-plain-text-auth")
+    @Default boolean saslPlainTextAuth = false;
+
+    @OptionName(name="truststore")
+    @Default String truststore = "";
+
+    @OptionName(name="truststore-password-file")
+    @Default String truststorePasswordFile = "";
+
+    @OptionName(name="implementation")
+    @Default String implementation = "local";
+
+    @OptionName(name="cache-heap-ratio")
+    @Default String cacheSizeHeapRatio = "0.5";
+
+    @OptionName(name="address")
+    @Default String address = "server";
+
+    @OptionName(name="<port>")
+    @Default String port = "9000";
+
+    @OptionName(name="sequencer-cache-size")
+    @Default String seqCache = "1000";
+
+    @OptionName(name="management-server")
+    @Default String managementBootstrapEndpoint = null;
+
+    @OptionName(name="Threads")
+    @Default String numThreads = "0";
+
+    @OptionName(name="HandshakeTimeout")
+    @Default String handshakeTimeout = "10";
+
+    @OptionName(name="Prefix")
+    @Default String prefix = "";
+
+    @OptionName(name="cluster-id")
+    @Default String clusterId = "auto";
+
+    @OptionName(name="boss")
+    EventLoopGroup bossGroup;
+
+    @OptionName(name="client")
+    EventLoopGroup clientGroup;
+
+    @OptionName(name="worker")
+    EventLoopGroup workerGroup;
+
+    public Map<String, Object> toMap() {
+        ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+
+        Arrays.stream(this.getClass().getDeclaredFields())
+            .filter(f -> f.getAnnotation(OptionName.class) != null)
+            .forEach(f ->insertFieldToBuilder(f, builder));
+
+        return builder.build();
+    }
+
+    private void insertFieldToBuilder(@Nonnull Field field,
+        @Nonnull ImmutableMap.Builder<String, Object> mapBuilder) {
+        try {
+            if (field.get(this) != null) {
+                String optionName = field.getAnnotation(OptionName.class).name();
+
+                // If the option is not < for port and not a EventLoopGroup (test supplied arg)
+                // we prepend it with -- for a switch.
+                if (!optionName.startsWith("<")
+                    && ! field.getType().equals(EventLoopGroup.class)) {
+                    optionName = "--" + optionName;
+                }
+
+                mapBuilder.put(optionName, field.get(this));
+            }
+        } catch (IllegalAccessException e) {
+            throw new UnrecoverableCorfuError(e);
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/test/benchmark/AbstractCorfuBenchmark.java
+++ b/test/src/test/java/org/corfudb/test/benchmark/AbstractCorfuBenchmark.java
@@ -1,0 +1,46 @@
+package org.corfudb.test.benchmark;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.Test;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+/** Junit bridge for jmh.
+ *
+ *  To implement your own benchmark class, subclass (extend) this class and
+ *  provide your own state by extending {@link CorfuBenchmarkState} as a
+ *  static inner class.
+ *
+ *  Annotate your benchmark functions with {@link org.openjdk.jmh.annotations.Benchmark}.
+ *  This will mark them for being run when the {@link this#runBenchmarks()} junit test
+ *  is run.
+ */
+public abstract class AbstractCorfuBenchmark {
+
+    static final int WARMUP_TIME_SECONDS = 5;
+    static final int MEASUREMENT_TIME_SECONDS = 5;
+
+    /** Actually runs all the benchmarks in the class. */
+    @Test
+    public void runBenchmarks() throws Exception {
+
+        Options opt = new OptionsBuilder()
+            .include(this.getClass().getName() + ".*")
+            .mode (Mode.Throughput)
+            .timeUnit(TimeUnit.MILLISECONDS)
+
+            // Overrides annotation options
+            .warmupTime(TimeValue.seconds(WARMUP_TIME_SECONDS))
+            .measurementTime(TimeValue.seconds(MEASUREMENT_TIME_SECONDS))
+            .forks(1)
+            .shouldFailOnError(true)
+            .shouldDoGC(true)
+            .build();
+
+        new Runner(opt).run();
+    }
+
+}

--- a/test/src/test/java/org/corfudb/test/benchmark/CorfuBenchmarkState.java
+++ b/test/src/test/java/org/corfudb/test/benchmark/CorfuBenchmarkState.java
@@ -1,0 +1,152 @@
+package org.corfudb.test.benchmark;
+
+import static org.corfudb.test.parameters.Servers.SERVER_0;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.netty.channel.DefaultEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import org.corfudb.comm.ChannelImplementation;
+import org.corfudb.infrastructure.AbstractServer;
+import org.corfudb.infrastructure.BaseServer;
+import org.corfudb.infrastructure.CorfuServer;
+import org.corfudb.infrastructure.LayoutServer;
+import org.corfudb.infrastructure.LogUnitServer;
+import org.corfudb.infrastructure.ManagementServer;
+import org.corfudb.infrastructure.SequencerServer;
+import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
+import org.corfudb.test.ServerOptionsMap;
+import org.corfudb.util.NodeLocator;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+
+/** State for a Corfu benchmark. Initializes a simple single-server instance.
+ *  Benchmark states for {@link AbstractCorfuBenchmark} should extend from this
+ *  class.
+ */
+@State(Scope.Benchmark)
+public class CorfuBenchmarkState {
+
+    /** A single boss group for the trial. */
+    @Getter
+    EventLoopGroup bossGroup;
+
+    /** A single worker group for the trial. */
+    @Getter
+    EventLoopGroup workerGroup;
+
+    /** A single client group for the trial. */
+    @Getter
+    EventLoopGroup clientGroup;
+
+    /** A single runtime group for the trial. */
+    @Getter
+    EventLoopGroup runtimeGroup;
+
+    /** A map of servers, updated on each iteration. */
+    @Getter
+    Map<NodeLocator, CorfuServer> serverMap;
+
+    /** Do iteration level setup, which sets up the server.
+     *
+     * You most likely want to override this method to load objects or initialize
+     * iteration state, after calling this supermethod.
+     */
+    @Setup(Level.Iteration)
+    public void initializeIteration() {
+        final ServerContext serverContext = new ServerContext(ServerOptionsMap
+            .builder()
+            .port("0")
+            .bossGroup(getBossGroup())
+            .workerGroup(getWorkerGroup())
+            .clientGroup(getClientGroup())
+            .build().toMap());
+
+        CorfuServer singleServer =
+            new CorfuServer(serverContext,
+                ImmutableMap.<Class<? extends AbstractServer>, AbstractServer>builder()
+                    .put(BaseServer.class, new BaseServer(serverContext))
+                    .put(SequencerServer.class, new SequencerServer(serverContext))
+                    .put(LayoutServer.class, new LayoutServer(serverContext))
+                    .put(LogUnitServer.class, new LogUnitServer(serverContext))
+                    .build()
+                );
+
+        singleServer.getServer(SequencerServer.class)
+            .setReadyStateEpoch(0);
+
+        singleServer.start();
+
+        serverMap.put(SERVER_0.getLocator(), singleServer);
+    }
+
+    /** Do trial level setup, which sets up the event loops. */
+    @Setup(Level.Trial)
+    public void initializeTrial() {
+        bossGroup = new DefaultEventLoopGroup(1,
+            new ThreadFactoryBuilder()
+                .setNameFormat("boss-%d")
+                .setDaemon(true)
+                .build());
+        int numThreads = Runtime.getRuntime().availableProcessors() * 2;
+
+        workerGroup = new DefaultEventLoopGroup(numThreads,
+            new ThreadFactoryBuilder()
+                .setNameFormat("worker-%d")
+                .setDaemon(true)
+                .build());
+
+        clientGroup = new DefaultEventLoopGroup(numThreads,
+            new ThreadFactoryBuilder()
+                .setNameFormat("client-%d")
+                .setDaemon(true)
+                .build());
+
+        runtimeGroup = new DefaultEventLoopGroup(numThreads,
+            new ThreadFactoryBuilder()
+                .setNameFormat("netty-%d")
+                .setDaemon(true)
+                .build());
+
+
+        serverMap = new HashMap<>();
+    }
+
+    /** Tear down the trial state, which shuts down the event loops. */
+    @TearDown(Level.Trial)
+    public void teardownTrial() {
+        bossGroup.shutdownGracefully();
+        workerGroup.shutdownGracefully();
+        clientGroup.shutdownGracefully();
+        runtimeGroup.shutdownGracefully();
+    }
+
+    /** Tear down the iteration state, which shuts down the servers. */
+    @TearDown(Level.Iteration)
+    public void teardownIteration() {
+        serverMap.values().forEach(CorfuServer::close);
+    }
+
+    /** Get a new {@link CorfuRuntime} which points to the first server. This {@link CorfuRuntime}
+     *  will not be cached.
+     * @return  A new {@link CorfuRuntime}.
+     */
+    public CorfuRuntime getNewRuntime() {
+        CorfuRuntime rt = CorfuRuntime.fromParameters(CorfuRuntimeParameters.builder()
+            .layoutServer(SERVER_0.getLocator())
+            .socketType(ChannelImplementation.LOCAL)
+            .nettyEventLoop(getRuntimeGroup())
+            .shutdownNettyEventLoop(false)
+            .build());
+        rt.connect();
+        return rt;
+    }
+}

--- a/test/src/test/java/org/corfudb/test/benchmark/CorfuBenchmarkStateTest.java
+++ b/test/src/test/java/org/corfudb/test/benchmark/CorfuBenchmarkStateTest.java
@@ -1,0 +1,33 @@
+package org.corfudb.test.benchmark;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.UUID;
+import org.corfudb.AbstractCorfuTest;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.runtime.CorfuRuntime;
+import org.junit.Test;
+
+public class CorfuBenchmarkStateTest extends AbstractCorfuTest {
+
+    /** Checks if the benchmark state can access the Corfu sequencer. */
+    @Test
+    public void benchmarkStateCanConnectAndAcquireToken() {
+        CorfuBenchmarkState bs = new CorfuBenchmarkState();
+        bs.initializeTrial();
+        bs.initializeIteration();
+
+        CorfuRuntime rt = bs.getNewRuntime();
+        rt.connect();
+
+        UUID stream = new UUID(0, 0);
+        TokenResponse tr = rt.getSequencerView().nextToken(Collections.singleton(stream), 1);
+        assertThat(tr.getTokenValue())
+            .isEqualTo(rt.getSequencerView().nextToken(Collections.emptySet(), 0)
+                .getTokenValue());
+
+        bs.teardownIteration();
+        bs.teardownTrial();
+    }
+}

--- a/test/src/test/java/org/corfudb/test/parameters/Servers.java
+++ b/test/src/test/java/org/corfudb/test/parameters/Servers.java
@@ -1,0 +1,34 @@
+package org.corfudb.test.parameters;
+
+import lombok.Getter;
+import org.corfudb.util.NodeLocator;
+import org.corfudb.util.NodeLocator.Protocol;
+
+// Magic number check disabled to make this constants more readable.
+@SuppressWarnings("checkstyle:magicnumber")
+public enum Servers {
+    SERVER_0(0),
+    SERVER_1(1),
+    SERVER_2(2),
+    SERVER_3(3),
+    SERVER_4(4),
+    SERVER_5(5),
+    SERVER_6(6),
+    SERVER_7(7),
+    SERVER_8(8),
+    SERVER_9(9)
+    ;
+
+    static final String SERVER_HOST = "server";
+
+    @Getter
+    final NodeLocator locator;
+
+    Servers(int port) {
+        locator = NodeLocator.builder()
+            .protocol(Protocol.LOCAL)
+            .host(SERVER_HOST)
+            .port(port)
+            .build();
+    }
+}

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -11,6 +11,21 @@
             <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{3}</pattern>
         </encoder>
     </appender>
+    <appender name="MetricsRollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/tmp/log/corfu-metrics.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/var/log/corfu-metrics.%i.log</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>10</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>100MB</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d %highlight(%-5level) - %msg%n %ex{short}</pattern>
+        </encoder>
+    </appender>
 
     <!-- Control logging levels for individual components here. -->
     <logger name="org.corfudb.runtime.object" level="TRACE"/>
@@ -20,8 +35,14 @@
     <logger name="io.netty.util.internal" level="INFO"/>
     <logger name="io.netty.buffer" level="INFO"/>
 
-    <root level="TRACE">
+    <logger name="org.corfudb.metricsdata" level="INFO">
+        <!--<appender-ref ref="MetricsRollingFile" />-->
+    </logger>
+
+
+    <root level="INFO">
         <!--<appender-ref ref="FILE" />-->
         <!--<appender-ref ref="STDOUT" />-->
+        <!--<appender-ref ref="MetricsRollingFile" />-->
     </root>
 </configuration>

--- a/test_checks.xml
+++ b/test_checks.xml
@@ -50,7 +50,9 @@
     <property name="fileExtensions" value="java, properties, xml"/>
 
     <module name="TreeWalker">
-        <module name="MagicNumber"/>
+        <module name="MagicNumber">
+            <property name="ignoreAnnotation" value="true"/>
+        </module>
 
         <module name="SuppressWarningsHolder" />
     </module>


### PR DESCRIPTION
## Overview

Description: This PR introduces a cached version of the sequencer view, which enables the sequencer view to remember tails it has learned about. This reduces calls to the sequencer at a small cost of local client memory (roughly equal to 32 bytes per stream).

Why should this be merged: Minor performance improvement.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
