### PR TITLE
peekUntilHoleFillRequired Lambda Bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
@@ -59,7 +59,7 @@ public class ReadWaitHoleFillPolicy implements IHoleFillPolicy {
         final AtomicLong startTime = new AtomicLong();
 
         try {
-            IRetry.build(ExponentialBackoffRetry.class, RetryExhaustedException.class, () -> {
+            return IRetry.build(ExponentialBackoffRetry.class, RetryExhaustedException.class, () -> {
 
                 // Try the read
                 ILogData data = peekFunction.apply(address);


### PR DESCRIPTION
The result of the peek function is not propagated to the
peekUntilHoleFillRequired, which results in throwing a
HoleFillRequiredException on every cache miss.

## Overview

Description:

Why should this be merged: Improves performance for reads that results in a cache miss. 

Related issue(s) (if applicable): #1612


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
