### PR TITLE
Streamlog compaction

### DIFF
--- a/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
+++ b/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
@@ -385,18 +385,14 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                             }
                         } else if (method.getAnnotation(InterfaceOverride.class) != null) {
                             interfacesToAdd.add(ParameterizedTypeName.get(ifaceElement.asType()));
-                            if (overwrite.isPresent()) {
-                                methodSet.remove(overwrite.get());
-                            }
-                            methodSet.add(new SmrMethodInfo(method,
-                                        ifaceElement));
+                            overwrite.ifPresent(methodSet::remove);
+                            methodSet.add(new SmrMethodInfo(method, ifaceElement));
                         } else if (
                                 // if we have a implementation, and we aren't already
                                 // implemented by the object.
                                 method.getModifiers().contains(Modifier.DEFAULT)
                                         &&
-                                methodSet.stream().noneMatch(x -> x.method.toString()
-                                .equals(method.toString()))) {
+                                methodSet.stream().noneMatch(x -> x.method.toString().equals(method.toString()))) {
                             methodSet.add(new SmrMethodInfo(method,
                                             ifaceElement, true));
                         }

--- a/checks.xml
+++ b/checks.xml
@@ -86,7 +86,7 @@
             <property name="allowNonPrintableEscapes" value="true"/>
         </module>
         <module name="LineLength">
-            <property name="max" value="100"/>
+            <property name="max" value="120"/>
             <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>

--- a/generator/src/main/java/org/corfudb/generator/Generator.java
+++ b/generator/src/main/java/org/corfudb/generator/Generator.java
@@ -1,11 +1,7 @@
 package org.corfudb.generator;
 
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 
 import org.corfudb.generator.operations.CheckpointOperation;
 import org.corfudb.generator.operations.Operation;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -19,10 +19,10 @@ public abstract class AbstractServer {
     @Setter
     volatile boolean shutdown;
 
-    static final ExecutorService sharedExecutor = Executors
-            .newFixedThreadPool(BatchWriter.BATCH_SIZE + Runtime.getRuntime().availableProcessors(),
-                    new ServerThreadFactory("SharedServerThread-",
-                            new ServerThreadFactory.ExceptionHandler()));
+    private static final ExecutorService sharedExecutor = Executors.newFixedThreadPool(
+            BatchWriter.BATCH_SIZE + Runtime.getRuntime().availableProcessors(),
+            new ServerThreadFactory("SharedServerThread-", new ServerThreadFactory.ExceptionHandler())
+    );
 
     public AbstractServer() {
         shutdown = false;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -72,7 +72,7 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
     @Override
     public void write(@Nonnull K key, @Nonnull V value) {
         try {
-            CompletableFuture<Void> cf = new CompletableFuture();
+            CompletableFuture<Void> cf = new CompletableFuture<>();
             operationsQueue.add(new BatchWriterOperation(BatchWriterOperation.Type.WRITE,
                     (Long) key, (LogData) value, ((LogData) value).getEpoch(), null, cf));
             cf.get();
@@ -88,7 +88,7 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
 
     public void bulkWrite(List<LogData> entries, long epoch) {
         try {
-            CompletableFuture<Void> cf = new CompletableFuture();
+            CompletableFuture<Void> cf = new CompletableFuture<>();
             operationsQueue.add(new BatchWriterOperation(BatchWriterOperation.Type.RANGE_WRITE,
                     null, null, epoch, entries, cf));
         } catch (Exception e) {
@@ -192,7 +192,7 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
         try {
             BatchWriterOperation lastOp = null;
             int processed = 0;
-            List<BatchWriterOperation> res = new LinkedList();
+            List<BatchWriterOperation> res = new LinkedList<>();
 
             while (true) {
                 BatchWriterOperation currOp;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
@@ -32,6 +32,5 @@ public class BatchWriterOperation {
     private Exception exception;
 
 
-    public static BatchWriterOperation SHUTDOWN = new BatchWriterOperation(Type.SHUTDOWN,
-            null, null, null, null, null);
+    public static BatchWriterOperation SHUTDOWN = new BatchWriterOperation(Type.SHUTDOWN, null, null, null, null, null);
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
@@ -241,6 +241,6 @@ public class CorfuMsgHandler {
                                        aType -> (CorfuComponent.INFRA_MSG_HANDLER +
                                                  aType.name().toLowerCase()));
 
-        return ServerContext.getMetrics().timer(timerNameCache.get(type));
+        return MetricsUtils.metrics.timer(timerNameCache.get(type));
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -209,8 +209,7 @@ public class CorfuServer {
         final boolean bindToAllInterfaces;
         // Fetch the address if given a network interface.
         if (opts.get("--network-interface") != null) {
-            opts.put("--address",
-                    getAddressFromInterfaceName((String) opts.get("--network-interface")));
+            opts.put("--address", getAddressFromInterfaceName((String) opts.get("--network-interface")));
             bindToAllInterfaces = false;
         } else if (opts.get("--address") == null) {
             // Default the address to localhost and set the bind to all interfaces flag to true,
@@ -227,13 +226,10 @@ public class CorfuServer {
             File serviceDir = new File((String) opts.get("--log-path"));
 
             if (!serviceDir.isDirectory()) {
-                log.error("Service directory {} does not point to a directory. Aborting.",
-                        serviceDir);
+                log.error("Service directory {} does not point to a directory. Aborting.", serviceDir);
                 throw new UnrecoverableCorfuError("Service directory must be a directory!");
             } else {
-                String corfuServiceDirPath = serviceDir.getAbsolutePath()
-                        + File.separator
-                        + "corfu";
+                String corfuServiceDirPath = serviceDir.getAbsolutePath() + File.separator + "corfu";
                 File corfuServiceDir = new File(corfuServiceDirPath);
                 // Update the new path with the dedicated child service directory.
                 opts.put("--log-path", corfuServiceDirPath);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -114,16 +114,14 @@ public class LayoutServer extends AbstractServer {
         }
         long epoch = msg.getPayload();
         if (epoch <= serverContext.getServerEpoch()) {
-            r.sendResponse(ctx, msg, new LayoutMsg(getCurrentLayout(), CorfuMsgType
-                    .LAYOUT_RESPONSE));
+            r.sendResponse(ctx, msg, new LayoutMsg(getCurrentLayout(), CorfuMsgType.LAYOUT_RESPONSE));
             return;
         } else {
             // else the client is somehow ahead of the server.
             //TODO figure out a strategy to deal with this situation
             long serverEpoch = serverContext.getServerEpoch();
             r.sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
-            log.warn("handleMessageLayoutRequest: Message Epoch {} ahead of Server epoch {}",
-                    epoch, serverEpoch);
+            log.warn("handleMessageLayoutRequest: Message Epoch {} ahead of Server epoch {}", epoch, serverEpoch);
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -67,9 +67,9 @@ public class ManagementAgent {
      * Detectors to be used to detect failures and healing.
      */
     @Getter
-    private IDetector failureDetector;
+    private final IDetector failureDetector;
     @Getter
-    private IDetector healingDetector;
+    private final IDetector healingDetector;
     /**
      * Failure Handler Dispatcher to launch configuration changes or recovery.
      */
@@ -85,7 +85,7 @@ public class ManagementAgent {
      * To dispatch initialization tasks for recovery and sequencer bootstrap.
      */
     @Getter
-    private Thread initializationTaskThread;
+    private final Thread initializationTaskThread;
     /**
      * Detection Task Scheduler Service
      * This service schedules the following tasks every policyExecuteInterval (1 sec):
@@ -115,7 +115,7 @@ public class ManagementAgent {
      * Future which is marked completed if the node has recovered.
      */
     @Getter
-    private volatile CompletableFuture<Boolean> recoveryBarrierFuture;
+    private final CompletableFuture<Boolean> recoveryBarrierFuture;
 
     /**
      * Future which is reset every time a new task to bootstrap the sequencer is launched by the
@@ -167,8 +167,7 @@ public class ManagementAgent {
      * @param runtimeSingletonResource Singleton resource to fetch runtime.
      * @param serverContext            Server Context.
      */
-    ManagementAgent(SingletonResource<CorfuRuntime> runtimeSingletonResource,
-                    ServerContext serverContext) {
+    ManagementAgent(SingletonResource<CorfuRuntime> runtimeSingletonResource, ServerContext serverContext) {
         this.runtimeSingletonResource = runtimeSingletonResource;
         this.serverContext = serverContext;
         this.opts = serverContext.getServerConfig();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -24,8 +24,7 @@ import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
  */
 @Slf4j
 @ChannelHandler.Sharable
-public class NettyServerRouter extends ChannelInboundHandlerAdapter
-        implements IServerRouter {
+public class NettyServerRouter extends ChannelInboundHandlerAdapter implements IServerRouter {
 
 
     /**
@@ -38,7 +37,7 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
      */
     @Getter
     @Setter
-    volatile long serverEpoch;
+    private volatile long serverEpoch;
 
     /** The {@link AbstractServer}s this {@link NettyServerRouter} routes messages for. */
     @Getter
@@ -54,8 +53,9 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
         this.serverEpoch = ((BaseServer) servers.get(0)).serverContext.getServerEpoch();
         this.servers = servers;
         handlerMap = new EnumMap<>(CorfuMsgType.class);
-        servers.forEach(server -> server.getHandler().getHandledTypes()
-            .forEach(x -> handlerMap.put(x, server)));
+        servers.forEach(server ->
+                server.getHandler().getHandledTypes().forEach(x -> handlerMap.put(x, server))
+        );
     }
 
     /**
@@ -95,10 +95,10 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
     public boolean validateEpoch(CorfuMsg msg, ChannelHandlerContext ctx) {
         long serverEpoch = getServerEpoch();
         if (!msg.getMsgType().ignoreEpoch && msg.getEpoch() != serverEpoch) {
-            sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH,
-                    serverEpoch));
+            sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
             log.trace("Incoming message with wrong epoch, got {}, expected {}, message was: {}",
-                    msg.getEpoch(), serverEpoch, msg);
+                    msg.getEpoch(), serverEpoch, msg
+            );
             return false;
         }
         return true;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -122,9 +122,6 @@ public class ServerContext implements AutoCloseable {
     @Setter
     private boolean bindToAllInterfaces = false;
 
-    @Getter
-    public static final MetricRegistry metrics = new MetricRegistry();
-
     /**
      * Returns a new ServerContext.
      *
@@ -134,7 +131,6 @@ public class ServerContext implements AutoCloseable {
         this.serverConfig = serverConfig;
         this.dataStore = new DataStore(serverConfig);
         generateNodeId();
-        this.serverRouter = serverRouter;
         this.failureDetector = new FailureDetector();
         this.healingDetector = new HealingDetector();
         this.failureHandlerPolicy = new ConservativeFailureHandlerPolicy();
@@ -156,8 +152,8 @@ public class ServerContext implements AutoCloseable {
             getNewBossGroup();
 
         // Metrics setup & reporting configuration
-        if (!isMetricsReportingSetUp(metrics)) {
-            MetricsUtils.metricsReportingSetup(metrics);
+        if (!isMetricsReportingSetUp()) {
+            MetricsUtils.metricsReportingSetup();
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/SegmentHandle.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/SegmentHandle.java
@@ -38,7 +38,7 @@ class SegmentHandle {
     @NonNull
     String fileName;
 
-    private Map<Long, AddressMetaData> knownAddresses = new ConcurrentHashMap();
+    private Map<Long, AddressMetaData> knownAddresses = new ConcurrentHashMap<>();
     private Set<Long> trimmedAddresses = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private Set<Long> pendingTrims = Collections.newSetFromMap(new ConcurrentHashMap<>());
     private volatile int refCount = 0;
@@ -57,7 +57,7 @@ class SegmentHandle {
 
     public void close() {
         Set<FileChannel> channels =
-                new HashSet(Arrays.asList(writeChannel, readChannel, trimmedChannel, pendingTrimChannel));
+                new HashSet<>(Arrays.asList(writeChannel, readChannel, trimmedChannel, pendingTrimChannel));
         for (FileChannel channel : channels) {
             try {
                 channel.force(true);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogCompaction.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogCompaction.java
@@ -1,0 +1,63 @@
+package org.corfudb.infrastructure.log;
+
+import com.codahale.metrics.Counter;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.util.MetricsUtils;
+
+import java.util.concurrent.*;
+
+/**
+ * Scheduled log compaction manager.
+ * Execute log compaction safely (prevent scheduled executor corruption if the task throws an exception)
+ * https://stackoverflow.com/questions/6894595/scheduledexecutorservice-exception-handling
+ */
+@Slf4j
+public class StreamLogCompaction {
+    private static final String METRIC_NAME = StreamLogCompaction.class.getName();
+
+    private final ThreadFactory threadFactory = new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat("LogUnit-Maintenance-%d")
+            .build();
+
+    /**
+     * How many times log compaction executed
+     */
+    private final Counter gc;
+
+    /**
+     * A scheduler, which is used to schedule periodic garbage collection.
+     */
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(threadFactory);
+    private final ScheduledFuture<?> compactor;
+
+    public StreamLogCompaction(StreamLog streamLog, long initialDelay, long period, TimeUnit timeUnit) {
+        gc = MetricsUtils.metrics.counter(String.format("%s-stream[%d]", METRIC_NAME, streamLog.hashCode()));
+
+        Runnable task = () -> {
+            gc.inc();
+            log.debug("Start log compaction. Counter: {}", gc.getCount());
+            try {
+                streamLog.compact();
+            } catch (Throwable ex) {
+                log.error("Can't compact stream log. Counter: {}", gc.getCount());
+            }
+        };
+        compactor = scheduler.scheduleAtFixedRate(task, initialDelay, period, timeUnit);
+    }
+
+    public void shutdown() {
+        compactor.cancel(true);
+        scheduler.shutdownNow();
+    }
+
+    /**
+     * How many times log gc was executed (the log was compacted)
+     *
+     * @return counter
+     */
+    public long getGcCounter() {
+        return gc.getCount();
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -84,9 +84,9 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     private final boolean noVerify;
     private final ServerContext serverContext;
     private final AtomicLong globalTail = new AtomicLong(0L);
-    private Map<String, SegmentHandle> writeChannels;
-    private Set<FileChannel> channelsToSync;
-    private MultiReadWriteLock segmentLocks = new MultiReadWriteLock();
+    private final Map<String, SegmentHandle> writeChannels;
+    private final Set<FileChannel> channelsToSync;
+    private final MultiReadWriteLock segmentLocks = new MultiReadWriteLock();
     private long lastSegment;
     private volatile long startingAddress;
 
@@ -103,7 +103,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             dir.mkdirs();
         }
 
-        writeChannels = new ConcurrentHashMap();
+        writeChannels = new ConcurrentHashMap<>();
         channelsToSync = new HashSet<>();
         this.noVerify = noVerify;
         this.serverContext = serverContext;
@@ -386,7 +386,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     private void spaseCompact() {
         //TODO(Maithem) Open all segment handlers?
         for (SegmentHandle sh : writeChannels.values()) {
-            Set<Long> pending = new HashSet(sh.getPendingTrims());
+            Set<Long> pending = new HashSet<>(sh.getPendingTrims());
             Set<Long> trimmed = sh.getTrimmedAddresses();
 
             if (sh.getKnownAddresses().size() + trimmed.size() != RECORDS_PER_LOG_FILE) {
@@ -398,8 +398,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
 
             //what if pending size  == knownaddresses size ?
             if (pending.size() < TRIM_THRESHOLD) {
-                log.trace("Thresh hold not exceeded. Ratio {} threshold {}",
-                            pending.size(), TRIM_THRESHOLD);
+                log.trace("Thresh hold not exceeded. Ratio {} threshold {}", pending.size(), TRIM_THRESHOLD);
                 return; // TODO - should not return if compact on ranked address space is necessary
             }
 
@@ -455,8 +454,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             }
         }
 
-        Files.move(Paths.get(filePath + ".copy"), Paths.get(filePath),
-                StandardCopyOption.ATOMIC_MOVE);
+        Files.move(Paths.get(filePath + ".copy"), Paths.get(filePath), StandardCopyOption.ATOMIC_MOVE);
 
         // Force the reload of the new segment
         writeChannels.remove(filePath);
@@ -911,7 +909,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     @Deprecated  // TODO: Add replacement method that conforms to style
     @SuppressWarnings("checkstyle:abbreviationaswordinname") // Due to deprecation
     Set<String> getStrUUID(Set<UUID> uuids) {
-        Set<String> strUUIds = new HashSet();
+        Set<String> strUUIds = new HashSet<>();
 
         for (UUID uuid : uuids) {
             strUUIds.add(uuid.toString());
@@ -1278,8 +1276,6 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         for (SegmentHandle fh : writeChannels.values()) {
             fh.close();
         }
-
-        writeChannels = new HashMap<>();
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.8.0</version>

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
@@ -27,7 +27,7 @@ public class CorfuMsg {
      */
     static final int markerField = 0xC0FC0FC0;
     static Map<Byte, CorfuMsgType> typeMap =
-            Arrays.<CorfuMsgType>stream(CorfuMsgType.values())
+            Arrays.stream(CorfuMsgType.values())
                     .collect(Collectors.toMap(CorfuMsgType::asByte, Function.identity()));
     /**
      * The unique id of the client making the request.

--- a/runtime/src/main/java/org/corfudb/runtime/BootstrapUtil.java
+++ b/runtime/src/main/java/org/corfudb/runtime/BootstrapUtil.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime;
 
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import lombok.NonNull;
@@ -37,9 +38,7 @@ public class BootstrapUtil {
      * @param retries      Number of retries to bootstrap each node before giving up.
      * @param retryTimeout Duration between retries.
      */
-    public static void bootstrap(@NonNull Layout layout,
-                                 int retries,
-                                 @NonNull Duration retryTimeout) {
+    public static void bootstrap(@NonNull Layout layout, int retries, @NonNull Duration retryTimeout) {
         bootstrap(layout, CorfuRuntimeParameters.builder().build(), retries, retryTimeout);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -365,18 +365,11 @@ public class CorfuRuntime {
     @Getter
     private volatile boolean isShutdown = false;
 
-    @Getter
-    private static MetricRegistry defaultMetrics = new MetricRegistry();
-    @Getter
-    @Setter
-    private MetricRegistry metrics = new MetricRegistry();
-
-    /** Initialize a default static registry which through that different metrics
-     * can be registered and reported */
+    /**
+     * Initialize a default static registry which through that different metrics can be registered and reported
+     */
     static {
-        synchronized (defaultMetrics) {
-            MetricsUtils.metricsReportingSetup(defaultMetrics);
-        }
+        MetricsUtils.metricsReportingSetup();
     }
 
     /**
@@ -470,9 +463,6 @@ public class CorfuRuntime {
         // Initializing the node router pool.
         nodeRouterPool = new NodeRouterPool(getRouterFunction);
 
-        synchronized (metrics) {
-            MetricsUtils.metricsReportingSetup(metrics);
-        }
         log.info("Corfu runtime version {} initialized.", getVersionString());
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
@@ -45,8 +45,7 @@ public interface IClientRouter {
      * @return A completable future which will be fulfilled by the reply,
      * or a timeout in the case there is no response.
      */
-    <T> CompletableFuture<T> sendMessageAndGetCompletable(ChannelHandlerContext ctx,
-                                                          CorfuMsg message);
+    <T> CompletableFuture<T> sendMessageAndGetCompletable(ChannelHandlerContext ctx, CorfuMsg message);
 
     /**
      * Send a message using the router channel handler and

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
@@ -43,8 +43,7 @@ public class LayoutClient extends AbstractClient {
      * bootstrap was successful, false otherwise.
      */
     public CompletableFuture<Boolean> bootstrapLayout(Layout l) {
-        return sendMessageWithFuture(CorfuMsgType.LAYOUT_BOOTSTRAP
-                .payloadMsg(new LayoutBootstrapRequest(l)));
+        return sendMessageWithFuture(CorfuMsgType.LAYOUT_BOOTSTRAP.payloadMsg(new LayoutBootstrapRequest(l)));
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -1,13 +1,10 @@
 package org.corfudb.runtime.clients;
 
-import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.Range;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import lombok.Getter;
-import lombok.NonNull;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.DataType;
@@ -22,9 +19,9 @@ import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.protocols.wireprotocol.TrimRequest;
 import org.corfudb.protocols.wireprotocol.WriteMode;
 import org.corfudb.protocols.wireprotocol.WriteRequest;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.WriteSizeException;
 import org.corfudb.util.CorfuComponent;
+import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.serializer.Serializers;
 
 import java.util.List;
@@ -54,14 +51,6 @@ public class LogUnitClient extends AbstractClient {
         return getRouter().getPort();
     }
 
-    @Getter
-    MetricRegistry metricRegistry = CorfuRuntime.getDefaultMetrics();
-
-    public LogUnitClient setMetricRegistry(@NonNull MetricRegistry metricRegistry) {
-        this.metricRegistry = metricRegistry;
-        return this;
-    }
-
     int maxWrite;
 
     public LogUnitClient setMaxWrite(int limit) {
@@ -75,7 +64,7 @@ public class LogUnitClient extends AbstractClient {
                 getHost(),
                 getPort().toString(),
                 opName);
-        Timer t = getMetricRegistry().timer(timerName);
+        Timer t = MetricsUtils.metrics.timer(timerName);
         return t.time();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -429,7 +429,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         }
 
         // Set up the timer and context to measure request
-        final Timer roundTripMsgTimer = CorfuRuntime.getDefaultMetrics()
+        final Timer roundTripMsgTimer =MetricsUtils.metrics
                 .timer(timerNameCache.get(message.getMsgType()));
 
         final Timer.Context roundTripMsgContext = MetricsUtils

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -96,7 +96,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
      */
     final Object[] args;
 
-    private final MetricRegistry metrics;
+    private static final MetricRegistry metrics = MetricsUtils.metrics;
     /**
      * Metrics: meter (counter), histogram.
      */
@@ -148,7 +148,6 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 upcallTargetMap, undoRecordTargetMap,
                 undoTargetMap, resetSet);
 
-        metrics = rt.getMetrics() != null ? rt.getMetrics() : CorfuRuntime.getDefaultMetrics();
         mpObj = CorfuComponent.OBJECT.toString();
         timerAccess = metrics.timer(mpObj + "access");
         timerLogWrite = metrics.timer(mpObj + "log-write");

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -35,6 +35,7 @@ import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.CorfuComponent;
+import org.corfudb.util.MetricsUtils;
 
 
 /**
@@ -48,7 +49,7 @@ public class AddressSpaceView extends AbstractView {
     /**
      * A cache for read results.
      */
-    final LoadingCache<Long, ILogData> readCache = Caffeine.<Long, ILogData>newBuilder()
+    final LoadingCache<Long, ILogData> readCache = Caffeine.newBuilder()
             .maximumSize(runtime.getParameters().getNumCacheEntries())
             .expireAfterAccess(runtime.getParameters().getCacheExpiryTime(), TimeUnit.SECONDS)
             .expireAfterWrite(runtime.getParameters().getCacheExpiryTime(), TimeUnit.SECONDS)
@@ -70,14 +71,10 @@ public class AddressSpaceView extends AbstractView {
      */
     public AddressSpaceView(@Nonnull final CorfuRuntime runtime) {
         super(runtime);
-        MetricRegistry metrics = runtime.getMetrics();
-        final String pfx = String.format("%s0x%x.cache.", CorfuComponent.ADDRESS_SPACE_VIEW.toString(),
-                                         this.hashCode());
-        metrics.register(pfx + "cache-size", (Gauge<Long>) readCache::estimatedSize);
-        metrics.register(pfx + "evictions", (Gauge<Long>) () -> readCache.stats().evictionCount());
-        metrics.register(pfx + "hit-rate", (Gauge<Double>) () -> readCache.stats().hitRate());
-        metrics.register(pfx + "hits", (Gauge<Long>) () -> readCache.stats().hitCount());
-        metrics.register(pfx + "misses", (Gauge<Long>) () -> readCache.stats().missCount());
+        final String pfx = String.format(
+                "%s0x%x.cache.", CorfuComponent.ADDRESS_SPACE_VIEW.toString(), this.hashCode()
+        );
+        MetricsUtils.addCacheGauges(pfx, readCache);
     }
 
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
@@ -144,8 +144,6 @@ public class RuntimeLayout {
 
     public LogUnitClient getLogUnitClient(String endpoint) {
         return ((LogUnitClient) getClient(LogUnitClient.class, endpoint))
-                .setMetricRegistry(getRuntime().getMetrics() != null
-                        ? getRuntime().getMetrics() : CorfuRuntime.getDefaultMetrics())
                 .setMaxWrite(getRuntime().getParameters().getMaxWriteSize());
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogCompactionTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogCompactionTest.java
@@ -1,0 +1,49 @@
+package org.corfudb.infrastructure.log;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.AbstractCorfuTest;
+import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.infrastructure.ServerContextBuilder;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.junit.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+@Slf4j
+public class StreamLogCompactionTest extends AbstractCorfuTest {
+
+    private String getDirPath() {
+        return PARAMETERS.TEST_TEMP_DIR;
+    }
+
+    private ServerContext getContext() {
+        String path = getDirPath();
+        return new ServerContextBuilder()
+                .setLogPath(path)
+                .setMemory(false)
+                .build();
+    }
+
+    /**
+     * Test that task catch all possible exceptions and doesn't break scheduled executor
+     *
+     * @throws InterruptedException thread sleep
+     */
+    @Test
+    public void testCompaction() throws InterruptedException {
+        log.debug("Start log compaction test");
+
+        StreamLog streamLog = mock(StreamLog.class);
+        doThrow(new RuntimeException("err")).when(streamLog).compact();
+        StreamLogCompaction compaction = new StreamLogCompaction(streamLog, 10, 10, TimeUnit.MILLISECONDS);
+        Thread.sleep(35);
+        compaction.shutdown();
+
+        assertEquals(3, compaction.getGcCounter());
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogCompactionTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogCompactionTest.java
@@ -16,18 +16,10 @@ import static org.mockito.Mockito.mock;
 
 @Slf4j
 public class StreamLogCompactionTest extends AbstractCorfuTest {
-
-    private String getDirPath() {
-        return PARAMETERS.TEST_TEMP_DIR;
-    }
-
-    private ServerContext getContext() {
-        String path = getDirPath();
-        return new ServerContextBuilder()
-                .setLogPath(path)
-                .setMemory(false)
-                .build();
-    }
+    private final long initialDelay = 10;
+    private final long period = 10;
+    private final long timeout = 35;
+    private final int expectedCompactCounter = 3;
 
     /**
      * Test that task catch all possible exceptions and doesn't break scheduled executor
@@ -40,10 +32,10 @@ public class StreamLogCompactionTest extends AbstractCorfuTest {
 
         StreamLog streamLog = mock(StreamLog.class);
         doThrow(new RuntimeException("err")).when(streamLog).compact();
-        StreamLogCompaction compaction = new StreamLogCompaction(streamLog, 10, 10, TimeUnit.MILLISECONDS);
-        Thread.sleep(35);
+        StreamLogCompaction compaction = new StreamLogCompaction(streamLog, initialDelay, period, TimeUnit.MILLISECONDS);
+        Thread.sleep(timeout);
         compaction.shutdown();
 
-        assertEquals(3, compaction.getGcCounter());
+        assertEquals(expectedCompactCounter, compaction.getGcCounter());
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -241,8 +241,7 @@ public class TestClientRouter implements IClientRouter {
                                CorfuComponent.CLIENT_ROUTER.toString() +
                                message.getMsgType().name().toLowerCase());
         }
-        return CorfuRuntime.getDefaultMetrics()
-                .timer(timerNameCache.get(message.getMsgType()));
+        return MetricsUtils.metrics.timer(timerNameCache.get(message.getMsgType()));
     }
 
     /**

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -30,7 +30,7 @@
     <!-- Control logging levels for individual components here. -->
     <logger name="org.corfudb.runtime.object" level="INFO"/>
     <logger name="org.corfudb.runtime.clients" level="INFO"/>
-    <logger name="org.corfudb.infrastructure" level="INFO"/>
+    <logger name="org.corfudb.infrastructure" level="trace"/>
     <logger name="io.netty.util" level="INFO"/>
     <logger name="io.netty.util.internal" level="INFO"/>
     <logger name="io.netty.buffer" level="INFO"/>
@@ -40,9 +40,9 @@
     </logger>
 
 
-    <root level="INFO">
+    <root level="trace">
         <!--<appender-ref ref="FILE" />-->
-        <!--<appender-ref ref="STDOUT" />-->
+        <appender-ref ref="STDOUT" />
         <!--<appender-ref ref="MetricsRollingFile" />-->
     </root>
 </configuration>


### PR DESCRIPTION
## Overview
Improve Log compaction functional

Description:
Log cleaner extracted from LogUnitServer into a separated class StreamLogCompaction. 

Why should this be merged: 
Added try-catch block to prevent scheduled pool corruption if the task throws an exception. MetricsUtil small improvement.

Related issue(s) (if applicable): #1402 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
