### PR TITLE
Ignore already bootstrapped nodes if BootstrapUtil retried.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -289,6 +289,24 @@ public class ManagementServer extends AbstractServer {
     }
 
     /**
+     * Handles the Management layout request.
+     *
+     * @param msg corfu message containing MANAGEMENT_LAYOUT_REQUEST
+     * @param ctx netty ChannelHandlerContext
+     * @param r   server router
+     */
+    @ServerHandler(type = CorfuMsgType.MANAGEMENT_LAYOUT_REQUEST)
+    public void handleLayoutRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+        // This server has not been bootstrapped yet, ignore all requests.
+        if (!checkBootstrap(msg, ctx, r)) {
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_NOBOOTSTRAP_ERROR));
+            return;
+        }
+        r.sendResponse(ctx, msg,
+                CorfuMsgType.LAYOUT_RESPONSE.payloadMsg(serverContext.getManagementLayout()));
+    }
+
+    /**
      * Management Server shutdown:
      * Shuts down the fault detector service.
      */

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -97,6 +97,7 @@ public enum CorfuMsgType {
     HEARTBEAT_RESPONSE(76, new TypeToken<CorfuPayloadMsg<NodeView>>(){}, true),
     ORCHESTRATOR_REQUEST(77, new TypeToken<CorfuPayloadMsg<OrchestratorMsg>>() {}, true),
     ORCHESTRATOR_RESPONSE(78, new TypeToken<CorfuPayloadMsg<OrchestratorResponse>>() {}, true),
+    MANAGEMENT_LAYOUT_REQUEST(79, TypeToken.of(CorfuMsg.class), true),
 
     ERROR_SERVER_EXCEPTION(200, new TypeToken<CorfuPayloadMsg<ExceptionMsg>>() {}, true),
     ERROR_SHUTDOWN_EXCEPTION(201, TypeToken.of(CorfuMsg.class), true),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -81,6 +81,15 @@ public class ManagementClient extends AbstractClient {
     }
 
     /**
+     * Requests for the layout persisted by the management server.
+     *
+     * @return A future which returns the layout persisted by the management server on completion.
+     */
+    public CompletableFuture<Layout> getLayout() {
+        return sendMessageWithFuture(CorfuMsgType.MANAGEMENT_LAYOUT_REQUEST.msg());
+    }
+
+    /**
      * Send a add node request to an orchestrator
      * @param endpoint the endpoint to add to the cluster
      * @return create workflow response that contains the uuid of the workflow


### PR DESCRIPTION
## Overview

Description: If layout server bootstrap attempt times out due to a late bootstrap response and is retried, it results in an AlreadyBootstrappedException. This needs to be asserted that it was initially bootstrapped with the same layout and if yes, the exception should be ignored.

Why should this be merged: Late response of Layout bootstrap can cause BootstrapUtil unusability.

Related issue(s) (if applicable): #1386 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
