### PR TITLE
Interface for Cluster Recommendation Engine

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterRecommendationEngine.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterRecommendationEngine.java
@@ -1,0 +1,53 @@
+package org.corfudb.infrastructure.management;
+
+import org.corfudb.protocols.wireprotocol.NodeView;
+import org.corfudb.runtime.view.Layout;
+
+import java.util.List;
+
+/**
+ * {@link ClusterRecommendationEngine} provides methods to decide the status of Corfu servers
+ * (failed or healed) in a given {@link Layout} and for a specific view of the cluster
+ * captured in a {@link NodeView}. Decisions are dependant on the concrete underlying algorithm
+ * corresponding to a {@link ClusterRecommendationStrategy}.
+ *
+ * Created by Sam Behnam on 10/19/18.
+ */
+public interface ClusterRecommendationEngine {
+
+    /**
+     * Get the corresponding {@link ClusterRecommendationStrategy} used in the current instance of
+     * {@link ClusterRecommendationEngine}. This strategy represents the characteristics of the
+     * underlying algorithm used for making a decision about the failed or healed status of
+     * Corfu servers.
+     *
+     * @return a concrete instance of {@link ClusterRecommendationStrategy}
+     */
+    ClusterRecommendationStrategy getClusterRecommendationStrategy();
+
+    /**
+     * Provide a list of servers in the Corfu cluster which according to the underlying algorithm
+     * for {@link ClusterRecommendationStrategy} have failed. The decision is made based on the
+     * given view of the cluster captured in {@link NodeView} along with the expected
+     * {@link Layout}.
+     *
+     * @param nodeView view of the Corfu cluster of servers from a client node's perspective.
+     * @param layout expected layout of the cluster.
+     * @return a {@link List} of Corfu servers suspected to have been failed according to the
+     * underlying {@link ClusterRecommendationStrategy}.
+     */
+    List<String> suspectedFailedServers(NodeView nodeView, Layout layout);
+
+    /**
+     * Provide a list of servers in the Corfu cluster which according to the underlying algorithm
+     * for {@link ClusterRecommendationStrategy} have healed. The decision is made based on the
+     * given view of the cluster captured in {@link NodeView} along with the expected
+     * {@link Layout}.
+     *
+     * @param nodeView view of the Corfu cluster of servers from a client node's perspective.
+     * @param layout expected layout of the cluster.
+     * @return a {@link List} of servers suspected to have been healed according to the underlying
+     * {@link ClusterRecommendationStrategy}.
+     */
+    List<String> suspectedHealedServers(NodeView nodeView, Layout layout);
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterRecommendationEngineFactory.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterRecommendationEngineFactory.java
@@ -1,0 +1,37 @@
+package org.corfudb.infrastructure.management;
+
+
+/**
+ * This is a factory for creating concrete {@link ClusterRecommendationEngine}s based on
+ * the requested {@link ClusterRecommendationStrategy}s.
+ *
+ * Created by Sam Behnam on 10/19/18.
+ */
+public class ClusterRecommendationEngineFactory {
+
+    private ClusterRecommendationEngineFactory() {
+        // To prevent instantiation of the factory class.
+    }
+
+    /**
+     * Create an instance of {@link ClusterRecommendationEngine} based on the provided
+     * {@link ClusterRecommendationStrategy}.
+     *
+     * @param strategy a {@link ClusterRecommendationStrategy} representing desired
+     *               algorithm to be used for determining failure and healing status of Corfu
+     *               servers.
+     * @return a concrete instance of {@link ClusterRecommendationEngine} specific to the
+     * provided strategy.
+     */
+    public ClusterRecommendationEngine createForStrategy(ClusterRecommendationStrategy strategy) {
+        switch (strategy) {
+            case FULLY_CONNECTED_CLUSTER:
+                throw new UnsupportedOperationException(strategy.name());
+            case CENTRALIZED_CLUSTER:
+                throw new UnsupportedOperationException(strategy.name());
+            default:
+                throw new UnsupportedOperationException("Unknown ClusterRecommendationStrategy");
+
+        }
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterRecommendationStrategy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterRecommendationStrategy.java
@@ -1,0 +1,35 @@
+package org.corfudb.infrastructure.management;
+
+/**
+ * {@link ClusterRecommendationStrategy} is the enumeration of policies each of which representing
+ * specific algorithms for evaluating the cluster and providing recommendation on the failure or
+ * healing status of servers in a Corfu cluster of servers.
+ *
+ * Created by Sam Behnam on 10/19/18.
+ */
+public enum ClusterRecommendationStrategy {
+    /**
+     * FULLY_CONNECTED_CLUSTER represents a cluster evaluation approach for recommending the
+     * failed and healed status of node in which the implementing algorithm:
+     * Determines a node to have failed when the given node is NOT FULLY connected to all the
+     * healthy servers in the cluster.
+     * Determines a node to have healed when the given node is FULLY connected to all the healthy
+     * servers in the cluster.
+     *
+     * After applying this strategy, the resulting graph of cluster nodes will resemble a Complete
+     * Graph.
+     */
+    FULLY_CONNECTED_CLUSTER,
+    /**
+     * CENTRALIZED_CLUSTER represents a cluster evaluation approach for recommending the
+     * failed and healed status of node in which the implementing algorithm:
+     * Determines a node to have failed when the given node is NOT connected to at least one
+     * CENTRAL node which in turn is connected to all the healthy servers in the cluster.
+     * Determines a node to have healed when the given node is connected to at least one
+     * CENTRAL node which in turn is connected to all the healthy servers in the cluster.
+     *
+     * After applying this strategy, the resulting graph of cluster nodes will resemble a Star
+     * Topology Graph.
+     */
+    CENTRALIZED_CLUSTER
+}


### PR DESCRIPTION
## Overview

Description:
This commit provides the interface which will be used for providing recommendation on whether a node is suspected of Failed or Healed status. The recommendation will be made based on the cluster view and underlying policy.
The introduced policy enables plugging different concrete algorithms for making the aforementioned recommendations.

Why should this be merged: 
Required for failure detection and tolerance in case of link failures.

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
