### PR TITLE
Handle restore redundancy and merge segments.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/ReconfigurationEventHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/ReconfigurationEventHandler.java
@@ -17,9 +17,10 @@ import org.corfudb.runtime.view.Layout;
 /**
  * The ReconfigurationEventHandler handles the trigger provided by any source
  * or policy detecting a failure or healing in the cluster. It performs the following functions:
- * Cluster recovery:    Recovers the cluster on trigger at startup.
- * Handle failures:     Handles any failures in the layout based on the desired policy.
- * Handle healing:      Handles healing of unresponsive marked nodes which are now responsive.
+ * Cluster recovery:        Recovers the cluster on trigger at startup.
+ * Handle failures:         Handles any failures in the layout based on the desired policy.
+ * Handle healing:          Handles healing of unresponsive marked nodes which are now responsive.
+ * Handle mergeSegments:    Handles merging of multiple segments.
  *
  * <p>Created by zlokhandwala on 11/18/16.
  */
@@ -30,7 +31,9 @@ public class ReconfigurationEventHandler {
     @Setter
     private static int workflowRetries = 3;
 
-    static Duration DEFAULT_HEAL_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration DEFAULT_HEAL_TIMEOUT = Duration.ofMinutes(5);
+
+    private static final double TIMEOUT_MULTIPLICATIVE_FACTOR = 1.5;
 
     /**
      * Takes in the existing layout and a set of failed nodes.
@@ -57,6 +60,32 @@ public class ReconfigurationEventHandler {
     }
 
     /**
+     * Estimate a timeout to complete stateTransfer depending on the number of addresses to be transferred,
+     * the RPC timeout of the corfu runtime and the bulk size  of the transfer.
+     * TODO: Resize the bulk size in state transfer in case of timeouts or failures.
+     *
+     * @param runtime Connected corfu runtime instance
+     * @return A reasonable timeout to complete state transfer and rebuild logging unit.
+     */
+    private static Duration getStateTransferTimeoutEstimate(CorfuRuntime runtime) {
+
+        // Try to estimate a reasonable timeout to rebuild the logging unit
+        Token trimMark = runtime.getAddressSpaceView().getTrimMark();
+        // TODO: Consider requesting just the global tail from sequencer than fetching all the stream tails.
+        long tail = runtime.getAddressSpaceView().getAllTails().getLogTail();
+
+        long rangeToReplicate = tail - trimMark.getSequence();
+        // Since the orchestrator client and the fault detector client use
+        // the same configuration its reasonable to use these arguments.
+        // TODO(Maithem): AddNode should use a similar mechanism to set the timeout
+        long numSections = rangeToReplicate / runtime.getParameters().getBulkReadSize();
+        long rpcTimeout
+                = (long) (runtime.getParameters().getRequestTimeout().toMillis() * TIMEOUT_MULTIPLICATIVE_FACTOR);
+        long timeoutInMs = Math.max(DEFAULT_HEAL_TIMEOUT.toMillis(), numSections * rpcTimeout);
+        return Duration.ofMillis(timeoutInMs);
+    }
+
+    /**
      * Takes in the existing layout and a set of healed nodes.
      * The LayoutManagementView launches a workflow to heal the specified node. This call is
      * blocked until the workflow is completed or aborted.
@@ -75,19 +104,8 @@ public class ReconfigurationEventHandler {
 
         try {
             for (String healedServer : healedServers) {
-                // Try to estimate a reasonable timeout to rebuild the logging unit
-                Token trimMark = runtime.getAddressSpaceView().getTrimMark();
-                long tail = runtime.getAddressSpaceView().getAllTails().getLogTail();
 
-                long rangeToReplicate = tail - trimMark.getSequence();
-                // Since the orchestrator client and the fault detector client use
-                // the same configuration its reasonable to use these arguments.
-                // TODO(Maithem): AddNode should use a similar mechanism to set the timeout
-                long numSections = rangeToReplicate / runtime.getParameters().getBulkReadSize();
-                long rpcTimeout = (long) (runtime.getParameters().getRequestTimeout().toMillis() * 1.5);
-                long timeoutInMs = Math.max(DEFAULT_HEAL_TIMEOUT.toMillis(), numSections * rpcTimeout);
-                Duration workflowTimeout = Duration.ofMillis(timeoutInMs);
-
+                Duration workflowTimeout = getStateTransferTimeoutEstimate(runtime);
                 log.info("handleHealing: Workflow to heal {} timeout set to {} ms", healedServer, workflowTimeout);
 
                 runtime.getManagementView().healNode(
@@ -99,6 +117,46 @@ public class ReconfigurationEventHandler {
             return true;
         } catch (Exception e) {
             log.error("Error: handleHealing: {}", e);
+            return false;
+        }
+    }
+
+    /**
+     * Launches a workflow to restore redundancy and merge all segments.
+     * This method sends an orchestrator request to restore redundancy and merge all segments. This task is run
+     * asynchronously by the failure detector if it detects multiple segments in the layout.
+     * This is a blocking task and will complete if the workflow completes with a success or a failure.
+     * To avoid multiple workflow being submitted by different management agents, the management agents need to
+     * deterministically provide the same identifiable endpoint to the orchestrator. In this case, we choose the
+     * last added endpoint in the first stripe.
+     *
+     * @param runtime           Connected corfu runtime instance.
+     * @param layout            Latest known layout.
+     * @param retryQueryTimeout Timeout to poll for workflow status.
+     * @return True if workflow completed successfully. False otherwise.
+     */
+    public static boolean handleMergeSegments(@Nonnull CorfuRuntime runtime,
+                                              @Nonnull Layout layout,
+                                              @Nonnull Duration retryQueryTimeout) {
+
+        log.info("Handling split segments");
+
+        try {
+            Duration workflowTimeout = getStateTransferTimeoutEstimate(runtime);
+            log.info("handleMergeSegments: Workflow to merge segments for layout {} timeout set to {} ms",
+                    layout, workflowTimeout);
+
+            // Multiple invocations of this workflow can be avoided if the workflow are mapped to the same endpoint.
+            // Thus to deterministically choose an endpoint we always choose the last added log unit in the first
+            // stripe.
+            runtime.getManagementView().mergeSegments(
+                    layout.getLastAddedNodeInLastSegment(),
+                    workflowRetries,
+                    workflowTimeout,
+                    retryQueryTimeout);
+            return true;
+        } catch (Exception e) {
+            log.error("Error: handleMergeSegments: ", e);
             return false;
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Action.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Action.java
@@ -43,9 +43,10 @@ public abstract class Action {
                 changeStatus(ActionStatus.COMPLETED);
                 return;
             } catch (Exception e) {
-                log.error("execute: error executing action {} on retry {}",
+                log.error("execute: Error executing action {} on retry {}. Invalidating layout.",
                         getName(), x, e);
                 changeStatus(ActionStatus.ERROR);
+                runtime.invalidateLayout();
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Orchestrator.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Orchestrator.java
@@ -8,7 +8,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.IServerRouter;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.orchestrator.workflows.AddNodeWorkflow;
+import org.corfudb.infrastructure.orchestrator.workflows.ForceRemoveWorkflow;
 import org.corfudb.infrastructure.orchestrator.workflows.HealNodeWorkflow;
+import org.corfudb.infrastructure.orchestrator.workflows.RestoreRedundancyMergeSegmentsWorkflow;
 import org.corfudb.infrastructure.orchestrator.workflows.RemoveNodeWorkflow;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
@@ -17,13 +19,13 @@ import org.corfudb.protocols.wireprotocol.orchestrator.CreateRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.ForceRemoveNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.HealNodeRequest;
+import org.corfudb.protocols.wireprotocol.orchestrator.RestoreRedundancyMergeSegmentsRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorMsg;
 import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.QueryRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.QueryResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.RemoveNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.Response;
-import org.corfudb.infrastructure.orchestrator.workflows.ForceRemoveWorkflow;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
@@ -122,6 +124,10 @@ public class Orchestrator {
                 break;
             case FORCE_REMOVE_NODE:
                 workflow = new ForceRemoveWorkflow((ForceRemoveNodeRequest) orchReq.getRequest());
+                dispatch(workflow, msg, ctx, r);
+                break;
+            case RESTORE_REDUNDANCY_MERGE_SEGMENTS:
+                workflow = new RestoreRedundancyMergeSegmentsWorkflow((RestoreRedundancyMergeSegmentsRequest) orchReq.getRequest());
                 dispatch(workflow, msg, ctx, r);
                 break;
             default:

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/RestoreRedundancyMergeSegments.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/RestoreRedundancyMergeSegments.java
@@ -1,0 +1,77 @@
+package org.corfudb.infrastructure.orchestrator.actions;
+
+import com.google.common.collect.Sets;
+
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import javax.annotation.Nonnull;
+
+import org.corfudb.infrastructure.orchestrator.Action;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.OutrankedException;
+import org.corfudb.runtime.view.Layout;
+
+/**
+ * This action attempts to restore redundancy for all servers across all segments
+ * starting from the oldest segment. It then collapses the segments once the set of
+ * servers in the 2 oldest subsequent segments are equal.
+ * Created by Zeeshan on 2019-02-06.
+ */
+public class RestoreRedundancyMergeSegments extends Action {
+
+    /**
+     * Returns set of nodes which are present in the next index but not in the specified segment. These
+     * nodes have reduced redundancy and state needs to be transferred only to these before these segments can be
+     * merged.
+     *
+     * @param layout             Current layout.
+     * @param layoutSegmentIndex Segment to compare to get nodes with reduced redundancy.
+     * @return Set of nodes with reduced redundancy.
+     */
+    private Set<String> getNodesWithReducedRedundancy(Layout layout, int layoutSegmentIndex) {
+        // Get the set of servers present in the next segment but not in the this
+        // segment.
+        return Sets.difference(
+                layout.getSegments().get(layoutSegmentIndex + 1).getAllLogServers(),
+                layout.getSegments().get(layoutSegmentIndex).getAllLogServers());
+    }
+
+    @Nonnull
+    @Override
+    public String getName() {
+        return "RestoreRedundancyAndMergeSegments";
+    }
+
+    @Override
+    public void impl(@Nonnull CorfuRuntime runtime) throws OutrankedException,
+            ExecutionException,
+            InterruptedException {
+
+        // Refresh layout.
+        runtime.invalidateLayout();
+        Layout layout = runtime.getLayoutView().getLayout();
+
+        // Each segment is compared with the first segment. The data is restored in any new LogUnit nodes and then
+        // merged to this segment. This is done for all the segments.
+        final int layoutSegmentToMergeTo = 0;
+
+        // Catchup all servers across all segments.
+        while (layout.getSegments().size() > 1) {
+
+            Set<String> lowRedundancyServers = getNodesWithReducedRedundancy(layout, layoutSegmentToMergeTo);
+
+            // Currently the state is transferred for the complete segment.
+            // TODO: Add stripe specific transfer granularity for optimization.
+            // Transfer the replicated segment to the difference set calculated above.
+            StateTransfer.transfer(layout, lowRedundancyServers, runtime, layout.getFirstSegment());
+
+            // Merge the 2 segments.
+            runtime.getLayoutManagementView().mergeSegments(new Layout(layout));
+
+            // Refresh layout
+            runtime.invalidateLayout();
+            layout = runtime.getLayoutView().getLayout();
+        }
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/StateTransfer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/StateTransfer.java
@@ -1,0 +1,120 @@
+package org.corfudb.infrastructure.orchestrator.actions;
+
+import com.google.common.collect.ContiguousSet;
+import com.google.common.collect.DiscreteDomain;
+import com.google.common.collect.Range;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.util.CFUtils;
+
+/**
+ * State transfer utility.
+ * Created by zlokhandwala on 2019-02-06.
+ */
+@Slf4j
+public class StateTransfer {
+
+    private StateTransfer() {
+        // Hide implicit public constructor.
+    }
+
+    /**
+     * Fetch and propagate the trimMark to the new/healing nodes. Else, a FastLoader reading from
+     * them will have to mark all the already trimmed entries as holes.
+     * Transfer an address segment from a cluster to a set of specified nodes.
+     * There are no cluster reconfigurations, hence no epoch change side effects.
+     *
+     * @param layout    layout
+     * @param endpoints destination nodes
+     * @param runtime   The runtime to read the segment from
+     * @param segment   segment to transfer
+     */
+    public static void transfer(Layout layout,
+                                Set<String> endpoints,
+                                CorfuRuntime runtime,
+                                Layout.LayoutSegment segment) throws ExecutionException, InterruptedException {
+
+        int batchSize = runtime.getParameters().getBulkReadSize();
+
+        long trimMark = runtime.getAddressSpaceView().getTrimMark().getSequence();
+        // Send the trimMark to the new/healing nodes.
+        // If this times out or fails, the Action performing the stateTransfer fails and retries.
+
+        endpoints.stream()
+                .map(endpoint -> {
+                    // TrimMark is the first address present on the log unit server.
+                    // Perform the prefix trim on the preceding address = (trimMark - 1).
+                    // Since the LU will reject trim decisions made from older epochs, we
+                    // need to adjust the new trim mark to have the new layout's epoch.
+                    Token prefixToken = new Token(layout.getEpoch(), trimMark - 1);
+                    return runtime.getLayoutView().getRuntimeLayout(layout)
+                            .getLogUnitClient(endpoint)
+                            .prefixTrim(prefixToken);
+                })
+                .forEach(CFUtils::getUninterruptibly);
+
+        if (trimMark > segment.getEnd()) {
+            log.info("stateTransfer: Nothing to transfer, trimMark {} greater than end of segment {}",
+                    trimMark, segment.getEnd());
+            return;
+        }
+
+        // State transfer should start from segment start address or trim mark whichever is lower.
+        long segmentStart = Math.max(trimMark, segment.getStart());
+
+        for (long chunkStart = segmentStart; chunkStart < segment.getEnd()
+                ; chunkStart = chunkStart + batchSize) {
+            long chunkEnd = Math.min((chunkStart + batchSize - 1), segment.getEnd() - 1);
+
+            long ts1 = System.currentTimeMillis();
+
+            Map<Long, ILogData> dataMap = runtime.getAddressSpaceView()
+                    .cacheFetch(ContiguousSet.create(
+                            Range.closed(chunkStart, chunkEnd),
+                            DiscreteDomain.longs()));
+
+            long ts2 = System.currentTimeMillis();
+
+            log.info("stateTransfer: read {}-{} in {} ms", chunkStart, chunkEnd, (ts2 - ts1));
+
+            List<LogData> entries = new ArrayList<>();
+            for (long x = chunkStart; x <= chunkEnd; x++) {
+                if (!dataMap.containsKey(x)) {
+                    log.error("Missing address {} in range {}-{}", x, chunkStart, chunkEnd);
+                    throw new IllegalStateException("Missing address");
+                }
+                entries.add((LogData) dataMap.get(x));
+            }
+
+            for (String endpoint : endpoints) {
+                // Write segment chunk to the new logunit
+                ts1 = System.currentTimeMillis();
+                boolean transferSuccess = runtime.getLayoutView().getRuntimeLayout(layout)
+                        .getLogUnitClient(endpoint)
+                        .writeRange(entries).get();
+                ts2 = System.currentTimeMillis();
+
+                if (!transferSuccess) {
+                    log.error("stateTransfer: Failed to transfer {}-{} to {}", chunkStart,
+                            chunkEnd, endpoint);
+                    throw new IllegalStateException("Failed to transfer!");
+                }
+
+                log.info("stateTransfer: Transferred address chunk [{}, {}] to {} in {} ms",
+                        chunkStart, chunkEnd, endpoint, (ts2 - ts1));
+            }
+        }
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/RestoreRedundancyMergeSegmentsWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/RestoreRedundancyMergeSegmentsWorkflow.java
@@ -1,0 +1,52 @@
+package org.corfudb.infrastructure.orchestrator.workflows;
+
+import static org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorRequestType.RESTORE_REDUNDANCY_MERGE_SEGMENTS;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.corfudb.infrastructure.orchestrator.Action;
+import org.corfudb.infrastructure.orchestrator.IWorkflow;
+import org.corfudb.infrastructure.orchestrator.actions.RestoreRedundancyMergeSegments;
+import org.corfudb.protocols.wireprotocol.orchestrator.RestoreRedundancyMergeSegmentsRequest;
+
+/**
+ * A definition of a workflow that merges all the segments in the layout.
+ * This workflow compares every two consequent segments and restores the redundancy in all nodes present in both the
+ * segments. After the state transfer, the workflow merges the segments. This is carried out for all segments until
+ * the layout has only one segment left.
+ * Created by Zeeshan on 2019-02-06.
+ */
+@Slf4j
+public class RestoreRedundancyMergeSegmentsWorkflow implements IWorkflow {
+
+
+    private final RestoreRedundancyMergeSegmentsRequest request;
+
+    @Getter
+    private final UUID id;
+
+    @Getter
+    private final List<Action> actions;
+
+    /**
+     * Creates a new merge segments workflow from a request.
+     *
+     * @param request request to restore redundancy and merge a segment.
+     */
+    public RestoreRedundancyMergeSegmentsWorkflow(RestoreRedundancyMergeSegmentsRequest request) {
+        this.id = UUID.randomUUID();
+        this.request = request;
+        this.actions = ImmutableList.of(new RestoreRedundancyMergeSegments());
+    }
+
+    @Override
+    public String getName() {
+        return RESTORE_REDUNDANCY_MERGE_SEGMENTS.toString();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/OrchestratorRequestType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/OrchestratorRequestType.java
@@ -39,7 +39,12 @@ public enum OrchestratorRequestType {
     /**
      * Force remove a node from the cluster
      */
-    FORCE_REMOVE_NODE(4, ForceRemoveNodeRequest::new);
+    FORCE_REMOVE_NODE(4, ForceRemoveNodeRequest::new),
+
+    /**
+     * Restore redundancy and merge segments in the layout.
+     */
+    RESTORE_REDUNDANCY_MERGE_SEGMENTS(5, RestoreRedundancyMergeSegmentsRequest::new);
 
 
     @Getter

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/RestoreRedundancyMergeSegmentsRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/orchestrator/RestoreRedundancyMergeSegmentsRequest.java
@@ -1,0 +1,38 @@
+package org.corfudb.protocols.wireprotocol.orchestrator;
+
+import static org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorRequestType.RESTORE_REDUNDANCY_MERGE_SEGMENTS;
+
+import java.nio.charset.StandardCharsets;
+
+import lombok.Getter;
+
+/**
+ * An orchestrator request message to restore redundancy and merge all segments in the cluster.
+ * Created by Zeeshan on 2019-02-06.
+ */
+public class RestoreRedundancyMergeSegmentsRequest implements CreateRequest {
+
+    /**
+     * Endpoint to restore redundancy to. Data needs to be transferred to this node.
+     */
+    @Getter
+    private final String endpoint;
+
+    public RestoreRedundancyMergeSegmentsRequest(String endpoint) {
+        this.endpoint = endpoint;
+    }
+
+    public RestoreRedundancyMergeSegmentsRequest(byte[] buf) {
+        endpoint = new String(buf, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public OrchestratorRequestType getType() {
+        return RESTORE_REDUNDANCY_MERGE_SEGMENTS;
+    }
+
+    @Override
+    public byte[] getSerialized() {
+        return endpoint.getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -17,6 +17,7 @@ import org.corfudb.protocols.wireprotocol.orchestrator.AddNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.ForceRemoveNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.HealNodeRequest;
+import org.corfudb.protocols.wireprotocol.orchestrator.RestoreRedundancyMergeSegmentsRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorMsg;
 import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.QueryRequest;
@@ -135,6 +136,21 @@ public class ManagementClient extends AbstractClient {
                         isSequencerServer,
                         isLogUnitServer,
                         stripeIndex));
+        CompletableFuture<OrchestratorResponse> resp = sendMessageWithFuture(CorfuMsgType
+                .ORCHESTRATOR_REQUEST
+                .payloadMsg(req));
+        return (CreateWorkflowResponse) CFUtils.getUninterruptibly(resp, TimeoutException.class).getResponse();
+    }
+
+    /**
+     * Creates a workflow request to restore all redundancies and merge all segments.
+     *
+     * @param endpoint Endpoint to restore redundancy.
+     * @return CreateWorkflowResponse which gives the workflowId.
+     * @throws TimeoutException when the rpc times out
+     */
+    public CreateWorkflowResponse mergeSegments(@Nonnull String endpoint) throws TimeoutException {
+        OrchestratorMsg req = new OrchestratorMsg(new RestoreRedundancyMergeSegmentsRequest(endpoint));
         CompletableFuture<OrchestratorResponse> resp = sendMessageWithFuture(CorfuMsgType
                 .ORCHESTRATOR_REQUEST
                 .payloadMsg(req));

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -275,11 +275,32 @@ public class Layout {
     }
 
     /**
+     * Get the first segment.
+     * @return Returns the segment at index 0.
+     */
+    public LayoutSegment getFirstSegment() {
+        return this.getSegments().get(0);
+    }
+
+    /**
      * Return latest segment.
-     *
+     * @return the latest segment.
      */
     public LayoutSegment getLatestSegment() {
         return this.getSegments().get(this.getSegments().size() - 1);
+    }
+
+    /**
+     * Get the last node in the last segment.
+     *
+     * @return Returns the last node in the last segment.
+     */
+    public String getLastAddedNodeInLastSegment() {
+
+        // Fetching the latest segment. Note: This is the unbounded segment with ongoing writes.
+        // Returning the last node in the first stripe for determinism.
+        List<String> firstStripeLogServers = getLatestSegment().getFirstStripe().getLogServers();
+        return firstStripeLogServers.get(firstStripeLogServers.size() - 1);
     }
 
     /**
@@ -563,6 +584,15 @@ public class Layout {
 
         public int getNumberOfStripes() {
             return stripes.size();
+        }
+
+        /**
+         * Gets the first stripe.
+         *
+         * @return Returns the stripe at index 0.
+         */
+        public LayoutStripe getFirstStripe() {
+            return stripes.get(0);
         }
 
         /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
@@ -34,6 +34,7 @@ import org.corfudb.runtime.view.Layout.LayoutSegment;
 import org.corfudb.runtime.view.workflows.AddNode;
 import org.corfudb.runtime.view.workflows.ForceRemoveNode;
 import org.corfudb.runtime.view.workflows.HealNode;
+import org.corfudb.runtime.view.workflows.RestoreRedundancyMergeSegments;
 import org.corfudb.runtime.view.workflows.RemoveNode;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.NodeLocator;
@@ -117,6 +118,21 @@ public class ManagementView extends AbstractView {
     public void healNode(@Nonnull String endpointToHeal, int retry, @Nonnull Duration timeout,
                          @Nonnull Duration pollPeriod) {
         new HealNode(endpointToHeal, runtime, retry, timeout, pollPeriod).invoke();
+    }
+
+    /**
+     * Restore redundancy and merge all split segments.
+     *
+     * @param endpointToRestoreRedundancy Endpoint whose redundancy is to be restored.
+     * @param retry                       the number of times to retry a workflow if it fails
+     * @param timeout                     total time to wait before the workflow times out
+     * @param pollPeriod                  the poll interval to check whether a workflow completed or not
+     * @throws WorkflowResultUnknownException when the side affect of the operation
+     *                                        can't be determined
+     */
+    public void mergeSegments(@Nonnull String endpointToRestoreRedundancy, int retry, @Nonnull Duration timeout,
+                              @Nonnull Duration pollPeriod) {
+        new RestoreRedundancyMergeSegments(endpointToRestoreRedundancy, runtime, retry, timeout, pollPeriod).invoke();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/workflows/RestoreRedundancyMergeSegments.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/workflows/RestoreRedundancyMergeSegments.java
@@ -1,0 +1,75 @@
+package org.corfudb.runtime.view.workflows;
+
+import java.time.Duration;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.clients.ManagementClient;
+import org.corfudb.runtime.view.Layout;
+
+/**
+ * Sending a workflow request to restore all redundancies and merge all segments.
+ * Created by Zeeshan on 2019-02-06.
+ */
+@Slf4j
+public class RestoreRedundancyMergeSegments extends WorkflowRequest {
+
+    /**
+     * Create a Merge segments workflow request.
+     *
+     * @param endpointToRestoreRedundancy Endpoint to restore redundancy to.
+     * @param runtime                     Connected instance of Corfu runtime.
+     * @param retry                       Number of retries.
+     * @param timeout                     Workflow timeout.
+     * @param pollPeriod                  Poll interval to check workflow status.
+     */
+    public RestoreRedundancyMergeSegments(@NonNull String endpointToRestoreRedundancy,
+                                          @NonNull CorfuRuntime runtime,
+                                          int retry,
+                                          @NonNull Duration timeout,
+                                          @NonNull Duration pollPeriod) {
+        this.nodeForWorkflow = endpointToRestoreRedundancy;
+        this.runtime = runtime;
+        this.retry = retry;
+        this.timeout = timeout;
+        this.pollPeriod = pollPeriod;
+    }
+
+    /**
+     * Creates and sends the workflow request to restore redundancy and merge the segments.
+     *
+     * @param managementClient Management Client to send the orchestrator request.
+     * @return Workflow ID.
+     * @throws TimeoutException thrown is orchestrator request was not acknowledged within the RPC timeout.
+     */
+    @Override
+    protected UUID sendRequest(@NonNull ManagementClient managementClient) throws TimeoutException {
+        CreateWorkflowResponse resp = managementClient.mergeSegments(nodeForWorkflow);
+        log.info("sendRequest: request to restore redundancy and merge segments for endpoint {} on orchestrator {}:{}",
+                nodeForWorkflow, managementClient.getRouter().getHost(),
+                managementClient.getRouter().getPort());
+        return resp.getWorkflowId();
+    }
+
+    /**
+     * Verify request has been completed if the layout contains only one segment.
+     *
+     * @param layout the layout to inspect
+     * @return True if the layout has only one segment. False otherwise.
+     */
+    @Override
+    protected boolean verifyRequest(@NonNull Layout layout) {
+        log.info("verifyRequest: {} in {}", this, layout);
+        return layout.getSegments().size() == 1;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + " " + nodeForWorkflow;
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -224,7 +224,7 @@ public class ClusterReconfigIT extends AbstractIT {
      * This is to ensure we have at least 1.5 data log files.
      * A daemon thread is instantiated to randomly put data while add node is executed.
      * 2 nodes - 9001 and 9002 are added to the cluster.
-     * Finally the epoch and the addition of the 2 nodes in the layout is verified.
+     * Finally the addition of the 2 nodes in the layout is verified.
      *
      * @throws Exception
      */
@@ -265,9 +265,10 @@ public class ClusterReconfigIT extends AbstractIT {
         runtime.getManagementView().addNode("localhost:9002", workflowNumRetry,
                 timeout, pollPeriod);
 
-        final long epochAfter2Adds = 4L;
-        runtime.invalidateLayout();
-        assertThat(runtime.getLayoutView().getLayout().getEpoch()).isEqualTo(epochAfter2Adds);
+        final int nodesCount = 3;
+        waitForLayoutChange(layout -> layout.getAllActiveServers().size() == nodesCount
+                && layout.getUnresponsiveServers().isEmpty()
+                && layout.getSegments().size() == 1, runtime);
 
         moreDataToBeWritten.set(false);
         t.join();

--- a/test/src/test/java/org/corfudb/integration/TransactionAbortedIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionAbortedIT.java
@@ -11,11 +11,8 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -41,18 +38,17 @@ public class TransactionAbortedIT extends AbstractIT {
                 .open();
         final String key = "key";
         final String value = "value";
-        map.put(key, value);
+
         startLatch.countDown();
+        runtime.getObjectsView().TXBegin();
+        UUID myTxId = TransactionalContext.getCurrentContext().getTransactionID();
+        map.put(key, value);
+
         try {
             startLatch.await();
         } catch (InterruptedException fail) {
             throw new RuntimeException(fail);
         }
-
-        runtime.getObjectsView().TXBegin();
-        UUID myTxId = TransactionalContext.getCurrentContext().getTransactionID();
-
-        map.put(key, value);
 
         try {
             offendingAddress = runtime.getObjectsView().TXEnd();


### PR DESCRIPTION
## Overview

Description: Detect split segments, restore redundancy and merge the segments.

Why should this be merged: If the heal/add node workflow crashes midway, the state transfer is never completed and the newly added nodes stay with reduced redundancy.

Related issue(s) (if applicable): Fixes #1390 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
