### PR TITLE
Simplifying adding metrics context to handlers on CorfuMsgHandler

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -70,9 +70,12 @@ public class LogUnitClient extends AbstractClient {
     }
 
     private Timer.Context getTimerContext(String opName) {
-        Timer t = getMetricRegistry().timer(
-                CorfuComponent.LUC.toString()
-                        + getHost() + ":" + getPort().toString() + "-" + opName);
+        final String timerName = String.format("%s%s:%s-%s",
+                CorfuComponent.LOG_UNIT_CLIENT.toString(),
+                getHost(),
+                getPort().toString(),
+                opName);
+        Timer t = getMetricRegistry().timer(timerName);
         return t.time();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -463,7 +463,8 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
     private Timer getTimer(@NonNull CorfuMsg message) {
         if (!timerNameCache.containsKey(message.getMsgType())) {
             timerNameCache.put(message.getMsgType(),
-                    CorfuComponent.CR.toString() + message.getMsgType().name().toLowerCase());
+                               CorfuComponent.CLIENT_ROUTER.toString() +
+                               message.getMsgType().name().toLowerCase());
         }
 
         return CorfuRuntime.getDefaultMetrics()

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -149,7 +149,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 undoTargetMap, resetSet);
 
         metrics = rt.getMetrics() != null ? rt.getMetrics() : CorfuRuntime.getDefaultMetrics();
-        mpObj = CorfuComponent.OBJ.toString();
+        mpObj = CorfuComponent.OBJECT.toString();
         timerAccess = metrics.timer(mpObj + "access");
         timerLogWrite = metrics.timer(mpObj + "log-write");
         timerTxn = metrics.timer(mpObj + "txn");

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -67,7 +67,7 @@ public class AddressSpaceView extends AbstractView {
     public AddressSpaceView(@Nonnull final CorfuRuntime runtime) {
         super(runtime);
         MetricRegistry metrics = runtime.getMetrics();
-        final String pfx = String.format("%s0x%x.cache.", CorfuComponent.ASV.toString(),
+        final String pfx = String.format("%s0x%x.cache.", CorfuComponent.ADDRESS_SPACE_VIEW.toString(),
                                          this.hashCode());
         metrics.register(pfx + "cache-size", (Gauge<Long>) readCache::estimatedSize);
         metrics.register(pfx + "evictions", (Gauge<Long>) () -> readCache.stats().evictionCount());

--- a/runtime/src/main/java/org/corfudb/util/CorfuComponent.java
+++ b/runtime/src/main/java/org/corfudb/util/CorfuComponent.java
@@ -7,10 +7,14 @@ package org.corfudb.util;
  * Created by Sam Behnam on 5/8/18.
  */
 public enum CorfuComponent {
-    ASV("corfu.runtime.as-view."),
-    LUC("corfu.runtime.log-unit-client."),
-    CR("corfu.runtime.client-router."),
-    OBJ("corfu.runtime.object.");
+    // Runtime components
+    ADDRESS_SPACE_VIEW("corfu.runtime.as-view."),
+    CLIENT_ROUTER("corfu.runtime.client-router."),
+    LOG_UNIT_CLIENT("corfu.runtime.log-unit-client."),
+    OBJECT("corfu.runtime.object."),
+
+    // Infrastructure components
+    INFRA_MSG_HANDLER("corfu.infrastructure.message-handler.");
 
     CorfuComponent(String value) {
         this.value = value;

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -238,7 +238,8 @@ public class TestClientRouter implements IClientRouter {
     private Timer getTimer(@NonNull CorfuMsg message) {
         if (!timerNameCache.containsKey(message.getMsgType())) {
             timerNameCache.put(message.getMsgType(),
-                    CorfuComponent.CR.toString() + message.getMsgType().name().toLowerCase());
+                               CorfuComponent.CLIENT_ROUTER.toString() +
+                               message.getMsgType().name().toLowerCase());
         }
         return CorfuRuntime.getDefaultMetrics()
                 .timer(timerNameCache.get(message.getMsgType()));


### PR DESCRIPTION
## Overview

Description:
This PR modifies the code on CorfuMsgHandler in order to simplify the logic for adding metrics context so that checking the configuration (for metrics being enabled) is delegated to MetricsUtil rather than being done in CorfuMsgHandler. Also the metrics name for timers are been reused in case they have already been created.

Why should this be merged: 
-Simplifying the unnecessary complexity of evaluating metrics configuration on the the handler side.

Related issue(s) (if applicable): #1311 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
