### PR TITLE
ADDRESSPACE FIX

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -21,6 +21,8 @@ import org.corfudb.protocols.logprotocol.MultiSMREntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.runtime.collections.CMap;
+import org.corfudb.runtime.collections.TNode;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CMap.java
@@ -1,0 +1,22 @@
+package org.corfudb.runtime.collections;
+
+import org.corfudb.annotations.Accessor;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+/**
+ * Created by box on 1/25/18.
+ */
+public interface CMap<K, V> extends Map<K, V>{
+    @Accessor
+    public @Nonnull
+    default TNode<K, V>[] getEntries() {
+        TNode<K, V>[] nodes = new TNode[size()];
+        int i = 0;
+        for (Map.Entry<K, V> entry : entrySet()) {
+            nodes[i++] = new TNode<>(entry.getKey(), entry.getValue());
+        }
+        return nodes;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ICorfuMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ICorfuMap.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 public interface ICorfuMap<K, V>
-    extends Map<K, V> {
+    extends Map<K, V>, CMap<K, V> {
 
     /** Insert a key-value pair into a map, overwriting any previous mapping.
      *

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -14,7 +14,7 @@ import org.corfudb.annotations.MutatorAccessor;
  */
 @Deprecated // TODO: Add replacement method that conforms to style
 @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
-public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
+public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject, CMap<K, V> {
 
     /**
      * {@inheritDoc}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TNode.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TNode.java
@@ -1,0 +1,12 @@
+package org.corfudb.runtime.collections;
+
+import lombok.Data;
+
+/**
+ * Created by Maithem on 1/25/18.
+ */
+@Data
+public class TNode<K, V> {
+    final  K k;
+    final V v;
+}

--- a/runtime/src/main/java/org/corfudb/util/LRU.java
+++ b/runtime/src/main/java/org/corfudb/util/LRU.java
@@ -1,0 +1,156 @@
+package org.corfudb.util;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.ILogData;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
+
+/**
+ * Created by Maithem on 1/7/18.
+ */
+@Slf4j
+public class LRU {
+    Map<Long, CacheEntry> map = new ConcurrentHashMap();
+
+    ReadWriteLock rwLock = new ReentrantReadWriteLock();
+
+    AtomicLong currentTimestamp = new AtomicLong(0l);
+
+    Function<Long, ILogData> loadKey;
+
+    Function<Iterable<Long>, Map<Long, ILogData>> loadKeys;
+
+    int cacheSize;
+
+    public LRU(int size, Function<Long, ILogData> loadKey, Function<Iterable<Long>, Map<Long, ILogData>> loadKeys) {
+        this.cacheSize = size;
+        this.loadKey = loadKey;
+        this.loadKeys = loadKeys;
+    }
+
+    public void invalidateAll() {
+        try {
+            rwLock.writeLock().lock();
+            map.clear();
+        } finally {
+            rwLock.writeLock().unlock();
+        }
+    }
+
+    @Nonnull
+    ILogData load(@Nonnull Long key) {
+        return loadKey.apply(key);
+    }
+
+    @Nonnull
+    public Map<Long, ILogData> load(@Nonnull Iterable<Long> keys) {
+        return loadKeys.apply(keys);
+    }
+
+    void checkGC() {
+        if (map.size() == cacheSize) {
+            long window = currentTimestamp.get() - (cacheSize / 2);
+            long evicted = 0;
+            for (Map.Entry<Long, CacheEntry> entry : map.entrySet()) {
+                if (entry.getValue().getTimestamp() < window) {
+                    map.remove(entry.getKey());
+                    evicted++;
+                }
+            }
+
+            log.info("checkGC: evicted {} entries", evicted);
+        }
+    }
+
+    void addToCache(@Nonnull Long key, @Nonnull ILogData val) {
+        try {
+            rwLock.writeLock().lock();
+            checkGC();
+            map.put(key, new CacheEntry(currentTimestamp.getAndIncrement(), val));
+        } finally {
+            rwLock.writeLock().unlock();
+        }
+    }
+
+    void addToCache(@Nonnull Map<Long, ILogData> vals) {
+        try {
+            rwLock.writeLock().lock();
+            checkGC();
+            // TODO(Maithem): this can potentially overflow
+            for (Map.Entry<Long, ILogData> entry : vals.entrySet()) {
+                map.put(entry.getKey(), new CacheEntry(currentTimestamp.getAndIncrement(),
+                        entry.getValue()));
+            }
+        } finally {
+            rwLock.writeLock().unlock();
+        }
+    }
+
+    @Nonnull
+    public Map<Long, ILogData> getAll(@Nonnull Iterable<? extends Long> keys) {
+        Set<Long> addressesToLoad = new HashSet<>();
+        Map<Long, ILogData> ret = new HashMap<>();
+
+        for (Long key : keys) {
+            CacheEntry entry = map.get(key);
+            if (entry == null) {
+                addressesToLoad.add(key);
+            } else {
+                ret.put(key,  entry.getVal());
+                try {
+                    rwLock.readLock().lock();
+                    map.put(key, new CacheEntry(currentTimestamp.getAndIncrement(),
+                             entry.getVal()));
+                } finally {
+                    rwLock.readLock().unlock();
+                }
+            }
+        }
+
+        Map<Long, ILogData> loaded = load(addressesToLoad);
+        addToCache(loaded);
+        ret.putAll(loaded);
+        return ret;
+    }
+
+    @CheckForNull
+    public ILogData get(@Nonnull Long key) {
+        CacheEntry v = map.get(key);
+        if (v == null) {
+            ILogData val = load(key);
+            addToCache(key, val);
+            return val;
+        } else {
+            try {
+                rwLock.readLock().lock();
+                // Cache size doesn't change, just update the timestamp
+                // TODO(Maithem) Don't generate new cache entries on every read
+                map.put(key, new CacheEntry(currentTimestamp.getAndIncrement(), v.getVal()));
+                return v.getVal();
+            } finally {
+                rwLock.readLock().unlock();
+            }
+        }
+    }
+
+    public void put(@Nonnull Long key, @Nonnull ILogData val) {
+        addToCache(key, val);
+    }
+
+    @Data
+    class CacheEntry {
+        final long timestamp;
+        final ILogData val;
+    }
+}


### PR DESCRIPTION
## Overview


On very large maps the checkpointing thread competes with other threads
that try to access the VLO as a result response times can be on the
magnitude of minutes.
Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
