### PR TITLE
Remove Extra LU Thread Pool

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -77,11 +77,6 @@ public class LogUnitServer extends AbstractServer {
                             .setNameFormat("LogUnit-Maintenance-%d")
                             .build());
 
-    ThreadFactory threadFactory = new ServerThreadFactory("Logunit-",
-            new ServerThreadFactory.ExceptionHandler());
-
-    ExecutorService executor = Executors.newFixedThreadPool(BatchWriter.BATCH_SIZE, threadFactory);
-
     private ScheduledFuture<?> compactor;
 
     /**
@@ -329,20 +324,15 @@ public class LogUnitServer extends AbstractServer {
         streamLog.release(address, (LogData) entry);
     }
 
-    @Override
-    public ExecutorService getExecutor() {
-        return executor;
-    }
-
     /**
      * Shutdown the server.
      */
     @Override
     public void shutdown() {
+        super.shutdown();
         compactor.cancel(true);
         scheduler.shutdownNow();
         batchWriter.close();
-        executor.shutdownNow();
     }
 
     @VisibleForTesting


### PR DESCRIPTION
## Overview
The shared pool size accounts for the logunit(LU) batch size, the LU
doesn't need a separate thread pool.

Why should this be merged: The LU thread pool was incorrectly cherry-picked from another PR, I didn't intend to have a separate thread pool for the LU in #1281



## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
