### PR TITLE
Fix partially sealed cluster and close handlers.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandshakeHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandshakeHandler.java
@@ -76,7 +76,9 @@ public class ServerHandshakeHandler extends ChannelDuplexHandler {
             handshake = (CorfuPayloadMsg<HandshakeMsg>) m;
             log.debug("channelRead: Handshake Message received. Removing {} from pipeline.",
                     READ_TIMEOUT_HANDLER);
-            ctx.pipeline().remove(READ_TIMEOUT_HANDLER);
+            // Remove the handler from the pipeline. Also remove the reference of the context from
+            // the handler so that it does not disconnect the channel.
+            ctx.pipeline().remove(READ_TIMEOUT_HANDLER).handlerRemoved(ctx);
         } catch (ClassCastException e) {
             log.warn("channelRead: Non-handshake message received by handshake handler." +
                     " Send upstream only if handshake succeeded.");

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
@@ -90,7 +90,9 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
             handshakeResponse = (CorfuPayloadMsg<HandshakeResponse>) m;
             log.info("channelRead: Handshake Response received. Removing {} from pipeline.",
                     READ_TIMEOUT_HANDLER);
-            ctx.pipeline().remove(READ_TIMEOUT_HANDLER);
+            // Remove the handler from the pipeline. Also remove the reference of the context from
+            // the handler so that it does not disconnect the channel.
+            ctx.pipeline().remove(READ_TIMEOUT_HANDLER).handlerRemoved(ctx);
         } catch (ClassCastException e) {
             log.warn("channelRead: Non-handshake message received by handshake handler. " +
                     "Send upstream only if handshake succeeded.");


### PR DESCRIPTION
## Overview

Description: 
Fix partially sealed cluster by filling the epoch slot.
Close unused netty pipeline duplex handlers which timeout every 30 seconds even if the channel is used.

Why should this be merged: Resolves liveness issue.

Related issue(s) (if applicable): Fixes #1478 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
