### PR TITLE
Change default retention number of local datastore files

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -140,7 +140,7 @@ public class CorfuServer {
                     + "              The read/write batch size used for data transfer operations [default: 100].\n"
                     + " -R <retention>, --metadata-retention=<retention>                         "
                     + "              Maximum number of system reconfigurations (i.e. layouts)    "
-                    + "retained for debugging purposes [default: 100].\n"
+                    + "retained for debugging purposes [default: 1000].\n"
                     + " -p <seconds>, --compact=<seconds>                                        "
                     + "              The rate the log unit should compact entries (find the,\n"
                     + "                                                                          "

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -44,7 +44,7 @@ public class ServerContextBuilder {
     String numThreads = "0";
     String handshakeTimeout = "10";
     String prefix = "";
-    String retention = "100";
+    String retention = "1000";
 
     String clusterId = "auto";
     boolean isTest = true;


### PR DESCRIPTION
## Overview

Description:

Change default retention number of local datastore files to improve debuggability.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
