### PR TITLE
Adding JVM and troubleshooting metrics

### DIFF
--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -50,6 +50,11 @@
             <version>3.1.0</version>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-logback</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.classic.version}</version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -98,6 +98,11 @@
             <artifactId>metrics-jvm</artifactId>
             <version>3.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-logback</artifactId>
+            <version>3.1.0</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
## Overview

Description:
Adding the ability to collect and report JVM and troubleshooting metrics. These metrics include: gc, memory, thread, and logger stats.
The collection and reporting is disabled by default.

Why should this be merged: 
By passing the corresponding flags, JVM metrics including gc, memory, thread, and logger stats will be included in collected and reported metrics.

Related issue(s) (if applicable): #1300 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
