### PR TITLE
Chain min replication factor set to 1.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -329,8 +329,8 @@ public class Layout {
             }
 
             @Override
-            public int getMinReplicationFactor(Layout layout) {
-                return 2;
+            public int getMinReplicationFactor(Layout layout, LayoutStripe stripe) {
+                return 1;
             }
 
             @Override
@@ -366,8 +366,8 @@ public class Layout {
             }
 
             @Override
-            public int getMinReplicationFactor(Layout layout) {
-                return (layout.getLayoutServers().size() / 2) + 1;
+            public int getMinReplicationFactor(Layout layout, LayoutStripe stripe) {
+                return (stripe.getLogServers().size() / 2) + 1;
             }
 
             @Override
@@ -421,7 +421,7 @@ public class Layout {
             }
 
             @Override
-            public int getMinReplicationFactor(Layout layout) {
+            public int getMinReplicationFactor(Layout layout, LayoutStripe stripe) {
                 return 1;
             }
 
@@ -447,12 +447,14 @@ public class Layout {
                 throws QuorumUnreachableException;
 
         /**
-         * Compute the min replication factor for replication protocol
+         * Compute the min replication factor for the log unit servers in the replication protocol
+         * for a specific stripe.
          *
-         * @param layout the layout to compute the min replication factor for
+         * @param layout the layout to compute the min replication factor for.
+         * @param stripe The stripe for which the minimum replication factor is needed.
          * @return the minimum amount of nodes required to maintain replication
          */
-        public abstract int getMinReplicationFactor(Layout layout);
+        public abstract int getMinReplicationFactor(Layout layout, LayoutStripe stripe);
 
         public abstract IStreamView getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options);
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutBuilder.java
@@ -390,7 +390,7 @@ public class LayoutBuilder {
         for (LayoutSegment layoutSegment : layoutSegments) {
             for (LayoutStripe layoutStripe : layoutSegment.getStripes()) {
                 int minReplicationFactor = layoutSegment.getReplicationMode()
-                        .getMinReplicationFactor(tempLayout);
+                        .getMinReplicationFactor(tempLayout, layoutStripe);
                 removeFromStripe(endpoint, layoutStripe, minReplicationFactor);
             }
         }
@@ -413,7 +413,7 @@ public class LayoutBuilder {
             for (LayoutStripe layoutStripe : layoutSegment.getStripes()) {
                 for (String endpoint : endpoints) {
                     int minReplicationFactor = layoutSegment.getReplicationMode()
-                            .getMinReplicationFactor(tempLayout);
+                            .getMinReplicationFactor(tempLayout, layoutStripe);
                     removeFromStripe(endpoint, layoutStripe, minReplicationFactor);
                 }
             }

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutBuilderTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutBuilderTest.java
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.runtime.exceptions.LayoutModificationException;
 import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.Layout.ReplicationMode;
 import org.corfudb.runtime.view.LayoutBuilder;
 import org.junit.Test;
 
@@ -42,6 +43,7 @@ public class LayoutBuilderTest extends AbstractCorfuTest {
                 .addSequencer(SERVERS.PORT_1)
                 .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
+                .setReplicationMode(ReplicationMode.QUORUM_REPLICATION)
                 .buildStripe()
                 .addLogUnit(SERVERS.PORT_0)
                 .addLogUnit(SERVERS.PORT_2)
@@ -111,6 +113,7 @@ public class LayoutBuilderTest extends AbstractCorfuTest {
                 .addSequencer(SERVERS.PORT_1)
                 .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
+                .setReplicationMode(ReplicationMode.QUORUM_REPLICATION)
                 .buildStripe()
                 .addLogUnit(SERVERS.PORT_2)
                 .addLogUnit(SERVERS.PORT_3)
@@ -143,6 +146,7 @@ public class LayoutBuilderTest extends AbstractCorfuTest {
                 .addLayoutServer(SERVERS.PORT_3)
                 .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
+                .setReplicationMode(ReplicationMode.QUORUM_REPLICATION)
                 .buildStripe()
                 .addLogUnit(SERVERS.PORT_2)
                 .addLogUnit(SERVERS.PORT_3)

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutManagementViewTest.java
@@ -5,6 +5,7 @@ import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.LayoutModificationException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.runtime.view.Layout.ReplicationMode;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +36,7 @@ public class LayoutManagementViewTest extends AbstractViewTest{
                 .addSequencer(SERVERS.PORT_1)
                 .addSequencer(SERVERS.PORT_2)
                 .buildSegment()
+                .setReplicationMode(ReplicationMode.QUORUM_REPLICATION)
                 .buildStripe()
                 .addLogUnit(SERVERS.PORT_0)
                 .addLogUnit(SERVERS.PORT_1)


### PR DESCRIPTION
## Overview
Description: Change the min replication factor for Chain replication to 1.
Also corrects the Quorum replication min factor to calculate the quorum based on log servers in each stripe.

Why should this be merged: Resolves liveness issue caused by #1325

Related issue(s) (if applicable): Resolves #1325 and #1322 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
