### PR TITLE
Shutdown EventLoop Once

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -690,7 +690,7 @@ public class CorfuRuntime {
 
         // Shutdown the event loop
         if (parameters.shutdownNettyEventLoop) {
-            nettyEventLoop.shutdownGracefully().syncUninterruptibly();
+            nettyEventLoop.shutdownGracefully();
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -118,11 +118,6 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      */
     private volatile Channel channel = null;
 
-    /**
-     * The {@link EventLoopGroup} for this router which services requests.
-     */
-    public final EventLoopGroup eventLoopGroup;
-
     /** Whether to shutdown the {@code eventLoopGroup} or not. Only applies when
      *  a deprecated constructor (which generates its own {@link EventLoopGroup} is used.
      */
@@ -168,7 +163,6 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         @Nonnull CorfuRuntimeParameters parameters) {
         this.node = node;
         this.parameters = parameters;
-        this.eventLoopGroup = eventLoopGroup;
 
         // Set timer mapping
         ImmutableMap.Builder<CorfuMsgType, String> mapBuilder = ImmutableMap.builder();
@@ -386,23 +380,6 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         log.debug("stop: Shutting down router for {}", node);
         shutdown = true;
         connectionFuture.completeExceptionally(new ShutdownException());
-        try {
-            channel.disconnect();
-            channel.close().syncUninterruptibly();
-        } catch (Exception e) {
-            log.error("Error in closing channel");
-        }
-        try {
-            if (shutdownEventLoop) {
-                eventLoopGroup.shutdownGracefully(
-                        parameters.getNettyShutdownQuitePeriod(),
-                        parameters.getNettyShutdownTimeout(),
-                        TimeUnit.MILLISECONDS
-                ).sync();
-            }
-        } catch (InterruptedException e) {
-            throw new UnrecoverableCorfuInterruptedError("Interrupted while stopping", e);
-        }
     }
 
     /** {@inheritDoc}


### PR DESCRIPTION
Description:
Only shutdown the event loop once and don't wait for the shut
down future to complete.


Why should this be merged: the shutdown method is called from both the application side and our servers, if this method never return it can block the server from cleanly shutting down restart (i.e partial shutdown)

Related issue(s) (if applicable): #1575


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
