### PR TITLE
Fixed Verify Order

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
@@ -116,20 +116,18 @@ public abstract class WorkflowRequest {
                 Layout requestLayout = new Layout(runtime.getLayoutView().getLayout());
                 UUID workflowId = sendRequest(requestLayout);
                 ManagementClient orchestrator = getOrchestrator(requestLayout);
-
                 waitForWorkflow(workflowId, orchestrator, timeout, pollPeriod);
-
-                for (int y = 0; y < runtime.getParameters().getInvalidateRetry(); y++) {
-                    runtime.invalidateLayout();
-                    Layout layoutToVerify = new Layout(runtime.getLayoutView().getLayout());
-                    if (verifyRequest(layoutToVerify)) {
-                        log.info("WorkflowRequest: Successfully completed {}", this);
-                        return;
-                    }
-                }
             } catch (NetworkException | TimeoutException e) {
-                log.warn("WorkflowRequest: Network error while running {} on attempt {}", this, x, e);
-                continue;
+                log.warn("WorkflowRequest: Error while running {} on attempt {}, cause {}", this, x, e);
+            }
+
+            for (int y = 0; y < runtime.getParameters().getInvalidateRetry(); y++) {
+                runtime.invalidateLayout();
+                Layout layoutToVerify = new Layout(runtime.getLayoutView().getLayout());
+                if (verifyRequest(layoutToVerify)) {
+                    log.info("WorkflowRequest: Successfully completed {}", this);
+                    return;
+                }
             }
             log.warn("WorkflowRequest: Retrying {} on attempt {}", this, x);
         }


### PR DESCRIPTION
Description:

After a Network/Timeout Exception, the runtime should veirfy
the result of the workflow before retrying.

Why should this be merged: After a timeout exception, the action might have completed, so verifying the result before retrying is more efficient. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
