### PR TITLE
Force Timeout On Connection

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -182,6 +182,12 @@ public class CorfuRuntime {
         @Default Duration requestTimeout = Duration.ofSeconds(5);
 
         /**
+         * This timeout (in seconds) is used to detect servers that
+         * shutdown abruptly without terminating the connection properly.
+         */
+        @Default int idleConnectionTimeout = 30;
+
+        /**
          * {@link Duration} before connections timeout.
          */
         @Default Duration connectionTimeout = Duration.ofMillis(500);

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -16,6 +16,7 @@ import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.util.concurrent.GlobalEventExecutor;
 import lombok.Getter;
 import lombok.NonNull;
@@ -277,6 +278,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         return new ChannelInitializer() {
             @Override
             protected void initChannel(@Nonnull Channel ch) throws Exception {
+                ch.pipeline().addLast(new ReadTimeoutHandler(parameters.getIdleConnectionTimeout()));
                 if (parameters.isTlsEnabled()) {
                     ch.pipeline().addLast("ssl", sslContext.newHandler(ch.alloc()));
                 }


### PR DESCRIPTION
## Overview

The tcp connection can get in a state where the client doesn't
receive a termination signal, but the server dies abruptly. In this
case, the client can hang until the OS times out the connection.
This can take a very long time (in our case 15min) until the system
becomes available again.

Why should this be merged: Fixes a bug where the system can hang indefinitely 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
