### PR TITLE
bump netty version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,13 +147,13 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
-            <version>4.1.18.Final</version>
+            <version>4.1.27.Final</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-tcnative-boringssl-static</artifactId>
-            <version>2.0.7.Final</version>
+            <version>2.0.17.Final</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
## Overview

Description:
Update netty version to 4.1.27

Why should this be merged: 
Netty version 4.1.18 has a number of memory leaks in it (see https://bugzilla.eng.vmware.com/show_bug.cgi?id=2183135#c32 for a list).

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
