### PR TITLE
Implements possibility of exporting corfu metrics to CSV files.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
@@ -2,6 +2,14 @@ package org.corfudb.infrastructure;
 
 import com.codahale.metrics.Timer;
 import io.netty.channel.ChannelHandlerContext;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.CorfuMsg;
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.ExceptionMsg;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.util.MetricsUtils;
+
+import javax.annotation.Nonnull;
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -12,14 +20,6 @@ import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Map;
 import java.util.Set;
-
-import javax.annotation.Nonnull;
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.protocols.wireprotocol.CorfuMsg;
-import org.corfudb.protocols.wireprotocol.CorfuMsgType;
-import org.corfudb.protocols.wireprotocol.ExceptionMsg;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
-import org.corfudb.util.MetricsUtils;
 
 /**
  * This class implements message handlers for {@link AbstractServer} implementations.
@@ -35,6 +35,8 @@ import org.corfudb.util.MetricsUtils;
  */
 @Slf4j
 public class CorfuMsgHandler {
+
+    private static final String CORFU_INFRASTRUCTURE_PREFIX = "corfu.infrastructure.message-handler.";
 
     /**
      * A functional interface for server message handlers. Server message handlers should
@@ -225,7 +227,8 @@ public class CorfuMsgHandler {
             };
         } else {
             // Otherwise, generate a timer based on the operation name
-            final Timer timer = ServerContext.getMetrics().timer(type.toString());
+            final Timer timer = ServerContext.getMetrics()
+                    .timer(CORFU_INFRASTRUCTURE_PREFIX + type.toString().toLowerCase());
             // And wrap the handler around a new lambda which measures the execution time.
             return (msg, ctx, r) -> {
                 if (server.isShutdown()) {


### PR DESCRIPTION
## Overview

Description:
This commit, implements the option of reporting corfu metrics to CSV files.

Why should this be merged: 
Creating CSV files for different metrics facilitates users' investigation of Corfu performance by analyzing and aggregating different metrics offline. Similarly developers can assess the performance implication of introduced changes by crunching results capturing different Corfu performance indicators along side each other.

Related issue(s) (if applicable): #1262 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
