### PR TITLE
Move systemDownHandler to CorfuRuntimeParameters.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -133,7 +133,7 @@ public class ManagementServer extends AbstractServer {
         }
         runtime.connect();
         log.info("getCorfuRuntime: Corfu Runtime connected successfully");
-        runtime.registerSystemDownHandler(runtimeSystemDownHandler);
+        params.setSystemDownHandler(runtimeSystemDownHandler);
         return runtime;
     }
 

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -693,12 +693,12 @@ public class ClusterReconfigIT extends AbstractIT {
                 .layoutServer(NodeLocator.parseString("localhost:9000"))
                 .cacheDisabled(true)
                 .systemDownHandlerTriggerLimit(1)
+                // Register the system down handler to throw a RuntimeException.
+                .systemDownHandler(() ->
+                        assertThatCode(semaphore::release).doesNotThrowAnyException())
                 .build();
 
-        CorfuRuntime runtime = CorfuRuntime.fromParameters(corfuRuntimeParameters)
-                .registerSystemDownHandler(() ->
-                        assertThatCode(semaphore::release).doesNotThrowAnyException())
-                .connect();
+        CorfuRuntime runtime = CorfuRuntime.fromParameters(corfuRuntimeParameters).connect();
 
         CorfuTable table = runtime.getObjectsView()
                 .build()
@@ -910,11 +910,11 @@ public class ClusterReconfigIT extends AbstractIT {
         CorfuRuntime runtime = CorfuRuntime.fromParameters(CorfuRuntimeParameters.builder()
                 .layoutServer(NodeLocator.parseString(DEFAULT_ENDPOINT))
                 .systemDownHandlerTriggerLimit(systemDownHandlerLimit)
+                // Register the system down handler to throw a RuntimeException.
+                .systemDownHandler(() -> {
+                    throw new RuntimeException("SystemDownHandler");
+                })
                 .build()).connect();
-        // Register the system down handler to throw a RuntimeException.
-        runtime.registerSystemDownHandler(() -> {
-            throw new RuntimeException("SystemDownHandler");
-        });
 
         UUID streamId = CorfuRuntime.getStreamID("testStream");
         IStreamView stream = runtime.getStreamsView().get(streamId);

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime;
 
 import org.corfudb.infrastructure.TestLayoutBuilder;
 
+import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.clients.TestRule;
 import org.corfudb.runtime.exceptions.unrecoverable.SystemUnavailableError;
@@ -138,7 +139,7 @@ public class CorfuRuntimeTest extends AbstractViewTest {
 
         rt.getLayoutView().updateLayout(currentLayout, 0);
 
-        assertThat(getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch() == 1);
+        assertThat(getLayoutServer(SERVERS.PORT_2).getCurrentLayout().getEpoch()).isEqualTo(1);
 
         // Timeout for this server is 1ms, so it will fail fast
         rt.getRouter(SERVERS.ENDPOINT_2).setTimeoutResponse(1);
@@ -237,11 +238,9 @@ public class CorfuRuntimeTest extends AbstractViewTest {
 
         CorfuRuntime runtime = getDefaultRuntime();
         TimeoutHandler th = new TimeoutHandler(runtime, TIMEOUT_CORFU_RUNTIME_IN_MS);
-
-        runtime
-                .registerBeforeRpcHandler(() -> th.startTimeout())
-                .registerSystemDownHandler(() -> th.checkIfTimeout())
-                .connect();
+        runtime.getParameters().setBeforeRpcHandler(th::startTimeout);
+        runtime.getParameters().setSystemDownHandler(th::checkIfTimeout);
+        runtime.connect();
 
         IStreamView sv = runtime.getStreamsView().get(CorfuRuntime.getStreamID("test"));
         sv.append("testPayload".getBytes());


### PR DESCRIPTION
## Overview

Description:
Moving the systemDownHandler to CorfuParameters. Making it volatile and adding additional logging.

Why should this be merged: Adding logging for debuggability.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
