### PR TITLE
Remove Parse Trimming Logic

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -104,23 +104,6 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
     }
 
     /**
-     * Trim an address from the log.
-     *
-     * @param address log address to trim
-     * @param epoch   Epoch at which the trim operation is received.
-     */
-    public void trim(@Nonnull long address, @Nonnull long epoch) {
-        try {
-            CompletableFuture<Void> cf = new CompletableFuture();
-            operationsQueue.add(new BatchWriterOperation(BatchWriterOperation.Type.TRIM,
-                    address, null, epoch, null, cf));
-            cf.get();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
      * Trim addresses from log up to a prefix.
      *
      * @param address prefix address to trim to (inclusive)
@@ -259,10 +242,6 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                 } else {
                     try {
                         switch (currOp.getType()) {
-                            case TRIM:
-                                streamLog.trim(currOp.getAddress());
-                                res.add(currOp);
-                                break;
                             case PREFIX_TRIM:
                                 streamLog.prefixTrim(currOp.getAddress());
                                 res.add(currOp);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriterOperation.java
@@ -17,7 +17,6 @@ public class BatchWriterOperation {
         SHUTDOWN,
         WRITE,
         RANGE_WRITE,
-        TRIM,
         PREFIX_TRIM,
         SEAL,
         RESET,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -223,14 +223,6 @@ public class LogUnitServer extends AbstractServer {
         }
     }
 
-    @ServerHandler(type = CorfuMsgType.TRIM)
-    private void trim(CorfuPayloadMsg<TrimRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
-        TrimRequest req = msg.getPayload();
-        batchWriter.trim(req.getAddress().getSequence(), req.getAddress().getEpoch());
-        //TODO(Maithem): should we return an error if the write fails
-        r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
-    }
-
     @ServerHandler(type = CorfuMsgType.PREFIX_TRIM)
     private void prefixTrim(CorfuPayloadMsg<TrimRequest> msg, ChannelHandlerContext ctx,
                             IServerRouter r) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -102,11 +102,6 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
     }
 
     @Override
-    public synchronized void trim(long address) {
-        trimmed.add(address);
-    }
-
-    @Override
     public LogData read(long address) {
         if (isTrimmed(address)) {
             return LogData.getTrimmed(address);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/SegmentHandle.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/SegmentHandle.java
@@ -32,12 +32,6 @@ class SegmentHandle {
     final FileChannel readChannel;
 
     @NonNull
-    final FileChannel trimmedChannel;
-
-    @NonNull
-    final FileChannel pendingTrimChannel;
-
-    @NonNull
     String fileName;
 
     private final Map<Long, AddressMetaData> knownAddresses = new ConcurrentHashMap<>();
@@ -59,7 +53,7 @@ class SegmentHandle {
 
     public void close() {
         Set<FileChannel> channels = new HashSet<>(
-                Arrays.asList(writeChannel, readChannel, trimmedChannel, pendingTrimChannel)
+                Arrays.asList(writeChannel, readChannel)
         );
 
         for (FileChannel channel : channels) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -39,12 +39,6 @@ public interface StreamLog {
     LogData read(long address);
 
     /**
-     * Mark a StreamLog address as trimmed.
-     * @param address  address to trim from the log
-     */
-    void trim(long address);
-
-    /**
      * Prefix trim the global log.
      * @param address address to trim the log up to
      */

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -57,7 +57,6 @@ public enum CorfuMsgType {
     READ_REQUEST(31, new TypeToken<CorfuPayloadMsg<ReadRequest>>() {}),
     READ_RESPONSE(32, new TypeToken<CorfuPayloadMsg<ReadResponse>>() {}),
     MULTIPLE_READ_REQUEST(35, new TypeToken<CorfuPayloadMsg<MultipleReadRequest>>() {}),
-    TRIM(33, new TypeToken<CorfuPayloadMsg<TrimRequest>>() {}),
     FILL_HOLE(34, new TypeToken<CorfuPayloadMsg<FillHoleRequest>>() {}),
     PREFIX_TRIM(38, new TypeToken<CorfuPayloadMsg<TrimRequest>>() {}),
     TAIL_REQUEST(41, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -229,14 +229,6 @@ public class LogUnitClient extends AbstractClient {
         return sendMessageWithFuture(CorfuMsgType.TRIM_MARK_REQUEST.msg());
     }
 
-    /**
-     * Send a hint to the logging unit that a stream can be trimmed.
-     *
-     * @param prefix The prefix of the stream, as a global physical offset, to trim.
-     */
-    public void trim(Token prefix) {
-        sendMessage(CorfuMsgType.TRIM.payloadMsg(new TrimRequest(prefix)));
-    }
 
     /**
      * Send a prefix trim request that will trim the log up to a certian address


### PR DESCRIPTION
## Overview
We currently only support prefix trimming, removed all the logic
related to sparse trimming, which will also prevent the related
metadata files from being created.

Why should this be merged: Prevents unnecessary metadata from being generated. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
