### PR TITLE
Fix partial bootstraps during AddNode.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LocalMonitoringService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LocalMonitoringService.java
@@ -73,7 +73,7 @@ class LocalMonitoringService implements MonitoringService {
                 .requestMetrics()
                 //Handle possible exceptions and transform to the sequencer status
                 .exceptionally(ex -> {
-                    if (ex instanceof ServerNotReadyException) {
+                    if (ex.getCause() instanceof ServerNotReadyException) {
                         return SequencerMetrics.NOT_READY;
                     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/workflows/AddNodeWorkflow.java
@@ -73,18 +73,14 @@ public class AddNodeWorkflow implements IWorkflow {
             return "BootstrapNode";
         }
 
+        /**
+         * Completes if bootstrap was successful.
+         *
+         * @param runtime A runtime that the action will use to execute
+         */
         @Override
         public void impl(@Nonnull CorfuRuntime runtime) throws Exception {
-            try {
-                runtime.getLayoutManagementView().bootstrapNewNode(request.getEndpoint());
-            } catch (Exception e) {
-                if (e.getCause() instanceof AlreadyBootstrappedException) {
-                    log.info("BootstrapNode: Node {} already bootstrapped, skipping.", request.getEndpoint());
-                } else {
-                    log.error("execute: Error during bootstrap", e);
-                    throw e;
-                }
-            }
+            runtime.getLayoutManagementView().bootstrapNewNode(request.getEndpoint()).get();
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -8,7 +8,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -97,24 +96,22 @@ public class LayoutManagementView extends AbstractView {
      * Bootstraps the new node with the current layout.
      * This action is invoked as a part of the add node workflow which requires the new node
      * to be added to the cluster to be bootstrapped with the existing layout of this cluster.
-     * This bootstraps the Layout and the Management server with the existing layout and also
+     * This bootstraps the Layout and the Management server with the existing layout which
      * initiates failure handling capabilities on the management server.
      *
      * @param endpoint New node endpoint.
+     * @return Completable Future which completes when the node's layout and management servers are bootstrapped.
      */
-    public void bootstrapNewNode(String endpoint) {
+    public CompletableFuture<Boolean> bootstrapNewNode(String endpoint) {
 
         // Bootstrap the to-be added node with the old layout.
         Layout layout = new Layout(runtime.getLayoutView().getLayout());
-        // Ignoring call result as the call returns ACK or throws an exception.
-        CFUtils.getUninterruptibly(runtime.getLayoutView().getRuntimeLayout(layout)
-                .getLayoutClient(endpoint)
-                .bootstrapLayout(layout));
-        CFUtils.getUninterruptibly(runtime.getLayoutView().getRuntimeLayout(layout)
-                .getManagementClient(endpoint)
-                .bootstrapManagement(layout));
-
-        log.info("bootstrapNewNode: New node {} bootstrapped.", endpoint);
+        return runtime.getLayoutView().bootstrapLayoutServer(endpoint, layout)
+                .thenCompose(result -> runtime.getManagementView().bootstrapManagementServer(endpoint, layout))
+                .thenApply(result -> {
+                    log.info("bootstrapNewNode: New node {} bootstrapped.", endpoint);
+                    return true;
+                });
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/util/CFUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/CFUtils.java
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -13,10 +14,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Created by mwei on 9/15/15.
  */
+@Slf4j
 public class CFUtils {
 
     private static final ScheduledExecutorService scheduler =
@@ -140,5 +143,41 @@ public class CFUtils {
     public static <T> CompletableFuture<Void> allOf(Collection<CompletableFuture<T>> futures) {
         CompletableFuture<T>[] futuresArr = futures.toArray(new CompletableFuture[futures.size()]);
         return CompletableFuture.allOf(futuresArr);
+    }
+
+    /**
+     * Unwraps ExecutionException thrown from a CompletableFuture.
+     *
+     * @param throwable  Throwable to unwrap.
+     * @param throwableA Checked Exception to expose.
+     * @param <A>        Class of checked exception.
+     * @throws A Throws checked exception.
+     */
+    public static <A extends Throwable> void unwrap(Throwable throwable, Class<A> throwableA) throws A {
+
+        Throwable unwrapThrowable = throwable;
+        if (throwable instanceof ExecutionException || throwable instanceof CompletionException) {
+            unwrapThrowable = throwable.getCause();
+        }
+
+        if (throwableA.isInstance(unwrapThrowable)) {
+            throw (A) unwrapThrowable;
+        }
+        if (unwrapThrowable instanceof RuntimeException) {
+            throw (RuntimeException) unwrapThrowable;
+        }
+        if (unwrapThrowable instanceof Error) {
+            throw (Error) unwrapThrowable;
+        }
+        throw new RuntimeException(unwrapThrowable);
+    }
+
+    /**
+     * Unwraps ExecutionException thrown from a CompletableFuture.
+     *
+     * @param throwable Throwable to unwrap.
+     */
+    public static void unwrap(Throwable throwable) {
+        unwrap(throwable, RuntimeException.class);
     }
 }


### PR DESCRIPTION
## Overview

Description: Fixes partial bootstraps in case of already bootstrapped components.

Why should this be merged: The management server remains un-bootstrapped forever.

Related issue(s) (if applicable): Fixes #1725 

Tests affecting this:
testPartialBootstrapNodeSuccess
testPartialBootstrapNodeFailure

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
