### PR TITLE
Add Stream Name to Tx Abort Exceptions

### DIFF
--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
@@ -54,6 +54,12 @@ public interface ICorfuSMRProxy<T> {
      */
     UUID getStreamID();
 
+    /** Get the name of the stream this proxy is subscribed to.
+     *
+     * @return  The name of the stream this proxy is subscribed to.
+     */
+    String getStreamName();
+
     /** Run in a transactional context.
      *
      * @param txFunction    The function to run in a transactional context.

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAbortedException.java
@@ -39,18 +39,19 @@ public class TransactionAbortedException extends RuntimeException {
     public TransactionAbortedException(
             TxResolutionInfo txResolutionInfo,
             byte[] conflictKey, AbortCause abortCause, AbstractTransactionalContext context) {
-        this(txResolutionInfo, conflictKey, null, abortCause, null, context);
+        this(txResolutionInfo, conflictKey, null, null, abortCause, null, context);
     }
 
     public TransactionAbortedException(
             TxResolutionInfo txResolutionInfo,
-            byte[] conflictKey, UUID conflictStream,
+            byte[] conflictKey, UUID conflictStream, String conflictStreamName,
             AbortCause abortCause, Throwable cause, AbstractTransactionalContext context) {
         super("TX ABORT "
                 + " | Snapshot Time = " + txResolutionInfo.getSnapshotTimestamp()
                 + " | Transaction ID = " + txResolutionInfo.getTXid()
-                + " | Conflict Key = " + Utils.bytesToHex(conflictKey)
-                + " | Conflict Stream = " + conflictStream
+                + (conflictKey == null ? "" : " | Conflict Key = " + Utils.bytesToHex(conflictKey))
+                + (conflictStream == null ? "" : " | Conflict Stream UUID = " + conflictStream)
+                + (conflictStreamName == null ? "" : " | Conflict Stream Name = " + conflictStreamName)
                 + " | Cause = " + abortCause
                 + " | Time = " + (context == null ? "Unknown" :
                 System.currentTimeMillis() -
@@ -63,5 +64,4 @@ public class TransactionAbortedException extends RuntimeException {
         this.conflictStream = conflictStream;
         this.context = context;
     }
-
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -81,6 +81,12 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
             UUID streamID;
 
     /**
+     * The name of the stream of the log
+     */
+    @Getter
+    final String streamName;
+
+    /**
      * The type of the underlying object. We use this to instantiate
      * new instances of the underlying object.
      */
@@ -121,7 +127,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
      * Creates a CorfuCompileProxy object on a particular stream.
      *
      * @param rt                  Connected CorfuRuntime instance.
-     * @param streamID            StreamID of the log.
+     * @param streamName          Name of the stream.
      * @param type                Type of underlying object to instantiate a new instance.
      * @param args                Arguments to create this proxy.
      * @param serializer          Serializer used by the SMR entries to serialize the arguments.
@@ -132,7 +138,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
      */
     @Deprecated // TODO: Add replacement method that conforms to style
     @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
-    public CorfuCompileProxy(CorfuRuntime rt, UUID streamID, Class<T> type, Object[] args,
+    public CorfuCompileProxy(CorfuRuntime rt, String streamName, Class<T> type, Object[] args,
                              ISerializer serializer,
                              Map<String, ICorfuSMRUpcallTarget<T>> upcallTargetMap,
                              Map<String, IUndoFunction<T>> undoTargetMap,
@@ -140,7 +146,8 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                              Set<String> resetSet
     ) {
         this.rt = rt;
-        this.streamID = streamID;
+        this.streamID = CorfuRuntime.getStreamID(streamName);
+        this.streamName = streamName;
         this.type = type;
         this.args = args;
         this.serializer = serializer;
@@ -336,6 +343,16 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
     }
 
     /**
+     * Get the name of the stream this proxy is subscribed to.
+     *
+     * @return The name of the stream this proxy is subscribed to.
+     */
+    @Override
+    public String getStreamName() {
+        return streamName;
+    }
+
+    /**
      * Run in a transactional context.
      *
      * @param txFunction The function to run in a transactional context.
@@ -466,7 +483,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
 
     @Override
     public String toString() {
-        return type.getSimpleName() + "[" + Utils.toReadableId(streamID) + "]";
+        return type.getSimpleName() + "[" + Utils.toReadableId(streamID) + " : " + streamName + "]";
     }
 
     private void abortTransaction(Exception e) {
@@ -497,7 +514,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
 
             TxResolutionInfo txInfo = new TxResolutionInfo(
                     context.getTransactionID(), snapshotTimestamp);
-            tae = new TransactionAbortedException(txInfo, null, getStreamID(),
+            tae = new TransactionAbortedException(txInfo, null, getStreamID(), getStreamName(),
                     abortCause, e, context);
             context.abortTransaction(tae);
         }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -3,6 +3,8 @@ package org.corfudb.runtime.object;
 import java.lang.reflect.Constructor;
 import java.util.UUID;
 
+import javax.annotation.Nonnull;
+
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.ISerializer;
 
@@ -30,7 +32,7 @@ public class CorfuCompileWrapperBuilder {
     @Deprecated // TODO: Add replacement method that conforms to style
     @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
     public static <T> T getWrapper(Class<T> type, CorfuRuntime rt,
-                                   UUID streamID, Object[] args,
+                                   @Nonnull String streamName, Object[] args,
                                    ISerializer serializer)
             throws ClassNotFoundException, IllegalAccessException,
             InstantiationException {
@@ -59,7 +61,7 @@ public class CorfuCompileWrapperBuilder {
 
         // Now we create the proxy, which actually manages
         // instances of this object. The wrapper delegates calls to the proxy.
-        wrapperObject.setCorfuSMRProxy(new CorfuCompileProxy<>(rt, streamID,
+        wrapperObject.setCorfuSMRProxy(new CorfuCompileProxy<>(rt, streamName,
                 type, args, serializer,
                 wrapperObject.getCorfuSMRUpcallMap(),
                 wrapperObject.getCorfuUndoMap(),

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -216,7 +216,7 @@ public abstract class AbstractTransactionalContext implements
                             new TransactionAbortedException(
                                     new TxResolutionInfo(getTransactionID(),
                                             snapshotTimestamp), null,
-                                    proxy.getStreamID(),
+                                    proxy.getStreamID(), proxy.getStreamName(),
                                     AbortCause.TRIM, te, this);
                     abortTransaction(tae);
                     throw tae;

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -304,7 +304,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         } catch (AppendException oe) {
             // We were overwritten (and the original snapshot is now conflicting),
             // which means we must abort.
-            throw new TransactionAbortedException(txInfo, null, null,
+            throw new TransactionAbortedException(txInfo, null, null, null,
                 AbortCause.OVERWRITE, oe, this);
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
@@ -14,7 +14,6 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.CorfuCompileWrapperBuilder;
@@ -100,14 +99,14 @@ public class ObjectBuilder<T> implements IObjectBuilder<T> {
 
         try {
             if (options.contains(ObjectOpenOptions.NO_CACHE)) {
-                return CorfuCompileWrapperBuilder.getWrapper(type, runtime, streamID,
+                return CorfuCompileWrapperBuilder.getWrapper(type, runtime, streamName,
                         arguments, serializer);
             } else {
                 ObjectsView.ObjectID<T> oid = new ObjectsView.ObjectID(streamID, type);
                 return (T) runtime.getObjectsView().objectCache.computeIfAbsent(oid, x -> {
                             try {
                                 T result = CorfuCompileWrapperBuilder.getWrapper(type, runtime,
-                                        streamID, arguments, serializer);
+                                        streamName, arguments, serializer);
 
                                 // Get object serializer to check if we didn't attempt to set another serializer
                                 // to an already existing map

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -1,6 +1,13 @@
 package org.corfudb.runtime.view;
 
 import com.codahale.metrics.Timer;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.Nonnull;
+
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -22,11 +29,6 @@ import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.MetricsUtils;
-
-import javax.annotation.Nonnull;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 
 /**
@@ -172,7 +174,6 @@ public class ObjectsView extends AbstractView {
             }
             TxResolutionInfo txInfo = new TxResolutionInfo(context.getTransactionID(),
                     snapshotTimestamp);
-
             AbortCause cause = AbortCause.UNDEFINED;
             if (e instanceof NetworkException) {
                 log.warn("TXEnd[{}] Network Exception {}", context, e);
@@ -183,7 +184,7 @@ public class ObjectsView extends AbstractView {
             }
 
             TransactionAbortedException tae = new TransactionAbortedException(txInfo,
-                    null, null, cause, e, context);
+                    null, null, null, cause, e, context);
             context.abortTransaction(tae);
             throw tae;
 
@@ -192,7 +193,7 @@ public class ObjectsView extends AbstractView {
             TxResolutionInfo txInfo = new TxResolutionInfo(context.getTransactionID(),
                     Token.UNINITIALIZED);
             TransactionAbortedException tae = new TransactionAbortedException(txInfo,
-                    null, null, AbortCause.UNDEFINED, e, context);
+                    null, null, null, AbortCause.UNDEFINED, e, context);
             context.abortTransaction(tae);
             throw new UnrecoverableCorfuError("Unexpected exception during commit", e);
         } finally {


### PR DESCRIPTION
## Overview

- Add stream name to transaction abort exception message for
  readibility and debugability.
- Remove conflict stream info from tx abort exception when not
  relevant and instead misleading.