### PR TITLE
Exponential back-off before address holefill.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -131,9 +131,13 @@ public class CorfuRuntime {
         // region Address Space Parameters
         /**
          * Number of times to attempt to read before hole filling.
-         */
-        @Default
-        int holeFillRetry = 10;
+         * @deprecated This is a no-op. Use holeFillWait
+         * */
+        @Deprecated
+        @Default int holeFillRetry = 10;
+
+        /** Time to wait between read requests reattempts before hole filling. */
+        @Default Duration holeFillRetryThreshold = Duration.ofSeconds(1L);
 
         /**
          * Whether or not to disable the cache.
@@ -237,6 +241,7 @@ public class CorfuRuntime {
         //region Connection parameters
         /**
          * {@link Duration} before requests timeout.
+         * This is the duration after which the reader hole fills the address.
          */
         @Default
         Duration requestTimeout = Duration.ofSeconds(5);

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/RetryExhaustedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/RetryExhaustedException.java
@@ -1,0 +1,13 @@
+package org.corfudb.runtime.exceptions;
+
+/**
+ * RetryExhaustedException is thrown when there is no hope in retrying and the current progress
+ * needs to be aborted.
+ * Created by zlokhandwala on 8/29/18.
+ */
+public class RetryExhaustedException extends RuntimeException {
+
+    public RetryExhaustedException(String s) {
+        super(s);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -351,8 +351,9 @@ public class Layout {
                 if (r.getParameters().isHoleFillingDisabled()) {
                     return new ChainReplicationProtocol(new NeverHoleFillPolicy(100));
                 } else {
-                    return new ChainReplicationProtocol(new ReadWaitHoleFillPolicy(100,
-                            r.getParameters().getHoleFillRetry()));
+                    return new ChainReplicationProtocol(
+                            new ReadWaitHoleFillPolicy(r.getParameters().getRequestTimeout(),
+                                    r.getParameters().getHoleFillRetryThreshold()));
                 }
             }
 
@@ -388,8 +389,9 @@ public class Layout {
                 if (r.getParameters().isHoleFillingDisabled()) {
                     return new QuorumReplicationProtocol(new NeverHoleFillPolicy(100));
                 } else {
-                    return new QuorumReplicationProtocol(new ReadWaitHoleFillPolicy(100,
-                            r.getParameters().getHoleFillRetry()));
+                    return new QuorumReplicationProtocol(
+                            new ReadWaitHoleFillPolicy(r.getParameters().getRequestTimeout(),
+                                    r.getParameters().getHoleFillRetryThreshold()));
                 }
             }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
@@ -1,36 +1,52 @@
 package org.corfudb.runtime.view.replication;
 
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+
 import javax.annotation.Nonnull;
 
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.exceptions.HoleFillRequiredException;
-import org.corfudb.util.Sleep;
+import org.corfudb.runtime.exceptions.RetryExhaustedException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.util.retry.ExponentialBackoffRetry;
+import org.corfudb.util.retry.IRetry;
+import org.corfudb.util.retry.RetryNeededException;
+import lombok.extern.slf4j.Slf4j;
 
 
-/** A hole filling policy which reads several times,
+/**
+ * A hole filling policy which reads several times,
  * waiting a static amount of time in between, before
  * requiring a hole fill.
  *
  * <p>Created by mwei on 4/6/17.
  */
+@Slf4j
 public class ReadWaitHoleFillPolicy implements IHoleFillPolicy {
 
-    /** The amount of time to wait between reads, in milliseconds. */
-    final int waitMs;
-
-    /** The amount of times to retry before requiring a hole fill. */
-    final int numRetries;
-
-    /** Create a ReadWaitHoleFillPolicy with the given wait times
-     * and retries.
-     * @param waitMs        The amount of time to wait before retrying.
-     * @param numRetries    The number of retries to apply before requiring a
-     *                      hole fill.
+    /**
+     * Duration after which no more read attempts are made and an address hole fill is
+     * attempted.
      */
-    public ReadWaitHoleFillPolicy(int waitMs, int numRetries) {
-        this.waitMs = waitMs;
-        this.numRetries = numRetries;
+    private final Duration holeFillThreshold;
+
+    /**
+     * Wait interval between consecutive read attempts to cap exponential back-off.
+     */
+    private final Duration retryWaitThreshold;
+
+    /**
+     * Create a ReadWaitHoleFillPolicy with the given wait times
+     * and retries.
+     *
+     * @param holeFillThreshold  The amount of time to wait before retrying.
+     * @param retryWaitThreshold The number of retries to apply before requiring a hole fill.
+     */
+    public ReadWaitHoleFillPolicy(Duration holeFillThreshold, Duration retryWaitThreshold) {
+        this.holeFillThreshold = holeFillThreshold;
+        this.retryWaitThreshold = retryWaitThreshold;
     }
 
     /**
@@ -40,22 +56,35 @@ public class ReadWaitHoleFillPolicy implements IHoleFillPolicy {
     @Override
     public ILogData peekUntilHoleFillRequired(long address, Function<Long, ILogData> peekFunction)
             throws HoleFillRequiredException {
-        int tryNum = 0;
-        do {
-            // If this is not the first try, sleep before trying again
-            if (tryNum != 0) {
-                Sleep.MILLISECONDS.sleepUninterruptibly(waitMs);
-            }
-            // Try the read
-            ILogData data = peekFunction.apply(address);
-            // If it was not null, we can return it.
-            if (data != null) {
-                return data;
-            }
-            // Otherwise increment the counter and try again.
-            tryNum++;
-        } while (numRetries > tryNum);
+        final AtomicLong startTime = new AtomicLong();
 
-        throw new HoleFillRequiredException("No data after " + tryNum + " retries");
+        try {
+            IRetry.build(ExponentialBackoffRetry.class, RetryExhaustedException.class, () -> {
+
+                // Try the read
+                ILogData data = peekFunction.apply(address);
+                // If it was not null, we can return it.
+                if (data != null) {
+                    return data;
+                } else if (startTime.get() == 0) {
+                    startTime.set(System.currentTimeMillis());
+                } else if (System.currentTimeMillis() - startTime.get() >= holeFillThreshold
+                        .toMillis()) {
+                    throw new RetryExhaustedException("Retries Exhausted.");
+                }
+
+                // Otherwise try again.
+                log.debug("peekUntilHoleFillRequired: Attempted read at address {}, "
+                        + "but data absent. Retrying.", address);
+                throw new RetryNeededException();
+            }).setOptions(x -> x.setMaxRetryThreshold(retryWaitThreshold)).run();
+        } catch (InterruptedException ie) {
+            throw new UnrecoverableCorfuInterruptedError(ie);
+        } catch (RetryExhaustedException ree) {
+            // Retries exhausted. Hole filling.
+            log.debug("peekUntilHoleFillRequired: Address:{} empty. Hole-filling.", address);
+        }
+
+        throw new HoleFillRequiredException("No data after " + holeFillThreshold.toMillis() + "ms.");
     }
 }

--- a/test/src/test/java/org/corfudb/util/retry/IRetryTest.java
+++ b/test/src/test/java/org/corfudb/util/retry/IRetryTest.java
@@ -11,7 +11,6 @@ import java.sql.SQLException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 /**
  * Created by Konstantin Spirov on 4/6/2017.
@@ -32,18 +31,11 @@ public class IRetryTest extends AbstractCorfuTest {
         assertThat(retries.get()).isEqualTo(PARAMETERS.NUM_ITERATIONS_MODERATE+1);
     }
 
-    @Test
-    public void testIRetryIsAbleToThrowCatchedExceptions() throws InterruptedException {
-        AtomicInteger retries = new AtomicInteger(0);
-        try {
-            String e = IRetry.build(ExponentialBackoffRetry.class, SQLException.class, () -> {
-                if (true) throw new SQLException();
-                return "";
-            }).run();
-            fail("Exception not propagated");
-        } catch (SQLException e) {
-            // expected
-        }
+    @Test(expected = SQLException.class)
+    public void testIRetryIsAbleToThrowCatchedExceptions()
+            throws SQLException, InterruptedException {
+        IRetry.build(ExponentialBackoffRetry.class, SQLException.class, () -> {
+            throw new SQLException();
+        }).run();
     }
-
 }


### PR DESCRIPTION
## Overview

Description:
The default HoleFill wait duration is currently 1 second and the Write timeout is 5 seconds. This inconsistency results in pre-mature timeouts and hole-fills.

Why should this be merged: To avoid pre-mature hole-fills.

Related issue(s) : Fixes #1471 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
