### PR TITLE
Expose the node and cluster status.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/ClusterStatusReport.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ClusterStatusReport.java
@@ -17,17 +17,37 @@ public class ClusterStatusReport {
     /**
      * Connectivity to the node.
      */
-    enum NodeStatus {
+    public enum NodeStatus {
+
+        /**
+         * Node is reachable.
+         */
         UP,
+
+        /**
+         * Node is not reachable.
+         */
         DOWN
     }
 
     /**
      * Health of the cluster.
      */
-    enum ClusterStatus {
+    public enum ClusterStatus {
+
+        /**
+         * The cluster is stable and all nodes are operational.
+         */
         STABLE(0),
+
+        /**
+         * The cluster is operational but working with reduced redundancy.
+         */
         DEGRADED(1),
+
+        /**
+         * The cluster is not operational.
+         */
         UNAVAILABLE(2);
 
         @Getter


### PR DESCRIPTION
## Overview

Description: Change the access modifiers for  Node and Cluster status enums to public.

Why should this be merged: Status not accessible by clients.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
