### PR TITLE
Transaction Abort Exception Cause for slow writers

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -179,7 +179,7 @@ public class LogUnitServer extends AbstractServer {
             r.sendResponse(ctx, msg, CorfuMsgType.WRITE_OK.msg());
 
         } catch (OverwriteException ex) {
-            r.sendResponse(ctx, msg, CorfuMsgType.ERROR_OVERWRITE.msg());
+            r.sendResponse(ctx, msg, CorfuMsgType.ERROR_OVERWRITE.payloadMsg(ex.getOverWriteCause().getId()));
         } catch (DataOutrankedException e) {
             r.sendResponse(ctx, msg, CorfuMsgType.ERROR_DATA_OUTRANKED.msg());
         } catch (ValueAdoptedException e) {
@@ -240,7 +240,7 @@ public class LogUnitServer extends AbstractServer {
             r.sendResponse(ctx, msg, CorfuMsgType.WRITE_OK.msg());
 
         } catch (OverwriteException e) {
-            r.sendResponse(ctx, msg, CorfuMsgType.ERROR_OVERWRITE.msg());
+            r.sendResponse(ctx, msg, CorfuMsgType.ERROR_OVERWRITE.payloadMsg(e.getOverWriteCause().getId()));
         } catch (DataOutrankedException e) {
             r.sendResponse(ctx, msg, CorfuMsgType.ERROR_DATA_OUTRANKED.msg());
         } catch (ValueAdoptedException e) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpace.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpace.java
@@ -11,6 +11,7 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.runtime.exceptions.DataOutrankedException;
+import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.ValueAdoptedException;
 
@@ -46,7 +47,7 @@ public interface StreamLogWithRankedAddressSpace extends StreamLog {
         }
         if (newEntry.getRank().getRank() == 0) {
             // data consistency in danger
-            throw new OverwriteException();
+            throw new OverwriteException(OverwriteCause.DIFF_DATA);
         }
         int compare = newEntry.getRank().compareTo(oldEntry.getRank());
         if (compare < 0) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -72,7 +72,7 @@ public enum CorfuMsgType {
 
     WRITE_OK(50, TypeToken.of(CorfuMsg.class)),
     ERROR_TRIMMED(51, TypeToken.of(CorfuMsg.class)),
-    ERROR_OVERWRITE(52, TypeToken.of(CorfuMsg.class)),
+    ERROR_OVERWRITE(52, new TypeToken<CorfuPayloadMsg<Integer>>(){}, true),
     ERROR_OOS(53, TypeToken.of(CorfuMsg.class)),
     ERROR_RANK(54, TypeToken.of(CorfuMsg.class)),
     ERROR_NOENTRY(55, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitHandler.java
@@ -6,6 +6,7 @@ import java.lang.invoke.MethodHandles;
 
 import lombok.Getter;
 import lombok.Setter;
+
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
@@ -13,6 +14,7 @@ import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.DataOutrankedException;
 import org.corfudb.runtime.exceptions.OutOfSpaceException;
+import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.ValueAdoptedException;
@@ -78,9 +80,9 @@ public class LogUnitHandler implements IClient, IHandler<LogUnitClient> {
      * @throws OverwriteException Throws OverwriteException if address has already been written to.
      */
     @ClientHandler(type = CorfuMsgType.ERROR_OVERWRITE)
-    private static Object handleOverwrite(CorfuMsg msg, ChannelHandlerContext ctx, IClientRouter r)
+    private static Object handleOverwrite(CorfuPayloadMsg<Integer> msg, ChannelHandlerContext ctx, IClientRouter r)
             throws Exception {
-        throw new OverwriteException();
+        throw new OverwriteException(OverwriteCause.fromId(msg.getPayload()));
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AbortCause {
     CONFLICT,
+    OVERWRITE, /** Aborted because of slow writer, i.e., continuously gets overwritten (hole filled by faster reader) */
     NEW_SEQUENCER,
     USER,
     NETWORK,

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/OverwriteCause.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/OverwriteCause.java
@@ -1,0 +1,33 @@
+package org.corfudb.runtime.exceptions;
+
+import lombok.Getter;
+
+@Getter
+public enum OverwriteCause {
+    /** Indicates this address has been already written by a hole.*/
+    HOLE(0),
+    /** Indicates this address has been already written and it is 'potentially' the same data
+     * (i.e., based on data length). The client will drive final verification. This intends to be
+     * a hint so verification is only driven in very specific cases.*/
+    SAME_DATA(1),
+    /** Indicates this address has been already written and it is a different data (derived from the length).*/
+    DIFF_DATA(2),
+    /** Indicates this address was already trimmed.*/
+    TRIM(3),
+    /** Indicates there is no actual cause for the overwrite, hence no overwrite ecception has occured. */
+    NONE(4);
+
+    private int id;
+    OverwriteCause(int i) {
+        this.id = i;
+    }
+
+    public static OverwriteCause fromId(int id) {
+        for (OverwriteCause type : values()) {
+            if (type.getId() == id) {
+                return type;
+            }
+        }
+        return null;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/OverwriteException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/OverwriteException.java
@@ -1,7 +1,15 @@
 package org.corfudb.runtime.exceptions;
 
+import lombok.Getter;
+
 /**
  * Created by mwei on 12/14/15.
  */
+@Getter
 public class OverwriteException extends LogUnitException {
+   private OverwriteCause overWriteCause;
+
+    public OverwriteException(OverwriteCause cause) {
+        this.overWriteCause = cause;
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -1,5 +1,7 @@
 package org.corfudb.runtime.object.transactions;
 
+import static org.corfudb.runtime.view.ObjectsView.TRANSACTION_STREAM_ID;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -20,8 +22,6 @@ import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.ICorfuSMRAccess;
 import org.corfudb.runtime.object.ICorfuSMRProxyInternal;
 import org.corfudb.runtime.object.VersionLockedObject;
-
-import static org.corfudb.runtime.view.ObjectsView.TRANSACTION_STREAM_ID;
 
 /** A Corfu optimistic transaction context.
  *
@@ -304,7 +304,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
             // We were overwritten (and the original snapshot is now conflicting),
             // which means we must abort.
             throw new TransactionAbortedException(txInfo, null, null,
-                AbortCause.CONFLICT, oe, this);
+                AbortCause.OVERWRITE, oe, this);
         }
 
         log.trace("Commit[{}] Acquire address {}", this, address);

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
@@ -6,9 +6,18 @@
 
 package org.corfudb.runtime.view.replication;
 
+import java.time.Duration;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
@@ -17,6 +26,7 @@ import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.runtime.exceptions.DataOutrankedException;
 import org.corfudb.runtime.exceptions.HoleFillRequiredException;
 import org.corfudb.runtime.exceptions.LogUnitException;
+import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.TrimmedException;
@@ -29,14 +39,6 @@ import org.corfudb.util.Holder;
 import org.corfudb.util.retry.ExponentialBackoffRetry;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.RetryNeededException;
-
-import java.time.Duration;
-import java.util.Comparator;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 
 /**
  * Created by kspirov on 4/23/17.
@@ -139,7 +141,7 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
                     return;
                 }
             }
-            throw new OverwriteException();
+            throw new OverwriteException(OverwriteCause.DIFF_DATA);
         }
     }
 


### PR DESCRIPTION
## Overview

The cause CONFLICT is reported whenever two transaction conflict over
the same keys for a given stream(s). This change corrects the overload
of this abort cause for the case of slow writers, i.e., whenever a
writer fails to write given that the designated address is continuously
overwritten (perhaps hole filled) by a faster reader. This is due to the
fact that it is not really conflicting with any other stream, the cause
of abort is that you are overwritten by a fast reader in the system.

Why should this be merged: this is an issue that has been reported by the Application Layer as conflicting keys/streams show up being NULL which makes no sense out of a Conflicting Transaction for upper layers.

Related issue(s) (if applicable): #1399


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
