### PR TITLE
Retry prefixTrim for Runtime on wrong epoch

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -233,8 +233,8 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                     processed++;
                     lastOp = currOp;
                 } else if (currOp.getEpoch() != sealEpoch) {
-                    log.warn("batchWriteProcessor: wrong epoch on {} msg, seal epoch is {}",
-                            currOp.getType(), currOp.getEpoch());
+                    log.warn("batchWriteProcessor: wrong epoch on {} msg, seal epoch is {}, and msg epoch is {}",
+                            currOp.getType(), sealEpoch, currOp.getEpoch());
                     currOp.setException(new WrongEpochException(sealEpoch));
                     res.add(currOp);
                     processed++;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -1,11 +1,11 @@
 package org.corfudb.infrastructure;
 
 import com.google.common.collect.ImmutableList;
+
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 
-import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -153,7 +153,7 @@ public abstract class AbstractView {
                     throw re;
                 }
                 if (rethrowAllExceptions) {
-                    throw new RuntimeException(re);
+                    throw re;
                 }
             }
 


### PR DESCRIPTION
## Overview

If client is in a stale epoch, prefixTrim is retried after a layout
invalidate.

Why should this be merged: prevents prefixTrim tasks failing due to clients on the wrong epoch. This is relevant as trimming is an operation typically performed periodically, if we do not retry, trim will have to wait for the next cycle unnecessarily. 

Related issue(s) (if applicable): #1673
