### PR TITLE
Prevent Incorrect Nesting

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 
 /** A class which allows access to transactional contexts, which manage
  * transactions. The static methods of this class provide access to the
@@ -76,6 +77,10 @@ public class TransactionalContext {
      */
     public static AbstractTransactionalContext newContext(AbstractTransactionalContext context) {
         log.debug("TX begin[{}]", context);
+        AbstractTransactionalContext parent = getTransactionStack().peekFirst();
+        if (parent != null && parent.getBuilder().getRuntime() != context.getBuilder().getRuntime()) {
+            throw new UnrecoverableCorfuError("Can't nest transactions from different clients!");
+        }
         getTransactionStack().addFirst(context);
         return context;
     }

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -382,6 +382,8 @@ public class CheckpointSmokeTest extends AbstractViewTest {
                     m2.size(); // Just call any accessor
                 } catch (TransactionAbortedException tae) {
                     fail();
+                } finally {
+                    r.getObjectsView().TXEnd();
                 }
 
             } else {


### PR DESCRIPTION
## Overview
Prevent transactions from different runtimes to be nested.

Why should this be merged: If this condition is not prevented then transactional consistency can be broken.  

Related issue(s) (if applicable): #1366

## Checklist (Definition of Done):
- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
