### PR TITLE
getOrchestrator Bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/WorkflowRequest.java
@@ -59,20 +59,19 @@ public abstract class WorkflowRequest {
      * orchestrator
      */
     protected ManagementClient getOrchestrator(@NonNull Layout layout) {
-        List<String> activeLayoutServers = layout.getLayoutServers().stream()
-                .filter(s -> !layout.getUnresponsiveServers().contains(s)
-                        && !s.equals(nodeForWorkflow))
+        List<String> availableLayoutServers = layout.getLayoutServers().stream()
+                .filter(s -> !s.equals(nodeForWorkflow))
                 .collect(Collectors.toList());
 
-        if (activeLayoutServers.isEmpty()) {
+        if (availableLayoutServers.isEmpty()) {
             throw new WorkflowException("getOrchestrator: no available orchestrators " + layout);
         }
 
         // Select an available orchestrator
         ManagementClient managementClient = runtime.getLayoutView().getRuntimeLayout(layout)
-                .getManagementClient(activeLayoutServers.get(0));
+                .getManagementClient(availableLayoutServers.get(0));
 
-        for (String endpoint : activeLayoutServers) {
+        for (String endpoint : availableLayoutServers) {
             BaseClient client = runtime.getLayoutView().getRuntimeLayout(layout)
                     .getBaseClient(endpoint);
             if (client.pingSync()) {


### PR DESCRIPTION
## Overview
Since the layout's view can reflect incorrect state (i.e. responsive
servers marked as unresponsive), all nodes should be considered
when selecting an orchestrator, not just responsive ones (based
on the layout)

Why should this be merged: Unblocks the cluster when the layout has marked all the responsive nodes as unresponsive and the unresponsive node as responsive. 

Related issue(s) (if applicable): #1576


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
