### PR TITLE
Reduce number of objects during copy layout

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -315,13 +315,12 @@ public class Layout {
      * @param layout layout to copy
      */
     public Layout(@Nonnull Layout layout) {
-        Layout layoutCopy = parser.fromJson(layout.asJSONString(), Layout.class);
-        this.layoutServers = layoutCopy.getLayoutServers();
-        this.sequencers = layoutCopy.getSequencers();
-        this.segments = layoutCopy.getSegments();
-        this.unresponsiveServers = layoutCopy.getUnresponsiveServers();
-        this.epoch = layoutCopy.getEpoch();
-        this.clusterId = layoutCopy.clusterId;
+        this.layoutServers = new ArrayList<>(layout.getLayoutServers());
+        this.sequencers = new ArrayList<>(layout.getSequencers());
+        this.segments = new ArrayList<>(layout.getSegments());
+        this.unresponsiveServers = new ArrayList<>(layout.getUnresponsiveServers());
+        this.epoch = layout.getEpoch();
+        this.clusterId = layout.clusterId;
     }
 
     public enum ReplicationMode {


### PR DESCRIPTION
## Overview

Description:
Fix copy constructor for a layout, reduce the number of objects created during the copy operation.

Current version:
 - transforms an object into a json string, which is a pretty expensive operation
 - parses json string and creates an object, which is a pretty expensive operation, it includes `reflection` to create an object.
 - reassign all internal collections to the current object from created copy.

New version:
 - use copy constructors for all internal collections and assign it to the current object. 

Why should this be merged: 
Makes code more simple, increases performance (do not need to parse to json and vise versa), don't generate trash objects

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
