### PR TITLE
Identify not ready sequencer correctly.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LocalMonitoringService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LocalMonitoringService.java
@@ -73,7 +73,8 @@ class LocalMonitoringService implements MonitoringService {
                 .requestMetrics()
                 //Handle possible exceptions and transform to the sequencer status
                 .exceptionally(ex -> {
-                    if (ex instanceof ServerNotReadyException) {
+                    // All Exceptions are CompletionExceptions. Need to unwrap them to obtain the cause.
+                    if (ex.getCause() instanceof ServerNotReadyException) {
                         return SequencerMetrics.NOT_READY;
                     }
 


### PR DESCRIPTION
## Overview

Description: Identify not ready sequencer correctly.

```
2019-02-05T02:01:09.799Z | ^[[1;31mERROR^[[0;39m | client-0 | o.c.i.LocalMonitoringService | Error while requesting metrics from the sequencer:
java.util.concurrent.CompletionException: org.corfudb.runtime.exceptions.ServerNotReadyException
        at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292)
        at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308)
        at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:593)
        at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:577)
        at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474)
        at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977)
        at org.corfudb.runtime.clients.NettyClientRouter.completeExceptionally(NettyClientRouter.java:528)
        at org.corfudb.runtime.clients.ClientMsgHandler.handle(ClientMsgHandler.java:81)
        at org.corfudb.runtime.clients.IClient.handleMessage(IClient.java:40)
        at org.corfudb.runtime.clients.NettyClientRouter.channelRead0(NettyClientRouter.java:567)
        at org.corfudb.runtime.clients.NettyClientRouter.channelRead0(NettyClientRouter.java:73)
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:105)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:310)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:284)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.ssl.SslHandler.unwrap(SslHandler.java:1407)
        at io.netty.handler.ssl.SslHandler.decodeNonJdkCompatible(SslHandler.java:1189)
        at io.netty.handler.ssl.SslHandler.decode(SslHandler.java:1223)
        at io.netty.handler.codec.ByteToMessageDecoder.decodeRemovalReentryProtection(ByteToMessageDecoder.java:489)
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:428)
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:265)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:340)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1434)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:362)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:348)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:965)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:163)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:646)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:581)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:498)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:460)
        at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:884)
        at java.lang.Thread.run(Thread.java:748)
Caused by: org.corfudb.runtime.exceptions.ServerNotReadyException: null
        at org.corfudb.runtime.clients.BaseHandler.handleNotReady(BaseHandler.java:129)
        at org.corfudb.runtime.clients.ClientMsgHandler.handle(ClientMsgHandler.java:76)
        ... 41 common frames omitted
```

Why should this be merged: To correctly identify the state of the sequencer.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
