### PR TITLE
Invalidate layout on systemDownHandler.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -68,6 +68,39 @@ public abstract class AbstractView {
     private AtomicReference<RuntimeLayout> runtimeLayout = new AtomicReference<>();
 
     /**
+     * Fetches the layout uninterruptibly and rethrows any systemDownHandlerExceptions or Errors
+     * encountered.
+     *
+     * @return Fetched layout
+     */
+    private Layout getLayoutUninterruptibly() {
+        try {
+            return runtime.layout.get();
+        } catch (InterruptedException ie) {
+            throw new UnrecoverableCorfuInterruptedError("Interrupted in layoutHelper", ie);
+        } catch (ExecutionException ex) {
+            // Invalidate layout since the layout completable future now contains an exception.
+            runtime.invalidateLayout();
+            // If an error or an unchecked exception is thrown by the layout.get() completable
+            // future, the exception will materialize as an ExecutionException. In that case,
+            // we need to propagate this Error or unchecked exception.
+            if (ex.getCause() instanceof Error) {
+                log.error("getLayoutUninterruptibly: Encountered error. Aborting layoutHelper", ex);
+                throw (Error) ex.getCause();
+            }
+
+            if (ex.getCause() instanceof RuntimeException) {
+                log.error("getLayoutUninterruptibly: Encountered unchecked exception. "
+                        + "Aborting layoutHelper", ex);
+                throw (RuntimeException) ex.getCause();
+            }
+
+            log.error("getLayoutUninterruptibly: Encountered exception while fetching layout");
+            throw new RuntimeException(ex);
+        }
+    }
+
+    /**
      * Helper function for view to retrieve layouts.
      * This function will retry the given function indefinitely,
      * invalidating the view if there was a exception contacting the endpoint.
@@ -75,26 +108,28 @@ public abstract class AbstractView {
      * There is a flag to set if we want the caller to handle Runtime Exceptions. For some
      * special cases (like writes), we need to do a bit more work upon a Runtime Exception than just retry.
      *
-     * @param function The function to execute.
-     * @param <T>      The return type of the function.
-     * @param <A>      Any exception the function may throw.
-     * @param <B>      Any exception the function may throw.
-     * @param <C>      Any exception the function may throw.
-     * @param <D>      Any exception the function may throw.
+     * @param function             The function to execute.
+     * @param <T>                  The return type of the function.
+     * @param <A>                  Any exception the function may throw.
+     * @param <B>                  Any exception the function may throw.
+     * @param <C>                  Any exception the function may throw.
+     * @param <D>                  Any exception the function may throw.
      * @param rethrowAllExceptions if all exceptions are rethrown to caller.
      * @return The return value of the function.
      */
     public <T, A extends RuntimeException, B extends RuntimeException, C extends RuntimeException,
             D extends RuntimeException> T layoutHelper(LayoutFunction<Layout, T, A, B, C, D>
-                                                                          function,
+                                                               function,
                                                        boolean rethrowAllExceptions)
             throws A, B, C, D {
         runtime.beforeRpcHandler.run();
         final Duration retryRate = runtime.getParameters().getConnectionRetryRate();
         int systemDownTriggerCounter = runtime.getParameters().getSystemDownHandlerTriggerLimit();
         while (true) {
+
+            final Layout layout = getLayoutUninterruptibly();
+
             try {
-                final Layout layout = runtime.layout.get();
                 return function.apply(runtimeLayout.updateAndGet(rLayout -> {
                     if (rLayout == null || rLayout.getLayout().getEpoch() != layout.getEpoch()) {
                         return new RuntimeLayout(layout, runtime);
@@ -103,8 +138,8 @@ public abstract class AbstractView {
                 }));
             } catch (RuntimeException re) {
                 if (re.getCause() instanceof TimeoutException) {
-                    log.warn("Timeout executing remote call, invalidating view and retrying in {}s",
-                            retryRate);
+                    log.warn("Timeout executing remote call, invalidating view and retrying "
+                            + "in {}s", retryRate);
                 } else if (re instanceof ServerNotReadyException) {
                     log.warn("Server still not ready. Waiting for server to start "
                             + "accepting requests.");
@@ -120,26 +155,6 @@ public abstract class AbstractView {
                 if (rethrowAllExceptions) {
                     throw new RuntimeException(re);
                 }
-
-            } catch (InterruptedException ie) {
-                throw new UnrecoverableCorfuInterruptedError("Interrupted in layoutHelper", ie);
-            } catch (ExecutionException ex) {
-                // If an error or an unchecked exception is thrown by the layout.get() completable
-                // future, the exception will materialize as an ExecutionException. In that case,
-                // we need to propagate this Error or unchecked exception.
-                if (ex.getCause() instanceof Error) {
-                    log.error("layoutHelper: Encountered error. Aborting layoutHelper", ex);
-                    throw (Error) ex.getCause();
-                }
-
-                if (ex.getCause() instanceof RuntimeException) {
-                    log.error("layoutHelper: Encountered unchecked exception. "
-                            + "Aborting layoutHelper", ex);
-                    throw (RuntimeException) ex.getCause();
-                }
-
-                log.warn("layoutHelper: Error executing remote call, invalidating view and "
-                        + "retrying in {} ms", retryRate, ex);
             }
 
             // Invoking the systemDownHandler if the client cannot connect to the server.

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -29,7 +29,13 @@ import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.BootstrapUtil;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
-import org.corfudb.runtime.clients.*;
+import org.corfudb.runtime.clients.BaseHandler;
+import org.corfudb.runtime.clients.IClientRouter;
+import org.corfudb.runtime.clients.LayoutClient;
+import org.corfudb.runtime.clients.LayoutHandler;
+import org.corfudb.runtime.clients.ManagementClient;
+import org.corfudb.runtime.clients.ManagementHandler;
+import org.corfudb.runtime.clients.NettyClientRouter;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
@@ -873,6 +879,94 @@ public class ClusterReconfigIT extends AbstractIT {
                 .getAddresses().values()) {
             assertThat(logData.getPayload(runtime))
                     .isEqualTo(Integer.toString(verificationCounter++).getBytes());
+        }
+
+        shutdownCorfuServer(corfuServer_1);
+        shutdownCorfuServer(corfuServer_2);
+        shutdownCorfuServer(corfuServer_3);
+    }
+
+    /**
+     * Test that a disconnected CorfuRuntime using a systemDownHandler reconnects itself once the
+     * cluster is back online. The client disconnection is simulated by taking 2 servers
+     * 9000 and 9002 offline by shutting them down. They are then restarted and the date is
+     * validated.
+     */
+    @Test
+    public void reconnectDisconnectedClient() throws Exception {
+        // Set up cluster of 3 nodes.
+        final int PORT_0 = 9000;
+        final int PORT_1 = 9001;
+        final int PORT_2 = 9002;
+        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
+        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        final Layout layout = get3NodeLayout();
+
+        final int retries = 3;
+        BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
+
+        final int systemDownHandlerLimit = 10;
+        CorfuRuntime runtime = CorfuRuntime.fromParameters(CorfuRuntimeParameters.builder()
+                .layoutServer(NodeLocator.parseString(DEFAULT_ENDPOINT))
+                .systemDownHandlerTriggerLimit(systemDownHandlerLimit)
+                .build()).connect();
+        // Register the system down handler to throw a RuntimeException.
+        runtime.registerSystemDownHandler(() -> {
+            throw new RuntimeException("SystemDownHandler");
+        });
+
+        UUID streamId = CorfuRuntime.getStreamID("testStream");
+        IStreamView stream = runtime.getStreamsView().get(streamId);
+
+        final int appendNum = 3;
+        int counter = 0;
+        // Preliminary writes.
+        for (int i = 0; i < appendNum; i++) {
+            stream.append(Integer.toString(counter++).getBytes());
+        }
+
+        // Shutdown the servers 9000 and 9002.
+        shutdownCorfuServer(corfuServer_1);
+        shutdownCorfuServer(corfuServer_3);
+
+        final Semaphore latch = new Semaphore(1);
+        latch.acquire();
+
+        // Invalidate the layout so that there are no cached layouts.
+        runtime.invalidateLayout();
+
+        // Spawn a thread which tries to append to the stream. This should initially get stuck and
+        // trigger the systemDownHandler.
+        // This would start the server and finally wait for the append to complete.
+        Thread t = new Thread(() -> {
+            final int counterValue = 3;
+            while (true) {
+                try {
+                    stream.append(Integer.toString(counterValue).getBytes());
+                    break;
+                } catch (RuntimeException sue) {
+                    // Release latch and try again..
+                    latch.release();
+                }
+            }
+        });
+        t.start();
+
+        assertThat(latch.tryAcquire(PARAMETERS.TIMEOUT_LONG.toMillis(), TimeUnit.MILLISECONDS))
+                .isTrue();
+        // Restart both the servers.
+        corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+
+        t.join(PARAMETERS.TIMEOUT_LONG.toMillis());
+
+        // Verify data
+        final int startAddress = 0;
+        final int endAddress = 3;
+        for (int i = startAddress; i <= endAddress; i++) {
+            assertThat(runtime.getAddressSpaceView().read(i).getPayload(runtime))
+                    .isEqualTo(Integer.toString(i).getBytes());
         }
 
         shutdownCorfuServer(corfuServer_1);


### PR DESCRIPTION
## Overview

Description:
Invalidate layout when invoking systemDownHandler. Else the layout completable future is stuck with the systemDownHandlerException forever.
Backported to 0.2.1 in #1465 

Why should this be merged: 
The layout completable future is stuck with the systemDownHandlerException forever.

Related issue(s) (if applicable): Fixes #1466 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
