### PR TITLE
Raw Streams Garbage Collection

### DIFF
--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -471,6 +471,7 @@ public class FastObjectLoader {
     private void cleanUpForRetry() {
         runtime.getAddressSpaceView().invalidateClientCache();
         runtime.getObjectsView().getObjectCache().clear();
+        runtime.getStreamsView().getStreamCache().clear();
         nextRead = logHead;
         resetAddressProcessed();
 

--- a/runtime/src/main/java/org/corfudb/runtime/ViewsGarbageCollector.java
+++ b/runtime/src/main/java/org/corfudb/runtime/ViewsGarbageCollector.java
@@ -75,6 +75,7 @@ public class ViewsGarbageCollector {
                     currTrimMark);
             long startTs = System.currentTimeMillis();
             runtime.getObjectsView().gc(currTrimMark);
+            runtime.getStreamsView().gc(currTrimMark);
             runtime.getAddressSpaceView().gc(currTrimMark);
             long endTs = System.currentTimeMillis();
             trimMark = currTrimMark;

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -144,8 +144,9 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         this.args = args;
         this.serializer = serializer;
 
+        // Since the VLO is thread safe we don't need to use a thread safe stream implementation
         underlyingObject = new VersionLockedObject<T>(this::getNewInstance,
-                new StreamViewSMRAdapter(rt, rt.getStreamsView().get(streamID)),
+                new StreamViewSMRAdapter(rt, rt.getStreamsView().getUnsafe(streamID)),
                 upcallTargetMap, undoRecordTargetMap,
                 undoTargetMap, resetSet);
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -18,6 +18,7 @@ import org.corfudb.runtime.view.replication.QuorumReplicationProtocol;
 import org.corfudb.runtime.view.replication.ReadWaitHoleFillPolicy;
 import org.corfudb.runtime.view.stream.BackpointerStreamView;
 import org.corfudb.runtime.view.stream.IStreamView;
+import org.corfudb.runtime.view.stream.ThreadSafeStreamView;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -340,6 +341,11 @@ public class Layout {
 
             @Override
             public IStreamView  getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
+                return new ThreadSafeStreamView(r, streamId, options);
+            }
+
+            @Override
+            public IStreamView getUnsafeStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
                 return new BackpointerStreamView(r, streamId, options);
             }
 
@@ -377,7 +383,12 @@ public class Layout {
             }
 
             @Override
-            public IStreamView getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
+            public IStreamView  getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
+                return new ThreadSafeStreamView(r, streamId, options);
+            }
+
+            @Override
+            public IStreamView getUnsafeStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
                 return new BackpointerStreamView(r, streamId, options);
             }
 
@@ -439,6 +450,12 @@ public class Layout {
             }
 
             @Override
+            public IStreamView getUnsafeStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
+                throw new UnsupportedOperationException("Stream view used without a"
+                        + " replication mode");
+            }
+
+            @Override
             public ClusterStatus getClusterHealthForSegment(LayoutSegment layoutSegment,
                                                             Set<String> responsiveNodes) {
                 throw new UnsupportedOperationException("Unsupported cluster health check.");
@@ -464,6 +481,8 @@ public class Layout {
         public abstract int getMinReplicationFactor(Layout layout, LayoutStripe stripe);
 
         public abstract IStreamView getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options);
+
+        public abstract IStreamView getUnsafeStreamView(CorfuRuntime r, UUID streamId, StreamOptions options);
 
         public IReplicationProtocol getReplicationProtocol(CorfuRuntime r) {
             throw new UnsupportedOperationException();

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -2,12 +2,15 @@ package org.corfudb.runtime.view;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.wireprotocol.ILogData;
@@ -20,6 +23,8 @@ import org.corfudb.runtime.exceptions.AppendException;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.object.CorfuCompileProxy;
+import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.Utils;
@@ -36,6 +41,9 @@ public class StreamsView extends AbstractView {
      */
     public static final String CHECKPOINT_SUFFIX = "_cp";
 
+    @Getter
+    Map<UUID, IStreamView> streamCache = new ConcurrentHashMap<>();
+
     public StreamsView(final CorfuRuntime runtime) {
         super(runtime);
     }
@@ -51,14 +59,45 @@ public class StreamsView extends AbstractView {
     }
 
     /**
+     * Since streams can also be used by higher level abstractions, some consumers implement
+     * synchronization at a higher level, so the stream implementation doesn't have to
+     * be thread-safe. Also, gc will not be called on unsafe streams therefore gc needs to
+     * be managed by the consumer.
+     *
+     * @param stream stream id
+     * @return an unsafe (not thread safe) stream implementation
+     */
+    public IStreamView getUnsafe(UUID stream) {
+        return this.getUnsafe(stream, StreamOptions.DEFAULT);
+    }
+
+    /**
      * Get a view on a stream. The view has its own pointer to the stream.
      *
      * @param stream The UUID of the stream to get a view on.
      * @return A view
      */
     public IStreamView get(UUID stream, StreamOptions options) {
+        return streamCache.computeIfAbsent(stream, id -> runtime.getLayoutView().getLayout().getLatestSegment()
+                .getReplicationMode().getStreamView(runtime, id, options));
+    }
+
+    public IStreamView getUnsafe(UUID stream, StreamOptions options) {
         return runtime.getLayoutView().getLayout().getLatestSegment()
-                .getReplicationMode().getStreamView(runtime, stream, options);
+                .getReplicationMode().getUnsafeStreamView(runtime, stream, options);
+    }
+
+    /**
+     * Run garbage collection on all opened streams. Note that opened
+     * unsafe streams will be excluded (because its unsafe for the garbage
+     * collector thread to operate on them while being used by a different
+     * thread).
+     *
+     */
+    public void gc(long trimMark) {
+        for (IStreamView streamView : getStreamCache().values()) {
+            streamView.gc(trimMark);
+        }
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
@@ -454,6 +455,11 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                 d -> BackpointerOp.INCLUDE);
 
         return ! context.readCpQueue.isEmpty() || !context.readQueue.isEmpty();
+    }
+
+    @VisibleForTesting
+    AbstractQueuedStreamView.QueuedStreamContext getContext() {
+        return this.baseContext;
     }
 }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/ThreadSafeStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/ThreadSafeStreamView.java
@@ -1,0 +1,106 @@
+package org.corfudb.runtime.view.stream;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.StreamOptions;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+
+/**
+ * A thread-safe implementation of IStreamView.
+ *
+ * Created by Maithem on 11/30/18.
+ */
+
+public class ThreadSafeStreamView implements IStreamView {
+
+    private final BackpointerStreamView stream;
+
+    public ThreadSafeStreamView(final CorfuRuntime runtime,
+                                 final UUID streamId,
+                                 @Nonnull final StreamOptions options) {
+        stream = new BackpointerStreamView(runtime, streamId, options);
+    }
+
+    public ThreadSafeStreamView(final CorfuRuntime runtime,
+                                 final UUID streamId) {
+        stream = new BackpointerStreamView(runtime, streamId, StreamOptions.DEFAULT);
+    }
+
+    @Override
+    public UUID getId() {
+        return stream.getId();
+    }
+
+    @Override
+    public synchronized void reset() {
+        stream.reset();
+    }
+
+    @Override
+    public synchronized void gc(long trimMark) {
+        stream.gc(trimMark);
+    }
+
+    @Override
+    public synchronized void seek(long globalAddress) {
+        stream.seek(globalAddress);
+    }
+
+    @Override
+    public synchronized long find(long globalAddress, SearchDirection direction) {
+        return stream.find(globalAddress, direction);
+    }
+
+    @Override
+    public synchronized long append(Object object,
+                Function<TokenResponse, Boolean> acquisitionCallback,
+                Function<TokenResponse, Boolean> deacquisitionCallback) {
+        return stream.append(object, acquisitionCallback, deacquisitionCallback);
+    }
+
+    @Override
+    public synchronized ILogData next() {
+        return stream.next();
+    }
+
+    @Override
+    public synchronized ILogData previous() {
+        return stream.previous();
+    }
+
+    @Override
+    public synchronized ILogData current() {
+        return stream.current();
+    }
+
+    @Override
+    public synchronized ILogData nextUpTo(long maxGlobal) {
+        return stream.nextUpTo(maxGlobal);
+    }
+
+    @Override
+    public synchronized List<ILogData> remainingUpTo(long maxGlobal) {
+        return stream.remainingUpTo(maxGlobal);
+    }
+
+    @Override
+    public synchronized boolean hasNext() {
+        return stream.hasNext();
+    }
+
+    @Override
+    public synchronized long getCurrentGlobalPosition() {
+        return stream.getCurrentGlobalPosition();
+    }
+
+    @VisibleForTesting
+    BackpointerStreamView getUnderlyingStream() {
+        return stream;
+    }
+}


### PR DESCRIPTION
## Overview
Made all raw streams (i.e. streams that are not consumed by the VLO)
thread-safe and extended the garbage collection process to include
the CorfuRuntime::StreamView.

Why should this be merged: Fixes memory leaks created by streams that don't belong to SMRObjects (i.e. transaction stream and any stream created by the CorfuRuntime consumer directly). 

Related issue(s) (if applicable): #1573


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
