### PR TITLE
Fix TAE abort cause on sequencer failover

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -1,7 +1,7 @@
 package org.corfudb.infrastructure;
 
+import static org.corfudb.protocols.wireprotocol.TokenType.TX_ABORT_NEWSEQ;
 import static org.corfudb.protocols.wireprotocol.TokenType.TX_ABORT_SEQ_OVERFLOW;
-
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
@@ -121,11 +121,19 @@ public class SequencerServer extends AbstractServer {
      *
      * {@link SequencerServer::maxConflictWildcard} :
      * a "wildcard" representing the maximal update timestamp of
-     * all the confict keys which were evicted from the cache
+     * all the conflict keys which were evicted from the cache
+     *
+     * * {@link SequencerServer::maxConflictNewSequencer} :
+     * represents the max update timestamp of all the conflict keys
+     * which were evicted from the cache by the time this server is elected
+     * the primary sequencer. This means that any snapshot timestamp below this
+     * actual threshold would abort due to NEW_SEQUENCER cause.
      */
+    private final Cache<String, Long> conflictToGlobalTailCache;
+
     private long maxConflictWildcard = Address.NOT_FOUND;
 
-    private final Cache<String, Long> conflictToGlobalTailCache;
+    private long maxConflictNewSequencer = Address.NOT_FOUND;
 
     /**
      * Handler for this server.
@@ -180,12 +188,11 @@ public class SequencerServer extends AbstractServer {
             cacheSize = Long.parseLong((String) opts.get("--sequencer-cache-size"));
 
         }
-
         conflictToGlobalTailCache = Caffeine.newBuilder()
                 .maximumSize(cacheSize)
                 .removalListener((String k, Long v, RemovalCause cause) -> {
                     if (!RemovalCause.REPLACED.equals(cause)) {
-                        log.trace("Updating maxConflictWildcard. Old value = '{}', new value='{}'"
+                         log.trace("Updating maxConflictWildcard. Old value = '{}', new value='{}'"
                                         + " conflictParam = '{}'. Removal cause = '{}'",
                                 maxConflictWildcard, v, k, cause);
                         maxConflictWildcard = Math.max(v, maxConflictWildcard);
@@ -259,6 +266,21 @@ public class SequencerServer extends AbstractServer {
                         break;
                     }
 
+                    // The maxConflictNewSequencer is modified whenever a server is elected
+                    // as the 'new' sequencer, we immediately set its value to the max timestamp
+                    // evicted from the cache at that time. If a txSnapshotTimestamp falls
+                    // under this threshold we can report that the cause of abort is due to
+                    // a NEW_SEQUENCER (not able to hold these in its cache).
+                    if (txSnapshotTimestamp < maxConflictNewSequencer) {
+                        log.debug("ABORT[{}] snapshot-ts[{}] WILDCARD New Sequencer ts=[{}]",
+                                txInfo, txSnapshotTimestamp, maxConflictNewSequencer);
+                        response.set(TX_ABORT_NEWSEQ);
+                        break;
+                    }
+
+                    // If the txSnapshotTimestamp did not fall under the new sequencer threshold
+                    // but it does fall under the latest evicted timestamp we report the cause of
+                    // abort as SEQUENCER_OVERFLOW
                     if (txSnapshotTimestamp < maxConflictWildcard) {
                         log.debug("ABORT[{}] snapshot-ts[{}] WILDCARD ts=[{}]",
                                 txInfo, txSnapshotTimestamp, maxConflictWildcard);
@@ -392,6 +414,7 @@ public class SequencerServer extends AbstractServer {
         if (!bootstrapWithoutTailsUpdate) {
             globalLogTail.set(initialToken);
             maxConflictWildcard = initialToken - 1;
+            maxConflictNewSequencer = maxConflictWildcard;
             conflictToGlobalTailCache.invalidateAll();
 
             // Clear the existing map as it could have been populated by an earlier reset.

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -1,12 +1,19 @@
 package org.corfudb.runtime.checkpoint;
 
-import lombok.extern.slf4j.Slf4j;
+import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.reflect.TypeToken;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import lombok.Getter;
-import org.assertj.core.api.ThrowableAssert;
+import lombok.extern.slf4j.Slf4j;
+
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.AbstractObjectTest;
@@ -15,13 +22,6 @@ import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Created by dmalkhi on 5/25/17.
@@ -399,6 +399,7 @@ public class CheckpointTest extends AbstractObjectTest {
                     try {
                         localm2A.get(0);
                     } catch (TransactionAbortedException te) {
+                        assertThat(te.getAbortCause()).isEqualTo(AbortCause.TRIM);
                         // this is an expected behavior!
                         trimExceptionFlag.set(true);
                     }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/TXConflictScenariosTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/TXConflictScenariosTest.java
@@ -1,16 +1,17 @@
 package org.corfudb.runtime.object.transactions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.reflect.TypeToken;
+
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.CorfuSharedCounter;
 import org.junit.Test;
-
-import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicIntegerArray;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by dalia on 12/29/16.
@@ -85,7 +86,7 @@ public abstract class TXConflictScenariosTest extends AbstractTransactionContext
                     .isEqualTo(OVERWRITE_TWICE);
         });
 
-        // SM step 8: all tasks try to commit their transacstion.
+        // SM step 8: all tasks try to commit their transaction.
         // Task k aborts if, and only if, counter k+1 was modified after it read it and transaction k+1 already committed.
         addTestStep((task_num) -> {
             try {

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/TXsFromTwoRuntimesTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/TXsFromTwoRuntimesTest.java
@@ -1,15 +1,16 @@
 package org.corfudb.runtime.object.transactions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.reflect.TypeToken;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.collections.ISMRMap;
-import org.corfudb.runtime.collections.SMRMap;
-import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.junit.Test;
 
 import java.util.concurrent.Semaphore;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.ISMRMap;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.exceptions.AbortCause;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.junit.Test;
 
 /**
  * Created by dalia on 1/6/17.
@@ -98,6 +99,7 @@ public class TXsFromTwoRuntimesTest extends AbstractTransactionsTest {
             } catch (InterruptedException e) {
                 e.printStackTrace();
             } catch (TransactionAbortedException te) {
+                assertThat(te.getAbortCause()).isEqualTo(AbortCause.CONFLICT);
                 isAbort = true;
             }
 
@@ -214,7 +216,7 @@ public class TXsFromTwoRuntimesTest extends AbstractTransactionsTest {
             // release thread1 to complete
             sem1.release();
 
-            // expect to abort
+            // expect not to abort
             assertThat(isAbort)
                     .isFalse();
 

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/UndoTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/UndoTest.java
@@ -1,14 +1,15 @@
 package org.corfudb.runtime.object.transactions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.reflect.TypeToken;
-import org.corfudb.runtime.collections.SMRMap;
-import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Map;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.exceptions.AbortCause;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.junit.Test;
 
 /**
  * Created by dalia on 3/6/17.
@@ -333,6 +334,7 @@ public class UndoTest extends AbstractTransactionsTest {
             try {
                 TXEnd();
             } catch (TransactionAbortedException te) {
+                assertThat(te.getAbortCause()).isEqualTo(AbortCause.CONFLICT);
                 aborted = true;
             }
             assertThat(aborted);


### PR DESCRIPTION
## Overview

Correct the cause of abort for transactions that cannot commit whenever
there is a sequencer failover from Sequencer Overflow to New Sequencer. 

Why should this be merged: this is a semantic problem that can lead to wrong solutions, like resizing the cache under the believe that transactions are aborting due to sequencer overflow.

Related issue(s) (if applicable): #1429


## Checklist (Definition of Done):

- [x ] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
