### PR TITLE
Learn trim mark and trim resolvedQueue.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -11,6 +11,7 @@ import java.lang.Thread.UncaughtExceptionHandler;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -24,12 +25,15 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Data;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 import lombok.Singular;
+import lombok.ToString;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,6 +53,7 @@ import org.corfudb.runtime.exceptions.ShutdownException;
 import org.corfudb.runtime.exceptions.WrongClusterException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.AddressSpaceView;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.LayoutManagementView;
@@ -125,6 +130,13 @@ public class CorfuRuntime {
 
         /** Sets expireAfterAccess and expireAfterWrite in seconds. */
         @Default long cacheExpiryTime = Long.MAX_VALUE;
+
+        /** Sets the period of retrieving the latest trim mark in minutes. */
+        @Default Duration trimMarkSyncPeriod = Duration.ofMinutes(10);
+
+        /** Sets the period of trimming the resolvedQueues in minutes. **/
+        // FIXME: Remove this with the Stream Layer refactor.
+        @Default Duration resolvedStreamTrimTimeout = Duration.ofMinutes(120);
         // endregion
 
         // region Handshake Parameters
@@ -353,6 +365,42 @@ public class CorfuRuntime {
     private NodeRouterPool nodeRouterPool;
 
     /**
+     * Trim Snapshot contains the address at which the log was trimmed and the timestamp at which
+     * the runtime learnt the trim.
+     * FIXME: This would be deprecated with the introduction of the Stream Layer refactoring.
+     */
+    @ToString
+    @AllArgsConstructor
+    public class TrimSnapshot {
+        public final long trimMark;
+        public final long trimTimestamp;
+    }
+
+    /**
+     * A linked list to keep a record of the trim snapshots learnt by the runtime.
+     * These snapshots are cleared when they expire after
+     * {@link CorfuRuntimeParameters#resolvedStreamTrimTimeout}
+     */
+    @Getter
+    private final LinkedList<TrimSnapshot> trimSnapshotList = new LinkedList<>();
+
+    /**
+     * Adds the trim snapshot to the linked list.
+     *
+     * @param trimMark  Address at which the log was trimmed.
+     * @param timestamp Timestamp at which the trim was learnt.
+     */
+    public void addTrimSnapshot(@NonNull long trimMark, @NonNull long timestamp) {
+        trimSnapshotList.addLast(new TrimSnapshot(trimMark, timestamp));
+    }
+
+    /**
+     * Trim snapshot which was recorded more than {@link CorfuRuntimeParameters#resolvedStreamTrimTimeout}
+     * duration ago and can now be used the trim the resolvedQueue safely.
+     */
+    public volatile long matureTrimMark = Address.NON_ADDRESS;
+
+    /**
      * A completable future containing a layout, when completed.
      */
     public volatile CompletableFuture<Layout> layout;
@@ -530,6 +578,8 @@ public class CorfuRuntime {
                 log.error("Runtime shutting down. Exception in terminating fetchLayout: {}", e);
             }
         }
+        // Clear the cache and stop running tasks.
+        this.getAddressSpaceView().shutdown();
 
         stop(true);
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -220,7 +220,7 @@ public class LogUnitClient extends AbstractClient {
     }
 
     /**
-     * Get the starting address of a loggining unit.
+     * Get the starting address of a logging unit.
      * @return A CompletableFuture for the starting address
      */
     public CompletableFuture<Long> getTrimMark() {

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -8,12 +8,15 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
@@ -45,6 +48,14 @@ import org.corfudb.util.CorfuComponent;
  */
 @Slf4j
 public class AddressSpaceView extends AbstractView {
+
+    /**
+     * Scheduler for periodically retrieving the latest trim mark and flush cache.
+     */
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder().setDaemon(true)
+                    .setNameFormat("SyncTrimMark")
+                    .build());
 
     /**
      * A cache for read results.
@@ -79,8 +90,25 @@ public class AddressSpaceView extends AbstractView {
         metrics.register(pfx + "hit-rate", (Gauge<Double>) () -> readCache.stats().hitRate());
         metrics.register(pfx + "hits", (Gauge<Long>) () -> readCache.stats().hitCount());
         metrics.register(pfx + "misses", (Gauge<Long>) () -> readCache.stats().missCount());
+
+        scheduler.scheduleWithFixedDelay(new TrimMarkSyncTask(),
+                runtime.getParameters().getTrimMarkSyncPeriod().toMillis(),
+                runtime.getParameters().getTrimMarkSyncPeriod().toMillis(), TimeUnit.MILLISECONDS);
     }
 
+    /**
+     * Shuts down the AddressSpaceView.
+     * Invalidate the whole cache.
+     * Stops periodic task for retrieving the latest trim mark.
+     */
+    public void shutdown() {
+        try {
+            readCache.invalidateAll();
+            scheduler.shutdownNow();
+        } catch (Exception e) {
+            log.error("Failed to shutdown AddressSpaceView.", e);
+        }
+    }
 
     /**
      * Reset all in-memory caches.
@@ -341,6 +369,27 @@ public class AddressSpaceView extends AbstractView {
     }
 
     /**
+     * Invalidate cache entries with keys less than the specific address.
+     *
+     * @param address Keys less than the input log address will be invalidated.
+     */
+    public void invalidateClientCache(long address) {
+        // TODO: Might need to do some statistics to clear up cache when the amount to
+        // invalidate is huge.
+        readCache.asMap().keySet().forEach(k -> {
+            if (k < address) {
+                try {
+                    readCache.invalidate(k);
+                } catch (RuntimeException e) {
+                    log.error("invalidateClientCache: Error while invalidating cache entry with key={}",
+                            k, e);
+                }
+            }
+        });
+        log.info("invalidateClientCache: Keys less than {} are invalidated in cache.", address);
+    }
+
+    /**
      * Fetch an address for insertion into the cache.
      *
      * @param address An address to read from.
@@ -416,5 +465,37 @@ public class AddressSpaceView extends AbstractView {
     @VisibleForTesting
     LoadingCache<Long, ILogData> getReadCache() {
         return readCache;
+    }
+
+    /**
+     * Running periodically to retrieve the latest trim mark and flush cache.
+     * Also updates the trimMark in the runtime once the time required to trim the resolvedQueue
+     * has elapsed.
+     */
+    class TrimMarkSyncTask implements Runnable {
+
+        @Override
+        public void run() {
+            long latestTrimMark = getTrimMark();
+            final long currentTimestamp = System.currentTimeMillis();
+
+            // Learns the trim mark and updates only if not previously recorded.
+            if (runtime.getTrimSnapshotList().isEmpty()
+                    || runtime.getTrimSnapshotList().getLast().trimMark < latestTrimMark) {
+                runtime.addTrimSnapshot(latestTrimMark, currentTimestamp);
+                log.info("TrimMarkSyncTask: trim mark is updated from {} to {}.",
+                        runtime.getTrimSnapshotList().getLast().trimMark, latestTrimMark);
+
+                invalidateClientCache(latestTrimMark);
+            }
+
+            // Removes the trim snapshot from the list if it has been recorded before
+            // resolvedStreamTrimTimeout duration in the runtime.
+            if (!runtime.getTrimSnapshotList().isEmpty()
+                    && currentTimestamp - runtime.getTrimSnapshotList().getFirst().trimTimestamp
+                    > runtime.getParameters().getResolvedStreamTrimTimeout().toMillis()) {
+                runtime.matureTrimMark = runtime.getTrimSnapshotList().removeFirst().trimMark;
+            }
+        }
     }
 }


### PR DESCRIPTION
## Overview

Description: Learns the trim mark from @cjqhenry14 's PR #1448 and trimming the resolved queue after a considerable amount of time.
However, this should be replaced by the introduction of the new StreamLayer.

Why should this be merged: Causes a memory leak as the resolvedQueue is never trimmed.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
