### PR TITLE
Simplify shutdown checks in AbstractServer

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -14,9 +14,7 @@ import java.util.concurrent.ExecutorService;
 @Slf4j
 public abstract class AbstractServer {
 
-    @Getter
-    @Setter
-    volatile boolean shutdown;
+    private volatile boolean shutdown;
 
     public AbstractServer() {
         shutdown = false;
@@ -51,6 +49,11 @@ public abstract class AbstractServer {
      * @param r   The router that took in the message.
      */
     public void handleMessage(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+        if (shutdown) {
+            log.warn("Server received {} but is already shutdown.", msg.getMsgType().toString());
+            return;
+        }
+
         if (!getHandler().handle(msg, ctx, r)) {
             log.warn("Received unhandled message type {}", msg.getMsgType());
         }
@@ -62,7 +65,7 @@ public abstract class AbstractServer {
      * Shutdown the server.
      */
     public void shutdown() {
-        setShutdown(true);
+        shutdown = true;
         getExecutor().shutdownNow();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
@@ -217,11 +217,6 @@ public class CorfuMsgHandler {
         // Register the handler. Depending on metrics collection configuration by MetricsUtil,
         // handler will be instrumented by the metrics context.
         return (msg, ctx, r) -> {
-            if (server.isShutdown()) {
-                log.warn("Server received {} but is shutdown.", msg.getMsgType().toString());
-                return;
-            }
-
             if (!server.isServerReadyToHandleMsg(msg)) {
                 r.sendResponse(ctx, msg, CorfuMsgType.NOT_READY.msg());
                 return;

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/AbstractServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/AbstractServerTest.java
@@ -1,0 +1,35 @@
+package org.corfudb.infrastructure;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.netty.channel.ChannelHandlerContext;
+import org.corfudb.protocols.wireprotocol.CorfuMsg;
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.junit.Test;
+
+public class AbstractServerTest {
+
+    @Test
+    public void testShutdown() {
+        final CorfuMsgHandler handler = mock(CorfuMsgHandler.class);
+
+        AbstractServer server = new AbstractServer() {
+            @Override
+            public CorfuMsgHandler getHandler() {
+                return handler;
+            }
+        };
+
+        server.shutdown();
+
+        server.handleMessage(
+                new CorfuMsg(CorfuMsgType.WRITE),
+                mock(ChannelHandlerContext.class),
+                mock(IServerRouter.class)
+        );
+
+        verify(handler, times(0));
+    }
+}

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/CorfuAbstractServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/CorfuAbstractServerTest.java
@@ -9,16 +9,27 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.junit.Test;
 
-public class AbstractServerTest {
+import java.util.concurrent.ExecutorService;
 
+public class CorfuAbstractServerTest {
+
+    /**
+     * Check that handler is not executed if the server  is in shutdown state.
+     */
     @Test
     public void testShutdown() {
         final CorfuMsgHandler handler = mock(CorfuMsgHandler.class);
+        final ExecutorService executor = mock(ExecutorService.class);
 
         AbstractServer server = new AbstractServer() {
             @Override
             public CorfuMsgHandler getHandler() {
                 return handler;
+            }
+
+            @Override
+            public ExecutorService getExecutor() {
+                return executor;
             }
         };
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -36,12 +36,6 @@
             <version>${logback.classic.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
@@ -121,7 +121,6 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         m.setBackpointerMap(Collections.emptyMap());
         sendMessage(u1, CorfuMsgType.WRITE.payloadMsg(m));
         sendMessage(u2, CorfuMsgType.WRITE.payloadMsg(m));
-        u2.setShutdown(true);
         u2.shutdown();
 
         LogUnitServerAssertions.assertThat(u0)


### PR DESCRIPTION
## Overview

Description:
Simplify shutdown checks in AbstractServer

Why should this be merged: 
It makes shutdown checks easier to understand
AbstractServer doesn't expose internal state which makes it more reliable

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
