### PR TITLE
Copy layout on daatastore access

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -82,7 +82,7 @@ public class LayoutServer extends AbstractServer {
         this.serverContext = serverContext;
 
         if (serverContext.installSingleNodeLayoutIfAbsent()) {
-            setLayoutInHistory(serverContext.getCurrentLayout());
+            setLayoutInHistory(getCurrentLayout());
         }
     }
 
@@ -341,7 +341,12 @@ public class LayoutServer extends AbstractServer {
 
 
     public Layout getCurrentLayout() {
-        return serverContext.getCurrentLayout();
+        Layout layout = serverContext.getCurrentLayout();
+        if (layout != null) {
+            return new Layout(layout);
+        } else {
+            return null;
+        }
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -100,10 +100,10 @@ public class ManagementServer extends AbstractServer {
         final CorfuRuntime.CorfuRuntimeParameters params =
                 serverContext.getDefaultRuntimeParameters();
         final CorfuRuntime runtime = CorfuRuntime.fromParameters(params);
+        final Layout managementLayout = serverContext.copyManagementLayout();
         // Runtime can be set up either using the layout or the bootstrapEndpoint address.
-        if (serverContext.getManagementLayout() != null) {
-            serverContext.getManagementLayout().getLayoutServers()
-                    .forEach(runtime::addLayoutServer);
+        if (managementLayout != null) {
+            managementLayout.getLayoutServers().forEach(runtime::addLayoutServer);
         } else {
             runtime.addLayoutServer(getBootstrapEndpoint());
         }
@@ -189,7 +189,7 @@ public class ManagementServer extends AbstractServer {
         log.info("handleFailureDetectedMsg: Received DetectorMsg : {}", msg.getPayload());
 
         DetectorMsg detectorMsg = msg.getPayload();
-        Layout layout = new Layout(serverContext.getManagementLayout());
+        Layout layout = serverContext.copyManagementLayout();
 
         // If this message is stamped with an older epoch which indicates the polling was
         // conducted in an old epoch. This message cannot be considered and is discarded.
@@ -236,7 +236,7 @@ public class ManagementServer extends AbstractServer {
         log.info("handleHealingDetectedMsg: Received DetectorMsg : {}", msg.getPayload());
 
         DetectorMsg detectorMsg = msg.getPayload();
-        Layout layout = new Layout(serverContext.getManagementLayout());
+        Layout layout = serverContext.copyManagementLayout();
 
         // If this message is stamped with an older epoch which indicates the polling was
         // conducted in an old epoch. This message cannot be considered and is discarded.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -424,8 +424,22 @@ public class ServerContext implements AutoCloseable {
      *
      * @return The last persisted layout
      */
-    public synchronized Layout getManagementLayout() {
+    public Layout getManagementLayout() {
         return dataStore.get(Layout.class, PREFIX_MANAGEMENT, MANAGEMENT_LAYOUT);
+    }
+
+    /**
+     * Fetches and creates a copy of the Management Layout from the local datastore.
+     *
+     * @return Copy of the management layout from the datastore.
+     */
+    public Layout copyManagementLayout() {
+        Layout l = getManagementLayout();
+        if (l != null) {
+            return new Layout(l);
+        } else {
+            return null;
+        }
     }
 
     /** Get a new "boss" group, which services (accepts) incoming connections.


### PR DESCRIPTION
## Overview

Description: The local datastore passes references of objects on `get()`. A lot of code paths assume that the object fetched from the datastore is a copy and make modifications to it. This now causes inconsistencies in the object itself.

Why should this be merged: To maintain consistency a copy of the layout needs to be propagated rather than the reference.
This bug was caught by an intermittently failing test: `removeSingleNodeFailure`

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
