### PR TITLE
LayoutView Cleanup.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/OutrankedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/OutrankedException.java
@@ -6,12 +6,12 @@ import org.corfudb.runtime.view.Layout;
 /**
  * Created by mwei on 12/14/15.
  */
-public class OutrankedException extends Exception {
+public class OutrankedException extends RuntimeException {
     @Getter
-    long newRank;
+    final long newRank;
 
     @Getter
-    Layout layout;
+    final Layout layout;
 
     /**
      * Constructor.


### PR DESCRIPTION
## Overview

Description: Prevent spinning in the while loop which causes verbose logging. Rather wait on the completable futures.

Why should this be merged: Prevents spinning and polluting logs.

Related issue(s) (if applicable): Resolves #1711 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
