### PR TITLE
Reject empty seq bootstrap msg on failover.

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/SequencerTailsRecoveryMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/SequencerTailsRecoveryMsg.java
@@ -17,7 +17,7 @@ public class SequencerTailsRecoveryMsg implements ICorfuPayload<SequencerTailsRe
 
     private Long globalTail;
     private Map<UUID, Long> streamTails;
-    private Long readyStateEpoch;
+    private Long sequencerEpoch;
 
     /**
      * Boolean flag to denote whether this bootstrap message is just updating an existing primary
@@ -29,7 +29,7 @@ public class SequencerTailsRecoveryMsg implements ICorfuPayload<SequencerTailsRe
     public SequencerTailsRecoveryMsg(ByteBuf buf) {
         globalTail = ICorfuPayload.fromBuffer(buf, Long.class);
         streamTails = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
-        readyStateEpoch = ICorfuPayload.fromBuffer(buf, Long.class);
+        sequencerEpoch = ICorfuPayload.fromBuffer(buf, Long.class);
         bootstrapWithoutTailsUpdate = ICorfuPayload.fromBuffer(buf, Boolean.class);
     }
 
@@ -38,7 +38,7 @@ public class SequencerTailsRecoveryMsg implements ICorfuPayload<SequencerTailsRe
 
         ICorfuPayload.serialize(buf, globalTail);
         ICorfuPayload.serialize(buf, streamTails);
-        ICorfuPayload.serialize(buf, readyStateEpoch);
+        ICorfuPayload.serialize(buf, sequencerEpoch);
         ICorfuPayload.serialize(buf, bootstrapWithoutTailsUpdate);
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -30,7 +30,7 @@ public class SequencerServerTest extends AbstractServerTest {
 
     @Before
     public void bootstrapSequencer() {
-        server.setBootstrapEpoch(0L);
+        server.setSequencerEpoch(0L);
     }
 
     /**
@@ -211,8 +211,8 @@ public class SequencerServerTest extends AbstractServerTest {
         tailMap.put(streamB, newTailB);
         tailMap.put(streamC, newTailC);
 
-        // Modifying the bootstrapEpoch to simulate sequencer reset.
-        server.setBootstrapEpoch(-1L);
+        // Modifying the sequencerEpoch to simulate sequencer reset.
+        server.setSequencerEpoch(-1L);
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.BOOTSTRAP_SEQUENCER,
                 new SequencerTailsRecoveryMsg(globalTail + 2, tailMap, 0L, false)));
 


### PR DESCRIPTION
## Overview

Description: Reject empty/delta sequencer bootstrap messages on the failover sequencer.

Why should this be merged: Causes a correctness issue where the sequencer dispatches stale tokens and regresses the token count.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
