### PR TITLE
Transactions Simulator

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -103,6 +103,11 @@
             <artifactId>sizeof</artifactId>
             <version>0.3.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>3.6.1</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/runtime/src/main/java/org/corfudb/util/Simulator.java
+++ b/runtime/src/main/java/org/corfudb/util/Simulator.java
@@ -1,0 +1,340 @@
+package org.corfudb.util;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.math3.distribution.AbstractRealDistribution;
+import org.apache.commons.math3.distribution.NormalDistribution;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.protocols.wireprotocol.TokenType;
+import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.StreamOptions;
+import org.corfudb.runtime.view.stream.IStreamView;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+
+@Slf4j
+public class Simulator {
+
+    final ThreadFactory workerThreadFactory = new ThreadFactoryBuilder()
+            .setNameFormat("Sim-Worker-%d")
+            .build();
+
+    final ThreadFactory managerThreadFactory = new ThreadFactoryBuilder()
+            .setNameFormat("Sim-manager-%d")
+            .build();
+
+    final CorfuRuntime rt;
+
+    final SimulatorConfig config;
+
+    final ExecutorService managerThread;
+
+    final ExecutorService workerThreads;
+
+    final AtomicInteger numRunningTasks;
+
+    volatile boolean running = false;
+
+    final Random rand = new Random();
+
+    //------------Distributions------------//
+    final AbstractRealDistribution payloadDist;
+    final AbstractRealDistribution keySizeDist;
+    final AbstractRealDistribution keysPerTxnDist;
+    final AbstractRealDistribution txnPerPeriodDist;
+    final AbstractRealDistribution tablesPerTxnDist;
+    final AbstractRealDistribution jitterDist;
+    final AbstractRealDistribution burstDist;
+
+
+    public Simulator(CorfuRuntime rt, SimulatorConfig config) {
+        this.rt = rt;
+        this.config = config;
+        managerThread = Executors.newSingleThreadExecutor(managerThreadFactory);
+        workerThreads = Executors.newFixedThreadPool(config.getNumThreads(), workerThreadFactory);
+        numRunningTasks = new AtomicInteger(0);
+
+        // Initialize Distributions
+        payloadDist = new NormalDistribution(config.getMedianTablesPerTxn(), config.getStdWriteSize());
+        txnPerPeriodDist = new NormalDistribution(config.getMedianTxnPerPeriod(), config.getStdTxnPerPeriod());
+        tablesPerTxnDist = new NormalDistribution(config.getMedianTablesPerTxn(), config.getStdTablesPerTxn());
+        jitterDist = new NormalDistribution(5000, 3000);
+        burstDist = new NormalDistribution(config.getMedianTxnPerPeriod(), config.getStdTxnPerPeriod());
+        keysPerTxnDist = new NormalDistribution(config.getMedianKeysPerTxn(), config.getStdKeysPerTxn());
+        keySizeDist = new NormalDistribution(config.getMedianKeySize(), config.getStdKeySize());
+    }
+
+    /**
+     * Samples a payload
+     */
+    private byte[] samplePayload() {
+        int payloadSize = Math.max((int) payloadDist.sample(), config.getMinWriteSize());
+        return new byte[payloadSize];
+    }
+
+    /**
+     *  Samples a key space
+     */
+    private byte[] sampleKey(int x) {
+        int size = Math.max((int) keySizeDist.sample(), config.getMinKeysPerTxn());
+        byte[] bytes = new byte[size + x];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        return bytes;
+    }
+
+    /**
+     * Samples number of keys in a transaction
+     */
+    private int sampleNumKeys() {
+        return Math.max((int) keysPerTxnDist.sample(), config.getMinKeysPerTxn());
+    }
+
+    /**
+     * Samples the number of transactions per burst
+     */
+    private int sampleBurstSize() {
+        return Math.max((int) burstDist.sample(), config.getMinTxnPerPeriod());
+    }
+
+    /**
+     * Samples RPC latency-jitter
+     */
+    private long sampleJitter() {
+        return Math.max(0, (long) jitterDist.sample());
+    }
+
+    /**
+     * Samples the number of tables to touch in a transaction
+     */
+    private int sampleNumTables() {
+        int numTables = Math.max((int) tablesPerTxnDist.sample(), config.getMinTablesPerTxn());
+        return numTables;
+    }
+
+    /**
+     * Fisher–Yates shuffle to sample without replacement.
+     * This is needed because a transaction can't include
+     * the same table twice in a single TxResolutionInfo
+     * instance.
+     * @param tables
+     */
+    private void shuffle(Table[] tables) {
+        int index;
+        for (int i = tables.length - 1; i > 0; i--) {
+            index = rand.nextInt(i + 1);
+            if (index != i) {
+                Table temp = tables[index];
+                tables[index] = tables[i];
+                tables[i] = temp;
+            }
+        }
+    }
+
+    /**
+     * Samples the table space
+     */
+    private Table[] sampleTables(Table[] tables) {
+        shuffle(tables);
+        int numTables = sampleNumTables();
+        Table[] sample = new Table[numTables];
+        for (int x = 0; x < numTables; x++) {
+            sample[x] = tables[x];
+        }
+        return sample;
+    }
+
+    /**
+     * Will start a manager thread that will initialize and run the simulation.
+     */
+    public synchronized void start() {
+        if (running) {
+            log.warn("Manager is already running!");
+            return;
+        }
+
+        managerThread.submit(() -> {
+            try {
+                manager();
+            } catch (Exception e) {
+                log.error("Manager Failure", e);
+            }
+        });
+        running = true;
+    }
+
+    public synchronized void stop() {
+        managerThread.shutdownNow();
+        workerThreads.shutdownNow();
+        log.info("Stopping simulation");
+    }
+
+    /**
+     * Create and initialize the tables.
+     */
+    private Table[] initializeTables(int n) {
+        Table[] tables = new Table[n];
+        StreamOptions options = new StreamOptions(true);
+        for (int x = 0; x < n; x++) {
+            IStreamView sv = rt.getStreamsView().get(UUID.randomUUID(), options);
+            tables[x] = new Table(sv);
+        }
+        return tables;
+    }
+
+    /**
+     * The managing logic that generates and forks tasks for the workers.
+     * @throws Exception
+     */
+    private void manager() throws Exception {
+        Table[] allTables = initializeTables(config.getNumTables());
+
+        while (true) {
+            int currentBurst = sampleBurstSize();
+            int tasksToFork = currentBurst - numRunningTasks.get();
+
+            if (tasksToFork <= 0) {
+                log.info("Old tasks still running, not forking any new work...");
+                continue;
+            }
+
+            log.info("Forking {} tasks", tasksToFork);
+
+            for (int x = 0; x < tasksToFork; x++) {
+                Table[] sampleTables = sampleTables(allTables);
+                workerThreads.submit(() -> {
+                    numRunningTasks.incrementAndGet();
+                    try {
+                        executeTransaction(sampleTables);
+                    } finally {
+                        numRunningTasks.decrementAndGet();
+                    }
+                });
+            }
+
+            log.info("Executed {} tasks for the current burst, sleeping for {}", tasksToFork, config.getBurstPeriod());
+            Sleep.MILLISECONDS.sleepUninterruptibly(config.getBurstPeriod());
+        }
+    }
+
+    /**
+     * Executes a random transaction on a set of tables
+     * @param tables The tables to execute the transaction on
+     */
+    private void executeTransaction(Table ... tables) {
+        log.debug("Executing transactions on {} tables", tables.length);
+        // Acquire global timestamp
+        long timestamp = rt.getSequencerView().query().getTokenValue();
+
+        // Sync table to simulate tail-reads
+        for (Table table : tables) {
+            table.sync(timestamp);
+        }
+
+        // Increment the tails of all streams and acquire a
+        // transaction token to write
+        UUID[] streamIds = getIds(tables);
+        TxResolutionInfo txResolutionInfo = getTxResolutionInfo(timestamp, streamIds);
+        TokenResponse tokenResponse = rt.getSequencerView().next(txResolutionInfo, streamIds);
+
+        // Construct a payload
+        byte[] payload = samplePayload();
+
+        if (tokenResponse.getRespType() != TokenType.NORMAL) {
+            log.error("Couldn't execute transaction, token {}", tokenResponse);
+            return;
+        }
+
+        // Write transaction
+        rt.getAddressSpaceView().write(tokenResponse, payload);
+    }
+
+    /**
+     * Generates a fake transaction by randomly generating keys and conflict sets
+     * @param timestamp timestamp of the transaction when it started
+     * @param ids ids of the tables in this transaction
+     * @return
+     */
+    private TxResolutionInfo getTxResolutionInfo(long timestamp, UUID ... ids) {
+        UUID txnId = UUID.randomUUID();
+        Map<UUID, Set<byte[]>> conflictParam = new HashMap<>();
+        Map<UUID, Set<byte[]>> writeConflicts = new HashMap<>();
+        for (UUID streamId : ids) {
+            Set<byte[]> writeSet = new HashSet<>();
+            int numKeysInTxn = sampleNumKeys();
+            // Generate fake keys for this transaction
+            for (int x = 0 ; x < numKeysInTxn; x++) {
+                writeSet.add(sampleKey(x));
+            }
+
+            writeConflicts.put(streamId, writeSet);
+        }
+        return new TxResolutionInfo(txnId, timestamp, conflictParam, writeConflicts);
+    }
+
+    /**
+     * Extract the stream view ids from a list of Tables
+     * @param tables tables to extract the ids from
+     * @return an array of stream UUIDs
+     */
+    private UUID[] getIds(Table ... tables) {
+        UUID[] ids = new UUID[tables.length];
+        for (int x = 0; x < tables.length; x++) {
+            ids[x] = tables[x].getId();
+        }
+        return ids;
+    }
+
+    class Table {
+        private final IStreamView streamView;
+
+        private final Lock lock;
+
+        public Table(IStreamView streamView) {
+            this.streamView = streamView;
+            lock = new ReentrantLock();
+        }
+
+        public UUID getId() {
+            return streamView.getId();
+        }
+
+        /**
+         * Sync to a particular time stamp. The stream view is not
+         * thread safe, so we need to use a lock, while going back-and-forth
+         * in time
+         * @param timestamp the time stamp to sync to
+         */
+        public void sync(long timestamp) {
+            lock.lock();
+            try {
+                long currentPos = streamView.getCurrentGlobalPosition();
+
+                if (timestamp <= currentPos) {
+                    streamView.nextUpTo(timestamp);
+                } else {
+                    while (streamView.getCurrentGlobalPosition() > timestamp) {
+                        streamView.previous();
+                    }
+                }
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/util/SimulatorConfig.java
+++ b/runtime/src/main/java/org/corfudb/util/SimulatorConfig.java
@@ -1,0 +1,31 @@
+package org.corfudb.util;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class SimulatorConfig {
+    int numThreads;
+    int burstPeriod;
+    int maxWriteSize;
+    int minWriteSize;
+    int medianWriteSize;
+    int stdWriteSize;
+    int maxTxnPerPeriod;
+    int minTxnPerPeriod;
+    int medianTxnPerPeriod;
+    int stdTxnPerPeriod;
+    int numTables;
+    int maxTablesPerTxn;
+    int minTablesPerTxn;
+    int medianTablesPerTxn;
+    int stdTablesPerTxn;
+    int maxKeysPerTxn;
+    int minKeysPerTxn;
+    int stdKeysPerTxn;
+    int medianKeysPerTxn;
+    int minKeySize;
+    int stdKeySize;
+    int medianKeySize;
+}

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -11,6 +11,8 @@ import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.LayoutBuilder;
+import org.corfudb.util.Simulator;
+import org.corfudb.util.SimulatorConfig;
 import org.corfudb.util.Sleep;
 import org.junit.Test;
 
@@ -30,372 +32,60 @@ import java.util.List;
  * Created by Maithem on 12/1/17.
  */
 @Slf4j
-public class WorkflowIT extends AbstractIT {
-
-    final String host = "localhost";
-
-    String getConnectionString(int port) {
-        return host + ":" + port;
-    }
-
-    final Duration timeout = Duration.ofMinutes(5);
-    final Duration pollPeriod = Duration.ofMillis(50);
-    final int workflowNumRetry = 3;
-
-    private Process runServer(int port, boolean single) throws IOException {
-        return new CorfuServerRunner()
-                .setHost(host)
-                .setPort(port)
-                .setSingle(single)
-                .runServer();
-    }
+public class WorkflowIT {
 
     @Test
     public void addAndRemoveNodeIT() throws Exception {
-        final String streamName = "s1";
-        final int n1Port = 9000;
-        final int numIter = 11_000;
 
-        // Start node one and populate it with data
-        Process server_1 = runServer(n1Port, true);
+        CorfuRuntime rt = new CorfuRuntime("localhost:9000").connect();
 
-        // start a second node
-        final int n2Port = 9001;
-        Process server_2 = runServer(n2Port, false);
-
-        // start a third node
-        final int n3Port = 9002;
-        Process server_3 = runServer(n3Port, false);
-
-        CorfuRuntime n1Rt = new CorfuRuntime(getConnectionString(n1Port))
-                .setCacheDisabled(true).connect();
-
-        CorfuTable table = n1Rt.getObjectsView()
-                .build()
-                .setType(CorfuTable.class)
-                .setStreamName(streamName)
-                .open();
-
-        for (int x = 0; x < numIter; x++) {
-            table.put(String.valueOf(x), String.valueOf(x));
-        }
-
-        n1Rt.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
-                timeout, pollPeriod);
-
-        n1Rt.invalidateLayout();
-        final int clusterSizeN2 = 2;
-        assertThat(n1Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
-
-        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
-        mcw.addMap(table);
-
-        long prefix = mcw.appendCheckpoints(n1Rt, "Maithem");
-
-        n1Rt.getAddressSpaceView().prefixTrim(prefix - 1);
-
-        n1Rt.getAddressSpaceView().invalidateClientCache();
-        n1Rt.getAddressSpaceView().invalidateServerCaches();
-        n1Rt.getAddressSpaceView().gc();
-
-        // Add a third node after compaction
-        n1Rt.getManagementView().addNode(getConnectionString(n3Port), workflowNumRetry,
-                timeout, pollPeriod);
-
-        // Verify that the third node has been added and data can be read back
-        n1Rt.invalidateLayout();
-        final int clusterSizeN3 = 3;
-        assertThat(n1Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN3);
-
-        Layout n3Layout = new Layout(n1Rt.getLayoutView().getLayout());
-
-        Layout expectedLayout = new LayoutBuilder(n3Layout)
-                .removeLayoutServer(getConnectionString(n2Port))
-                .removeSequencerServer(getConnectionString(n2Port))
-                .removeLogunitServer(getConnectionString(n2Port))
-                .removeUnresponsiveServer(getConnectionString(n2Port))
-                .setEpoch(n3Layout.getEpoch() + 1)
+        SimulatorConfig config = SimulatorConfig
+                .builder()
+                .numThreads(250)
+                .numTables(300)
+                .burstPeriod(10 * 1000)
+                .maxTxnPerPeriod(7000)
+                .minTxnPerPeriod(1000)
+                .stdTxnPerPeriod(3000)
+                .medianTxnPerPeriod(3000)
+                .maxWriteSize(16777216)
+                .minWriteSize(1000)
+                .stdWriteSize(14000)
+                .medianWriteSize(2000)
+                .maxTablesPerTxn(50)
+                .minTablesPerTxn(1)
+                .stdTablesPerTxn(5)
+                .medianTablesPerTxn(5)
+                .maxKeysPerTxn(100)
+                .minKeysPerTxn(1)
+                .stdKeysPerTxn(5)
+                .medianKeysPerTxn(8)
+                .maxKeysPerTxn(1000)
+                .minKeySize(100)
+                .medianKeySize(100)
+                .stdKeySize(100)
                 .build();
 
-        // Remove node 2
-        n1Rt.getManagementView().removeNode(getConnectionString(n2Port), workflowNumRetry,
-                timeout, pollPeriod);
-        n1Rt.invalidateLayout();
-        assertThat(n1Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
+        Simulator sim = new Simulator(rt, config);
+        sim.start();
 
-
-        // Remove node 2 again and verify that the epoch doesn't change
-        n1Rt.getManagementView().removeNode(getConnectionString(n2Port), workflowNumRetry,
-                timeout, pollPeriod);
-        shutdownCorfuServer(server_2);
-
-        n1Rt.invalidateLayout();
-        // Verify that the layout epoch hasn't changed after the second remove and that
-        // the sequencers/layouts/segments nodes include the first and third node
-        assertThat(n1Rt.getLayoutView().getLayout()).isEqualTo(expectedLayout);
-
-        // Force remove node 3
-        n1Rt.getManagementView().forceRemoveNode(getConnectionString(n3Port), workflowNumRetry,
-                timeout, pollPeriod);
-        shutdownCorfuServer(server_3);
-
-        n1Rt.invalidateLayout();
-        assertThat(n1Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(1);
-
-        server_2 = runServer(n2Port, false);
-        // Re-add node 2
-        n1Rt.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
-                timeout, pollPeriod);
-
-        n1Rt.invalidateLayout();
-        assertThat(n1Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
-
-        for (int x = 0; x < numIter; x++) {
-            String v = (String) table.get(String.valueOf(x));
-            assertThat(v).isEqualTo(String.valueOf(x));
-        }
-
-        shutdownCorfuServer(server_1);
-        shutdownCorfuServer(server_2);
-    }
-
-    /**
-     * This tests will resize the cluster according to the following order,
-     * create a cluster of size 2, then force remove one node. Then, it will
-     * regrow the cluster to 3 nodes and remove one node.
-     */
-    @Test
-    public void clusterResizingTest1() throws Exception {
-        final int n0Port = 9000;
-        final int n1Port = 9001;
-        final int n2Port = 9002;
-
-        final int clusterSizeN1 = 1;
-        final int clusterSizeN2 = 2;
-        final int clusterSizeN3 = 3;
-
-        Process p0 = runServer(n0Port, true);
-        Process p1 = runServer(n1Port, false);
-        Process p2 = runServer(n2Port, false);
-
-        CorfuRuntime n0Rt = new CorfuRuntime(getConnectionString(n0Port)).connect();
-        CorfuTable table = n0Rt.getObjectsView().build()
-                .setType(CorfuTable.class)
-                .setStreamName("table1").open();
-
-        final int iter = 1000;
-        for (int x = 0; x < iter; x++) {
-            table.put(String.valueOf(x), String.valueOf(x));
-        }
-
-        n0Rt.getManagementView().addNode(getConnectionString(n1Port), workflowNumRetry,
-                timeout, pollPeriod);
-        n0Rt.invalidateLayout();
-
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
-
-        n0Rt.getManagementView().forceRemoveNode(getConnectionString(n1Port), workflowNumRetry,
-                timeout, pollPeriod);
-        n0Rt.invalidateLayout();
-
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN1);
-
-        n0Rt.getManagementView().addNode(getConnectionString(n1Port), workflowNumRetry,
-                timeout, pollPeriod);
-
-        n0Rt.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
-                timeout, pollPeriod);
-
-        n0Rt.invalidateLayout();
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN3);
-
-        n0Rt.getManagementView().removeNode(getConnectionString(n1Port), workflowNumRetry,
-                timeout, pollPeriod);
-        n0Rt.invalidateLayout();
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
-
-        for (int x = 0; x < iter; x++) {
-            assertThat(table.get(String.valueOf(x))).isEqualTo(String.valueOf(x));
-        }
-
-        shutdownCorfuServer(p0);
-        shutdownCorfuServer(p1);
-        shutdownCorfuServer(p2);
-    }
-
-    @Test
-    public void clusterResizingTest2() throws Exception {
-        // This test will create a 3 node cluster, then simulate loss of quorum by terminating
-        // two of the three nodes, then the failed nodes are forcefully removed from the cluster.
-        final int n0Port = 9000;
-        final int n1Port = 9001;
-        final int n2Port = 9002;
-
-        final int clusterSizeN1 = 1;
-        final int clusterSizeN3 = 3;
-
-        Process p0 = runServer(n0Port, true);
-        Process p1 = runServer(n1Port, false);
-        Process p2 = runServer(n2Port, false);
-
-        CorfuRuntime n0Rt = new CorfuRuntime(getConnectionString(n0Port)).connect();
-        CorfuTable table = n0Rt.getObjectsView().build()
-                .setType(CorfuTable.class)
-                .setStreamName("table1").open();
-
-        final int iter = 100;
-        for (int x = 0; x < iter; x++) {
-            table.put(String.valueOf(x), String.valueOf(x));
-        }
-
-        n0Rt.getManagementView().addNode(getConnectionString(n1Port), workflowNumRetry,
-                timeout, pollPeriod);
-
-        n0Rt.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
-                timeout, pollPeriod);
-
-        n0Rt.invalidateLayout();
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN3);
-
-        // Kill two nodes from a three node cluster
-        shutdownCorfuServer(p1);
-        shutdownCorfuServer(p2);
-
-        // Force remove the "failed" node
-        n0Rt.getManagementView().forceRemoveNode(getConnectionString(n1Port), workflowNumRetry,
-                timeout, pollPeriod);
-        n0Rt.getManagementView().forceRemoveNode(getConnectionString(n2Port), workflowNumRetry,
-                timeout, pollPeriod);
-        n0Rt.invalidateLayout();
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN1);
-
-        for (int x = 0; x < iter; x++) {
-            assertThat(table.get(String.valueOf(x))).isEqualTo(String.valueOf(x));
-        }
-
-        shutdownCorfuServer(p0);
-    }
-
-    @Test
-    public void forceRemoveTwoDeadNodes() throws Exception {
-        // Create a 3 node cluster and attempt to force remove two
-        // dead nodes. This will test the case where the layout doesn't
-        // reflect the set of unresponsive servers and thus needs to rely
-        // on selecting an available orchestrator to force remove the dead nodes.
-        Harness harness = Harness.getDefaultHarness();
-
-        final int numNodes = 3;
-        List<Node> nodeList = harness.deployCluster(numNodes);
-        Node n0 = nodeList.get(0);
-        Node n1 = nodeList.get(1);
-        Node n2 = nodeList.get(2);
-
-        CorfuRuntime rt = harness.createRuntimeForNode(n2);
-
-        assertThat(rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(numNodes);
-
-        // Shutdown two nodes
-        run(n0.shutdown, n1.shutdown);
-
-        rt.getManagementView().forceRemoveNode(n0.getAddress(), workflowNumRetry, timeout, pollPeriod);
-        rt.getManagementView().forceRemoveNode(n1.getAddress(), workflowNumRetry, timeout, pollPeriod);
-
-        assertThat(rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(1);
-        assertThat(rt.getLayoutView().getLayout().getAllServers()).containsExactly(n2.getAddress());
-    }
-
-    /**
-     * Tests whether the trimMark is transferred during stateTransfer.
-     * Scenario: Setup a cluster of 1 node.
-     * 1000 entries are written to node_1. These are then checkpointed and trimmed.
-     * Another 1000 entries are added. Now node_1 has a trimMark at address 1000.
-     * Now 2 new nodes node_2 and node_3 are added to the cluster after which node_1 is shutdown.
-     * Finally we should see that the trimMark should be updated on the new nodes and the
-     * FastObjectLoader trying to recreate the state from these 2 nodes should be able to do so.
-     */
-    @Test
-    public void addNodeWithTrim() throws Exception {
-        Harness harness = Harness.getDefaultHarness();
-
-        final int numNodes = 3;
-        final int PORT_1 = 9001;
-        final int PORT_2 = 9002;
-        List<Node> nodeList = harness.deployCluster(1);
-        Node n0 = nodeList.get(0);
-        Node n1 = harness.deployUnbootstrappedNode(PORT_1);
-        Node n2 = harness.deployUnbootstrappedNode(PORT_2);
-
-        CorfuRuntime rt = harness.createRuntimeForNode(n0);
-        final String streamName = "test";
-        CorfuTable<String, Integer> table = rt.getObjectsView()
-                .build()
-                .setType(CorfuTable.class)
-                .setStreamName(streamName)
-                .open();
-        final int entriesCount = 1_000;
-
-        // Write 1_000 entries.
-        for (int i = 0; i < entriesCount; i++) {
-            table.put(Integer.toString(i), i);
-        }
-
-        // Checkpoint and trim the entries.
-        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
-        mcw.addMap(table);
-        long prefixTrimAddress = mcw.appendCheckpoints(rt, "author");
-        rt.getAddressSpaceView().prefixTrim(prefixTrimAddress);
-        rt.getAddressSpaceView().invalidateServerCaches();
-        rt.getAddressSpaceView().invalidateClientCache();
-        rt.getAddressSpaceView().gc();
-
-        assertThat(rt.getAddressSpaceView().getTrimMark()).isEqualTo(entriesCount);
-
-        // 2 Checkpoint entries for the start and end.
-        // 1000 entries being checkpointed = 20 checkpoint entries due to batch size of 50.
-        final int checkpointEntriesCount = 22;
-
-        // Write another batch of 1_000 entries.
-        for (int i = 0; i < entriesCount; i++) {
-            table.put(Integer.toString(i), i);
-        }
-        final long streamTail = entriesCount + checkpointEntriesCount + entriesCount - 1;
-
-        // Add 2 new nodes.
-        final int retries = 3;
-        final Duration timeout = PARAMETERS.TIMEOUT_LONG;
-        final Duration pollPeriod = PARAMETERS.TIMEOUT_VERY_SHORT;
-        rt.getManagementView().addNode("localhost:9001", retries, timeout, pollPeriod);
-        rt.getManagementView().addNode("localhost:9002", retries, timeout, pollPeriod);
-
-        rt.invalidateLayout();
-        Layout layoutAfterAdds = rt.getLayoutView().getLayout();
-        assertThat(layoutAfterAdds.getSegments().stream()
-                .allMatch(s -> s.getAllLogServers().size() == numNodes)).isTrue();
-
-        run(n0.shutdown);
-
-        assertThat(rt.getAddressSpaceView().getTrimMark()).isEqualTo(entriesCount);
-
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
-            if (rt.getLayoutView().getLayout().getEpoch() > layoutAfterAdds.getEpoch()) {
-                break;
+        Thread thread = new Thread(() -> {
+            while (true) {
+                try {
+                    Thread.sleep(60 * 1000);
+                    long globalTs = rt.getSequencerView().next().getTokenValue();
+                    rt.getAddressSpaceView().prefixTrim(Math.max(globalTs - 10, 0));
+                    rt.getAddressSpaceView().gc();
+                    log.info("Prefix Trim address {}", globalTs);
+                } catch (Exception e) {
+                    log.error("Error while trimming", e);
+                    return;
+                }
             }
-            rt.invalidateLayout();
-            Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_SHORT);
-        }
+        });
+        thread.start();
 
-        // Assert that the new nodes should have the correct trimMark.
-        assertThat(rt.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9001").getTrimMark().get())
-                .isEqualTo(prefixTrimAddress + 1);
-        assertThat(rt.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9002").getTrimMark().get())
-                .isEqualTo(prefixTrimAddress + 1);
-        FastObjectLoader fastObjectLoader = new FastObjectLoader(rt);
-        fastObjectLoader.setRecoverSequencerMode(true);
-        fastObjectLoader.loadMaps();
-        assertThat(fastObjectLoader.getStreamTails().get(CorfuRuntime.getStreamID(streamName)))
-                .isEqualTo(streamTail);
-
-        // Shutdown two nodes
-        run(n1.shutdown, n2.shutdown);
+        thread.join();
+        Thread.sleep(1000 * 60 * 3);
     }
 }

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -42,7 +42,7 @@
 
     <root level="INFO">
         <!--<appender-ref ref="FILE" />-->
-        <!--<appender-ref ref="STDOUT" />-->
+        <appender-ref ref="STDOUT" />
         <!--<appender-ref ref="MetricsRollingFile" />-->
     </root>
 </configuration>

--- a/test_checks.xml
+++ b/test_checks.xml
@@ -50,7 +50,7 @@
     <property name="fileExtensions" value="java, properties, xml"/>
 
     <module name="TreeWalker">
-        <module name="MagicNumber"/>
+        
 
         <module name="SuppressWarningsHolder" />
     </module>


### PR DESCRIPTION
## Overview
A parametric model to simulate a transactional load on the cluster.
The simulator is immune to prematurely trimmed streams, so it doesn't
run a checkpoint/trimmer and doesn't care if its streams have been
trimmed. The parameters include, txn size, number of touched tables
in a transaction, the size of conflict keys etc.

Why should this be merged: 
Stats collected in production can be used to seeds the parameters of this simulator and
start generating a synthetic load. This is helpful to use when measuring latency effects
on certain access patterns. 

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
