### PR TITLE
Correctly seal servers on epoch change

### DIFF
--- a/corfu_scripts/corfu_layouts.clj
+++ b/corfu_scripts/corfu_layouts.clj
@@ -34,7 +34,7 @@ Options:
   [layout]
   ; For now, we start at rank 0, but we really should get the highest rank proposed
       (.setEpoch layout (inc (.getEpoch layout)))
-      (.moveServersToEpoch layout)
+      (.sealMinServerSet layout)
   (loop [layout-rank 0]
     (when (> layout-rank -1)
       (do

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -28,10 +28,21 @@ public abstract class AbstractServer {
         shutdown = false;
     }
 
-    /** Get the message handler for this instance.
-     * @return  A message handler.
+    /**
+     * Get the message handler for this instance.
+     *
+     * @return A message handler.
      */
     public abstract CorfuMsgHandler getHandler();
+
+    /**
+     * Seal the server with the epoch.
+     *
+     * @param epoch Epoch to seal with
+     */
+    public void sealServerWithEpoch(long epoch) {
+        // Overridden in log unit to flush operations stamped with an old epoch
+    }
 
     public boolean isServerReadyToHandleMsg(CorfuMsg msg) {
         // Overridden in sequencer to mark ready/not-ready state.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -31,8 +31,8 @@ public class BaseServer extends AbstractServer {
     private final CorfuMsgHandler handler =
             CorfuMsgHandler.generateHandler(MethodHandles.lookup(), this);
 
-
-    /** Respond to a ping message.
+    /**
+     * Respond to a ping message.
      *
      * @param msg   The incoming message
      * @param ctx   The channel context
@@ -43,7 +43,8 @@ public class BaseServer extends AbstractServer {
         r.sendResponse(ctx, msg, CorfuMsgType.PONG.msg());
     }
 
-    /** Respond to a version request message.
+    /**
+     * Respond to a version request message.
      *
      * @param msg   The incoming message
      * @param ctx   The channel context
@@ -58,6 +59,7 @@ public class BaseServer extends AbstractServer {
 
     /**
      * Respond to a epoch change message.
+     * This method also executes sealing logic on each individual server type.
      *
      * @param msg The incoming message
      * @param ctx The channel context
@@ -68,9 +70,10 @@ public class BaseServer extends AbstractServer {
                                                    ChannelHandlerContext ctx,
                                                    @NonNull IServerRouter r) {
         try {
-            log.info("handleMessageSetEpoch: Received SET_EPOCH, moving to new epoch {}",
-                    msg.getPayload());
-            serverContext.setServerEpoch(msg.getPayload(), r);
+            long epoch = msg.getPayload();
+            log.info("handleMessageSetEpoch: Received SET_EPOCH, moving to new epoch {}", epoch);
+            serverContext.setServerEpoch(epoch, r);
+            serverContext.getServers().forEach(s -> s.sealServerWithEpoch(epoch));
             r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
         } catch (WrongEpochException e) {
             log.debug("handleMessageSetEpoch: Rejected SET_EPOCH current={}, requested={}",
@@ -80,7 +83,8 @@ public class BaseServer extends AbstractServer {
         }
     }
 
-    /** Reset the JVM. This mechanism leverages that corfu_server runs in a bash script
+    /**
+     * Reset the JVM. This mechanism leverages that corfu_server runs in a bash script
      * which monitors the exit code of Corfu. If the exit code is 100, then it resets
      * the server and DELETES ALL EXISTING DATA.
      *
@@ -95,7 +99,8 @@ public class BaseServer extends AbstractServer {
         CorfuServer.restartServer(serverContext, true);
     }
 
-    /** Restart the JVM. This mechanism leverages that corfu_server runs in a bash script
+    /**
+     * Restart the JVM. This mechanism leverages that corfu_server runs in a bash script
      * which monitors the exit code of Corfu. If the exit code is 200, then it restarts
      * the server.
      *

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
@@ -19,7 +19,7 @@ public class BatchWriterOperation {
         RANGE_WRITE,
         TRIM,
         PREFIX_TRIM,
-        EPOCH_WATER_MARK,
+        SEAL,
         RESET
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -284,7 +284,7 @@ public class CorfuServer {
             serverContext.setBindToAllInterfaces(bindToAllInterfaces);
 
             // Register shutdown handler
-            shutdownThread = new Thread(() -> cleanShutdown(router));
+            shutdownThread = new Thread(() -> cleanShutdown(servers));
             shutdownThread.setName("ShutdownThread");
             Runtime.getRuntime().addShutdownHook(shutdownThread);
 
@@ -487,7 +487,7 @@ public class CorfuServer {
         final boolean bindToAllInterfaces = serverContext.isBindToAllInterfaces();
 
         corfuServerThread = new Thread(() -> {
-            cleanShutdown((NettyServerRouter) serverContext.getServerRouter());
+            cleanShutdown(serverContext.getServers());
             if (resetData && !(Boolean) serverContext.getServerConfig().get("--memory")) {
                 File serviceDir = new File((String) serverContext.getServerConfig()
                         .get("--log-path"));
@@ -521,10 +521,8 @@ public class CorfuServer {
     /**
      * Attempt to cleanly shutdown all the servers.
      */
-    public static void cleanShutdown(@Nonnull NettyServerRouter router) {
+    public static void cleanShutdown(@Nonnull List<AbstractServer> servers) {
         log.info("CleanShutdown: Starting Cleanup.");
-        // Create a list of servers
-        final List<AbstractServer> servers = router.getServers();
 
         // A executor service to create the shutdown threads
         // plus name the threads correctly.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IServerRouter.java
@@ -3,6 +3,8 @@ package org.corfudb.infrastructure;
 import io.netty.channel.ChannelHandlerContext;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 
+import java.util.List;
+
 /**
  * Created by mwei on 12/13/15.
  */
@@ -24,4 +26,9 @@ public interface IServerRouter {
      * @param server    The server to route messages to
      */
     void addServer(AbstractServer server);
+
+    /**
+     * Get a list of registered servers.
+     */
+    List<AbstractServer> getServers();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -725,7 +725,7 @@ public class ManagementAgent {
 
             // Re-seal all servers with the latestLayout epoch.
             // This has no effect on up-to-date servers. Only the trailing servers are caught up.
-            getCorfuRuntime().getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
+            getCorfuRuntime().getLayoutView().getRuntimeLayout(layout).sealMinServerSet();
 
             // Check if any layout server has a stale layout.
             // If yes patch it (commit) with the latestLayout (received from quorum).

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -725,7 +725,7 @@ public class ManagementAgent {
 
             // Re-seal all servers with the latestLayout epoch.
             // This has no effect on up-to-date servers. Only the trailing servers are caught up.
-            getCorfuRuntime().getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
+            getCorfuRuntime().getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
 
             // Check if any layout server has a stale layout.
             // If yes patch it (commit) with the latestLayout (received from quorum).

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -175,7 +175,7 @@ public class ServerContext implements AutoCloseable {
      * fileName when so that the number of these files don't exceed the user-defined
      * retention limit. Cleanup is always done on files with lower epochs.
      */
-     void dataStoreFileCleanup(String fileName) {
+    void dataStoreFileCleanup(String fileName) {
         String logDirPath = getServerConfig(String.class, "--log-path");
         if (logDirPath == null) {
             return;
@@ -344,12 +344,22 @@ public class ServerContext implements AutoCloseable {
         return getDataStore().get(Layout.class, PREFIX_LAYOUT, KEY_LAYOUT);
     }
 
-    /** Set the current {@link Layout} stored in the {@link DataStore}.
+    /**
+     * Set the current {@link Layout} stored in the {@link DataStore}.
      *
      * @param layout The {@link Layout} to set in the {@link DataStore}.
      */
     public void setCurrentLayout(Layout layout) {
         getDataStore().put(Layout.class, PREFIX_LAYOUT, KEY_LAYOUT, layout);
+    }
+
+    /**
+     * Get the list of servers registered in serverRouter
+     *
+     * @return A list of servers registered in serverRouter
+     */
+    public List<AbstractServer> getServers() {
+        return serverRouter.getServers();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -67,7 +67,6 @@ public enum CorfuMsgType {
     TRIM_MARK_REQUEST(45, TypeToken.of(CorfuMsg.class)),
     TRIM_MARK_RESPONSE(46, new TypeToken<CorfuPayloadMsg<Long>>(){}),
     RESET_LOGUNIT(47, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
-    SET_EPOCH_WATER_MARK(48, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
 
     WRITE_OK(50, TypeToken.of(CorfuMsg.class)),
     ERROR_TRIMMED(51, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -67,6 +67,7 @@ public enum CorfuMsgType {
     TRIM_MARK_REQUEST(45, TypeToken.of(CorfuMsg.class)),
     TRIM_MARK_RESPONSE(46, new TypeToken<CorfuPayloadMsg<Long>>(){}),
     RESET_LOGUNIT(47, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
+    SET_EPOCH_WATER_MARK(48, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
 
     WRITE_OK(50, TypeToken.of(CorfuMsg.class)),
     ERROR_TRIMMED(51, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -320,21 +320,10 @@ public class LogUnitClient extends AbstractClient {
     /**
      * Send a reset request.
      *
-     * @param epoch Epoch to set epochWaterMark.
+     * @param epoch Epoch to check and set epochWaterMark.
      * @return Completable future which returns true on success.
      */
     public CompletableFuture<Boolean> resetLogUnit(long epoch) {
         return sendMessageWithFuture(CorfuMsgType.RESET_LOGUNIT.payloadMsg(epoch));
-    }
-
-    /**
-     * Sets the Epoch water mark on the log unit to invalidate any operations stamped with an
-     * older epoch.
-     *
-     * @param epoch Epoch to set epochWaterMark.
-     * @return Completable future which returns true on success.
-     */
-    public CompletableFuture<Boolean> setEpochWaterMark(long epoch) {
-        return sendMessageWithFuture(CorfuMsgType.SET_EPOCH_WATER_MARK.payloadMsg(epoch));
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -319,8 +319,22 @@ public class LogUnitClient extends AbstractClient {
 
     /**
      * Send a reset request.
+     *
+     * @param epoch Epoch to set epochWaterMark.
+     * @return Completable future which returns true on success.
      */
     public CompletableFuture<Boolean> resetLogUnit(long epoch) {
         return sendMessageWithFuture(CorfuMsgType.RESET_LOGUNIT.payloadMsg(epoch));
+    }
+
+    /**
+     * Sets the Epoch water mark on the log unit to invalidate any operations stamped with an
+     * older epoch.
+     *
+     * @param epoch Epoch to set epochWaterMark.
+     * @return Completable future which returns true on success.
+     */
+    public CompletableFuture<Boolean> setEpochWaterMark(long epoch) {
+        return sendMessageWithFuture(CorfuMsgType.SET_EPOCH_WATER_MARK.payloadMsg(epoch));
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -343,7 +343,7 @@ public class LayoutManagementView extends AbstractView {
      */
     private void sealEpoch(Layout layout) throws QuorumUnreachableException {
         layout.setEpoch(layout.getEpoch() + 1);
-        runtime.getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
+        runtime.getLayoutView().getRuntimeLayout(layout).sealMinServerSet();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -343,7 +343,7 @@ public class LayoutManagementView extends AbstractView {
      */
     private void sealEpoch(Layout layout) throws QuorumUnreachableException {
         layout.setEpoch(layout.getEpoch() + 1);
-        runtime.getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
+        runtime.getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
@@ -61,7 +61,7 @@ public class RuntimeLayout {
      * @throws WrongEpochException        If any server is in a higher epoch.
      * @throws QuorumUnreachableException If enough number of servers cannot be sealed.
      */
-    public void moveServersToEpoch()
+    public void sealAndFlushMinSet()
             throws WrongEpochException, QuorumUnreachableException {
         log.debug("Requested move of servers to new epoch {} servers are {}", layout.getEpoch(),
                 layout.getAllServers());
@@ -76,6 +76,13 @@ public class RuntimeLayout {
         // replication mode.
         for (LayoutSegment layoutSegment : layout.getSegments()) {
             layoutSegment.getReplicationMode().validateSegmentSeal(layoutSegment, resultMap);
+        }
+
+        for (LayoutSegment layoutSegment : layout.getSegments()) {
+            for (String endpoint : layoutSegment.getAllLogServers()) {
+
+            }
+            layoutSegment.getReplicationMode().flush(layoutSegment);
         }
         log.debug("Layout has been sealed successfully.");
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/SealServersHelper.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SealServersHelper.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -24,16 +25,18 @@ import org.corfudb.util.CFUtils;
 public class SealServersHelper {
 
     /**
-     * Asynchronously set remote epoch on all servers of layout.
+     * Asynchronously seal all servers in layout by setting remote epochs.
+     * Different type of servers can have their own logic of sealing, the
+     * base server dispatches sealing logic to each individual server.
      *
      * @param runtimeLayout RuntimeLayout stamped with the layout to be sealed.
      * @return A map of completableFutures for every remoteSetEpoch call.
      */
-    public static Map<String, CompletableFuture<Boolean>> asyncSetRemoteEpoch(
+    public static Map<String, CompletableFuture<Boolean>> asyncSealServers(
             RuntimeLayout runtimeLayout) {
         Layout layout = runtimeLayout.getLayout();
         Map<String, CompletableFuture<Boolean>> resultMap = new HashMap<>();
-        // Seal layout servers
+        // Seal all servers
         layout.getAllServers().forEach(server -> {
             CompletableFuture<Boolean> cf = new CompletableFuture<>();
             try {
@@ -45,25 +48,7 @@ public class SealServersHelper {
             }
             resultMap.put(server, cf);
         });
-        return resultMap;
-    }
 
-    public static Map<String, CompletableFuture<Boolean>> asyncFlush(
-            RuntimeLayout runtimeLayout) {
-        Layout layout = runtimeLayout.getLayout();
-        Map<String, CompletableFuture<Boolean>> resultMap = new HashMap<>();
-        // Seal layout servers
-        layout.getAllServers().forEach(server -> {
-            CompletableFuture<Boolean> cf = new CompletableFuture<>();
-            try {
-                // Creating router can cause NetworkException which should be handled.
-                cf = runtimeLayout.getBaseClient(server).setRemoteEpoch(layout.getEpoch());
-            } catch (NetworkException ne) {
-                cf.completeExceptionally(ne);
-                log.error("Remote seal SET_EPOCH failed for server {} with {}", server, ne);
-            }
-            resultMap.put(server, cf);
-        });
         return resultMap;
     }
 
@@ -78,10 +63,8 @@ public class SealServersHelper {
     public static void waitForLayoutSeal(List<String> layoutServers, Map<String,
             CompletableFuture<Boolean>> completableFutureMap)
             throws QuorumUnreachableException {
-        CompletableFuture<Boolean>[] completableFutures = completableFutureMap.entrySet().stream()
-                .filter(pair -> layoutServers.contains(pair.getKey()))
-                .map(pair -> pair.getValue())
-                .toArray(CompletableFuture[]::new);
+        CompletableFuture<Boolean>[] completableFutures =
+                filterFutureMapAndGetArray(completableFutureMap, layoutServers::contains);
         waitForQuorum(completableFutures);
     }
 
@@ -98,10 +81,7 @@ public class SealServersHelper {
             throws QuorumUnreachableException {
         for (Layout.LayoutStripe layoutStripe : layoutSegment.getStripes()) {
             CompletableFuture<Boolean>[] completableFutures =
-                    completableFutureMap.entrySet().stream()
-                            .filter(pair -> layoutStripe.getLogServers().contains(pair.getKey()))
-                            .map(pair -> pair.getValue())
-                            .toArray(CompletableFuture[]::new);
+                    filterFutureMapAndGetArray(completableFutureMap, layoutStripe.getLogServers()::contains);
             QuorumFuturesFactory.CompositeFuture<Boolean> quorumFuture =
                     QuorumFuturesFactory.getFirstWinsFuture(Boolean::compareTo, completableFutures);
 
@@ -113,14 +93,17 @@ public class SealServersHelper {
                 log.error("waitForChainSegmentSeal: timeout", e);
             }
 
+            if (success) {
+                log.debug("waitForChainSegmentSeal: Successfully waited at least one " +
+                        "log unit server in every strip");
+                continue;
+            }
+
             int reachableServers = (int) Arrays.stream(completableFutures)
                     .filter(booleanCompletableFuture ->
-                            !booleanCompletableFuture.isCompletedExceptionally()).count();
-
-            if (!success) {
-                throw new QuorumUnreachableException(reachableServers,
-                        completableFutures.length);
-            }
+                            !booleanCompletableFuture.isCompletedExceptionally())
+                    .count();
+            throw new QuorumUnreachableException(reachableServers, completableFutures.length);
         }
     }
 
@@ -137,10 +120,7 @@ public class SealServersHelper {
             throws QuorumUnreachableException {
         for (Layout.LayoutStripe layoutStripe : layoutSegment.getStripes()) {
             CompletableFuture<Boolean>[] completableFutures =
-                    completableFutureMap.entrySet().stream()
-                    .filter(pair -> layoutStripe.getLogServers().contains(pair.getKey()))
-                    .map(pair -> pair.getValue())
-                    .toArray(CompletableFuture[]::new);
+                    filterFutureMapAndGetArray(completableFutureMap, layoutStripe.getLogServers()::contains);
             waitForQuorum(completableFutures);
         }
     }
@@ -165,14 +145,26 @@ public class SealServersHelper {
                 throw (QuorumUnreachableException) e.getCause();
             }
         }
+
+        if (success) {
+            log.debug("Successfully waited for quorum");
+            return;
+        }
+
         int reachableServers = (int) Arrays.stream(completableFutures)
                 .filter(booleanCompletableFuture ->
-                        !booleanCompletableFuture.isCompletedExceptionally()).count();
-
-        if (!success) {
-            throw new QuorumUnreachableException(reachableServers,
-                    completableFutures.length);
-        }
+                        !booleanCompletableFuture.isCompletedExceptionally())
+                .count();
+        throw new QuorumUnreachableException(reachableServers, completableFutures.length);
     }
 
+    @SuppressWarnings("unchecked")
+    private static CompletableFuture<Boolean>[] filterFutureMapAndGetArray(
+            Map<String, CompletableFuture<Boolean>> completableFutureMap,
+            Predicate<String> filterPredicate) {
+        return completableFutureMap.entrySet().stream()
+                .filter(pair -> filterPredicate.test(pair.getKey()))
+                .map(Map.Entry::getValue)
+                .toArray(CompletableFuture[]::new);
+    }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -30,6 +30,9 @@ public class TestServerRouter implements IServerRouter {
     @Getter
     public Map<CorfuMsgType, AbstractServer> handlerMap;
 
+    @Getter
+    public List<AbstractServer> servers;
+
     public List<TestRule> rules;
 
     AtomicLong requestCounter;
@@ -53,6 +56,7 @@ public class TestServerRouter implements IServerRouter {
     public void reset() {
         this.responseMessages = new ArrayList<>();
         this.requestCounter = new AtomicLong();
+        this.servers = new ArrayList<>();
         this.handlerMap = new ConcurrentHashMap<>();
         this.rules = new ArrayList<>();
     }
@@ -79,13 +83,13 @@ public class TestServerRouter implements IServerRouter {
      */
     @Override
     public void addServer(AbstractServer server) {
+        servers.add(server);
         server.getHandler()
                 .getHandledTypes().forEach(x -> {
             handlerMap.put(x, server);
             log.trace("Registered {} to handle messages of type {}", server, x);
         });
     }
-
 
     /**
      * Validate the epoch of a CorfuMsg, and send a WRONG_EPOCH response if

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -332,7 +332,7 @@ public class ClusterReconfigIT extends AbstractIT {
         long oldEpoch = corfuRuntime.getLayoutView().getLayout().getEpoch();
         Layout l = new Layout(corfuRuntime.getLayoutView().getLayout());
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealMinServerSet();
         corfuRuntime.getLayoutView().updateLayout(l, 1L);
         corfuRuntime.invalidateLayout();
         assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(oldEpoch + 1);

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -332,7 +332,7 @@ public class ClusterReconfigIT extends AbstractIT {
         long oldEpoch = corfuRuntime.getLayoutView().getLayout().getEpoch();
         Layout l = new Layout(corfuRuntime.getLayoutView().getLayout());
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
         corfuRuntime.getLayoutView().updateLayout(l, 1L);
         corfuRuntime.invalidateLayout();
         assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(oldEpoch + 1);

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -43,7 +43,7 @@ public class SealIT extends AbstractIT{
         /* 1 */
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
         /* 2 */
-        cr1.getLayoutView().getRuntimeLayout(currentLayout).moveServersToEpoch();
+        cr1.getLayoutView().getRuntimeLayout(currentLayout).sealAndFlushMinSet();
         /* 3 */
         cr1.getLayoutView().updateLayout(currentLayout, 0);
 

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Created by rmichoud on 2/12/17.
  */
-public class SealIT extends AbstractIT{
+public class SealIT extends AbstractIT {
     static String corfuSingleNodeHost;
     static int corfuSingleNodePort;
 
@@ -43,7 +43,7 @@ public class SealIT extends AbstractIT{
         /* 1 */
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
         /* 2 */
-        cr1.getLayoutView().getRuntimeLayout(currentLayout).sealAndFlushMinSet();
+        cr1.getLayoutView().getRuntimeLayout(currentLayout).sealMinServerSet();
         /* 3 */
         cr1.getLayoutView().updateLayout(currentLayout, 0);
 

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -2,7 +2,6 @@ package org.corfudb.runtime;
 
 import org.corfudb.infrastructure.TestLayoutBuilder;
 
-import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.clients.TestRule;
 import org.corfudb.runtime.exceptions.unrecoverable.SystemUnavailableError;
@@ -130,7 +129,7 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         // Seal
         Layout currentLayout = new Layout(rt.getLayoutView().getCurrentLayout());
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
-        rt.getLayoutView().getRuntimeLayout(currentLayout).sealAndFlushMinSet();
+        rt.getLayoutView().getRuntimeLayout(currentLayout).sealMinServerSet();
 
         // Server2 is sealed but will not be able to commit the layout.
         addClientRule(rt, SERVERS.ENDPOINT_2,
@@ -184,7 +183,7 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         sv.append("testPayload".getBytes());
 
         l.setEpoch(l.getEpoch() + 1);
-        runtime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
+        runtime.getLayoutView().getRuntimeLayout(l).sealMinServerSet();
 
         // We need to be sure that the layout is invalidated before proceeding
         // This is what would trigger the wrong epoch exception in the consequent read.

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -130,7 +130,7 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         // Seal
         Layout currentLayout = new Layout(rt.getLayoutView().getCurrentLayout());
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
-        rt.getLayoutView().getRuntimeLayout(currentLayout).moveServersToEpoch();
+        rt.getLayoutView().getRuntimeLayout(currentLayout).sealAndFlushMinSet();
 
         // Server2 is sealed but will not be able to commit the layout.
         addClientRule(rt, SERVERS.ENDPOINT_2,
@@ -184,7 +184,7 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         sv.append("testPayload".getBytes());
 
         l.setEpoch(l.getEpoch() + 1);
-        runtime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        runtime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
 
         // We need to be sure that the layout is invalidated before proceeding
         // This is what would trigger the wrong epoch exception in the consequent read.

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -458,8 +458,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
         IServerRouter serverRouter;
         int port;
 
-        TestServer(Map<String, Object> optsMap)
-        {
+        TestServer(Map<String, Object> optsMap) {
             this(new ServerContext(optsMap));
             serverContext.setServerRouter(new TestServerRouter());
         }
@@ -483,8 +482,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
             this.serverRouter.addServer(managementServer);
         }
 
-        TestServer(int port)
-        {
+        TestServer(int port) {
             this(ServerContextBuilder.defaultTestContext(port).getServerConfig());
         }
 

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutSealTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutSealTest.java
@@ -125,7 +125,7 @@ public class LayoutSealTest extends AbstractViewTest {
         Layout l = runtimeLayout.getLayout();
         l.setEpoch(l.getEpoch() + 1);
         try {
-            runtimeLayout.moveServersToEpoch();
+            runtimeLayout.sealAndFlushMinSet();
         } catch (QuorumUnreachableException e) {
             e.printStackTrace();
         }
@@ -151,7 +151,7 @@ public class LayoutSealTest extends AbstractViewTest {
         addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_4, new TestRule().drop().always());
 
         l.setEpoch(l.getEpoch() + 1);
-        assertThatThrownBy(runtimeLayout::moveServersToEpoch)
+        assertThatThrownBy(runtimeLayout::sealAndFlushMinSet)
                 .isInstanceOf(QuorumUnreachableException.class);
         assertLayoutEpochs(2, 1, 2);
         assertServerRouterEpochs(2, 1, 2, 1, 1);
@@ -168,7 +168,7 @@ public class LayoutSealTest extends AbstractViewTest {
         Layout l = runtimeLayout.getLayout();
         l.setEpoch(l.getEpoch() + 1);
         try {
-            runtimeLayout.moveServersToEpoch();
+            runtimeLayout.sealAndFlushMinSet();
         } catch (QuorumUnreachableException e) {
             e.printStackTrace();
         }
@@ -193,7 +193,7 @@ public class LayoutSealTest extends AbstractViewTest {
                 new TestRule().drop().always());
 
         l.setEpoch(l.getEpoch() + 1);
-        assertThatThrownBy(runtimeLayout::moveServersToEpoch)
+        assertThatThrownBy(runtimeLayout::sealAndFlushMinSet)
                 .isInstanceOf(QuorumUnreachableException.class);
         assertLayoutEpochs(2, 2, 2);
         assertServerRouterEpochs(2, 2, 2, 1, 2);

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutSealTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutSealTest.java
@@ -125,7 +125,7 @@ public class LayoutSealTest extends AbstractViewTest {
         Layout l = runtimeLayout.getLayout();
         l.setEpoch(l.getEpoch() + 1);
         try {
-            runtimeLayout.sealAndFlushMinSet();
+            runtimeLayout.sealMinServerSet();
         } catch (QuorumUnreachableException e) {
             e.printStackTrace();
         }
@@ -151,7 +151,7 @@ public class LayoutSealTest extends AbstractViewTest {
         addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_4, new TestRule().drop().always());
 
         l.setEpoch(l.getEpoch() + 1);
-        assertThatThrownBy(runtimeLayout::sealAndFlushMinSet)
+        assertThatThrownBy(runtimeLayout::sealMinServerSet)
                 .isInstanceOf(QuorumUnreachableException.class);
         assertLayoutEpochs(2, 1, 2);
         assertServerRouterEpochs(2, 1, 2, 1, 1);
@@ -168,7 +168,7 @@ public class LayoutSealTest extends AbstractViewTest {
         Layout l = runtimeLayout.getLayout();
         l.setEpoch(l.getEpoch() + 1);
         try {
-            runtimeLayout.sealAndFlushMinSet();
+            runtimeLayout.sealMinServerSet();
         } catch (QuorumUnreachableException e) {
             e.printStackTrace();
         }
@@ -193,7 +193,7 @@ public class LayoutSealTest extends AbstractViewTest {
                 new TestRule().drop().always());
 
         l.setEpoch(l.getEpoch() + 1);
-        assertThatThrownBy(runtimeLayout::sealAndFlushMinSet)
+        assertThatThrownBy(runtimeLayout::sealMinServerSet)
                 .isInstanceOf(QuorumUnreachableException.class);
         assertLayoutEpochs(2, 2, 2);
         assertServerRouterEpochs(2, 2, 2, 1, 2);

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -69,7 +69,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .addToLayout()
                 .setClusterId(r.clusterId)
                 .build();
-        r.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
+        r.getLayoutView().getRuntimeLayout(l).sealMinServerSet();
         r.getLayoutView().updateLayout(l, 1L);
         r.invalidateLayout();
         assertThat(r.getLayoutView().getLayout().epoch)
@@ -94,7 +94,7 @@ public class LayoutViewTest extends AbstractViewTest {
             .addToLayout()
             .setClusterId(UUID.nameUUIDFromBytes("wrong cluster".getBytes()))
             .build();
-        r.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
+        r.getLayoutView().getRuntimeLayout(l).sealMinServerSet();
         r.invalidateLayout();
         assertThatThrownBy(() -> r.getLayoutView().updateLayout(l, 1L))
             .isInstanceOf(WrongClusterException.class);
@@ -203,7 +203,7 @@ public class LayoutViewTest extends AbstractViewTest {
                         .build();
                 //TODO need to figure out if we can move to
                 //update layout
-                corfuRuntime.getLayoutView().getRuntimeLayout(newLayout).sealAndFlushMinSet();
+                corfuRuntime.getLayoutView().getRuntimeLayout(newLayout).sealMinServerSet();
 
                 corfuRuntime.getLayoutView().updateLayout(newLayout, newLayout.getEpoch());
                 corfuRuntime.invalidateLayout();
@@ -280,7 +280,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .build();
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealMinServerSet();
         corfuRuntime.getLayoutView().updateLayout(newLayout, 1L);
 
         assertThat(getLayoutServer(SERVERS.PORT_0).getCurrentLayout()).isEqualTo(newLayout);
@@ -344,7 +344,7 @@ public class LayoutViewTest extends AbstractViewTest {
         // Keep old layout untouched for assertion
         Layout oldLayout = new Layout(l);
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealMinServerSet();
 
         // We receive responses from PORT_0 and PORT_2
         corfuRuntime.getLayoutView().updateLayout(newLayout, 1L);
@@ -465,7 +465,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .build();
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealMinServerSet();
 
         // STEP 1
         final long rank1 = 1L;
@@ -589,7 +589,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .build();
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime1.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
+        corfuRuntime1.getLayoutView().getRuntimeLayout(l).sealMinServerSet();
 
         Semaphore proposeLock = new Semaphore(0);
         ExecutorService executorService = Executors.newSingleThreadExecutor();

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -69,7 +69,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .addToLayout()
                 .setClusterId(r.clusterId)
                 .build();
-        r.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        r.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
         r.getLayoutView().updateLayout(l, 1L);
         r.invalidateLayout();
         assertThat(r.getLayoutView().getLayout().epoch)
@@ -94,7 +94,7 @@ public class LayoutViewTest extends AbstractViewTest {
             .addToLayout()
             .setClusterId(UUID.nameUUIDFromBytes("wrong cluster".getBytes()))
             .build();
-        r.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        r.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
         r.invalidateLayout();
         assertThatThrownBy(() -> r.getLayoutView().updateLayout(l, 1L))
             .isInstanceOf(WrongClusterException.class);
@@ -203,7 +203,7 @@ public class LayoutViewTest extends AbstractViewTest {
                         .build();
                 //TODO need to figure out if we can move to
                 //update layout
-                corfuRuntime.getLayoutView().getRuntimeLayout(newLayout).moveServersToEpoch();
+                corfuRuntime.getLayoutView().getRuntimeLayout(newLayout).sealAndFlushMinSet();
 
                 corfuRuntime.getLayoutView().updateLayout(newLayout, newLayout.getEpoch());
                 corfuRuntime.invalidateLayout();
@@ -280,7 +280,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .build();
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
         corfuRuntime.getLayoutView().updateLayout(newLayout, 1L);
 
         assertThat(getLayoutServer(SERVERS.PORT_0).getCurrentLayout()).isEqualTo(newLayout);
@@ -344,7 +344,7 @@ public class LayoutViewTest extends AbstractViewTest {
         // Keep old layout untouched for assertion
         Layout oldLayout = new Layout(l);
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
 
         // We receive responses from PORT_0 and PORT_2
         corfuRuntime.getLayoutView().updateLayout(newLayout, 1L);
@@ -465,7 +465,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .build();
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
 
         // STEP 1
         final long rank1 = 1L;
@@ -589,7 +589,7 @@ public class LayoutViewTest extends AbstractViewTest {
                 .build();
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime1.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        corfuRuntime1.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
 
         Semaphore proposeLock = new Semaphore(0);
         ExecutorService executorService = Executors.newSingleThreadExecutor();

--- a/test/src/test/java/org/corfudb/runtime/view/LogUnitSealTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LogUnitSealTest.java
@@ -1,0 +1,105 @@
+package org.corfudb.runtime.view;
+
+import org.corfudb.infrastructure.TestLayoutBuilder;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Tests log unit server sealing behavior
+ *
+ * Created by WenbinZhu on 11/8/18.
+ */
+public class LogUnitSealTest extends AbstractViewTest {
+
+    private RuntimeLayout getRuntimeLayout(long epoch) {
+        addServer(SERVERS.PORT_0);
+
+        Layout l = new TestLayoutBuilder()
+                .setEpoch(epoch)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_0)
+                .buildSegment()
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addToSegment()
+                .addToLayout()
+                .build();
+
+        bootstrapAllServers(l);
+        CorfuRuntime corfuRuntime = getRuntime(l).connect();
+        RuntimeLayout runtimeLayout = corfuRuntime.getLayoutView().getRuntimeLayout(l);
+
+        getManagementServer(SERVERS.PORT_0).shutdown();
+
+        return runtimeLayout;
+    }
+
+    /**
+     * Test that log unit server seals correctly.
+     * Check operations in the queue that come after the seal operation, but stamped with
+     * an older epoch, are completed exceptionally with a WrongEpochException.
+     */
+    @Test
+    public void checkOperationWithOldEpochFailedAfterSeal() {
+        long epoch = 1L;
+        RuntimeLayout runtimeLayout = getRuntimeLayout(epoch);
+        Layout layout = runtimeLayout.getLayout();
+        LogUnitClient client = runtimeLayout.getLogUnitClient(SERVERS.ENDPOINT_0);
+
+        List<CompletableFuture<Boolean>> successOpFutures1 = new ArrayList<>();
+        List<CompletableFuture<Boolean>> successOpFutures2 = new ArrayList<>();
+        List<CompletableFuture<Boolean>> failedOpFutures = new ArrayList<>();
+
+        final int numOp = 3;
+        long address = 0L;
+
+        for (int i = 0; i < numOp; i++) {
+            LogData ld = LogData.getHole(address++);
+            successOpFutures1.add(client.write(ld));
+        }
+
+        // Seal server
+        layout.setEpoch(layout.getEpoch() + 1);
+        runtimeLayout.sealMinServerSet();
+
+        // Intentionally reset router epoch to bypass epoch check on router
+        getLayoutServer(SERVERS.PORT_0).getServerContext().getServerRouter().setServerEpoch(epoch);
+
+        // Still using the old client to send messages stamped with old epoch
+        for (int i = 0; i < numOp; i++) {
+            LogData ld = LogData.getHole(address++);
+            failedOpFutures.add(client.write(ld));
+        }
+
+        // Set the router epoch to new epoch and get the new client
+        getLayoutServer(SERVERS.PORT_0).getServerContext().getServerRouter().setServerEpoch(layout.getEpoch());
+        runtimeLayout = new RuntimeLayout(layout, getRuntime(layout));
+        client = runtimeLayout.getLogUnitClient(SERVERS.ENDPOINT_0);
+
+        // Using the new client to send messages stamped with epoch 2
+        for (int i = 0; i < numOp; i++) {
+            LogData ld = LogData.getHole(address++);
+            successOpFutures2.add(client.write(ld));
+        }
+
+        // Before sealing, all operations should complete normally
+        successOpFutures1.forEach(f -> assertThatCode(f::get).doesNotThrowAnyException());
+        // After sealing, operations stamped with old epoch should fail
+        failedOpFutures.forEach(f -> assertThatThrownBy(f::get)
+                .isInstanceOf(ExecutionException.class)
+                .hasCauseExactlyInstanceOf(WrongEpochException.class));
+        // After sealing, operations stamped with new epoch should still complete normally
+        successOpFutures2.forEach(f -> assertThatCode(f::get).doesNotThrowAnyException());
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -887,7 +887,7 @@ public class ManagementViewTest extends AbstractViewTest {
         // Seal
         Layout newLayout = new Layout(l);
         newLayout.setEpoch(newLayout.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(newLayout).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(newLayout).sealMinServerSet();
         assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(l.getEpoch());
     }
 
@@ -899,7 +899,7 @@ public class ManagementViewTest extends AbstractViewTest {
 
         addClientRule(corfuRuntime, SERVERS.ENDPOINT_0, new TestRule().always().drop());
         layout.setEpoch(2L);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealMinServerSet();
         // We increase to a higher rank to avoid being outranked. We could be outranked if the management
         // agent attempts to fill in the epoch slot before we update.
         corfuRuntime.getLayoutView().updateLayout(layout, highRank);
@@ -931,7 +931,7 @@ public class ManagementViewTest extends AbstractViewTest {
         waitForSequencerToBootstrap(SERVERS.PORT_0);
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealMinServerSet();
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
             Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
@@ -1388,7 +1388,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .assignResponsiveSequencerAsPrimary(Collections.singleton(SERVERS.ENDPOINT_0))
                 .build();
         layout_2.setEpoch(layout_2.getEpoch() + 1);
-        runtime_1.getLayoutView().getRuntimeLayout(layout_2).sealAndFlushMinSet();
+        runtime_1.getLayoutView().getRuntimeLayout(layout_2).sealMinServerSet();
         runtime_1.getLayoutView().updateLayout(layout_2, 1L);
         runtime_1.getLayoutManagementView().reconfigureSequencerServers(layout_1, layout_2, false);
 
@@ -1416,7 +1416,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .assignResponsiveSequencerAsPrimary(Collections.singleton(SERVERS.ENDPOINT_1))
                 .build();
         layout_3.setEpoch(layout_3.getEpoch() + 1);
-        runtime_1.getLayoutView().getRuntimeLayout(layout_3).sealAndFlushMinSet();
+        runtime_1.getLayoutView().getRuntimeLayout(layout_3).sealMinServerSet();
         runtime_1.getLayoutView().updateLayout(layout_3, 1L);
         runtime_1.getLayoutManagementView().reconfigureSequencerServers(layout_2, layout_3, false);
 
@@ -1449,7 +1449,7 @@ public class ManagementViewTest extends AbstractViewTest {
         // Due to the router and sequencer epoch mismatch, the sequencer becomes NOT_READY.
         // Note that this reconfiguration is not followed by the explicit sequencer bootstrap step.
         layout.setEpoch(layout.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealMinServerSet();
         // We increase to a higher rank to avoid being outranked. We could be outranked if the management
         // agent attempts to fill in the epoch slot before we update.
         corfuRuntime.getLayoutView().updateLayout(layout, highRank);
@@ -1708,7 +1708,7 @@ public class ManagementViewTest extends AbstractViewTest {
         // Trigger an epoch change to trigger FastObjectLoader to run for sequencer bootstrap.
         Layout layout1 = new Layout(layout);
         layout1.setEpoch(layout1.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout1).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout1).sealMinServerSet();
         corfuRuntime.getLayoutView().updateLayout(layout1, 1L);
 
         assertThat(semaphore
@@ -1720,7 +1720,7 @@ public class ManagementViewTest extends AbstractViewTest {
         corfuRuntime.invalidateLayout();
         Layout layout2 = new Layout(corfuRuntime.getLayoutView().getLayout());
         layout2.setEpoch(layout2.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout2).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout2).sealMinServerSet();
 
 
         clearClientRules(managementRuntime0);
@@ -1946,7 +1946,7 @@ public class ManagementViewTest extends AbstractViewTest {
 
         Layout layout = new Layout(corfuRuntime.getLayoutView().getLayout());
         layout.setEpoch(layout.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealMinServerSet();
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
             corfuRuntime.invalidateLayout();

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -887,7 +887,7 @@ public class ManagementViewTest extends AbstractViewTest {
         // Seal
         Layout newLayout = new Layout(l);
         newLayout.setEpoch(newLayout.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(newLayout).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(newLayout).sealAndFlushMinSet();
         assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(l.getEpoch());
     }
 
@@ -899,7 +899,7 @@ public class ManagementViewTest extends AbstractViewTest {
 
         addClientRule(corfuRuntime, SERVERS.ENDPOINT_0, new TestRule().always().drop());
         layout.setEpoch(2L);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
         // We increase to a higher rank to avoid being outranked. We could be outranked if the management
         // agent attempts to fill in the epoch slot before we update.
         corfuRuntime.getLayoutView().updateLayout(layout, highRank);
@@ -931,7 +931,7 @@ public class ManagementViewTest extends AbstractViewTest {
         waitForSequencerToBootstrap(SERVERS.PORT_0);
 
         l.setEpoch(l.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(l).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(l).sealAndFlushMinSet();
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
             Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
@@ -1388,7 +1388,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .assignResponsiveSequencerAsPrimary(Collections.singleton(SERVERS.ENDPOINT_0))
                 .build();
         layout_2.setEpoch(layout_2.getEpoch() + 1);
-        runtime_1.getLayoutView().getRuntimeLayout(layout_2).moveServersToEpoch();
+        runtime_1.getLayoutView().getRuntimeLayout(layout_2).sealAndFlushMinSet();
         runtime_1.getLayoutView().updateLayout(layout_2, 1L);
         runtime_1.getLayoutManagementView().reconfigureSequencerServers(layout_1, layout_2, false);
 
@@ -1416,7 +1416,7 @@ public class ManagementViewTest extends AbstractViewTest {
                 .assignResponsiveSequencerAsPrimary(Collections.singleton(SERVERS.ENDPOINT_1))
                 .build();
         layout_3.setEpoch(layout_3.getEpoch() + 1);
-        runtime_1.getLayoutView().getRuntimeLayout(layout_3).moveServersToEpoch();
+        runtime_1.getLayoutView().getRuntimeLayout(layout_3).sealAndFlushMinSet();
         runtime_1.getLayoutView().updateLayout(layout_3, 1L);
         runtime_1.getLayoutManagementView().reconfigureSequencerServers(layout_2, layout_3, false);
 
@@ -1449,7 +1449,7 @@ public class ManagementViewTest extends AbstractViewTest {
         // Due to the router and sequencer epoch mismatch, the sequencer becomes NOT_READY.
         // Note that this reconfiguration is not followed by the explicit sequencer bootstrap step.
         layout.setEpoch(layout.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
         // We increase to a higher rank to avoid being outranked. We could be outranked if the management
         // agent attempts to fill in the epoch slot before we update.
         corfuRuntime.getLayoutView().updateLayout(layout, highRank);
@@ -1708,7 +1708,7 @@ public class ManagementViewTest extends AbstractViewTest {
         // Trigger an epoch change to trigger FastObjectLoader to run for sequencer bootstrap.
         Layout layout1 = new Layout(layout);
         layout1.setEpoch(layout1.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout1).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout1).sealAndFlushMinSet();
         corfuRuntime.getLayoutView().updateLayout(layout1, 1L);
 
         assertThat(semaphore
@@ -1720,7 +1720,8 @@ public class ManagementViewTest extends AbstractViewTest {
         corfuRuntime.invalidateLayout();
         Layout layout2 = new Layout(corfuRuntime.getLayoutView().getLayout());
         layout2.setEpoch(layout2.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout2).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout2).sealAndFlushMinSet();
+
 
         clearClientRules(managementRuntime0);
         clearClientRules(managementRuntime1);
@@ -1945,7 +1946,7 @@ public class ManagementViewTest extends AbstractViewTest {
 
         Layout layout = new Layout(corfuRuntime.getLayoutView().getLayout());
         layout.setEpoch(layout.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
             corfuRuntime.invalidateLayout();

--- a/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
@@ -112,7 +112,7 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
         layout.setEpoch(layout.getEpoch() + 1);
         layout.getLayoutServers().add(endpoint);
         layout.getSegment(0L).getStripes().get(0).getLogServers().remove(endpoint);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout).moveServersToEpoch();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
         corfuRuntime.getLayoutView().updateLayout(layout, 1L);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
@@ -106,13 +106,13 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
                 .isEqualTo("incomplete".getBytes());
     }
 
-    private void removeLogunit(Layout currentLayout, String endpoint) throws Exception {
+    private void removeLogUnit(Layout currentLayout, String endpoint) throws Exception {
         CorfuRuntime corfuRuntime = getRuntime(currentLayout).connect();
         Layout layout = new Layout(corfuRuntime.getLayoutView().getLayout());
         layout.setEpoch(layout.getEpoch() + 1);
         layout.getLayoutServers().add(endpoint);
         layout.getSegment(0L).getStripes().get(0).getLogServers().remove(endpoint);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealAndFlushMinSet();
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealMinServerSet();
         corfuRuntime.getLayoutView().updateLayout(layout, 1L);
     }
 
@@ -137,7 +137,7 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
 
         // Write the incomplete write to the head of the chain
         runtimeLayout.getLogUnitClient(SERVERS.ENDPOINT_0).write(incompleteWrite);
-        removeLogunit(layout, SERVERS.ENDPOINT_2);
+        removeLogUnit(layout, SERVERS.ENDPOINT_2);
         r.invalidateLayout();
         r.getLayoutView().getLayout();
         runtimeLayout = r.getLayoutView().getRuntimeLayout();


### PR DESCRIPTION
## Overview

The current seal logic is not correct as described in #1528. This patch fix this issue by setting remote epoch on all servers and execute correct sealing logic on each server types. For now only the log unit servers has the needs to do the additional sealing logic, which flushes all the operations before the seal and fail all the operations after this, but stamped with an older epoch.

This patch also fix the incorrect behavior when flushing and failing operations on log unit servers with BatchWriter, which could cause tests to fail intermittently.

Related issue(s) (if applicable): #1528

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
