### PR TITLE
Get Cluster Status API

### DIFF
--- a/it/src/test/java/org/corfudb/universe/scenario/OneNodeDownIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/OneNodeDownIT.java
@@ -1,5 +1,13 @@
 package org.corfudb.universe.scenario;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.universe.scenario.ScenarioUtils.waitForUnresponsiveServersChange;
+import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_STREAM_NAME;
+import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_TABLE_ITER;
+
+import java.time.Duration;
+import java.util.Map;
+
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.view.ClusterStatusReport;
 import org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
@@ -11,14 +19,6 @@ import org.corfudb.universe.node.client.CorfuClient;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.corfudb.util.Sleep;
 import org.junit.Test;
-
-import java.time.Duration;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.corfudb.universe.scenario.ScenarioUtils.waitForUnresponsiveServersChange;
-import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_STREAM_NAME;
-import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_TABLE_ITER;
 
 public class OneNodeDownIT extends GenericIntegrationTest {
 
@@ -59,7 +59,7 @@ public class OneNodeDownIT extends GenericIntegrationTest {
                 ClusterStatusReport clusterStatusReport = corfuClient.getManagementView().getClusterStatus();
                 assertThat(clusterStatusReport.getClusterStatus()).isEqualTo(ClusterStatus.DEGRADED);
 
-                Map<String, NodeStatus> statusMap = clusterStatusReport.getClientServerConnectivityStatusMap();
+                Map<String, NodeStatus> statusMap = clusterStatusReport.getClusterNodeStatusMap();
                 assertThat(statusMap.get(server0.getEndpoint())).isEqualTo(NodeStatus.DOWN);
 
                 // Verify data path working fine

--- a/it/src/test/java/org/corfudb/universe/scenario/OneNodePausedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/OneNodePausedIT.java
@@ -1,5 +1,14 @@
 package org.corfudb.universe.scenario;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
+import static org.corfudb.universe.scenario.ScenarioUtils.waitForUnresponsiveServersChange;
+import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_STREAM_NAME;
+import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_TABLE_ITER;
+
+import java.time.Duration;
+import java.util.Map;
+
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.view.ClusterStatusReport;
 import org.corfudb.runtime.view.ClusterStatusReport.NodeStatus;
@@ -10,15 +19,6 @@ import org.corfudb.universe.node.client.CorfuClient;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.corfudb.util.Sleep;
 import org.junit.Test;
-
-import java.time.Duration;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
-import static org.corfudb.universe.scenario.ScenarioUtils.waitForUnresponsiveServersChange;
-import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_STREAM_NAME;
-import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_TABLE_ITER;
 
 public class OneNodePausedIT extends GenericIntegrationTest {
 
@@ -57,7 +57,7 @@ public class OneNodePausedIT extends GenericIntegrationTest {
                 // Verify cluster status is DEGRADED with one node down
                 ClusterStatusReport clusterStatusReport = corfuClient.getManagementView().getClusterStatus();
                 assertThat(clusterStatusReport.getClusterStatus()).isEqualTo(ClusterStatus.DEGRADED);
-                Map<String, NodeStatus> statusMap = clusterStatusReport.getClientServerConnectivityStatusMap();
+                Map<String, NodeStatus> statusMap = clusterStatusReport.getClusterNodeStatusMap();
                 assertThat(statusMap.get(server1.getEndpoint())).isEqualTo(NodeStatus.DOWN);
 
                 // Verify data path working fine

--- a/it/src/test/java/org/corfudb/universe/scenario/TwoNodesDownIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/TwoNodesDownIT.java
@@ -1,7 +1,20 @@
 package org.corfudb.universe.scenario;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
+import static org.corfudb.universe.scenario.ScenarioUtils.waitForClusterDown;
+import static org.corfudb.universe.scenario.ScenarioUtils.waitForLayoutChange;
+import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_STREAM_NAME;
+import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_TABLE_ITER;
+
+import java.time.Duration;
+import java.util.Map;
+
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.view.ClusterStatusReport;
+import org.corfudb.runtime.view.ClusterStatusReport.ClusterStatusReliability;
+import org.corfudb.runtime.view.ClusterStatusReport.ConnectivityStatus;
+import org.corfudb.runtime.view.ClusterStatusReport.NodeStatus;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.universe.GenericIntegrationTest;
 import org.corfudb.universe.group.cluster.CorfuCluster;
@@ -9,17 +22,6 @@ import org.corfudb.universe.node.client.CorfuClient;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.corfudb.util.Sleep;
 import org.junit.Test;
-
-import java.time.Duration;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
-import static org.corfudb.runtime.view.ClusterStatusReport.NodeStatus;
-import static org.corfudb.universe.scenario.ScenarioUtils.waitForClusterDown;
-import static org.corfudb.universe.scenario.ScenarioUtils.waitForLayoutChange;
-import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_STREAM_NAME;
-import static org.corfudb.universe.scenario.fixture.Fixtures.TestFixtureConst.DEFAULT_TABLE_ITER;
 
 public class TwoNodesDownIT extends GenericIntegrationTest {
 
@@ -56,11 +58,17 @@ public class TwoNodesDownIT extends GenericIntegrationTest {
                 // Verify cluster status is UNAVAILABLE with two node down and one node up
                 corfuClient.invalidateLayout();
                 ClusterStatusReport clusterStatusReport = corfuClient.getManagementView().getClusterStatus();
-                Map<String, NodeStatus> statusMap = clusterStatusReport.getClientServerConnectivityStatusMap();
-                assertThat(statusMap.get(server0.getEndpoint())).isEqualTo(NodeStatus.UP);
-                assertThat(statusMap.get(server1.getEndpoint())).isEqualTo(NodeStatus.DOWN);
-                assertThat(statusMap.get(server2.getEndpoint())).isEqualTo(NodeStatus.DOWN);
+                Map<String, NodeStatus> nodeStatusMap = clusterStatusReport.getClusterNodeStatusMap();
+                Map<String, ConnectivityStatus> connectivityStatusMap = clusterStatusReport.getClientServerConnectivityStatusMap();
+                ClusterStatusReliability reliability = clusterStatusReport.getClusterStatusReliability();
+                assertThat(connectivityStatusMap.get(server0.getEndpoint())).isEqualTo(ConnectivityStatus.RESPONSIVE);
+                assertThat(connectivityStatusMap.get(server1.getEndpoint())).isEqualTo(ConnectivityStatus.UNRESPONSIVE);
+                assertThat(connectivityStatusMap.get(server2.getEndpoint())).isEqualTo(ConnectivityStatus.UNRESPONSIVE);
+                assertThat(nodeStatusMap.get(server0.getEndpoint())).isEqualTo(NodeStatus.NA);
+                assertThat(nodeStatusMap.get(server1.getEndpoint())).isEqualTo(NodeStatus.NA);
+                assertThat(nodeStatusMap.get(server2.getEndpoint())).isEqualTo(NodeStatus.NA);
                 assertThat(clusterStatusReport.getClusterStatus()).isEqualTo(ClusterStatus.UNAVAILABLE);
+                assertThat(reliability).isEqualTo(ClusterStatusReliability.WEAK_NO_QUORUM);
 
                 // Wait for failure detector finds cluster is down before recovering
                 waitForClusterDown(table);

--- a/runtime/src/main/java/org/corfudb/runtime/view/ClusterStatusReport.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ClusterStatusReport.java
@@ -32,7 +32,15 @@ public class ClusterStatusReport {
         /**
          * Node is not reachable.
          */
-        DOWN
+        DOWN,
+
+        /**
+         * Whenever the state of a node cannot be determined.
+         * If a client looses connection to all nodes
+         * it is wrong to report them DOWN, nodes might be up and clients are unable
+         * to connect.
+         */
+        NA;
     }
 
     /**
@@ -46,14 +54,20 @@ public class ClusterStatusReport {
         STABLE(0),
 
         /**
+         * The cluster is operational but one or several nodes are syncing in the background.
+         * i.e., (replica catch up)
+         */
+        DB_SYNCING(1),
+
+        /**
          * The cluster is operational but working with reduced redundancy.
          */
-        DEGRADED(1),
+        DEGRADED(2),
 
         /**
          * The cluster is not operational.
          */
-        UNAVAILABLE(2);
+        UNAVAILABLE(3);
 
         @Getter
         final int healthValue;
@@ -64,17 +78,71 @@ public class ClusterStatusReport {
     }
 
     /**
+     * Represents the connectivity status of this runtime to a node.
+     */
+    public enum ConnectivityStatus {
+        /**
+         * The node responds to pings from client.
+         */
+        RESPONSIVE(true),
+
+        /**
+         * The node does not respond to pings from client.
+         */
+        UNRESPONSIVE(false);
+
+        @Getter
+        final boolean ping;
+
+        ConnectivityStatus(boolean ping) {
+            this.ping = ping;
+        }
+    }
+
+    /**
+     * Represents the sources for cluster status computation.
+     * This aims to provide an indicative of status reliability.
+     */
+    public enum ClusterStatusReliability {
+        /**
+         * Cluster Status reported based on quorum.
+         */
+        STRONG_QUORUM,
+
+        /**
+         * Cluster Status reported based on highest layout in the system.
+         */
+        WEAK_NO_QUORUM,
+
+        /**
+         * Unavailable, whenever communication fails to ALL nodes, the source of reliability is
+         * not available.
+         */
+        UNAVAILABLE
+    }
+
+    /**
      * Layout at which the report was generated.
      */
     private final Layout layout;
 
     /**
-     * Map of connectivity of the report generator client to the cluster nodes.
-     */
-    private final Map<String, NodeStatus> clientServerConnectivityStatusMap;
-
-    /**
      * Cluster health.
      */
     private final ClusterStatus clusterStatus;
+
+    /**
+     * Cluster Status Reliability (source of information)
+     */
+    private final ClusterStatusReliability clusterStatusReliability;
+
+    /**
+     * Individual Node Status (within cluster view).
+     */
+    private final Map<String, NodeStatus> clusterNodeStatusMap;
+
+    /**
+     * Map of connectivity of the client to the each cluster node.
+     */
+    private final Map<String, ConnectivityStatus> clientServerConnectivityStatusMap;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
@@ -1,18 +1,15 @@
 package org.corfudb.runtime.view;
 
-import com.google.common.collect.Sets;
-
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -21,8 +18,6 @@ import javax.annotation.Nonnull;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
-import org.corfudb.protocols.wireprotocol.ClusterState;
-import org.corfudb.protocols.wireprotocol.NodeState;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.IClientRouter;
 import org.corfudb.runtime.clients.LayoutClient;
@@ -30,8 +25,9 @@ import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.WorkflowException;
 import org.corfudb.runtime.exceptions.WorkflowResultUnknownException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
+import org.corfudb.runtime.view.ClusterStatusReport.ClusterStatusReliability;
+import org.corfudb.runtime.view.ClusterStatusReport.ConnectivityStatus;
 import org.corfudb.runtime.view.ClusterStatusReport.NodeStatus;
 import org.corfudb.runtime.view.Layout.LayoutSegment;
 import org.corfudb.runtime.view.workflows.AddNode;
@@ -175,7 +171,7 @@ public class ManagementView extends AbstractView {
         // stateTransfer and is in process of achieving full redundancy.
         ClusterStatus logUnitRedundancyStatus = peerResponsiveNodes.stream()
                 .anyMatch(s -> getLogUnitNodeStatusInLayout(layout, s) == NodeStatus.DB_SYNCING)
-                ? ClusterStatus.DEGRADED : ClusterStatus.STABLE;
+                ? ClusterStatus.DB_SYNCING : ClusterStatus.STABLE;
         // Check the availability of the log servers in all segments as reads to all addresses
         // should be accessible.
         ClusterStatus logunitClusterStatus = layout.getSegments().stream()
@@ -215,84 +211,6 @@ public class ManagementView extends AbstractView {
     }
 
     /**
-     * Prunes out the unresponsive nodes as seen by the Management Agents on the Corfu nodes.
-     *
-     * @param layout           Layout based on which the health is analyzed.
-     * @param clusterStatusMap Map of clusterStatus from the ManagementAgents.
-     * @return Set of responsive servers as seen by the Corfu cluster nodes.
-     */
-    private Set<String> filterResponsiveNodes(Layout layout, Map<String, ClusterState> clusterStatusMap) {
-
-        // Using the peer views from the nodes to determine health of the cluster.
-        // First all nodes are added to the set. All are assumed to be responsive.
-        Set<String> peerResponsiveNodes = new HashSet<>(layout.getAllServers());
-        // Truncates all nodes which did not respond to the Heartbeat request.
-        peerResponsiveNodes.retainAll(clusterStatusMap.keySet());
-        // Filter out all nodes which are not reachable by the cluster nodes.
-        clusterStatusMap.forEach((endpoint, clusterStatus) -> clusterStatus.getNodeStatusMap()
-                // For each clusterState we are only interested in the nodeState of the polling endpoint.
-                // In node X's cluster state we fetch node X's node state and so on.
-                .getOrDefault(endpoint, NodeState.getDefaultNodeState(NodeLocator.parseString(endpoint)))
-                .getConnectivityStatus().entrySet().stream()
-                // Filter out all unreachable nodes from each node state's connectivity view.
-                .filter(entry -> !entry.getValue())
-                .map(Entry::getKey)
-                // Remove all the unreachable nodes from the set of all nodes.
-                .forEach(peerResponsiveNodes::remove));
-        // Filter out the unresponsive servers in the layout.
-        layout.getUnresponsiveServers().forEach(peerResponsiveNodes::remove);
-        return peerResponsiveNodes;
-    }
-
-    /**
-     * Attempts to fetch the layout with the highest epoch.
-     * This does not consume the corfu runtime layout as that can get stuck in an infinite retry
-     * loop.
-     *
-     * @param layoutServers Layout Servers to fetch the layout from.
-     * @return Latest layout from the servers or null if none of them responded with a layout.
-     */
-    private Layout getHighestEpochLayout(List<String> layoutServers) {
-        Layout layout = null;
-        Map<String, CompletableFuture<Layout>> layoutFuturesMap = new HashMap<>();
-        // Get layout futures for layout requests to all layout servers.
-        for (String server : layoutServers) {
-            try {
-                // Router creation can throw a NetworkException.
-                IClientRouter router = runtime.getRouter(server);
-                layoutFuturesMap.put(server,
-                        new LayoutClient(router, Layout.INVALID_EPOCH).getLayout());
-            } catch (NetworkException e) {
-                log.error("getClusterStatus: Exception encountered connecting to {}. ",
-                        server, e);
-                CompletableFuture<Layout> cf = new CompletableFuture<>();
-                cf.completeExceptionally(e);
-                layoutFuturesMap.put(server, cf);
-            }
-        }
-
-        // Wait on the Completable futures and retain the layout with the highest epoch.
-        for (Entry<String, CompletableFuture<Layout>> entry : layoutFuturesMap.entrySet()) {
-            try {
-                Layout nodeLayout = entry.getValue().get();
-                log.debug("Server:{} responded with: {}", entry.getKey(), nodeLayout);
-
-                if (layout == null || nodeLayout.getEpoch() > layout.getEpoch()) {
-                    layout = nodeLayout;
-                }
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                throw new UnrecoverableCorfuInterruptedError(ie);
-            } catch (ExecutionException ee) {
-                log.error("getClusterStatus: Error while fetching layout from {}.",
-                        entry.getKey(), ee);
-            }
-        }
-        log.info("getHighestEpochLayout: Layout for cluster status query: {}", layout);
-        return layout;
-    }
-
-    /**
      * Returns a LogUnit Server's status in the layout. It is marked as:
      * UP if it is present in all segments or none of the segments and not in the unresponsive list,
      * NOTE: A node is UP if its not in any of the segments as it might not be a LogUnit component
@@ -320,125 +238,313 @@ public class ManagementView extends AbstractView {
     }
 
     /**
-     * Create node status map.
-     * Assigns a node status to all the nodes in the layout.
-     * UP: If the node is responsive and present in all the segments OR present in none (for cases
-     * where a node is a Layout or Sequencer Server only and does not possess a LogUnit component.)
-     * DB_SYNCING: If the node is present in a few segments but not all. This node is syncing data.
-     * DOWN: If the node is unresponsive.
+     * Get the Cluster Status.
      *
-     * @param layout            Layout used to compute cluster status
-     * @param responsiveServers Set of responsive servers excluding unresponsive Servers list.
-     * @param allServers        All servers in the layout.
-     * @return Map of nodes mapped to their status.
-     */
-    private Map<String, NodeStatus> createNodeStatusMap(Layout layout,
-                                                        Set<String> responsiveServers,
-                                                        Set<String> allServers) {
-        Map<String, NodeStatus> nodeStatusMap = new HashMap<>();
-        for (String server : allServers) {
-            nodeStatusMap.put(server, NodeStatus.DOWN);
-            if (responsiveServers.contains(server)) {
-                nodeStatusMap.put(server, getLogUnitNodeStatusInLayout(layout, server));
-            }
-        }
-        return nodeStatusMap;
-    }
-
-    /**
-     * Gets the cluster status by pinging each node.
-     * These pings are then compared to the layout to decide whether the cluster is:
-     * STABLE, DEGRADED OR UNAVAILABLE.
-     * The report consists of the following:
-     * Layout - at which the report was generated.
-     * ClientServerConnectivityStatusMap - the connectivity status of this client to the cluster.
-     * ClusterStatus - Health of the Corfu cluster.
+     * This is reported as follows:
+     * - (1) The status of the cluster itself (regardless of clients connectivity) as reflected in the
+     *   layout. This information is presented along each node's status (up, down, db_sync).
+     *
+     *   It is important to note that as the cluster state is obtained from the layout,
+     *   when quorum is not available (majority of nodes) there are lower guarantees on the
+     *   reliability of this state.
+     *   For example, in the absence of quorum the system might be in an unstable state which
+     *   cannot converge due to lack of consensus. This is reflected in the
+     *   cluster status report as clusterStatusReliability.
+     *
+     * - (2) The connectivity status of the client to every node in the cluster,
+     *   i.e., can the client connect to the cluster. This will be obtained by
+     *   ping(ing) every node and show as RESPONSIVE, for successful connections or UNRESPONSIVE for
+     *   clients unable to communicate.
+     *
+     *  In this sense a cluster can be STABLE with all nodes UP, while not being available for a
+     *  client, as all connections from the client to the cluster nodes are down, showing in this
+     *  case connectivity status to all nodes as UNRESPONSIVE.
+     *
+     *  The ClusterStatusReport consists of the following:
+     *
+     *  CLUSTER-SPECIFIC STATUS
+     *  - clusterStatus: the cluster status a perceived by the system's layout.
+     *  STABLE, DEGRADED, DB_SYNCING or UNAVAILABLE
+     *  - nodeStatusMap: each node's status as perceived by the system's layout.
+     *  (UP, DOWN or DB_SYNC)
+     *  - Cluster Status Reliability: STRONG_QUORUM, WEAK_NO_QUORUM or UNAVAILABLE
+     *
+     *  CLIENT-CLUSTER SPECIFIC STATUS:
+     *  - clientServerConnectivityStatusMap: the connectivity status of this client to the cluster.
+     *    (RESPONSIVE, UNRESPONSIVE).
      *
      * @return ClusterStatusReport
      */
     public ClusterStatusReport getClusterStatus() {
+        Layout layout;
+        ClusterStatusReliability statusReliability = ClusterStatusReliability.STRONG_QUORUM;
+        List<String> layoutServers = runtime.getLayoutServers().stream()
+                .map(endpoint -> NodeLocator.getLegacyEndpoint(NodeLocator.parseString(endpoint)))
+                .collect(Collectors.toList());
 
-        List<String> layoutServers
-                = new ArrayList<>(runtime.getLayoutServers());
-        Layout layout = getHighestEpochLayout(layoutServers);
+        try {
+            // Obtain Layout from layout servers:
+            //      Attempt to get layout from quorum (majority of nodes),
+            //            ---if we fail to get from quorum----
+            //      we are unable to provide a reliable state of the cluster from the layout,
+            //      therefore, the cluster status is UNAVAILABLE.
 
-        // If layout is null, none of the existing layout servers have a layout.
-        if (layout == null) {
-            return new ClusterStatusReport(null,
-                    layoutServers.stream().collect(Collectors.toMap(
-                            endpoint -> endpoint,
-                            node -> NodeStatus.DOWN)),
-                    ClusterStatus.UNAVAILABLE);
+            // The initial list of layoutServers is obtained from the runtime, this list might
+            // not be complete as it can be based on a a minimum of servers required for bootstrap,
+            // by setting the discoverLayoutServers flag, we request layouts from all available
+            // layout servers present in the actual layout file.
+            Map<String, Layout> layoutMap = getLayouts(layoutServers, true);
+
+            int quorum = runtime.getLayoutView().getQuorumNumber();
+
+            if (layoutMap.isEmpty()) {
+                // If no layout server responded with a Layout, report cluster status as UNAVAILABLE.
+                log.debug("getClusterStatus: all layout servers {} failed to respond with layouts.", layoutServers);
+                // Even if we weren't able to obtain any layout fom LayoutServers, we attempt to ping all
+                // layoutServers for this runtime, to provide info of connectivity.
+                // Note: layout should be null, as this is not the layout that leads to cluster status.
+                Map<String, ConnectivityStatus> connectivityStatusMap = getConnectivityStatusMap(runtime.getLayoutView().getLayout());
+                return getUnavailableClusterStatusReport(layoutServers, ClusterStatusReliability.UNAVAILABLE,
+                        connectivityStatusMap.entrySet().stream()
+                                .filter(x -> x.getValue().equals(ConnectivityStatus.RESPONSIVE))
+                                .map(x -> x.getKey()).collect(Collectors.toSet()), null);
+            } else {
+                int serversLayoutResponses = layoutMap.size();
+
+                if (serversLayoutResponses < quorum) {
+                    // If quorum unreachable, report cluster status unavailable, but still for debug purposes provide
+                    // information of the highest epoch layout in the system.
+                    log.info("getClusterStatus: Quorum unreachable, reachable={}, required={}. Cluster status in unavailable.",
+                            serversLayoutResponses, quorum);
+                    layout = getHighestEpochLayout(layoutMap);
+                    return getUnavailableClusterStatusReport(layoutServers, ClusterStatusReliability.WEAK_NO_QUORUM, layoutMap.keySet(), layout);
+                } else {
+                    layout = getLayoutFromQuorum(layoutMap, quorum);
+
+                    if (layout == null) {
+                        // No quorum nodes with same layout
+                        // Report cluster status unavailable, but still for debug purposes provide
+                        // information of the highest epoch layout in the system.
+                        log.info("getClusterStatus: majority of nodes sharing the same layout not found. Cluster status is unavailable.");
+                        layout = getHighestEpochLayout(layoutMap);
+                        return getUnavailableClusterStatusReport(layoutServers, ClusterStatusReliability.WEAK_NO_QUORUM, layoutMap.keySet(), layout);
+                    }
+
+                    log.debug("getClusterStatus: quorum layout {}", layout);
+                }
+            }
+
+            // Get Cluster Status from Layout
+            ClusterStatus clusterStatus = getClusterHealth(layout, layout.getAllActiveServers());
+
+            // Get Node Status from Layout
+            Map<String, NodeStatus> nodeStatusMap = getNodeStatusMap(layout);
+
+            // To complete cluster status with connectivity information of this
+            // client to every node in the cluster, ping all servers
+            // TODO: we could eventually skip pinging the nodes, as the layout fetch is indirectly a measure of connectivity.
+            Map <String, ClusterStatusReport.ConnectivityStatus> connectivityStatusMap = getConnectivityStatusMap(layout);
+
+            log.debug("getClusterStatus: successful. Overall cluster status: {}", clusterStatus);
+
+            return new ClusterStatusReport(layout, clusterStatus, statusReliability, nodeStatusMap, connectivityStatusMap);
+        } catch (Exception e) {
+            log.error("getClusterStatus[{}]: cluster status unavailable. Exception: {}",
+                    this.runtime.getParameters().getClientId(), e);
+            return getUnavailableClusterStatusReport(layoutServers);
+        }
+    }
+
+    private ClusterStatusReport getUnavailableClusterStatusReport(List<String> layoutServers, ClusterStatusReliability reliability, @Nonnull Set<String> responsiveServers, Layout layout) {
+        return new ClusterStatusReport(layout,
+                ClusterStatus.UNAVAILABLE,
+                reliability,
+                layoutServers.stream().collect(Collectors.toMap(
+                        endpoint -> endpoint,
+                        node -> NodeStatus.NA)),
+                layoutServers.stream().collect(Collectors.toMap(
+                        endpoint -> endpoint,
+                        endpoint -> responsiveServers.contains(endpoint) ? ConnectivityStatus.RESPONSIVE : ConnectivityStatus.UNRESPONSIVE)));
+    }
+
+    private ClusterStatusReport getUnavailableClusterStatusReport(List<String> layoutServers) {
+        return getUnavailableClusterStatusReport(layoutServers, ClusterStatusReliability.UNAVAILABLE, Collections.emptySet(), null);
+    }
+
+    /**
+     * Get Layouts from list of specified layout servers.
+     *
+     * @param layoutServers list of initial layout servers to retrieve layouts from.
+     * @param discoverLayoutServers flag to indicate if we want to discover new layout servers from
+     *                              the layouts retrieved from initial set of layout servers.
+     *                              Note: this is required as runtime.getLayoutServers might have been
+     *                              initialized with a single server (from all in cluster).
+     * @return Map of endpoint id and layout.
+     */
+    private Map<String, Layout> getLayouts(List<String> layoutServers, Boolean discoverLayoutServers) {
+        Map<String, CompletableFuture<Layout>> layoutFuturesMap = getLayoutFutures(layoutServers);
+        Map<String, Layout> layoutMap = new HashMap<>();
+
+        // Wait on the Completable futures
+        for (Entry<String, CompletableFuture<Layout>> entry : layoutFuturesMap.entrySet()) {
+            try {
+                Layout nodeLayout = entry.getValue().get();
+                log.debug("Server:{} responded with layout: {}", entry.getKey(), nodeLayout);
+                layoutMap.put(entry.getKey(), nodeLayout);
+            } catch (Exception e) {
+                log.error("getClusterStatus: Error while fetching layout from {}. Exception: ",
+                        entry.getKey(), e);
+            }
+        }
+
+        // If discoverLayoutServers is set, fetch layouts from all other layout servers
+        // discovered in the first search which are not contained in the initial list.
+        if (discoverLayoutServers) {
+            List<String> discoveredLayoutServers = layoutMap.values().stream()
+                    .map(layout -> layout.getLayoutServers())
+                    .flatMap(servers -> servers.stream())
+                    .distinct()
+                    .filter(servers -> !layoutServers.contains(servers))
+                    .collect(Collectors.toList());
+
+            if (!discoveredLayoutServers.isEmpty()) {
+                Map <String, Layout> recursiveLayouts = getLayouts(new ArrayList<>(discoveredLayoutServers), false);
+                layoutMap.putAll(recursiveLayouts);
+            }
+        }
+
+        return layoutMap;
+    }
+
+    private Layout getLayoutFromQuorum(@Nonnull Map<String, Layout> layoutMap, int quorum) {
+        Layout layout = null;
+        // Map of layout to number of nodes containing this layout.
+        Map<Layout, Integer> uniqueLayoutMap = new HashMap<>();
+
+        // Find if layouts are the same in all nodes (at least quorum nodes should agree in the
+        // same layout) - count occurrences of each layout in cluster nodes.
+        for (Layout nodeLayout : layoutMap.values()) {
+            if (uniqueLayoutMap.keySet().contains(nodeLayout)) {
+                uniqueLayoutMap.merge(nodeLayout, 1, Integer::sum);
+            } else {
+                uniqueLayoutMap.put(nodeLayout, 1);
+            }
+        }
+
+        // Filter layouts present in quorum number of nodes
+        Map<Layout, Integer> uniqueLayoutsQuorumMap = uniqueLayoutMap.entrySet().stream()
+                .filter(uniqueLayout -> uniqueLayout.getValue() >= quorum)
+                .collect(Collectors.toMap(uniqueLayout -> uniqueLayout.getKey(),
+                        uniqueLayout -> uniqueLayout.getValue()));
+
+        // Select layout with greater number of occurrences.
+        if (!uniqueLayoutsQuorumMap.isEmpty()) {
+            Map.Entry<Layout, Integer> maxEntry = null;
+            for (Map.Entry<Layout, Integer> entry : uniqueLayoutsQuorumMap.entrySet()) {
+                if (maxEntry == null || entry.getValue().compareTo(maxEntry.getValue()) > 0) {
+                    maxEntry = entry;
+                }
+            }
+            layout = maxEntry.getKey();
+        }
+
+        return layout;
+    }
+
+    private Layout getHighestEpochLayout(Map<String, Layout> layoutMap) {
+        Layout layout  = null;
+        for (Entry<String, Layout> entry : layoutMap.entrySet()) {
+            Layout nodeLayout = entry.getValue();
+            if (layout == null || nodeLayout.getEpoch() > layout.getEpoch()) {
+                layout = nodeLayout;
+            }
+        }
+
+        return layout;
+    }
+
+
+    private Map<String, CompletableFuture<Layout>> getLayoutFutures(List<String> layoutServers) {
+
+        Map<String, CompletableFuture<Layout>> layoutFuturesMap = new HashMap<>();
+
+        // Get layout futures for layout requests from all layout servers.
+        for (String server : layoutServers) {
+            try {
+                // Router creation can throw a NetworkException.
+                IClientRouter router = runtime.getRouter(server);
+                layoutFuturesMap.put(server,
+                        new LayoutClient(router, Layout.INVALID_EPOCH).getLayout());
+            } catch (NetworkException e) {
+                log.error("getClusterStatus: Exception encountered connecting to {}. ",
+                        server, e);
+                CompletableFuture<Layout> cf = new CompletableFuture<>();
+                cf.completeExceptionally(e);
+                layoutFuturesMap.put(server, cf);
+            }
+        }
+
+        return layoutFuturesMap;
+    }
+
+    private Map<String, ClusterStatusReport.ConnectivityStatus> getConnectivityStatusMap(Layout layout) {
+        Map<String, ClusterStatusReport.ConnectivityStatus> connectivityStatusMap = new HashMap<>();
+
+        // Initialize connectivity status map to all servers as unresponsive
+        for (String serverEndpoint : layout.getAllServers()) {
+            connectivityStatusMap.put(serverEndpoint, ClusterStatusReport.ConnectivityStatus.UNRESPONSIVE);
         }
 
         RuntimeLayout runtimeLayout = new RuntimeLayout(layout, runtime);
+        Map<String, CompletableFuture<Boolean>> pingFutureMap = new HashMap<>();
 
-        // All configured nodes.
-        Set<String> allNodes = new HashSet<>(layout.getAllServers());
 
-        // Counters to track heartbeat responses from nodes.
-        // A counter is incremented even if we get a WrongEpochException as the node is alive.
-        Map<String, Integer> counters = new HashMap<>();
-        allNodes.forEach(endpoint -> counters.put(endpoint, 0));
-
-        // Map of clusterStatus received from heartbeatResponses.
-        Map<String, ClusterState> clusterStatusMap = new HashMap<>();
-
-        // Ping all nodes CLUSTER_STATUS_QUERY_ATTEMPTS times.
-        // Increment the counter map and save the ClusterState response received in the
-        // heartbeat responses.
         for (int i = 0; i < CLUSTER_STATUS_QUERY_ATTEMPTS; i++) {
-            Map<String, CompletableFuture<ClusterState>> futureMap = new HashMap<>();
+            // If a server is unresponsive attempt to ping for cluster_status_query_attempts
+            if(connectivityStatusMap.containsValue(ConnectivityStatus.UNRESPONSIVE)) {
+                // Ping only unresponsive endpoints
+                List<String> endpoints = connectivityStatusMap.entrySet()
+                        .stream()
+                        .filter(entry -> entry.getValue().equals(ClusterStatusReport.ConnectivityStatus.UNRESPONSIVE))
+                        .map(Entry::getKey)
+                        .collect(Collectors.toList());
 
-            // Ping all nodes asynchronously
-            for (String endpoint : allNodes) {
-                CompletableFuture<ClusterState> cf = new CompletableFuture<>();
-                try {
-                    cf = runtimeLayout.getManagementClient(endpoint).sendHeartbeatRequest();
-                } catch (Exception e) {
-                    // Requesting the heartbeat can cause NetworkException if connection cannot
-                    // be established.
-                    cf.completeExceptionally(e);
+                for (String serverEndpoint : endpoints) {
+                    // Ping all nodes asynchronously
+                    CompletableFuture<Boolean> cf = runtimeLayout.getBaseClient(serverEndpoint).ping();
+                    pingFutureMap.put(serverEndpoint, cf);
                 }
-                futureMap.put(endpoint, cf);
+
+                // Accumulate all responses.
+                pingFutureMap.forEach((endpoint, pingFuture) -> {
+                    try {
+                        ClusterStatusReport.ConnectivityStatus connectivityStatus = CFUtils.getUninterruptibly(pingFuture,
+                                WrongEpochException.class) ? ConnectivityStatus.RESPONSIVE : ConnectivityStatus.UNRESPONSIVE;
+                        connectivityStatusMap.put(endpoint, connectivityStatus);
+                    } catch (WrongEpochException wee) {
+                        connectivityStatusMap.put(endpoint, ConnectivityStatus.RESPONSIVE);
+                    } catch (Exception e) {
+                        connectivityStatusMap.put(endpoint, ConnectivityStatus.UNRESPONSIVE);
+                    }
+                });
             }
-
-            // Accumulate all responses.
-            futureMap.forEach((endpoint, clusterStateFuture) -> {
-                try {
-                    clusterStatusMap.put(endpoint, CFUtils.getUninterruptibly(clusterStateFuture,
-                            WrongEpochException.class));
-                    counters.computeIfPresent(endpoint, (s, count) -> count + 1);
-                } catch (WrongEpochException wee) {
-                    counters.computeIfPresent(endpoint, (s, count) -> count + 1);
-                } catch (Exception ignored) {
-                    // Ignore all exceptions.
-                }
-            });
         }
 
-        // Using the peer views from the nodes to determine health of the cluster.
-        Set<String> peerResponsiveNodes = filterResponsiveNodes(layout, clusterStatusMap);
+        return connectivityStatusMap;
+    }
 
-        // Set of all nodes which are responsive to this client.
-        // Client connectivity to the cluster.
-        Set<String> responsiveEndpoints = counters.entrySet().stream()
-                // Only count nodes which have counter > 0
-                .filter(entry -> entry.getValue() > 0)
-                .map(Entry::getKey)
-                .collect(Collectors.toSet());
+    private Map<String, NodeStatus> getNodeStatusMap(Layout layout) {
+        Map<String, NodeStatus> nodeStatusMap = new HashMap<>();
+        for (String endpoint: layout.getAllServers()) {
+            if (layout.getUnresponsiveServers().contains(endpoint)) {
+                nodeStatusMap.put(endpoint, NodeStatus.DOWN);
+            } else if (layout.getSegments().size() != layout.getSegmentsForEndpoint(endpoint).size()) {
+                nodeStatusMap.put(endpoint, NodeStatus.DB_SYNCING);
+            } else {
+                nodeStatusMap.put(endpoint, NodeStatus.UP);
+            }
+        }
 
-        // Analyzes the responsive nodes as seen by the fault detectors to determine the health
-        // of the cluster.
-        ClusterStatus clusterStatus = getClusterHealth(layout,
-                // We need to consider the intersection of how the clients view the cluster and
-                // how the server nodes perceive each other. Together we determine the cluster
-                // status.
-                Sets.intersection(peerResponsiveNodes, responsiveEndpoints));
-
-        Map<String, NodeStatus> nodeStatusMap
-                = createNodeStatusMap(layout, responsiveEndpoints, allNodes);
-
-        return new ClusterStatusReport(layout, nodeStatusMap, clusterStatus);
+        return nodeStatusMap;
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -2,9 +2,17 @@ package org.corfudb.runtime.checkpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
-
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.MultiSMREntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
@@ -23,10 +31,6 @@ import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.util.*;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 /**
  * Basic smoke tests for checkpoint-in-stream PoC.


### PR DESCRIPTION
## Overview

Simplify and remove dependency with failure detector.
Introduce DB_SYNCING as a cluster state.

Why should this be merged: this API currently relies on the failure detector to determine the state of the cluster which is rather complex. We should be reporting the cluster state based on the layout.
