### PR TITLE
Cluster status query API

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.management.IDetector;
 import org.corfudb.infrastructure.management.PollReport;
 import org.corfudb.infrastructure.management.ReconfigurationEventHandler;
+import org.corfudb.protocols.wireprotocol.NetworkMetrics;
 import org.corfudb.protocols.wireprotocol.NodeView;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics.SequencerStatus;
@@ -117,8 +118,8 @@ public class ManagementAgent {
     private volatile CompletableFuture<Boolean> sequencerBootstrappedFuture;
 
     /**
-     * The management agent attempts to bootstrap a NOT_READY sequencer if the sequencerNotReadyCounter
-     * counter exceeds this value.
+     * The management agent attempts to bootstrap a NOT_READY sequencer if the
+     * sequencerNotReadyCounter counter exceeds this value.
      */
     private static final int SEQUENCER_NOT_READY_THRESHOLD = 3;
 
@@ -146,6 +147,12 @@ public class ManagementAgent {
     //  Local copy of the local node's server metrics.
     @Getter(AccessLevel.PROTECTED)
     private volatile ServerMetrics localServerMetrics;
+    //  A view of peers' connectivity.
+    // Connectivity of any unresponsive nodes responding. Updated by HealingDetector.
+    private Set<String> responsiveNodesPeerView = Collections.emptySet();
+    // Connectivity of any responsive nodes not responding. Updated by FailureDetector.
+    private Set<String> unresponsiveNodesPeerView = Collections.emptySet();
+
 
     /**
      * Checks and restores if a layout is present in the local datastore to recover from.
@@ -448,6 +455,23 @@ public class ManagementAgent {
     }
 
     /**
+     * Combines the peer connectivity view from the failure and the healing detectors.
+     * This map containing the view of the detectors is used to create the NodeView.
+     * This NodeView is sent in the HeartbeatResponse message.
+     *
+     * @return Peer connectivity view map
+     */
+    NetworkMetrics getConnectivityView() {
+        Map<String, Boolean> peerConnectivityDeltaMap = new HashMap<>();
+        responsiveNodesPeerView.forEach(s -> peerConnectivityDeltaMap.put(s, true));
+        unresponsiveNodesPeerView.forEach(s -> peerConnectivityDeltaMap.put(s, false));
+        // If the management server is not bootstrapped, stamp with INVALID_EPOCH.
+        long peerConnectivitySnapshotEpoch = serverContext.getManagementLayout() != null
+                ? serverContext.getManagementLayout().getEpoch() : Layout.INVALID_EPOCH;
+        return new NetworkMetrics(peerConnectivitySnapshotEpoch, peerConnectivityDeltaMap);
+    }
+
+    /**
      * This contains the healing mechanism.
      * - This task is executed in intervals of 1 second (default). This task is blocked until
      * the management server is bootstrapped and has a connected runtime.
@@ -468,6 +492,8 @@ public class ManagementAgent {
                 CorfuRuntime corfuRuntime = getCorfuRuntime();
                 PollReport pollReport =
                         healingDetector.poll(serverContext.getManagementLayout(), corfuRuntime);
+
+                responsiveNodesPeerView = pollReport.getHealingNodes();
 
                 if (!pollReport.getHealingNodes().isEmpty()) {
 
@@ -516,6 +542,8 @@ public class ManagementAgent {
                 // Execute the failure detection poll round.
                 PollReport pollReport =
                         failureDetector.poll(serverContext.getManagementLayout(), corfuRuntime);
+
+                unresponsiveNodesPeerView = pollReport.getFailingNodes();
 
                 // Corrects out of phase epoch issues if present in the report. This method
                 // performs re-sealing of all nodes if required and catchup of a layout server to

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -278,7 +278,9 @@ public class ManagementServer extends AbstractServer {
     public void handleHeartbeatRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         ServerMetrics localServerMetrics = getManagementAgent().getLocalServerMetrics();
         NodeView.NodeViewBuilder nodeViewBuilder = NodeView.builder()
-                .endpoint(NodeLocator.parseString(getLocalEndpoint()));
+                .endpoint(NodeLocator.parseString(getLocalEndpoint()))
+                // Fetch the node's view of the cluster.
+                .networkMetrics(managementAgent.getConnectivityView());
         if (localServerMetrics != null) {
             nodeViewBuilder.serverMetrics(getManagementAgent().getLocalServerMetrics());
         }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NetworkMetrics.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NetworkMetrics.java
@@ -1,0 +1,41 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.Map;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * Node's view of the peers. Contains connectivity status detected by the polling services.
+ *
+ * <p>Created by zlokhandwala on 5/7/18.
+ */
+@Data
+@Builder
+@AllArgsConstructor
+public class NetworkMetrics implements ICorfuPayload<NetworkMetrics> {
+
+    /**
+     * Epoch at which the connectivity status was captured.
+     */
+    private final long epoch;
+
+    /**
+     * Peer connectivity view.
+     */
+    private final Map<String, Boolean> peerConnectivityView;
+
+    public NetworkMetrics(ByteBuf buf) {
+        epoch = ICorfuPayload.fromBuffer(buf, Long.class);
+        peerConnectivityView = ICorfuPayload.mapFromBuffer(buf, String.class, Boolean.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, epoch);
+        ICorfuPayload.serialize(buf, peerConnectivityView);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NodeView.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NodeView.java
@@ -28,20 +28,29 @@ public class NodeView implements ICorfuPayload<NodeView> {
      */
     private final ServerMetrics serverMetrics;
 
+    /**
+     * Node's view of the cluster.
+     */
+    private final NetworkMetrics networkMetrics;
+
     public NodeView(NodeLocator endpoint,
-                    ServerMetrics serverMetrics) {
+                    ServerMetrics serverMetrics,
+                    NetworkMetrics networkMetrics) {
         this.endpoint = endpoint;
         this.serverMetrics = serverMetrics;
+        this.networkMetrics = networkMetrics;
     }
 
     public NodeView(ByteBuf buf) {
         endpoint = NodeLocator.parseString(ICorfuPayload.fromBuffer(buf, String.class));
         serverMetrics = ICorfuPayload.fromBuffer(buf, ServerMetrics.class);
+        networkMetrics = ICorfuPayload.fromBuffer(buf, NetworkMetrics.class);
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, endpoint.toString());
         ICorfuPayload.serialize(buf, serverMetrics);
+        ICorfuPayload.serialize(buf, networkMetrics);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ClusterStatusReport.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ClusterStatusReport.java
@@ -1,0 +1,55 @@
+package org.corfudb.runtime.view;
+
+import java.util.Map;
+
+import lombok.Data;
+import lombok.Getter;
+
+/**
+ * Status report of the connectivity of the client to the cluster and the health of the cluster
+ * based on the views of the management agents on the Corfu nodes.
+ *
+ * <p>Created by zlokhandwala on 5/7/18.
+ */
+@Data
+public class ClusterStatusReport {
+
+    /**
+     * Connectivity to the node.
+     */
+    enum NodeStatus {
+        UP,
+        DOWN
+    }
+
+    /**
+     * Health of the cluster.
+     */
+    enum ClusterStatus {
+        STABLE(0),
+        DEGRADED(1),
+        UNAVAILABLE(2);
+
+        @Getter
+        final int healthValue;
+
+        ClusterStatus(int healthValue) {
+            this.healthValue = healthValue;
+        }
+    }
+
+    /**
+     * Layout at which the report was generated.
+     */
+    private final Layout layout;
+
+    /**
+     * Map of connectivity of the report generator client to the cluster nodes.
+     */
+    private final Map<String, NodeStatus> clientServerConnectivityStatusMap;
+
+    /**
+     * Cluster health.
+     */
+    private final ClusterStatus clusterStatus;
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
@@ -1,19 +1,36 @@
 package org.corfudb.runtime.view;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
 
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import org.corfudb.protocols.wireprotocol.NetworkMetrics;
+import org.corfudb.protocols.wireprotocol.NodeView;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.WorkflowException;
 import org.corfudb.runtime.exceptions.WorkflowResultUnknownException;
+import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
+import org.corfudb.runtime.view.ClusterStatusReport.NodeStatus;
 import org.corfudb.runtime.view.workflows.AddNode;
-import org.corfudb.runtime.view.workflows.HealNode;
 import org.corfudb.runtime.view.workflows.ForceRemoveNode;
+import org.corfudb.runtime.view.workflows.HealNode;
 import org.corfudb.runtime.view.workflows.RemoveNode;
-
-import javax.annotation.Nonnull;
+import org.corfudb.util.CFUtils;
 
 /**
  * A view of the Management Service to manage reconfigurations of the Corfu Cluster.
@@ -22,6 +39,11 @@ import javax.annotation.Nonnull;
  */
 @Slf4j
 public class ManagementView extends AbstractView {
+
+    /**
+     * Number of attempts to ping a node to query the cluster status.
+     */
+    private static final int CLUSTER_STATUS_QUERY_ATTEMPTS = 3;
 
     public ManagementView(@NonNull CorfuRuntime runtime) {
         super(runtime);
@@ -53,10 +75,10 @@ public class ManagementView extends AbstractView {
      * @param pollPeriod       the poll interval to check whether a workflow completed or not
      * @throws WorkflowResultUnknownException when the side affect of the operation
      *                                        can't be determined
-     * @throws WorkflowException when the remove operation fails
+     * @throws WorkflowException              when the remove operation fails
      */
     public void forceRemoveNode(@Nonnull String endpointToRemove, int retry,
-                           @Nonnull Duration timeout, @Nonnull Duration pollPeriod) {
+                                @Nonnull Duration timeout, @Nonnull Duration pollPeriod) {
         new ForceRemoveNode(endpointToRemove, runtime, retry, timeout, pollPeriod).invoke();
     }
 
@@ -89,5 +111,193 @@ public class ManagementView extends AbstractView {
     public void healNode(@Nonnull String endpointToHeal, int retry, @Nonnull Duration timeout,
                          @Nonnull Duration pollPeriod) {
         new HealNode(endpointToHeal, runtime, retry, timeout, pollPeriod).invoke();
+    }
+
+    /**
+     * If all the layout servers are responsive the cluster status is STABLE,
+     * if a minority of them are unresponsive then the status is DEGRADED,
+     * else the cluster is UNAVAILABLE.
+     *
+     * @param layout              Current layout on which responsiveness was checked.
+     * @param peerResponsiveNodes responsive nodes in the current layout.
+     * @return ClusterStatus
+     */
+    private ClusterStatus getLayoutServersClusterHealth(Layout layout,
+                                                        Set<String> peerResponsiveNodes) {
+        ClusterStatus clusterStatus = ClusterStatus.STABLE;
+        // A quorum of layout servers need to be responsive for the cluster to be STABLE.
+        List<String> responsiveLayoutServers = new ArrayList<>(layout.getLayoutServers());
+        // Retain only the responsive servers.
+        responsiveLayoutServers.retainAll(peerResponsiveNodes);
+        if (responsiveLayoutServers.size() != layout.getLayoutServers().size()) {
+            clusterStatus = ClusterStatus.DEGRADED;
+            int quorumSize = (layout.getLayoutServers().size() / 2) + 1;
+            if (responsiveLayoutServers.size() < quorumSize) {
+                clusterStatus = ClusterStatus.UNAVAILABLE;
+            }
+        }
+        return clusterStatus;
+    }
+
+    /**
+     * If the primary sequencer is unresponsive then the cluster is UNAVAILABLE.
+     *
+     * @param layout              Current layout on which responsiveness was checked.
+     * @param peerResponsiveNodes responsive nodes in the current layout.
+     * @return ClusterStatus
+     */
+    private ClusterStatus getSequencerServersClusterHealth(Layout layout,
+                                                           Set<String> peerResponsiveNodes) {
+        // The primary sequencer should be reachable for the cluster to be STABLE.
+        return !peerResponsiveNodes.contains(layout.getPrimarySequencer())
+                ? ClusterStatus.UNAVAILABLE : ClusterStatus.STABLE;
+    }
+
+    /**
+     * Gets the log unit cluster status based on the replication protocol.
+     *
+     * @param layout              Current layout on which responsiveness was checked.
+     * @param peerResponsiveNodes responsive nodes in the current layout.
+     * @return ClusterStatus
+     */
+    private ClusterStatus getLogUnitServersClusterHealth(Layout layout,
+                                                         Set<String> peerResponsiveNodes) {
+        // Check the availability of the log servers in all segments as reads to all addresses
+        // should be accessible.
+        return layout.getSegments().stream()
+                .map(segment -> segment.getReplicationMode()
+                        .getClusterHealthForSegment(segment, peerResponsiveNodes))
+                .max(Comparator.comparingInt(ClusterStatus::getHealthValue))
+                .get();
+    }
+
+    /**
+     * Analyzes the health of the cluster based on the views of the cluster of all the
+     * ManagementAgents.
+     * STABLE: if all nodes in the layout are responsive.
+     * DEGRADED: if a minority of Layout servers
+     * or a minority of LogUnit servers - in QUORUM_REPLICATION mode only are unresponsive.
+     * UNAVAILABLE: if a majority of Layout servers or the Primary Sequencer
+     * or a node in the CHAIN_REPLICATION or a majority of nodes in QUORUM_REPLICATION is
+     * unresponsive.
+     *
+     * @param layout              Layout based on which the health is analyzed.
+     * @param peerResponsiveNodes Responsive nodes according to the management services.
+     * @return ClusterStatus
+     */
+    private ClusterStatus getClusterHealth(Layout layout, Set<String> peerResponsiveNodes) {
+
+        return Stream.of(getLayoutServersClusterHealth(layout, peerResponsiveNodes),
+                getSequencerServersClusterHealth(layout, peerResponsiveNodes),
+                getLogUnitServersClusterHealth(layout, peerResponsiveNodes))
+                // Gets cluster status from the layout, sequencer and log unit clusters.
+                // The status is then aggregated by the max of the 3 statuses acquired.
+                .max(Comparator.comparingInt(ClusterStatus::getHealthValue))
+                .get();
+    }
+
+    /**
+     * Prunes out the unresponsive nodes as seen by the Management Agents on the Corfu nodes.
+     *
+     * @param layout      Layout based on which the health is analyzed.
+     * @param nodeViewMap Map of nodeViews from the ManagementAgents.
+     * @return Set of responsive servers as seen by the Corfu cluster nodes.
+     */
+    private Set<String> filterResponsiveNodes(Layout layout, Map<String, NodeView> nodeViewMap) {
+
+        // Using the peer views from the nodes to determine health of the cluster.
+        Set<String> peerResponsiveNodes = new HashSet<>(layout.getAllServers());
+        nodeViewMap.values().stream()
+                .map(NodeView::getNetworkMetrics)
+                // Get all peer connectivity maps from all node views.
+                .map(NetworkMetrics::getPeerConnectivityView)
+                .flatMap(stringBooleanMap -> stringBooleanMap.entrySet().stream())
+                // Filter out all unresponsive nodes from all the fault detectors.
+                .filter(entry -> !entry.getValue())
+                .map(Entry::getKey)
+                // Remove the unresponsive nodes from the set of all nodes.
+                .forEach(peerResponsiveNodes::remove);
+        layout.getUnresponsiveServers().forEach(peerResponsiveNodes::remove);
+        return peerResponsiveNodes;
+    }
+
+    /**
+     * Gets the cluster status by pinging each node.
+     * These pings are then compared to the layout to decide whether the cluster is:
+     * STABLE, DEGRADED OR UNAVAILABLE.
+     * The report consists of the following:
+     * Layout - at which the report was generated.
+     * ClientServerConnectivityStatusMap - the connectivity status of this client to the cluster.
+     * ClusterStatus - Health of the Corfu cluster.
+     *
+     * @return ClusterStatusReport
+     */
+    public ClusterStatusReport getClusterStatus() {
+        RuntimeLayout runtimeLayout =
+                new RuntimeLayout(runtime.getLayoutView().getLayout(), runtime);
+        Layout layout = runtimeLayout.getLayout();
+        // All configured nodes.
+        Set<String> allNodes = new HashSet<>(layout.getAllServers());
+
+        // Counters to track heartbeat responses from nodes.
+        // A counter is incremented even if we get a WrongEpochException as the node is alive.
+        Map<String, Integer> counters = new HashMap<>();
+        allNodes.forEach(endpoint -> counters.put(endpoint, 0));
+
+        // Map of nodeView received from heartbeatResponses.
+        Map<String, NodeView> nodeViewMap = new HashMap<>();
+
+        // Ping all nodes CLUSTER_STATUS_QUERY_ATTEMPTS times.
+        // Increment the counter map and save the NodeView response received in the
+        // heartbeat responses.
+        for (int i = 0; i < CLUSTER_STATUS_QUERY_ATTEMPTS; i++) {
+            Map<String, CompletableFuture<NodeView>> futureMap = new HashMap<>();
+
+            // Ping all nodes asynchronously
+            for (String endpoint : allNodes) {
+                CompletableFuture<NodeView> cf = new CompletableFuture<>();
+                try {
+                    cf = runtimeLayout.getManagementClient(endpoint).sendHeartbeatRequest();
+                } catch (Exception e) {
+                    // Requesting the heartbeat can cause NetworkException if connection cannot
+                    // be established.
+                    cf.completeExceptionally(e);
+                }
+                futureMap.put(endpoint, cf);
+            }
+
+            // Accumulate all responses.
+            for (String endpoint : futureMap.keySet()) {
+                try {
+                    nodeViewMap.put(endpoint, CFUtils.getUninterruptibly(futureMap.get(endpoint),
+                            WrongEpochException.class));
+                    counters.computeIfPresent(endpoint, (s, count) -> count + 1);
+                } catch (WrongEpochException wee) {
+                    counters.computeIfPresent(endpoint, (s, count) -> count + 1);
+                } catch (Exception ignored) {
+                    // Ignore all exceptions.
+                }
+            }
+        }
+
+        // Using the peer views from the nodes to determine health of the cluster.
+        Set<String> peerResponsiveNodes = filterResponsiveNodes(layout, nodeViewMap);
+
+        // Analyzes the responsive nodes as seen by the fault detectors to determine the health
+        // of the cluster.
+        ClusterStatus clusterStatus = getClusterHealth(layout, peerResponsiveNodes);
+
+        // Set of all nodes which are responsive to this client.
+        // Client connectivity to the cluster.
+        Set<String> responsiveEndpoints = counters.entrySet().stream()
+                // Only count nodes which have counter > 0
+                .filter(entry -> entry.getValue() > 0)
+                .map(Entry::getKey)
+                .collect(Collectors.toSet());
+
+        return new ClusterStatusReport(layout, allNodes.stream()
+                .collect(Collectors.toMap(o -> o,
+                        t -> responsiveEndpoints.contains(t) ? NodeStatus.UP : NodeStatus.DOWN)),
+                clusterStatus);
     }
 }


### PR DESCRIPTION
## Overview

Description: API to request for cluster status and client connectivity.
The Management Agents exchange their view of the cluster through the failure and healing detectors. This view is relayed via the Heartbeat Responses. The Client cluster status query API also uses this heartbeat requests to ping and query the cluster view.

Why should this be merged: Required to query the status of client's connectivity to the cluster and the health of the cluster.

Related issue(s) (if applicable): #1272 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
