### PR TITLE
Handshake handler cleanup, remove redundant channel close

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandshakeHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerHandshakeHandler.java
@@ -183,7 +183,6 @@ public class ServerHandshakeHandler extends ChannelDuplexHandler {
             if (!this.state.completed()) {
                 log.error("exceptionCaught: Handshake timeout checker: timed out. Close Connection.");
                 this.state.set(true, false);
-                ctx.channel().close();
             } else {
                 log.debug("exceptionCaught: Handshake timeout " +
                         "checker: discarded (handshake OK)");

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
@@ -200,7 +200,6 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
                 log.error("exceptionCaught: Handshake timeout checker: timed out." +
                     " Close Connection.");
                 this.handshakeState.set(true, false);
-                ctx.channel().close();
             } else {
                 // Handshake completed successfully,
                 log.debug("exceptionCaught: Handshake timeout checker: discarded " +

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/HandshakeState.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/HandshakeState.java
@@ -38,7 +38,7 @@ public class HandshakeState {
      * @return true, if failed
      *         false, otherwise.
      */
-    public boolean failed(){
+    public boolean failed() {
         return this.handshakeFailed.get();
     }
 
@@ -47,7 +47,7 @@ public class HandshakeState {
      * @return true, if handshake completed.
      *         false, if handshake never concluded.
      */
-    public boolean completed(){
+    public boolean completed() {
         return this.handshakeComplete.get();
     }
 }


### PR DESCRIPTION
## Overview

Removed redundant channel close calls in client and server handshake handlers.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
