### PR TITLE
Enabling multi indexing

### DIFF
--- a/generator/src/main/java/org/corfudb/generator/StringIndexer.java
+++ b/generator/src/main/java/org/corfudb/generator/StringIndexer.java
@@ -1,22 +1,27 @@
 package org.corfudb.generator;
 
+import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.CorfuTable.Index;
+
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import org.corfudb.runtime.collections.CorfuTable;
-import org.corfudb.runtime.collections.CorfuTable.Index;
-
 public class StringIndexer implements CorfuTable.IndexRegistry<String, String> {
 
-    public static CorfuTable.IndexName BY_VALUE = () -> "BY_VALUE";
-    public static CorfuTable.IndexName BY_FIRST_CHAR = () -> "BY_FIRST_LETTER";
+    public static final CorfuTable.IndexName BY_VALUE = () -> "BY_VALUE";
+    public static final CorfuTable.IndexName BY_FIRST_CHAR = () -> "BY_FIRST_LETTER";
 
-    private static CorfuTable.Index<String, String, ? extends Comparable<?>> BY_VALUE_INDEX =
-            new CorfuTable.Index<>(BY_VALUE, (key, val) -> val);
+    private static final CorfuTable.Index<String, String, ? extends Comparable<?>> BY_VALUE_INDEX =
+            new CorfuTable.Index<>(
+                    BY_VALUE,
+                    (CorfuTable.IndexFunction<String, String, String>) (key, val) -> val);
 
-    private CorfuTable.Index<String, String, ? extends Comparable<?>> BY_FIRST_CHAR_INDEX =
-            new CorfuTable.Index<>(BY_FIRST_CHAR, (key, val) -> Character.toString(val.charAt(0)));
+    private static final CorfuTable.Index<String, String, ? extends Comparable<?>> BY_FIRST_CHAR_INDEX =
+            new CorfuTable.Index<>(
+                    BY_FIRST_CHAR,
+                    (CorfuTable.IndexFunction<String, String, String>) (key, val) ->
+                            Character.toString(val.charAt(0)));
 
     @Override
     public Iterator<Index<String, String, ? extends Comparable<?>>> iterator() {
@@ -24,26 +29,16 @@ public class StringIndexer implements CorfuTable.IndexRegistry<String, String> {
     }
 
     @Override
-    public <I extends Comparable<?>>
-    Optional<CorfuTable.IndexFunction<String, String, I>> get(CorfuTable.IndexName name) {
+    public Optional<CorfuTable.Index<String, String, ? extends Comparable<?>>> get(CorfuTable.IndexName name) {
         String indexName = (name != null)? name.get() : null;
 
         if (BY_VALUE.get().equals(indexName)) {
-            @SuppressWarnings("unchecked")
-            CorfuTable.IndexFunction<String, String, I> function =
-                    (CorfuTable.IndexFunction<String, String, I>)
-                            BY_VALUE_INDEX.getIndexFunction();
-            return Optional.of(function);
+            return Optional.of(BY_VALUE_INDEX);
 
         } else if (BY_FIRST_CHAR.get().equals(indexName)) {
-            @SuppressWarnings("unchecked")
-            CorfuTable.IndexFunction<String, String, I> function =
-                    (CorfuTable.IndexFunction<String, String, I>)
-                            BY_FIRST_CHAR_INDEX.getIndexFunction();
-            return Optional.of(function);
+            return Optional.of(BY_FIRST_CHAR_INDEX);
         } else {
             return Optional.empty();
         }
     }
-
 }

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -1,16 +1,16 @@
 package org.corfudb.runtime.collections;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.reflect.TypeToken;
+import org.assertj.core.data.MapEntry;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import org.assertj.core.data.MapEntry;
-import org.corfudb.runtime.view.AbstractViewTest;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CorfuTableTest extends AbstractViewTest {
 
@@ -62,6 +62,28 @@ public class CorfuTableTest extends AbstractViewTest {
                 .containsExactly("ab");
     }
 
+    /**
+     * Can create create multiple index for the same value
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void canReadFromMultipleIndices() {
+                CorfuTable<String, String> corfuTable = getDefaultRuntime()
+                        .getObjectsView()
+                        .build()
+                        .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                        .setArguments(new StringMultiIndexer())
+                        .setStreamName("test-map")
+                        .open();
+
+        corfuTable.put("k1", "dog fox cat");
+        corfuTable.put("k2", "dog bat");
+        corfuTable.put("k3", "fox");
+
+        final Collection<Map.Entry<String, String>> result =
+                corfuTable.getByIndex(StringMultiIndexer.BY_EACH_WORD, "fox");
+        assertThat(project(result)).containsExactlyInAnyOrder("dog fox cat", "fox");
+    }
 
     @Test
     @SuppressWarnings("unchecked")

--- a/test/src/test/java/org/corfudb/runtime/collections/StringIndexer.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/StringIndexer.java
@@ -6,14 +6,19 @@ import java.util.stream.Stream;
 
 public class StringIndexer implements CorfuTable.IndexRegistry<String, String> {
 
-    public static CorfuTable.IndexName BY_VALUE = () -> "BY_VALUE";
-    public static CorfuTable.IndexName BY_FIRST_LETTER = () -> "BY_FIRST_LETTER";
+    public static final CorfuTable.IndexName BY_VALUE = () -> "BY_VALUE";
+    public static final CorfuTable.IndexName BY_FIRST_LETTER = () -> "BY_FIRST_LETTER";
 
-    private static CorfuTable.Index<String, String, ? extends Comparable<?>> BY_VALUE_INDEX =
-            new CorfuTable.Index<>(BY_VALUE, (key, val) -> val);
+    private static final CorfuTable.Index<String, String, ? extends Comparable<?>> BY_VALUE_INDEX =
+            new CorfuTable.Index<>(
+                                   BY_VALUE,
+                                   (CorfuTable.IndexFunction<String, String, String>) (key, val) -> val);
 
-    private static CorfuTable.Index<String, String, ? extends Comparable<?>> BY_FIRST_LETTER_INDEX =
-            new CorfuTable.Index<>(BY_FIRST_LETTER, (key, val) -> Character.toString(val.charAt(0)));
+    private static final CorfuTable.Index<String, String, ? extends Comparable<?>> BY_FIRST_LETTER_INDEX =
+            new CorfuTable.Index<>(
+                                   BY_FIRST_LETTER,
+                                   (CorfuTable.IndexFunction<String, String, String>) (key, val) ->
+                                           Character.toString(val.charAt(0)));
 
     @Override
     public Iterator<CorfuTable.Index<String, String, ? extends Comparable<?>>> iterator() {
@@ -21,23 +26,14 @@ public class StringIndexer implements CorfuTable.IndexRegistry<String, String> {
     }
 
     @Override
-    public <I extends Comparable<?>>
-    Optional<CorfuTable.IndexFunction<String, String, I>> get(CorfuTable.IndexName name) {
+    public Optional<CorfuTable.Index<String, String, ? extends Comparable<?>>> get(CorfuTable.IndexName name) {
         String indexName = (name != null)? name.get() : null;
 
         if (BY_VALUE.get().equals(indexName)) {
-            @SuppressWarnings("unchecked")
-            CorfuTable.IndexFunction<String, String, I> function =
-                    (CorfuTable.IndexFunction<String, String, I>)
-                            BY_VALUE_INDEX.getIndexFunction();
-            return Optional.of(function);
+            return Optional.of(BY_VALUE_INDEX);
 
         } else if (BY_FIRST_LETTER.get().equals(indexName)) {
-            @SuppressWarnings("unchecked")
-            CorfuTable.IndexFunction<String, String, I> function =
-                    (CorfuTable.IndexFunction<String, String, I>)
-                            BY_FIRST_LETTER_INDEX.getIndexFunction();
-            return Optional.of(function);
+            return Optional.of(BY_FIRST_LETTER_INDEX);
         } else {
             return Optional.empty();
         }

--- a/test/src/test/java/org/corfudb/runtime/collections/StringMultiIndexer.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/StringMultiIndexer.java
@@ -1,0 +1,41 @@
+package org.corfudb.runtime.collections;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Created by Sam Behnam on 5/10/18.
+ */
+public class StringMultiIndexer implements CorfuTable.IndexRegistry<String, String> {
+    public static final CorfuTable.IndexName BY_EACH_WORD = () -> "BY_EACH_WORD";
+
+    private static final CorfuTable.Index<String, String, ? extends Comparable<?>> BY_WORD_INDEX =
+            new CorfuTable.Index<>(BY_EACH_WORD,
+                    (CorfuTable.MultiValueIndexFunction<String, String, String>) (key, val) -> keySetOWords(val));
+
+    private static Iterable<String> keySetOWords(String val) {
+        return new HashSet<>(Arrays.asList(val.split(" ")));
+    }
+
+    @Override
+    public Optional<CorfuTable.Index<String, String, ? extends Comparable<?>>> get(CorfuTable.IndexName name) {
+        String indexName = (name != null) ? name.get() : null;
+        if (BY_EACH_WORD.get().equals(indexName)) {
+            return Optional.of(BY_WORD_INDEX);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public Iterator<CorfuTable.Index<String, String, ? extends Comparable<?>>> iterator() {
+        final List<CorfuTable.Index<String, String, ? extends Comparable<?>>> indices = new ArrayList<>();
+        indices.add(BY_WORD_INDEX);
+        return indices.iterator();
+
+    }
+}


### PR DESCRIPTION
## Overview

Description:
This commit enables multi value indexing by enabling CorfuTable of having indexes with mono index function or multi-index function. In other words, when a {K, V} being indexed by a multi index function, it will emit multiple index mappings.

Why should this be merged: 
This features is going to be used by clients (e.g. management plane) to emit multiple index mappings for each key/value pair.

Related issue(s) (if applicable): #1285 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
