### PR TITLE
Use Auto ChannelImplementation

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -85,7 +85,7 @@ public class CorfuServer {
                     + "              The name of the network interface.\n"
                     + " -i <channel-implementation>, --implementation <channel-implementation>   "
                     + "              The type of channel to use (auto, nio, epoll, kqueue)"
-                    + "[default: nio].\n"
+                    + "[default: auto].\n"
                     + " -m, --memory                                                             "
                     + "              Run the unit in-memory (non-persistent).\n"
                     + "                                                                          "

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -332,7 +332,7 @@ public class CorfuRuntime {
          * an NIO based implementation is used.
          */
         @Default
-        ChannelImplementation socketType = ChannelImplementation.NIO;
+        ChannelImplementation socketType = ChannelImplementation.AUTO;
 
         /**
          * Number of retries to reconnect to an unresponsive system before invoking the


### PR DESCRIPTION
## Overview
The default behavior is to try to use EPOLL/KQUEUE, or default
to NIO, if they are not available.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
