### PR TITLE
Invalidate Layout on SystemDownHandler trigger

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -124,6 +124,8 @@ public abstract class AbstractView {
             } catch (InterruptedException ie) {
                 throw new UnrecoverableCorfuInterruptedError("Interrupted in layoutHelper", ie);
             } catch (ExecutionException ex) {
+                // Invalidate layout since the layout completable future now contains an exception.
+                runtime.invalidateLayout();
                 // If an error or an unchecked exception is thrown by the layout.get() completable
                 // future, the exception will materialize as an ExecutionException. In that case,
                 // we need to propagate this Error or unchecked exception.


### PR DESCRIPTION
## Overview

Description:
Invalidate layout when invoking systemDownHandler. Else the layout completable future is stuck with the systemDownHandlerException forever.

Why should this be merged: The layout completable future is stuck with the systemDownHandlerException forever.

Related issue(s) (if applicable): Fixes #1466 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
