### PR TITLE
Prefix Trim On Token

### DIFF
--- a/generator/src/main/java/org/corfudb/generator/operations/CheckpointOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/CheckpointOperation.java
@@ -32,7 +32,7 @@ public class CheckpointOperation extends Operation {
             Token trimAddress = mcw.appendCheckpoints(state.getRuntime(), "Maithem");
             state.updateTrimMark(trimAddress);
             Thread.sleep(1000l * 30l * 1l);
-            state.getRuntime().getAddressSpaceView().prefixTrim(trimAddress.getSequence() - 1);
+            state.getRuntime().getAddressSpaceView().prefixTrim(trimAddress);
             state.getRuntime().getAddressSpaceView().gc();
             state.getRuntime().getAddressSpaceView().invalidateClientCache();
             state.getRuntime().getAddressSpaceView().invalidateServerCaches();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -73,7 +73,6 @@ public class BaseServer extends AbstractServer {
             long epoch = msg.getPayload();
             log.info("handleMessageSetEpoch: Received SET_EPOCH, moving to new epoch {}", epoch);
             serverContext.setServerEpoch(epoch, r);
-            serverContext.getServers().forEach(s -> s.sealServerWithEpoch(epoch));
             r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
         } catch (WrongEpochException e) {
             log.debug("handleMessageSetEpoch: Rejected SET_EPOCH current={}, requested={}",

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -236,7 +236,8 @@ public class LogUnitServer extends AbstractServer {
 
     @ServerHandler(type = CorfuMsgType.TRIM)
     private void trim(CorfuPayloadMsg<TrimRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
-        batchWriter.trim(msg.getPayload().getAddress(), msg.getEpoch());
+        TrimRequest req = msg.getPayload();
+        batchWriter.trim(req.getAddress().getSequence(), req.getAddress().getEpoch());
         //TODO(Maithem): should we return an error if the write fails
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
     }
@@ -245,7 +246,8 @@ public class LogUnitServer extends AbstractServer {
     private void prefixTrim(CorfuPayloadMsg<TrimRequest> msg, ChannelHandlerContext ctx,
                             IServerRouter r) {
         try {
-            batchWriter.prefixTrim(msg.getPayload().getAddress(), msg.getEpoch());
+            TrimRequest req = msg.getPayload();
+            batchWriter.prefixTrim(req.getAddress());
             r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
         } catch (TrimmedException ex) {
             r.sendResponse(ctx, msg, CorfuMsgType.ERROR_TRIMMED.msg());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -374,6 +374,7 @@ public class ServerContext implements AutoCloseable {
         if (lastEpoch == null || lastEpoch < serverEpoch) {
             dataStore.put(Long.class, PREFIX_EPOCH, KEY_EPOCH, serverEpoch);
             r.setServerEpoch(serverEpoch);
+            getServers().forEach(s -> s.sealServerWithEpoch(serverEpoch));
         } else if (serverEpoch == lastEpoch) {
             // Setting to the same epoch, don't need to do anything.
         } else {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TrimRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TrimRequest.java
@@ -15,8 +15,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class TrimRequest implements ICorfuPayload<TrimRequest> {
 
-    final UUID stream;
-    final Long address;
+    final Token address;
 
     /**
      * Deserialization Constructor from Bytebuf to TrimRequest.
@@ -24,20 +23,14 @@ public class TrimRequest implements ICorfuPayload<TrimRequest> {
      * @param buf The buffer to deserialize
      */
     public TrimRequest(ByteBuf buf) {
-        if (ICorfuPayload.fromBuffer(buf, Boolean.class)) {
-            stream = ICorfuPayload.fromBuffer(buf, UUID.class);
-        } else {
-            stream = null;
-        }
-        address = ICorfuPayload.fromBuffer(buf, Long.class);
+        long epoch = buf.readLong();
+        long sequence = buf.readLong();
+        address = new Token(epoch, sequence);
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
-        ICorfuPayload.serialize(buf, stream != null);
-        if (stream != null) {
-            ICorfuPayload.serialize(buf, stream);
-        }
-        ICorfuPayload.serialize(buf, address);
+        buf.writeLong(address.getEpoch());
+        buf.writeLong(address.getSequence());
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -233,8 +233,8 @@ public class LogUnitClient extends AbstractClient {
      *
      * @param prefix The prefix of the stream, as a global physical offset, to trim.
      */
-    public void trim(long prefix) {
-        sendMessage(CorfuMsgType.TRIM.payloadMsg(new TrimRequest(null, prefix)));
+    public void trim(Token prefix) {
+        sendMessage(CorfuMsgType.TRIM.payloadMsg(new TrimRequest(prefix)));
     }
 
     /**
@@ -242,9 +242,9 @@ public class LogUnitClient extends AbstractClient {
      *
      * @param address An address to trim up to (i.e. [0, address))
      */
-    public CompletableFuture<Void> prefixTrim(long address) {
+    public CompletableFuture<Void> prefixTrim(Token address) {
         return sendMessageWithFuture(CorfuMsgType.PREFIX_TRIM
-                .payloadMsg(new TrimRequest(null, address)));
+                .payloadMsg(new TrimRequest(address)));
     }
 
     /**

--- a/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
@@ -38,7 +37,6 @@ public class TestServerRouter implements IServerRouter {
     AtomicLong requestCounter;
 
     @Getter
-    @Setter
     long serverEpoch;
 
     @Getter
@@ -160,4 +158,8 @@ public class TestServerRouter implements IServerRouter {
         return msgOut;
     }
 
+    public void setServerEpoch(long serverEpoch) {
+        this.serverEpoch = serverEpoch;
+        getServers().forEach(s -> s.sealServerWithEpoch(serverEpoch));
+    }
 }

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -560,10 +560,10 @@ public class ServerRestartIT extends AbstractIT {
                 MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
                 mcw1.addMap((SMRMap) mapA);
                 mcw1.addMap((SMRMap) mapB);
-                long checkpointAddress = mcw1.appendCheckpoints(corfuRuntime, "dahlia").getSequence();
+                Token checkpointAddress = mcw1.appendCheckpoints(corfuRuntime, "dahlia");
 
                 // Trim the log
-                corfuRuntime.getAddressSpaceView().prefixTrim(checkpointAddress - 1);
+                corfuRuntime.getAddressSpaceView().prefixTrim(checkpointAddress);
                 corfuRuntime.getAddressSpaceView().gc();
                 corfuRuntime.getAddressSpaceView().invalidateServerCaches();
                 corfuRuntime.getAddressSpaceView().invalidateClientCache();
@@ -695,7 +695,7 @@ public class ServerRestartIT extends AbstractIT {
         // Checkpoint and trim the log.
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(corfuTable1);
-        long trimMark = mcw.appendCheckpoints(rt1, "author").getSequence();
+        Token trimMark = mcw.appendCheckpoints(rt1, "author");
         Collection<Map.Entry<String, String>> c1a =
                 corfuTable1.getByIndex(StringIndexer.BY_FIRST_LETTER, "9");
         Collection<Map.Entry<String, String>> c1b =
@@ -767,7 +767,7 @@ public class ServerRestartIT extends AbstractIT {
         // Checkpoint and trim
         MultiCheckpointWriter multiCheckpointWriter = new MultiCheckpointWriter();
         multiCheckpointWriter.addMap(corfuTable1);
-        long trimMark = multiCheckpointWriter.appendCheckpoints(runtime1, "Sam.Behnam").getSequence();
+        Token trimMark = multiCheckpointWriter.appendCheckpoints(runtime1, "Sam.Behnam");
         Collection<Map.Entry<String, String>> resultInitial =
                 corfuTable1.getByIndex(StringMultiIndexer.BY_EACH_WORD, "tag666");
         runtime1.getAddressSpaceView().prefixTrim(trimMark);

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -5,6 +5,7 @@ import static org.corfudb.integration.Harness.run;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.integration.cluster.Harness.Node;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.recovery.FastObjectLoader;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
@@ -90,9 +91,9 @@ public class WorkflowIT extends AbstractIT {
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
 
-        long prefix = mcw.appendCheckpoints(n1Rt, "Maithem").getSequence();
+        Token prefix = mcw.appendCheckpoints(n1Rt, "Maithem");
 
-        n1Rt.getAddressSpaceView().prefixTrim(prefix - 1);
+        n1Rt.getAddressSpaceView().prefixTrim(prefix);
 
         n1Rt.getAddressSpaceView().invalidateClientCache();
         n1Rt.getAddressSpaceView().invalidateServerCaches();
@@ -314,7 +315,7 @@ public class WorkflowIT extends AbstractIT {
         // Checkpoint and trim the entries.
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
-        long prefixTrimAddress = mcw.appendCheckpoints(rt, "author").getSequence();
+        Token prefixTrimAddress = mcw.appendCheckpoints(rt, "author");
         rt.getAddressSpaceView().prefixTrim(prefixTrimAddress);
         rt.getAddressSpaceView().invalidateServerCaches();
         rt.getAddressSpaceView().invalidateClientCache();
@@ -358,9 +359,9 @@ public class WorkflowIT extends AbstractIT {
 
         // Assert that the new nodes should have the correct trimMark.
         assertThat(rt.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9001").getTrimMark().get())
-                .isEqualTo(prefixTrimAddress + 1);
+                .isEqualTo(prefixTrimAddress.getSequence() + 1);
         assertThat(rt.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9002").getTrimMark().get())
-                .isEqualTo(prefixTrimAddress + 1);
+                .isEqualTo(prefixTrimAddress.getSequence() + 1);
         FastObjectLoader fastObjectLoader = new FastObjectLoader(rt);
         fastObjectLoader.setRecoverSequencerMode(true);
         fastObjectLoader.loadMaps();

--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -77,12 +77,12 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         map.clear());
     }
 
-    private long checkPointAll(CorfuRuntime rt) throws Exception {
+    private Token checkPointAll(CorfuRuntime rt) throws Exception {
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         maps.forEach((streamName, map) -> {
             mcw.addMap(map);
         });
-        return mcw.appendCheckpoints(rt, "author").getSequence();
+        return mcw.appendCheckpoints(rt, "author");
     }
 
     private void assertThatMapsAreBuilt(CorfuRuntime rt1, CorfuRuntime rt2) {
@@ -301,7 +301,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
     @Test
     public void canReadCheckPointMultipleStreamsTrim() throws Exception {
         populateMaps(SOME, getDefaultRuntime(), CorfuTable.class, true, 1);
-        long checkpointAddress = checkPointAll(getDefaultRuntime());
+        Token checkpointAddress = checkPointAll(getDefaultRuntime());
         clearAllMaps();
 
         populateMaps(SOME, getDefaultRuntime(), CorfuTable.class, false, 1);
@@ -322,8 +322,8 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         clearAllMaps();
 
         populateMaps(SOME, getDefaultRuntime(), CorfuTable.class, false, 1);
-
-        Helpers.trim(getDefaultRuntime(), 2);
+        Token token = new Token(getDefaultRuntime().getLayoutView().getLayout().getEpoch(), 2);
+        Helpers.trim(getDefaultRuntime(), token);
 
         CorfuRuntime rt2 = Helpers.createNewRuntimeWithFastLoader(getDefaultConfigurationString());
 
@@ -387,7 +387,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         populateMaps(2, getDefaultRuntime(), CorfuTable.class, false, 1);
         int mapCount = maps.size();
 
-        long checkPointAddress = checkPointAll(getDefaultRuntime());
+        Token checkPointAddress = checkPointAll(getDefaultRuntime());
 
         Helpers.trim(getDefaultRuntime(), checkPointAddress);
         Map<UUID, Long> streamTails = Helpers.getRecoveryStreamTails(getDefaultConfigurationString());
@@ -475,7 +475,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
     @Test
     public void canReadWithTruncatedCheckPoint() throws Exception{
         populateMaps(SOME, getDefaultRuntime(), CorfuTable.class, true, 1);
-        long firstCheckpointAddress = checkPointAll(getDefaultRuntime());
+        Token firstCheckpointAddress = checkPointAll(getDefaultRuntime());
 
         populateMaps(SOME, getDefaultRuntime(), CorfuTable.class, false, 1);
 
@@ -571,7 +571,8 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         incrementalLoader.setDefaultObjectsType(CorfuTable.class);
         incrementalLoader.loadMaps();
 
-        Helpers.trim(getDefaultRuntime(),firstMileStone+2);
+        Token token = new Token(rt2.getLayoutView().getLayout().getEpoch(), firstMileStone + 2);
+        Helpers.trim(getDefaultRuntime(), token);
 
         incrementalLoader.setLogHead(firstMileStone + 1);
         incrementalLoader.setLogTail(getDefaultRuntime().getSequencerView().next().getSequence());
@@ -585,7 +586,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         populateMaps(SOME, getDefaultRuntime(), CorfuTable.class, true, 1);
         populateMaps(2, getDefaultRuntime(), CorfuTable.class, false, 1);
 
-        long snapShotAddress = checkPointAll(getDefaultRuntime());
+        Token snapShotAddress = checkPointAll(getDefaultRuntime());
         Helpers.trim(getDefaultRuntime(), snapShotAddress);
 
         CorfuRuntime rt2 = getNewRuntime(getDefaultNode())
@@ -778,7 +779,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
 
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(originalTable);
-        long cpAddress = mcw.appendCheckpoints(originalRuntime, "author").getSequence();
+        Token cpAddress = mcw.appendCheckpoints(originalRuntime, "author");
         Helpers.trim(originalRuntime, cpAddress);
 
 

--- a/test/src/test/java/org/corfudb/recovery/Helpers.java
+++ b/test/src/test/java/org/corfudb/recovery/Helpers.java
@@ -4,6 +4,7 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.SMRMap;
@@ -98,8 +99,9 @@ public class Helpers{
         return loader.getStreamTails();
     }
 
-    static void trim(CorfuRuntime rt, long address) {
-        rt.getAddressSpaceView().prefixTrim(address - 1);
+    static void trim(CorfuRuntime rt, Token address) {
+        Token prefix = new Token(address.getEpoch(), address.getSequence() - 1);
+        rt.getAddressSpaceView().prefixTrim(prefix);
         rt.getAddressSpaceView().gc();
         rt.getAddressSpaceView().invalidateServerCaches();
         rt.getAddressSpaceView().invalidateClientCache();

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -553,9 +553,9 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
         mcw1.addMap((SMRMap) mA);
         mcw1.addMap((SMRMap) mB);
-        long trimAddress = mcw1.appendCheckpoints(r, author).getSequence();
+        Token trimAddress = mcw1.appendCheckpoints(r, author);
 
-        r.getAddressSpaceView().prefixTrim(trimAddress - 1);
+        r.getAddressSpaceView().prefixTrim(trimAddress);
         r.getAddressSpaceView().gc();
         r.getAddressSpaceView().invalidateServerCaches();
         r.getAddressSpaceView().invalidateClientCache();

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -180,7 +180,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
 
-        client.prefixTrim(address0);
+        client.prefixTrim(new Token(0L, address0));
         client.compact();
 
         // For logunit cach flush

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.object;
 
 import com.google.common.reflect.TypeToken;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TrimmedException;
@@ -51,7 +52,8 @@ public class CompileProxyTest extends AbstractViewTest {
         rt.getSequencerView().next(CorfuRuntime.getStreamID(streamName));
 
         // Trim all the way up to the tail
-        rt.getAddressSpaceView().prefixTrim(numOfTokens);
+        Token token = new Token(rt.getLayoutView().getLayout().getEpoch(), numOfTokens);
+        rt.getAddressSpaceView().prefixTrim(token);
         rt.getAddressSpaceView().gc();
         rt.getAddressSpaceView().invalidateServerCaches();
 

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/SequencerCacheTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/SequencerCacheTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 
 import org.corfudb.infrastructure.SequencerServer;
 import org.corfudb.infrastructure.TestLayoutBuilder;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.SequencerClient;
 import org.corfudb.runtime.collections.SMRMap;
@@ -38,7 +39,7 @@ public class SequencerCacheTest extends AbstractObjectTest {
                 .open();
 
         final int numTxn = 500;
-        final int trimAddress = 250;
+        final Token trimAddress = new Token(getDefaultRuntime().getLayoutView().getLayout().getEpoch(), 250);
         for (int x = 0; x < numTxn; x++) {
             getRuntime().getObjectsView().TXBegin();
             map.put(x, x);
@@ -49,6 +50,6 @@ public class SequencerCacheTest extends AbstractObjectTest {
         Cache<String, Long> cache = sequencerServer.getConflictToGlobalTailCache();
         assertThat(cache.asMap().size()).isEqualTo(numTxn);
         getDefaultRuntime().getAddressSpaceView().prefixTrim(trimAddress);
-        assertThat(cache.asMap().size()).isEqualTo(trimAddress);
+        assertThat(cache.asMap().size()).isEqualTo((int) trimAddress.getSequence());
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -120,10 +120,10 @@ public class AddressSpaceViewTest extends AbstractViewTest {
     public void testGetTrimMark() {
         CorfuRuntime r = getRuntime().connect();
         assertThat(r.getAddressSpaceView().getTrimMark().getSequence()).isEqualTo(0);
-        final long trimAddress = 10;
+        final Token trimAddress = new Token(r.getLayoutView().getLayout().getEpoch(), 10);
 
         r.getAddressSpaceView().prefixTrim(trimAddress);
-        assertThat(r.getAddressSpaceView().getTrimMark().getSequence()).isEqualTo(trimAddress + 1);
+        assertThat(r.getAddressSpaceView().getTrimMark().getSequence()).isEqualTo(trimAddress.getSequence() + 1);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/runtime/view/LogUnitSealTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LogUnitSealTest.java
@@ -73,8 +73,12 @@ public class LogUnitSealTest extends AbstractViewTest {
         layout.setEpoch(layout.getEpoch() + 1);
         runtimeLayout.sealMinServerSet();
 
-        // Intentionally reset router epoch to bypass epoch check on router
-        getLayoutServer(SERVERS.PORT_0).getServerContext().getServerRouter().setServerEpoch(epoch);
+        // Intentionally reset router epoch to bypass epoch check on router.
+        // We expect that the test server router's epoch is reset, but the
+        // batchWriter should reject update its epoch with a smaller epoch.
+        assertThatThrownBy(() -> getLayoutServer(SERVERS.PORT_0)
+                .getServerContext().getServerRouter().setServerEpoch(epoch))
+                .isExactlyInstanceOf(WrongEpochException.class);
 
         // Still using the old client to send messages stamped with old epoch
         for (int i = 0; i < numOp; i++) {

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.view;
 
 import lombok.Getter;
 import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TrimmedException;
@@ -67,7 +68,8 @@ public class StreamViewTest extends AbstractViewTest {
         List<ILogData> entries = txStream.remainingUpTo((firstIter - 1) / 2);
         assertThat(entries.size()).isEqualTo(firstIter / 2);
 
-        runtime.getAddressSpaceView().prefixTrim((firstIter - 1) / 2);
+        Token token = new Token(runtime.getLayoutView().getLayout().getEpoch(), (firstIter - 1) / 2);
+        runtime.getAddressSpaceView().prefixTrim(token);
         runtime.getAddressSpaceView().invalidateServerCaches();
         runtime.getAddressSpaceView().invalidateClientCache();
 
@@ -373,7 +375,8 @@ public class StreamViewTest extends AbstractViewTest {
         sv.append(testPayload);
 
         // Trim the entry
-        runtime.getAddressSpaceView().prefixTrim(0);
+        Token token = new Token(runtime.getLayoutView().getLayout().getEpoch(), 0);
+        runtime.getAddressSpaceView().prefixTrim(token);
         runtime.getAddressSpaceView().gc();
         runtime.getAddressSpaceView().invalidateServerCaches();
         runtime.getAddressSpaceView().invalidateClientCache();

--- a/test/src/test/java/org/corfudb/runtime/view/ViewsGarbageCollectorTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ViewsGarbageCollectorTest.java
@@ -49,7 +49,7 @@ public class ViewsGarbageCollectorTest extends AbstractViewTest {
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
         Token trimMark = mcw.appendCheckpoints(rt, "cp1");
-        rt.getAddressSpaceView().prefixTrim(trimMark.getSequence());
+        rt.getAddressSpaceView().prefixTrim(trimMark);
         rt.getParameters().setRuntimeGCPeriod(Duration.ofMinutes(0));
         rt.getGarbageCollector().runRuntimeGC();
         long sizeOfTableAfterGc = sizeOf.deepSizeOf(table);


### PR DESCRIPTION
## Overview
Makes prefix trim epoch aware.

Why should this be merged: Prevents stray prefix trims from truncating uncheckpointed data

Related issue(s) (if applicable): #1513


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
