### PR TITLE
Remaining up to behavior non-existing addresses

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -135,7 +135,7 @@ public abstract class AbstractQueuedStreamView extends
 
         // If maxGlobal is before the checkpoint position, throw a
         // trimmed exception
-        if (maxGlobal < context.checkpointSuccessStartAddr) {
+        if (maxGlobal < context.checkpointSuccessStartAddr && Address.isAddress(maxGlobal)) {
             throw new TrimmedException();
         }
 

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -1,6 +1,13 @@
 package org.corfudb.runtime.view;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.UUID;
+
 import lombok.Getter;
+
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
@@ -8,12 +15,6 @@ import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.List;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Created by mwei on 1/8/16.
@@ -83,6 +84,19 @@ public class StreamViewTest extends AbstractViewTest {
         txStream = rt2.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID, options);
         entries = txStream.remainingUpTo(Long.MAX_VALUE);
         assertThat(entries.size()).isEqualTo((firstIter / 2));
+    }
+
+    /**
+     * Test Remaining Up To when attempting to access the space of non-existing addresses
+     * (negative space). In this case we expect 0 entries to be retrieved.
+     */
+    @Test
+    public void testRemainingUpToNonExistingSpace() {
+        UUID streamID = UUID.randomUUID();
+        IStreamView testStream = runtime.getStreamsView().get(streamID);
+        final long nonExistingAddress = -10L;
+        List<ILogData> entries = testStream.remainingUpTo(nonExistingAddress);
+        assertThat(entries.size()).isEqualTo(0);
     }
 
     @Test


### PR DESCRIPTION
## Overview

Fix behavior of remaining up to when attempting to retrieve entries up
to a non-existing address (negative address).


Description:

Why should this be merged: wrong behavior. Currently it throws a Trimmed Exception which is fundamentally wrong, because it is not that the address was trimmed, but instead by being an invalid address no entries are retrieved. 

Related issue(s) (if applicable): #1419


## Checklist (Definition of Done):

- [x ] There are no TODOs left in the code
- [ x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ x] Change is covered by automated tests
- [x ] Public API has Javadoc
