### PR TITLE
Ability to measure and collect memory consumptions metrics of corfu objects

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -98,6 +98,11 @@
             <artifactId>metrics-jvm</artifactId>
             <version>3.1.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.ehcache</groupId>
+            <artifactId>sizeof</artifactId>
+            <version>0.3.0</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -49,7 +49,7 @@ public class AbstractIT extends AbstractCorfuTest {
     private static final int SHUTDOWN_RETRIES = 10;
     private static final long SHUTDOWN_RETRY_WAIT = 500;
 
-    static final Properties PROPERTIES = new Properties();
+    public static final Properties PROPERTIES = new Properties();
 
     public static final String TEST_SEQUENCE_LOG_PATH = CORFU_LOG_PATH + File.separator + "testSequenceLog";
 

--- a/test/src/test/java/org/corfudb/integration/MemoryFootprintIT.java
+++ b/test/src/test/java/org/corfudb/integration/MemoryFootprintIT.java
@@ -1,0 +1,157 @@
+package org.corfudb.integration;
+
+import com.codahale.metrics.Gauge;
+import com.google.common.reflect.TypeToken;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.util.MetricsUtils;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * An integration test to utilize memory assessment utilities. It can be used as an example
+ * for implementing programmatic assessment of memory footprint for objects of interest.
+ * Follow the instruction in {@link MetricsUtils} in order to enable collection and reporting
+ * of memory footprint metrics on objects of interest.
+ *
+ * Created by Sam Behnam on 6/15/18.
+ */
+@Slf4j
+public class MemoryFootprintIT extends AbstractIT {
+
+    private static String corfuSingleNodeHost;
+    private static int corfuStringNodePort;
+    private static String singleNodeEndpoint;
+
+    /* A helper method that takes host and port specification, start a single server and
+     *  returns a process. */
+    private Process runSinglePersistentServer(String host, int port) throws IOException {
+        return new AbstractIT.CorfuServerRunner()
+                .setHost(host)
+                .setPort(port)
+                .setLogPath(getCorfuServerLogPath(host, port))
+                .setSingle(true)
+                .runServer();
+    }
+
+    /** Load properties for a single node corfu server before each test*/
+    @Before
+    public void loadProperties() {
+        corfuSingleNodeHost = PROPERTIES.getProperty("corfuSingleNodeHost");
+        corfuStringNodePort = Integer.valueOf(PROPERTIES.getProperty("corfuSingleNodePort"));
+        singleNodeEndpoint = String.format("%s:%d",
+                corfuSingleNodeHost,
+                corfuStringNodePort);
+    }
+
+    /**
+     * This test utilizes the {@link MetricsUtils}'s memory measurement tools to test the memory
+     * footprint assessment of the provided tool. This is done by putting key and value pairs
+     * to a corfu table and then evaluating that this has the expected effects on the memory
+     * consumption of the object being measured (i.e. the underlying corfu table)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCorfuTablePutMemoryFootprint() throws Exception {
+        // Run a corfu server
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
+
+        // Start a Corfu runtime
+        CorfuRuntime corfuRuntime = createRuntime(singleNodeEndpoint);
+
+        // Create CorfuTable
+        CorfuTable testTable = corfuRuntime
+                .getObjectsView()
+                .build()
+                .setTypeToken(new TypeToken<CorfuTable<String, Object>>() {})
+                .setStreamName("volbeat")
+                .open();
+
+        // Register memory footprint tracking
+        final Gauge<Long> corfuTableSizeGauge = MetricsUtils.addMemoryMeasurerFor(
+                corfuRuntime.getMetrics(),
+                testTable);
+        final Long initialSize = corfuTableSizeGauge.getValue();
+
+        // Put key values in CorfuTable
+        final int count = 100;
+        final int entrySize = 100000;
+        for (int i = 0; i < count; i++) {
+            testTable.put(String.valueOf(i), new byte[entrySize]);
+        }
+
+        // Assert that memory measurer detects the effect of puts on table size
+        final Long sizeAfterPuts = corfuTableSizeGauge.getValue();
+        assertThat(sizeAfterPuts - initialSize)
+                .isGreaterThanOrEqualTo(count * entrySize);
+        log.info("initialSize:{}, sizeAfterPuts:{}",
+                initialSize,
+                sizeAfterPuts);
+
+        // Assert that table has correct size (i.e. count) and and server is shutdown
+        assertThat(testTable.size()).isEqualTo(count);
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
+    }
+
+    /**
+     * This test utilizes the {@link MetricsUtils}'s memory measurement tools to test the memory
+     * footprint assessment of the provided tool. This is done by removing key and value pairs
+     * on a corfu table and then evaluating that this has the expected effects on the memory
+     * consumption of the object being measured (i.e. the underlying corfu table)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testCorfuTableRemoveMemoryFootprint() throws Exception {
+        // Run a corfu server
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
+
+        // Start a Corfu runtime
+        CorfuRuntime corfuRuntime = createRuntime(singleNodeEndpoint);
+
+        // Create CorfuTable
+        CorfuTable testTable = corfuRuntime
+                .getObjectsView()
+                .build()
+                .setTypeToken(new TypeToken<CorfuTable<String, Object>>() {})
+                .setStreamName("volbeat")
+                .open();
+
+        // Register memory footprint tracking
+        final Gauge<Long> corfuTableSizeGauge =
+                MetricsUtils.addMemoryMeasurerFor(corfuRuntime.getMetrics(), testTable);
+
+        // Put key values in CorfuTable and capture the memory consumption after puts
+        final int count = 100;
+        final int entrySize = 100000;
+        for (int i = 0; i < count; i++) {
+            testTable.put(String.valueOf(i), new byte[entrySize]);
+        }
+
+        final Long sizeAfterPuts = corfuTableSizeGauge.getValue();
+
+        // Remove (count - 1) of the added entries
+        for (int i = 0; i < count - 1; i++) {
+            final String keyToRemove = String.valueOf(i);
+            testTable.remove(keyToRemove);
+        }
+
+        // Assert that memory measurer detects the effect of removes on table size
+        System.gc();
+        final Long sizeAfterRemoves = corfuTableSizeGauge.getValue();
+        assertThat(sizeAfterRemoves).isLessThanOrEqualTo(sizeAfterPuts);
+        log.info("sizeAfterPuts:{}, sizeAfterRemoves:{}",
+                sizeAfterPuts,
+                sizeAfterRemoves);
+
+        // Assert that table has correct size (i.e. one) and and server is shutdown
+        assertThat(testTable.size()).isEqualTo(1);
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
+    }
+}

--- a/test/src/test/java/org/corfudb/util/MemoryFootprintMeasurerIT.java
+++ b/test/src/test/java/org/corfudb/util/MemoryFootprintMeasurerIT.java
@@ -1,0 +1,161 @@
+package org.corfudb.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.codahale.metrics.Gauge;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.integration.AbstractIT;
+import org.corfudb.runtime.CorfuRuntime;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This is an integration test that exercises the functionality and expectations of
+ * memory measurement tool provided in {@link MetricsUtils}.
+ *
+ * Created by Sam Behnam on 7/16/18.
+ */
+@Slf4j
+public class MemoryFootprintMeasurerIT extends AbstractIT{
+    private static String corfuSingleNodeHost;
+    private static int corfuStringNodePort;
+    private static String singleNodeEndpoint;
+
+    /* A helper method that takes host and port specification, start a single server and
+     *  returns a process. */
+    private Process runSinglePersistentServer(String host, int port) throws IOException {
+        return new AbstractIT.CorfuServerRunner()
+                .setHost(host)
+                .setPort(port)
+                .setLogPath(getCorfuServerLogPath(host, port))
+                .setSingle(true)
+                .runServer();
+    }
+
+    /** Load properties for a single node corfu server before each test*/
+    @Before
+    public void loadProperties() {
+        corfuSingleNodeHost = PROPERTIES.getProperty("corfuSingleNodeHost");
+        corfuStringNodePort = Integer.valueOf(PROPERTIES.getProperty("corfuSingleNodePort"));
+        singleNodeEndpoint = String.format("%s:%d",
+                corfuSingleNodeHost,
+                corfuStringNodePort);
+    }
+
+    /**
+     * This test measures the size of an object (an instance of an ArrayList)
+     * while adding small and large items to the list and then remove them. It
+     * evaluates that measured size of list follows the expectation. Note that
+     * evaluating the removal will depend on the request to System for garbage
+     * collection taking effect. This is not deterministic and depends on JVM's
+     * priorities.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testMemoryFootprintMeasurerUsingArrayList() throws Exception {
+        final int smallSize = 10;
+        final int largeSize = 10000;
+
+        // Run a corfu server
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost,
+                                                        corfuStringNodePort);
+
+        // Start a Corfu runtime
+        CorfuRuntime corfuRuntime = createRuntime(singleNodeEndpoint);
+
+        // Create an object be measured
+        List<byte[]> arrayList = new ArrayList<>();
+
+        // Create memory measurer for the object under investigation
+        final Gauge<Long> arrayListSizeGauge =
+                MetricsUtils.addMemoryMeasurerFor(corfuRuntime.getMetrics(), arrayList);
+        final Long initialArraySize = arrayListSizeGauge.getValue();
+
+        // Increase the memory consumption and assert the expected behavior
+        arrayList.add(new byte[smallSize]);
+        final Long arraySizeAfterSmallIncrease = arrayListSizeGauge.getValue();
+        log.info("ArrayList size:{}", arraySizeAfterSmallIncrease);
+        assertThat(arraySizeAfterSmallIncrease - initialArraySize)
+                .isGreaterThanOrEqualTo(smallSize);
+
+        arrayList.add(new byte[largeSize]);
+        final Long arraySizeAfterLargeIncrease = arrayListSizeGauge.getValue();
+        log.info("ArrayList size:{}", arraySizeAfterLargeIncrease);
+        assertThat(arraySizeAfterLargeIncrease - arraySizeAfterSmallIncrease)
+                .isGreaterThanOrEqualTo(largeSize);
+
+        // Decrease the memory consumption and assert the expected behavior
+        arrayList.clear();
+        System.gc();
+        final Long arraySizeAfterRemoval = arrayListSizeGauge.getValue();
+        log.info("ArrayList size:{}", arraySizeAfterRemoval);
+        assertThat(arraySizeAfterRemoval).isLessThan(arraySizeAfterLargeIncrease);
+
+        // Assert the server is shutdown
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
+    }
+
+    /**
+     * This test examines whether {@link MetricsUtils} follows the contract of not
+     * retaining a strong reference to objects that are being measured. As a result,
+     * once the test removes (null out) a reference, it should be reflected on the
+     * size returned by the gauge for that object.
+     * Note that evaluating the removal will depend on the request to System for
+     * garbage collection taking effect. This is not deterministic and depends on
+     * JVM's priorities.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testWeakReferenceRemoval() throws Exception {
+        // Run a corfu server
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost,
+                                                        corfuStringNodePort);
+
+        // Start a Corfu runtime
+        CorfuRuntime corfuRuntime = createRuntime(singleNodeEndpoint);
+
+        // Create and fill a map that will be used to assess nulling out behavior
+        Map<String, String> map1 = new HashMap<>();
+        final Gauge<Long> map1Measurer =
+                MetricsUtils.addMemoryMeasurerFor(corfuRuntime.getMetrics(), map1);
+
+        final int countMap1 = 300000;
+        for (int i = 0; i < countMap1; i++) {
+            map1.put("t1-key-" + i, "t1-value-" + i);
+        }
+
+        log.info("Size of map1 before removing reference: {}",
+                map1Measurer.getValue());
+
+        // Null out the variable under investigation and request a garbage collection
+        map1 = null;
+        System.gc();
+
+        // Create and fill a map that will not be nulled out
+        Map<String, String> map2 = new HashMap<>();
+        final Gauge<Long> map2Measurer =
+                MetricsUtils.addMemoryMeasurerFor(corfuRuntime.getMetrics(), map2);
+
+        final int countMap2 = 1000;
+        for (int i = 0; i < countMap2; i++) {
+            map2.put("t2-key-" + i, "t2-value" + i);
+        }
+
+        // Assert the that once the reference to an object is removed, MetricUtil
+        // does not hold a reference to the object.
+        assertThat(map1Measurer.getValue()).isEqualTo(0);
+        assertThat(map2Measurer.getValue()).isNotEqualTo(0);
+        log.info("Size of map1 after nulling out the reference:{}",
+                map1Measurer.getValue());
+        log.info("Size of map2 after at the end of test:{}",
+                map2Measurer.getValue());
+    }
+}


### PR DESCRIPTION
## Overview

Description:
This enables MetricsUtil to collect and report on memory footprint of objects. The objects can be registered to Metrics registry for measurement and reporting of their memory footprints.

Why should this be merged: 
This provides a tool that facilitates debugging and monitoring of memory size of objects as this has been a concern and evaluating such measures has not been straightforward. 

Related issue(s) (if applicable): #1315

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
