### PR TITLE
Transaction Optimization

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelHandlerContext;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -350,7 +351,7 @@ public class SequencerServer extends AbstractServer {
     public synchronized void resetServer(CorfuPayloadMsg<SequencerTailsRecoveryMsg> msg,
                                          ChannelHandlerContext ctx, IServerRouter r) {
         long initialToken = msg.getPayload().getGlobalTail();
-        final Map<UUID, Long> streamTails = msg.getPayload().getStreamTails();
+        final Map<UUID, Long> tails = msg.getPayload().getStreamTails();
         final long readyEpoch = msg.getPayload().getReadyStateEpoch();
 
         // Boolean flag to denote whether this bootstrap message is just updating an existing
@@ -391,7 +392,7 @@ public class SequencerServer extends AbstractServer {
 
             // Clear the existing map as it could have been populated by an earlier reset.
             streamTailToGlobalTailMap.clear();
-            streamTailToGlobalTailMap.putAll(streamTails);
+            streamTailToGlobalTailMap.putAll(tails);
         }
 
         // Mark the sequencer as ready after the tails have been populated.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenRequest.java
@@ -32,6 +32,8 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
     public static final byte TK_MULTI_STREAM = 3;
     public static final byte TK_TX = 4;
 
+    public static final byte TK_QUERY_ALL = 5;
+
     /** The type of request, one of the above. */
     final byte reqType;
 
@@ -88,6 +90,7 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
 
         switch (reqType) {
 
+            case TK_QUERY_ALL:
             case TK_QUERY:
                 numTokens = 0L;
                 streams = ICorfuPayload.listFromBuffer(buf, UUID.class);
@@ -123,7 +126,7 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, reqType);
-        if (reqType != TK_QUERY) {
+        if (reqType != TK_QUERY && reqType != TK_QUERY_ALL) {
             ICorfuPayload.serialize(buf, numTokens);
         }
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -1,20 +1,19 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
-
 /**
  * Created by mwei on 8/8/16.
  */
-@Data
 @AllArgsConstructor
+@Data
 public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
 
     public static byte[] NO_CONFLICT_KEY = new byte[]{};
@@ -49,6 +48,9 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
     /** The backpointer map, if available. */
     final Map<UUID, Long> backpointerMap;
 
+    /**
+     * A tails map that contains the result for a multi-tail query.
+     */
     final List<Long> streamTails;
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionBuilder.java
@@ -5,6 +5,9 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.corfudb.runtime.CorfuRuntime;
 
+import java.util.List;
+import java.util.UUID;
+
 /** Helper class to build transactional contexts.
  *
  * <p>Created by mwei on 11/21/16.
@@ -23,6 +26,14 @@ public class TransactionBuilder {
      *
      */
     public TransactionType type = TransactionType.OPTIMISTIC;
+
+    /**
+     * List of stream ids that the transaction might access.
+     * These hints can improve the performance of transactions
+     * that touch many tables.
+     *
+     */
+    public UUID[] accessHints;
 
     /** For snapshot transactions, the address the
      * snapshot will start at.

--- a/test/src/test/java/org/corfudb/CorfuTestParameters.java
+++ b/test/src/test/java/org/corfudb/CorfuTestParameters.java
@@ -104,8 +104,7 @@ public class CorfuTestParameters {
                                         Duration.of(1, SECONDS);
         TIMEOUT_NORMAL = TRAVIS_BUILD ? Duration.of(20, SECONDS) :
                                         Duration.of(10, SECONDS);
-        TIMEOUT_LONG = TRAVIS_BUILD ? Duration.of(2, MINUTES):
-                                        Duration.of(1, MINUTES);
+        TIMEOUT_LONG = Duration.of(20, MINUTES);
 
         // Iterations
         NUM_ITERATIONS_VERY_LOW = TRAVIS_BUILD ? 1 : 10;

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -777,15 +777,9 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
 
         // Write a partial buffer
         entryBuf.limit(entryBuf.capacity() - 1);
-        System.out.println("cap " + entryBuf.capacity());
-        System.out.println("limit " + entryBuf.limit());
         // Append the buffer after the header
         long end = logFile.getChannel().size();
         logFile.getChannel().position(end);
-        System.out.println("position " + logFile.getChannel().position());
-        int bytesWritten = logFile.getChannel().write(entryBuf);
-        System.out.println("bytesWritten " + bytesWritten);
-        System.out.println("position " + logFile.getChannel().position());
         logFile.close();
 
         // Verify that the segment address space can be parsed and that the partial write is ignored


### PR DESCRIPTION

## Overview
When a non-snapshot transaction begins, retrieve the tails map
with the global snapshot.

Why should this be merged: Improves transactional workload. Now a transaction will only go to the sequencer  2 in the worst case (tx start/tx commit), as opposed to the current behavior where the number of sequencer calls is a function of the different streams accessed). 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
