### PR TITLE
Exit with error code on crash.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -40,7 +40,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import static org.corfudb.util.NetworkUtils.getAddressFromInterfaceName;
 import static org.fusesource.jansi.Ansi.Color.BLUE;
@@ -185,6 +184,8 @@ public class CorfuServer {
     private static volatile Thread corfuServerThread;
     private static volatile Thread shutdownThread;
 
+    private static final int EXIT_ERROR_CODE = 100;
+
     /**
      * Main program entry point.
      *
@@ -288,7 +289,7 @@ public class CorfuServer {
                     port).channel().closeFuture().syncUninterruptibly();
         } catch (Exception e) {
             log.error("CorfuServer: Server exiting due to unrecoverable error: ", e);
-            throw new UnrecoverableCorfuError(e);
+            System.exit(EXIT_ERROR_CODE);
         }
     }
 


### PR DESCRIPTION
## Overview

Description: Crash with an error code if cannot bind to address.

Why should this be merged: The server does not shut down gracefully in case there is a router instantiation error.

Related issue(s) : Fixes #1470 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
