### PR TITLE
It profile

### DIFF
--- a/.travis_scripts/verify.sh
+++ b/.travis_scripts/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_SECURE_ENV_VARS" == "true" ]; then
-    ./mvnw verify -Dmaven.javadoc.skip=true -Dtest.travisBuild=true  sonar:sonar \
+    ./mvnw verify -Pit -Dmaven.javadoc.skip=true -Dtest.travisBuild=true  sonar:sonar \
         -Dsonar.analysis.mode=preview \
         -Dsonar.host.url=https://sonarqube.com \
         -Dsonar.github.pullRequest=$TRAVIS_PULL_REQUEST \
@@ -12,11 +12,11 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] && [ "$TRAVIS_SECURE_ENV_VARS" == "true
 else
     if [ "$TRAVIS_SECURE_ENV_VARS" == "false" ] ; then
         echo "Not submitting sonar status to github because this is an external build"
-        ./mvnw verify -Dmaven.javadoc.skip=true -Dsonar.host.url=https://sonarqube.com \
+        ./mvnw verify -Pit -Dmaven.javadoc.skip=true -Dsonar.host.url=https://sonarqube.com \
         -Dsonar.organization=corfudb -Dsonar.analysis.mode=preview \
         -Dtest.travisBuild=true sonar:sonar
     else
-        ./mvnw verify -Dmaven.javadoc.skip=true -Dsonar.host.url=https://sonarqube.com \
+        ./mvnw verify -Pit -Dmaven.javadoc.skip=true -Dsonar.host.url=https://sonarqube.com \
         -Dsonar.organization=corfudb -Dsonar.login=$SONAR_TOKEN -Dtest.travisBuild=true sonar:sonar
     fi
 fi

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -64,52 +64,94 @@
 
     <build>
         <plugins>
+            <!-- Disable integration tests by default -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <tasks>
-                                <echo>Copy infrastructure jar into target dir</echo>
-                                <copy file="../infrastructure/target/infrastructure-${project.version}-shaded.jar"
-                                      tofile="${project.build.directory}/corfu/infrastructure-${project.version}-shaded.jar"/>
-                            </tasks>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.8</version>
-                <executions>
-                    <execution>
-                        <id>Docker build</id>
-                        <phase>pre-integration-test</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <exec dir="${project.basedir}"
-                                      executable="docker"
-                                      failonerror="true">
-                                    <arg line="build"/>
-                                    <arg line="--network=host"/>
-                                    <arg line="--build-arg CORFU_JAR=infrastructure-${project.version}-shaded.jar"/>
-                                    <arg line="-t corfu-server:${project.version}"/>
-                                    <arg line="."/>
-                                </exec>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.0.0-M1</version>
+                <configuration>
+                    <skipITs>true</skipITs>
+                </configuration>
             </plugin>
         </plugins>
     </build>
+
+
+    <profiles>
+        <profile>
+            <id>it</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>3.0.0-M1</version>
+                        <configuration>
+                            <skipITs>false</skipITs>
+                            <forkCount>3</forkCount>
+                            <reuseForks>true</reuseForks>
+                            <systemProperties>
+                                <property>
+                                    <name>project.version</name>
+                                    <value>${project.version}</value>
+                                </property>
+                            </systemProperties>
+                            <workingDirectory>${project.build.directory}/fork_${surefire.forkNumber}</workingDirectory>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-resources-plugin</artifactId>
+                        <version>2.5</version>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>copy-resources</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}/corfu/</outputDirectory>
+                                    <resources>
+                                        <resource>
+                                            <directory>../infrastructure/target/</directory>
+                                            <includes>
+                                                <include>infrastructure-${project.version}-shaded.jar</include>
+                                            </includes>
+                                        </resource>
+                                    </resources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>1.6.0</version>
+                        <executions>
+                            <execution>
+                                <id>Docker build</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>docker</executable>
+                                    <arguments>
+                                        <argument>build</argument>
+                                        <argument>--network=host</argument>
+                                        <argument>--build-arg</argument>
+                                        <argument>CORFU_JAR=infrastructure-${project.version}-shaded.jar</argument>
+                                        <argument>-t</argument>
+                                        <argument>corfu-server:${project.version}</argument>
+                                        <argument>.</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -88,7 +88,7 @@
                         <version>3.0.0-M1</version>
                         <configuration>
                             <skipITs>false</skipITs>
-                            <forkCount>3</forkCount>
+                            <forkCount>2</forkCount>
                             <reuseForks>true</reuseForks>
                             <systemProperties>
                                 <property>

--- a/it/src/main/java/org/corfudb/universe/UniverseFactory.java
+++ b/it/src/main/java/org/corfudb/universe/UniverseFactory.java
@@ -45,8 +45,8 @@ public class UniverseFactory {
     /**
      * Build a VM {@link Universe} based on provided {@link VmUniverseParams}.
      *
-     * @param universeParams {@link VmUniverse} parameters
-     * @param applianceManager      appliances manager.
+     * @param universeParams   {@link VmUniverse} parameters
+     * @param applianceManager appliances manager.
      * @return a instance of {@link VmUniverse}
      */
     public VmUniverse buildVmUniverse(VmUniverseParams universeParams, ApplianceManager applianceManager) {

--- a/it/src/main/java/org/corfudb/universe/group/Group.java
+++ b/it/src/main/java/org/corfudb/universe/group/Group.java
@@ -1,7 +1,6 @@
 package org.corfudb.universe.group;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import org.corfudb.universe.node.Node;

--- a/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCorfuCluster.java
@@ -1,7 +1,5 @@
 package org.corfudb.universe.group.cluster;
 
-import static lombok.Builder.Default;
-
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
 import lombok.Getter;
@@ -26,6 +24,8 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
+
+import static lombok.Builder.Default;
 
 @Slf4j
 public abstract class AbstractCorfuCluster<P extends CorfuClusterParams, U extends UniverseParams>
@@ -88,6 +88,7 @@ public abstract class AbstractCorfuCluster<P extends CorfuClusterParams, U exten
 
     /**
      * Stop the cluster
+     *
      * @param timeout allowed time to gracefully stop the {@link Group}
      */
     @Override

--- a/it/src/main/java/org/corfudb/universe/group/cluster/docker/DockerCorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/docker/DockerCorfuCluster.java
@@ -9,13 +9,13 @@ import org.corfudb.runtime.BootstrapUtil;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.Layout.LayoutSegment;
 import org.corfudb.universe.group.cluster.AbstractCorfuCluster;
+import org.corfudb.universe.group.cluster.CorfuCluster;
 import org.corfudb.universe.group.cluster.CorfuClusterParams;
 import org.corfudb.universe.logging.LoggingParams;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.corfudb.universe.node.server.CorfuServerParams;
 import org.corfudb.universe.node.server.docker.DockerCorfuServer;
 import org.corfudb.universe.universe.UniverseParams;
-import org.corfudb.universe.group.cluster.CorfuCluster;
 import org.corfudb.universe.util.DockerManager;
 
 import java.util.Collections;

--- a/it/src/main/java/org/corfudb/universe/group/cluster/vm/VmCorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/vm/VmCorfuCluster.java
@@ -1,6 +1,5 @@
 package org.corfudb.universe.group.cluster.vm;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedSet;
 import com.vmware.vim25.mo.VirtualMachine;
@@ -9,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.BootstrapUtil;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.universe.group.cluster.AbstractCorfuCluster;
+import org.corfudb.universe.group.cluster.CorfuCluster;
 import org.corfudb.universe.group.cluster.CorfuClusterParams;
 import org.corfudb.universe.node.Node;
 import org.corfudb.universe.node.Node.NodeParams;
@@ -19,7 +19,6 @@ import org.corfudb.universe.node.server.vm.VmCorfuServerParams;
 import org.corfudb.universe.node.stress.vm.VmStress;
 import org.corfudb.universe.universe.vm.VmUniverseParams;
 import org.corfudb.universe.util.ClassUtils;
-import org.corfudb.universe.group.cluster.CorfuCluster;
 
 import java.util.Collections;
 import java.util.List;

--- a/it/src/main/java/org/corfudb/universe/node/client/ClientParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/client/ClientParams.java
@@ -5,7 +5,6 @@ import lombok.Builder.Default;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
-import org.corfudb.universe.node.Node;
 import org.corfudb.universe.node.Node.NodeParams;
 import org.corfudb.universe.node.Node.NodeType;
 

--- a/it/src/main/java/org/corfudb/universe/node/client/LocalCorfuClient.java
+++ b/it/src/main/java/org/corfudb/universe/node/client/LocalCorfuClient.java
@@ -1,6 +1,5 @@
 package org.corfudb.universe.node.client;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.reflect.TypeToken;
 import lombok.Builder;
@@ -54,6 +53,7 @@ public class LocalCorfuClient implements CorfuClient {
 
     /**
      * Connect corfu runtime to the server
+     *
      * @return
      */
     @Override
@@ -64,6 +64,7 @@ public class LocalCorfuClient implements CorfuClient {
 
     /**
      * Shutdown corfu runtime
+     *
      * @param timeout a limit within which the method attempts to gracefully stop the client (not used for a client).
      */
     @Override
@@ -96,7 +97,8 @@ public class LocalCorfuClient implements CorfuClient {
     public <K, V> CorfuTable<K, V> createDefaultCorfuTable(String streamName) {
         return runtime.getObjectsView()
                 .build()
-                .setTypeToken(new TypeToken<CorfuTable<K, V>>() {})
+                .setTypeToken(new TypeToken<CorfuTable<K, V>>() {
+                })
                 .setStreamName(streamName)
                 .open();
     }

--- a/it/src/main/java/org/corfudb/universe/node/server/AbstractCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/AbstractCorfuServer.java
@@ -3,12 +3,10 @@ package org.corfudb.universe.node.server;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.corfudb.universe.node.NodeException;
-import org.corfudb.universe.universe.UniverseException;
 import org.corfudb.universe.universe.UniverseParams;
 
 import java.io.FileReader;
@@ -16,6 +14,8 @@ import java.io.IOException;
 
 @Slf4j
 public abstract class AbstractCorfuServer<T extends CorfuServerParams, U extends UniverseParams> implements CorfuServer {
+
+    private static final String POM_FILE = "pom.xml";
 
     @Getter
     @NonNull
@@ -69,13 +69,23 @@ public abstract class AbstractCorfuServer<T extends CorfuServerParams, U extends
 
     /**
      * Provides a current version of this project. It parses the version from pom.xml
+     *
      * @return maven/project version
      */
     protected static String getAppVersion() {
+        String version = System.getProperty("project.version");
+        if (version != null && !version.isEmpty()) {
+            return version;
+        }
+
+        return parseAppVersionInPom();
+    }
+
+    private static String parseAppVersionInPom() {
         MavenXpp3Reader reader = new MavenXpp3Reader();
         Model model;
         try {
-            model = reader.read(new FileReader("pom.xml"));
+            model = reader.read(new FileReader(POM_FILE));
             return model.getParent().getVersion();
         } catch (IOException | XmlPullParserException e) {
             throw new NodeException("Can't parse application version", e);

--- a/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
@@ -56,7 +56,7 @@ public class CorfuServerParams implements NodeParams<CorfuServerParams> {
         return clusterName + "-corfu-node" + getPort();
     }
 
-    public String getStreamLogDir(){
+    public String getStreamLogDir() {
         return getName() + "/" + streamLogDir;
     }
 

--- a/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
@@ -1,13 +1,11 @@
 package org.corfudb.universe.node.server.docker;
 
 import com.spotify.docker.client.DockerClient;
-import com.spotify.docker.client.DockerClient.ExecCreateParam;
 import com.spotify.docker.client.LogStream;
 import com.spotify.docker.client.exceptions.DockerException;
 import com.spotify.docker.client.messages.ContainerConfig;
 import com.spotify.docker.client.messages.ContainerCreation;
 import com.spotify.docker.client.messages.ContainerInfo;
-import com.spotify.docker.client.messages.ExecCreation;
 import com.spotify.docker.client.messages.HostConfig;
 import com.spotify.docker.client.messages.IpamConfig;
 import com.spotify.docker.client.messages.PortBinding;

--- a/it/src/main/java/org/corfudb/universe/node/server/vm/VmCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/vm/VmCorfuServer.java
@@ -17,8 +17,6 @@ import org.corfudb.universe.universe.vm.VmUniverseParams;
 import org.corfudb.universe.util.IpTablesUtil;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Duration;
 
 /**

--- a/it/src/main/java/org/corfudb/universe/universe/vm/ApplianceManager.java
+++ b/it/src/main/java/org/corfudb/universe/universe/vm/ApplianceManager.java
@@ -204,7 +204,7 @@ public class ApplianceManager {
         return vmCloneSpec;
     }
 
-    public ImmutableMap<String, VirtualMachine> getVms(){
+    public ImmutableMap<String, VirtualMachine> getVms() {
         return ImmutableMap.copyOf(vms);
     }
 

--- a/it/src/main/java/org/corfudb/universe/util/DockerManager.java
+++ b/it/src/main/java/org/corfudb/universe/util/DockerManager.java
@@ -167,7 +167,7 @@ public class DockerManager {
     /**
      * Run `docker exec` on a container
      */
-    public void execCommand(String containerName,  String... command) throws DockerException, InterruptedException {
+    public void execCommand(String containerName, String... command) throws DockerException, InterruptedException {
         log.info("Executing docker command: {}", String.join(" ", command));
 
         ExecCreation execCreation = docker.execCreate(

--- a/it/src/main/java/org/corfudb/universe/util/IpTablesUtil.java
+++ b/it/src/main/java/org/corfudb/universe/util/IpTablesUtil.java
@@ -7,6 +7,7 @@ public class IpTablesUtil {
 
     /**
      * Drop input packages for a particular ip address
+     *
      * @param ipAddress ip address to drop packages
      * @return command line
      */
@@ -16,6 +17,7 @@ public class IpTablesUtil {
 
     /**
      * Drop output packages for a particular ip address
+     *
      * @param ipAddress ip address to drop packages
      * @return command line
      */
@@ -25,6 +27,7 @@ public class IpTablesUtil {
 
     /**
      * Clean all input rules
+     *
      * @return command line
      */
     public static String[] cleanInput() {
@@ -33,6 +36,7 @@ public class IpTablesUtil {
 
     /**
      * Clean all output rules
+     *
      * @return command line
      */
     public static String[] cleanOutput() {
@@ -41,6 +45,7 @@ public class IpTablesUtil {
 
     /**
      * Clean all rules
+     *
      * @return command line
      */
     public static String cleanAll() {

--- a/it/src/test/java/org/corfudb/universe/group/CorfuClusterParamsTest.java
+++ b/it/src/test/java/org/corfudb/universe/group/CorfuClusterParamsTest.java
@@ -5,7 +5,6 @@ import org.corfudb.universe.node.server.CorfuServerParams;
 import org.corfudb.universe.node.server.ServerUtil;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.SortedSet;
 import java.util.TreeSet;

--- a/it/src/test/java/org/corfudb/universe/node/server/CorfuServerParamsTest.java
+++ b/it/src/test/java/org/corfudb/universe/node/server/CorfuServerParamsTest.java
@@ -3,10 +3,7 @@ package org.corfudb.universe.node.server;
 import org.junit.Test;
 import org.slf4j.event.Level;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/it/src/test/java/org/corfudb/universe/scenario/ClusterResizeIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/ClusterResizeIT.java
@@ -50,7 +50,7 @@ public class ClusterResizeIT extends GenericIntegrationTest {
                 CorfuServer server0 = corfuCluster.getFirstServer();
 
                 // Sequentially remove two nodes from cluster
-                for (CorfuServer candidate: servers) {
+                for (CorfuServer candidate : servers) {
                     corfuClient.getManagementView().removeNode(
                             candidate.getEndpoint(),
                             clientFixture.getNumRetry(),
@@ -72,7 +72,7 @@ public class ClusterResizeIT extends GenericIntegrationTest {
 
             testCase.it("should add two nodes back to corfu cluster", data -> {
                 // Sequentially add two nodes back into cluster
-                for (CorfuServer candidate: servers) {
+                for (CorfuServer candidate : servers) {
                     corfuClient.getManagementView().addNode(
                             candidate.getEndpoint(),
                             clientFixture.getNumRetry(),

--- a/it/src/test/java/org/corfudb/universe/scenario/NodesDownAndPartitionedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/NodesDownAndPartitionedIT.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 import java.time.Duration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
 import static org.corfudb.universe.scenario.ScenarioUtils.waitForUnresponsiveServersChange;
 import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_STREAM_NAME;
 import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_TABLE_ITER;

--- a/it/src/test/java/org/corfudb/universe/scenario/OneNodePartitionedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/OneNodePartitionedIT.java
@@ -1,11 +1,5 @@
 package org.corfudb.universe.scenario;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
-import static org.corfudb.universe.scenario.ScenarioUtils.waitForUnresponsiveServersChange;
-import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_STREAM_NAME;
-import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_TABLE_ITER;
-
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.view.ClusterStatusReport;
 import org.corfudb.runtime.view.Layout;
@@ -15,6 +9,12 @@ import org.corfudb.universe.node.client.CorfuClient;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
+import static org.corfudb.universe.scenario.ScenarioUtils.waitForUnresponsiveServersChange;
+import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_STREAM_NAME;
+import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_TABLE_ITER;
 
 public class OneNodePartitionedIT extends GenericIntegrationTest {
 

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <argLine>${argLine}</argLine>
                     <trimStackTrace>false</trimStackTrace>
@@ -350,7 +350,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>3.0.0-M1</version>
                 <configuration>
                     <includes>
                         <include>**/*IT.java</include>


### PR DESCRIPTION
## Overview

Description:
 - Run integration tests in parallel
 - deactivate integration tests by default
 - use `-Pit` profile to run integration tests. By default, it uses 3 forks

Why should this be merged: 
 - improves stability and performance for `it` module

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
