### PR TITLE
Skip sequencer bootstrap on ForceRemove

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -289,8 +289,6 @@ public class LayoutManagementView extends AbstractView {
         }
 
         runtime.getLayoutView().committed(forceLayout.getEpoch(), forceLayout, true);
-
-        reconfigureSequencerServers(currentLayout, forceLayout, true);
     }
 
 

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -256,12 +256,8 @@ public class WorkflowIT extends AbstractIT {
         assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN3);
 
         // Kill two nodes from a three node cluster
-        final long timeToWaitForProc = 5000;
-        p1.destroy();
-        p1.waitFor(timeToWaitForProc, TimeUnit.SECONDS);
-
-        p2.destroy();
-        p2.waitFor(timeToWaitForProc, TimeUnit.SECONDS);
+        shutdownCorfuServer(p1);
+        shutdownCorfuServer(p2);
 
         // Force remove the "failed" node
         n0Rt.getManagementView().forceRemoveNode(getConnectionString(n1Port), workflowNumRetry,


### PR DESCRIPTION
## Overview

Description: Skip sequencer bootstrap in force remove node. Allow the management server to detect and bootstrap the sequencer.

Why should this be merged: Allows 2 out of 3 nodes to be forcibly removed in case of 2/3 failures.

Related issue(s) (if applicable): #1244 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
