### PR TITLE
Reducing log emission

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -46,18 +46,13 @@ import java.util.concurrent.TimeUnit;
  * Distributed Shared Log.
  *
  * <p>All reads and writes go through a cache. For persistence, every 10,000 log entries are written
- * to individual
- * files (logs), which are represented as FileHandles. Each FileHandle contains a pointer to the
- * tail of the file, a
- * memory-mapped file channel, and a set of addresses known to be in the file. To append an
- * entry, the pointer to the
- * tail is first extended to the length of the entry, and the entry is added to the set of known
- * addresses. A header
- * is written, which consists of the ASCII characters LE, followed by a set of flags, the log
- * unit address, the size
- * of the entry, then the metadata size, metadata and finally the entry itself. When the entry is
- * complete, a written
- * flag is set in the flags field.
+ * to individual files (logs), which are represented as FileHandles. Each FileHandle contains a
+ * pointer to the tail of the file, a memory-mapped file channel, and a set of addresses known
+ * to be in the file. To append an entry, the pointer to the tail is first extended to the
+ * length of the entry, and the entry is added to the set of known addresses. A header is
+ * written, which consists of the ASCII characters LE, followed by a set of flags, the log unit
+ * address, the size of the entry, then the metadata size, metadata and finally the entry itself
+ * . When the entry is complete, a written flag is set in the flags field.
  */
 @Slf4j
 public class LogUnitServer extends AbstractServer {
@@ -319,13 +314,13 @@ public class LogUnitServer extends AbstractServer {
      *     the read() and append(). Any address that cannot be retrieved should be returned as
      *     unwritten (null).
      */
-    public synchronized ILogData handleRetrieval(long address) {
+    private synchronized ILogData handleRetrieval(long address) {
         LogData entry = streamLog.read(address);
         log.trace("Retrieved[{} : {}]", address, entry);
         return entry;
     }
 
-    public synchronized void handleEviction(long address, ILogData entry, RemovalCause cause) {
+    private synchronized void handleEviction(long address, ILogData entry, RemovalCause cause) {
         log.trace("Eviction[{}]: {}", address, cause);
         streamLog.release(address, (LogData) entry);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -487,7 +487,7 @@ public class ServerContext implements AutoCloseable {
             log.info("saveManagementLayout: Updated to new layout at epoch {}",
                     getManagementLayout().getEpoch());
         } else {
-            log.debug("saveManagementLayout: "
+            log.trace("saveManagementLayout: "
                             + "Ignoring layout because new epoch {} <= old epoch {}",
                     layout.getEpoch(), currentLayout.getEpoch());
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -1,16 +1,32 @@
 package org.corfudb.infrastructure.log;
 
 import static org.corfudb.infrastructure.utils.Persistence.syncDirectory;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.corfudb.format.Types;
+import org.corfudb.format.Types.LogEntry;
+import org.corfudb.format.Types.LogHeader;
+import org.corfudb.format.Types.Metadata;
+import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
+import org.corfudb.protocols.wireprotocol.IMetadata;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
+import org.corfudb.runtime.exceptions.DataCorruptionException;
+import org.corfudb.runtime.exceptions.OverwriteCause;
+import org.corfudb.runtime.exceptions.OverwriteException;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FileNotFoundException;
@@ -31,25 +47,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-
-import javax.annotation.Nullable;
-
-import lombok.extern.slf4j.Slf4j;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
-import org.corfudb.format.Types;
-import org.corfudb.format.Types.LogEntry;
-import org.corfudb.format.Types.LogHeader;
-import org.corfudb.format.Types.Metadata;
-import org.corfudb.infrastructure.ServerContext;
-import org.corfudb.protocols.logprotocol.CheckpointEntry;
-import org.corfudb.protocols.wireprotocol.IMetadata;
-import org.corfudb.protocols.wireprotocol.LogData;
-import org.corfudb.protocols.wireprotocol.TailsResponse;
-import org.corfudb.runtime.exceptions.DataCorruptionException;
-import org.corfudb.runtime.exceptions.OverwriteCause;
-import org.corfudb.runtime.exceptions.OverwriteException;
 
 
 /**
@@ -610,7 +607,8 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         }
     }
 
-    private @Nullable FileChannel getChannel(String filePath, boolean readOnly) throws IOException {
+    @Nullable
+    private FileChannel getChannel(String filePath, boolean readOnly) throws IOException {
         try {
 
             if (readOnly) {
@@ -783,7 +781,8 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         return Optional.of(result);
     }
 
-    private @Nullable IMetadata.DataRank createDataRank(LogEntry entity) {
+    @Nullable
+    private IMetadata.DataRank createDataRank(LogEntry entity) {
         if (!entity.hasRank()) {
             return null;
         }

--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -8,7 +8,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>${LOG_DIRECTORY}/corfu.9000.%i.log.gz</fileNamePattern>
             <minIndex>1</minIndex>
-            <maxIndex>20</maxIndex>
+            <maxIndex>30</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
             <maxFileSize>100MB</maxFileSize>


### PR DESCRIPTION
## Overview

Description:
Reducing log emission

Why should this be merged: 
There is a lot of noise in the corfu logs that makes it difficult to investigate the logs. Further more it causes the size of collected log to grow ver quickly.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
