### PR TITLE
Seperate Sequencer Threads

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -6,6 +6,9 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 /**
  * Created by mwei on 12/4/15.
  */
@@ -15,6 +18,11 @@ public abstract class AbstractServer {
     @Getter
     @Setter
     volatile boolean shutdown;
+
+    static final ExecutorService sharedExecutor = Executors
+            .newFixedThreadPool(BatchWriter.BATCH_SIZE + Runtime.getRuntime().availableProcessors(),
+                    new ServerThreadFactory("SharedServerThread-",
+                            new ServerThreadFactory.ExceptionHandler()));
 
     public AbstractServer() {
         shutdown = false;
@@ -41,6 +49,10 @@ public abstract class AbstractServer {
         if (!getHandler().handle(msg, ctx, r)) {
             log.warn("Received unhandled message type {}", msg.getMsgType());
         }
+    }
+
+    public ExecutorService getExecutor() {
+        return sharedExecutor;
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerThreadFactory.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerThreadFactory.java
@@ -1,0 +1,44 @@
+package org.corfudb.infrastructure;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+public class ServerThreadFactory implements ThreadFactory {
+
+    private static final ThreadFactory defaultFactory = Executors.defaultThreadFactory();
+
+    private final Thread.UncaughtExceptionHandler handler;
+
+    private final String threadPrefix;
+
+    final AtomicInteger threadNumber = new AtomicInteger(0);
+
+    public ServerThreadFactory(String threadPrefix, Thread.UncaughtExceptionHandler handler) {
+        this.threadPrefix = threadPrefix;
+        this.handler = handler;
+    }
+
+    @Override
+    public Thread newThread(Runnable run) {
+        Thread thread = defaultFactory.newThread(run);
+        thread.setName(threadPrefix + threadNumber.getAndIncrement());
+        thread.setUncaughtExceptionHandler(handler);
+        thread.setDaemon(true);
+        return thread;
+    }
+
+    public static class ExceptionHandler implements Thread.UncaughtExceptionHandler {
+        @Override
+        public void uncaughtException(Thread t, Throwable e) {
+            log.error("handleUncaughtException[{}]: Uncaught {}:{}",
+                    t.getName(),
+                    e.getClass().getSimpleName(),
+                    e.getMessage(),
+                    e);
+        }
+    }
+}


### PR DESCRIPTION
## Overview
Allow different servers to use their own thread pools, with that, the Sequencer requests are now serviced on a different thread pool.

Why should this be merged: This allows us to dedicate threads for particular servers without having the negative effects of sharing same thread pool. Having granular control over each server threading will also pave the way for future optimizations. 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
