### PR TITLE
Seal before reset of healing node.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -11,16 +11,17 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.corfudb.infrastructure.BatchWriterOperation.Type;
 import org.corfudb.infrastructure.log.StreamLog;
 import org.corfudb.protocols.wireprotocol.LogData;
-import org.corfudb.runtime.exceptions.DataOutrankedException;
-import org.corfudb.runtime.exceptions.OverwriteException;
-import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 
 /**
  * BatchWriter is a class that will intercept write-through calls to batch and
@@ -39,11 +40,22 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                     .build());
 
     /**
+     * The epochWaterMark is the epoch up to which all operations have been sealed. Any
+     * BatchWriterOperation arriving after the epochWaterMark with an epoch less than the epochWaterMark, is
+     * completed exceptionally with a WrongEpochException.
+     * This is persisted in the ServerContext by the LogUnitServer to withstand restarts.
+     */
+    private volatile long epochWaterMark;
+
+    /**
      * Returns a new BatchWriter for a stream log.
      *
-     * @param streamLog stream log for writes (can be in memory or file)
+     * @param streamLog      stream log for writes (can be in memory or file)
+     * @param epochWaterMark All operations stamped with epoch less than the epochWaterMark are
+     *                       discarded.
      */
-    public BatchWriter(StreamLog streamLog) {
+    public BatchWriter(StreamLog streamLog, long epochWaterMark) {
+        this.epochWaterMark = epochWaterMark;
         this.streamLog = streamLog;
         operationsQueue = new LinkedBlockingQueue<>();
         writerService.submit(this::batchWriteProcessor);
@@ -54,7 +66,7 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
         try {
             CompletableFuture<Void> cf = new CompletableFuture();
             operationsQueue.add(new BatchWriterOperation(BatchWriterOperation.Type.WRITE,
-                    (Long) key, (LogData) value, null, cf));
+                    (Long) key, (LogData) value, ((LogData) value).getEpoch(), null, cf));
             cf.get();
         } catch (Exception e) {
             log.trace("Write Exception {}", e);
@@ -66,11 +78,11 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
         }
     }
 
-    public void bulkWrite(List<LogData> entries) {
+    public void bulkWrite(List<LogData> entries, long epoch) {
         try {
             CompletableFuture<Void> cf = new CompletableFuture();
             operationsQueue.add(new BatchWriterOperation(BatchWriterOperation.Type.RANGE_WRITE,
-                    null, null, entries, cf));
+                    null, null, epoch, entries, cf));
         } catch (Exception e) {
             log.trace("Write Exception {}", e);
             if (e.getCause() instanceof RuntimeException) {
@@ -85,12 +97,13 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
      * Trim an address from the log.
      *
      * @param address log address to trim
+     * @param epoch   Epoch at which the trim operation is received.
      */
-    public void trim(@Nonnull long address) {
+    public void trim(@Nonnull long address, @Nonnull long epoch) {
         try {
             CompletableFuture<Void> cf = new CompletableFuture();
             operationsQueue.add(new BatchWriterOperation(BatchWriterOperation.Type.TRIM,
-                    address, null, null, cf));
+                    address, null, epoch, null, cf));
             cf.get();
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -101,12 +114,49 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
      * Trim addresses from log up to a prefix.
      *
      * @param address prefix address to trim to (inclusive)
+     * @param epoch   Epoch at which the prefixTrim operation is received.
      */
-    public void prefixTrim(@Nonnull long address) {
+    public void prefixTrim(@Nonnull long address, @Nonnull long epoch) {
         try {
             CompletableFuture<Void> cf = new CompletableFuture();
             operationsQueue.add(new BatchWriterOperation(BatchWriterOperation.Type.PREFIX_TRIM,
-                    address, null, null, cf));
+                    address, null, epoch, null, cf));
+            cf.get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Insert epochWaterMark in queue and wait for queue to process all preceding operations.
+     * All operations in the queue after the epochWaterMark operation, that have epoch less than
+     * the epochWaterMark epoch are discarded and their futures are completed exceptionally with a
+     * WrongEpochException. The epochWaterMark is used in case of:
+     * Reset - All operations need to be flushed before a reset and no new operations for the
+     * previous epoch should be accepted.
+     * SealAndFlush - Similarly on a seal, all operations need to be flushed before a seal and no
+     * new operations for the previous epoch should be accepted.
+     *
+     * @param epoch Epoch to epochWaterMark with.
+     */
+    public void waitForEpochWaterMark(@Nonnull long epoch) {
+        try {
+            CompletableFuture<Void> cf = new CompletableFuture<>();
+            epochWaterMark = epoch;
+            operationsQueue.add(new BatchWriterOperation(Type.EPOCH_WATER_MARK, null, null, epoch, null, cf));
+            cf.get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Reset the log unit node.
+     */
+    public void reset(@Nonnull long epoch) {
+        try {
+            CompletableFuture<Void> cf = new CompletableFuture<>();
+            operationsQueue.add(new BatchWriterOperation(Type.RESET, null, null, epoch, null, cf));
             cf.get();
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -159,6 +209,11 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                     log.trace("Shutting down the write processor");
                     streamLog.sync(true);
                     break;
+                } else if (currOp.getEpoch() < epochWaterMark) {
+                    currOp.setException(new WrongEpochException(epochWaterMark));
+                    res.add(currOp);
+                    processed++;
+                    lastOp = currOp;
                 } else {
                     try {
                         switch (currOp.getType()) {
@@ -176,6 +231,13 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                                 break;
                             case RANGE_WRITE:
                                 streamLog.append(currOp.getEntries());
+                                res.add(currOp);
+                                break;
+                            case EPOCH_WATER_MARK:
+                                res.add(currOp);
+                                break;
+                            case RESET:
+                                streamLog.reset();
                                 res.add(currOp);
                                 break;
                             default:
@@ -199,6 +261,12 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
     public void close() {
         operationsQueue.add(BatchWriterOperation.SHUTDOWN);
         writerService.shutdown();
+        try {
+            writerService.awaitTermination(ServerContext.SHUTDOWN_TIMER.toMillis(),
+                    TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            throw new UnrecoverableCorfuInterruptedError("BatchWriter close interrupted.", e);
+        }
     }
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
@@ -18,17 +18,20 @@ public class BatchWriterOperation {
         WRITE,
         RANGE_WRITE,
         TRIM,
-        PREFIX_TRIM
+        PREFIX_TRIM,
+        EPOCH_WATER_MARK,
+        RESET
     }
 
     private final Type type;
     private final Long address;
     private final LogData logData;
+    private final Long epoch;
     private final List<LogData> entries;
     private final CompletableFuture future;
     private Exception exception;
 
 
     public static BatchWriterOperation SHUTDOWN = new BatchWriterOperation(Type.SHUTDOWN,
-            null, null, null, null);
+            null, null, null, null, null);
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -69,6 +69,10 @@ public class ServerContext implements AutoCloseable {
     private static final String PREFIX_MANAGEMENT = "MANAGEMENT";
     private static final String MANAGEMENT_LAYOUT = "LAYOUT";
 
+    // LogUnit Server
+    private static final String PREFIX_LOGUNIT = "LOGUNIT";
+    private static final String EPOCH_WATER_MARK = "EPOCH_WATER_MARK";
+
     /** The node Id, stored as a base64 string. */
     public static final String NODE_ID = "NODE_ID";
 
@@ -421,6 +425,25 @@ public class ServerContext implements AutoCloseable {
      */
     public Layout getManagementLayout() {
         return dataStore.get(Layout.class, PREFIX_MANAGEMENT, MANAGEMENT_LAYOUT);
+    }
+
+    /**
+     * Sets the log unit epoch water mark.
+     *
+     * @param resetEpoch Epoch at which the reset command was received.
+     */
+    public synchronized void setLogUnitEpochWaterMark(long resetEpoch) {
+        dataStore.put(Long.class, PREFIX_LOGUNIT, EPOCH_WATER_MARK, resetEpoch);
+    }
+
+    /**
+     * Fetches the epoch at which the last epochWaterMark operation was received.
+     *
+     * @return Reset epoch.
+     */
+    public synchronized long getLogUnitEpochWaterMark() {
+        Long resetEpoch = dataStore.get(Long.class, PREFIX_LOGUNIT, EPOCH_WATER_MARK);
+        return resetEpoch == null ? Layout.INVALID_EPOCH : resetEpoch;
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
@@ -42,33 +42,10 @@ public class HealNodeWorkflow extends AddNodeWorkflow {
 
     @Override
     public List<Action> getActions() {
-        return Arrays.asList(new ResetNode(),
+        return Arrays.asList(
                 new HealNodeToLayout(),
                 new RestoreRedundancyAndMergeSegments());
     }
-
-    /**
-     * Resets the node's data.
-     */
-    class ResetNode extends Action {
-        @Override
-        public String getName() {
-            return "ResetNode";
-        }
-
-        @Override
-        public void impl(@Nonnull CorfuRuntime runtime) throws Exception {
-            runtime.invalidateLayout();
-            Layout layout = new Layout(runtime.getLayoutView().getLayout());
-            if (layout.getUnresponsiveServers().contains(request.getEndpoint())) {
-                runtime.getLayoutView().getRuntimeLayout(layout)
-                        .getLogUnitClient(request.getEndpoint())
-                        .resetLogUnit()
-                        .get();
-            }
-        }
-    }
-
 
     /**
      * This action adds a new node to the layout. If it is also

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -68,7 +68,7 @@ public enum CorfuMsgType {
     FLUSH_CACHE(44, TypeToken.of(CorfuMsg.class), true),
     TRIM_MARK_REQUEST(45, TypeToken.of(CorfuMsg.class), true),
     TRIM_MARK_RESPONSE(46, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
-    RESET_LOGUNIT(47, TypeToken.of(CorfuMsg.class)),
+    RESET_LOGUNIT(47, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
 
     WRITE_OK(50, TypeToken.of(CorfuMsg.class)),
     ERROR_TRIMMED(51, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -22,6 +22,7 @@ import lombok.Value;
 
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.Layout;
 
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_ID;
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_START_LOG_ADDRESS;
@@ -101,6 +102,10 @@ public interface IMetadata {
         getMetadataMap().put(LogUnitMetadataType.GLOBAL_ADDRESS, address);
     }
 
+    default void setEpoch(Long epoch) {
+        getMetadataMap().put(LogUnitMetadataType.EPOCH, epoch);
+    }
+
     default void setClientId(UUID clientId) {getMetadataMap().put(LogUnitMetadataType.CLIENT_ID, clientId); }
 
     @SuppressWarnings("unchecked")
@@ -132,6 +137,20 @@ public interface IMetadata {
         }
         return Optional.ofNullable((Long) getMetadataMap()
                 .get(LogUnitMetadataType.GLOBAL_ADDRESS)).orElse((long) -1);
+    }
+
+    /**
+     * Get Log's epoch.
+     *
+     * @return epoch.
+     */
+    default Long getEpoch() {
+        if (getMetadataMap() == null
+                || getMetadataMap().get(LogUnitMetadataType.EPOCH) == null) {
+            return Layout.INVALID_EPOCH;
+        }
+        return Optional.ofNullable((Long) getMetadataMap()
+                .get(LogUnitMetadataType.EPOCH)).orElse(Layout.INVALID_EPOCH);
     }
 
     default void clearCommit() {
@@ -205,7 +224,8 @@ public interface IMetadata {
         CHECKPOINTED_STREAM_ID(8, TypeToken.of(UUID.class)),
         CHECKPOINTED_STREAM_START_LOG_ADDRESS(9, TypeToken.of(Long.class)),
         CLIENT_ID(10, TypeToken.of(UUID.class)),
-        THREAD_ID(11, TypeToken.of(Long.class))
+        THREAD_ID(11, TypeToken.of(Long.class)),
+        EPOCH(12, TypeToken.of(Long.class))
         ;
         final int type;
         @Getter
@@ -247,5 +267,5 @@ public interface IMetadata {
         }
     }
 
-    
+
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -320,7 +320,7 @@ public class LogUnitClient extends AbstractClient {
     /**
      * Send a reset request.
      */
-    public CompletableFuture<Boolean> resetLogUnit() {
-        return sendMessageWithFuture(CorfuMsgType.RESET_LOGUNIT.msg());
+    public CompletableFuture<Boolean> resetLogUnit(long epoch) {
+        return sendMessageWithFuture(CorfuMsgType.RESET_LOGUNIT.payloadMsg(epoch));
     }
 }

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -30,6 +30,7 @@ import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Sleep;
 import org.junit.Before;
@@ -598,5 +599,156 @@ public class ClusterReconfigIT extends AbstractIT {
 
         // Wait for the systemDownHandler to be invoked.
         semaphore.tryAcquire(PARAMETERS.TIMEOUT_LONG.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Ensure that multiple resets on the same epoch reset the log unit server only once.
+     * Consider 3 nodes 9000, 9001 and 9002.
+     * Kill node 9002 and recover it so that the heal node workflow is triggered, the node is
+     * reset and added back to the chain.
+     * We then perform a write on addresses 6-10.
+     * Now we attempt to reset the node 9002 again on the same epoch and assert that the write
+     * performed on address 1 is not erased by the new reset.
+     */
+    @Test
+    public void preventMultipleResets() throws Exception {
+        // Set up cluster of 3 nodes.
+        final int PORT_0 = 9000;
+        final int PORT_1 = 9001;
+        final int PORT_2 = 9002;
+        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
+        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        final Layout layout = get3NodeLayout();
+
+        final int retries = 3;
+        BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
+
+        CorfuRuntime runtime = createDefaultRuntime();
+        UUID streamId = CorfuRuntime.getStreamID("testStream");
+        IStreamView stream = runtime.getStreamsView().get(streamId);
+        int counter = 0;
+
+        // Shutdown server 3.
+        shutdownCorfuServer(corfuServer_3);
+        waitForEpochChange(refreshedEpoch -> refreshedEpoch > layout.getEpoch(), runtime);
+        final Layout layoutAfterFailure = runtime.getLayoutView().getLayout();
+
+        final int appendNum = 5;
+        // Write at address 1-5.
+        for (int i = 0; i < appendNum; i++) {
+            stream.append(Integer.toString(counter++).getBytes());
+        }
+
+        // Restart server 3 and wait for heal node workflow to modify the layout.
+        corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        waitForEpochChange(refreshedEpoch -> refreshedEpoch > layoutAfterFailure.getEpoch(), runtime);
+
+        // Write at address 6-10.
+        final long startAddress = 1L;
+        final long endAddress = 10L;
+        for (int i = 0; i < appendNum; i++) {
+            stream.append(Integer.toString(counter++).getBytes());
+        }
+
+        // Trigger a reset on the node.
+        runtime.getLayoutView().getRuntimeLayout(layoutAfterFailure)
+                .getLogUnitClient("localhost:9002")
+                .resetLogUnit(layoutAfterFailure.getEpoch()).get();
+
+        // Verify data
+        int verificationCounter = 0;
+        for (LogData logData : runtime.getLayoutView().getRuntimeLayout()
+                .getLogUnitClient("localhost:9002")
+                .read(Range.closed(startAddress, endAddress)).get()
+                .getAddresses().values()) {
+            assertThat(logData.getPayload(runtime))
+                    .isEqualTo(Integer.toString(verificationCounter++).getBytes());
+        }
+
+        shutdownCorfuServer(corfuServer_1);
+        shutdownCorfuServer(corfuServer_2);
+        shutdownCorfuServer(corfuServer_3);
+    }
+
+    /**
+     * Test that a node with a stale layout can recover.
+     * Consider a cluster of 3 nodes - 9000, 9001 and 9002.
+     * 9002 is first shutdown. This node is now stuck with the layout at epoch 0.
+     * Now 9000 is restarted, forcing an epoch increment.
+     * Next, 9002 is also restarted. The test then asserts that even though 9002 is lagging
+     * by a few epochs, it recovers and is added back to the chain.
+     */
+    @Test
+    public void healNodesWorkflowTest() throws Exception {
+        // Set up cluster of 3 nodes.
+        final int PORT_0 = 9000;
+        final int PORT_1 = 9001;
+        final int PORT_2 = 9002;
+        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
+        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        final int nodesCount = 3;
+        final Layout layout = get3NodeLayout();
+
+        final int retries = 3;
+        BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
+
+        CorfuRuntime runtime = createDefaultRuntime();
+        UUID streamId = CorfuRuntime.getStreamID("testStream");
+        IStreamView stream = runtime.getStreamsView().get(streamId);
+
+        shutdownCorfuServer(corfuServer_3);
+        waitForEpochChange(refreshedEpoch -> refreshedEpoch > layout.getEpoch(), runtime);
+        final Layout layoutAfterFailure1 = runtime.getLayoutView().getLayout();
+
+        shutdownCorfuServer(corfuServer_1);
+        corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        waitForEpochChange(refreshedEpoch -> refreshedEpoch > layoutAfterFailure1.getEpoch(), runtime);
+        final Layout layoutAfterHeal1 = runtime.getLayoutView().getLayout();
+        int counter = 0;
+
+        final int appendNum = 3;
+        final long startAddress = 1;
+        // Write at address 1-3.
+        for (int i = 0; i < appendNum; i++) {
+            stream.append(Integer.toString(counter++).getBytes());
+        }
+
+        corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        waitForEpochChange(refreshedEpoch -> refreshedEpoch > layoutAfterHeal1.getEpoch(), runtime);
+
+        // Write at address 4-6.
+        for (int i = 0; i < appendNum; i++) {
+            stream.append(Integer.toString(counter++).getBytes());
+        }
+        final long endAddress = 6;
+
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
+            Layout finalLayout = runtime.getLayoutView().getLayout();
+            if (finalLayout.getUnresponsiveServers().isEmpty()
+                    && finalLayout.getSegments().size() == 1
+                    && finalLayout.getSegments().get(0).getAllLogServers().size() == nodesCount) {
+                break;
+            }
+            runtime.invalidateLayout();
+            Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_VERY_SHORT);
+        }
+
+        assertThat(runtime.getLayoutView().getLayout().getUnresponsiveServers()).isEmpty();
+
+        // Verify data
+        int verificationCounter = 0;
+        for (LogData logData : runtime.getLayoutView().getRuntimeLayout()
+                .getLogUnitClient("localhost:9002")
+                .read(Range.closed(startAddress, endAddress)).get()
+                .getAddresses().values()) {
+            assertThat(logData.getPayload(runtime))
+                    .isEqualTo(Integer.toString(verificationCounter++).getBytes());
+        }
+
+        shutdownCorfuServer(corfuServer_1);
+        shutdownCorfuServer(corfuServer_2);
+        shutdownCorfuServer(corfuServer_3);
     }
 }


### PR DESCRIPTION
## Overview

Description: Reset the logunit node while `HealNodeWorkflow` after we have sealed. Also, make the reset epoch unaware to allow a stale node to recover. The reset epoch is persisted by the node to prevent multiple resets from wiping the data on the same epoch.

Why should this be merged: A node with a very old epoch can never heal as it fails on reset with a wrong epoch exception.

Related issue(s) (if applicable): Resolves #1340 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
