### PR TITLE
Lookup by Index when Index is not specified

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -54,7 +54,8 @@ public class TransactionAbortedException extends RuntimeException {
                 + " | Cause = " + abortCause
                 + " | Time = " + (context == null ? "Unknown" :
                 System.currentTimeMillis() -
-                context.getStartTime()) + " ms");
+                context.getStartTime()) + " ms"
+                + (cause == null ? "" : " | Message = " + cause.getMessage()));
         this.txResolutionInfo = txResolutionInfo;
         this.conflictKey = conflictKey;
         this.abortCause = abortCause;

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -1,16 +1,16 @@
 package org.corfudb.runtime.collections;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.reflect.TypeToken;
-import org.assertj.core.data.MapEntry;
-import org.corfudb.runtime.view.AbstractViewTest;
-import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.assertj.core.data.MapEntry;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.junit.Test;
 
 public class CorfuTableTest extends AbstractViewTest {
 
@@ -60,6 +60,43 @@ public class CorfuTableTest extends AbstractViewTest {
 
         assertThat(project(corfuTable.getByIndex(StringIndexer.BY_VALUE, "ab")))
                 .containsExactly("ab");
+    }
+
+    /**
+     * Verify that a  lookup by index throws an exception,
+     * when the index has never been specified for this CorfuTable.
+     */
+    @Test (expected = IllegalArgumentException.class)
+    @SuppressWarnings("unchecked")
+    public void cannotLookupByIndexWhenIndexNotSpecified() {
+        CorfuTable<String, String>
+                corfuTable = getDefaultRuntime().getObjectsView().build()
+                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setStreamName("test")
+                .open();
+
+        corfuTable.put("k1", "a");
+        corfuTable.put("k2", "ab");
+        corfuTable.put("k3", "b");
+
+        corfuTable.getByIndex(StringIndexer.BY_FIRST_LETTER, "a");
+    }
+
+    /**
+     * Verify that a  lookup by index and filter throws an exception,
+     * when the index has never been specified for this CorfuTable.
+     */
+    @Test (expected = IllegalArgumentException.class)
+    @SuppressWarnings("unchecked")
+    public void cannotLookupByIndexAndFilterWhenIndexNotSpecified() {
+        CorfuTable<String, String>
+                corfuTable = getDefaultRuntime().getObjectsView().build()
+                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setStreamName("test")
+                .open();
+
+        corfuTable.put("a", "abcdef");
+        corfuTable.getByIndexAndFilter(StringIndexer.BY_FIRST_LETTER, p -> p.getValue().contains("cd"), "a");
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/StreamTest.java
@@ -3,21 +3,22 @@ package org.corfudb.runtime.object.transactions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.ISMRMap;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.collections.StringIndexer;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.AppendException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * These tests generate workloads with mixed reads/writes on multiple maps.
@@ -288,5 +289,45 @@ public class StreamTest extends AbstractTransactionsTest {
         scheduleInterleaved(NUM_THREADS, NUM_THREADS);
     }
 
+    /**
+     * Verify that a transaction is aborted if we attempt to lookup by index,
+     * when the index has never been specified for this CorfuTable.
+     */
+    @Test (expected = TransactionAbortedException.class)
+    public void checkTransactionAbortIfLookupByIndexWhenIndexNotSpecified() {
+        CorfuTable<String, String> map = instantiateCorfuObject(CorfuTable.class, "Test");
 
+        try {
+            TXBegin();
+            map.put("ak", "av");
+            map.getByIndex(StringIndexer.BY_FIRST_LETTER, "a");
+            TXEnd();
+        } catch (TransactionAbortedException tae) {
+            assertThat(tae.getAbortCause()).isEqualTo(AbortCause.UNDEFINED);
+            assertThat(tae.getCause().getClass()).isEqualTo(IllegalArgumentException.class);
+            throw tae;
+        }
+    }
+
+    /**
+     * Verify that a transaction is aborted if we attempt to lookup by index and filter,
+     * when the index has never been specified for this CorfuTable.
+     */
+    @Test (expected = TransactionAbortedException.class)
+    public void checkTransactionAbortIfLookupByIndexAndFilterWhenIndexNotSpecified() {
+        CorfuTable<String, String> map = instantiateCorfuObject(CorfuTable.class, "Test");
+
+        try {
+            TXBegin();
+            map.put("ab", "cccc");
+            map.put("ac", "bbbb");
+            map.put("ad", "bcbc");
+            map.getByIndexAndFilter(StringIndexer.BY_FIRST_LETTER, p -> p.getValue().contains("c"),"a");
+            TXEnd();
+        } catch (TransactionAbortedException tae) {
+            assertThat(tae.getAbortCause()).isEqualTo(AbortCause.UNDEFINED);
+            assertThat(tae.getCause().getClass()).isEqualTo(IllegalArgumentException.class);
+            throw tae;
+        }
+    }
 }


### PR DESCRIPTION
## Overview

The use of the getByIndex API should fail whenever the index has not
been specified for the given table. This should be followed by the
proper exception and logging. In addition we add a message field to
the transaction aborted exception info in case a message for the cause
of abort is available.