### PR TITLE
SystemDownHandler invocation trigger threshold

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -91,6 +91,7 @@ public abstract class AbstractView {
             throws A, B, C, D {
         runtime.beforeRpcHandler.run();
         final Duration retryRate = runtime.getParameters().getConnectionRetryRate();
+        int systemDownTriggerCounter = runtime.getParameters().getSystemDownHandlerTriggerLimit();
         while (true) {
             try {
                 final Layout layout = runtime.layout.get();
@@ -118,7 +119,9 @@ public abstract class AbstractView {
                 } else if (re instanceof NetworkException) {
                     log.warn("layoutHelper: System seems unavailable", re);
 
-                    runtime.systemDownHandler.run();
+                    if (--systemDownTriggerCounter <= 0) {
+                        runtime.systemDownHandler.run();
+                    }
                     runtime.invalidateLayout();
                     Sleep.sleepUninterruptibly(retryRate);
                 } else {


### PR DESCRIPTION
## Overview

Description: Retry a configurable number of times before invoking the systemDownHandler on Network Exceptions. This allows the system to detect and reconfigure in the event of a failure.
The failure detector takes at least 3 seconds to detect the failure after which it proposes the new layout.

Why should this be merged: This allows the user to configure a retry timeout before which the client can take appropriate action to shut down the client due to system unavailability.

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
