### PR TITLE
Replacing string concatenations with lazy argument evaluations

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -1,8 +1,6 @@
 package org.corfudb.infrastructure;
 
 import io.netty.channel.ChannelHandlerContext;
-import java.lang.invoke.MethodHandles;
-import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -12,7 +10,9 @@ import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.JSONPayloadMsg;
 import org.corfudb.protocols.wireprotocol.VersionInfo;
 import org.corfudb.runtime.exceptions.WrongEpochException;
-import org.corfudb.util.Sleep;
+
+import javax.annotation.Nonnull;
+import java.lang.invoke.MethodHandles;
 
 /**
  * Created by mwei on 12/8/15.
@@ -90,7 +90,7 @@ public class BaseServer extends AbstractServer {
      */
     @ServerHandler(type = CorfuMsgType.RESET)
     private void doReset(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
-        log.warn("Remote reset requested from client " + msg.getClientID());
+        log.warn("Remote reset requested from client {}", msg.getClientID());
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
         CorfuServer.restartServer(serverContext, true);
     }
@@ -105,7 +105,7 @@ public class BaseServer extends AbstractServer {
      */
     @ServerHandler(type = CorfuMsgType.RESTART)
     private void doRestart(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
-        log.warn("Remote restart requested from client " + msg.getClientID());
+        log.warn("Remote restart requested from client {}", msg.getClientID());
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
         CorfuServer.restartServer(serverContext, false);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -1,13 +1,5 @@
 package org.corfudb.infrastructure;
 
-import static org.corfudb.util.NetworkUtils.getAddressFromInterfaceName;
-
-import static org.fusesource.jansi.Ansi.Color.BLUE;
-import static org.fusesource.jansi.Ansi.Color.MAGENTA;
-import static org.fusesource.jansi.Ansi.Color.RED;
-import static org.fusesource.jansi.Ansi.Color.WHITE;
-import static org.fusesource.jansi.Ansi.ansi;
-
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.google.common.collect.ImmutableList;
@@ -23,18 +15,6 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLException;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.corfudb.protocols.wireprotocol.NettyCorfuMessageDecoder;
@@ -48,6 +28,26 @@ import org.corfudb.util.Version;
 import org.docopt.Docopt;
 import org.fusesource.jansi.AnsiConsole;
 import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLException;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static org.corfudb.util.NetworkUtils.getAddressFromInterfaceName;
+import static org.fusesource.jansi.Ansi.Color.BLUE;
+import static org.fusesource.jansi.Ansi.Color.MAGENTA;
+import static org.fusesource.jansi.Ansi.Color.RED;
+import static org.fusesource.jansi.Ansi.Color.WHITE;
+import static org.fusesource.jansi.Ansi.ansi;
 
 
 /**
@@ -201,7 +201,7 @@ public class CorfuServer {
         final Level level = Level.toLevel(((String) opts.get("--log-level")).toUpperCase());
         root.setLevel(level);
 
-        log.debug("Started with arguments: " + opts);
+        log.debug("Started with arguments: {}", opts);
 
         // Bind to all interfaces only if no address or interface specified by the user.
         final boolean bindToAllInterfaces;

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
@@ -6,14 +6,6 @@
 
 package org.corfudb.runtime.view.replication;
 
-import java.time.Duration;
-import java.util.Comparator;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -28,15 +20,23 @@ import org.corfudb.runtime.exceptions.LogUnitException;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.TrimmedException;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.exceptions.ValueAdoptedException;
-import org.corfudb.runtime.view.RuntimeLayout;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.view.QuorumFuturesFactory;
+import org.corfudb.runtime.view.RuntimeLayout;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.Holder;
 import org.corfudb.util.retry.ExponentialBackoffRetry;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.RetryNeededException;
+
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 
 /**
  * Created by kspirov on 4/23/17.
@@ -170,7 +170,7 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
             IRetry.build(ExponentialBackoffRetry.class, () -> {
                 QuorumFuturesFactory.CompositeFuture<Boolean> future = null;
                 try {
-                    log.debug("Recovery write loop for " + log);
+                    log.debug("Recovery write loop for {}", log);
                     // increment the rank
                     dh.getRef().releaseBuffer();
                     dh.getRef().setRank(dh.getRef().getRank().buildHigherRank());

--- a/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
@@ -171,8 +171,8 @@ public class MetricsUtils {
         if (!directory.isDirectory() ||
             !directory.exists() ||
             !directory.canWrite()) {
-            log.warn("Provided CSV directory : {} doesn't exist, isn't a directory, or not accessible " +
-                    "for writes. Disabling CSV Reporting.");
+            log.warn("Provided CSV directory : {} doesn't exist, isn't a directory, or " +
+                    "not accessible for writes. Disabling CSV Reporting.", directory);
             metricsCsvReportingEnabled = false;
             return;
         }

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -3,6 +3,22 @@ package org.corfudb.util;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import io.netty.buffer.ByteBuf;
+import jdk.internal.org.objectweb.asm.ClassReader;
+import jdk.internal.org.objectweb.asm.tree.AbstractInsnNode;
+import jdk.internal.org.objectweb.asm.tree.ClassNode;
+import jdk.internal.org.objectweb.asm.tree.InsnList;
+import jdk.internal.org.objectweb.asm.tree.MethodNode;
+import jdk.internal.org.objectweb.asm.util.Printer;
+import jdk.internal.org.objectweb.asm.util.Textifier;
+import jdk.internal.org.objectweb.asm.util.TraceMethodVisitor;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.LogEntry;
+import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.recovery.FastObjectLoader;
+import org.corfudb.recovery.RecoveryUtils;
+import org.corfudb.runtime.CorfuRuntime;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -19,21 +35,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import jdk.internal.org.objectweb.asm.ClassReader;
-import jdk.internal.org.objectweb.asm.tree.AbstractInsnNode;
-import jdk.internal.org.objectweb.asm.tree.ClassNode;
-import jdk.internal.org.objectweb.asm.tree.InsnList;
-import jdk.internal.org.objectweb.asm.tree.MethodNode;
-import jdk.internal.org.objectweb.asm.util.Printer;
-import jdk.internal.org.objectweb.asm.util.Textifier;
-import jdk.internal.org.objectweb.asm.util.TraceMethodVisitor;
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.protocols.logprotocol.LogEntry;
-import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
-import org.corfudb.protocols.wireprotocol.ILogData;
-import org.corfudb.recovery.FastObjectLoader;
-import org.corfudb.recovery.RecoveryUtils;
-import org.corfudb.runtime.CorfuRuntime;
 
 
 /**
@@ -440,10 +441,10 @@ public class Utils {
                 log.info("printLogAnatomy: Number of Entries: 1");
                 log.info("--------------------------");
             } else if (le.getType() == LogEntry.LogEntryType.MULTIOBJSMR) {
-                log.info("printLogAnatomy: Number of Streams: " + logData.getStreams().size());
+                log.info("printLogAnatomy: Number of Streams: {}", logData.getStreams().size());
                 ((MultiObjectSMREntry)le).getEntryMap().forEach((stream, multiSmrEntry) -> {
-                    log.info("printLogAnatomy: Number of Entries: " + multiSmrEntry
-                            .getSMRUpdates(stream).size());
+                    log.info("printLogAnatomy: Number of Entries: {}",
+                            multiSmrEntry.getSMRUpdates(stream).size());
                 });
                 log.info("--------------------------");
             }

--- a/test/src/test/java/org/corfudb/runtime/concurrent/MapsAsMQsTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/MapsAsMQsTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Created by dalia on 3/18/17.
@@ -47,13 +46,13 @@ public class MapsAsMQsTest extends AbstractTransactionsTest {
 
             for (int i = 0; i < numIterations; i++) {
                 // place a value in the map
-                log.debug("- sending 1st trigger " + i);
+                log.debug("- sending 1st trigger {}", i);
                 testMap1.put(1L, (long) i);
 
                 // await for the consumer condition to circulate back
                 s2.acquire();
 
-                log.debug("- s2.await() finished at " + i);
+                log.debug("- s2.await() finished at {}", i);
             }
         });
 
@@ -67,14 +66,14 @@ public class MapsAsMQsTest extends AbstractTransactionsTest {
 
             for (int i = 0; i < numIterations; i++) {
                 while (testMap1.get(1L) == null || testMap1.get(1L) != (long) i) {
-                    log.debug( "- wait for 1st trigger " + i);
+                    log.debug( "- wait for 1st trigger {}", i);
                     Thread.sleep(busyDelay);
                 }
-                log.debug( "- received 1st trigger " + i);
+                log.debug( "- received 1st trigger {}", i);
 
                 // 1st producer signal through lock
                 // 1st producer signal
-                log.debug( "- sending 1st signal " + i);
+                log.debug( "- sending 1st signal {}", i);
                 s1.release();
             }
         });
@@ -87,14 +86,14 @@ public class MapsAsMQsTest extends AbstractTransactionsTest {
 
             for (int i = 0; i < numIterations; i++) {
                 TXBegin();
-                log.debug( "- received 1st condition POST-lock PRE-await" + i);
+                log.debug( "- received 1st condition POST-lock PRE-await{}", i);
 
                 // wait for 1st producer signal
                 s1.acquire();
-                log.debug( "- received 1st condition " + i);
+                log.debug( "- received 1st condition {}", i);
 
                 // produce another tigger value
-                log.debug( "- sending 2nd trigger " + i);
+                log.debug( "- sending 2nd trigger {}", i);
                 testMap1.put(2L, (long) i);
                 TXEnd();
             }
@@ -111,11 +110,11 @@ public class MapsAsMQsTest extends AbstractTransactionsTest {
             for (int i = 0; i < numIterations; i++) {
                 while (testMap1.get(2L) == null || testMap1.get(2L) != (long) i)
                     Thread.sleep(busyDelay);
-                log.debug( "- received 2nd trigger " + i);
+                log.debug( "- received 2nd trigger {}", i);
 
                 // 2nd producer signal through lock
                 // 2nd producer signal
-                log.debug( "- sending 2nd signal " + i);
+                log.debug( "- sending 2nd signal {}", i);
                 s2.release();
             }
         });


### PR DESCRIPTION
## Overview

Description:
This PR, replaces the eager log message preparations with lazy argument evaluations. 

Why should this be merged: 
Eager message preparation creates log messages regardless of the logging level which leads to unnecessary message creation. Lazy evaluation however only prepares the messages when logging level requires a message to be logged.

Related issue(s) (if applicable): #1298 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
