### PR TITLE
Complete unmapping secondary indices

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -727,7 +727,7 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
                     Map<K, V> slot = secondaryIndex.get(indexKey);
 
                     if (slot == null) {
-                        return;
+                        continue;
                     }
                     slot.remove(key, value);
                 }


### PR DESCRIPTION
## Overview

Description: Unmap all secondary indexes.

Why should this be merged: This checks and returns if the slot is null and does not continue to other indexes in the indexSpec.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
