### PR TITLE
Removing logback analyzer

### DIFF
--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -50,11 +50,6 @@
             <version>3.1.0</version>
         </dependency>
         <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-logback</artifactId>
-            <version>3.1.0</version>
-        </dependency>
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <version>${logback.classic.version}</version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -98,11 +98,6 @@
             <artifactId>metrics-jvm</artifactId>
             <version>3.1.0</version>
         </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-logback</artifactId>
-            <version>3.1.0</version>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
## Overview

Description:
Removing the logback statistic.

Why should this be merged: 
This removes the dependency on logback as it might be undesirable for some clients.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
