### PR TITLE
@log-unit: Deal gracefully with partial-writes

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -211,6 +211,7 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                     if (currOp == null || processed == BATCH_SIZE
                             || currOp == BatchWriterOperation.SHUTDOWN) {
                         streamLog.sync(sync);
+                        streamLog.persistCommittedAddress();
                         log.trace("Sync'd {} writes", processed);
 
                         for (BatchWriterOperation operation : res) {
@@ -226,6 +227,7 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
                 } else if (currOp == BatchWriterOperation.SHUTDOWN) {
                     log.trace("Shutting down the write processor");
                     streamLog.sync(true);
+                    streamLog.persistCommittedAddress();
                     break;
                 } else if (currOp.getType() == Type.SEAL && currOp.getEpoch() >= sealEpoch) {
                     sealEpoch = currOp.getEpoch();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -13,6 +13,7 @@ import org.corfudb.comm.ChannelImplementation;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.ConservativeFailureHandlerPolicy;
 import org.corfudb.runtime.view.IReconfigurationHandlerPolicy;
 import org.corfudb.runtime.view.Layout;
@@ -54,34 +55,35 @@ import java.util.regex.Pattern;
 @Slf4j
 public class ServerContext implements AutoCloseable {
     // Layout Server
-    private static final String PREFIX_EPOCH = "SERVER_EPOCH";
-    private static final String KEY_EPOCH = "CURRENT";
-    private static final String PREFIX_LAYOUT = "LAYOUT";
-    private static final String KEY_LAYOUT = "CURRENT";
-    private static final String PREFIX_PHASE_1 = "PHASE_1";
-    private static final String KEY_SUFFIX_PHASE_1 = "RANK";
-    private static final String PREFIX_PHASE_2 = "PHASE_2";
-    private static final String KEY_SUFFIX_PHASE_2 = "DATA";
-    private static final String PREFIX_LAYOUTS = "LAYOUTS";
+    public static final String PREFIX_EPOCH = "SERVER_EPOCH";
+    public static final String KEY_EPOCH = "CURRENT";
+    public static final String PREFIX_LAYOUT = "LAYOUT";
+    public static final String KEY_LAYOUT = "CURRENT";
+    public static final String PREFIX_PHASE_1 = "PHASE_1";
+    public static final String KEY_SUFFIX_PHASE_1 = "RANK";
+    public static final String PREFIX_PHASE_2 = "PHASE_2";
+    public static final String KEY_SUFFIX_PHASE_2 = "DATA";
+    public static final String PREFIX_LAYOUTS = "LAYOUTS";
 
     // Sequencer Server
-    private static final String PREFIX_TAIL_SEGMENT = "TAIL_SEGMENT";
-    private static final String KEY_TAIL_SEGMENT = "CURRENT";
-    private static final String PREFIX_STARTING_ADDRESS = "STARTING_ADDRESS";
-    private static final String KEY_STARTING_ADDRESS = "CURRENT";
-    private static final String KEY_SEQUENCER = "SEQUENCER";
-    private static final String PREFIX_SEQUENCER_EPOCH = "EPOCH";
+    public static final String PREFIX_TAIL_SEGMENT = "TAIL_SEGMENT";
+    public static final String KEY_TAIL_SEGMENT = "CURRENT";
+    public static final String PREFIX_STARTING_ADDRESS = "STARTING_ADDRESS";
+    public static final String KEY_STARTING_ADDRESS = "CURRENT";
+    public static final String KEY_SEQUENCER = "SEQUENCER";
+    public static final String PREFIX_SEQUENCER_EPOCH = "EPOCH";
 
     // Management Server
-    private static final String PREFIX_MANAGEMENT = "MANAGEMENT";
-    private static final String MANAGEMENT_LAYOUT = "LAYOUT";
+    public static final String PREFIX_MANAGEMENT = "MANAGEMENT";
+    public static final String MANAGEMENT_LAYOUT = "LAYOUT";
 
     // LogUnit Server
-    private static final String PREFIX_LOGUNIT = "LOGUNIT";
-    private static final String EPOCH_WATER_MARK = "EPOCH_WATER_MARK";
+    public static final String PREFIX_LOGUNIT = "LOGUNIT";
+    public static final String EPOCH_WATER_MARK = "EPOCH_WATER_MARK";
+    public static final String ADDRESS_JOURNAL = "ADDRESS_JOURNAL";
 
     /** The node Id, stored as a base64 string. */
-    private static final String NODE_ID = "NODE_ID";
+    public static final String NODE_ID = "NODE_ID";
 
     /**
      * various duration constants.
@@ -440,8 +442,28 @@ public class ServerContext implements AutoCloseable {
         return startingAddress == null ? 0 : startingAddress;
     }
 
+
     public void setStartingAddress(long startingAddress) {
         dataStore.put(Long.class, PREFIX_STARTING_ADDRESS, KEY_STARTING_ADDRESS, startingAddress);
+    }
+
+    /**
+     * Fetch last globally committed address for this server context.
+     *
+     * @return global address
+     */
+    public long getLastCommittedAddress() {
+        Long address = dataStore.get(Long.class, PREFIX_LOGUNIT, ADDRESS_JOURNAL);
+        return address == null ? Address.NON_ADDRESS : address;
+    }
+
+    /**
+     * Set the last globally committed address for this server context.
+     *
+     * @param address the address to set
+     */
+    public synchronized void setLastCommittedAddress(long address) {
+        dataStore.put(Long.class, PREFIX_LOGUNIT, ADDRESS_JOURNAL, address);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -111,6 +111,11 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
     }
 
     @Override
+    public void persistCommittedAddress(){
+        //no-op
+    }
+
+    @Override
     public void sync(boolean force){
         //no-op
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -60,6 +60,11 @@ public interface StreamLog {
     long getTrimMark();
 
     /**
+     * Persist the committed address. This effectively acts as a journal.
+     */
+    void persistCommittedAddress();
+
+    /**
      * Sync the stream log file to secondary storage.
      *
      * @param force force data to secondary storage if true

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/DataCorruptionException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/DataCorruptionException.java
@@ -4,4 +4,13 @@ package org.corfudb.runtime.exceptions;
  * An exception that is thrown by the logunit when it detects data corruption.
  */
 public class DataCorruptionException extends LogUnitException {
+
+    public DataCorruptionException() {
+        super();
+    }
+
+    public DataCorruptionException(long currentAddress, long committedAddress) {
+        super(String.format("detected data corruption at address %d/%d.",
+                currentAddress, committedAddress));
+    }
 }


### PR DESCRIPTION
On a partial write, a log unit would refuse to start due to a detected
data corruption. This patch changes this behaviour by simply discarding
partial written (corrupted) data and leaving it up to the client to
instantiate the repair protocol.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
