### PR TITLE
Use Native Implementation for SSL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-tcnative-boringssl-static</artifactId>
+            <version>2.0.7.Final</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>findbugs-maven-plugin</artifactId>
             <version>3.0.3</version>

--- a/runtime/src/main/java/org/corfudb/security/tls/SslContextConstructor.java
+++ b/runtime/src/main/java/org/corfudb/security/tls/SslContextConstructor.java
@@ -8,6 +8,8 @@ import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLException;
+
+import io.netty.handler.ssl.SslProvider;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
@@ -40,9 +42,9 @@ public class SslContextConstructor {
         ReloadableTrustManagerFactory tmf = new ReloadableTrustManagerFactory(trustStorePath, tsPasswordFile);
 
         if (isServer) {
-            return SslContextBuilder.forServer(kmf).trustManager(tmf).build();
+            return SslContextBuilder.forServer(kmf).sslProvider(SslProvider.OPENSSL).trustManager(tmf).build();
         } else {
-            return SslContextBuilder.forClient().keyManager(kmf).trustManager(tmf).build();
+            return SslContextBuilder.forClient().sslProvider(SslProvider.OPENSSL).keyManager(kmf).trustManager(tmf).build();
         }
     }
 


### PR DESCRIPTION
## Overview
This patch changes the ssl context constructor to use a native
engine implementation. My test show 4.5x improvement on server
and client restart.

Why should this be merged: Improves client/sequencer reboot performance when TLS is used.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
