### PR TITLE
Hole Fill RPC Bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -58,7 +58,7 @@ public enum CorfuMsgType {
     READ_RESPONSE(32, new TypeToken<CorfuPayloadMsg<ReadResponse>>() {}),
     MULTIPLE_READ_REQUEST(35, new TypeToken<CorfuPayloadMsg<MultipleReadRequest>>() {}),
     TRIM(33, new TypeToken<CorfuPayloadMsg<TrimRequest>>() {}),
-    FILL_HOLE(34, new TypeToken<CorfuPayloadMsg<TrimRequest>>() {}),
+    FILL_HOLE(34, new TypeToken<CorfuPayloadMsg<FillHoleRequest>>() {}),
     PREFIX_TRIM(38, new TypeToken<CorfuPayloadMsg<TrimRequest>>() {}),
     TAIL_REQUEST(41, TypeToken.of(CorfuMsg.class)),
     TAIL_RESPONSE(42, new TypeToken<CorfuPayloadMsg<Long>>(){}),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/FillHoleRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/FillHoleRequest.java
@@ -16,8 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class FillHoleRequest implements ICorfuPayload<FillHoleRequest> {
 
-    final UUID stream;
-    final Long prefix;
+    final Token address;
 
     /**
      * Constructor to generate a Fill Hole Request Payload.
@@ -25,20 +24,14 @@ public class FillHoleRequest implements ICorfuPayload<FillHoleRequest> {
      * @param buf The buffer to deserialize.
      */
     public FillHoleRequest(ByteBuf buf) {
-        if (ICorfuPayload.fromBuffer(buf, Boolean.class)) {
-            stream = ICorfuPayload.fromBuffer(buf, UUID.class);
-        } else {
-            stream = null;
-        }
-        prefix = ICorfuPayload.fromBuffer(buf, Long.class);
+        long epoch = buf.readLong();
+        long sequence = buf.readLong();
+        address = new Token(epoch, sequence);
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
-        ICorfuPayload.serialize(buf, stream != null);
-        if (stream != null) {
-            ICorfuPayload.serialize(buf, stream);
-        }
-        ICorfuPayload.serialize(buf, prefix);
+        buf.writeLong(address.getEpoch());
+        buf.writeLong(address.getSequence());
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -19,6 +19,7 @@ import org.corfudb.protocols.wireprotocol.MultipleReadRequest;
 import org.corfudb.protocols.wireprotocol.RangeWriteMsg;
 import org.corfudb.protocols.wireprotocol.ReadRequest;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TrimRequest;
 import org.corfudb.protocols.wireprotocol.WriteMode;
 import org.corfudb.protocols.wireprotocol.WriteRequest;
@@ -265,28 +266,10 @@ public class LogUnitClient extends AbstractClient {
      *
      * @param address The address to fill a hole at.
      */
-    public CompletableFuture<Boolean> fillHole(long address) {
+    public CompletableFuture<Boolean> fillHole(Token address) {
         Timer.Context context = getTimerContext("fillHole");
         CompletableFuture<Boolean> cf = sendMessageWithFuture(
-                CorfuMsgType.FILL_HOLE.payloadMsg(new FillHoleRequest(null, address)));
-        return cf.thenApply(x -> {
-            context.stop();
-            return x;
-        });
-    }
-
-    /**
-     * Fills hole at a given address for a particular streamID.
-     *
-     * @param streamID StreamID to hole fill.
-     * @param address  The address to fill a hole at.
-     */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
-    public CompletableFuture<Boolean> fillHole(UUID streamID, long address) {
-        Timer.Context context = getTimerContext("fillHole");
-        CompletableFuture<Boolean> cf = sendMessageWithFuture(
-                CorfuMsgType.FILL_HOLE.payloadMsg(new FillHoleRequest(streamID, address)));
+                CorfuMsgType.FILL_HOLE.payloadMsg(new FillHoleRequest(address)));
         return cf.thenApply(x -> {
             context.stop();
             return x;

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.RecoveryException;
 import org.corfudb.runtime.view.RuntimeLayout;
@@ -158,9 +159,10 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
                                     .write(data),
                             OverwriteException.class);
                 } else {
+                    Token token = new Token(runtimeLayout.getLayout().getEpoch(), globalAddress);
                     CFUtils.getUninterruptibly(runtimeLayout
                             .getLogUnitClient(globalAddress, i)
-                            .fillHole(globalAddress), OverwriteException.class);
+                            .fillHole(token), OverwriteException.class);
                 }
             } catch (OverwriteException oe) {
                 log.trace("Propogate[{}]: Completed by other writer", globalAddress);
@@ -236,9 +238,10 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
         // In chain replication, we write synchronously to every unit in
         // the chain.
         try {
+            Token token = new Token(runtimeLayout.getLayout().getEpoch(), globalAddress);
             CFUtils.getUninterruptibly(runtimeLayout
                     .getLogUnitClient(globalAddress, 0)
-                    .fillHole(globalAddress), OverwriteException.class);
+                    .fillHole(token), OverwriteException.class);
             propagate(runtimeLayout, globalAddress, null);
         } catch (OverwriteException oe) {
             // The hole-fill failed. We must ensure the other writer's

--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -186,12 +186,12 @@ public class FastObjectLoaderTest extends AbstractViewTest {
                 .getSequencerClient(getDefaultConfigurationString());
 
         seq.nextToken(null, 1);
-        luc.fillHole(getDefaultRuntime().getSequencerView().next().getSequence());
+        luc.fillHole(getDefaultRuntime().getSequencerView().next().getToken());
 
         populateMaps(1, getDefaultRuntime(), CorfuTable.class, false, 1);
 
         seq.nextToken(null, 1);
-        luc.fillHole(getDefaultRuntime().getSequencerView().next().getSequence());
+        luc.fillHole(getDefaultRuntime().getSequencerView().next().getToken());
 
         CorfuRuntime rt2 = Helpers.createNewRuntimeWithFastLoader(getDefaultConfigurationString());
         assertThatMapsAreBuilt(rt2);

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -33,6 +33,7 @@ import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
@@ -308,7 +309,8 @@ public class LogUnitHandlerTest extends AbstractClientTest {
             throws Exception {
         byte[] testString = "hello world".getBytes();
         final long address0 = 0;
-        client.fillHole(address0).get();
+        Token token = new Token(0, address0);
+        client.fillHole(token).get();
         LogData r = client.read(address0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.HOLE);
@@ -337,8 +339,8 @@ public class LogUnitHandlerTest extends AbstractClientTest {
                 return false;
             }
         }, "Expected overwrite cause to be DIFF_DATA");
-
-        assertThatThrownBy(() -> client.fillHole(0).get())
+        Token token = new Token(0, 0);
+        assertThatThrownBy(() -> client.fillHole(token).get())
                 .isInstanceOf(ExecutionException.class)
                 .hasCauseInstanceOf(OverwriteException.class)
                 .has(conditionOverwrite);


### PR DESCRIPTION
## Overview
Hole fill methods were using the TrimRequest type to send rpcs
to the server, since they share the same number of fields and types
this issue is not detected at compile/runtime.

Why should this be merged: Fixes an rpc bug


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
