### PR TITLE
Surface Timeout Exceptions

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Nonnull;
 
@@ -83,13 +84,14 @@ public class ManagementClient extends AbstractClient {
      * Send a add node request to an orchestrator
      * @param endpoint the endpoint to add to the cluster
      * @return create workflow response that contains the uuid of the workflow
+     * @throws TimeoutException when the rpc times out
      */
-    public CreateWorkflowResponse addNodeRequest(@Nonnull String endpoint) {
+    public CreateWorkflowResponse addNodeRequest(@Nonnull String endpoint) throws TimeoutException {
         OrchestratorMsg req = new OrchestratorMsg(new AddNodeRequest(endpoint));
         CompletableFuture<OrchestratorResponse> resp = sendMessageWithFuture(CorfuMsgType
                 .ORCHESTRATOR_REQUEST
                 .payloadMsg(req));
-        return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp).getResponse();
+        return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp, TimeoutException.class).getResponse();
     }
 
     /**
@@ -101,12 +103,13 @@ public class ManagementClient extends AbstractClient {
      * @param isLogUnitServer   True if the node to be healed is a logunit server.
      * @param stripeIndex       Stripe index of the node if it is a logunit server.
      * @return CreateWorkflowResponse which gives the workflowId.
+     * @throws TimeoutException when the rpc times out
      */
     public CreateWorkflowResponse healNodeRequest(@Nonnull String endpoint,
                                                   boolean isLayoutServer,
                                                   boolean isSequencerServer,
                                                   boolean isLogUnitServer,
-                                                  int stripeIndex) {
+                                                  int stripeIndex) throws TimeoutException {
         OrchestratorMsg req = new OrchestratorMsg(
                 new HealNodeRequest(endpoint,
                         isLayoutServer,
@@ -116,33 +119,35 @@ public class ManagementClient extends AbstractClient {
         CompletableFuture<OrchestratorResponse> resp = sendMessageWithFuture(CorfuMsgType
                 .ORCHESTRATOR_REQUEST
                 .payloadMsg(req));
-        return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp).getResponse();
+        return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp, TimeoutException.class).getResponse();
     }
 
     /**
      * Query the state of a workflow on a particular orchestrator.
      * @param workflowId the workflow to query
      * @return Query response that contains whether the workflow is running or not
+     * @throws TimeoutException when the rpc times out
      */
-    public QueryResponse queryRequest(@Nonnull UUID workflowId) {
+    public QueryResponse queryRequest(@Nonnull UUID workflowId) throws TimeoutException {
         OrchestratorMsg req = new OrchestratorMsg(new QueryRequest(workflowId));
         CompletableFuture<OrchestratorResponse> resp = sendMessageWithFuture(CorfuMsgType
                 .ORCHESTRATOR_REQUEST
                 .payloadMsg(req));
-        return (QueryResponse) CFUtils.getUninterruptibly(resp).getResponse();
+        return (QueryResponse) CFUtils.getUninterruptibly(resp, TimeoutException.class).getResponse();
     }
 
     /**
      * Return a workflow id for this remove operation request.
      * @param endpoint the endpoint to remove
      * @return uuid of the remove workflow
+     * @throws TimeoutException when the rpc times out
      */
-    public CreateWorkflowResponse removeNode(@Nonnull String endpoint) {
+    public CreateWorkflowResponse removeNode(@Nonnull String endpoint) throws TimeoutException {
         OrchestratorMsg req = new OrchestratorMsg(new RemoveNodeRequest(endpoint));
         CompletableFuture<OrchestratorResponse> resp = sendMessageWithFuture(CorfuMsgType
                 .ORCHESTRATOR_REQUEST
                 .payloadMsg(req));
-        return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp).getResponse();
+        return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp, TimeoutException.class).getResponse();
     }
 
     /**
@@ -151,12 +156,13 @@ public class ManagementClient extends AbstractClient {
      *
      * @param endpoint the endpoint to force remove
      * @return CreateWorkflowResponse
+     * @throws TimeoutException when the rpc times out
      */
-    public CreateWorkflowResponse forceRemoveNode(@Nonnull String endpoint) {
+    public CreateWorkflowResponse forceRemoveNode(@Nonnull String endpoint) throws TimeoutException {
         OrchestratorMsg req = new OrchestratorMsg(new ForceRemoveNodeRequest(endpoint));
         CompletableFuture<OrchestratorResponse> resp = sendMessageWithFuture(CorfuMsgType
                 .ORCHESTRATOR_REQUEST
                 .payloadMsg(req));
-        return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp).getResponse();
+        return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp, TimeoutException.class).getResponse();
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/AddNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/AddNode.java
@@ -8,6 +8,7 @@ import org.corfudb.runtime.view.Layout;
 import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.TimeoutException;
 
 /**
  *
@@ -30,7 +31,7 @@ public class AddNode extends WorkflowRequest {
     }
 
     @Override
-    protected UUID sendRequest(@Nonnull Layout layout) {
+    protected UUID sendRequest(@Nonnull Layout layout) throws TimeoutException {
         // Select the current tail node and send an add node request to the orchestrator
         CreateWorkflowResponse resp = getOrchestrator(layout).addNodeRequest(nodeForWorkflow);
         log.info("sendRequest: requested to add {} on orchestrator {}:{}, layout {}",

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/ForceRemoveNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/ForceRemoveNode.java
@@ -8,6 +8,7 @@ import org.corfudb.runtime.view.Layout;
 import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.TimeoutException;
 
 /**
  *
@@ -26,7 +27,7 @@ public class ForceRemoveNode extends RemoveNode {
     }
 
     @Override
-    protected UUID sendRequest(@Nonnull Layout layout) {
+    protected UUID sendRequest(@Nonnull Layout layout) throws TimeoutException {
         // Select the current tail node and send an add node request to the orchestrator
         CreateWorkflowResponse resp = getOrchestrator(layout).forceRemoveNode(nodeForWorkflow);
         log.info("sendRequest: requested to force remove {} on orchestrator {}:{}, layout {}",

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/HealNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/HealNode.java
@@ -8,6 +8,7 @@ import org.corfudb.runtime.view.Layout;
 import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.TimeoutException;
 
 
 @Slf4j
@@ -24,7 +25,7 @@ public class HealNode extends WorkflowRequest {
     }
 
     @Override
-    protected UUID sendRequest(Layout layout) {
+    protected UUID sendRequest(Layout layout) throws TimeoutException {
         CreateWorkflowResponse resp = getOrchestrator(layout).healNodeRequest(nodeForWorkflow,
                 true, true, true, 0);
         log.info("sendRequest: requested to heal {} on orchestrator {}:{}, layout {}",

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/RemoveNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/RemoveNode.java
@@ -8,6 +8,7 @@ import org.corfudb.runtime.view.Layout;
 import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.util.UUID;
+import java.util.concurrent.TimeoutException;
 
 /**
  * A workflow request that makes an orchestrator call to remove a node from
@@ -29,7 +30,7 @@ public class RemoveNode extends WorkflowRequest {
     }
 
     @Override
-    protected UUID sendRequest(@Nonnull Layout layout) {
+    protected UUID sendRequest(@Nonnull Layout layout) throws TimeoutException {
         // Send an remove node request to an orchestrator that is not on the node
         // to be removed
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
@@ -42,7 +42,7 @@ public abstract class WorkflowRequest {
      * @param layout current layout
      * @return a uuid that corresponds to the created workflow
      */
-    protected abstract UUID sendRequest(Layout layout);
+    protected abstract UUID sendRequest(Layout layout) throws TimeoutException;
 
     /**
      * Select an orchestrator and return a client. Orchestrator's that


### PR DESCRIPTION
## Overview
The client workflows were recasting TimeoutException to
RuntimeException as a result retries don't get triggered.

Why should this be merged: Makes workflow retries more robust. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
