### PR TITLE
Datastore Performance Issue

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.CacheWriter;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
@@ -13,9 +14,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
@@ -47,37 +46,35 @@ import static org.corfudb.infrastructure.utils.Persistence.syncDirectory;
  *
  * <p>Created by mdhawan on 7/27/16.
  */
+
 public class DataStore implements IDataStore {
 
     static String EXTENSION = ".ds";
 
-    private final Map<String, Object> opts;
-    private final boolean isPersistent;
     @Getter
-    private final LoadingCache<String, String> cache;
+    private final Cache<String, Object> cache;
     private final String logDir;
 
     @Getter
     private final long dsCacheSize = 1_000; // size bound for in-memory cache for dataStore
+
+    private final boolean inMem;
 
     /**
      * Return a new DataStore object.
      * @param opts  map of option strings
      */
     public DataStore(Map<String, Object> opts) {
-        this.opts = opts;
 
         if ((opts.get("--memory") != null && (Boolean) opts.get("--memory"))
                 || opts.get("--log-path") == null) {
-            // in-memory dataSture case
-            isPersistent = false;
             this.logDir = null;
             cache = buildMemoryDs();
+            inMem = true;
         } else {
-            // persistent dataSture case
-            isPersistent = true;
             this.logDir = (String) opts.get("--log-path");
             cache = buildPersistentDs();
+            inMem = false;
         }
     }
 
@@ -85,11 +82,8 @@ public class DataStore implements IDataStore {
      * obtain an in-memory cache, no content loader, no writer, no size limit.
      * @return  new LoadingCache for the DataStore
      */
-    private LoadingCache<String, String> buildMemoryDs() {
-        LoadingCache<String, String> cache = Caffeine
-                .newBuilder()
-                .build(k -> null);
-        return cache;
+    private Cache<String, Object> buildMemoryDs() {
+        return Caffeine.newBuilder().build(k -> null);
     }
 
 
@@ -109,20 +103,28 @@ public class DataStore implements IDataStore {
      *
      * @return the cache object
      */
-    private LoadingCache<String, String> buildPersistentDs() {
-        LoadingCache<String, String> cache = Caffeine.newBuilder()
+    private Cache<String, Object> buildPersistentDs() {
+        return Caffeine.newBuilder()
                 .recordStats()
-                .writer(new CacheWriter<String, String>() {
+                .writer(new CacheWriter<String, Object>() {
                     @Override
-                    public synchronized void write(@Nonnull String key, @Nonnull String value) {
+                    public synchronized void write(@Nonnull String key, @Nonnull Object value) {
+
+                        if (value == NullValue.NULL_VALUE) {
+                            return;
+                        }
+
                         try {
                             Path path = Paths.get(logDir + File.separator + key + EXTENSION);
                             Path tmpPath = Paths.get(logDir + File.separator + key + EXTENSION + ".tmp");
-                            byte[] stringBytes = value.getBytes();
-                            ByteBuffer buffer = ByteBuffer.allocate(value.getBytes().length
+
+                            String jsonPayload = JsonUtils.parser.toJson(value, value.getClass());
+                            byte[] bytes = jsonPayload.getBytes();
+
+                            ByteBuffer buffer = ByteBuffer.allocate(bytes.length
                                     + Integer.BYTES);
-                            buffer.putInt(getChecksum(stringBytes));
-                            buffer.put(stringBytes);
+                            buffer.putInt(getChecksum(bytes));
+                            buffer.put(bytes);
                             Files.write(tmpPath, buffer.array(), StandardOpenOption.CREATE,
                                     StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
                             Files.move(tmpPath, path, StandardCopyOption.REPLACE_EXISTING,
@@ -135,7 +137,7 @@ public class DataStore implements IDataStore {
 
                     @Override
                     public synchronized void delete(@Nonnull String key,
-                                                    @Nullable String value,
+                                                    @Nullable Object value,
                                                     @Nonnull RemovalCause cause) {
                         try {
                             Path path = Paths.get(logDir + File.separator + key);
@@ -146,66 +148,61 @@ public class DataStore implements IDataStore {
                     }
                 })
                 .maximumSize(dsCacheSize)
-                .build(key -> {
-                    try {
-                        Path path = Paths.get(logDir + File.separator + key + EXTENSION);
-                        if (Files.notExists(path)) {
-                            return null;
-                        }
-                        byte[] bytes = Files.readAllBytes(path);
-                        ByteBuffer buf = ByteBuffer.wrap(bytes);
-                        int checksum = buf.getInt();
-                        byte[] strBytes = Arrays.copyOfRange(bytes, 4, bytes.length);
-                        if (checksum != getChecksum(strBytes)) {
-                            throw new DataCorruptionException();
-                        }
-                        return new String(strBytes);
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
-
-        return cache;
+                .build();
     }
 
     @Override
     public synchronized  <T> void put(Class<T> tclass, String prefix, String key, T value) {
-        cache.put(getKey(prefix, key), JsonUtils.parser.toJson(value, tclass));
+        cache.put(getKey(prefix, key), value);
     }
 
-    @Override
-    public synchronized  <T> T get(Class<T> tclass, String prefix, String key) {
-        String json = cache.get(getKey(prefix, key));
-        return getObject(json, tclass);
+    private <T> T load(Class<T> tClass, String key) {
+        try {
+            Path path = Paths.get(logDir + File.separator + key + EXTENSION);
+            if (Files.notExists(path)) {
+                return null;
+            }
+            byte[] bytes = Files.readAllBytes(path);
+            ByteBuffer buf = ByteBuffer.wrap(bytes);
+            int checksum = buf.getInt();
+            byte[] strBytes = Arrays.copyOfRange(bytes, 4, bytes.length);
+            if (checksum != getChecksum(strBytes)) {
+                throw new DataCorruptionException();
+            }
+
+            String json = new String(strBytes);
+            T val = JsonUtils.parser.fromJson(json, tClass);
+            return val;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     /**
-     * This is an atomic conditional get/put: If the key is not found,
-     * then the specified value is inserted.
-     * It returns the latest value, either the original one found,
-     * or the newly inserted value
-     * @param tclass type of value
-     * @param prefix prefix part of key
-     * @param key suffice part of key
-     * @param value value to be conditionally accepted
-     * @param <T> value class
-     * @return the latest value in the cache
+     * Since the cache can't maintain key->null mappings, this enum
+     * is a place holder for null to allow keys to map to null.
      */
-    public <T> T get(Class<T> tclass, String prefix, String key, T value) {
-        String keyString = getKey(prefix, key);
-        String json = cache.get(keyString, k -> JsonUtils.parser.toJson(value, tclass));
-        return getObject(json, tclass);
+    private enum NullValue {
+        NULL_VALUE
     }
 
     @Override
-    public synchronized  <T> List<T> getAll(Class<T> tclass, String prefix) {
-        List<T> list = new ArrayList<T>();
-        for (Map.Entry<String, String> entry : cache.asMap().entrySet()) {
-            if (entry.getKey().startsWith(prefix)) {
-                list.add(getObject(entry.getValue(), tclass));
+    public synchronized <T> T get(Class<T> tclass, String prefix, String key) {
+        String path = getKey(prefix, key);
+        Object val = cache.get(path, k -> {
+            if (!inMem) {
+                T loadedVal = load(tclass, path);
+                if (loadedVal != null) {
+                    return loadedVal;
+                }
             }
-        }
-        return list;
+
+            // We need to maintain a path -> null mapping for keys that were loaded, but
+            // were empty. This is required to prevent loading an empty key more than once, which is expensive.
+            return NullValue.NULL_VALUE;
+        });
+        
+        return val == NullValue.NULL_VALUE ? null : (T) val;
     }
 
     @Override
@@ -213,18 +210,7 @@ public class DataStore implements IDataStore {
         cache.invalidate(getKey(prefix, key));
     }
 
-    // Helper methods
-
-    private <T> T getObject(String json, Class<T> tclass) {
-        return isNotNull(json) ? JsonUtils.parser.fromJson(json, tclass) : null;
-    }
-
     private String getKey(String prefix, String key) {
         return prefix + "_" + key;
     }
-
-    private boolean isNotNull(String value) {
-        return value != null && !value.trim().isEmpty();
-    }
-
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IDataStore.java
@@ -1,6 +1,5 @@
 package org.corfudb.infrastructure;
 
-import java.util.List;
 
 /**
  * Key Value data store abstraction that provides persistence for variables that need
@@ -18,7 +17,7 @@ public interface IDataStore {
      * @param tclass the class of the object being stored
      * @param prefix namespace
      * @param key    key-value key to store into
-     * @param value  key-value value
+     * @param value  Immutable value (or a value that won't be changed)
      */
     public <T> void put(Class<T> tclass, String prefix, String key, T value);
 
@@ -40,16 +39,4 @@ public interface IDataStore {
      * @param key    key-value key to delete
      */
     public <T> void delete(Class<T> tclass, String prefix, String key);
-
-    /**
-     * Retrieves all the values under a prefix.
-     *
-     * <p>NOTE there is no ordered retrieval provided.
-     *
-     * @param tclass the class of the objects being retrieved.
-     * @param prefix namespace
-     * @return list of all values stored under namespace
-     */
-    public <T> List<T> getAll(Class<T> tclass, String prefix);
-
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -301,17 +301,6 @@ public class ServerContext implements AutoCloseable {
     }
 
     /**
-     * Returns the layout history.
-     *
-     * @return list of layouts in the history
-     */
-    public List<Layout> getLayoutHistory() {
-        List<Layout> layouts = dataStore.getAll(Layout.class, PREFIX_LAYOUTS);
-        layouts.sort(Comparator.comparingLong(Layout::getEpoch));
-        return layouts;
-    }
-
-    /**
      * The epoch of this router. This is managed by the base server implementation.
      */
     public synchronized long getServerEpoch() {

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -316,7 +316,8 @@ public class LayoutViewTest extends AbstractViewTest {
                 .addToSegment()
                 .addToLayout()
                 .build();
-        bootstrapAllServers(l);
+        Layout copy = new Layout(l);
+        bootstrapAllServers(copy);
         CorfuRuntime corfuRuntime = getRuntime(l).connect();
 
 


### PR DESCRIPTION
## Overview
The local datastore cache used to cache a key to the serialized
form of the value, as a result every get was desrializing the
object. This is inefficient, this PR maps a key to the deserilized
form of the object.

Why should this be merged: Improves contention on the local datastore

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
