### PR TITLE
Learn trim mark (#1442)

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -125,6 +125,9 @@ public class CorfuRuntime {
 
         /** Sets expireAfterAccess and expireAfterWrite in seconds. */
         @Default long cacheExpiryTime = Long.MAX_VALUE;
+
+        /** Sets the period of retrieving the latest trim mark in minutes. */
+        @Default long trimMarkSyncPeriod = 10;
         // endregion
 
         // region Handshake Parameters
@@ -530,6 +533,8 @@ public class CorfuRuntime {
                 log.error("Runtime shutting down. Exception in terminating fetchLayout: {}", e);
             }
         }
+        // Clear the cache and stop running tasks.
+        this.getAddressSpaceView().shutdown();
 
         stop(true);
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -220,7 +220,7 @@ public class LogUnitClient extends AbstractClient {
     }
 
     /**
-     * Get the starting address of a loggining unit.
+     * Get the starting address of a logging unit.
      * @return A CompletableFuture for the starting address
      */
     public CompletableFuture<Long> getTrimMark() {

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -127,6 +127,41 @@ public class AddressSpaceViewTest extends AbstractViewTest {
     }
 
     @Test
+    public void testSyncTrimMark() {
+        CorfuRuntime r = getRuntime().connect();
+        AddressSpaceView spaceView = r.getAddressSpaceView();
+        assertThat(spaceView.getTrimMark()).isEqualTo(0);
+
+        final String basicTestPayload = "payload";
+        final long layoutEpoch = r.getLayoutView().getLayout().getEpoch();
+        final int entryNum = 10;
+
+        for (int i = 0; i< entryNum; i++) {
+            String payload = basicTestPayload + String.valueOf(i);
+            spaceView.write(new Token(i, layoutEpoch), payload.getBytes());
+        }
+
+        final int inclusiveTrimAddress = 3;
+        spaceView.prefixTrim(inclusiveTrimAddress);
+        final int trimMark = (int) spaceView.getTrimMark();
+        assertThat(trimMark).isEqualTo(inclusiveTrimAddress + 1);
+        assertThat(spaceView.readCache.asMap().size()).isEqualTo(entryNum);
+
+        // Run TrimMarkSyncTask once.
+        AddressSpaceView.TrimMarkSyncTask trimMarkSyncTask = spaceView.new TrimMarkSyncTask();
+        trimMarkSyncTask.run();
+
+        // Keys less than trimMark should be removed from cache.
+        int expectedCacheSize = entryNum - trimMark;
+        assertThat(spaceView.readCache.asMap().size()).isEqualTo(expectedCacheSize);
+        assertThat(Collections.min(spaceView.readCache.asMap().keySet())).isEqualTo(trimMark);
+
+        // After shutdown, cache has been cleared.
+        spaceView.shutdown();
+        assertThat(spaceView.readCache.asMap().isEmpty()).isTrue();
+    }
+
+    @Test
     @SuppressWarnings("unchecked")
     public void ensureStripingReadAllWorks()
             throws Exception {


### PR DESCRIPTION
## Overview

Description:
1. Periodically try to learn the trim mark by querying the system.
This will help flush CorfuRuntime caches.

2. Clear cache when runtime is shutdown.

Why should this be merged: 

Related issue(s) (if applicable): #1442 


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
