### PR TITLE
Refactoring: emptying handler's queues and using singleton instead of list

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandshakeHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandshakeHandler.java
@@ -14,7 +14,7 @@ import org.corfudb.protocols.wireprotocol.HandshakeMsg;
 import org.corfudb.protocols.wireprotocol.HandshakeResponse;
 import org.corfudb.protocols.wireprotocol.HandshakeState;
 
-import java.util.ArrayDeque;
+import java.util.LinkedList;
 import java.util.Queue;
 import java.util.UUID;
 
@@ -31,10 +31,9 @@ public class ServerHandshakeHandler extends ChannelDuplexHandler {
     private final String corfuVersion;
     private final HandshakeState state;
     private final int timeoutInSeconds;
-    private final Queue<CorfuMsg> messages = new ArrayDeque();
+    private final Queue<CorfuMsg> messages = new LinkedList<>();
     private static final  AttributeKey<UUID> clientIdAttrKey = AttributeKey.valueOf("ClientID");
     private static final String READ_TIMEOUT_HANDLER = "readTimeoutHandler";
-
 
     /**
      * Creates a new ServerHandshakeHandler which will handle the handshake--initiated by a client
@@ -122,8 +121,8 @@ public class ServerHandshakeHandler extends ChannelDuplexHandler {
 
         // Flush messages in queue
         log.debug("channelRead: There are [{}] messages in queue to be flushed.", this.messages.size());
-        for (CorfuMsg message : this.messages) {
-            ctx.writeAndFlush(message);
+        while (!messages.isEmpty()) {
+            ctx.writeAndFlush(messages.poll());
         }
 
         // Remove this handler from the pipeline; handshake is completed.
@@ -241,4 +240,3 @@ public class ServerHandshakeHandler extends ChannelDuplexHandler {
         this.state.set(false, true);
     }
 }
-

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
@@ -8,7 +8,7 @@ import io.netty.handler.timeout.ReadTimeoutHandler;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayDeque;
+import java.util.LinkedList;
 import java.util.Queue;
 import java.util.UUID;
 
@@ -30,7 +30,7 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
     private final UUID nodeId;
     private final int handshakeTimeout;
     private final HandshakeState handshakeState;
-    private final Queue<CorfuMsg> messages = new ArrayDeque();
+    private final Queue<CorfuMsg> messages = new LinkedList<>();
     private static final String READ_TIMEOUT_HANDLER = "readTimeoutHandler";
 
     /** Events that the handshaker sends to downstream handlers.
@@ -40,7 +40,6 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
         CONNECTED,  /* Connection succeeded. */
         FAILED      /* Handshake failed. */
     }
-
 
     /**
      * Creates a new ClientHandshakeHandler which will handle the handshake between the
@@ -130,8 +129,8 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
         log.info("channelRead: Handshake succeeded. Server Corfu Version: [{}]", corfuVersion);
         log.debug("channelRead: There are [{}] messages in queue to be flushed.", this.messages.size());
         // Flush messages in queue
-        for (CorfuMsg message : this.messages) {
-            ctx.writeAndFlush(message);
+        while (!messages.isEmpty()) {
+            ctx.writeAndFlush(messages.poll());
         }
 
         // Remove this handler from the pipeline; handshake is completed.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/MultipleReadRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/MultipleReadRequest.java
@@ -1,13 +1,12 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-
-import java.util.Arrays;
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * A request to read multiple addresses.
@@ -30,7 +29,7 @@ public class MultipleReadRequest implements ICorfuPayload<MultipleReadRequest> {
     }
 
     public MultipleReadRequest(Long address) {
-        addresses = Arrays.asList(address);
+        addresses = Collections.singletonList(address);
     }
 
     @Override


### PR DESCRIPTION
## Overview

Description of refactoring:
This is a refactoring on Server and Client HandshakeHandlers and MultipleReadRequest for the following purposes:
- Removing messages from queue at the time of writing and flushing them by the HandshakeHandlers
- Fixing unchecked assignment
- Replacing implementation of Queue (from ArrayDeque to LinkedList) for memory allocation and consistent o(1) 
- Using singleton instead of creating a list of one

Why should this be merged: 
- Avoiding to unnecessarily keep messages in queue of HandshakeHandler
- Consistent o(1) add/remove from queue and avoiding ArrayDeque's memory overhead
- Replacing unchecked assignment
- Avoiding list creation for one member

Related issue(s) (if applicable): #1316 

## Checklist (Definition of Done): 

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
