### PR TITLE
Prevent layout commit on committed epoch.

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -481,9 +481,6 @@ public class LayoutServerTest extends AbstractServerTest {
         sendCommitted(newEpoch, layout);
         Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
 
-        sendCommitted(newEpoch, layout);
-        Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
-
         requestLayout(newEpoch);
         Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.LAYOUT_RESPONSE);
         Assertions.assertThat(((LayoutMsg) getLastMessage()).getLayout()).isEqualTo(layout);

--- a/test/src/test/java/org/corfudb/infrastructure/ReconfigurationEventHandlerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ReconfigurationEventHandlerTest.java
@@ -60,7 +60,7 @@ public class ReconfigurationEventHandlerTest extends AbstractViewTest {
         ReconfigurationEventHandler reconfigurationEventHandler = new ReconfigurationEventHandler();
         IReconfigurationHandlerPolicy failureHandlerPolicy = new PurgeFailurePolicy();
         reconfigurationEventHandler.handleFailure(failureHandlerPolicy,
-                        originalLayout,
+                        new Layout(originalLayout),
                         corfuRuntime,
                         failedServers);
 

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -279,8 +279,9 @@ public class LayoutViewTest extends AbstractViewTest {
                 .addToLayout()
                 .build();
 
-        l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        Layout sealLayout = new Layout(l);
+        sealLayout.setEpoch(l.getEpoch() + 1);
+        corfuRuntime.getLayoutView().getRuntimeLayout(sealLayout).moveServersToEpoch();
         corfuRuntime.getLayoutView().updateLayout(newLayout, 1L);
 
         assertThat(getLayoutServer(SERVERS.PORT_0).getCurrentLayout()).isEqualTo(newLayout);

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1008,7 +1008,7 @@ public class ManagementViewTest extends AbstractViewTest {
         rt.getStreamsView().get(CorfuRuntime.getStreamID("test"))
                 .append("testPayload".getBytes());
 
-        rt.getLayoutManagementView().addNode(l1, SERVERS.ENDPOINT_1,
+        rt.getLayoutManagementView().addNode(new Layout(l1), SERVERS.ENDPOINT_1,
                 true,
                 true,
                 true,


### PR DESCRIPTION
## Overview

Description: Prevent subsequent layout commit requests acceptance on the same epoch. We can have multiple layout commit requests on the same epoch via Paxos and hand of god path.

Why should this be merged: There exists a race where the hand of god or Paxos can overwrite each other's layout.

Related issue(s) (if applicable): Resolves #1397 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
