### PR TITLE
Create Actions once - HealNodeWorkflow

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
@@ -55,7 +55,7 @@ public class AddNodeWorkflow implements IWorkflow {
     final UUID id;
 
     @Getter
-    final List<Action> actions;
+    protected List<Action> actions;
 
     /**
      * Creates a new add node workflow from a request.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/HealNodeWorkflow.java
@@ -2,10 +2,9 @@ package org.corfudb.infrastructure.orchestrator.workflows;
 
 import static org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorRequestType.HEAL_NODE;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
@@ -33,18 +32,13 @@ public class HealNodeWorkflow extends AddNodeWorkflow {
     public HealNodeWorkflow(HealNodeRequest healNodeRequest) {
         super(new AddNodeRequest(healNodeRequest.getEndpoint()));
         this.request = healNodeRequest;
+        this.actions = ImmutableList.of(new HealNodeToLayout(),
+                new RestoreRedundancyAndMergeSegments());
     }
 
     @Override
     public String getName() {
         return HEAL_NODE.toString();
-    }
-
-    @Override
-    public List<Action> getActions() {
-        return Arrays.asList(
-                new HealNodeToLayout(),
-                new RestoreRedundancyAndMergeSegments());
     }
 
     /**


### PR DESCRIPTION
## Overview

Description: Avoid creating multiple actions on every`getActions` invocation.

Related issue(s) (if applicable): Resolves #1357 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
