### PR TITLE
Fix The Multi-Stream Query API

### DIFF
--- a/generator/src/main/java/org/corfudb/generator/operations/SnapshotTxOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/SnapshotTxOperation.java
@@ -5,7 +5,6 @@ import org.corfudb.generator.Correctness;
 import org.corfudb.generator.State;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 
@@ -31,7 +30,7 @@ public class SnapshotTxOperation extends Operation {
             // Safety Hack for not having snapshot in the future
 
             long currentMax = state.getRuntime().getSequencerView()
-                    .nextToken(Collections.emptySet(), 0)
+                    .query()
                     .getToken().getTokenValue();
 
             long snapShotAddress = Long.min(trimMark + delta, currentMax);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -9,7 +9,9 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import io.netty.channel.ChannelHandlerContext;
 import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -291,33 +293,35 @@ public class SequencerServer extends AbstractServer {
      * @param r   server router
      */
     private void handleTokenQuery(CorfuPayloadMsg<TokenRequest> msg,
-                                 ChannelHandlerContext ctx, IServerRouter r) {
+                                  ChannelHandlerContext ctx, IServerRouter r) {
         TokenRequest req = msg.getPayload();
-
-        // sanity backward-compatibility assertion; TODO: remove
-        if (req.getStreams().size() > 1) {
-            log.error("TOKEN-QUERY[{}]", req.getStreams());
-        }
-
-        long maxStreamGlobalTail = Address.NON_EXIST;
-
-        // see if this query is for a specific stream-tail
-        if (req.getStreams().size() == 1) {
-            UUID streamId = req.getStreams().iterator().next();
-
-            if (streamTailToGlobalTailMap.get(streamId) != null) {
-                maxStreamGlobalTail = streamTailToGlobalTailMap.get(streamId);
+        List<UUID> streams = req.getStreams();
+        List<Long> streamTails;
+        Token token;
+        if (req.getStreams().isEmpty()) {
+            // Global tail query
+            token = new Token(globalLogTail.get() - 1, bootstrapEpoch);
+            streamTails = Collections.emptyList();
+        } else if (req.getStreams().size() == 1) {
+            // single stream query
+            token = new Token(streamTailToGlobalTailMap.getOrDefault(streams.get(0), Address.NON_EXIST), bootstrapEpoch);
+            streamTails = Collections.emptyList();
+        } else {
+            // multiple stream query, the token is populated with the global tail and the tail queries are stored in
+            // streamTails
+            token = new Token(globalLogTail.get() - 1, bootstrapEpoch);
+            streamTails = new ArrayList<>(streams.size());
+            for (int x = 0; x < streams.size(); x++) {
+                streamTails.add(streamTailToGlobalTailMap.getOrDefault(streams.get(x), Address.NON_EXIST));
             }
         }
 
-        // If no streams are specified in the request, this value returns the last global token
-        // issued.
-        long responseGlobalTail = (req.getStreams().size() == 0) ? globalLogTail.get() - 1 :
-                maxStreamGlobalTail;
-        Token token = new Token(responseGlobalTail, bootstrapEpoch);
         r.sendResponse(ctx, msg, CorfuMsgType.TOKEN_RES.payloadMsg(new TokenResponse(
-                TokenType.NORMAL, TokenResponse.NO_CONFLICT_KEY, token, Collections.emptyMap())));
+                TokenType.NORMAL, TokenResponse.NO_CONFLICT_KEY, token, Collections.emptyMap(),
+                streamTails)));
+
     }
+
 
     @ServerHandler(type = CorfuMsgType.SEQUENCER_TRIM_REQ)
     public synchronized void trimCache(CorfuPayloadMsg<Long> msg,
@@ -454,7 +458,7 @@ public class SequencerServer extends AbstractServer {
 
         Token token = new Token(globalLogTail.getAndAdd(req.getNumTokens()), bootstrapEpoch);
         r.sendResponse(ctx, msg, CorfuMsgType.TOKEN_RES.payloadMsg(new TokenResponse(
-                TokenType.NORMAL, TokenResponse.NO_CONFLICT_KEY, token, Collections.emptyMap())));
+                TokenType.NORMAL, TokenResponse.NO_CONFLICT_KEY, token, Collections.emptyMap(), Collections.emptyList())));
 
     }
 
@@ -488,7 +492,7 @@ public class SequencerServer extends AbstractServer {
             // If the txn aborts, then DO NOT hand out a token.
             Token token = new Token(Address.ABORTED, bootstrapEpoch);
             r.sendResponse(ctx, msg, CorfuMsgType.TOKEN_RES.payloadMsg(new TokenResponse(tokenType,
-                    conflictKey.get(), token, Collections.emptyMap())));
+                    conflictKey.get(), token, Collections.emptyMap(), Collections.emptyList())));
             return;
         }
 
@@ -559,7 +563,7 @@ public class SequencerServer extends AbstractServer {
         Token token = new Token(currentTail, bootstrapEpoch);
         r.sendResponse(ctx, msg, CorfuMsgType.TOKEN_RES.payloadMsg(new TokenResponse(
                 TokenType.NORMAL, TokenResponse.NO_CONFLICT_KEY, token,
-                backPointerMap.build())));
+                backPointerMap.build(), Collections.emptyList())));
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenRequest.java
@@ -2,7 +2,7 @@ package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
 
-import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 
 import lombok.AllArgsConstructor;
@@ -39,7 +39,7 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
     final Long numTokens;
 
     /** The streams which are written to by this token request. */
-    final Set<UUID> streams;
+    final List<UUID> streams;
 
     /* used for transaction resolution. */
     final TxResolutionInfo txnResolution;
@@ -51,7 +51,7 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
      * @param streams streams UUIDs required in the token request
      * @param conflictInfo transaction resolution information
      */
-    public TokenRequest(Long numTokens, Set<UUID> streams,
+    public TokenRequest(Long numTokens, List<UUID> streams,
                         TxResolutionInfo conflictInfo) {
         reqType = TK_TX;
         this.numTokens = numTokens;
@@ -65,10 +65,10 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
      * @param numTokens number of tokens to request
      * @param streams streams UUIDs required in the token request
      */
-    public TokenRequest(Long numTokens, Set<UUID> streams) {
+    public TokenRequest(Long numTokens, List<UUID> streams) {
         if (numTokens == 0) {
             this.reqType = TK_QUERY;
-        } else if (streams == null || streams.size() == 0) {
+        } else if (streams == null || streams.isEmpty()) {
             this.reqType = TK_RAW;
         } else {
             this.reqType = TK_MULTI_STREAM;
@@ -90,7 +90,7 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
 
             case TK_QUERY:
                 numTokens = 0L;
-                streams = ICorfuPayload.setFromBuffer(buf, UUID.class);
+                streams = ICorfuPayload.listFromBuffer(buf, UUID.class);
                 txnResolution = null;
                 break;
 
@@ -102,13 +102,13 @@ public class TokenRequest implements ICorfuPayload<TokenRequest> {
 
             case TK_MULTI_STREAM:
                 numTokens = ICorfuPayload.fromBuffer(buf, Long.class);
-                streams = ICorfuPayload.setFromBuffer(buf, UUID.class);
+                streams = ICorfuPayload.listFromBuffer(buf, UUID.class);
                 txnResolution = null;
                 break;
 
             case TK_TX:
                 numTokens = ICorfuPayload.fromBuffer(buf, Long.class);
-                streams = ICorfuPayload.setFromBuffer(buf, UUID.class);
+                streams = ICorfuPayload.listFromBuffer(buf, UUID.class);
                 txnResolution = new TxResolutionInfo(buf);
                 break;
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -2,6 +2,8 @@ package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -29,6 +31,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
         conflictKey = NO_CONFLICT_KEY;
         token = new Token(tokenValue, epoch);
         this.backpointerMap = backpointerMap;
+        this.streamTails = Collections.emptyList();
     }
 
     /** the cause/type of response. */
@@ -46,6 +49,8 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
     /** The backpointer map, if available. */
     final Map<UUID, Long> backpointerMap;
 
+    final List<Long> streamTails;
+
     /**
      * Deserialization Constructor from a Bytebuf to TokenResponse.
      *
@@ -58,6 +63,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
         Long epoch = ICorfuPayload.fromBuffer(buf, Long.class);
         token = new Token(tokenValue, epoch);
         backpointerMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
+        streamTails = ICorfuPayload.listFromBuffer(buf, Long.class);
     }
 
     @Override
@@ -67,6 +73,7 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
         ICorfuPayload.serialize(buf, token.getTokenValue());
         ICorfuPayload.serialize(buf, token.getEpoch());
         ICorfuPayload.serialize(buf, backpointerMap);
+        ICorfuPayload.serialize(buf, streamTails);
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -2,7 +2,6 @@ package org.corfudb.recovery;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -249,7 +248,7 @@ public class FastObjectLoader {
     }
 
     private void findAndSetLogTail() {
-        logTail = runtime.getSequencerView().nextToken(Collections.emptySet(), 0).getTokenValue();
+        logTail = runtime.getSequencerView().query().getTokenValue();
     }
 
     private void resetAddressProcessed() {

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -2,15 +2,12 @@ package org.corfudb.runtime;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -179,7 +176,7 @@ public class CheckpointWriter<T extends Map> {
                 ImmutableMap.copyOf(this.mdkv);
         CheckpointEntry cp = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.START,
                 author, checkpointId, streamId, mdkv, null);
-        startAddress = sv.append(Collections.singleton(checkpointStreamID), cp, null);
+        startAddress = sv.append(cp, null, checkpointStreamID);
 
         postAppendFunc.accept(cp, startAddress);
         return startAddress;
@@ -235,7 +232,7 @@ public class CheckpointWriter<T extends Map> {
                 CheckpointEntry cp = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.CONTINUATION,
                         author, checkpointId, streamId, mdkv, smrEntries);
 
-                long pos = sv.append(Collections.singleton(checkpointStreamID), cp, null);
+                long pos = sv.append(cp, null, checkpointStreamID);
 
                 postAppendFunc.accept(cp, pos);
                 continuationAddresses.add(pos);
@@ -261,7 +258,7 @@ public class CheckpointWriter<T extends Map> {
                 CheckpointEntry cp = new CheckpointEntry(CheckpointEntry
                         .CheckpointEntryType.CONTINUATION,
                         author, checkpointId, streamId, mdkv, smrEntries);
-                long pos = sv.append(Collections.singleton(checkpointStreamID), cp, null);
+                long pos = sv.append(cp, null, checkpointStreamID);
 
                 postAppendFunc.accept(cp, pos);
                 continuationAddresses.add(pos);
@@ -295,7 +292,7 @@ public class CheckpointWriter<T extends Map> {
         CheckpointEntry cp = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.END,
                 author, checkpointId, streamId, mdkv, null);
 
-        endAddress = sv.append(Collections.singleton(checkpointStreamID), cp, null);
+        endAddress = sv.append(cp, null, checkpointStreamID);
 
         postAppendFunc.accept(cp, endAddress);
         return endAddress;
@@ -308,7 +305,7 @@ public class CheckpointWriter<T extends Map> {
      */
     public static long startGlobalSnapshotTxn(CorfuRuntime rt) {
         TokenResponse tokenResponse =
-                rt.getSequencerView().nextToken(Collections.EMPTY_SET, 0);
+                rt.getSequencerView().query();
         long globalTail = tokenResponse.getToken().getTokenValue();
         rt.getObjectsView().TXBuild()
                 .setType(TransactionType.SNAPSHOT)

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -1,7 +1,7 @@
 package org.corfudb.runtime.clients;
 
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
@@ -40,7 +40,7 @@ public class SequencerClient extends AbstractClient {
      * @param numTokens Number of tokens to be reserved.
      * @return A completable future with the token response from the sequencer.
      */
-    public CompletableFuture<TokenResponse> nextToken(Set<UUID> streamIDs, long numTokens) {
+    public CompletableFuture<TokenResponse> nextToken(List<UUID> streamIDs, long numTokens) {
         return sendMessageWithFuture(CorfuMsgType.TOKEN_REQ.payloadMsg(
                 new TokenRequest(numTokens, streamIDs)));
     }
@@ -53,7 +53,7 @@ public class SequencerClient extends AbstractClient {
      * @param conflictInfo Transaction resolution conflict parameters.
      * @return A completable future with the token response from the sequencer.
      */
-    public CompletableFuture<TokenResponse> nextToken(Set<UUID> streamIDs, long numTokens,
+    public CompletableFuture<TokenResponse> nextToken(List<UUID> streamIDs, long numTokens,
                                                       TxResolutionInfo conflictInfo) {
         return sendMessageWithFuture(CorfuMsgType.TOKEN_REQ.payloadMsg(
                 new TokenRequest(numTokens, streamIDs, conflictInfo)));

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -24,7 +24,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -189,7 +188,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         for (int x = 0; x < rt.getParameters().getTrimRetry(); x++) {
             // Linearize this read against a timestamp
             final long timestamp = rt.getSequencerView()
-                            .nextToken(Collections.singleton(streamID), 0).getToken().getTokenValue();
+                            .query(getStreamID()).getToken().getTokenValue();
             log.debug("Access[{}] conflictObj={} version={}", this, conflictObject, timestamp);
 
             try {
@@ -266,11 +265,10 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         // Linearize this read against a timestamp
         final long timestamp =
                 rt.getSequencerView()
-                        .nextToken(Collections.singleton(streamID), 0).getToken()
+                        .query(getStreamID()).getToken()
                         .getTokenValue();
 
         log.debug("Sync[{}] {}", this, timestamp);
-
         // Acquire locks and perform read.
         underlyingObject.update(o -> {
             o.syncObjectUnsafe(timestamp);

--- a/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
@@ -1,8 +1,11 @@
 package org.corfudb.runtime.view;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 
+import com.google.common.collect.Lists;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.CorfuRuntime;
@@ -20,6 +23,47 @@ public class SequencerView extends AbstractView {
     }
 
     /**
+     * Return the next token in the sequencer for the global tail or the tails
+     * of multiple streams.
+     *
+     * @param streamIds the streams to query
+     * @return the global tail or a list of tails
+     */
+    public TokenResponse query(UUID... streamIds) {
+        if (streamIds.length == 0) {
+            return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
+                    .nextToken(Collections.emptyList(), 0)));
+        } else {
+            return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
+                    .nextToken(Arrays.asList(streamIds), 0)));
+        }
+    }
+
+    /**
+     * Return the next token in the sequencer for a particular stream.
+     *
+     * @param streamIds The stream IDs to retrieve from.
+     * @return The first token retrieved.
+     */
+    public TokenResponse next(UUID ... streamIds) {
+        return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
+                .nextToken(Arrays.asList(streamIds), 1)));
+    }
+
+    /**
+     *
+     * Acquire a token for a number of streams if there are no conflicts.
+     *
+     * @param conflictInfo transaction conflict info
+     * @param streamIds streams to acquire the token for
+     * @return First token to be written for the streams if there are no conflicts
+     */
+    public TokenResponse next(TxResolutionInfo conflictInfo, UUID ... streamIds) {
+        return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
+                .nextToken(Arrays.asList(streamIds), 1, conflictInfo)));
+    }
+
+    /**
      * Return the next token in the sequencer for a particular stream.
      *
      * <p>If numTokens == 0, then the streamAddressesMap returned is the last handed out token for
@@ -30,16 +74,17 @@ public class SequencerView extends AbstractView {
      * @param numTokens The number of tokens to reserve.
      * @return The first token retrieved.
      */
+    @Deprecated
     public TokenResponse nextToken(Set<UUID> streamIDs, int numTokens) {
         return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
-                .nextToken(streamIDs, numTokens)));
+                .nextToken(Lists.newArrayList(streamIDs), numTokens)));
     }
 
-
+    @Deprecated
     public TokenResponse nextToken(Set<UUID> streamIDs, int numTokens,
                                    TxResolutionInfo conflictInfo) {
         return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
-                .nextToken(streamIDs, numTokens, conflictInfo)));
+                .nextToken(Lists.newArrayList(streamIDs), numTokens, conflictInfo)));
     }
 
     public void trimCache(long address) {

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -46,7 +46,7 @@ public class SequencerServerTest extends AbstractServerTest {
     @Test
     public void responseForEachRequest() {
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
-            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet())));
+            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.emptyList())));
             assertThat(getResponseMessages().size())
                     .isEqualTo(i + 1);
         }
@@ -56,7 +56,7 @@ public class SequencerServerTest extends AbstractServerTest {
     public void tokensAreIncreasing() {
         long lastTokenValue = -1;
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
-            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet())));
+            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.emptyList())));
             Token thisToken = getLastPayloadMessageAs(TokenResponse.class).getToken();
             assertThat(thisToken.getTokenValue())
                     .isGreaterThan(lastTokenValue);
@@ -67,11 +67,11 @@ public class SequencerServerTest extends AbstractServerTest {
     @Test
     public void checkTokenPositionWorks() {
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
-            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.<UUID>emptySet())));
+            sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.emptyList())));
             Token thisToken = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(0L, Collections.<UUID>emptySet())));
+                    new TokenRequest(0L, Collections.emptyList())));
             Token checkToken = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             assertThat(thisToken)
@@ -86,29 +86,29 @@ public class SequencerServerTest extends AbstractServerTest {
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA))));
+                    new TokenRequest(1L, Collections.singletonList(streamA))));
             Token thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(0L, Collections.singleton(streamA))));
+                    new TokenRequest(0L, Collections.singletonList(streamA))));
             Token checkTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             assertThat(thisTokenA)
                     .isEqualTo(checkTokenA);
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamB))));
+                    new TokenRequest(1L, Collections.singletonList(streamB))));
             Token thisTokenB = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(0L, Collections.singleton(streamB))));
+                    new TokenRequest(0L, Collections.singletonList(streamB))));
             Token checkTokenB = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             assertThat(thisTokenB)
                     .isEqualTo(checkTokenB);
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(0L, Collections.singleton(streamA))));
+                    new TokenRequest(0L, Collections.singletonList(streamA))));
             Token checkTokenA2 = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             assertThat(checkTokenA2)
@@ -126,22 +126,22 @@ public class SequencerServerTest extends AbstractServerTest {
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA))));
+                    new TokenRequest(1L, Collections.singletonList(streamA))));
             Token thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA))));
+                    new TokenRequest(1L, Collections.singletonList(streamA))));
             long checkTokenAValue = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
             assertThat(thisTokenA.getTokenValue())
                     .isEqualTo(checkTokenAValue);
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamB))));
+                    new TokenRequest(1L, Collections.singletonList(streamB))));
             Token thisTokenB = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamB))));
+                    new TokenRequest(1L, Collections.singletonList(streamB))));
             long checkTokenBValue = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamB);
 
             assertThat(thisTokenB.getTokenValue())
@@ -150,11 +150,11 @@ public class SequencerServerTest extends AbstractServerTest {
             final long MULTI_TOKEN = 5L;
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(MULTI_TOKEN, Collections.singleton(streamA))));
+                    new TokenRequest(MULTI_TOKEN, Collections.singletonList(streamA))));
             thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA))));
+                    new TokenRequest(1L, Collections.singletonList(streamA))));
             checkTokenAValue = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
             assertThat(thisTokenA.getTokenValue() + MULTI_TOKEN - 1)
@@ -162,11 +162,11 @@ public class SequencerServerTest extends AbstractServerTest {
 
             // check the requesting multiple tokens does not break the back-pointer for the multi-entry
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(1L, Collections.singleton(streamA))));
+                    new TokenRequest(1L, Collections.singletonList(streamA))));
             thisTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                    new TokenRequest(MULTI_TOKEN, Collections.singleton(streamA))));
+                    new TokenRequest(MULTI_TOKEN, Collections.singletonList(streamA))));
             checkTokenAValue = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
             assertThat(thisTokenA.getTokenValue())
@@ -182,22 +182,22 @@ public class SequencerServerTest extends AbstractServerTest {
         UUID streamC = UUID.nameUUIDFromBytes("streamC".getBytes());
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                new TokenRequest(1L, Collections.singleton(streamA))));
+                new TokenRequest(1L, Collections.singletonList(streamA))));
         long tailA = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                new TokenRequest(1L, Collections.singleton(streamB))));
+                new TokenRequest(1L, Collections.singletonList(streamB))));
         long tailB = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                new TokenRequest(1L, Collections.singleton(streamC))));
+                new TokenRequest(1L, Collections.singletonList(streamC))));
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                new TokenRequest(1L, Collections.singleton(streamC))));
+                new TokenRequest(1L, Collections.singletonList(streamC))));
 
         long tailC = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                new TokenRequest(0L, Collections.EMPTY_SET)));
+                new TokenRequest(0L, Collections.emptyList())));
         long globalTail = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
 
         // Construct new tails
@@ -217,16 +217,16 @@ public class SequencerServerTest extends AbstractServerTest {
                 new SequencerTailsRecoveryMsg(globalTail + 2, tailMap, 0L, false)));
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                new TokenRequest(0L, Collections.singleton(streamA))));
+                new TokenRequest(0L, Collections.singletonList(streamA))));
         assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue()).isEqualTo(newTailA);
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                new TokenRequest(0L, Collections.singleton(streamB))));
+                new TokenRequest(0L, Collections.singletonList(streamB))));
         assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue()).isEqualTo(newTailB);
 
         // We should have the same value than before
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
-                new TokenRequest(0L, Collections.singleton(streamC))));
+                new TokenRequest(0L, Collections.singletonList(streamC))));
         assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue()).isEqualTo(newTailC);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -214,7 +214,7 @@ public class ClusterReconfigIT extends AbstractIT {
     private void verifyData(CorfuRuntime corfuRuntime) throws Exception {
 
         TokenResponse tokenResponse = corfuRuntime.getSequencerView()
-                .nextToken(Collections.singleton(CorfuRuntime.getStreamID("test")), 0);
+                .query(CorfuRuntime.getStreamID("test"));
         long lastAddress = tokenResponse.getTokenValue();
 
         Map<Long, LogData> map_0 = getAllNonEmptyData(corfuRuntime, "localhost:9000", lastAddress);

--- a/test/src/test/java/org/corfudb/integration/CmdletIT.java
+++ b/test/src/test/java/org/corfudb/integration/CmdletIT.java
@@ -184,8 +184,7 @@ public class CmdletIT extends AbstractIT {
         runCmdletGetOutput(commandNextToken);
 
         Token token = runtime.getSequencerView()
-                .nextToken(Collections.singleton(CorfuRuntime.getStreamID(streamA)), 0)
-                .getToken();
+                .query(CorfuRuntime.getStreamID(streamA)).getToken();
 
         String commandLatest = CORFU_PROJECT_DIR + "bin/corfu_sequencer -i " + streamA + " -c " + ENDPOINT + " latest";
         String output = runCmdletGetOutput(commandLatest);

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -6,7 +6,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.HashSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -32,7 +31,7 @@ public class SealIT extends AbstractIT{
         CorfuRuntime cr1 = createDefaultRuntime();
         CorfuRuntime cr2 = createDefaultRuntime();
 
-        Long beforeAddress = cr2.getSequencerView().nextToken(new HashSet<>(),1).getToken().getTokenValue();
+        Long beforeAddress = cr2.getSequencerView().next().getToken().getTokenValue();
 
         /* We will trigger a Paxos round, this is what will happen:
          *   1. Set our layout (same than before) with a new Epoch
@@ -67,7 +66,7 @@ public class SealIT extends AbstractIT{
          *
          * These steps get cr2 in the new epoch.
          */
-        Long afterAddress = cr2.getSequencerView().nextToken(new HashSet<>(),1).getToken().getTokenValue();
+        Long afterAddress = cr2.getSequencerView().next().getToken().getTokenValue();
         assertThat(cr2.getLayoutView().getCurrentLayout().getEpoch()).
             isEqualTo(cr1.getLayoutView().getCurrentLayout().getEpoch());
         assertThat(afterAddress).isEqualTo(beforeAddress+1);

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -441,12 +441,8 @@ public class ServerRestartIT extends AbstractIT {
 
         restartServer(corfuRuntime, DEFAULT_ENDPOINT);
 
-        TokenResponse tokenResponseA = corfuRuntime
-                .getSequencerView()
-                .nextToken(Collections.singleton(streamNameA), 1);
-        TokenResponse tokenResponseB = corfuRuntime
-                .getSequencerView()
-                .nextToken(Collections.singleton(streamNameB), 1);
+        TokenResponse tokenResponseA = corfuRuntime.getSequencerView().next(streamNameA);
+        TokenResponse tokenResponseB = corfuRuntime.getSequencerView().next(streamNameB);
 
         assertThat(tokenResponseA.getToken().getTokenValue()).isEqualTo(newGlobalTail + 1);
         assertThat(tokenResponseA.getBackpointerMap().get(streamNameA))
@@ -474,15 +470,14 @@ public class ServerRestartIT extends AbstractIT {
         final CorfuRuntime corfuRuntime = createDefaultRuntime();
 
         // wait for this server long enough to start (by requesting token service)
-        TokenResponse firsttr = corfuRuntime.getSequencerView().nextToken(Collections.emptySet(),
-                1);
+        TokenResponse firsttr = corfuRuntime.getSequencerView().next();
 
         assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
 
         corfuServerProcess = runCorfuServer();
 
         corfuRuntime.invalidateLayout();
-        TokenResponse tr = corfuRuntime.getSequencerView().nextToken(Collections.emptySet(), 1);
+        TokenResponse tr = corfuRuntime.getSequencerView().next();
 
         assertThat(tr.getEpoch())
                 .isEqualTo(1);
@@ -581,15 +576,15 @@ public class ServerRestartIT extends AbstractIT {
                     .getSequencerClient(corfuSingleNodeHost + ":" + corfuSingleNodePort);
 
             TokenResponse expectedTokenResponseA = sequencerClient
-                    .nextToken(Collections.singleton(streamNameA), 0)
+                    .nextToken(Collections.singletonList(streamNameA), 0)
                     .get();
 
             TokenResponse expectedTokenResponseB = sequencerClient
-                    .nextToken(Collections.singleton(streamNameB), 0)
+                    .nextToken(Collections.singletonList(streamNameB), 0)
                     .get();
 
             TokenResponse expectedGlobalTailResponse = sequencerClient
-                    .nextToken(Collections.emptySet(), 0)
+                    .nextToken(Collections.emptyList(), 0)
                     .get();
 
 
@@ -606,11 +601,11 @@ public class ServerRestartIT extends AbstractIT {
 
             // check tail recovery after restart
             TokenResponse tokenResponseA = sequencerClient
-                    .nextToken(Collections.singleton(streamNameA), 1)
+                    .nextToken(Collections.singletonList(streamNameA), 1)
                     .get();
 
             TokenResponse tokenResponseB = sequencerClient
-                    .nextToken(Collections.singleton(streamNameB), 1)
+                    .nextToken(Collections.singletonList(streamNameB), 1)
                     .get();
 
             assertThat(tokenResponseA.getTokenValue()).isEqualTo(expectedGlobalTailResponse

--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -122,9 +122,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
     private void assertThatStreamTailsAreCorrect(Map<UUID, Long> streamTails) {
         maps.keySet().forEach((streamName) -> {
             UUID id = CorfuRuntime.getStreamID(streamName);
-            long tail = getDefaultRuntime().getSequencerView().
-                    nextToken(Collections.singleton(id),
-                            0).getToken().getTokenValue();
+            long tail = getDefaultRuntime().getSequencerView().query(id).getToken().getTokenValue();
             if (streamTails.containsKey(id)) {
                 assertThat(streamTails.get(id)).isEqualTo(tail);
             }
@@ -187,16 +185,12 @@ public class FastObjectLoaderTest extends AbstractViewTest {
                 .getSequencerClient(getDefaultConfigurationString());
 
         seq.nextToken(null, 1);
-        luc.fillHole(getDefaultRuntime().getSequencerView()
-                .nextToken(Collections.emptySet(), 0)
-                .getTokenValue());
+        luc.fillHole(getDefaultRuntime().getSequencerView().next().getTokenValue());
 
         populateMaps(1, getDefaultRuntime(), CorfuTable.class, false, 1);
 
         seq.nextToken(null, 1);
-        luc.fillHole(getDefaultRuntime().getSequencerView()
-                .nextToken(Collections.emptySet(), 0)
-                .getTokenValue());
+        luc.fillHole(getDefaultRuntime().getSequencerView().next().getTokenValue());
 
         CorfuRuntime rt2 = Helpers.createNewRuntimeWithFastLoader(getDefaultConfigurationString());
         assertThatMapsAreBuilt(rt2);
@@ -405,14 +399,14 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         SequencerClient seq = getDefaultRuntime().getLayoutView().getRuntimeLayout()
                 .getSequencerClient(getDefaultConfigurationString());
 
-        long address = seq.nextToken(Collections.emptySet(),1).get().getTokenValue();
+        long address = seq.nextToken(Collections.emptyList(),1).get().getTokenValue();
         ILogData data = Helpers.createEmptyData(address, DataType.RANK_ONLY,  new IMetadata.DataRank(2))
                 .getSerialized();
         luc.write(data).get();
 
         populateMaps(1, getDefaultRuntime(), CorfuTable.class, false, 1);
 
-        address = seq.nextToken(Collections.emptySet(),1).get().getTokenValue();
+        address = seq.nextToken(Collections.emptyList(),1).get().getTokenValue();
         data = Helpers.createEmptyData(address, DataType.RANK_ONLY,  new IMetadata.DataRank(2))
                 .getSerialized();
         luc.write(data).get();
@@ -575,8 +569,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         Helpers.trim(getDefaultRuntime(),firstMileStone+2);
 
         incrementalLoader.setLogHead(firstMileStone + 1);
-        incrementalLoader.setLogTail(getDefaultRuntime().getSequencerView().
-                nextToken(Collections.emptySet(), 0).getTokenValue());
+        incrementalLoader.setLogTail(getDefaultRuntime().getSequencerView().next().getTokenValue());
         incrementalLoader.loadMaps();
 
     }
@@ -650,8 +643,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
 
 
         UUID transactionStreams = rt1.getObjectsView().TRANSACTION_STREAM_ID;
-        long tailTransactionStream = rt1.getSequencerView()
-                .nextToken(Collections.singleton(transactionStreams), 0).
+        long tailTransactionStream = rt1.getSequencerView().query(transactionStreams).
                 getToken().getTokenValue();
 
         // Also recover the Transaction Stream

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -427,8 +427,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
 
         // Write cp #1 of 3
         if (write1) {
-            TokenResponse tokResp1 = r.getSequencerView().nextToken(Collections.singleton(streamId)
-                    , 0);
+            TokenResponse tokResp1 = r.getSequencerView().query(streamId);
             long addr1 = tokResp1.getToken().getTokenValue();
             mdKV.put(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS, Long.toString(addr1 + 1));
             CheckpointEntry cp1 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.START,

--- a/test/src/test/java/org/corfudb/runtime/clients/SequencerHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/SequencerHandlerTest.java
@@ -54,14 +54,14 @@ public class SequencerHandlerTest extends AbstractClientTest {
     @Test
     public void canGetAToken()
             throws Exception {
-        client.nextToken(Collections.<UUID>emptySet(), 1).get();
+        client.nextToken(Collections.emptyList(), 1).get();
     }
 
     @Test
     public void tokensAreIncrementing()
             throws Exception {
-        Token token = client.nextToken(Collections.<UUID>emptySet(), 1).get().getToken();
-        Token token2 = client.nextToken(Collections.<UUID>emptySet(), 1).get().getToken();
+        Token token = client.nextToken(Collections.emptyList(), 1).get().getToken();
+        Token token2 = client.nextToken(Collections.emptyList(), 1).get().getToken();
         assertThat(token2.getTokenValue())
                 .isGreaterThan(token.getTokenValue());
     }
@@ -69,8 +69,8 @@ public class SequencerHandlerTest extends AbstractClientTest {
     @Test
     public void checkTokenPositionWorks()
             throws Exception {
-        Token token = client.nextToken(Collections.<UUID>emptySet(), 1).get().getToken();
-        Token token2 = client.nextToken(Collections.<UUID>emptySet(), 0).get().getToken();
+        Token token = client.nextToken(Collections.emptyList(), 1).get().getToken();
+        Token token2 = client.nextToken(Collections.emptyList(), 0).get().getToken();
         assertThat(token)
                 .isEqualTo(token2);
     }
@@ -80,19 +80,19 @@ public class SequencerHandlerTest extends AbstractClientTest {
             throws Exception {
         UUID streamA = UUID.nameUUIDFromBytes("streamA".getBytes());
         UUID streamB = UUID.nameUUIDFromBytes("streamB".getBytes());
-        client.nextToken(Collections.singleton(streamA), 1).get();
-        Token tokenA = client.nextToken(Collections.singleton(streamA), 1).get().getToken();
-        Token tokenA2 = client.nextToken(Collections.singleton(streamA), 0).get().getToken();
+        client.nextToken(Collections.singletonList(streamA), 1).get();
+        Token tokenA = client.nextToken(Collections.singletonList(streamA), 1).get().getToken();
+        Token tokenA2 = client.nextToken(Collections.singletonList(streamA), 0).get().getToken();
         assertThat(tokenA)
                 .isEqualTo(tokenA2);
-        Token tokenB = client.nextToken(Collections.singleton(streamB), 0).get().getToken();
+        Token tokenB = client.nextToken(Collections.singletonList(streamB), 0).get().getToken();
         assertThat(tokenB)
                 .isNotEqualTo(tokenA2);
-        Token tokenB2 = client.nextToken(Collections.singleton(streamB), 1).get().getToken();
-        Token tokenB3 = client.nextToken(Collections.singleton(streamB), 0).get().getToken();
+        Token tokenB2 = client.nextToken(Collections.singletonList(streamB), 1).get().getToken();
+        Token tokenB3 = client.nextToken(Collections.singletonList(streamB), 0).get().getToken();
         assertThat(tokenB2)
                 .isEqualTo(tokenB3);
-        Token tokenA3 = client.nextToken(Collections.singleton(streamA), 0).get().getToken();
+        Token tokenA3 = client.nextToken(Collections.singletonList(streamA), 0).get().getToken();
         assertThat(tokenA3)
                 .isEqualTo(tokenA2);
     }

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapEntrySetTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapEntrySetTest.java
@@ -6,7 +6,6 @@ import org.corfudb.runtime.object.transactions.AbstractTransactionsTest;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CountDownLatch;
@@ -80,7 +79,7 @@ public class SMRMapEntrySetTest extends AbstractTransactionsTest {
         CountDownLatch l3 = new CountDownLatch(1);
 
         // Block until sequencer operational.
-        r.getSequencerView().nextToken(Collections.EMPTY_SET, 0);
+        r.getSequencerView().next();
 
         // first thread: create and manipulate map
         scheduleConcurrently(t -> {

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -2,19 +2,15 @@ package org.corfudb.runtime.object;
 
 import com.google.common.reflect.TypeToken;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TrimmedException;
-import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -52,8 +48,7 @@ public class CompileProxyTest extends AbstractViewTest {
         // read will be on a trimmed address
         final int numOfTokens = 10;
         String streamName = "s1";
-        rt.getSequencerView().nextToken(Collections.singleton(CorfuRuntime.getStreamID(streamName)),
-                numOfTokens);
+        rt.getSequencerView().next(CorfuRuntime.getStreamID(streamName));
 
         // Trim all the way up to the tail
         rt.getAddressSpaceView().prefixTrim(numOfTokens);
@@ -304,7 +299,7 @@ public class CompileProxyTest extends AbstractViewTest {
         int concurrency = PARAMETERS.CONCURRENCY_LOTS;
 
         // Blocking until sequencer becomes functional.
-        getDefaultRuntime().getSequencerView().nextToken(Collections.EMPTY_SET, 0);
+        getDefaultRuntime().getSequencerView().next();
 
         // schedule 'concurrency' number of threads,
         // each one put()'s a key with its thread index
@@ -371,7 +366,7 @@ public class CompileProxyTest extends AbstractViewTest {
         int concurrency = PARAMETERS.CONCURRENCY_LOTS;
 
         // Block until sequencer operational.
-        getDefaultRuntime().getSequencerView().nextToken(Collections.EMPTY_SET, 0);
+        getDefaultRuntime().getSequencerView().next();
 
         // set up 'concurrency' number of threads that concurrency update sharedCorfuCompound, each to a different value
         scheduleConcurrently(concurrency, t -> {

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
@@ -57,8 +57,8 @@ public class StreamTest extends AbstractTransactionsTest {
         final long trimMark = getRuntime().getParameters().getWriteRetry() - 1;
         getRuntime().getAddressSpaceView().prefixTrim(trimMark);
         final int payloadSize = 100;
-        assertThatThrownBy(() -> getRuntime().getStreamsView().append(Collections.singleton(svId),
-                new byte[payloadSize], null))
+        assertThatThrownBy(() -> getRuntime().getStreamsView().append(
+                new byte[payloadSize], null, svId))
                 .isInstanceOf(AppendException.class);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -523,9 +523,7 @@ public class ManagementViewTest extends AbstractViewTest {
         induceSequencerFailureAndWait();
 
         // Block until new sequencer reaches READY state.
-        getCorfuRuntime().getSequencerView().nextToken(
-                Collections.singleton(CorfuRuntime.getStreamID("streamA")),
-                0);
+        getCorfuRuntime().getSequencerView().query(CorfuRuntime.getStreamID("streamA"));
         // verify that a failover sequencer was started with the correct starting-tail
         //
         assertThat(getSequencer(SERVERS.PORT_1).getGlobalLogTail().get()).isEqualTo(beforeFailure);
@@ -794,7 +792,7 @@ public class ManagementViewTest extends AbstractViewTest {
      */
     private void getTokenWriteAndAssertBackPointer(UUID streamID, Long expectedBackpointerValue) {
         TokenResponse tokenResponse =
-                corfuRuntime.getSequencerView().nextToken(Collections.singleton(streamID), 1);
+                corfuRuntime.getSequencerView().next(streamID);
         if (expectedBackpointerValue == null) {
             assertThat(tokenResponse.getBackpointerMap()).isEmpty();
         } else {
@@ -833,7 +831,7 @@ public class ManagementViewTest extends AbstractViewTest {
                             // server is sealed and we get a WrongEpochException.
                             corfuRuntime.getLayoutView().getRuntimeLayout(layout)
                                     .getSequencerClient(SERVERS.ENDPOINT_1)
-                                    .nextToken(Collections.singleton(CorfuRuntime
+                                    .nextToken(Collections.singletonList(CorfuRuntime
                                             .getStreamID("testStream")), 1).get();
                             fail();
                         } catch (InterruptedException | ExecutionException e) {
@@ -850,8 +848,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .isTrue();
 
         // We should be able to request a token now.
-        corfuRuntime.getSequencerView().nextToken(Collections.singleton(CorfuRuntime
-                .getStreamID("testStream")), 1);
+        corfuRuntime.getSequencerView().next(CorfuRuntime.getStreamID("testStream"));
     }
 
     @Test
@@ -1154,8 +1151,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .build();
         assertThat(rt.getLayoutView().getLayout()).isEqualTo(expectedLayout);
 
-        TokenResponse tokenResponse = rt.getSequencerView()
-                .nextToken(Collections.singleton(CorfuRuntime.getStreamID("test")), 0);
+        TokenResponse tokenResponse = rt.getSequencerView().query(CorfuRuntime.getStreamID("test"));
         long lastAddress = tokenResponse.getTokenValue();
 
         Map<Long, LogData> map_0 = getAllNonEmptyData(rt, SERVERS.ENDPOINT_0, lastAddress);
@@ -1289,8 +1285,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .build();
         assertThat(rt.getLayoutView().getLayout()).isEqualTo(expectedLayout);
 
-        TokenResponse tokenResponse = rt.getSequencerView()
-                .nextToken(Collections.singleton(CorfuRuntime.getStreamID("test")), 0);
+        TokenResponse tokenResponse = rt.getSequencerView().query(CorfuRuntime.getStreamID("test"));
         long lastAddress = tokenResponse.getTokenValue();
 
         Map<Long, LogData> map_0 = getAllNonEmptyData(rt, SERVERS.ENDPOINT_0, lastAddress);
@@ -1361,8 +1356,10 @@ public class ManagementViewTest extends AbstractViewTest {
 
         // Using the stale client with view of epoch 1, request 10 tokens.
         final int tokenCount = 5;
-        runtime_2.getSequencerView().nextToken(Collections.singleton(streamA), tokenCount);
-        runtime_2.getSequencerView().nextToken(Collections.singleton(streamB), tokenCount);
+        for (int x = 0; x < tokenCount; x++) {
+            runtime_2.getSequencerView().next(streamA);
+            runtime_2.getSequencerView().next(streamB);
+        }
         // Using the new client request 2 tokens and write to the log.
         streamViewA.append(payload);
         streamViewA.append(payload);
@@ -1392,8 +1389,7 @@ public class ManagementViewTest extends AbstractViewTest {
 
         // Assert that the streamTailMap has been reset and returns the correct backpointer.
         final long expectedBackpointerStreamA = 11;
-        TokenResponse tokenResponse = runtime_1.getSequencerView()
-                .nextToken(Collections.singleton(streamA), 1);
+        TokenResponse tokenResponse = runtime_1.getSequencerView().next(streamA);
         assertThat(tokenResponse.getBackpointerMap().get(streamA))
                 .isEqualTo(expectedBackpointerStreamA);
     }
@@ -1422,7 +1418,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .requestMetrics().get()).hasCauseInstanceOf(ServerNotReadyException.class);
 
         // Wait for the management service to detect and bootstrap the sequencer.
-        corfuRuntime.getSequencerView().nextToken(Collections.emptySet(), 0);
+        corfuRuntime.getSequencerView().query();
 
         // Assert that the primary sequencer is bootstrapped.
         assertThat(corfuRuntime.getLayoutView().getRuntimeLayout().getPrimarySequencerClient()

--- a/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
@@ -5,7 +5,6 @@ import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -21,25 +20,42 @@ public class SequencerViewTest extends AbstractViewTest {
     @Test
     public void canAcquireFirstToken() {
         CorfuRuntime r = getDefaultRuntime();
-        assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
+        assertThat(r.getSequencerView().next().getToken())
                 .isEqualTo(new Token(0L, 0L));
+    }
+
+    @Test
+    public void canQueryMultipleStreams() {
+        CorfuRuntime r = getDefaultRuntime();
+
+        UUID stream1 = UUID.randomUUID();
+        UUID stream2 = UUID.randomUUID();
+        UUID stream3 = UUID.randomUUID();
+
+        assertThat(r.getSequencerView().next(stream1).getToken())
+                .isEqualTo(new Token(0l, 0l));
+        assertThat(r.getSequencerView().next(stream2).getToken())
+                .isEqualTo(new Token(1l, 0l));
+
+        assertThat(r.getSequencerView().query(stream1, stream2, stream3).getStreamTails())
+                .containsExactly(0l, 1l, Address.NON_EXIST);
     }
 
     @Test
     public void tokensAreIncrementing() {
         CorfuRuntime r = getDefaultRuntime();
-        assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
+        assertThat(r.getSequencerView().next().getToken())
                 .isEqualTo(new Token(0L, 0L));
-        assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
+        assertThat(r.getSequencerView().next().getToken())
                 .isEqualTo(new Token(1L, 0L));
     }
 
     @Test
     public void checkTokenWorks() {
         CorfuRuntime r = getDefaultRuntime();
-        assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 1).getToken())
+        assertThat(r.getSequencerView().next().getToken())
                 .isEqualTo(new Token(0L, 0L));
-        assertThat(r.getSequencerView().nextToken(Collections.emptySet(), 0).getToken())
+        assertThat(r.getSequencerView().query().getToken())
                 .isEqualTo(new Token(0L, 0L));
     }
 
@@ -49,15 +65,15 @@ public class SequencerViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         UUID streamB = UUID.nameUUIDFromBytes("stream B".getBytes());
 
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 1).getToken())
+        assertThat(r.getSequencerView().next(streamA).getToken())
                 .isEqualTo(new Token(0L, 0L));
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 0).getToken())
+        assertThat(r.getSequencerView().query(streamA).getToken())
                 .isEqualTo(new Token(0L, 0L));
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamB), 1).getToken())
+        assertThat(r.getSequencerView().next(streamB).getToken())
                 .isEqualTo(new Token(1L, 0L));
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamB), 0).getToken())
+        assertThat(r.getSequencerView().query(streamB).getToken())
                 .isEqualTo(new Token(1L, 0L));
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 0).getToken())
+        assertThat(r.getSequencerView().query(streamA).getToken())
                 .isEqualTo(new Token(0L, 0L));
     }
 
@@ -67,17 +83,17 @@ public class SequencerViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         UUID streamB = UUID.nameUUIDFromBytes("stream B".getBytes());
 
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 1).getBackpointerMap())
+        assertThat(r.getSequencerView().next(streamA).getBackpointerMap())
                 .containsEntry(streamA, Address.NON_EXIST);
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 0).getBackpointerMap())
+        assertThat(r.getSequencerView().query(streamA).getBackpointerMap())
                 .isEmpty();
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamB), 1).getBackpointerMap())
+        assertThat(r.getSequencerView().next(streamB).getBackpointerMap())
                 .containsEntry(streamB, Address.NON_EXIST);
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamB), 0).getBackpointerMap())
+        assertThat(r.getSequencerView().query(streamB).getBackpointerMap())
                 .isEmpty();
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamA), 1).getBackpointerMap())
+        assertThat(r.getSequencerView().next(streamA).getBackpointerMap())
                 .containsEntry(streamA, 0L);
-        assertThat(r.getSequencerView().nextToken(Collections.singleton(streamB), 1).getBackpointerMap())
+        assertThat(r.getSequencerView().next(streamB).getBackpointerMap())
                 .containsEntry(streamB, 1L);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -9,7 +9,6 @@ import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -309,7 +308,7 @@ public class StreamViewTest extends AbstractViewTest {
         byte[] testPayload = "hello world".getBytes();
 
         // Generate a hole.
-        r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
+        r.getSequencerView().next(streamA);
 
         // Write to the stream, and read back. The hole should be filled.
         IStreamView sv = r.getStreamsView().get(streamA);
@@ -337,14 +336,14 @@ public class StreamViewTest extends AbstractViewTest {
 
         //generate a stream hole
         TokenResponse tr =
-                r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
+                r.getSequencerView().next(streamA);
 
         // read from an address that hasn't been written to
         // causing a hole fill
         r.getAddressSpaceView().read(tr.getToken().getTokenValue());
 
 
-        tr = r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
+        tr = r.getSequencerView().next(streamA);
 
         // read from an address that hasn't been written to
         // causing a hole fill

--- a/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
@@ -156,12 +156,12 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
 
         //generate a stream hole
         TokenResponse tr =
-                r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
+                r.getSequencerView().next(streamA);
 
         IStreamView sv = r.getStreamsView().get(streamA);
         sv.append(testPayload);
 
-        tr = r.getSequencerView().nextToken(Collections.singleton(streamA), 1);
+        tr = r.getSequencerView().next(streamA);
 
         //make sure we can still read the stream.
         assertThat(sv.next().getPayload(getRuntime()))

--- a/test/src/test/java/org/corfudb/runtime/view/stream/BackpointerStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/BackpointerStreamViewTest.java
@@ -111,7 +111,6 @@ public class BackpointerStreamViewTest extends AbstractViewTest {
     public void moreReadQueueTest() {
         CorfuRuntime runtime = getDefaultRuntime();
         IStreamView sv = runtime.getStreamsView().get(CorfuRuntime.getStreamID("streamA"));
-        final int ten = 10;
 
         // initially, populate the stream with appends
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {


### PR DESCRIPTION
## Overview

Enbales the sequencer to query the tails of multiple streams in
one call.

Why should this be merged: Fixes the stream query API  and will be used by #1278 and #1277

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
