### PR TITLE
Initialize Router Epoch

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -229,7 +229,7 @@ public class ManagementAgent {
         // Creating the initialization task thread.
         // This thread pool is utilized to dispatch one time recovery and sequencer bootstrap tasks.
         // One these tasks finish successfully, they initiate the detection tasks.
-        this.initializationTaskThread = new Thread(this::initializationTask);
+        this.initializationTaskThread = new Thread(this::initializationTask, "initializationTaskThread");
         this.initializationTaskThread.setUncaughtExceptionHandler(
                 (thread, throwable) -> {
                     log.error("Error in initialization task: {}", throwable);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -38,7 +38,7 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
      */
     @Getter
     @Setter
-    long serverEpoch;
+    volatile long serverEpoch;
 
     /** The {@link AbstractServer}s this {@link NettyServerRouter} routes messages for. */
     @Getter
@@ -50,6 +50,8 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
      *                  messages for.
      */
     public NettyServerRouter(List<AbstractServer> servers) {
+        // Initialize the router epoch from the persisted server epoch
+        this.serverEpoch = ((BaseServer) servers.get(0)).serverContext.getServerEpoch();
         this.servers = servers;
         handlerMap = new EnumMap<>(CorfuMsgType.class);
         servers.forEach(server -> server.getHandler().getHandledTypes()


### PR DESCRIPTION


## Overview
Initializes the router's epoch to the last epoch it received
(through set_epoch), defaulting to 0 can cause deadlocks.

Why should this be merged: Fixes a deadlock scenario 

Related issue(s) (if applicable): #1372


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [] Change is covered by automated tests
- [x] Public API has Javadoc
