### PR TITLE
Ignore intermittent failing test

### DIFF
--- a/it/src/test/java/org/corfudb/universe/scenario/NodeUpAndPartitionedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/NodeUpAndPartitionedIT.java
@@ -13,6 +13,7 @@ import org.corfudb.universe.group.cluster.CorfuCluster;
 import org.corfudb.universe.node.client.CorfuClient;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.corfudb.util.Sleep;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -40,6 +41,7 @@ public class NodeUpAndPartitionedIT extends GenericIntegrationTest {
      * 5) Verify that the restarted unresponsive node in step 3 gets healed
      * 6) Verify cluster status and data path
      */
+    @Ignore("Fix timeouts on travis")
     @Test(timeout = 300000)
     public void nodeUpAndPartitionedTest() {
         getScenario().describe((fixture, testCase) -> {


### PR DESCRIPTION
## Overview

Description:
The test NodeUpAndPartitioned is failing intermittently but frequently.  Suggesting to ignore until the underlying timeout on travis is addressed. 

Why should this be merged: 
Avoid intermittent failing test slows down unrelated checkins.

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
