### PR TITLE
Mulithreaded Checkpointer

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/CheckpointException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/CheckpointException.java
@@ -1,0 +1,14 @@
+package org.corfudb.runtime.exceptions;
+
+/**
+ * Exception thrown when a checkpointer thread fails.
+ */
+public class CheckpointException extends RuntimeException {
+    public CheckpointException(Throwable t) {
+        super((t));
+    }
+
+    public CheckpointException(String msg) {
+        super(msg);
+    }
+}


### PR DESCRIPTION
## Overview
This patch introduces multithreading to CheckpointWriter in order
to emit checkpoints faster for very large tables.

Why should this be merged: for very large tables, a single writer can be very slow, so writing the checkpoint state in parallel can improve performance by reducing the checkpointing cycle. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
