### PR TITLE
Force remove bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/AddNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/AddNode.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.view.workflows;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.view.Layout;
 
 import javax.annotation.Nonnull;
@@ -31,12 +32,12 @@ public class AddNode extends WorkflowRequest {
     }
 
     @Override
-    protected UUID sendRequest(@Nonnull Layout layout) throws TimeoutException {
+    protected UUID sendRequest(@Nonnull ManagementClient managementClient) throws TimeoutException {
         // Select the current tail node and send an add node request to the orchestrator
-        CreateWorkflowResponse resp = getOrchestrator(layout).addNodeRequest(nodeForWorkflow);
-        log.info("sendRequest: requested to add {} on orchestrator {}:{}, layout {}",
-                nodeForWorkflow, getOrchestrator(layout).getRouter().getHost(),
-                getOrchestrator(layout).getRouter().getPort(), layout);
+        CreateWorkflowResponse resp = managementClient.addNodeRequest(nodeForWorkflow);
+        log.info("sendRequest: requested to add {} on orchestrator {}:{}",
+                nodeForWorkflow, managementClient.getRouter().getHost(),
+                managementClient.getRouter().getPort());
         return resp.getWorkflowId();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/ForceRemoveNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/ForceRemoveNode.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.view.workflows;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.view.Layout;
 
 import javax.annotation.Nonnull;
@@ -27,12 +28,12 @@ public class ForceRemoveNode extends RemoveNode {
     }
 
     @Override
-    protected UUID sendRequest(@Nonnull Layout layout) throws TimeoutException {
+    protected UUID sendRequest(@Nonnull ManagementClient managementClient) throws TimeoutException {
         // Select the current tail node and send an add node request to the orchestrator
-        CreateWorkflowResponse resp = getOrchestrator(layout).forceRemoveNode(nodeForWorkflow);
-        log.info("sendRequest: requested to force remove {} on orchestrator {}:{}, layout {}",
-                nodeForWorkflow, getOrchestrator(layout).getRouter().getHost(),
-                getOrchestrator(layout).getRouter().getPort(), layout);
+        CreateWorkflowResponse resp = managementClient.forceRemoveNode(nodeForWorkflow);
+        log.info("sendRequest: requested to force remove {} on orchestrator {}:{}",
+                nodeForWorkflow, managementClient.getRouter().getHost(),
+                managementClient.getRouter().getPort());
         return resp.getWorkflowId();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/HealNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/HealNode.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.view.workflows;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.view.Layout;
 
 import javax.annotation.Nonnull;
@@ -25,12 +26,12 @@ public class HealNode extends WorkflowRequest {
     }
 
     @Override
-    protected UUID sendRequest(Layout layout) throws TimeoutException {
-        CreateWorkflowResponse resp = getOrchestrator(layout).healNodeRequest(nodeForWorkflow,
+    protected UUID sendRequest(@Nonnull ManagementClient managementClient) throws TimeoutException {
+        CreateWorkflowResponse resp = managementClient.healNodeRequest(nodeForWorkflow,
                 true, true, true, 0);
-        log.info("sendRequest: requested to heal {} on orchestrator {}:{}, layout {}",
-                nodeForWorkflow, getOrchestrator(layout).getRouter().getHost(),
-                getOrchestrator(layout).getRouter().getPort(), layout);
+        log.info("sendRequest: requested to heal {} on orchestrator {}:{}",
+                nodeForWorkflow, managementClient.getRouter().getHost(),
+                managementClient.getRouter().getPort());
         return resp.getWorkflowId();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/RemoveNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/RemoveNode.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.view.workflows;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.view.Layout;
 
 import javax.annotation.Nonnull;
@@ -30,14 +31,13 @@ public class RemoveNode extends WorkflowRequest {
     }
 
     @Override
-    protected UUID sendRequest(@Nonnull Layout layout) throws TimeoutException {
+    protected UUID sendRequest(@Nonnull ManagementClient managementClient) throws TimeoutException {
         // Send an remove node request to an orchestrator that is not on the node
         // to be removed
-
-        CreateWorkflowResponse resp = getOrchestrator(layout).removeNode(nodeForWorkflow);
-        log.info("sendRequest: requested to remove {} on orchestrator {}:{}, layout {}",
-                nodeForWorkflow, getOrchestrator(layout).getRouter().getHost(),
-                getOrchestrator(layout).getRouter().getPort(), layout);
+        CreateWorkflowResponse resp = managementClient.removeNode(nodeForWorkflow);
+        log.info("sendRequest: requested to remove {} on orchestrator {}:{}",
+                nodeForWorkflow, managementClient.getRouter().getHost(),
+                managementClient.getRouter().getPort());
         return resp.getWorkflowId();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.view.workflows;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.BaseClient;
 import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.WorkflowException;
@@ -14,6 +15,7 @@ import javax.annotation.Nonnull;
 import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -39,15 +41,19 @@ public abstract class WorkflowRequest {
     /**
      * Send a workflow request
      *
-     * @param layout current layout
+     * @param client the client to the selected orchestrator
      * @return a uuid that corresponds to the created workflow
      */
-    protected abstract UUID sendRequest(Layout layout) throws TimeoutException;
+    protected abstract UUID sendRequest(ManagementClient client) throws TimeoutException;
 
     /**
      * Select an orchestrator and return a client. Orchestrator's that
      * are on unresponsive nodes and the affected endpoint by the workflow
-     * will not be selected.
+     * will not be selected. The layout might not reflect the state
+     * of responsive servers, so we ping the endpoint before we select it.
+     * An example of this would be a 3 node cluster, with two nodes that
+     * die immediately, the layout won't have those two nodes as unresponsive
+     * because it can't commit to a quorum.
      *
      * @param layout the layout that is used to select an orchestrator
      * @return a management client that is connected to the selected
@@ -63,8 +69,22 @@ public abstract class WorkflowRequest {
             throw new WorkflowException("getOrchestrator: no available orchestrators " + layout);
         }
 
-        return runtime.getLayoutView().getRuntimeLayout(layout)
+        // Select an available orchestrator
+        ManagementClient managementClient = runtime.getLayoutView().getRuntimeLayout(layout)
                 .getManagementClient(activeLayoutServers.get(0));
+
+        for (String endpoint : activeLayoutServers) {
+            BaseClient client = runtime.getLayoutView().getRuntimeLayout(layout)
+                    .getBaseClient(endpoint);
+            if (client.pingSync()) {
+                log.info("getOrchestrator: orchestrator selected {}, layout {}", endpoint, layout);
+                managementClient = runtime.getLayoutView().getRuntimeLayout(layout)
+                        .getManagementClient(endpoint);
+                break;
+            }
+        }
+
+        return managementClient;
     }
 
     /**
@@ -114,8 +134,8 @@ public abstract class WorkflowRequest {
             try {
                 runtime.invalidateLayout();
                 Layout requestLayout = new Layout(runtime.getLayoutView().getLayout());
-                UUID workflowId = sendRequest(requestLayout);
                 ManagementClient orchestrator = getOrchestrator(requestLayout);
+                UUID workflowId = sendRequest(orchestrator);
                 waitForWorkflow(workflowId, orchestrator, timeout, pollPeriod);
             } catch (NetworkException | TimeoutException e) {
                 log.warn("WorkflowRequest: Error while running {} on attempt {}, cause {}", this, x, e);

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -280,7 +280,7 @@ public class AbstractIT extends AbstractCorfuTest {
     public static class CorfuServerRunner {
 
         private boolean single = true;
-        private String logLevel = "TRACE";
+        private String logLevel = "INFO";
         private String host = DEFAULT_HOST;
         private int port = DEFAULT_PORT;
         private String managementBootstrap = null;

--- a/test/src/test/java/org/corfudb/integration/Harness.java
+++ b/test/src/test/java/org/corfudb/integration/Harness.java
@@ -1,6 +1,8 @@
-package org.corfudb.integration.cluster.Harness;
+package org.corfudb.integration;
 
 import org.corfudb.integration.AbstractIT;
+import org.corfudb.integration.cluster.Harness.Action;
+import org.corfudb.integration.cluster.Harness.Node;
 import org.corfudb.runtime.BootstrapUtil;
 import org.corfudb.runtime.view.Layout;
 
@@ -44,9 +46,10 @@ public class Harness {
         long epoch = 0;
 
         for (int x = 0; x < n; x++) {
-            layoutServers.add(getAddressForNode(x));
-            sequencer.add(getAddressForNode(x));
-            stripServers.add(getAddressForNode(x));
+            int port = basePort + x;
+            layoutServers.add(getAddressForNode(port));
+            sequencer.add(getAddressForNode(port));
+            stripServers.add(getAddressForNode(port));
         }
 
         Layout.LayoutSegment segment = new Layout.LayoutSegment(Layout.ReplicationMode.CHAIN_REPLICATION, 0L, -1L,
@@ -58,7 +61,8 @@ public class Harness {
     String getClusterConnectionString(int n) {
         String conn = "";
         for (int i = 0; i < n; i++) {
-            conn += getAddressForNode(i) + ",";
+            int port = basePort + i;
+            conn += getAddressForNode(port) + ",";
         }
         return conn.substring(0, conn.length() - 1);
     }
@@ -86,13 +90,14 @@ public class Harness {
         List<Node> nodes = new ArrayList<>(n);
         String conn = getClusterConnectionString(n);
         for (int i = 0; i < n; i++) {
+            int port = basePort + i;
             Process proc = new AbstractIT.CorfuServerRunner()
                     .setHost(localAddress)
-                    .setPort(basePort + i)
-                    .setLogPath(getCorfuServerLogPath(localAddress, basePort + i))
+                    .setPort(port)
+                    .setLogPath(getCorfuServerLogPath(localAddress, port))
                     .setSingle(false)
                     .runServer();
-            nodes.add(new Node(getAddressForNode(i), conn, getCorfuServerLogPath(localAddress, basePort + i)));
+            nodes.add(new Node(getAddressForNode(port), conn, getCorfuServerLogPath(localAddress, port)));
         }
 
         final Layout layout = getLayoutForNodes(n);


### PR DESCRIPTION
## Overview
The workflow requests should select a random orchestrator to prevent
selecting dead nodes (in the case of a stale layout).

Why should this be merged: Fixes a bug that blocks force remove requests

Related issue(s) (if applicable): #1384


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
