### PR TITLE
Link failure simplification

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -190,8 +190,7 @@ public class ManagementServer extends AbstractServer {
      * @param r   server router
      */
     @ServerHandler(type = CorfuMsgType.MANAGEMENT_FAILURE_DETECTED)
-    public void handleFailureDetectedMsg(CorfuPayloadMsg<DetectorMsg> msg,
-                                         ChannelHandlerContext ctx, IServerRouter r) {
+    public void handleFailureDetectedMsg(CorfuPayloadMsg<DetectorMsg> msg, ChannelHandlerContext ctx, IServerRouter r) {
 
         // This server has not been bootstrapped yet, ignore all requests.
         if (!checkBootstrap(msg)) {
@@ -199,7 +198,7 @@ public class ManagementServer extends AbstractServer {
             return;
         }
 
-        log.info("handleFailureDetectedMsg: Received DetectorMsg : {}", msg.getPayload());
+        log.info("Handle failure. Client: {}, Received DetectorMsg: {}", msg.getClientID(), msg.getPayload());
 
         DetectorMsg detectorMsg = msg.getPayload();
         Layout layout = serverContext.copyManagementLayout();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/HealingDetector.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/HealingDetector.java
@@ -97,9 +97,7 @@ public class HealingDetector implements IDetector {
      *
      * @return Poll Report with detected healed nodes.
      */
-    private PollReport pollRound(List<String> members,
-                                 Map<String, IClientRouter> routerMap,
-                                 long epoch) {
+    private PollReport pollRound(List<String> members, Map<String, IClientRouter> routerMap, long epoch) {
 
         Map<String, Integer> pollResultMap = new HashMap<>();
 
@@ -114,8 +112,7 @@ public class HealingDetector implements IDetector {
                     pollOnceAsync(members, routerMap, epoch);
 
             // Collect all poll responses.
-            Set<String> responses = collectResponsesAndVerifyEpochs(members,
-                    pollCompletableFutures, clusterStateMap);
+            Set<String> responses = collectResponsesAndVerifyEpochs(members, pollCompletableFutures, clusterStateMap);
 
             // Count unsuccessful ping responses.
             // If we receive no responses and there are no nodes to heal,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/ReconfigurationEventHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/ReconfigurationEventHandler.java
@@ -47,8 +47,7 @@ public class ReconfigurationEventHandler {
                                         @Nonnull CorfuRuntime corfuRuntime,
                                         @Nonnull Set<String> failedServers) {
         try {
-            corfuRuntime.getLayoutManagementView().handleFailure(failureHandlerPolicy,
-                    currentLayout, failedServers);
+            corfuRuntime.getLayoutManagementView().handleFailure(failureHandlerPolicy, currentLayout, failedServers);
             return true;
         } catch (Exception e) {
             log.error("Error: handleFailure: {}", e);

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -8,8 +8,10 @@ import java.util.concurrent.TimeoutException;
 
 import javax.annotation.Nonnull;
 
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.DetectorMsg;
 import org.corfudb.protocols.wireprotocol.orchestrator.AddNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
@@ -31,6 +33,7 @@ import org.corfudb.util.CFUtils;
  *
  * <p>Created by zlokhandwala on 11/4/16.
  */
+@Slf4j
 public class ManagementClient extends AbstractClient {
 
     public ManagementClient(IClientRouter router, long epoch) {
@@ -55,8 +58,13 @@ public class ManagementClient extends AbstractClient {
      * @return A future which will be return TRUE if completed successfully else returns FALSE.
      */
     public CompletableFuture<Boolean> handleFailure(long detectorEpoch, Set<String> failedNodes) {
-        return sendMessageWithFuture(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED
-                .payloadMsg(new DetectorMsg(detectorEpoch, failedNodes, Collections.emptySet())));
+        log.debug("Handle failure, detectorEpoch: {}, failed nodes: {}", detectorEpoch, failedNodes);
+
+        CorfuPayloadMsg<DetectorMsg> message = CorfuMsgType.MANAGEMENT_FAILURE_DETECTED.payloadMsg(
+                new DetectorMsg(detectorEpoch, failedNodes, Collections.emptySet())
+        );
+
+        return sendMessageWithFuture(message);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -55,8 +55,7 @@ public abstract class AbstractView {
     }
 
     public <T, A extends RuntimeException, B extends RuntimeException, C extends RuntimeException,
-            D extends RuntimeException> T layoutHelper(LayoutFunction<Layout, T, A, B, C, D>
-                                                               function)
+            D extends RuntimeException> T layoutHelper(LayoutFunction<Layout, T, A, B, C, D> function)
             throws A, B, C, D {
         return layoutHelper(function, false);
     }
@@ -65,7 +64,7 @@ public abstract class AbstractView {
      * Maintains reference of the RuntimeLayout which gets invalidated if the AbstractView
      * encounters a newer layout. (with a greater epoch)
      */
-    private AtomicReference<RuntimeLayout> runtimeLayout = new AtomicReference<>();
+    private final AtomicReference<RuntimeLayout> runtimeLayout = new AtomicReference<>();
 
     /**
      * Fetches the layout uninterruptibly and rethrows any systemDownHandlerExceptions or Errors
@@ -90,8 +89,7 @@ public abstract class AbstractView {
             }
 
             if (ex.getCause() instanceof RuntimeException) {
-                log.error("getLayoutUninterruptibly: Encountered unchecked exception. "
-                        + "Aborting layoutHelper", ex);
+                log.error("getLayoutUninterruptibly: Encountered unchecked exception. Aborting layoutHelper", ex);
                 throw (RuntimeException) ex.getCause();
             }
 
@@ -118,10 +116,9 @@ public abstract class AbstractView {
      * @return The return value of the function.
      */
     public <T, A extends RuntimeException, B extends RuntimeException, C extends RuntimeException,
-            D extends RuntimeException> T layoutHelper(LayoutFunction<Layout, T, A, B, C, D>
-                                                               function,
-                                                       boolean rethrowAllExceptions)
-            throws A, B, C, D {
+            D extends RuntimeException> T layoutHelper(
+                    LayoutFunction<Layout, T, A, B, C, D> function, boolean rethrowAllExceptions) throws A, B, C, D {
+
         runtime.getParameters().getBeforeRpcHandler().run();
         final Duration retryRate = runtime.getParameters().getConnectionRetryRate();
         int systemDownTriggerCounter = 0;

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -324,6 +324,10 @@ public class Layout {
         this.clusterId = layoutCopy.clusterId;
     }
 
+    public void nextEpoch() {
+        epoch += 1;
+    }
+
     public enum ReplicationMode {
         CHAIN_REPLICATION {
             @Override

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -74,6 +74,8 @@ public class LayoutView extends AbstractView {
     @SuppressWarnings("unchecked")
     public void updateLayout(Layout layout, long rank)
             throws QuorumUnreachableException, OutrankedException, WrongEpochException {
+        log.debug("Update layout: {}, rank: {}", layout, rank);
+
         // Note this step is done because we have added the layout to the Epoch.
         long epoch = layout.getEpoch();
         Layout currentLayout = getLayout();

--- a/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
@@ -63,8 +63,9 @@ public class RuntimeLayout {
      */
     public void sealMinServerSet()
             throws WrongEpochException, QuorumUnreachableException {
-        log.debug("Requested move of servers to new epoch {} servers are {}", layout.getEpoch(),
-                layout.getAllServers());
+        log.debug("Requested move of servers to new epoch {} servers are {}",
+                layout.getEpoch(), layout.getAllServers()
+        );
 
         // Set remote epoch on all servers in layout.
         Map<String, CompletableFuture<Boolean>> resultMap = SealServersHelper.asyncSealServers(this);


### PR DESCRIPTION
## Overview

Description:
Mostly code reformats for easier reading.
Add some logs for easier/better debugging
Pass layout to failureTask instead of reading it twice form management data store
Reduce cognitive complexity for `handleFailures()` method.

Why should this be merged: 
A first step to improve\fix link failure mechanism

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
