### PR TITLE
NodeRouterPool indexes routers on NodeLocator.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -718,7 +718,7 @@ public class CorfuRuntime {
      * @return The router.
      */
     public IClientRouter getRouter(String address) {
-        return nodeRouterPool.getRouter(address);
+        return nodeRouterPool.getRouter(NodeLocator.parseString(address));
     }
 
     /**
@@ -768,7 +768,11 @@ public class CorfuRuntime {
      */
     private void pruneRemovedRouters(@Nonnull Layout layout) {
         nodeRouterPool.getNodeRouters().keySet().stream()
-                .filter(endpoint -> !layout.getAllServers().contains(endpoint))
+                // Check if endpoint is present in the layout.
+                .filter(endpoint -> !layout.getAllServers()
+                        // Converting to legacy endpoint format as the layout only contains
+                        // legacy format - host:port.
+                        .contains(NodeLocator.getLegacyEndpoint(endpoint)))
                 .forEach(endpoint -> {
                     try {
                         nodeRouterPool.getNodeRouters().get(endpoint).stop();

--- a/runtime/src/main/java/org/corfudb/util/NodeLocator.java
+++ b/runtime/src/main/java/org/corfudb/util/NodeLocator.java
@@ -9,8 +9,10 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
 import lombok.Builder;
 import lombok.Data;
+import lombok.NonNull;
 import lombok.Singular;
 
 /** {@link NodeLocator}s represent locators for Corfu nodes.
@@ -121,5 +123,15 @@ public class NodeLocator implements Serializable {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Creates and returns the endpoint address in the legacy format host:port.
+     *
+     * @param nodeLocator Nodelocator to convert to legacy format.
+     * @return Returns the endpoint address.
+     */
+    public static String getLegacyEndpoint(@NonNull NodeLocator nodeLocator) {
+        return nodeLocator.getHost() + ":" + nodeLocator.getPort();
     }
 }


### PR DESCRIPTION
## Overview

Description:
Duplicate routers cause unexpected ShutdownExceptions or NetworkExceptions.

Why should this be merged: Uses NodeLocators legacyEndpoint in the NodeRouterPool until NodeLocator is used everywhere.

Related issue(s) (if applicable): Fixes #1487 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
