### PR TITLE
Corfu db logging

### DIFF
--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -6,7 +6,7 @@
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIRECTORY}/corfu.9000.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${LOG_DIRECTORY}/corfu.9000.%i.log.zip</fileNamePattern>
+            <fileNamePattern>${LOG_DIRECTORY}/corfu.9000.%i.log.tar.gz</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>20</maxIndex>
         </rollingPolicy>

--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true" scanPeriod="30 seconds">
+
+    <property name="LOG_DIRECTORY" value="/var/log/corfu" />
+
+    <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIRECTORY}/corfu.9000.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${LOG_DIRECTORY}/corfu.9000.%i.log.zip</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>20</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>100MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder>
+            <pattern>
+                %date{yy/MM/dd HH:mm:ss.SSS} %-5level %-10.10thread | %25.25logger{25} | %msg%n%xException
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="file"/>
+    </root>
+</configuration>

--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -15,7 +15,7 @@
         </triggeringPolicy>
         <encoder>
             <pattern>
-                %date{yy/MM/dd HH:mm:ss.SSS} %-5level %-10.10thread | %25.25logger{25} | %msg%n%xException
+                %date{yyyy-MM-dd HH:mm:ss.SSS} %-5level %-10.10thread | %25.25logger{25} | %msg%n%xException
             </pattern>
         </encoder>
     </appender>

--- a/infrastructure/src/main/resources/logback.xml
+++ b/infrastructure/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
     <appender name="std" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                %date{yy/MM/dd HH:mm:ss.SSS} %-5level %-10.10thread | %20.30logger{30} [%10.10(%M:%L)] | %msg%n%xException
+                %date{yyyy-MM-dd HH:mm:ss.SSS} %-5level %-10.10thread | %20.30logger{30} [%10.10(%M:%L)] | %msg%n%xException
             </pattern>
         </encoder>
     </appender>

--- a/infrastructure/src/main/resources/logback.xml
+++ b/infrastructure/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="std" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %date{yy/MM/dd HH:mm:ss.SSS} %-5level %-10.10thread | %20.30logger{30} [%10.10(%M:%L)] | %msg%n%xException
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="std"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Overview

Description:
Setup logging in corfu db. `Infrastructure`/resource directory contains two logback configs:
 - logback.xml - for development purposes
 - logback.prod.xml - production config

Why should this be merged: 
This PR provides logging config for production and development environments. The production config missing on prod environment.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
