### PR TITLE
RPC Failure On Unavailable Servers

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
@@ -219,7 +219,7 @@ public class CorfuMsgHandler {
         return (msg, ctx, r) -> {
             if (server.isShutdown()) {
                 log.warn("Server received {} but is shutdown.", msg.getMsgType().toString());
-                r.sendResponse(ctx, msg, CorfuMsgType.ERROR_SHUTDOWN_EXCEPTION.msg());
+                r.sendResponse(ctx, msg, CorfuMsgType.ERROR_SERVER_UNAVAILABLE.msg());
                 return;
             }
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -100,6 +100,7 @@ public enum CorfuMsgType {
 
     ERROR_SERVER_EXCEPTION(200, new TypeToken<CorfuPayloadMsg<ExceptionMsg>>() {}, true),
     ERROR_SHUTDOWN_EXCEPTION(201, TypeToken.of(CorfuMsg.class), true),
+    ERROR_SERVER_UNAVAILABLE(202, TypeToken.of(CorfuMsg.class), true),
 
     // Handshake Messages
     HANDSHAKE_INITIATE(80, new TypeToken<CorfuPayloadMsg<HandshakeMsg>>() {}, true),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseHandler.java
@@ -16,6 +16,7 @@ import org.corfudb.protocols.wireprotocol.JSONPayloadMsg;
 import org.corfudb.protocols.wireprotocol.VersionInfo;
 import org.corfudb.runtime.exceptions.ServerNotReadyException;
 import org.corfudb.runtime.exceptions.ShutdownException;
+import org.corfudb.runtime.exceptions.UnavailableServerException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 
 /**
@@ -153,5 +154,19 @@ public class BaseHandler implements IClient {
     private static Object handleShutdownException(CorfuMsg msg, ChannelHandlerContext ctx,
                                                   IClientRouter r) {
         throw new ShutdownException();
+    }
+
+    /**
+     * Handle a ERROR_SERVER_UNAVAILABLE response from the server.
+     *
+     * @param msg The unavailable exception message
+     * @param ctx The context the message was sent under
+     * @param r   A reference to the router
+     * @return none, throw a shutdown exception instead.
+     */
+    @ClientHandler(type = CorfuMsgType.ERROR_SERVER_UNAVAILABLE)
+    private static Object handleUnavailableException(CorfuMsg msg, ChannelHandlerContext ctx,
+                                                     IClientRouter r) {
+        throw new UnavailableServerException();
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/UnavailableServerException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/UnavailableServerException.java
@@ -1,0 +1,15 @@
+package org.corfudb.runtime.exceptions;
+
+
+/**
+ * An exception that is thrown when an rpc reaches an unavailable server that
+ * needs to be retried.
+ *
+ * Created by Maithem on 7/17/18.
+ */
+
+public class UnavailableServerException extends RuntimeException {
+
+    public UnavailableServerException() {
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.ServerNotReadyException;
+import org.corfudb.runtime.exceptions.UnavailableServerException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.exceptions.unrecoverable.SystemUnavailableError;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
@@ -114,6 +115,8 @@ public abstract class AbstractView {
                             + "invalidate view", we.getCorrectEpoch());
                 } else if (re instanceof NetworkException) {
                     log.warn("layoutHelper: System seems unavailable", re);
+                } else if (re instanceof UnavailableServerException) {
+                    log.warn("layoutHelper: Server unavailable, retrying rpc", re);
                 } else {
                     throw re;
                 }

--- a/test/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
@@ -32,6 +32,6 @@ public class BaseServerTest extends AbstractServerTest {
         getDefaultServer().shutdown();
         sendMessage(new CorfuMsg(CorfuMsgType.PING));
         Assertions.assertThat(getLastMessage().getMsgType())
-            .isEqualTo(CorfuMsgType.ERROR_SHUTDOWN_EXCEPTION);
+            .isEqualTo(CorfuMsgType.ERROR_SERVER_UNAVAILABLE);
     }
 }


### PR DESCRIPTION
## Overview
This fix addresses the case when an rpc fails without retrying
when it reaches a server that is shutting down.

Why should this be merged: Prevents rpc failure some nodes are unavailable. 

Related issue(s) (if applicable): #1371


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
