### PR TITLE
Fix crash on SSLException.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -232,7 +232,10 @@ public class ManagementAgent {
         // One these tasks finish successfully, they initiate the detection tasks.
         this.initializationTaskThread = new Thread(this::initializationTask);
         this.initializationTaskThread.setUncaughtExceptionHandler(
-                (thread, throwable) -> log.error("Error in initialization task: {}", throwable));
+                (thread, throwable) -> {
+                    log.error("Error in initialization task: {}", throwable);
+                    shutdown();
+                });
         this.initializationTaskThread.start();
     }
 


### PR DESCRIPTION
## Overview

Description: Move SSL initialization to channel implementation. This allows the user the replace the SSL credentials on demand without restarting the server.

Why should this be merged: Prevents server crash on SSL Exception.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
