### PR TITLE
Upgraded slf4j-api from 1.7.6 to 1.7.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.6</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): 
[Bug 2124747: Build and Packaging: Build] [OSS/TP] Outdated version of slf4j 1.7.6 found
https://bugzilla.eng.vmware.com/show_bug.cgi?id=2124747#c9
