### PR TITLE
Sequencer Recovery Enhancement

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
@@ -20,7 +20,8 @@ public class BatchWriterOperation {
         TRIM,
         PREFIX_TRIM,
         SEAL,
-        RESET
+        RESET,
+        TAILS_QUERY
     }
 
     private final Type type;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -30,6 +30,7 @@ import org.corfudb.protocols.wireprotocol.RangeWriteMsg;
 import org.corfudb.protocols.wireprotocol.ReadRequest;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.protocols.wireprotocol.TrimRequest;
 import org.corfudb.protocols.wireprotocol.WriteRequest;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
@@ -137,7 +138,8 @@ public class LogUnitServer extends AbstractServer {
      */
     @ServerHandler(type = CorfuMsgType.TAIL_REQUEST)
     public void handleTailRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
-        r.sendResponse(ctx, msg, CorfuMsgType.TAIL_RESPONSE.payloadMsg(streamLog.getGlobalTail()));
+        TailsResponse tails = batchWriter.queryTails(msg.getEpoch());
+        r.sendResponse(ctx, msg, CorfuMsgType.TAIL_RESPONSE.payloadMsg(tails));
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -435,9 +435,9 @@ public class SequencerServer extends AbstractServer {
         sequencerEpoch = bootstrapMsgEpoch;
         serverContext.setSequencerEpoch(bootstrapMsgEpoch);
 
-        log.info("Sequencer reset with token = {}, streamTailToGlobalTailMap = {},"
+        log.info("Sequencer reset with token = {}, size {} streamTailToGlobalTailMap = {},"
                         + " sequencerEpoch = {}",
-                globalLogTail.get(), streamTailToGlobalTailMap, sequencerEpoch);
+                globalLogTail.get(), streamTailToGlobalTailMap.size(), streamTailToGlobalTailMap, sequencerEpoch);
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
@@ -1,0 +1,79 @@
+package org.corfudb.infrastructure.log;
+
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.runtime.view.Address;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A container object that holds log tail offsets and the global
+ * log tail that has been seen. Note that holes don't belong to any
+ * stream therefore the globalTail needs to be tracked separately.
+ *
+ * <p>Created by maithem on 10/15/18.
+ */
+
+@NotThreadSafe
+@ToString
+@Slf4j
+public class LogMetadata {
+
+    @Getter
+    private volatile long globalTail;
+
+    @Getter
+    private final Map<UUID, Long> streamTails;
+
+    public LogMetadata() {
+        this.globalTail = Address.NON_ADDRESS;
+        this.streamTails = new HashMap();
+    }
+
+    public void update(List<LogData> entries) {
+        for (LogData entry : entries) {
+            update(entry);
+        }
+    }
+
+    public void update(LogData entry) {
+        long entryAddress = entry.getGlobalAddress();
+        updateGlobalTail(entryAddress);
+        for (UUID streamId : entry.getStreams()) {
+            long currentStreamTail = streamTails.getOrDefault(streamId, Address.NON_ADDRESS);
+            streamTails.put(streamId, Math.max(currentStreamTail, entryAddress));
+        }
+
+        // We should also consider checkpoint metadata while updating the tails.
+        // This is important because there could be streams that have checkpoint
+        // data on the checkpoint stream, but not entries on the regular stream.
+        // If those streams are not updated, then clients would observe those
+        // streams as empty, which is not correct.
+        if (entry.hasCheckpointMetadata()) {
+            UUID streamId = entry.getCheckpointedStreamId();
+            long streamTailAtCP = entry.getCheckpointedStreamStartLogAddress();
+
+            if (Address.isAddress(streamTailAtCP)) {
+                // TODO(Maithem) This is needed to filter out checkpoints of empty streams,
+                // if the map has an entry (streamId, Address.Non_ADDRESS), then
+                // when the sequencer services queries on that stream it will
+                // "think" that the tail is not empty and return Address.Non_ADDRESS
+                // instead of NON_EXIST. The sequencer, should handle both cases,
+                // but that can be addressed in another issue.
+                long currentStreamTail = streamTails.getOrDefault(streamId, Address.NON_ADDRESS);
+                streamTails.put(streamId, Math.max(currentStreamTail, streamTailAtCP));
+            }
+        }
+    }
+
+    public void updateGlobalTail(long newTail) {
+        globalTail = Math.max(globalTail, newTail);
+    }
+
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.exceptions.OverwriteCause;
 
 /**
@@ -55,9 +56,9 @@ public interface StreamLog {
     void compact();
 
     /**
-     * Get the last global address that was written.
+     * Get the global tail and stream tails.
      */
-    long getGlobalTail();
+    TailsResponse getTails();
 
     /**
      * Get the first untrimmed address in the address space.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -20,10 +20,10 @@ import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
-import org.corfudb.runtime.view.Address;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -53,7 +53,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static org.corfudb.infrastructure.utils.Persistence.syncDirectory;
 
@@ -81,12 +80,19 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     public final String logDir;
     private final boolean noVerify;
     private final ServerContext serverContext;
-    private final AtomicLong globalTail = new AtomicLong(Address.NON_ADDRESS);
     private Map<String, SegmentHandle> writeChannels;
     private Set<FileChannel> channelsToSync;
     private MultiReadWriteLock segmentLocks = new MultiReadWriteLock();
+
+    //=================Log Metadata=================
+    // TODO(Maithem) this should effectively be final, but it is used
+    // by a reset API that clears the state of this class, on reset
+    // a new instance of this class should be created after deleting
+    // the files of the old instance
+    private LogMetadata logMetadata;
     private long lastSegment;
     private volatile long startingAddress;
+
 
     /**
      * Returns a file-based stream log object.
@@ -108,14 +114,51 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         verifyLogs();
         // Starting address initialization should happen before
         // initializing the tail segment (i.e. initializeMaxGlobalAddress)
-        initializeStartingAddress();
-        initializeMaxGlobalAddress();
+        startingAddress = serverContext.getStartingAddress();
+        long firstSegment = startingAddress / RECORDS_PER_LOG_FILE;
+        lastSegment = serverContext.getTailSegment();
+        logMetadata = initializeLogMetadata(firstSegment, lastSegment);
 
         // This can happen if a prefix trim happens on
         // addresses that haven't been written
-        if (Math.max(getGlobalTail(), 0L) < getTrimMark()) {
+        if (Math.max(logMetadata.getGlobalTail(), 0L) < getTrimMark()) {
             syncTailSegment(getTrimMark() - 1);
         }
+    }
+
+    /**
+     * This method will scan the log (i.e. read all log segment files)
+     * on this LU and create a map of stream offsets and the global
+     * addresses seen.
+     * @param startSegment first segment in the log to be scanned
+     * @param endSegment the last segment to be scanned
+     * @return LogMetadata constructed from all the addresses in the
+     * consecutive segments from [startSegment, endSegment]
+     */
+    private LogMetadata initializeLogMetadata(long startSegment, long endSegment) {
+        LogMetadata metadata = new LogMetadata();
+        long start = System.currentTimeMillis();
+        for (long currentSegment = startSegment; currentSegment <= endSegment; currentSegment++) {
+            // TODO(Maithem): factor out getSegmentHandleForAddress to allow getting
+            // segments by segment number
+            SegmentHandle sh = getSegmentHandleForAddress(currentSegment * RECORDS_PER_LOG_FILE + 1);
+            try {
+                for (Map.Entry<Long, AddressMetaData> record : sh.getKnownAddresses().entrySet()) {
+                    // skip trimmed entries
+                    if (record.getKey() < startingAddress) continue;
+                    LogData logEntry = read(record.getKey());
+                    metadata.update(logEntry);
+                }
+            } finally {
+                sh.close();
+            }
+        }
+
+        // Open segment will add entries to the writeChannels map, therefore we need to clear it
+        writeChannels.clear();
+        long end = System.currentTimeMillis();
+        log.info("initializeStreamTails: took {} ms to load {}", end - start, metadata);
+        return metadata;
     }
 
     public static String getPendingTrimsFilePath(String segmentPath) {
@@ -200,15 +243,20 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     }
 
     @Override
-    public long getGlobalTail() {
-        return globalTail.get();
+    public TailsResponse getTails() {
+        Map<UUID, Long> tails = new HashMap<>(logMetadata.getStreamTails().size());
+
+        for (Map.Entry<UUID, Long> entry : logMetadata.getStreamTails().entrySet()) {
+            tails.put(entry.getKey(), entry.getValue());
+        }
+        return new TailsResponse(logMetadata.getGlobalTail(), tails);
     }
 
     private void syncTailSegment(long address) {
         // TODO(Maithem) since writing a record and setting the tail segment is not
         // an atomic operation, it is possible to set an incorrect tail segment. In
         // that case we will need to scan more than one segment
-        globalTail.getAndUpdate(maxTail -> address > maxTail ? address : maxTail);
+        logMetadata.updateGlobalTail(address);
         long segment = address / RECORDS_PER_LOG_FILE;
         if (lastSegment < segment) {
             serverContext.setTailSegment(segment);
@@ -238,29 +286,6 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             return true;
         }
         return false;
-    }
-
-    private void initializeStartingAddress() {
-        startingAddress = serverContext.getStartingAddress();
-    }
-
-    private void initializeMaxGlobalAddress() {
-        long tailSegment = serverContext.getTailSegment();
-        long addressInTailSegment = (tailSegment * RECORDS_PER_LOG_FILE) + 1;
-        SegmentHandle sh = getSegmentHandleForAddress(addressInTailSegment);
-
-        try {
-
-            for (long address : sh.getKnownAddresses().keySet()) {
-                globalTail.getAndUpdate(maxTail -> address > maxTail
-                        ? address : maxTail);
-            }
-
-        } finally {
-            sh.release();
-        }
-
-        lastSegment = tailSegment;
     }
 
     private void verifyLogs() {
@@ -1037,7 +1062,10 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             allRecordsBuf.flip();
             safeWrite(sh.getWriteChannel(), allRecordsBuf);
             channelsToSync.add(sh.getWriteChannel());
+            // Sync the global and stream tail(s)
+            // TODO(Maithem): on ioexceptions the StreamLogFiles needs to be reinitialized
             syncTailSegment(entries.get(entries.size() - 1).getGlobalAddress());
+            logMetadata.update(entries);
         }
 
         return recordsMap;
@@ -1062,11 +1090,11 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             // can overwrite the failed write.
 
             // Note that after rewinding the channel pointer, it is important to truncate
-            // any bytes that were written. This is required to avoid an ambigous case
+            // any bytes that were written. This is required to avoid an ambiguous case
             // where a subsequent write (after a failed write) succeeds but writes less
             // bytes than the partially written buffer. In that case, the log unit can't
-            // determine if the bytes correspund to a partially written buffer that needs
-            // to be ignored, or if the bytes corrrespond to a corrupted metadata field.
+            // determine if the bytes correspond to a partially written buffer that needs
+            // to be ignored, or if the bytes correspond to a corrupted metadata field.
             channel.position(prev);
             channel.truncate(prev);
             channel.force(true);
@@ -1096,6 +1124,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             safeWrite(fh.getWriteChannel(), record);
             channelsToSync.add(fh.getWriteChannel());
             syncTailSegment(address);
+            logMetadata.update(entry);
         }
 
         return new AddressMetaData(metadata.getPayloadChecksum(), metadata.getLength(), channelOffset);
@@ -1336,6 +1365,9 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     }
 
     /**
+     * TODO(Maithem) remove this method. Obtaining a new instance should happen
+     * through instantiation not by clearing this class' state
+     *
      * Resets the Stream log.
      * Clears all data and resets the handlers.
      * Usage: To heal a recovering node, we require to wipe off existing data.
@@ -1343,8 +1375,8 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     @Override
     public void reset() {
         // Trim all segments
-        long endSegment = (Math.max(globalTail.get(), 0L) / RECORDS_PER_LOG_FILE);
-        log.warn("Global Tail:{}, endSegment={}", globalTail.get(), endSegment);
+        long endSegment = (Math.max(logMetadata.getGlobalTail(), 0L) / RECORDS_PER_LOG_FILE);
+        log.warn("Global Tail:{}, endSegment={}", logMetadata.getGlobalTail(), endSegment);
 
         // Close segments before deleting their corresponding log files
         closeSegmentHandlers(endSegment);
@@ -1361,10 +1393,10 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
 
         serverContext.setStartingAddress(0L);
         serverContext.setTailSegment(0L);
-        globalTail.set(Address.NON_ADDRESS);
-        initializeStartingAddress();
-        initializeMaxGlobalAddress();
-
+        startingAddress = 0L;
+        lastSegment = 0L;
+        logMetadata = new LogMetadata();
+        writeChannels.clear();
         log.info("reset: Completed, end segment {}", endSegment);
     }
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -61,7 +61,7 @@ public enum CorfuMsgType {
     FILL_HOLE(34, new TypeToken<CorfuPayloadMsg<FillHoleRequest>>() {}),
     PREFIX_TRIM(38, new TypeToken<CorfuPayloadMsg<TrimRequest>>() {}),
     TAIL_REQUEST(41, TypeToken.of(CorfuMsg.class)),
-    TAIL_RESPONSE(42, new TypeToken<CorfuPayloadMsg<Long>>(){}),
+    TAIL_RESPONSE(42, new TypeToken<CorfuPayloadMsg<TailsResponse>>(){}),
     COMPACT_REQUEST(43, TypeToken.of(CorfuMsg.class), true),
     FLUSH_CACHE(44, TypeToken.of(CorfuMsg.class), true),
     TRIM_MARK_REQUEST(45, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TailsResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TailsResponse.java
@@ -1,0 +1,37 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ *
+ * A container that contains information about the log's stream tails
+ * map and max global address written (i.e. global tail)
+ *
+ * Created by Maithem on 10/22/18.
+ */
+
+@Data
+@RequiredArgsConstructor
+public class TailsResponse implements ICorfuPayload<TailsResponse> {
+
+    final long logTail;
+
+    final Map<UUID, Long> streamTails;
+
+    public TailsResponse(ByteBuf buf) {
+        logTail = ICorfuPayload.fromBuffer(buf, Long.class);
+        streamTails = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, logTail);
+        ICorfuPayload.serialize(buf, streamTails);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -7,7 +7,6 @@ import static org.corfudb.recovery.RecoveryUtils.getLogData;
 import static org.corfudb.recovery.RecoveryUtils.getSnapShotAddressOfCheckPoint;
 import static org.corfudb.recovery.RecoveryUtils.getStartAddressOfCheckPoint;
 import static org.corfudb.recovery.RecoveryUtils.isCheckPointEntry;
-import static org.corfudb.runtime.view.Address.isAddress;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -103,10 +102,6 @@ public class FastObjectLoader {
 
     @Setter
     @Getter
-    private boolean recoverSequencerMode;
-
-    @Setter
-    @Getter
     private boolean logHasNoCheckPoint = false;
 
     private boolean whiteList = false;
@@ -185,9 +180,6 @@ public class FastObjectLoader {
 
     private Map<UUID, StreamMetaData> streamsMetaData;
 
-    @Getter
-    private Map<UUID, Long> streamTails = new HashMap<>();
-
     @Setter
     @Getter
     private int numberOfAttempt = NUMBER_OF_ATTEMPT;
@@ -261,32 +253,11 @@ public class FastObjectLoader {
     }
 
     private void findAndSetLogTail() {
-        logTail = runtime.getAddressSpaceView().getLogTail().getSequence();
+        logTail = runtime.getAddressSpaceView().getAllTails().getLogTail();
     }
 
     private void resetAddressProcessed() {
         addressProcessed = logHead - 1;
-    }
-
-    /**
-     * Book keeping of the the stream tails
-     *
-     * @param logData
-     */
-    public void updateStreamTails(long address, ILogData logData) {
-        // On checkpoint, we also need to track the stream tail of the checkpoint
-        if (isCheckPointEntry(logData)) {
-            if (logData.getCheckpointType() == CheckpointEntry.CheckpointEntryType.END &&
-                    isAddress(getStartAddressOfCheckPoint(logData))) {
-                streamTails.compute(logData.getCheckpointedStreamId(),
-                        (uuid, value) -> (value == null) ? getStartAddressOfCheckPoint(logData)
-                            : Math.max(value, getStartAddressOfCheckPoint(logData)));
-            }
-        }
-        for (UUID streamId : logData.getStreams()) {
-            streamTails.compute(streamId,
-                    (uuid, value) -> (value == null) ? address : Math.max(value, address));
-        }
     }
 
     /**
@@ -500,7 +471,6 @@ public class FastObjectLoader {
     private void cleanUpForRetry() {
         runtime.getAddressSpaceView().invalidateClientCache();
         runtime.getObjectsView().getObjectCache().clear();
-        streamTails.clear();
         nextRead = logHead;
         resetAddressProcessed();
 
@@ -661,15 +631,6 @@ public class FastObjectLoader {
     }
 
     /**
-     * This method will only resurrect the stream tails. It is used
-     * to recover a sequencer.
-     */
-    private void recoverSequencer() {
-        log.info("recoverSequencer: Resurrecting the stream tails");
-        applyForEachAddress(this::updateStreamTails);
-    }
-
-    /**
      * This method will use the checkpoints and the entries
      * after checkpoints to resurrect the SMRMaps
      */
@@ -699,13 +660,7 @@ public class FastObjectLoader {
     public void loadMaps() {
         log.info("loadMaps: Starting to resurrect maps");
         initializeHeadAndTails();
-
-        if(recoverSequencerMode) {
-            recoverSequencer();
-        }
-        else {
-            recoverRuntime();
-        }
+        recoverRuntime();
 
         log.info("loadMaps[startAddress: {}, stopAddress (included): {}, addressProcessed: {}]",
                 logHead, logTail, addressProcessed);

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -20,6 +20,7 @@ import org.corfudb.protocols.wireprotocol.RangeWriteMsg;
 import org.corfudb.protocols.wireprotocol.ReadRequest;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.protocols.wireprotocol.TrimRequest;
 import org.corfudb.protocols.wireprotocol.WriteMode;
 import org.corfudb.protocols.wireprotocol.WriteRequest;
@@ -216,7 +217,7 @@ public class LogUnitClient extends AbstractClient {
      * @return A CompletableFuture which will complete with the globalTail once
      * received.
      */
-    public CompletableFuture<Long> getTail() {
+    public CompletableFuture<TailsResponse> getTail() {
         return sendMessageWithFuture(CorfuMsgType.TAIL_REQUEST.msg());
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitHandler.java
@@ -11,6 +11,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.DataOutrankedException;
 import org.corfudb.runtime.exceptions.OutOfSpaceException;
@@ -190,7 +191,7 @@ public class LogUnitHandler implements IClient, IHandler<LogUnitClient> {
      * @param r   Router
      */
     @ClientHandler(type = CorfuMsgType.TAIL_RESPONSE)
-    private static Object handleTailResponse(CorfuPayloadMsg<Long> msg,
+    private static Object handleTailResponse(CorfuPayloadMsg<TailsResponse> msg,
                                              ChannelHandlerContext ctx, IClientRouter r) {
         return msg.getPayload();
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -1,6 +1,6 @@
 package org.corfudb.runtime.view;
 
-import static org.corfudb.util.Utils.getMaxGlobalTail;
+import static org.corfudb.util.Utils.getTails;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.github.benmanes.caffeine.cache.CacheLoader;
@@ -27,6 +27,7 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IToken;
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.LogUnitClient;
@@ -281,9 +282,9 @@ public class AddressSpaceView extends AbstractView {
     /**
      * Get the last address in the address space
      */
-    public Token getLogTail() {
+    public TailsResponse getAllTails() {
         return layoutHelper(
-                e -> getMaxGlobalTail(e.getLayout(), runtime));
+                e -> getTails(e.getLayout(), runtime));
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -1,6 +1,6 @@
 package org.corfudb.runtime.view;
 
-import static org.corfudb.util.Utils.getMaxGlobalTail;
+import static org.corfudb.util.Utils.getTails;
 
 import java.util.Collections;
 import java.util.Map;
@@ -17,7 +17,7 @@ import javax.annotation.Nonnull;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
-import org.corfudb.recovery.FastObjectLoader;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.LayoutModificationException;
 import org.corfudb.runtime.exceptions.OutrankedException;
@@ -151,7 +151,7 @@ public class LayoutManagementView extends AbstractView {
             }
             if (isLogUnitServer) {
                 layoutBuilder.addLogunitServer(logUnitStripeIndex,
-                        getMaxGlobalTail(currentLayout, runtime).getSequence(),
+                        getTails(currentLayout, runtime).getLogTail(),
                         endpoint);
             }
             if (isUnresponsiveServer) {
@@ -197,7 +197,7 @@ public class LayoutManagementView extends AbstractView {
 
             LayoutBuilder layoutBuilder = new LayoutBuilder(currentLayout);
             layoutBuilder.addLogunitServer(0,
-                    getMaxGlobalTail(currentLayout, runtime).getSequence(),
+                    getTails(currentLayout, runtime).getLogTail(),
                     endpoint);
             layoutBuilder.removeUnresponsiveServers(Collections.singleton(endpoint));
             newLayout = layoutBuilder.build();
@@ -430,14 +430,12 @@ public class LayoutManagementView extends AbstractView {
                         || !originalLayout.getPrimarySequencer()
                         .equals(newLayout.getPrimarySequencer())) {
 
-                    FastObjectLoader fastObjectLoader = new FastObjectLoader(runtime);
-                    fastObjectLoader.setRecoverSequencerMode(true);
-                    fastObjectLoader.setLoadInCache(false);
+                    //TODO(Maithem) why isn't this getting the tails
+                    // from utils?
+                    TailsResponse tails = runtime.getAddressSpaceView().getAllTails();
 
-                    // FastSMRLoader sets the logHead based on trim mark.
-                    fastObjectLoader.loadMaps();
-                    maxTokenRequested = fastObjectLoader.getLogTail();
-                    streamTails = fastObjectLoader.getStreamTails();
+                    maxTokenRequested = tails.getLogTail();
+                    streamTails = tails.getStreamTails();
                     verifyStreamTailsMap(streamTails);
 
                     // Incrementing the maxTokenRequested value for sequencer reset.

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -510,30 +510,30 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
     public void testGetGlobalTail() {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
 
-        assertThat(log.getGlobalTail()).isEqualTo(Address.NON_ADDRESS);
+        assertThat(log.getTails().getLogTail()).isEqualTo(Address.NON_ADDRESS);
 
         // Write to multiple segments
         final int segments = 3;
         long lastAddress = segments * StreamLogFiles.RECORDS_PER_LOG_FILE;
         for (long x = 0; x <= lastAddress; x++){
             writeToLog(log, x);
-            assertThat(log.getGlobalTail()).isEqualTo(x);
+            assertThat(log.getTails().getLogTail()).isEqualTo(x);
         }
 
         // Restart and try to retrieve the global tail
         log = new StreamLogFiles(getContext(), false);
-        assertThat(log.getGlobalTail()).isEqualTo(lastAddress);
+        assertThat(log.getTails().getLogTail()).isEqualTo(lastAddress);
 
         // Advance the tail some more
         final long tailDelta = 5;
         for (long x = lastAddress + 1; x <= lastAddress + tailDelta; x++){
             writeToLog(log, x);
-            assertThat(log.getGlobalTail()).isEqualTo(x);
+            assertThat(log.getTails().getLogTail()).isEqualTo(x);
         }
 
         // Restart and try to retrieve the global tail one last time
         log = new StreamLogFiles(getContext(), false);
-        assertThat(log.getGlobalTail()).isEqualTo(lastAddress + tailDelta);
+        assertThat(log.getTails().getLogTail()).isEqualTo(lastAddress + tailDelta);
     }
 
     @Test
@@ -620,7 +620,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         log.compact();
         log = new StreamLogFiles(getContext(), false);
 
-        assertThat(log.getGlobalTail()).isEqualTo(midSegmentAddress);
+        assertThat(log.getTails().getLogTail()).isEqualTo(midSegmentAddress);
         assertThat(log.getTrimMark()).isEqualTo(midSegmentAddress + 1);
     }
 
@@ -669,20 +669,16 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         final long globalTailBeforeReset = (RECORDS_PER_LOG_FILE * numSegments) - 1;
         final long trimMarkBeforeReset = (RECORDS_PER_LOG_FILE * (filesToBeTrimmed + 1)) + 1;
         assertThat(logsDir.list()).hasSize(expectedFilesBeforeReset);
-        assertThat(log.getGlobalTail()).isEqualTo(globalTailBeforeReset);
+        assertThat(log.getTails().getLogTail()).isEqualTo(globalTailBeforeReset);
         assertThat(log.getTrimMark()).isEqualTo(trimMarkBeforeReset);
 
         log.reset();
 
-        // Files have been deleted and new 0.log files are created due to reset.
-        Arrays.stream(logsDir.list()).forEach(
-                s -> assertThat(new File(s).length()).isEqualTo(0L));
-
-        final int expectedFilesAfterReset = 3;
+        final int expectedFilesAfterReset = 0;
         final long globalTailAfterReset = Address.NON_ADDRESS;
         final long trimMarkAfterReset = 0L;
         assertThat(logsDir.list()).hasSize(expectedFilesAfterReset);
-        assertThat(log.getGlobalTail()).isEqualTo(globalTailAfterReset);
+        assertThat(log.getTails().getLogTail()).isEqualTo(globalTailAfterReset);
         assertThat(log.getTrimMark()).isEqualTo(trimMarkAfterReset);
     }
 

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -362,10 +362,7 @@ public class WorkflowIT extends AbstractIT {
                 .isEqualTo(prefixTrimAddress.getSequence() + 1);
         assertThat(rt.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9002").getTrimMark().get())
                 .isEqualTo(prefixTrimAddress.getSequence() + 1);
-        FastObjectLoader fastObjectLoader = new FastObjectLoader(rt);
-        fastObjectLoader.setRecoverSequencerMode(true);
-        fastObjectLoader.loadMaps();
-        assertThat(fastObjectLoader.getStreamTails().get(CorfuRuntime.getStreamID(streamName)))
+        assertThat(rt.getAddressSpaceView().getAllTails().getStreamTails().get(CorfuRuntime.getStreamID(streamName)))
                 .isEqualTo(streamTail);
 
         // Shutdown two nodes

--- a/test/src/test/java/org/corfudb/recovery/Helpers.java
+++ b/test/src/test/java/org/corfudb/recovery/Helpers.java
@@ -91,12 +91,7 @@ public class Helpers{
     static Map<UUID, Long> getRecoveryStreamTails(String configurationString) {
         CorfuRuntime rt = new CorfuRuntime(configurationString)
                 .connect();
-
-        FastObjectLoader loader = new FastObjectLoader(rt);
-        loader.setRecoverSequencerMode(true);
-        loader.loadMaps();
-
-        return loader.getStreamTails();
+        return rt.getAddressSpaceView().getAllTails().getStreamTails();
     }
 
     static void trim(CorfuRuntime rt, Token address) {

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -413,16 +413,16 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         file.getChannel().read(metaDataBuf);
         metaDataBuf.flip();
 
+        LogUnitServer server2 = new LogUnitServer(serverContext);
+        serverRouter.reset();
+        serverRouter.addServer(server2);
+
         Types.Metadata metadata = Types.Metadata.parseFrom(metaDataBuf.array());
         final int fileOffset = Integer.BYTES + METADATA_SIZE + metadata.getLength() + 20;
         final int CORRUPT_BYTES = 0xFFFF;
         file.seek(fileOffset); // Skip file header
         file.writeInt(CORRUPT_BYTES);
         file.close();
-
-        LogUnitServer server2 = new LogUnitServer(serverContext);
-        serverRouter.reset();
-        serverRouter.addServer(server2);
 
         // Try to read a corrupted log entry
         assertThatThrownBy(() -> client.read(0).get())

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1698,9 +1698,10 @@ public class ManagementViewTest extends AbstractViewTest {
         addClientRule(managementRuntime0, testRule);
         addClientRule(managementRuntime1, testRule);
 
-        // Add rule to drop all read responses to hang the FastObjectLoaders.
-        addServerRule(SERVERS.PORT_1, new TestRule().matches(m -> {
-            if (m.getMsgType().equals(CorfuMsgType.READ_RESPONSE)) {
+        // Since the fast loader will retrieve the tails from the head node,
+        // we need to drop all tail requests to hang the FastObjectLoaders
+        addServerRule(SERVERS.PORT_0, new TestRule().matches(m -> {
+            if (m.getMsgType().equals(CorfuMsgType.TAIL_RESPONSE)) {
                 semaphore.release();
                 return true;
             }
@@ -1740,7 +1741,7 @@ public class ManagementViewTest extends AbstractViewTest {
         assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch())
                 .isEqualTo(layout2.getEpoch());
 
-        clearServerRules(SERVERS.PORT_1);
+        clearServerRules(SERVERS.PORT_0);
         // Once the rules are cleared, the detectors should resolve the epoch instability,
         // bootstrap the sequencer and fetch a new token.
         assertThat(corfuRuntime.getSequencerView().query()).isNotNull();


### PR DESCRIPTION
This patch enables the logging units to track the stream tails
and expose that via rpc. Also, changed the sequencer recovery
logic to consume the new rpc in order to greatly reduce the
failover time.

Why should this be merged: Significantly improves the time it takes for the sequencer to failover. 

Related issue(s) (if applicable): #1504 and #1503


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
