### PR TITLE
Implement round trip timing of Corfu Messages from client

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/clients/ClientMsgHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ClientMsgHandler.java
@@ -1,7 +1,10 @@
 package org.corfudb.runtime.clients;
 
 import io.netty.channel.ChannelHandlerContext;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.CorfuMsg;
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 
 import java.lang.invoke.LambdaMetafactory;
 import java.lang.invoke.MethodHandle;
@@ -12,9 +15,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
-import org.corfudb.protocols.wireprotocol.CorfuMsg;
-import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 
 /**
  * Invokes the message handler to handle incoming messages.
@@ -93,7 +93,8 @@ public class ClientMsgHandler {
      * @param o      The object that implements the client.
      * @return Returns a handler to handle incoming messages to clients.
      */
-    public ClientMsgHandler generateHandlers(final MethodHandles.Lookup caller, final Object o) {
+    public ClientMsgHandler generateHandlers(@NonNull final MethodHandles.Lookup caller,
+                                             @NonNull final Object o) {
         Arrays.stream(o.getClass().getDeclaredMethods())
                 .filter(x -> x.isAnnotationPresent(ClientHandler.class))
                 .forEach(x -> {

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -6,16 +6,8 @@ import com.google.common.collect.Range;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-
 import lombok.Getter;
 import lombok.NonNull;
-
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.DataType;
@@ -32,7 +24,14 @@ import org.corfudb.protocols.wireprotocol.WriteMode;
 import org.corfudb.protocols.wireprotocol.WriteRequest;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.WriteSizeException;
+import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.serializer.Serializers;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 
 /**
@@ -72,7 +71,7 @@ public class LogUnitClient extends AbstractClient {
 
     private Timer.Context getTimerContext(String opName) {
         Timer t = getMetricRegistry().timer(
-                CorfuRuntime.getMpLUC()
+                CorfuComponent.LUC.toString()
                         + getHost() + ":" + getPort().toString() + "-" + opName);
         return t.time();
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -1,10 +1,27 @@
 package org.corfudb.runtime.object;
 
-import static java.lang.Long.min;
-
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.AbortCause;
+import org.corfudb.runtime.exceptions.NetworkException;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.exceptions.TrimmedUpcallException;
+import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
+import org.corfudb.util.CorfuComponent;
+import org.corfudb.util.MetricsUtils;
+import org.corfudb.util.Sleep;
+import org.corfudb.util.Utils;
+import org.corfudb.util.serializer.ISerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.util.Collections;
@@ -13,29 +30,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
 
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
-
-import org.corfudb.protocols.logprotocol.SMREntry;
-import org.corfudb.protocols.wireprotocol.Token;
-import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.exceptions.AbortCause;
-import org.corfudb.runtime.exceptions.NetworkException;
-import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.exceptions.TrimmedException;
-import org.corfudb.runtime.exceptions.TrimmedUpcallException;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
-import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
-import org.corfudb.runtime.object.transactions.TransactionalContext;
-import org.corfudb.runtime.view.Address;
-import org.corfudb.util.MetricsUtils;
-import org.corfudb.util.Sleep;
-import org.corfudb.util.Utils;
-import org.corfudb.util.serializer.ISerializer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static java.lang.Long.min;
 
 /**
  * In the Corfu runtime, on top of a stream,
@@ -155,7 +150,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 undoTargetMap, resetSet);
 
         metrics = rt.getMetrics() != null ? rt.getMetrics() : CorfuRuntime.getDefaultMetrics();
-        mpObj = CorfuRuntime.getMpObj();
+        mpObj = CorfuComponent.OBJ.toString();
         timerAccess = metrics.timer(mpObj + "access");
         timerLogWrite = metrics.timer(mpObj + "log-write");
         timerTxn = metrics.timer(mpObj + "txn");

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -6,33 +6,30 @@ import com.github.benmanes.caffeine.cache.CacheLoader;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.collect.Iterables;
-
-
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IToken;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.LogUnitClient;
-import org.corfudb.runtime.exceptions.WriteSizeException;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.exceptions.WriteSizeException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.util.CFUtils;
+import org.corfudb.util.CorfuComponent;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -69,7 +66,8 @@ public class AddressSpaceView extends AbstractView {
     public AddressSpaceView(@Nonnull final CorfuRuntime runtime) {
         super(runtime);
         MetricRegistry metrics = runtime.getMetrics();
-        final String pfx = String.format("%s0x%x.cache.", runtime.getMpASV(), this.hashCode());
+        final String pfx = String.format("%s0x%x.cache.", CorfuComponent.ASV.toString(),
+                                         this.hashCode());
         metrics.register(pfx + "cache-size", (Gauge<Long>) readCache::estimatedSize);
         metrics.register(pfx + "evictions", (Gauge<Long>) () -> readCache.stats().evictionCount());
         metrics.register(pfx + "hit-rate", (Gauge<Double>) () -> readCache.stats().hitRate());

--- a/runtime/src/main/java/org/corfudb/util/CorfuComponent.java
+++ b/runtime/src/main/java/org/corfudb/util/CorfuComponent.java
@@ -1,0 +1,25 @@
+package org.corfudb.util;
+
+/**
+ * An enum used to hold the corfu component names and is used to name metrics
+ * collected from different components.
+ *
+ * Created by Sam Behnam on 5/8/18.
+ */
+public enum CorfuComponent {
+    ASV("corfu.runtime.as-view."),
+    LUC("corfu.runtime.log-unit-client."),
+    CR("corfu.runtime.client-router."),
+    OBJ("corfu.runtime.object.");
+
+    CorfuComponent(String value) {
+        this.value = value;
+    }
+
+    private final String value;
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
@@ -121,6 +121,8 @@ public class MetricsUtils {
      * @param metrics Metrics registry
      */
     public static void metricsReportingSetup(@NonNull MetricRegistry metrics) {
+        if (isMetricsReportingSetUp(metrics)) return;
+
         metrics.counter(mpTrigger);
         loadVmProperties();
 


### PR DESCRIPTION
## Overview
Description:
This commit implements collection of client side metrics on different Corfu _messages_ from the _runtime_ point of view. In other words these added metrics, measure the round trip life of the messages from when Netty client starts processing a message until when the request is completed. 

Why should this be merged: 
Being able to access the metrics from server and client sides is required for monitoring of CorfuDB behavior in response to different workloads as well as for comparison of performance and debugging of the code.

Related issue(s) (if applicable): #1273 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
