### PR TITLE
Make integration tests more generic

### DIFF
--- a/it/src/main/java/org/corfudb/universe/group/Group.java
+++ b/it/src/main/java/org/corfudb/universe/group/Group.java
@@ -2,6 +2,8 @@ package org.corfudb.universe.group;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import org.corfudb.universe.node.Node;
 import org.corfudb.universe.node.Node.NodeType;
 import org.corfudb.universe.universe.Universe;
@@ -64,14 +66,14 @@ public interface Group {
      *
      * @return an {@link ImmutableList} of {@link Node}s.
      */
-    <T extends Node> ImmutableMap<String, T> nodes();
+    <T extends Node> ImmutableSortedMap<String, T> nodes();
 
     <T extends Node> T getNode(String nodeName);
 
     interface GroupParams {
         String getName();
 
-        <T extends NodeParams> ImmutableList<T> getNodesParams();
+        <T extends NodeParams> ImmutableSortedSet<T> getNodesParams();
 
         NodeType getNodeType();
     }

--- a/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCorfuCluster.java
@@ -2,8 +2,9 @@ package org.corfudb.universe.group.cluster;
 
 import static lombok.Builder.Default;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -21,8 +22,8 @@ import org.corfudb.universe.util.ClassUtils;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -31,7 +32,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractCorfuCluster<P extends CorfuClusterParams, U extends UniverseParams>
         implements CorfuCluster {
     @Default
-    protected final ConcurrentMap<String, CorfuServer> nodes = new ConcurrentHashMap<>();
+    protected final ConcurrentNavigableMap<String, CorfuServer> nodes = new ConcurrentSkipListMap<>();
     @Getter
     @NonNull
     protected final P params;
@@ -54,7 +55,7 @@ public abstract class AbstractCorfuCluster<P extends CorfuClusterParams, U exten
      */
     @Override
     public AbstractCorfuCluster<P, U> deploy() {
-        log.info("Deploy vm corfu cluster. Params: {}", params);
+        log.info("Deploy corfu cluster. Params: {}", params);
 
         List<CompletableFuture<CorfuServer>> asyncDeployment = params
                 .getNodesParams()
@@ -155,8 +156,8 @@ public abstract class AbstractCorfuCluster<P extends CorfuClusterParams, U exten
     }
 
     @Override
-    public <T extends Node> ImmutableMap<String, T> nodes() {
-        return ClassUtils.cast(ImmutableMap.copyOf(nodes));
+    public <T extends Node> ImmutableSortedMap<String, T> nodes() {
+        return ClassUtils.cast(ImmutableSortedMap.copyOf(nodes));
     }
 
     @Override
@@ -167,5 +168,5 @@ public abstract class AbstractCorfuCluster<P extends CorfuClusterParams, U exten
                 .deploy();
     }
 
-    protected abstract ImmutableList<String> getClusterLayoutServers();
+    protected abstract ImmutableSortedSet<String> getClusterLayoutServers();
 }

--- a/it/src/main/java/org/corfudb/universe/group/cluster/CorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/CorfuCluster.java
@@ -1,6 +1,8 @@
 package org.corfudb.universe.group.cluster;
 
+import org.corfudb.universe.node.NodeException;
 import org.corfudb.universe.node.client.LocalCorfuClient;
+import org.corfudb.universe.node.server.CorfuServer;
 
 /**
  * Provides a Corfu specific cluster of servers
@@ -9,8 +11,38 @@ public interface CorfuCluster extends Cluster {
 
     /**
      * Provides a corfu client running on local machine
+     *
      * @return local corfu client
      */
     LocalCorfuClient getLocalCorfuClient();
 
+    /**
+     * Find a corfu server by index in the cluster:
+     * - get all corfu servers in the cluster
+     * - skip particular number of servers in the cluster according to index offset
+     * - extract first server from the list
+     *
+     * @param index corfu server position
+     * @return a corfu server
+     */
+    default CorfuServer getServerByIndex(int index) {
+        return nodes()
+                .values()
+                .stream()
+                .skip(index)
+                .findFirst()
+                .map(CorfuServer.class::cast)
+                .orElseThrow(() -> new NodeException("Corfu server not found by index: " + index));
+    }
+
+    /**
+     * To find the first corfu server in a cluster:
+     * - get all corfu servers in the cluster
+     * - extract first element in the list
+     *
+     * @return the first corfu server
+     */
+    default CorfuServer getFirstServer() {
+        return getServerByIndex(0);
+    }
 }

--- a/it/src/main/java/org/corfudb/universe/group/cluster/CorfuClusterParams.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/CorfuClusterParams.java
@@ -1,6 +1,6 @@
 package org.corfudb.universe.group.cluster;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.EqualsAndHashCode;
@@ -14,9 +14,9 @@ import org.corfudb.universe.node.server.CorfuServerParams;
 import org.corfudb.universe.util.ClassUtils;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 @Builder
@@ -30,7 +30,7 @@ class CorfuClusterParams implements GroupParams {
     private String name = RandomStringUtils.randomAlphabetic(6).toLowerCase();
     @Default
     @NonNull
-    private final List<CorfuServerParams> nodes = new ArrayList<>();
+    private final SortedSet<CorfuServerParams> nodes = new TreeSet<>();
     @Getter
     @Default
     @NonNull
@@ -45,8 +45,8 @@ class CorfuClusterParams implements GroupParams {
     private final Duration retryTimeout = Duration.ofSeconds(3);
 
     @Override
-    public ImmutableList<CorfuServerParams> getNodesParams() {
-        return ImmutableList.copyOf(nodes);
+    public ImmutableSortedSet<CorfuServerParams> getNodesParams() {
+        return ImmutableSortedSet.copyOf(nodes);
     }
 
     public synchronized CorfuServerParams getNode(String serverName) {

--- a/it/src/main/java/org/corfudb/universe/group/cluster/docker/DockerCorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/docker/DockerCorfuCluster.java
@@ -1,6 +1,7 @@
 package org.corfudb.universe.group.cluster.docker;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
 import com.spotify.docker.client.DockerClient;
 import lombok.Builder;
 import lombok.NonNull;
@@ -19,6 +20,8 @@ import org.corfudb.universe.group.cluster.CorfuCluster;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
@@ -53,13 +56,14 @@ public class DockerCorfuCluster extends AbstractCorfuCluster<CorfuClusterParams,
     }
 
     @Override
-    protected ImmutableList<String> getClusterLayoutServers() {
-        List<String> servers = nodes.values()
+    protected ImmutableSortedSet<String> getClusterLayoutServers() {
+        List<String> servers = nodes
+                .values()
                 .stream()
                 .map(CorfuServer::getEndpoint)
                 .collect(Collectors.toList());
 
-        return ImmutableList.copyOf(servers);
+        return ImmutableSortedSet.copyOf(servers);
     }
 
     @Override
@@ -73,7 +77,7 @@ public class DockerCorfuCluster extends AbstractCorfuCluster<CorfuClusterParams,
     private Layout getLayout() {
         long epoch = 0;
         UUID clusterId = UUID.randomUUID();
-        List<String> servers = getClusterLayoutServers();
+        List<String> servers = getClusterLayoutServers().asList();
 
         LayoutSegment segment = new LayoutSegment(
                 Layout.ReplicationMode.CHAIN_REPLICATION,

--- a/it/src/main/java/org/corfudb/universe/group/cluster/vm/VmCorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/vm/VmCorfuCluster.java
@@ -2,6 +2,7 @@ package org.corfudb.universe.group.cluster.vm;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
 import com.vmware.vim25.mo.VirtualMachine;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
@@ -66,8 +67,8 @@ public class VmCorfuCluster extends AbstractCorfuCluster<CorfuClusterParams, VmU
     }
 
     @Override
-    protected ImmutableList<String> getClusterLayoutServers() {
-        return ImmutableList.copyOf(buildLayout().getLayoutServers());
+    protected ImmutableSortedSet<String> getClusterLayoutServers() {
+        return ImmutableSortedSet.copyOf(buildLayout().getLayoutServers());
     }
 
     @Override

--- a/it/src/main/java/org/corfudb/universe/node/Node.java
+++ b/it/src/main/java/org/corfudb/universe/node/Node.java
@@ -48,7 +48,7 @@ public interface Node {
     /**
      * Common interface for the configurations of different implementation of {@link Node}.
      */
-    interface NodeParams {
+    interface NodeParams<T> extends Comparable<T> {
         String getName();
 
         NodeType getNodeType();

--- a/it/src/main/java/org/corfudb/universe/node/client/ClientParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/client/ClientParams.java
@@ -14,8 +14,7 @@ import java.time.Duration;
 @Builder
 @Getter
 @EqualsAndHashCode(exclude = {"numRetry", "timeout", "pollPeriod"})
-public
-class ClientParams implements NodeParams {
+public class ClientParams implements NodeParams<ClientParams> {
     @Default
     @NonNull
     private final String name = "corfuClient";
@@ -39,4 +38,12 @@ class ClientParams implements NodeParams {
     @Default
     @NonNull
     private final Duration pollPeriod = Duration.ofMillis(50);
+
+    @Default
+    private final int order = 0;
+
+    @Override
+    public int compareTo(ClientParams other) {
+        return Integer.compare(order, other.order);
+    }
 }

--- a/it/src/main/java/org/corfudb/universe/node/client/CorfuClient.java
+++ b/it/src/main/java/org/corfudb/universe/node/client/CorfuClient.java
@@ -22,7 +22,7 @@ public interface CorfuClient extends Node {
      * @param streamName stream name of the table
      * @return CorfuTable object created by runtime
      */
-    CorfuTable createDefaultCorfuTable(String streamName);
+    <K, V> CorfuTable<K, V> createDefaultCorfuTable(String streamName);
 
     /**
      * See {@link CorfuRuntime#connect()}

--- a/it/src/main/java/org/corfudb/universe/node/client/LocalCorfuClient.java
+++ b/it/src/main/java/org/corfudb/universe/node/client/LocalCorfuClient.java
@@ -1,6 +1,8 @@
 package org.corfudb.universe.node.client;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.reflect.TypeToken;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -29,14 +31,15 @@ public class LocalCorfuClient implements CorfuClient {
     @Getter
     private final ClientParams params;
     @Getter
-    private final ImmutableList<String> serverEndpoints;
+    private final ImmutableSortedSet<String> serverEndpoints;
 
     @Builder
-    public LocalCorfuClient(ClientParams params, ImmutableList<String> serverEndpoints) {
+    public LocalCorfuClient(ClientParams params, ImmutableSortedSet<String> serverEndpoints) {
         this.params = params;
         this.serverEndpoints = serverEndpoints;
 
         List<NodeLocator> layoutServers = serverEndpoints.stream()
+                .sorted()
                 .map(NodeLocator::parseString)
                 .collect(Collectors.toList());
 
@@ -90,10 +93,10 @@ public class LocalCorfuClient implements CorfuClient {
     }
 
     @Override
-    public CorfuTable createDefaultCorfuTable(String streamName) {
+    public <K, V> CorfuTable<K, V> createDefaultCorfuTable(String streamName) {
         return runtime.getObjectsView()
                 .build()
-                .setType(CorfuTable.class)
+                .setTypeToken(new TypeToken<CorfuTable<K, V>>() {})
                 .setStreamName(streamName)
                 .open();
     }

--- a/it/src/main/java/org/corfudb/universe/node/server/AbstractCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/AbstractCorfuServer.java
@@ -62,6 +62,11 @@ public abstract class AbstractCorfuServer<T extends CorfuServerParams, U extends
         return cmdLineParams;
     }
 
+    @Override
+    public int compareTo(CorfuServer other) {
+        return Integer.compare(getParams().getPort(), other.getParams().getPort());
+    }
+
     /**
      * Provides a current version of this project. It parses the version from pom.xml
      * @return maven/project version

--- a/it/src/main/java/org/corfudb/universe/node/server/CorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/CorfuServer.java
@@ -7,7 +7,7 @@ import org.corfudb.universe.universe.Universe;
 /**
  * Represent a Corfu server implementation of {@link Node} used in the {@link Universe}.
  */
-public interface CorfuServer extends Node {
+public interface CorfuServer extends Node, Comparable<CorfuServer> {
 
     @Override
     CorfuServer deploy();
@@ -63,7 +63,7 @@ public interface CorfuServer extends Node {
     default String getEndpoint() {
         return getNetworkInterface() + ":" + getParams().getPort();
     }
-
+    
     enum Mode {
         SINGLE, CLUSTER
     }

--- a/it/src/main/java/org/corfudb/universe/node/server/CorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/CorfuServer.java
@@ -63,7 +63,7 @@ public interface CorfuServer extends Node, Comparable<CorfuServer> {
     default String getEndpoint() {
         return getNetworkInterface() + ":" + getParams().getPort();
     }
-    
+
     enum Mode {
         SINGLE, CLUSTER
     }

--- a/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
@@ -19,13 +19,12 @@ import java.time.Duration;
 @AllArgsConstructor
 @EqualsAndHashCode(exclude = {"logLevel", "stopTimeout"})
 @ToString
-public
-class CorfuServerParams implements NodeParams {
+public class CorfuServerParams implements NodeParams<CorfuServerParams> {
     @NonNull
     private final String streamLogDir = "db";
     @Default
     @Getter
-    private final int port = 9000;
+    private final int port = ServerUtil.getRandomOpenPort();
     @Default
     @NonNull
     @Getter
@@ -54,10 +53,15 @@ class CorfuServerParams implements NodeParams {
 
     @Override
     public String getName() {
-        return clusterName + "-corfu-node" + port;
+        return clusterName + "-corfu-node" + getPort();
     }
 
     public String getStreamLogDir(){
         return getName() + "/" + streamLogDir;
+    }
+
+    @Override
+    public int compareTo(CorfuServerParams other) {
+        return Integer.compare(port, other.port);
     }
 }

--- a/it/src/main/java/org/corfudb/universe/node/server/ServerUtil.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/ServerUtil.java
@@ -1,0 +1,21 @@
+package org.corfudb.universe.node.server;
+
+import org.corfudb.universe.node.NodeException;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+public class ServerUtil {
+
+    private ServerUtil() {
+        //prevent creating class instances
+    }
+
+    public static int getRandomOpenPort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new NodeException("Can't get any open port", e);
+        }
+    }
+}

--- a/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
@@ -168,7 +168,7 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
         log.info("Disconnecting the server from docker network. Docker container: {}", params.getName());
 
         clusterParams.getNodesParams().forEach(neighbourServer -> {
-            if (neighbourServer.equals(params)){
+            if (neighbourServer.equals(params)) {
                 return;
             }
 
@@ -180,7 +180,7 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
                 ContainerInfo server = docker.inspectContainer(neighbourServer.getName());
                 String neighbourhoodIp = server.networkSettings().networks().values().asList().get(0).ipAddress();
 
-                if (StringUtils.isEmpty(neighbourhoodIp)){
+                if (StringUtils.isEmpty(neighbourhoodIp)) {
                     throw new NodeException("Empty ip address. Container: " + neighbourServer.getName());
                 }
 
@@ -329,7 +329,7 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
                     .values().asList().get(0)
                     .ipAddress();
 
-            if (StringUtils.isEmpty(ipAddr)){
+            if (StringUtils.isEmpty(ipAddr)) {
                 throw new NodeException("Empty Ip address for container: " + params.getName());
             }
 

--- a/it/src/main/java/org/corfudb/universe/scenario/fixture/Fixtures.java
+++ b/it/src/main/java/org/corfudb/universe/scenario/fixture/Fixtures.java
@@ -7,6 +7,7 @@ import org.corfudb.universe.group.cluster.CorfuClusterParams;
 import org.corfudb.universe.node.client.ClientParams;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.corfudb.universe.node.server.CorfuServerParams;
+import org.corfudb.universe.node.server.ServerUtil;
 import org.corfudb.universe.node.server.vm.VmCorfuServerParams;
 import org.corfudb.universe.universe.UniverseParams;
 import org.corfudb.universe.universe.vm.VmUniverseParams;
@@ -20,6 +21,8 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 /**
  * Fixture factory provides predefined fixtures
@@ -117,18 +120,19 @@ public interface Fixtures {
     class FixtureUtil {
 
         static ImmutableList<CorfuServerParams> buildMultipleServers(int numNodes, String clusterName) {
-            List<CorfuServerParams> serversParams = new ArrayList<>();
 
-            for (int i = 0; i < numNodes; i++) {
-                final int port = 9000 + i;
+            List<CorfuServerParams> serversParams = IntStream
+                    .rangeClosed(1, numNodes)
+                    .map(i -> ServerUtil.getRandomOpenPort())
+                    .boxed()
+                    .sorted()
+                    .map(port -> CorfuServerParams.serverParamsBuilder()
+                            .port(port)
+                            .clusterName(clusterName)
+                            .build()
+                    )
+                    .collect(Collectors.toList());
 
-                CorfuServerParams serverParam = CorfuServerParams.serverParamsBuilder()
-                        .port(port)
-                        .clusterName(clusterName)
-                        .build();
-
-                serversParams.add(serverParam);
-            }
             return ImmutableList.copyOf(serversParams);
         }
 
@@ -136,7 +140,7 @@ public interface Fixtures {
             List<CorfuServerParams> serversParams = new ArrayList<>();
 
             for (int i = 0; i < numNodes; i++) {
-                final int port = 9000 + i;
+                final int port = ServerUtil.getRandomOpenPort();
 
                 VmCorfuServerParams serverParam = VmCorfuServerParams.builder()
                         .clusterName(clusterName)

--- a/it/src/main/resources/logback.xml
+++ b/it/src/main/resources/logback.xml
@@ -19,7 +19,7 @@
     <logger name="org.corfudb.runtime.view.workflows.WorkflowRequest" level="off"/>
 
     <!-- Control logging levels for individual components here. -->
-    <root level="debug">
+    <root level="warn">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/it/src/main/resources/logback.xml
+++ b/it/src/main/resources/logback.xml
@@ -19,7 +19,7 @@
     <logger name="org.corfudb.runtime.view.workflows.WorkflowRequest" level="off"/>
 
     <!-- Control logging levels for individual components here. -->
-    <root level="info">
+    <root level="debug">
         <appender-ref ref="STDOUT"/>
     </root>
 </configuration>

--- a/it/src/test/java/org/corfudb/universe/group/CorfuClusterParamsTest.java
+++ b/it/src/test/java/org/corfudb/universe/group/CorfuClusterParamsTest.java
@@ -2,9 +2,13 @@ package org.corfudb.universe.group;
 
 import org.corfudb.universe.group.cluster.CorfuClusterParams;
 import org.corfudb.universe.node.server.CorfuServerParams;
+import org.corfudb.universe.node.server.ServerUtil;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,17 +17,19 @@ public class CorfuClusterParamsTest {
     @Test
     public void testFullNodeName() {
         final String clusterName = "mycluster";
-        final int port = 9000;
+        final int port = ServerUtil.getRandomOpenPort();
 
-        CorfuServerParams corfuServerParams = CorfuServerParams
+        CorfuServerParams param = CorfuServerParams
                 .serverParamsBuilder()
                 .port(port)
                 .clusterName(clusterName)
                 .build();
 
+        SortedSet<CorfuServerParams> corfuServers = new TreeSet<>(Collections.singletonList(param));
+
         CorfuClusterParams clusterParams = CorfuClusterParams.builder()
                 .name(clusterName)
-                .nodes(Collections.singletonList(corfuServerParams))
+                .nodes(corfuServers)
                 .build();
 
         String fqdn = clusterParams.getFullNodeName("node" + port);

--- a/it/src/test/java/org/corfudb/universe/node/server/CorfuServerParamsTest.java
+++ b/it/src/test/java/org/corfudb/universe/node/server/CorfuServerParamsTest.java
@@ -3,7 +3,10 @@ package org.corfudb.universe.node.server;
 import org.junit.Test;
 import org.slf4j.event.Level;
 
+import java.io.IOException;
+import java.net.ServerSocket;
 import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,10 +15,11 @@ public class CorfuServerParamsTest {
 
     @Test
     public void testEquals() {
+        final int port = 9000;
 
         CorfuServerParams p1 = CorfuServerParams.serverParamsBuilder()
                 .clusterName("test-cluster")
-                .port(9000)
+                .port(port)
                 .logLevel(Level.TRACE)
                 .mode(CorfuServer.Mode.CLUSTER)
                 .persistence(CorfuServer.Persistence.DISK)
@@ -24,7 +28,7 @@ public class CorfuServerParamsTest {
 
         CorfuServerParams p2 = CorfuServerParams.serverParamsBuilder()
                 .clusterName("test-cluster")
-                .port(9000)
+                .port(port)
                 .logLevel(Level.WARN)
                 .mode(CorfuServer.Mode.CLUSTER)
                 .persistence(CorfuServer.Persistence.DISK)

--- a/it/src/test/java/org/corfudb/universe/scenario/AllNodesPartitionedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/AllNodesPartitionedIT.java
@@ -34,7 +34,8 @@ public class AllNodesPartitionedIT extends GenericIntegrationTest {
 
             CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
 
-            CorfuTable table = corfuClient.createDefaultCorfuTable(TestFixtureConst.DEFAULT_STREAM_NAME);
+            CorfuTable<String, String> table =
+                    corfuClient.createDefaultCorfuTable(TestFixtureConst.DEFAULT_STREAM_NAME);
             for (int i = 0; i < TestFixtureConst.DEFAULT_TABLE_ITER; i++) {
                 table.put(String.valueOf(i), String.valueOf(i));
             }

--- a/it/src/test/java/org/corfudb/universe/scenario/ClusterResizeIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/ClusterResizeIT.java
@@ -8,6 +8,10 @@ import org.corfudb.universe.node.client.CorfuClient;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst;
 
@@ -25,25 +29,29 @@ public class ClusterResizeIT extends GenericIntegrationTest {
     @Test(timeout = 300000)
     public void clusterResizeTest() {
         getScenario().describe((fixture, testCase) -> {
-            final int numNodes = fixture.getNumNodes();
             ClientParams clientFixture = fixture.getClient();
 
             CorfuCluster corfuCluster = universe.getGroup(fixture.getCorfuCluster().getName());
 
             CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
 
-            CorfuTable table = corfuClient.createDefaultCorfuTable(TestFixtureConst.DEFAULT_STREAM_NAME);
+            CorfuTable<String, String> table =
+                    corfuClient.createDefaultCorfuTable(TestFixtureConst.DEFAULT_STREAM_NAME);
 
             for (int i = 0; i < TestFixtureConst.DEFAULT_TABLE_ITER; i++) {
                 table.put(String.valueOf(i), String.valueOf(i));
             }
 
+            List<CorfuServer> servers = Arrays.asList(
+                    corfuCluster.getServerByIndex(1),
+                    corfuCluster.getServerByIndex(2)
+            );
+
             testCase.it("should remove two nodes from corfu cluster", data -> {
-                CorfuServer server0 = corfuCluster.getNode("node9000");
+                CorfuServer server0 = corfuCluster.getFirstServer();
 
                 // Sequentially remove two nodes from cluster
-                for (int i = 1; i <= numNodes - 1; i++) {
-                    CorfuServer candidate = corfuCluster.getNode("node" + (9000 + i));
+                for (CorfuServer candidate: servers) {
                     corfuClient.getManagementView().removeNode(
                             candidate.getEndpoint(),
                             clientFixture.getNumRetry(),
@@ -62,10 +70,10 @@ public class ClusterResizeIT extends GenericIntegrationTest {
                 }
             });
 
+
             testCase.it("should add two nodes back to corfu cluster", data -> {
                 // Sequentially add two nodes back into cluster
-                for (int i = 1; i <= numNodes - 1; i++) {
-                    CorfuServer candidate = corfuCluster.getNode("node" + (9000 + i));
+                for (CorfuServer candidate: servers) {
                     corfuClient.getManagementView().addNode(
                             candidate.getEndpoint(),
                             clientFixture.getNumRetry(),

--- a/it/src/test/java/org/corfudb/universe/scenario/HandOfGodIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/HandOfGodIT.java
@@ -33,15 +33,15 @@ public class HandOfGodIT extends GenericIntegrationTest {
 
             CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
 
-            CorfuTable table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
+            CorfuTable<String, String> table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
             for (int i = 0; i < DEFAULT_TABLE_ITER; i++) {
                 table.put(String.valueOf(i), String.valueOf(i));
             }
 
             testCase.it("Should force remove two nodes from cluster", data -> {
-                CorfuServer server0 = corfuCluster.getNode("node9000");
-                CorfuServer server1 = corfuCluster.getNode("node9001");
-                CorfuServer server2 = corfuCluster.getNode("node9002");
+                CorfuServer server0 = corfuCluster.getServerByIndex(0);
+                CorfuServer server1 = corfuCluster.getServerByIndex(1);
+                CorfuServer server2 = corfuCluster.getServerByIndex(2);
 
                 // Sequentially kill two nodes
                 server1.kill();

--- a/it/src/test/java/org/corfudb/universe/scenario/NodesDownAndPartitionedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/NodesDownAndPartitionedIT.java
@@ -37,15 +37,15 @@ public class NodesDownAndPartitionedIT extends GenericIntegrationTest {
 
             CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
 
-            CorfuTable table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
+            CorfuTable<String, String> table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
             for (int i = 0; i < DEFAULT_TABLE_ITER; i++) {
                 table.put(String.valueOf(i), String.valueOf(i));
             }
 
             testCase.it("Should stop one node and partition another one", data -> {
-                CorfuServer server0 = corfuCluster.getNode("node9000");
-                CorfuServer server1 = corfuCluster.getNode("node9001");
-                CorfuServer server2 = corfuCluster.getNode("node9002");
+                CorfuServer server0 = corfuCluster.getServerByIndex(0);
+                CorfuServer server1 = corfuCluster.getServerByIndex(1);
+                CorfuServer server2 = corfuCluster.getServerByIndex(2);
 
                 // Stop one node and partition another one
                 server1.stop(Duration.ofSeconds(10));

--- a/it/src/test/java/org/corfudb/universe/scenario/NodesPausedAndPartitionedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/NodesPausedAndPartitionedIT.java
@@ -34,15 +34,16 @@ public class NodesPausedAndPartitionedIT extends GenericIntegrationTest {
 
             CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
 
-            CorfuTable table = corfuClient.createDefaultCorfuTable(TestFixtureConst.DEFAULT_STREAM_NAME);
+            CorfuTable<String, String> table =
+                    corfuClient.createDefaultCorfuTable(TestFixtureConst.DEFAULT_STREAM_NAME);
             for (int i = 0; i < TestFixtureConst.DEFAULT_TABLE_ITER; i++) {
                 table.put(String.valueOf(i), String.valueOf(i));
             }
 
             testCase.it("Should pause one node and partition another", data -> {
-                CorfuServer server0 = corfuCluster.getNode("node9000");
-                CorfuServer server1 = corfuCluster.getNode("node9001");
-                CorfuServer server2 = corfuCluster.getNode("node9002");
+                CorfuServer server0 = corfuCluster.getServerByIndex(0);
+                CorfuServer server1 = corfuCluster.getServerByIndex(1);
+                CorfuServer server2 = corfuCluster.getServerByIndex(2);
 
                 // Pause one node and partition another one
                 server1.pause();

--- a/it/src/test/java/org/corfudb/universe/scenario/OneNodeDownIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/OneNodeDownIT.java
@@ -38,13 +38,13 @@ public class OneNodeDownIT extends GenericIntegrationTest {
 
             CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
 
-            CorfuTable table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
+            CorfuTable<String, String> table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
             for (int i = 0; i < DEFAULT_TABLE_ITER; i++) {
                 table.put(String.valueOf(i), String.valueOf(i));
             }
 
             testCase.it("Should stop one node and then restart", data -> {
-                CorfuServer server1 = corfuCluster.getNode("node9000");
+                CorfuServer server1 = corfuCluster.getFirstServer();
 
                 // Stop one node and wait for layout's unresponsive servers to change
                 server1.stop(Duration.ofSeconds(10));
@@ -56,8 +56,11 @@ public class OneNodeDownIT extends GenericIntegrationTest {
 
                 // Verify cluster status is DEGRADED with one node down
                 ClusterStatusReport clusterStatusReport = corfuClient.getManagementView().getClusterStatus();
-                assertThat(clusterStatusReport.getClusterStatus()).isEqualTo(ClusterStatusReport.ClusterStatus.DEGRADED);
-                Map<String, ClusterStatusReport.NodeStatus> statusMap = clusterStatusReport.getClientServerConnectivityStatusMap();
+                assertThat(clusterStatusReport.getClusterStatus())
+                        .isEqualTo(ClusterStatusReport.ClusterStatus.DEGRADED);
+
+                Map<String, ClusterStatusReport.NodeStatus> statusMap = clusterStatusReport
+                        .getClientServerConnectivityStatusMap();
                 assertThat(statusMap.get(server1.getEndpoint())).isEqualTo(ClusterStatusReport.NodeStatus.DOWN);
 
                 // Verify data path working fine

--- a/it/src/test/java/org/corfudb/universe/scenario/OneNodePartitionedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/OneNodePartitionedIT.java
@@ -36,13 +36,13 @@ public class OneNodePartitionedIT extends GenericIntegrationTest {
 
             CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
 
-            CorfuTable table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
+            CorfuTable<String, String> table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
             for (int i = 0; i < DEFAULT_TABLE_ITER; i++) {
                 table.put(String.valueOf(i), String.valueOf(i));
             }
 
             testCase.it("should symmetrically partition one node from cluster", data -> {
-                CorfuServer server1 = corfuCluster.getNode("node9001");
+                CorfuServer server1 = corfuCluster.getServerByIndex(1);
 
                 // Symmetrically Partition one node and wait for layout's unresponsive servers to change
                 server1.disconnect();

--- a/it/src/test/java/org/corfudb/universe/scenario/OneNodePausedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/OneNodePausedIT.java
@@ -36,13 +36,13 @@ public class OneNodePausedIT extends GenericIntegrationTest {
 
             CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
 
-            CorfuTable table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
+            CorfuTable<String, String> table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
             for (int i = 0; i < DEFAULT_TABLE_ITER; i++) {
                 table.put(String.valueOf(i), String.valueOf(i));
             }
 
             testCase.it("Should pause one node and then resume", data -> {
-                CorfuServer server1 = corfuCluster.getNode("node9001");
+                CorfuServer server1 = corfuCluster.getServerByIndex(1);
 
                 // Pause one node and wait for layout's unresponsive servers to change
                 server1.pause();

--- a/it/src/test/java/org/corfudb/universe/scenario/TwoNodesDownIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/TwoNodesDownIT.java
@@ -37,15 +37,15 @@ public class TwoNodesDownIT extends GenericIntegrationTest {
 
             CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
 
-            CorfuTable table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
+            CorfuTable<String, String> table = corfuClient.createDefaultCorfuTable(DEFAULT_STREAM_NAME);
             for (int i = 0; i < DEFAULT_TABLE_ITER; i++) {
                 table.put(String.valueOf(i), String.valueOf(i));
             }
 
             testCase.it("Should stop two nodes and then restart", data -> {
-                CorfuServer server0 = corfuCluster.getNode("node9000");
-                CorfuServer server1 = corfuCluster.getNode("node9001");
-                CorfuServer server2 = corfuCluster.getNode("node9002");
+                CorfuServer server0 = corfuCluster.getServerByIndex(0);
+                CorfuServer server1 = corfuCluster.getServerByIndex(1);
+                CorfuServer server2 = corfuCluster.getServerByIndex(2);
 
                 // Sequentially stop two nodes
                 server1.stop(Duration.ofSeconds(10));

--- a/runtime/src/main/java/org/corfudb/runtime/BootstrapUtil.java
+++ b/runtime/src/main/java/org/corfudb/runtime/BootstrapUtil.java
@@ -119,11 +119,11 @@ public class BootstrapUtil {
                     router.stop();
                     break;
                 } catch (AlreadyBootstrappedException abe) {
-                    log.error("Bootstrapping node:{} failed with exception:", server, abe);
+                    log.error("Bootstrapping node: {} failed with exception:", server, abe);
                     log.error("Cannot retry since already bootstrapped.");
                     throw new RuntimeException(abe);
                 } catch (Exception e) {
-                    log.error("Bootstrapping node:{} failed with exception:", server, e);
+                    log.error("Bootstrapping node: {} failed with exception:", server, e);
                     if (retry == 0) {
                         throw new RuntimeException(e);
                     }


### PR DESCRIPTION
## Overview

Description:
Make integration tests more generic:
 - open random `open` port for a corfu server, which allows running integration tests in parallel in the future
 - get rid of hard-coded names for nodes in tests

Why should this be merged: 
 - allows running integration tests in parallel in the future
Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
