### PR TITLE
Added Cache Options Per Write

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/CacheOption.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/CacheOption.java
@@ -1,0 +1,19 @@
+package org.corfudb.runtime.view;
+
+/**
+ *
+ * Cache options for write operations.
+ *
+ * Created by Maithem on 6/19/18.
+ */
+public enum CacheOption {
+    /**
+     * Issue a write without caching the result
+     */
+    WRITE_AROUND,
+    /**
+     * Issue a write and cache the result if the write
+     * succeeds
+     */
+    WRITE_THROUGH
+}


### PR DESCRIPTION
Description:
Now appends can specify a caching option per append. Also, changed
the CheckpointWriter to no cache checkpoint entries.

Why should this be merged: This helps relieve memory pressure.

Related issue(s) (if applicable): #1329

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
