### PR TITLE
Invoke systemDownHandler on cluster unreachability.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -114,15 +114,16 @@ public abstract class AbstractView {
                             + "invalidate view", we.getCorrectEpoch());
                 } else if (re instanceof NetworkException) {
                     log.warn("layoutHelper: System seems unavailable", re);
-
-                    if (--systemDownTriggerCounter <= 0) {
-                        runtime.systemDownHandler.run();
-                    }
                 } else {
                     throw re;
                 }
                 if (rethrowAllExceptions) {
                     throw new RuntimeException(re);
+                }
+
+                // Invoking the systemDownHandler if the client cannot connect to the server.
+                if (--systemDownTriggerCounter <= 0) {
+                    runtime.systemDownHandler.run();
                 }
                 runtime.invalidateLayout();
                 Sleep.sleepUninterruptibly(retryRate);


### PR DESCRIPTION
## Overview

Description: Invoke the systemDownHandler when the client is unable to reach the server after a certain number of retries. This should be invoked regardless of the exception in connecting to the server.

Why should this be merged: The systemDownHandler is not invoked if 2/3 servers are down as it throws a TimeoutException rather than a NetworkException.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
