### PR TITLE
MultiVersion Checkpoints

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/Token.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/Token.java
@@ -30,6 +30,20 @@ public class Token implements IToken, Comparable<Token> {
         return epochCmp;
     }
 
+    /**
+     * Given two tokens return the min
+     * @param a first token
+     * @param b second token
+     * @return the reference to the min token
+     */
+    public static Token min(Token a, Token b) {
+        if (a.compareTo(b) <= 0) {
+            return a;
+        } else {
+            return b;
+        }
+    }
+
     public static Token of(long epoch, long sequence) {
         return new Token(epoch, sequence);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -26,7 +26,7 @@ import org.corfudb.runtime.object.transactions.Transaction;
 import org.corfudb.runtime.object.transactions.Transaction.TransactionBuilder;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
-import sun.nio.ch.Net;
+
 
 /**
  * A view of the objects inside a Corfu instance.

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -101,7 +101,7 @@ public class CheckpointTest extends AbstractObjectTest {
                 // shouldn't happen
                 te.printStackTrace();
                 throw te;
-            } catch (ExecutionException ee) {
+            } catch (Exception e) {
                 // We are the only thread performing trimming, therefore any
                 // prior trim must have been by our own action.  We assume
                 // that we don't go backward, so checking for equality will


### PR DESCRIPTION
## Overview
Instead of using the same snapshot to checkpoint all the maps
to be checkpointed, this patch makes the CheckpointWriter
use increasing checkpoint snapshots for every map and
therefore decreasing the probability of rolling back the stream.
Because multiple increasing snapshots are used, only the smallest
snapshot is used for trimming.

Why should this be merged: Improves the currently broken compaction design by a "bit"

Related issue(s) (if applicable): #1681

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
