### PR TITLE
StreamView Bug Fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -145,6 +145,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         this.serializer = serializer;
 
         // Since the VLO is thread safe we don't need to use a thread safe stream implementation
+        // because the VLO will control access to the stream
         underlyingObject = new VersionLockedObject<T>(this::getNewInstance,
                 new StreamViewSMRAdapter(rt, rt.getStreamsView().getUnsafe(streamID)),
                 upcallTargetMap, undoRecordTargetMap,


### PR DESCRIPTION
## Overview
Fixes a bug in the stream view where when iterating backwards,
the stream pointer gets stuck at incorrect positions, which
triggers a NoRollBackException that causes a complete object
rebuild.

Why should this be merged: Improves performance for some pathological access patterns by 20x +

Related issue(s) (if applicable): #1625


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
