### PR TITLE
Remove FastObjectLoader Dependency on Sequencer

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -13,6 +13,8 @@ import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
 
+import org.corfudb.runtime.view.Address;
+
 /**
  * This class implements the StreamLog interface using a Java hash map.
  * The stream log is only stored in-memory and not persisted.
@@ -22,7 +24,7 @@ import org.corfudb.runtime.exceptions.OverwriteException;
 @Slf4j
 public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressSpace {
 
-    private final AtomicLong globalTail = new AtomicLong(0L);
+    private final AtomicLong globalTail = new AtomicLong(Address.NON_ADDRESS);
     private Map<Long, LogData> logCache;
     private Set<Long> trimmed;
     private volatile long startingAddress;
@@ -158,7 +160,7 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
     @Override
     public void reset() {
         startingAddress = 0;
-        globalTail.set(0L);
+        globalTail.set(Address.NON_ADDRESS);
         // Clear the trimmed addresses record.
         trimmed.clear();
         // Clearing all data from the cache.

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.view;
 
+import static org.corfudb.util.Utils.getMaxGlobalTail;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.github.benmanes.caffeine.cache.CacheLoader;
@@ -259,6 +260,14 @@ public class AddressSpaceView extends AbstractView {
                         .map(LogUnitClient::getTrimMark)
                         .map(CFUtils::getUninterruptibly)
                         .max(Comparator.naturalOrder()).get());
+    }
+
+    /**
+     * Get the last address in the address space
+     */
+    public long getLogTail() {
+        return layoutHelper(
+                e -> getMaxGlobalTail(e.getLayout(), runtime));
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -270,6 +270,14 @@ public class Layout {
     }
 
     /**
+     * Return latest segment.
+     *
+     */
+    public LayoutSegment getLatestSegment() {
+        return this.getSegments().get(this.getSegments().size() - 1);
+    }
+
+    /**
      * Get the length of a segment at a particular address.
      *
      * @param address The address to check.

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -1,11 +1,11 @@
 package org.corfudb.runtime.view;
 
+import static org.corfudb.util.Utils.getMaxGlobalTail;
+
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.locks.ReentrantLock;
 
 import javax.annotation.Nonnull;
@@ -133,10 +133,8 @@ public class LayoutManagementView extends AbstractView {
                 layoutBuilder.addSequencerServer(endpoint);
             }
             if (isLogUnitServer) {
-                Layout.LayoutSegment latestSegment =
-                        currentLayout.getSegments().get(currentLayout.getSegments().size() - 1);
                 layoutBuilder.addLogunitServer(logUnitStripeIndex,
-                        getMaxGlobalTail(currentLayout, latestSegment),
+                        getMaxGlobalTail(currentLayout, runtime),
                         endpoint);
             }
             if (isUnresponsiveServer) {
@@ -181,10 +179,8 @@ public class LayoutManagementView extends AbstractView {
                     .getLogUnitClient(endpoint).resetLogUnit(currentLayout.getEpoch()));
 
             LayoutBuilder layoutBuilder = new LayoutBuilder(currentLayout);
-            Layout.LayoutSegment latestSegment =
-                    currentLayout.getSegments().get(currentLayout.getSegments().size() - 1);
             layoutBuilder.addLogunitServer(0,
-                    getMaxGlobalTail(currentLayout, latestSegment),
+                    getMaxGlobalTail(currentLayout, runtime),
                     endpoint);
             layoutBuilder.removeUnresponsiveServers(Collections.singleton(endpoint));
             newLayout = layoutBuilder.build();
@@ -385,48 +381,6 @@ public class LayoutManagementView extends AbstractView {
     }
 
     /**
-     * Fetches the max global log tail from the log unit cluster. This depends on the mode of
-     * replication being used.
-     * CHAIN: Block on fetch of global log tail from the head log unitin every stripe.
-     * QUORUM: Block on fetch of global log tail from a majority in every stripe.
-     *
-     * @param layout  Latest layout to get clients to fetch tails.
-     * @param segment Latest layout segment.
-     * @return The max global log tail obtained from the log unit servers.
-     */
-    private long getMaxGlobalTail(Layout layout, Layout.LayoutSegment segment) {
-        long maxTokenRequested = 0;
-
-        // Query the tail of the head log unit in every stripe.
-        if (segment.getReplicationMode().equals(Layout.ReplicationMode.CHAIN_REPLICATION)) {
-            for (Layout.LayoutStripe stripe : segment.getStripes()) {
-                maxTokenRequested = Math.max(maxTokenRequested,
-                        CFUtils.getUninterruptibly(
-                                runtime.getLayoutView().getRuntimeLayout(layout)
-                                        .getLogUnitClient(stripe.getLogServers().get(0))
-                                        .getTail()));
-
-            }
-        } else if (segment.getReplicationMode()
-                .equals(Layout.ReplicationMode.QUORUM_REPLICATION)) {
-            for (Layout.LayoutStripe stripe : segment.getStripes()) {
-                CompletableFuture<Long>[] completableFutures = stripe.getLogServers()
-                        .stream()
-                        .map(s -> runtime.getLayoutView().getRuntimeLayout(layout)
-                                .getLogUnitClient(s).getTail())
-                        .toArray(CompletableFuture[]::new);
-                QuorumFuturesFactory.CompositeFuture<Long> quorumFuture =
-                        QuorumFuturesFactory.getQuorumFuture(Comparator.naturalOrder(),
-                                completableFutures);
-                maxTokenRequested = Math.max(maxTokenRequested,
-                        CFUtils.getUninterruptibly(quorumFuture));
-
-            }
-        }
-        return maxTokenRequested;
-    }
-
-    /**
      * Reconfigures the sequencer.
      * If the primary sequencer has changed in the new layout,
      * the global tail of the log units are queried and used to set
@@ -450,7 +404,7 @@ public class LayoutManagementView extends AbstractView {
                     return;
                 }
 
-                long maxTokenRequested = 0L;
+                long maxTokenRequested = -1L;
                 Map<UUID, Long> streamTails = Collections.emptyMap();
                 boolean bootstrapWithoutTailsUpdate = true;
 
@@ -458,17 +412,14 @@ public class LayoutManagementView extends AbstractView {
                 if (forceReconfigure
                         || !originalLayout.getPrimarySequencer()
                         .equals(newLayout.getPrimarySequencer())) {
-                    Layout.LayoutSegment latestSegment = newLayout.getSegments()
-                            .get(newLayout.getSegments().size() - 1);
-                    maxTokenRequested = getMaxGlobalTail(newLayout, latestSegment);
 
                     FastObjectLoader fastObjectLoader = new FastObjectLoader(runtime);
                     fastObjectLoader.setRecoverSequencerMode(true);
                     fastObjectLoader.setLoadInCache(false);
 
                     // FastSMRLoader sets the logHead based on trim mark.
-                    fastObjectLoader.setLogTail(maxTokenRequested);
                     fastObjectLoader.loadMaps();
+                    maxTokenRequested = fastObjectLoader.getLogTail();
                     streamTails = fastObjectLoader.getStreamTails();
                     verifyStreamTailsMap(streamTails);
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -57,8 +57,7 @@ public class StreamsView extends AbstractView {
      * @return A view
      */
     public IStreamView get(UUID stream, StreamOptions options) {
-        return runtime.getLayoutView().getLayout().getSegments().get(
-                runtime.getLayoutView().getLayout().getSegments().size() - 1)
+        return runtime.getLayoutView().getLayout().getLatestSegment()
                 .getReplicationMode().getStreamView(runtime, stream, options);
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -6,6 +6,7 @@ import static org.corfudb.infrastructure.log.StreamLogFiles.METADATA_SIZE;
 import static org.corfudb.infrastructure.log.StreamLogFiles.RECORDS_PER_LOG_FILE;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 
 import java.io.File;
 import java.io.RandomAccessFile;
@@ -16,7 +17,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import io.netty.buffer.Unpooled;
 import org.apache.commons.io.FileUtils;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.format.Types;
@@ -28,6 +28,7 @@ import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.view.Address;
 import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
@@ -509,7 +510,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
     public void testGetGlobalTail() {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
 
-        assertThat(log.getGlobalTail()).isEqualTo(0);
+        assertThat(log.getGlobalTail()).isEqualTo(Address.NON_ADDRESS);
 
         // Write to multiple segments
         final int segments = 3;
@@ -678,7 +679,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
                 s -> assertThat(new File(s).length()).isEqualTo(0L));
 
         final int expectedFilesAfterReset = 3;
-        final long globalTailAfterReset = 0L;
+        final long globalTailAfterReset = Address.NON_ADDRESS;
         final long trimMarkAfterReset = 0L;
         assertThat(logsDir.list()).hasSize(expectedFilesAfterReset);
         assertThat(log.getGlobalTail()).isEqualTo(globalTailAfterReset);

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -274,12 +274,13 @@ public class ClusterReconfigIT extends AbstractIT {
      * @throws Exception
      */
     private Layout incrementClusterEpoch(CorfuRuntime corfuRuntime) throws Exception {
+        long oldEpoch = corfuRuntime.getLayoutView().getLayout().getEpoch();
         Layout l = new Layout(corfuRuntime.getLayoutView().getLayout());
         l.setEpoch(l.getEpoch() + 1);
         corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
         corfuRuntime.getLayoutView().updateLayout(l, 1L);
         corfuRuntime.invalidateLayout();
-        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(1L);
+        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(oldEpoch + 1);
         return l;
     }
 
@@ -762,7 +763,7 @@ public class ClusterReconfigIT extends AbstractIT {
         final Layout layoutAfterFailure = runtime.getLayoutView().getLayout();
 
         final int appendNum = 5;
-        // Write at address 1-5.
+        // Write at address 0-4.
         for (int i = 0; i < appendNum; i++) {
             stream.append(Integer.toString(counter++).getBytes());
         }
@@ -771,9 +772,9 @@ public class ClusterReconfigIT extends AbstractIT {
         corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
         waitForEpochChange(refreshedEpoch -> refreshedEpoch > layoutAfterFailure.getEpoch(), runtime);
 
-        // Write at address 6-10.
-        final long startAddress = 1L;
-        final long endAddress = 10L;
+        // Write at address 5-9.
+        final long startAddress = 0L;
+        final long endAddress = 9L;
         for (int i = 0; i < appendNum; i++) {
             stream.append(Integer.toString(counter++).getBytes());
         }
@@ -836,8 +837,8 @@ public class ClusterReconfigIT extends AbstractIT {
         int counter = 0;
 
         final int appendNum = 3;
-        final long startAddress = 1;
-        // Write at address 1-3.
+        final long startAddress = 0;
+        // Write at address 0-1-2
         for (int i = 0; i < appendNum; i++) {
             stream.append(Integer.toString(counter++).getBytes());
         }
@@ -845,11 +846,11 @@ public class ClusterReconfigIT extends AbstractIT {
         corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
         waitForEpochChange(refreshedEpoch -> refreshedEpoch > layoutAfterHeal1.getEpoch(), runtime);
 
-        // Write at address 4-6.
+        // Write at address 3-4-5
         for (int i = 0; i < appendNum; i++) {
             stream.append(Integer.toString(counter++).getBytes());
         }
-        final long endAddress = 6;
+        final long endAddress = 5;
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
             Layout finalLayout = runtime.getLayoutView().getLayout();


### PR DESCRIPTION
## Overview

Description: Now the FastObjectLoader will obtain the log globalTail by polling the Log Unit servers instead of relying on the sequencers view, which in turn needs to wait for the sequencer to
recover. This will allow clients and servers restarting at the same time to run in parallel rather than having to wait for the sequencer to totally recover.

Why should this be merged: This fixes a performance issue (#1389) and is required also in the effort of optimizing the stream tail recreation on sequencer bootstrap, which is currently lead by the Layout Servers and will be moved into the sequencer server.

Related issue(s) (if applicable): #1389


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [x] Public API has Javadoc
