### PR TITLE
Change date format in production logger

### DIFF
--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -6,7 +6,7 @@
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIRECTORY}/corfu.9000.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-            <fileNamePattern>${LOG_DIRECTORY}/corfu.9000.%i.log.tar.gz</fileNamePattern>
+            <fileNamePattern>${LOG_DIRECTORY}/corfu.9000.%i.log.gz</fileNamePattern>
             <minIndex>1</minIndex>
             <maxIndex>20</maxIndex>
         </rollingPolicy>
@@ -15,7 +15,7 @@
         </triggeringPolicy>
         <encoder>
             <pattern>
-                %date{yyyy-MM-dd HH:mm:ss.SSS} %-5level %-10.10thread | %25.25logger{25} | %msg%n%xException
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'} %-5level %-10.10thread | %25.25logger{25} | %msg%n%xException
             </pattern>
         </encoder>
     </appender>

--- a/infrastructure/src/main/resources/logback.xml
+++ b/infrastructure/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
     <appender name="std" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                %date{yyyy-MM-dd HH:mm:ss.SSS} %-5level %-10.10thread | %20.30logger{30} [%10.10(%M:%L)] | %msg%n%xException
+                %date{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %-10.10thread | %20.30logger{30} [%10.10(%M:%L)] | %msg%n%xException
             </pattern>
         </encoder>
     </appender>

--- a/infrastructure/src/main/resources/logback.xml
+++ b/infrastructure/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
     <appender name="std" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                %date{yyyy-MM-dd HH:mm:ss.SSS} %highlight(%-5level) %-10.10thread | %20.30logger{30} [%10.10(%M:%L)] | %msg%n%xException
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'} %highlight(%-5level) %-10.10thread | %20.30logger{30} | %msg%n%xException
             </pattern>
         </encoder>
     </appender>

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -2,13 +2,17 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{3}</pattern>
+            <pattern>
+                %date{HH:mm:ss.SSS} %highlight(%-5level) %-15.15thread | %25.25logger{25} | %msg%n%xException{10}
+            </pattern>
         </encoder>
     </appender>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>${user.home}/corfudb.log</file>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) [%thread] %cyan(%logger{15}) - %msg%n %ex{3}</pattern>
+            <pattern>
+                %date{yyyy-MM-dd HH:mm:ss.SSS} %-5level %-10.10thread | %25.25logger{25} | %msg%n%xException{10}
+            </pattern>
         </encoder>
     </appender>
     <appender name="MetricsRollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -3,7 +3,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <pattern>
-                %date{HH:mm:ss.SSS} %highlight(%-5level) %-15.15thread | %25.25logger{25} | %msg%n%xException{10}
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'} %highlight(%-5level) %-10.10thread | %20.30logger{30} [%10.10(%M:%L)] | %msg%n%xException
             </pattern>
         </encoder>
     </appender>
@@ -11,7 +11,7 @@
         <file>${user.home}/corfudb.log</file>
         <encoder>
             <pattern>
-                %date{yyyy-MM-dd HH:mm:ss.SSS} %-5level %-10.10thread | %25.25logger{25} | %msg%n%xException{10}
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'} %highlight(%-5level) %-10.10thread | %20.30logger{30} [%10.10(%M:%L)] | %msg%n%xException
             </pattern>
         </encoder>
     </appender>


### PR DESCRIPTION
## Overview

Description:
Change the date format for the production log, change extension from `tar.gz` to `gz` for log files, improve message format in logback-test.xml

Why should this be merged: 
Improve logging format for log messages

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
