### PR TITLE
Transfer trimMark on stateTransfer.

### DIFF
--- a/test/src/test/java/org/corfudb/integration/Harness.java
+++ b/test/src/test/java/org/corfudb/integration/Harness.java
@@ -105,4 +105,22 @@ public class Harness {
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
         return nodes;
     }
+
+    /**
+     * Deploys an unbootstrapped node.
+     *
+     * @param port Port to bind node to.
+     * @return Node instance.
+     * @throws IOException
+     */
+    public Node deployUnbootstrappedNode(int port) throws IOException {
+
+        Process proc = new AbstractIT.CorfuServerRunner()
+                .setHost(localAddress)
+                .setPort(port)
+                .setLogPath(getCorfuServerLogPath(localAddress, port))
+                .setSingle(false)
+                .runServer();
+        return new Node(getAddressForNode(port), getCorfuServerLogPath(localAddress, port));
+    }
 }

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -2,11 +2,13 @@ package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.integration.cluster.Harness.Node;
+import org.corfudb.recovery.FastObjectLoader;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.LayoutBuilder;
+import org.corfudb.util.Sleep;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -159,11 +161,9 @@ public class WorkflowIT extends AbstractIT {
     }
 
     /**
-     *
      * This tests will resize the cluster according to the following order,
      * create a cluster of size 2, then force remove one node. Then, it will
-     * regrow the cluster to 3 nodes and remove one node. 
-     *
+     * regrow the cluster to 3 nodes and remove one node.
      */
     @Test
     public void clusterResizingTest1() throws Exception {
@@ -303,5 +303,100 @@ public class WorkflowIT extends AbstractIT {
 
         assertThat(rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(1);
         assertThat(rt.getLayoutView().getLayout().getAllServers()).containsExactly(n2.getAddress());
+    }
+
+    /**
+     * Tests whether the trimMark is transferred during stateTransfer.
+     * Scenario: Setup a cluster of 1 node.
+     * 1000 entries are written to node_1. These are then checkpointed and trimmed.
+     * Another 1000 entries are added. Now node_1 has a trimMark at address 1000.
+     * Now 2 new nodes node_2 and node_3 are added to the cluster after which node_1 is shutdown.
+     * Finally we should see that the trimMark should be updated on the new nodes and the
+     * FastObjectLoader trying to recreate the state from these 2 nodes should be able to do so.
+     */
+    @Test
+    public void addNodeWithTrim() throws Exception {
+        Harness harness = new Harness();
+
+        final int numNodes = 3;
+        final int PORT_1 = 9001;
+        final int PORT_2 = 9002;
+        List<Node> nodeList = harness.deployCluster(1);
+        Node n0 = nodeList.get(0);
+        Node n1 = harness.deployUnbootstrappedNode(PORT_1);
+        Node n2 = harness.deployUnbootstrappedNode(PORT_2);
+
+        CorfuRuntime rt = new CorfuRuntime(n0.getClusterAddress()).connect();
+        final String streamName = "test";
+        CorfuTable<String, Integer> table = rt.getObjectsView()
+                .build()
+                .setType(CorfuTable.class)
+                .setStreamName(streamName)
+                .open();
+        final int entriesCount = 1_000;
+
+        // Write 1_000 entries.
+        for (int i = 0; i < entriesCount; i++) {
+            table.put(Integer.toString(i), i);
+        }
+
+        // Checkpoint and trim the entries.
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap(table);
+        long prefixTrimAddress = mcw.appendCheckpoints(rt, "author");
+        rt.getAddressSpaceView().prefixTrim(prefixTrimAddress);
+        rt.getAddressSpaceView().invalidateServerCaches();
+        rt.getAddressSpaceView().invalidateClientCache();
+        rt.getAddressSpaceView().gc();
+
+        assertThat(rt.getAddressSpaceView().getTrimMark()).isEqualTo(entriesCount);
+
+        // 2 Checkpoint entries for the start and end.
+        // 1000 entries being checkpointed = 20 checkpoint entries due to batch size of 50.
+        final int checkpointEntriesCount = 22;
+
+        // Write another batch of 1_000 entries.
+        for (int i = 0; i < entriesCount; i++) {
+            table.put(Integer.toString(i), i);
+        }
+        final long streamTail = entriesCount + checkpointEntriesCount + entriesCount - 1;
+
+        // Add 2 new nodes.
+        final int retries = 3;
+        final Duration timeout = PARAMETERS.TIMEOUT_LONG;
+        final Duration pollPeriod = PARAMETERS.TIMEOUT_VERY_SHORT;
+        rt.getManagementView().addNode("localhost:9001", retries, timeout, pollPeriod);
+        rt.getManagementView().addNode("localhost:9002", retries, timeout, pollPeriod);
+
+        rt.invalidateLayout();
+        Layout layoutAfterAdds = rt.getLayoutView().getLayout();
+        assertThat(layoutAfterAdds.getSegments().stream()
+                .allMatch(s -> s.getAllLogServers().size() == numNodes)).isTrue();
+
+        run(n0.shutdown);
+
+        assertThat(rt.getAddressSpaceView().getTrimMark()).isEqualTo(entriesCount);
+
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
+            if (rt.getLayoutView().getLayout().getEpoch() > layoutAfterAdds.getEpoch()) {
+                break;
+            }
+            rt.invalidateLayout();
+            Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_SHORT);
+        }
+
+        // Assert that the new nodes should have the correct trimMark.
+        assertThat(rt.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9001").getTrimMark().get())
+                .isEqualTo(prefixTrimAddress + 1);
+        assertThat(rt.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9002").getTrimMark().get())
+                .isEqualTo(prefixTrimAddress + 1);
+        FastObjectLoader fastObjectLoader = new FastObjectLoader(rt);
+        fastObjectLoader.setRecoverSequencerMode(true);
+        fastObjectLoader.loadMaps();
+        assertThat(fastObjectLoader.getStreamTails().get(CorfuRuntime.getStreamID(streamName)))
+                .isEqualTo(streamTail);
+
+        // Shutdown two nodes
+        run(n1.shutdown, n2.shutdown);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/cluster/Harness/Node.java
+++ b/test/src/test/java/org/corfudb/integration/cluster/Harness/Node.java
@@ -13,7 +13,7 @@ public class Node {
     final String address;
 
     @Getter
-    final String clusterAddress;
+    String clusterAddress;
 
     @Getter
     final String logPath;
@@ -28,6 +28,10 @@ public class Node {
         this.logPath = logPath;
         this.shutdown = new ShutdownAction(this);
         this.start = new StartAction(this);
+    }
+
+    public Node(String address, String logPath) {
+        this(address, null, logPath);
     }
 
     public String getProcessKillCommand() {


### PR DESCRIPTION
## Overview

Description: Transfer the trim-mark during state transfer

Why should this be merged: The new/healed nodes will not have the trim mark. A new CorfuRuntime does not realize this and attempts to hole fill all the trimmed entries.

Related issue(s) (if applicable): Resolves #1395  

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
