### PR TITLE
Using named generic instead of wildcard generic of Comparable for IndexRegistry

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -161,7 +161,7 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
 
         CorfuTable.IndexRegistry<?, ?> EMPTY = new CorfuTable.IndexRegistry<Object, Object>() {
             @Override
-            public Optional<CorfuTable.Index<Object, Object, ? extends Comparable<?>>> get(CorfuTable.IndexName name) {
+            public <I extends Comparable<?>> Optional<CorfuTable.Index<Object, Object, I>> get(CorfuTable.IndexName name) {
                 return Optional.empty();
             }
 
@@ -177,7 +177,7 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
          * @param name name of the {@code IndexKey} previously registered.
          * @return the instance of {@link CorfuTable.IndexFunction} registered to the lookup name.
          */
-        Optional<CorfuTable.Index<K, V, ? extends Comparable<?>>> get(CorfuTable.IndexName name);
+        <I extends Comparable<?>> Optional<CorfuTable.Index<K, V, I>> get(CorfuTable.IndexName name);
 
         /**
          * Obtain a static {@link CorfuTable.IndexRegistry} with no registered {@link CorfuTable.IndexFunction}s.


### PR DESCRIPTION
## Overview

Description:
Using named generic instead of wildcard generic of Comparable in IndexRegistry to address casting issues on the client side.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
