### PR TITLE
Rpc batching

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -105,7 +105,7 @@ public class CorfuServer {
                     + "              The name of the network interface.\n"
                     + " -i <channel-implementation>, --implementation <channel-implementation>   "
                     + "              The type of channel to use (auto, nio, epoll, kqueue)"
-                    + "[default: nio].\n"
+                    + "[default: epoll].\n"
                     + " -m, --memory                                                             "
                     + "              Run the unit in-memory (non-persistent).\n"
                     + "                                                                          "

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
+import org.corfudb.runtime.clients.Batcher;
 
 
 /**
@@ -79,7 +80,8 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter
      */
     public void sendResponse(ChannelHandlerContext ctx, CorfuMsg inMsg, CorfuMsg outMsg) {
         outMsg.copyBaseFields(inMsg);
-        ctx.writeAndFlush(outMsg, ctx.voidPromise());
+        //ctx.writeAndFlush(outMsg, ctx.voidPromise());
+        Batcher.writeAndFlush(ctx.channel(), outMsg);
         log.trace("Sent response: {}", outMsg);
     }
 

--- a/perfClient/checks.xml
+++ b/perfClient/checks.xml
@@ -37,7 +37,15 @@
     <module name="SuppressWarningsFilter" />
 
     <module name="TreeWalker">
-       
+        <module name="RegexpSinglelineJava">
+            <property name="severity" value="error"/>
+            <property name="id" value="ThreadSleep"/>
+            <property name="format" value="Thread.sleep\("/>
+            <property name="message" value="Don't use Thread.sleep, use org.corfudb.util.Sleep"/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+	      <module name="SuppressWarningsHolder" />
+
         <module name="RegexpSinglelineJava">
             <!-- Check for e.printStackTrace().-->
             <property name="id" value="printStackTrace"/>
@@ -46,6 +54,25 @@
             <property name="message" value="Using printStackTrace() is forbidden. Rethrow or handle the exception."/>
             <property name="ignoreComments" value="true"/>
         </module>
+
+        <module name="RegexpSinglelineJava">
+            <!-- Check for System.out.println().-->
+            <property name="id" value="printLine"/>
+            <property name="severity" value="error"/>
+            <property name="format" value="System\.osut\.println\("/>
+            <property name="message" value="Using System.out.println() is forbidden. Use a logger or output utility."/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
+        <module name="RegexpSinglelineJava">
+            <!-- Check for System.out.print().-->
+            <property name="id" value="print"/>
+            <property name="severity" value="error"/>
+            <property name="format" value="System\.out\.print\("/>
+            <property name="message" value="Using System.out.print() is forbidden. Use a logger or output utility."/>
+            <property name="ignoreComments" value="true"/>
+        </module>
+
 
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">

--- a/perfClient/pom.xml
+++ b/perfClient/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>corfu</artifactId>
+        <groupId>org.corfudb</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>perfClient</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.corfudb</groupId>
+            <artifactId>runtime</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+            <version>2.1.10</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.6</version>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>Driver</mainClass>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/perfClient/src/main/java/Driver.java
+++ b/perfClient/src/main/java/Driver.java
@@ -1,0 +1,82 @@
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.SequencerClient;
+import org.corfudb.runtime.view.RuntimeLayout;
+
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+public class Driver {
+
+    public static void main(String[] args) throws Exception {
+
+        String connString = args[0];
+        int numThreads = Integer.valueOf(args[1]);
+        final int numOps = Integer.valueOf(args[2]);
+        final int numRt = Integer.valueOf(args[3]);
+
+        final int numAsync = 500 * 2;
+
+        CorfuRuntime[] rts = new CorfuRuntime[numRt];
+
+        for (int x = 0; x < numRt; x++) {
+            rts[x] = new CorfuRuntime(connString).connect();
+        }
+
+        Thread[] threads = new Thread[numThreads];
+
+        for (int x = 0; x < numThreads; x++) {
+            final CorfuRuntime rt = rts[x%numRt];
+
+            final SequencerClient client = new RuntimeLayout(rt.getLayoutView().getLayout(),
+                    rt).getPrimarySequencerClient();
+
+            Runnable r = () -> {
+                long avg = 0;
+                int numIter = numOps / numAsync;
+                CompletableFuture[] futures = new CompletableFuture[numAsync];
+                for (int y = 0; y < numIter; y++) {
+                    long ts1 = System.nanoTime();
+
+                    for (int t = 0; t < numAsync; t++) {
+                        futures[t] = client.nextToken(Collections.EMPTY_LIST, 0);
+                    }
+
+                    for (int t = 0; t < numAsync; t++) {
+                        try {
+                            futures[t].get();
+                        } catch (Exception e) {
+                            System.out.println(e);
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    long ts2 = System.nanoTime();
+                    avg += (ts2 - ts1);
+                }
+
+                System.out.println("latency ms/op " + ((avg*1.0)/numOps/1000000));
+            };
+
+            threads[x] = new Thread(r);
+        }
+
+
+        long ts1 = System.currentTimeMillis();
+
+        for (int x = 0; x < numThreads; x++) {
+            threads[x].start();
+        }
+
+        for (int x = 0; x < numThreads; x++) {
+            threads[x].join();
+        }
+
+
+        long ts2 = System.currentTimeMillis();
+
+        System.out.println("Total time: " + (ts2 - ts1));
+        System.out.println("Num Ops: " + (numThreads * numOps));
+        System.out.println("Throughput: " + ((numThreads * numOps) / (ts2 - ts1)));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>debian</module>
         <module>generator</module>
         <module>migration</module>
+        <module>perfClient</module>
 
     </modules>
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ICorfuPayload.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ICorfuPayload.java
@@ -18,6 +18,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -38,8 +39,8 @@ public interface ICorfuPayload<T> {
         T construct(ByteBuf buf);
     }
 
-    ConcurrentHashMap<Class<?>, PayloadConstructor<?>>
-            constructorMap = new ConcurrentHashMap<>(
+    static Map<Class<?>, PayloadConstructor<?>>
+            constructorMap = new HashMap<>(
                     ImmutableMap.<Class<?>, PayloadConstructor<?>>builder()
                 .put(Byte.class, ByteBuf::readByte)
                 .put(Integer.class, ByteBuf::readInt)

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -220,7 +220,7 @@ public class CorfuRuntime {
          *  an NIO based implementation is used.
          */
         @Default
-        ChannelImplementation socketType = ChannelImplementation.NIO;
+        ChannelImplementation socketType = ChannelImplementation.EPOLL;
 
         /**
          * Number of retries to reconnect to an unresponsive system before invoking the

--- a/runtime/src/main/java/org/corfudb/runtime/clients/Batcher.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/Batcher.java
@@ -1,0 +1,28 @@
+package org.corfudb.runtime.clients;
+
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+import lombok.Data;
+
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Created by m on 6/19/18.
+ */
+public class Batcher {
+
+    private static final AttributeKey<BatchingChannel> KEY = AttributeKey.newInstance(BatchingChannel.class.getName());
+
+    public static void writeAndFlush(Channel channel, Object message) {
+        BatchingChannel batchingChannel = channel.attr(KEY).get();
+        if (batchingChannel == null) {
+            batchingChannel = new BatchingChannel(channel);
+            channel.attr(KEY).set(batchingChannel);
+        }
+        batchingChannel.getQueue().add(message);
+        channel.pipeline().lastContext().executor().execute(batchingChannel::flush);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BatchingChannel.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BatchingChannel.java
@@ -1,0 +1,40 @@
+package org.corfudb.runtime.clients;
+
+import io.netty.channel.Channel;
+import lombok.Getter;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * Created by box on 7/13/18.
+ */
+public class BatchingChannel {
+
+    private final Channel channel;
+
+    @Getter
+    final Queue<Object> queue = new ConcurrentLinkedQueue<>();
+
+    final int batchSize = 1000;
+
+    public BatchingChannel(Channel channel) {
+        this.channel = channel;
+    }
+
+    public void flush() {
+        int i = 0;
+        while (queue.peek() != null && i++ < batchSize) {
+            Object message = queue.poll();
+            if (message == null) break;
+            channel.write(message);
+        }
+
+        if (i == 0) {
+            return;
+        }
+
+        channel.flush();
+    }
+
+}

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
@@ -48,6 +49,7 @@ import javax.annotation.Nonnull;
 import javax.net.ssl.SSLException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -184,7 +186,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
 
         connectionFuture = new CompletableFuture<>();
 
-        handlerMap = new ConcurrentHashMap<>();
+        handlerMap = new HashMap<>();
         clientList = new ArrayList<>();
         requestID = new AtomicLong();
         outstandingRequests = new ConcurrentHashMap<>();
@@ -214,6 +216,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         b.handler(getChannelInitializer());
         b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
                 (int) parameters.getConnectionTimeout().toMillis());
+        b.option(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
 
         // Asynchronously connect, retrying until shut down.
         // Once connected, connectionFuture will be completed.
@@ -456,9 +459,11 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
 
         // Write the message out to the channel.
         if (ctx == null) {
-            channel.writeAndFlush(message, channel.voidPromise());
+            Batcher.writeAndFlush(channel, message);
+            //channel.writeAndFlush(message, channel.voidPromise());
         } else {
-            ctx.writeAndFlush(message, ctx.voidPromise());
+            Batcher.writeAndFlush(ctx.channel(), message);
+            //ctx.writeAndFlush(message, ctx.voidPromise());
         }
         log.trace("Sent message: {}", message);
 
@@ -508,7 +513,8 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      */
     public void sendResponseToServer(ChannelHandlerContext ctx, CorfuMsg inMsg, CorfuMsg outMsg) {
         outMsg.copyBaseFields(inMsg);
-        ctx.writeAndFlush(outMsg, ctx.voidPromise());
+        //ctx.writeAndFlush(outMsg, ctx.voidPromise());
+        Batcher.writeAndFlush(ctx.channel(), outMsg);
         log.trace("Sent response: {}", outMsg);
     }
 

--- a/scripts/corfu_server.sh
+++ b/scripts/corfu_server.sh
@@ -37,8 +37,8 @@ fi
 
 
 # default heap for corfudb
-CORFUDB_HEAP="${CORFUDB_HEAP:-2000}"
-export JVMFLAGS="-Xmx${CORFUDB_HEAP}m $SERVER_JVMFLAGS"
+CORFUDB_HEAP="${CORFUDB_HEAP:-4000}"
+export JVMFLAGS="-Xmx${CORFUDB_HEAP}m -Xms${CORFUDB_HEAP}m $SERVER_JVMFLAGS"
 
 if [[ $* == *--agent* ]]
 then

--- a/test/src/test/java/org/corfudb/integration/StreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamIT.java
@@ -2,7 +2,10 @@ package org.corfudb.integration;
 
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.WriteSizeException;
+import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Test;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -11,40 +14,59 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * A set integration tests that exercise the stream API.
  */
 
-public class StreamIT extends AbstractIT {
+public class StreamIT{
 
     @Test
     public void largeStreamWrite() throws Exception {
-        final String host = "localhost";
-        final String streamName = "s1";
-        final int port = 9000;
 
-        // Start node one and populate it with data
-        Process server_1 = new CorfuServerRunner()
-                .setHost(host)
-                .setPort(port)
-                .setSingle(true)
-                .runServer();
+        String connString = "localhost:9000";
+        int numThreads = 64;
+        final int numOps = 10_000;
+        final int numRt = 1;
 
-        final int maxWriteSize = 100;
+        CorfuRuntime[] rts = new CorfuRuntime[numRt];
 
-        // Configure a client with a max write limit
-        CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
-                .builder()
-                .maxWriteSize(maxWriteSize)
-                .build();
+        for (int x = 0; x < numRt; x++) {
+            rts[x] = new CorfuRuntime(connString).connect();
+        }
 
-        CorfuRuntime rt = CorfuRuntime.fromParameters(params);
-        rt.parseConfigurationString(host + ":" + port);
-        rt.connect();
+        Thread[] threads = new Thread[numThreads];
+        final byte[] payload = new byte[120];
 
-        final int bufSize = maxWriteSize * 2;
+        for (int x = 0; x < numThreads; x++) {
+            final CorfuRuntime rt = rts[x%numRt];
+            final IStreamView sv = rt.getStreamsView().get(UUID.randomUUID());
+            Runnable r = () -> {
+                long avg = 0;
+                for (int y = 0; y < numOps; y++) {
+                    long ts1 = System.nanoTime();
+                    sv.append(payload);
+                    long ts2 = System.nanoTime();
+                    avg += (ts2 - ts1);
+                }
 
-        // Attempt to write a payload that is greater than the configured limit.
-        assertThatThrownBy(() -> rt.getStreamsView()
-                .get(CorfuRuntime.getStreamID(streamName))
-                .append(new byte[bufSize]))
-                .isInstanceOf(WriteSizeException.class);
-        shutdownCorfuServer(server_1);
+                System.out.println("latency ms/op " + ((avg*1.0)/numOps/1000000));
+            };
+
+            threads[x] = new Thread(r);
+        }
+
+
+        long ts1 = System.currentTimeMillis();
+
+        for (int x = 0; x < numThreads; x++) {
+            threads[x].start();
+        }
+
+        for (int x = 0; x < numThreads; x++) {
+            threads[x].join();
+        }
+
+
+        long ts2 = System.currentTimeMillis();
+
+        System.out.println("Total time: " + (ts2 - ts1));
+        System.out.println("Num Ops: " + (numThreads * numOps));
+        System.out.println("Throughput: " + ((numThreads * numOps) / (ts2 - ts1)));
     }
 }

--- a/test_checks.xml
+++ b/test_checks.xml
@@ -50,7 +50,7 @@
     <property name="fileExtensions" value="java, properties, xml"/>
 
     <module name="TreeWalker">
-        <module name="MagicNumber"/>
+    
 
         <module name="SuppressWarningsHolder" />
     </module>


### PR DESCRIPTION
## Overview

This PR introduces no-wait batching on the netty channels. On every write, we either write and flush, or write a full batch (without waiting) and flush. This improves the performance significantly by reducing the number of system calls (i.e. currently a sys call per rpc).

Why should this be merged: Improves RPC Performance

Related issue(s) (if applicable): #1490

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
