### PR TITLE
Add DB_SYNCING Node status

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -356,6 +356,7 @@ public class CorfuRuntime {
     /**
      * A list of known layout servers.
      */
+    @Getter
     private List<String> layoutServers;
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/ClusterStatusReport.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ClusterStatusReport.java
@@ -25,6 +25,11 @@ public class ClusterStatusReport {
         UP,
 
         /**
+         * Node is reachable but does not have complete data redundancy.
+         */
+        DB_SYNCING,
+
+        /**
          * Node is not reachable.
          */
         DOWN


### PR DESCRIPTION
## Overview

Description: Add an intermediate node status- DB_SYNCING to denote that the node is recovering and does not have full redundancy.

Why should this be merged: Provides better visibility to the users.

Related issue(s) (if applicable): Resolves #1415 and #1416 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
