### PR TITLE
Added An Epoch To the Transaction's Timestamp

### DIFF
--- a/generator/src/main/java/org/corfudb/generator/Correctness.java
+++ b/generator/src/main/java/org/corfudb/generator/Correctness.java
@@ -25,7 +25,7 @@ public class Correctness {
         if (transactionPrefix) {
             String txOperation = "Tx" + operation;
             correctnessLogger.info("{}, {}", txOperation,
-                    TransactionalContext.getCurrentContext().getSnapshotTimestamp());
+                    TransactionalContext.getCurrentContext().getSnapshotTimestamp().getSequence());
         } else {
             correctnessLogger.info(operation);
         }

--- a/generator/src/main/java/org/corfudb/generator/State.java
+++ b/generator/src/main/java/org/corfudb/generator/State.java
@@ -12,6 +12,7 @@ import org.corfudb.generator.distributions.Keys;
 import org.corfudb.generator.distributions.OperationCount;
 import org.corfudb.generator.distributions.Operations;
 import org.corfudb.generator.distributions.Streams;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.object.transactions.TransactionType;
@@ -53,8 +54,7 @@ public class State {
     volatile long lastSuccessfulWriteOperationTimestamp = -1;
 
     @Getter
-    @Setter
-    volatile long trimMark = -1;
+    volatile Token trimMark = Token.UNINITIALIZED;
 
     public final Random rand;
 
@@ -75,6 +75,12 @@ public class State {
         operations.populate();
 
         openObjects();
+    }
+
+    public void updateTrimMark(Token newTrimMark) {
+        if (newTrimMark.compareTo(trimMark) > 0) {
+            trimMark = newTrimMark;
+        }
     }
 
     private void openObjects() {
@@ -111,7 +117,7 @@ public class State {
         return runtime.getObjectsView().TXEnd();
     }
 
-    public void startSnapshotTx(long snapshot) {
+    public void startSnapshotTx(Token snapshot) {
         runtime.getObjectsView()
                 .TXBuild()
                 .setType(TransactionType.SNAPSHOT)

--- a/generator/src/main/java/org/corfudb/generator/operations/CheckpointOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/CheckpointOperation.java
@@ -2,6 +2,7 @@ package org.corfudb.generator.operations;
 
 import org.corfudb.generator.Correctness;
 import org.corfudb.generator.State;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.MultiCheckpointWriter;
 
 import lombok.extern.slf4j.Slf4j;
@@ -28,10 +29,10 @@ public class CheckpointOperation extends Operation {
 
             MultiCheckpointWriter mcw = new MultiCheckpointWriter();
             mcw.addAllMaps(state.getMaps());
-            long trimAddress = mcw.appendCheckpoints(state.getRuntime(), "Maithem");
-            state.setTrimMark(trimAddress);
+            Token trimAddress = mcw.appendCheckpoints(state.getRuntime(), "Maithem");
+            state.updateTrimMark(trimAddress);
             Thread.sleep(1000l * 30l * 1l);
-            state.getRuntime().getAddressSpaceView().prefixTrim(trimAddress - 1);
+            state.getRuntime().getAddressSpaceView().prefixTrim(trimAddress.getSequence() - 1);
             state.getRuntime().getAddressSpaceView().gc();
             state.getRuntime().getAddressSpaceView().invalidateClientCache();
             state.getRuntime().getAddressSpaceView().invalidateServerCaches();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
@@ -135,7 +135,7 @@ public class AddNodeWorkflow implements IWorkflow {
 
         int batchSize = runtime.getParameters().getBulkReadSize();
 
-        long trimMark = runtime.getAddressSpaceView().getTrimMark();
+        long trimMark = runtime.getAddressSpaceView().getTrimMark().getSequence();
         // Send the trimMark to the new/healing nodes.
         // If this times out or fails, the Action performing the stateTransfer fails and retries.
         for (String endpoint : endpoints) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -146,7 +146,7 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      * @param token     The token to use.
      */
     default void useToken(IToken token) {
-        setGlobalAddress(token.getTokenValue());
+        setGlobalAddress(token.getSequence());
         if (token.getBackpointerMap().size() > 0) {
             setBackpointerMap(token.getBackpointerMap());
         }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IToken.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IToken.java
@@ -17,7 +17,7 @@ public interface IToken {
      * on the log the token is for.
      * @return  The value of the token.
      */
-    long getTokenValue();
+    long getSequence();
 
     /** Get the epoch of the token, which represents the epoch the
      * token is valid in.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/Token.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/Token.java
@@ -2,6 +2,8 @@ package org.corfudb.protocols.wireprotocol;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.corfudb.runtime.view.Address;
 
 /**
  * Token returned by the sequencer is a combination of the
@@ -11,9 +13,20 @@ import lombok.Data;
  */
 @Data
 @AllArgsConstructor
-public class Token implements IToken {
+@EqualsAndHashCode
+public class Token implements IToken, Comparable<Token> {
 
-    private final long tokenValue;
+    public static final Token UNINITIALIZED = new Token(Address.NON_ADDRESS, Address.NON_ADDRESS);
+
     private final long epoch;
+    private final long sequence;
 
+    @Override
+    public int compareTo(Token o) {
+        int epochCmp = Long.compare(epoch, o.getEpoch());
+        if (epochCmp == 0) {
+            return Long.compare(sequence, o.getSequence());
+        }
+        return epochCmp;
+    }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -22,14 +22,13 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
     /**
      * Constructor for TokenResponse.
      *
-     * @param tokenValue token value
-     * @param epoch current epoch
+     * @param token token value
      * @param backpointerMap  map of backpointers for all requested streams
      */
-    public TokenResponse(long tokenValue, long epoch, Map<UUID, Long> backpointerMap) {
+    public TokenResponse(Token token, Map<UUID, Long> backpointerMap) {
         respType = TokenType.NORMAL;
         conflictKey = NO_CONFLICT_KEY;
-        token = new Token(tokenValue, epoch);
+        this.token = token;
         this.backpointerMap = backpointerMap;
         this.streamTails = Collections.emptyList();
     }
@@ -59,9 +58,9 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
     public TokenResponse(ByteBuf buf) {
         respType = TokenType.values()[ICorfuPayload.fromBuffer(buf, Byte.class)];
         conflictKey = ICorfuPayload.fromBuffer(buf, byte[].class);
-        Long tokenValue = ICorfuPayload.fromBuffer(buf, Long.class);
         Long epoch = ICorfuPayload.fromBuffer(buf, Long.class);
-        token = new Token(tokenValue, epoch);
+        Long sequence = ICorfuPayload.fromBuffer(buf, Long.class);
+        token = new Token(epoch, sequence);
         backpointerMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
         streamTails = ICorfuPayload.listFromBuffer(buf, Long.class);
     }
@@ -70,15 +69,15 @@ public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, respType);
         ICorfuPayload.serialize(buf, conflictKey);
-        ICorfuPayload.serialize(buf, token.getTokenValue());
         ICorfuPayload.serialize(buf, token.getEpoch());
+        ICorfuPayload.serialize(buf, this.getSequence());
         ICorfuPayload.serialize(buf, backpointerMap);
         ICorfuPayload.serialize(buf, streamTails);
     }
 
     @Override
-    public long getTokenValue() {
-        return token.getTokenValue();
+    public long getSequence() {
+        return token.getSequence();
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -257,11 +257,11 @@ public class FastObjectLoader {
      * by the user.
      */
     private void findAndSetLogHead() {
-         logHead = runtime.getAddressSpaceView().getTrimMark();
+         logHead = runtime.getAddressSpaceView().getTrimMark().getSequence();
     }
 
     private void findAndSetLogTail() {
-        logTail = runtime.getAddressSpaceView().getLogTail();
+        logTail = runtime.getAddressSpaceView().getLogTail().getSequence();
     }
 
     private void resetAddressProcessed() {

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -19,6 +19,7 @@ import lombok.Setter;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.MultiSMREntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuSMR;
@@ -164,7 +165,7 @@ public class CheckpointWriter<T extends Map> {
     public long startCheckpoint() {
         startTime = LocalDateTime.now();
         AbstractTransactionalContext context = TransactionalContext.getCurrentContext();
-        long txBeginGlobalAddress = context.getSnapshotTimestamp();
+        Token txBeginGlobalAddress = context.getSnapshotTimestamp();
 
         this.mdkv.put(CheckpointEntry.CheckpointDictKey.START_TIME, startTime.toString());
         // Need the actual object's version
@@ -172,7 +173,7 @@ public class CheckpointWriter<T extends Map> {
         this.mdkv.put(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS,
                 Long.toString(corfuObject.getCorfuSMRProxy().getVersion()));
         this.mdkv.put(CheckpointEntry.CheckpointDictKey.SNAPSHOT_ADDRESS,
-                Long.toString(txBeginGlobalAddress));
+                Long.toString(txBeginGlobalAddress.getSequence()));
 
         ImmutableMap<CheckpointEntry.CheckpointDictKey,String> mdkv =
                 ImmutableMap.copyOf(this.mdkv);

--- a/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuSMR;
@@ -54,7 +55,7 @@ public class MultiCheckpointWriter<T extends Map> {
      * @param author Author's name, stored in checkpoint metadata
      * @return Global log address of the first record of
      */
-    public long appendCheckpoints(CorfuRuntime rt, String author)
+    public Token appendCheckpoints(CorfuRuntime rt, String author)
             throws Exception {
         return appendCheckpoints(rt, author, (x,y) -> { });
     }
@@ -68,12 +69,12 @@ public class MultiCheckpointWriter<T extends Map> {
      * @return Global log address of the first record of
      */
 
-    public long appendCheckpoints(CorfuRuntime rt, String author,
+    public Token appendCheckpoints(CorfuRuntime rt, String author,
                                   BiConsumer<CheckpointEntry, Long> postAppendFunc) {
 
         // We retrieve the tail from the logging units because the tail
         // returned from the sequencer might not be materialized
-        long globalTail = rt.getAddressSpaceView().getLogTail();
+        Token globalTail = rt.getAddressSpaceView().getLogTail();
         rt.getObjectsView().TXBuild()
                 .setType(TransactionType.SNAPSHOT)
                 .setSnapshot(globalTail)

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -355,13 +355,13 @@ public class VersionLockedObject<T> {
         return smrStream.append(entry,
                 t -> {
                     if (saveUpcall) {
-                        pendingUpcalls.add(t.getToken().getTokenValue());
+                        pendingUpcalls.add(t.getToken().getSequence());
                     }
                     return true;
                 },
                 t -> {
                     if (saveUpcall) {
-                        pendingUpcalls.remove(t.getToken().getTokenValue());
+                        pendingUpcalls.remove(t.getToken().getSequence());
                     }
                     return true;
                 });

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -15,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.ISMRConsumable;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.AppendException;
@@ -88,7 +89,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         // to the correct version, reflecting any optimistic
         // updates.
         // Get snapshot timestamp in advance so it is not performed under the VLO lock
-        long ts = getSnapshotTimestamp();
+        long ts = getSnapshotTimestamp().getSequence();
         return proxy
                 .getUnderlyingObject()
                 .access(o -> {
@@ -149,7 +150,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         }
         // Otherwise, we need to sync the object
         // Get snapshot timestamp in advance so it is not performed under the VLO lock
-        long ts = getSnapshotTimestamp();
+        Token ts = getSnapshotTimestamp();
         return proxy.getUnderlyingObject().update(o -> {
             log.trace("Upcall[{}] {} Sync'd", this,  timestamp);
             syncWithRetryUnsafe(o, ts, proxy, this::setAsOptimisticStream);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -48,7 +48,7 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
         // Hence, we do not need to add this access to a conflict set
         // do not add: addToReadSet(proxy, conflictObject);
         return proxy.getUnderlyingObject().access(o -> o.getVersionUnsafe()
-                        == getSnapshotTimestamp()
+                        == getSnapshotTimestamp().getSequence()
                         && !o.isOptimisticallyModifiedUnsafe(),
                 o -> {
                     syncWithRetryUnsafe(o, getSnapshotTimestamp(), proxy, null);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionBuilder.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.object.transactions;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
 
@@ -28,7 +29,7 @@ public class TransactionBuilder {
     /** For snapshot transactions, the address the
      * snapshot will start at.
      */
-    long snapshot = Address.NON_ADDRESS;
+    Token snapshot = Token.UNINITIALIZED;
 
     public TransactionBuilder(CorfuRuntime runtime) {
         this.runtime = runtime;

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -134,7 +134,7 @@ public class LayoutManagementView extends AbstractView {
             }
             if (isLogUnitServer) {
                 layoutBuilder.addLogunitServer(logUnitStripeIndex,
-                        getMaxGlobalTail(currentLayout, runtime),
+                        getMaxGlobalTail(currentLayout, runtime).getSequence(),
                         endpoint);
             }
             if (isUnresponsiveServer) {
@@ -180,7 +180,7 @@ public class LayoutManagementView extends AbstractView {
 
             LayoutBuilder layoutBuilder = new LayoutBuilder(currentLayout);
             layoutBuilder.addLogunitServer(0,
-                    getMaxGlobalTail(currentLayout, runtime),
+                    getMaxGlobalTail(currentLayout, runtime).getSequence(),
                     endpoint);
             layoutBuilder.removeUnresponsiveServers(Collections.singleton(endpoint));
             newLayout = layoutBuilder.build();

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -15,6 +15,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.AbortCause;
@@ -149,11 +150,11 @@ public class ObjectsView extends AbstractView {
                 throw e;
             } catch (NetworkException e) {
                 log.warn("TXEnd[{}] Network Exception {}", context, e);
-                long snapshotTimestamp;
+                Token snapshotTimestamp;
                 try {
                     snapshotTimestamp = context.getSnapshotTimestamp();
                 } catch (NetworkException ne) {
-                    snapshotTimestamp = -1L;
+                    snapshotTimestamp = Token.UNINITIALIZED;
                 }
                 TxResolutionInfo txInfo = new TxResolutionInfo(context.getTransactionID(),
                     snapshotTimestamp);
@@ -165,7 +166,7 @@ public class ObjectsView extends AbstractView {
             } catch (Exception e) {
                log.error("TXEnd[{}]: Unexpected exception", context, e);
                 TxResolutionInfo txInfo = new TxResolutionInfo(context.getTransactionID(),
-                    -1L);
+                    Token.UNINITIALIZED);
                 TransactionAbortedException tae = new TransactionAbortedException(txInfo,
                     null, null, AbortCause.UNDEFINED, e, context);
                 context.abortTransaction(tae);

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -113,12 +113,12 @@ public class StreamsView extends AbstractView {
             try {
                 runtime.getAddressSpaceView().write(tokenResponse, object, cacheOption);
                 // If we're here, we succeeded, return the acquired token
-                return tokenResponse.getTokenValue();
+                return tokenResponse.getSequence();
             } catch (OverwriteException oe) {
 
                 // We were overwritten, get a new token and try again.
                 log.warn("append[{}]: Overwritten after {} retries, streams {}",
-                        tokenResponse.getTokenValue(),
+                        tokenResponse.getSequence(),
                         x,
                         Arrays.stream(streamIDs).map(Utils::toReadableId).collect(Collectors.toSet()));
 
@@ -130,7 +130,7 @@ public class StreamsView extends AbstractView {
 
                     // On retry, check for conflicts only from the previous
                     // attempt position
-                    conflictInfo.setSnapshotTimestamp(tokenResponse.getToken().getTokenValue());
+                    conflictInfo.setSnapshotTimestamp(tokenResponse.getToken());
 
                     // Token w/ conflict info
                     temp = runtime.getSequencerView().next(conflictInfo, streamIDs);
@@ -144,7 +144,7 @@ public class StreamsView extends AbstractView {
 
             } catch (StaleTokenException se) {
                 // the epoch changed from when we grabbed the token from sequencer
-                log.warn("append[{}]: StaleToken , streams {}", tokenResponse.getTokenValue(),
+                log.warn("append[{}]: StaleToken , streams {}", tokenResponse.getSequence(),
                         Arrays.stream(streamIDs).map(Utils::toReadableId).collect(Collectors.toSet()));
 
                 throw new TransactionAbortedException(
@@ -156,7 +156,7 @@ public class StreamsView extends AbstractView {
         }
 
         log.error("append[{}]: failed after {} retries , streams {}, write size {} bytes",
-                tokenResponse.getTokenValue(),
+                tokenResponse.getSequence(),
                 runtime.getParameters().getWriteRetry(),
                 Arrays.stream(streamIDs).map(Utils::toReadableId).collect(Collectors.toSet()),
                 ILogData.getSerializedSize(object));

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -29,6 +29,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.recovery.FastObjectLoader;
 import org.corfudb.recovery.RecoveryUtils;
 import org.corfudb.runtime.CorfuRuntime;
@@ -474,7 +475,7 @@ public class Utils {
      * @param layout  Latest layout to get clients to fetch tails.
      * @return The max global log tail obtained from the log unit servers.
      */
-    public static long getMaxGlobalTail(Layout layout, CorfuRuntime runtime) {
+    public static Token getMaxGlobalTail(Layout layout, CorfuRuntime runtime) {
         long maxTokenRequested = Address.NON_ADDRESS;
         Layout.LayoutSegment segment = layout.getLatestSegment();
 
@@ -504,6 +505,6 @@ public class Utils {
 
             }
         }
-        return maxTokenRequested;
+        return new Token(layout.getEpoch(), maxTokenRequested);
     }
 }

--- a/samples/src/main/java/org/corfudb/samples/WriteWriteTXs.java
+++ b/samples/src/main/java/org/corfudb/samples/WriteWriteTXs.java
@@ -57,18 +57,6 @@ public class WriteWriteTXs extends BaseCorfuAppUtils {
     }
 
     /**
-     * This variant of TXBegin sets a snapshot-point,
-     * as well as sets the transaction type to WRITE_AFTER_WRITE
-     */
-    protected void TXBegin(long snapTime) {
-        getCorfuRuntime().getObjectsView().TXBuild()
-                .setSnapshot(snapTime)
-                .setType(TransactionType.WRITE_AFTER_WRITE)
-                .begin();
-    }
-
-
-    /**
      * This is where activity is started
      */
     @Override

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -58,9 +58,9 @@ public class SequencerServerTest extends AbstractServerTest {
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ, new TokenRequest(1L, Collections.emptyList())));
             Token thisToken = getLastPayloadMessageAs(TokenResponse.class).getToken();
-            assertThat(thisToken.getTokenValue())
+            assertThat(thisToken.getSequence())
                     .isGreaterThan(lastTokenValue);
-            lastTokenValue = thisToken.getTokenValue();
+            lastTokenValue = thisToken.getSequence();
         }
     }
 
@@ -114,8 +114,8 @@ public class SequencerServerTest extends AbstractServerTest {
             assertThat(checkTokenA2)
                     .isEqualTo(checkTokenA);
 
-            assertThat(thisTokenB.getTokenValue())
-                    .isGreaterThan(checkTokenA2.getTokenValue());
+            assertThat(thisTokenB.getSequence())
+                    .isGreaterThan(checkTokenA2.getSequence());
         }
     }
 
@@ -133,7 +133,7 @@ public class SequencerServerTest extends AbstractServerTest {
                     new TokenRequest(1L, Collections.singletonList(streamA))));
             long checkTokenAValue = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
-            assertThat(thisTokenA.getTokenValue())
+            assertThat(thisTokenA.getSequence())
                     .isEqualTo(checkTokenAValue);
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
@@ -144,7 +144,7 @@ public class SequencerServerTest extends AbstractServerTest {
                     new TokenRequest(1L, Collections.singletonList(streamB))));
             long checkTokenBValue = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamB);
 
-            assertThat(thisTokenB.getTokenValue())
+            assertThat(thisTokenB.getSequence())
                     .isEqualTo(checkTokenBValue);
 
             final long MULTI_TOKEN = 5L;
@@ -157,7 +157,7 @@ public class SequencerServerTest extends AbstractServerTest {
                     new TokenRequest(1L, Collections.singletonList(streamA))));
             checkTokenAValue = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
-            assertThat(thisTokenA.getTokenValue() + MULTI_TOKEN - 1)
+            assertThat(thisTokenA.getSequence() + MULTI_TOKEN - 1)
                     .isEqualTo(checkTokenAValue);
 
             // check the requesting multiple tokens does not break the back-pointer for the multi-entry
@@ -169,7 +169,7 @@ public class SequencerServerTest extends AbstractServerTest {
                     new TokenRequest(MULTI_TOKEN, Collections.singletonList(streamA))));
             checkTokenAValue = getLastPayloadMessageAs(TokenResponse.class).getBackpointerMap().get(streamA);
 
-            assertThat(thisTokenA.getTokenValue())
+            assertThat(thisTokenA.getSequence())
                     .isEqualTo(checkTokenAValue);
 
         }
@@ -183,22 +183,22 @@ public class SequencerServerTest extends AbstractServerTest {
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(1L, Collections.singletonList(streamA))));
-        long tailA = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
+        long tailA = getLastPayloadMessageAs(TokenResponse.class).getToken().getSequence();
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(1L, Collections.singletonList(streamB))));
-        long tailB = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
+        long tailB = getLastPayloadMessageAs(TokenResponse.class).getToken().getSequence();
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(1L, Collections.singletonList(streamC))));
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(1L, Collections.singletonList(streamC))));
 
-        long tailC = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
+        long tailC = getLastPayloadMessageAs(TokenResponse.class).getToken().getSequence();
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(0L, Collections.emptyList())));
-        long globalTail = getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue();
+        long globalTail = getLastPayloadMessageAs(TokenResponse.class).getToken().getSequence();
 
         // Construct new tails
         Map<UUID, Long> tailMap = new HashMap<>();
@@ -218,15 +218,15 @@ public class SequencerServerTest extends AbstractServerTest {
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(0L, Collections.singletonList(streamA))));
-        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue()).isEqualTo(newTailA);
+        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getSequence()).isEqualTo(newTailA);
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(0L, Collections.singletonList(streamB))));
-        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue()).isEqualTo(newTailB);
+        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getSequence()).isEqualTo(newTailB);
 
         // We should have the same value than before
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(0L, Collections.singletonList(streamC))));
-        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getTokenValue()).isEqualTo(newTailC);
+        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getSequence()).isEqualTo(newTailC);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.BootstrapUtil;
 import org.corfudb.runtime.CorfuRuntime;
@@ -37,6 +38,7 @@ import org.corfudb.runtime.clients.ManagementClient;
 import org.corfudb.runtime.clients.ManagementHandler;
 import org.corfudb.runtime.clients.NettyClientRouter;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.Layout;
@@ -64,34 +66,24 @@ public class ClusterReconfigIT extends AbstractIT {
         return new Random(SEED);
     }
 
-    private Layout get3NodeLayout() {
-        return new Layout(
-                new ArrayList<>(
-                        Arrays.asList("localhost:9000", "localhost:9001", "localhost:9002")),
-                new ArrayList<>(
-                        Arrays.asList("localhost:9000", "localhost:9001", "localhost:9002")),
-                Collections.singletonList(new Layout.LayoutSegment(
-                        Layout.ReplicationMode.CHAIN_REPLICATION,
-                        0L,
-                        -1L,
-                        Collections.singletonList(new Layout.LayoutStripe(
-                                Arrays.asList("localhost:9000", "localhost:9001", "localhost:9002")
-                        )))),
-                0L,
-                UUID.randomUUID());
-    }
+    final int basePort = 9000;
 
-    private Layout get1NodeLayout() {
+    private Layout getLayout(int numNodes) {
+        List<String> servers = new ArrayList<>();
+
+        for (int x = 0; x < numNodes; x++) {
+            String serverAddress = "localhost:" + (basePort + x);
+            servers.add(serverAddress);
+        }
+
         return new Layout(
-                new ArrayList<>(Collections.singletonList("localhost:9000")),
-                new ArrayList<>(Collections.singletonList("localhost:9000")),
+                new ArrayList<>(servers),
+                new ArrayList<>(servers),
                 Collections.singletonList(new Layout.LayoutSegment(
                         Layout.ReplicationMode.CHAIN_REPLICATION,
                         0L,
                         -1L,
-                        Collections.singletonList(new Layout.LayoutStripe(
-                                Collections.singletonList("localhost:9000")
-                        )))),
+                        Collections.singletonList(new Layout.LayoutStripe(servers)))),
                 0L,
                 UUID.randomUUID());
     }
@@ -131,21 +123,12 @@ public class ClusterReconfigIT extends AbstractIT {
         return sb.toString();
     }
 
-    private Process runSinglePersistentServer(String address, int port) throws IOException {
+    private Process runPersistentServer(String address, int port, boolean singleNode) throws IOException {
         return new CorfuServerRunner()
                 .setHost(address)
                 .setPort(port)
                 .setLogPath(getCorfuServerLogPath(address, port))
-                .setSingle(true)
-                .runServer();
-    }
-
-    private Process runUnbootstrappedPersistentServer(String address, int port) throws IOException {
-        return new CorfuServerRunner()
-                .setHost(address)
-                .setPort(port)
-                .setLogPath(getCorfuServerLogPath(address, port))
-                .setSingle(false)
+                .setSingle(singleNode)
                 .runServer();
     }
 
@@ -171,6 +154,72 @@ public class ClusterReconfigIT extends AbstractIT {
     }
 
     /**
+     * This test verifies transactions that span system reconfigurations are
+     * aborted. There are two cases, transactions that start at an older epoch
+     * and commit at a later epoch and transactions that start an a newer epoch (i.e.
+     * epoch greater than the current system's epoch). The latter is not expected to happen
+     * normally, but we check for the sake of guarding against user defined (i.e. transactions
+     * that use a timestamp passed from the user) transactions.
+     */
+    @Test
+    public void transactionsSpanningReconfigurationTest() throws Exception {
+        final int PORT_0 = 9000;
+        final int PORT_1 = 9001;
+        final Duration timeout = Duration.ofMinutes(5);
+        final Duration pollPeriod = Duration.ofSeconds(5);
+        final int workflowNumRetry = 3;
+
+        runPersistentServer(corfuSingleNodeHost, PORT_0, true);
+        runPersistentServer(corfuSingleNodeHost, PORT_1, false);
+
+        CorfuRuntime runtime = createDefaultRuntime();
+
+        Map<String, String> map = runtime.getObjectsView()
+                .build()
+                .setType(CorfuTable.class)
+                .setStreamName("test")
+                .open();
+
+        // Start a transaction and add a new node before the transaction commits
+        runtime.getObjectsView().TXBegin();
+        map.put("key", "val");
+
+        runtime.getManagementView().addNode("localhost:9001", workflowNumRetry,
+                timeout, pollPeriod);
+
+        // Try to commit a transaction from an older epoch to the new system
+        boolean txnFailed = false;
+        try {
+            runtime.getObjectsView().TXEnd();
+        } catch (TransactionAbortedException tae) {
+            assertThat(tae.getAbortCause()).isEqualTo(AbortCause.NEW_SEQUENCER);
+            txnFailed = true;
+        }
+
+        assertThat(txnFailed).isTrue();
+
+        final int clusterSize2N = 2;
+
+        // Try to commit a transaction from a future epoch
+        Layout twoNodeLayout = runtime.getLayoutView().getLayout();
+        assertThat(twoNodeLayout.getAllServers().size()).isEqualTo(clusterSize2N);
+        final int offset = 100;
+        Token futureTimestamp = new Token(twoNodeLayout.getEpoch() + offset, offset);
+
+        runtime.getObjectsView().TXBuild().setSnapshot(futureTimestamp).begin();
+        map.put("key", "val");
+
+        try {
+            runtime.getObjectsView().TXEnd();
+        } catch (TransactionAbortedException tae) {
+            assertThat(tae.getAbortCause()).isEqualTo(AbortCause.NEW_SEQUENCER);
+            txnFailed = true;
+        }
+
+        assertThat(txnFailed).isTrue();
+    }
+
+    /**
      * A cluster of one node is started - 9000.
      * Then a block of data of 15,000 entries is written to the node.
      * This is to ensure we have at least 1.5 data log files.
@@ -189,9 +238,9 @@ public class ClusterReconfigIT extends AbstractIT {
         final Duration pollPeriod = Duration.ofSeconds(5);
         final int workflowNumRetry = 3;
 
-        Process corfuServer_1 = runSinglePersistentServer(corfuSingleNodeHost, PORT_0);
-        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
-        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, true);
+        Process corfuServer_2 = runPersistentServer(corfuSingleNodeHost, PORT_1, false);
+        Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
 
         CorfuRuntime runtime = createDefaultRuntime();
 
@@ -242,7 +291,7 @@ public class ClusterReconfigIT extends AbstractIT {
 
         TokenResponse tokenResponse = corfuRuntime.getSequencerView()
                 .query(CorfuRuntime.getStreamID("test"));
-        long lastAddress = tokenResponse.getTokenValue();
+        long lastAddress = tokenResponse.getSequence();
 
         Map<Long, LogData> map_0 = getAllNonEmptyData(corfuRuntime, "localhost:9000", lastAddress);
         Map<Long, LogData> map_1 = getAllNonEmptyData(corfuRuntime, "localhost:9001", lastAddress);
@@ -302,7 +351,7 @@ public class ClusterReconfigIT extends AbstractIT {
 
         final int PORT_0 = 9000;
 
-        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer = runPersistentServer(corfuSingleNodeHost, PORT_0, true);
 
         CorfuRuntime corfuRuntime = createDefaultRuntime();
         incrementClusterEpoch(corfuRuntime);
@@ -337,7 +386,7 @@ public class ClusterReconfigIT extends AbstractIT {
 
         final int PORT_0 = 9000;
 
-        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer = runPersistentServer(corfuSingleNodeHost, PORT_0, true);
 
         CorfuRuntime corfuRuntime = createDefaultRuntime();
         Layout l = incrementClusterEpoch(corfuRuntime);
@@ -367,11 +416,11 @@ public class ClusterReconfigIT extends AbstractIT {
         final int PORT_0 = 9000;
         final int PORT_1 = 9001;
         final int PORT_2 = 9002;
-        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
-        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
-        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
+        Process corfuServer_2 = runPersistentServer(corfuSingleNodeHost, PORT_1, false);
+        Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
         List<Process> corfuServers = Arrays.asList(corfuServer_1, corfuServer_2, corfuServer_3);
-        final Layout layout = get3NodeLayout();
+        final Layout layout = getLayout(3);
         final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
@@ -466,10 +515,10 @@ public class ClusterReconfigIT extends AbstractIT {
         final int PORT_0 = 9000;
         final int PORT_1 = 9001;
         final int PORT_2 = 9002;
-        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
-        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
-        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
-        final Layout layout = get3NodeLayout();
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
+        Process corfuServer_2 = runPersistentServer(corfuSingleNodeHost, PORT_1, false);
+        Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
+        final Layout layout = getLayout(3);
 
         final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
@@ -506,8 +555,8 @@ public class ClusterReconfigIT extends AbstractIT {
 
         // Set up cluster of 1 nodes.
         final int PORT_0 = 9000;
-        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
-        final Layout layout = get1NodeLayout();
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
+        final Layout layout = getLayout(1);
         final int retries = 5;
 
         IClientRouter router = new NettyClientRouter(NodeLocator
@@ -537,8 +586,8 @@ public class ClusterReconfigIT extends AbstractIT {
 
         // Set up cluster of 1 node.
         final int PORT_0 = 9000;
-        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
-        final Layout layout = get1NodeLayout();
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
+        final Layout layout = getLayout(1);
         final int retries = 3;
 
         IClientRouter router = new NettyClientRouter(NodeLocator
@@ -566,8 +615,8 @@ public class ClusterReconfigIT extends AbstractIT {
 
         // Set up cluster of 1 node.
         final int PORT_0 = 9000;
-        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
-        final Layout layout = get1NodeLayout();
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
+        final Layout layout = getLayout(1);
         final int retries = 3;
 
         IClientRouter router = new NettyClientRouter(NodeLocator
@@ -609,10 +658,10 @@ public class ClusterReconfigIT extends AbstractIT {
         final int PORT_0 = 9000;
         final int PORT_1 = 9001;
         final int PORT_2 = 9002;
-        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
-        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
-        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
-        final Layout layout = get3NodeLayout();
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
+        Process corfuServer_2 = runPersistentServer(corfuSingleNodeHost, PORT_1, false);
+        Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
+        final Layout layout = getLayout(3);
         final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
@@ -661,7 +710,7 @@ public class ClusterReconfigIT extends AbstractIT {
 
         // PART 2.
         // Reviving same node.
-        corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
         final long epochAfterHealingNode = 3L;
 
         // Waiting node to be healed and added back to the layout.
@@ -682,7 +731,7 @@ public class ClusterReconfigIT extends AbstractIT {
     public void testSystemDownHandler() throws Exception {
 
         final int PORT_0 = 9000;
-        Process corfuServer_1 = runSinglePersistentServer(corfuSingleNodeHost, PORT_0);
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, true);
         final Semaphore semaphore = new Semaphore(1);
         semaphore.acquire();
 
@@ -748,10 +797,10 @@ public class ClusterReconfigIT extends AbstractIT {
         final int PORT_0 = 9000;
         final int PORT_1 = 9001;
         final int PORT_2 = 9002;
-        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
-        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
-        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
-        final Layout layout = get3NodeLayout();
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
+        Process corfuServer_2 = runPersistentServer(corfuSingleNodeHost, PORT_1, false);
+        Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
+        final Layout layout = getLayout(3);
 
         final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
@@ -773,7 +822,7 @@ public class ClusterReconfigIT extends AbstractIT {
         }
 
         // Restart server 3 and wait for heal node workflow to modify the layout.
-        corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
         waitForEpochChange(refreshedEpoch -> refreshedEpoch > layoutAfterFailure.getEpoch(), runtime);
 
         // Write at address 5-9.
@@ -817,11 +866,11 @@ public class ClusterReconfigIT extends AbstractIT {
         final int PORT_0 = 9000;
         final int PORT_1 = 9001;
         final int PORT_2 = 9002;
-        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
-        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
-        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
+        Process corfuServer_2 = runPersistentServer(corfuSingleNodeHost, PORT_1, false);
+        Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
         final int nodesCount = 3;
-        final Layout layout = get3NodeLayout();
+        final Layout layout = getLayout(3);
 
         final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
@@ -835,7 +884,7 @@ public class ClusterReconfigIT extends AbstractIT {
         final Layout layoutAfterFailure1 = runtime.getLayoutView().getLayout();
 
         shutdownCorfuServer(corfuServer_1);
-        corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
+        corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
         waitForEpochChange(refreshedEpoch -> refreshedEpoch > layoutAfterFailure1.getEpoch(), runtime);
         final Layout layoutAfterHeal1 = runtime.getLayoutView().getLayout();
         int counter = 0;
@@ -847,7 +896,7 @@ public class ClusterReconfigIT extends AbstractIT {
             stream.append(Integer.toString(counter++).getBytes());
         }
 
-        corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
         waitForEpochChange(refreshedEpoch -> refreshedEpoch > layoutAfterHeal1.getEpoch(), runtime);
 
         // Write at address 3-4-5
@@ -896,10 +945,10 @@ public class ClusterReconfigIT extends AbstractIT {
         final int PORT_0 = 9000;
         final int PORT_1 = 9001;
         final int PORT_2 = 9002;
-        Process corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
-        Process corfuServer_2 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_1);
-        Process corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
-        final Layout layout = get3NodeLayout();
+        Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
+        Process corfuServer_2 = runPersistentServer(corfuSingleNodeHost, PORT_1, false);
+        Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
+        final Layout layout = getLayout(3);
 
         final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
@@ -954,8 +1003,8 @@ public class ClusterReconfigIT extends AbstractIT {
         assertThat(latch.tryAcquire(PARAMETERS.TIMEOUT_LONG.toMillis(), TimeUnit.MILLISECONDS))
                 .isTrue();
         // Restart both the servers.
-        corfuServer_1 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_0);
-        corfuServer_3 = runUnbootstrappedPersistentServer(corfuSingleNodeHost, PORT_2);
+        corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
+        corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
 
         t.join(PARAMETERS.TIMEOUT_LONG.toMillis());
 

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -31,7 +31,7 @@ public class SealIT extends AbstractIT{
         CorfuRuntime cr1 = createDefaultRuntime();
         CorfuRuntime cr2 = createDefaultRuntime();
 
-        Long beforeAddress = cr2.getSequencerView().next().getToken().getTokenValue();
+        Long beforeAddress = cr2.getSequencerView().next().getToken().getSequence();
 
         /* We will trigger a Paxos round, this is what will happen:
          *   1. Set our layout (same than before) with a new Epoch
@@ -66,7 +66,7 @@ public class SealIT extends AbstractIT{
          *
          * These steps get cr2 in the new epoch.
          */
-        Long afterAddress = cr2.getSequencerView().next().getToken().getTokenValue();
+        Long afterAddress = cr2.getSequencerView().next().getToken().getSequence();
         assertThat(cr2.getLayoutView().getCurrentLayout().getEpoch()).
             isEqualTo(cr1.getLayoutView().getCurrentLayout().getEpoch());
         assertThat(afterAddress).isEqualTo(beforeAddress+1);

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -90,7 +90,7 @@ public class WorkflowIT extends AbstractIT {
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
 
-        long prefix = mcw.appendCheckpoints(n1Rt, "Maithem");
+        long prefix = mcw.appendCheckpoints(n1Rt, "Maithem").getSequence();
 
         n1Rt.getAddressSpaceView().prefixTrim(prefix - 1);
 
@@ -314,13 +314,13 @@ public class WorkflowIT extends AbstractIT {
         // Checkpoint and trim the entries.
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
-        long prefixTrimAddress = mcw.appendCheckpoints(rt, "author");
+        long prefixTrimAddress = mcw.appendCheckpoints(rt, "author").getSequence();
         rt.getAddressSpaceView().prefixTrim(prefixTrimAddress);
         rt.getAddressSpaceView().invalidateServerCaches();
         rt.getAddressSpaceView().invalidateClientCache();
         rt.getAddressSpaceView().gc();
 
-        assertThat(rt.getAddressSpaceView().getTrimMark()).isEqualTo(entriesCount);
+        assertThat(rt.getAddressSpaceView().getTrimMark().getSequence()).isEqualTo(entriesCount);
 
         // 2 Checkpoint entries for the start and end.
         // 1000 entries being checkpointed = 20 checkpoint entries due to batch size of 50.
@@ -346,7 +346,7 @@ public class WorkflowIT extends AbstractIT {
 
         run(n0.shutdown);
 
-        assertThat(rt.getAddressSpaceView().getTrimMark()).isEqualTo(entriesCount);
+        assertThat(rt.getAddressSpaceView().getTrimMark().getSequence()).isEqualTo(entriesCount);
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
             if (rt.getLayoutView().getLayout().getEpoch() > layoutAfterAdds.getEpoch()) {

--- a/test/src/test/java/org/corfudb/protocols/wireprotocol/TokenTest.java
+++ b/test/src/test/java/org/corfudb/protocols/wireprotocol/TokenTest.java
@@ -1,0 +1,23 @@
+package org.corfudb.protocols.wireprotocol;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TokenTest {
+
+    @Test
+    public void tokenComparisionTest() {
+
+        Token uninitialized = Token.UNINITIALIZED;
+        Token a = new Token(0, 0);
+        Token a2 = new Token(0, 0);
+        Token b = new Token(0, 1);
+
+        // Verify that uninitialized < a <= a2 < b < c
+        assertThat(uninitialized.compareTo(a)).isEqualTo(-1);
+        assertThat(a.compareTo(a2)).isEqualTo(0);
+        assertThat(a2.compareTo(b)).isEqualTo(-1);
+        assertThat(b.compareTo(a)).isEqualTo(1);
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/clients/SequencerHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/SequencerHandlerTest.java
@@ -62,8 +62,8 @@ public class SequencerHandlerTest extends AbstractClientTest {
             throws Exception {
         Token token = client.nextToken(Collections.emptyList(), 1).get().getToken();
         Token token2 = client.nextToken(Collections.emptyList(), 1).get().getToken();
-        assertThat(token2.getTokenValue())
-                .isGreaterThan(token.getTokenValue());
+        assertThat(token2.getSequence())
+                .isGreaterThan(token.getSequence());
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.object.transactions;
 
 import com.google.common.reflect.TypeToken;
 import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.collections.ISMRMap;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.object.CorfuSharedCounter;
@@ -103,7 +104,7 @@ public abstract class AbstractTransactionContextTest extends AbstractTransaction
 
     @Test
     public void ensureUserTsIsInherited() {
-        final long parentTs = 10L;
+        final Token parentTs = new Token(0L, 10L);
         getRuntime().getObjectsView().TXBuild()
                 .setSnapshot(parentTs)
                 .begin();
@@ -142,12 +143,12 @@ public abstract class AbstractTransactionContextTest extends AbstractTransaction
         // when a user defined snapshot isn't defined
         assertThat(TransactionalContext
                 .getCurrentContext()
-                .getSnapshotTimestamp())
+                .getSnapshotTimestamp().getSequence())
                 .isEqualTo(newTail);
         getRuntime().getObjectsView().TXEnd();
         assertThat(TransactionalContext
                 .getCurrentContext()
-                .getSnapshotTimestamp())
+                .getSnapshotTimestamp().getSequence())
                 .isEqualTo(newTail);
         getRuntime().getObjectsView().TXEnd();
     }
@@ -156,7 +157,7 @@ public abstract class AbstractTransactionContextTest extends AbstractTransaction
     public void nestingUserDefineAndDefaultTs() {
         // Let the parent transaction set its its ts
         // from the sequencer
-        final long childTs = 5;
+        final Token childTs = new Token(0L, 5L);
         getRuntime().getObjectsView()
                 .TXBuild()
                 .begin();

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionsTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionsTest.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.object.transactions;
 
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.object.AbstractObjectTest;
 import org.junit.Before;
 
@@ -44,7 +45,7 @@ public abstract class AbstractTransactionsTest extends AbstractObjectTest {
         // By default, begin a snapshot at address 2L
         getRuntime().getObjectsView().TXBuild()
                 .setType(TransactionType.SNAPSHOT)
-                .setSnapshot(2L)
+                .setSnapshot(new Token(0L, 2L))
                 .begin();
     }
 

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -179,7 +179,7 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
         TestRule testRule = new TestRule()
                 .matches(m -> {
                     if (m.getMsgType().equals(CorfuMsgType.WRITE) && retry[0] < rtSlowWriter.getParameters().getWriteRetry()) {
-                        rtIntersect.getAddressSpaceView().write(new Token(retry[0], 0), "hello world".getBytes());
+                        rtIntersect.getAddressSpaceView().write(new Token( 0, retry[0]), "hello world".getBytes());
                         retry[0]++;
                         return true;
                     } else {

--- a/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.view;
 
 import org.corfudb.infrastructure.TestLayoutBuilder;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.junit.Test;
@@ -25,8 +26,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(new TokenResponse(0,
-                        runtime.getLayoutView().getLayout().getEpoch(),
+        r.getAddressSpaceView().write(new TokenResponse(new Token(runtime.getLayoutView()
+                        .getLayout().getEpoch(), 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
@@ -49,8 +50,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
             for (int i = base; i < base + numberRecords; i++) {
-                r.getAddressSpaceView().write(new TokenResponse((long)i,
-                                runtime.getLayoutView().getLayout().getEpoch(),
+                r.getAddressSpaceView().write(new TokenResponse(new Token(
+                                runtime.getLayoutView().getLayout().getEpoch(), i),
                                 Collections.singletonMap(CorfuRuntime.getStreamID("a"), Address.NO_BACKPOINTER)),
                         Integer.toString(i).getBytes());
             }
@@ -97,8 +98,8 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(new TokenResponse(0,
-                        runtime.getLayoutView().getLayout().getEpoch(),
+        r.getAddressSpaceView().write(new TokenResponse(new Token(
+                        runtime.getLayoutView().getLayout().getEpoch(), 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
@@ -137,7 +138,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(new TokenResponse(0, 0,
+        r.getAddressSpaceView().write(new TokenResponse(new Token(0, 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1180,7 +1180,7 @@ public class ManagementViewTest extends AbstractViewTest {
         assertThat(rt.getLayoutView().getLayout()).isEqualTo(expectedLayout);
 
         TokenResponse tokenResponse = rt.getSequencerView().query(CorfuRuntime.getStreamID("test"));
-        long lastAddress = tokenResponse.getTokenValue();
+        long lastAddress = tokenResponse.getSequence();
 
         Map<Long, LogData> map_0 = getAllNonEmptyData(rt, SERVERS.ENDPOINT_0, lastAddress);
         Map<Long, LogData> map_2 = getAllNonEmptyData(rt, SERVERS.ENDPOINT_2, lastAddress);
@@ -1314,7 +1314,7 @@ public class ManagementViewTest extends AbstractViewTest {
         assertThat(rt.getLayoutView().getLayout()).isEqualTo(expectedLayout);
 
         TokenResponse tokenResponse = rt.getSequencerView().query(CorfuRuntime.getStreamID("test"));
-        long lastAddress = tokenResponse.getTokenValue();
+        long lastAddress = tokenResponse.getSequence();
 
         Map<Long, LogData> map_0 = getAllNonEmptyData(rt, SERVERS.ENDPOINT_0, lastAddress);
         Map<Long, LogData> map_2 = getAllNonEmptyData(rt, SERVERS.ENDPOINT_2, lastAddress);
@@ -1914,7 +1914,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 TimeUnit.MILLISECONDS)).isTrue();
 
         final long expectedTokenValue = 19L;
-        assertThat(corfuRuntime.getSequencerView().query().getTokenValue())
+        assertThat(corfuRuntime.getSequencerView().query().getSequence())
                 .isEqualTo(expectedTokenValue);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
@@ -35,7 +35,7 @@ public class SequencerViewTest extends AbstractViewTest {
         assertThat(r.getSequencerView().next(stream1).getToken())
                 .isEqualTo(new Token(0l, 0l));
         assertThat(r.getSequencerView().next(stream2).getToken())
-                .isEqualTo(new Token(1l, 0l));
+                .isEqualTo(new Token( 0l, 1l));
 
         assertThat(r.getSequencerView().query(stream1, stream2, stream3).getStreamTails())
                 .containsExactly(0l, 1l, Address.NON_EXIST);
@@ -47,7 +47,7 @@ public class SequencerViewTest extends AbstractViewTest {
         assertThat(r.getSequencerView().next().getToken())
                 .isEqualTo(new Token(0L, 0L));
         assertThat(r.getSequencerView().next().getToken())
-                .isEqualTo(new Token(1L, 0L));
+                .isEqualTo(new Token(0L, 1L));
     }
 
     @Test
@@ -70,9 +70,9 @@ public class SequencerViewTest extends AbstractViewTest {
         assertThat(r.getSequencerView().query(streamA).getToken())
                 .isEqualTo(new Token(0L, 0L));
         assertThat(r.getSequencerView().next(streamB).getToken())
-                .isEqualTo(new Token(1L, 0L));
+                .isEqualTo(new Token(0L, 1L));
         assertThat(r.getSequencerView().query(streamB).getToken())
-                .isEqualTo(new Token(1L, 0L));
+                .isEqualTo(new Token(0L, 1L));
         assertThat(r.getSequencerView().query(streamA).getToken())
                 .isEqualTo(new Token(0L, 0L));
     }

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -340,14 +340,14 @@ public class StreamViewTest extends AbstractViewTest {
 
         // read from an address that hasn't been written to
         // causing a hole fill
-        r.getAddressSpaceView().read(tr.getToken().getTokenValue());
+        r.getAddressSpaceView().read(tr.getToken().getSequence());
 
 
         tr = r.getSequencerView().next(streamA);
 
         // read from an address that hasn't been written to
         // causing a hole fill
-        r.getAddressSpaceView().read(tr.getToken().getTokenValue());
+        r.getAddressSpaceView().read(tr.getToken().getSequence());
 
 
         sv.append(testPayload2);

--- a/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
@@ -16,6 +16,7 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.WriteMode;
 import org.corfudb.protocols.wireprotocol.WriteRequest;
@@ -186,8 +187,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         CorfuRuntime r = getDefaultRuntime();
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
-        r.getAddressSpaceView().write(new TokenResponse(0,
-                        r.getLayoutView().getLayout().getEpoch(),
+        r.getAddressSpaceView().write(new TokenResponse(new Token(r.getLayoutView().getLayout().getEpoch(), 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
         ILogData x = r.getAddressSpaceView().read(0);
@@ -215,8 +215,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
             for (int i = base; i < base + numberRecords; i++) {
-                r.getAddressSpaceView().write(new TokenResponse((long)i,
-                                r.getLayoutView().getLayout().getEpoch(),
+                r.getAddressSpaceView().write(new TokenResponse(new Token(r.getLayoutView().getLayout().getEpoch(), i),
                                 Collections.singletonMap(CorfuRuntime.getStreamID("a"), Address.NO_BACKPOINTER)),
                         Integer.toString(i).getBytes());
             }
@@ -249,8 +248,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(new TokenResponse(0,
-                        r.getLayoutView().getLayout().getEpoch(),
+        r.getAddressSpaceView().write(new TokenResponse(new Token(r.getLayoutView().getLayout().getEpoch(), 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
@@ -276,7 +274,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(new TokenResponse(0, 1,
+        r.getAddressSpaceView().write(new TokenResponse(new Token(1, 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 


### PR DESCRIPTION
## Overview
When a transaction's timestamp is used for conflict resolution
the sequencer needs to know which epoch the timestamp belongs
to, this patch adds the epoch to the timestamp.

Why should this be merged: Fixes #1321

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
