### PR TITLE
Cleanup seq cache before setting maxConflictWildcard.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -421,10 +421,12 @@ public class SequencerServer extends AbstractServer {
         // Note, this is correct, but conservative (may lead to false abort).
         // It is necessary because we reset the sequencer.
         if (!bootstrapWithoutTailsUpdate) {
+            // Evict all entries from the cache. This eviction triggers the callback modifying the maxConflictWildcard.
+            conflictToGlobalTailCache.cleanUp();
+
             globalLogTail.set(initialToken);
             maxConflictWildcard = initialToken - 1;
             maxConflictNewSequencer = maxConflictWildcard;
-            conflictToGlobalTailCache.invalidateAll();
 
             // Clear the existing map as it could have been populated by an earlier reset.
             streamTailToGlobalTailMap.clear();


### PR DESCRIPTION
## Overview

Description: Cleanup sequencer cache before we set the new bootstrapped values on the sequencer.

Why should this be merged: The invalidate cache is async and is not same as cache eviction. The Eviction should take place before the value of maxConflictWildcard is set.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
