### PR TITLE
Change The Reporter Logger

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -98,11 +98,6 @@
             <artifactId>metrics-jvm</artifactId>
             <version>3.1.0</version>
         </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-logback</artifactId>
-            <version>3.1.0</version>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
## Overview
Replaced logback for the slf4j logger.

Why should this be merged: The consuming application should specify the logger backend. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
