### PR TITLE
Restore the interrupted status

### DIFF
--- a/generator/src/main/java/org/corfudb/generator/LongevityApp.java
+++ b/generator/src/main/java/org/corfudb/generator/LongevityApp.java
@@ -5,6 +5,7 @@ import org.corfudb.generator.operations.CheckpointOperation;
 import org.corfudb.generator.operations.Operation;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.unrecoverable.SystemUnavailableError;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -121,7 +122,7 @@ public class LongevityApp {
                 System.exit(1);
             }
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
+            throw new UnrecoverableCorfuInterruptedError(e);
         } finally {
             taskProducer.shutdownNow();
             checkpointer.shutdownNow();
@@ -131,8 +132,7 @@ public class LongevityApp {
             try {
                 checkpointHasFinished = checkpointer.awaitTermination(APPLICATION_TIMEOUT_IN_MS, TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                exitStatus = 1;
+                throw new UnrecoverableCorfuInterruptedError(e);
             }
 
             exitStatus = checkpointHasFinished ? 0 : 1;
@@ -164,8 +164,7 @@ public class LongevityApp {
                 try {
                     operationQueue.put(current);
                 } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    break;
+                    throw new UnrecoverableCorfuInterruptedError(e);
                 } catch (Exception e) {
                     log.error("operation error", e);
                 }

--- a/generator/src/main/java/org/corfudb/generator/operations/SleepOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/SleepOperation.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.generator.State;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 
 /**
  * Created by maithem on 7/14/17.
@@ -25,9 +26,7 @@ public class SleepOperation extends Operation {
         try {
             Thread.sleep(sleepTime);
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-
+            throw new UnrecoverableCorfuInterruptedError(e);
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -12,6 +12,7 @@ import org.corfudb.infrastructure.management.FailureDetector;
 import org.corfudb.infrastructure.management.HealingDetector;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.util.Sleep;
 import org.corfudb.util.concurrent.SingletonResource;
@@ -149,7 +150,7 @@ public class ManagementAgent {
 
         } catch (InterruptedException e) {
             log.error("initializationTask: InitializationTask interrupted.");
-            Thread.currentThread().interrupt();
+            throw new UnrecoverableCorfuInterruptedError(e);
         } catch (Exception e) {
             log.error("initializationTask: Error in initializationTask.", e);
             throw new UnrecoverableCorfuError(e);
@@ -180,7 +181,7 @@ public class ManagementAgent {
             initializationTaskThread.join(ServerContext.SHUTDOWN_TIMER.toMillis());
         } catch (InterruptedException ie) {
             log.error("initializationTask interrupted : {}", ie);
-            Thread.currentThread().interrupt();
+            throw new UnrecoverableCorfuInterruptedError(ie);
         }
 
         log.info("Management Agent shutting down.");

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
@@ -259,7 +259,7 @@ public class RemoteMonitoringService implements MonitoringService {
                 log.error("Healing nodes failed: ", ee);
             } catch (InterruptedException ie) {
                 log.error("Healing nodes interrupted: ", ie);
-                Thread.currentThread().interrupt();
+                throw new UnrecoverableCorfuInterruptedError(ie);
             }
         });
     }
@@ -499,7 +499,6 @@ public class RemoteMonitoringService implements MonitoringService {
             throw new QuorumUnreachableException(reachableServers, completableFutures.length);
         } catch (InterruptedException ie) {
             log.error("fetchQuorumLayout: Interrupted Exception.");
-            Thread.currentThread().interrupt();
             throw new UnrecoverableCorfuInterruptedError(ie);
         }
     }
@@ -527,7 +526,6 @@ public class RemoteMonitoringService implements MonitoringService {
             } catch (InterruptedException ie) {
                 log.error("updateTrailingLayoutServers: layout fetch from {} failed: {}",
                         layoutServer, ie);
-                Thread.currentThread().interrupt();
                 throw new UnrecoverableCorfuInterruptedError(ie);
             }
 
@@ -553,7 +551,6 @@ public class RemoteMonitoringService implements MonitoringService {
                 log.error("Updating layout servers failed due to : {}", ee);
             } catch (InterruptedException ie) {
                 log.error("Updating layout servers failed due to : {}", ie);
-                Thread.currentThread().interrupt();
                 throw new UnrecoverableCorfuInterruptedError(ie);
             }
         });

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogCompaction.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogCompaction.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.Timer;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.MetricsUtils;
 
@@ -61,7 +62,7 @@ public class StreamLogCompaction {
             scheduler.awaitTermination(shutdownTimer.toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException ie) {
             log.debug("Stream log compaction, awaitTermination interrupted : {}", ie);
-            Thread.currentThread().interrupt();
+            throw new UnrecoverableCorfuInterruptedError(ie);
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Orchestrator.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Orchestrator.java
@@ -26,6 +26,7 @@ import org.corfudb.protocols.wireprotocol.orchestrator.Response;
 import org.corfudb.infrastructure.orchestrator.workflows.ForceRemoveWorkflow;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.concurrent.SingletonResource;
@@ -262,7 +263,7 @@ public class Orchestrator {
             executor.awaitTermination(ServerContext.SHUTDOWN_TIMER.getSeconds(), TimeUnit.SECONDS);
         } catch (InterruptedException ie) {
             log.debug("Orchestrator executor awaitTermination interrupted : {}", ie);
-            Thread.currentThread().interrupt();
+            throw new UnrecoverableCorfuInterruptedError(ie);
         }
         log.info("Orchestrator shutting down.");
     }

--- a/runtime/src/main/java/org/corfudb/runtime/ViewsGarbageCollector.java
+++ b/runtime/src/main/java/org/corfudb/runtime/ViewsGarbageCollector.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.exceptions.GarbageCollectorException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.view.Address;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -83,8 +84,7 @@ public class ViewsGarbageCollector {
                     endTs - startTs, runtime.getObjectsView().getObjectCache().size(), trimMark);
         } catch (Exception e) {
             if (e.getCause() instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-                throw new GarbageCollectorException(e);
+                throw new UnrecoverableCorfuInterruptedError((InterruptedException) e.getCause());
             } else {
                 log.error("Encountered an error while running runtime GC", e);
             }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -416,7 +416,6 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
             connectionFuture
                 .get(parameters.getConnectionTimeout().toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
             throw new UnrecoverableCorfuInterruptedError(e);
         } catch (TimeoutException | ExecutionException e) {
             CompletableFuture<T> f = new CompletableFuture<>();

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/unrecoverable/UnrecoverableCorfuInterruptedError.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/unrecoverable/UnrecoverableCorfuInterruptedError.java
@@ -5,19 +5,25 @@ import javax.annotation.Nonnull;
 /** Thrown when a Corfu Client/Server is interrupted in an unrecoverable manner.
  *  Once interrupted in this manner, Corfu can only guarantee safety if the application
  *  exits, as Corfu safety is no longer recoverable.
+ *
+ *  The constructors are not side-effect free, since they re-enable the interrupt flag. This is
+ *  done in order to avoid situations in which a developer forgets to set interrupt flag.
  */
 public class UnrecoverableCorfuInterruptedError extends UnrecoverableCorfuError {
 
-    /** Construct a new {@link UnrecoverableCorfuInterruptedError} with a root cause.
+    /** Construct a new {@link UnrecoverableCorfuInterruptedError} with a root cause and
+     * re-enable the interrupt flag.
      *
      * @param cause     The root cause of the exception.
      */
     public UnrecoverableCorfuInterruptedError(@Nonnull InterruptedException cause) {
         super(cause);
+        // Restore the interrupted status.
+        Thread.currentThread().interrupt();
     }
 
     /** Construct a new {@link UnrecoverableCorfuInterruptedError} with a given message
-     * and root cause.
+     * and root cause and re-enable the interrupt flag.
      *
      * @param message   A message describing the exception.
      * @param cause     The root cause of the exception.
@@ -25,5 +31,7 @@ public class UnrecoverableCorfuInterruptedError extends UnrecoverableCorfuError 
     public UnrecoverableCorfuInterruptedError( @Nonnull String message,
                                                @Nonnull InterruptedException cause) {
         super(message, cause);
+        // Restore the interrupted status.
+        Thread.currentThread().interrupt();
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
@@ -281,7 +281,6 @@ public class ManagementView extends AbstractView {
                     layout = nodeLayout;
                 }
             } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
                 throw new UnrecoverableCorfuInterruptedError(ie);
             } catch (ExecutionException ee) {
                 log.error("getClusterStatus: Error while fetching layout from {}.",

--- a/runtime/src/main/java/org/corfudb/util/Sleep.java
+++ b/runtime/src/main/java/org/corfudb/util/Sleep.java
@@ -117,7 +117,6 @@ public enum Sleep {
             final long ms = toMillis(duration);
             Thread.sleep(ms, excessNanos(duration, ms));
         } catch (InterruptedException ie) {
-            Thread.currentThread().interrupt();
             throw new UnrecoverableCorfuInterruptedError(
                 "Uninterruptible sleep interrupted", ie);
         }

--- a/samples/src/main/java/org/corfudb/samples/WriteWriteTXs.java
+++ b/samples/src/main/java/org/corfudb/samples/WriteWriteTXs.java
@@ -88,7 +88,6 @@ public class WriteWriteTXs extends BaseCorfuAppUtils {
             try {
                 th.join(THREAD_TIMEOUT);
             } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
                 System.out.println("Thread timeout!");
                 throw new UnrecoverableCorfuInterruptedError(ie);
             }
@@ -108,7 +107,6 @@ public class WriteWriteTXs extends BaseCorfuAppUtils {
             try {
                 th.join(THREAD_TIMEOUT);
             } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
                 System.out.println("Thread timeout!");
                 throw new UnrecoverableCorfuInterruptedError(ie);
             }

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -1,14 +1,14 @@
 package org.corfudb.runtime;
 
+import org.assertj.core.api.Assertions;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 
-import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.clients.TestRule;
-import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.exceptions.unrecoverable.SystemUnavailableError;
 
 import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.stream.IStreamView;
@@ -62,6 +62,19 @@ public class CorfuRuntimeTest extends AbstractViewTest {
 
         executeScheduled(PARAMETERS.CONCURRENCY_TWO, PARAMETERS.TIMEOUT_LONG);
 
+    }
+
+    /**
+     * Ensure that the interrupt flag is always set to true when throwing
+     * {@link UnrecoverableCorfuInterruptedError}
+     */
+    @Test
+    public void interruptedFlagSet() {
+        try {
+            throw new UnrecoverableCorfuInterruptedError(new InterruptedException());
+        } catch (UnrecoverableCorfuInterruptedError ok) {
+            Assertions.assertThat(Thread.currentThread().isInterrupted()).isTrue();
+        }
     }
 
     @Test


### PR DESCRIPTION
Ensure that all code paths that deal with interrupts re-enable the interrupt flag. In order to solve this issue systematically, during the construction of UnrecoverableCorfuInterruptedError we call Thread.currentThread().interrupt().

After capturing InterruptedException, we need to re-enable the interrupt
flag, since InterruptedException is wrapped in an unchecked exception.

Related issue(s) (if applicable): #1668