### PR TITLE
FillReadQueue Optimization

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -35,6 +35,9 @@ message LogEntry {
     optional int64 checkpointedStreamId_least_significant = 14;
     //  Tail of the stream at the time of taking the checkpoint snapshot.
     optional int64 checkpointedStreamStartLogAddress = 15;
+    // Checkpoint snapshot address
+    optional int64 checkpointedStreamSnapshotAddress = 19;
+
 
     // ClientId is the Corfu runtime id that created this LogEntry
     optional int64 clientId_least_significant = 16;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -381,6 +381,9 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
 
             logData.setCheckpointedStreamStartLogAddress(
                     entry.getCheckpointedStreamStartLogAddress());
+
+            logData.setCheckpointedStreamSnapshotAddress(
+                    entry.getCheckpointedStreamSnapshotAddress());
         }
 
         return logData;
@@ -732,6 +735,8 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                     entry.getCheckpointedStreamId().getMostSignificantBits());
             logEntryBuilder.setCheckpointedStreamStartLogAddress(
                     entry.getCheckpointedStreamStartLogAddress());
+            logEntryBuilder.setCheckpointedStreamSnapshotAddress(
+                    entry.getCheckpointedStreamSnapshotAddress());
         }
 
         return logEntryBuilder.build();

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -28,6 +28,7 @@ import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.C
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_START_LOG_ADDRESS;
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_ID;
 import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_TYPE;
+import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_SNAPSHOT_ADDRESS;
 
 /**
  * Created by mwei on 9/18/15.
@@ -218,6 +219,19 @@ public interface IMetadata {
         getMetadataMap().put(CHECKPOINTED_STREAM_START_LOG_ADDRESS, startLogAddress);
     }
 
+    /**
+     * Returns the snapshot at which the checkpoint was taken.
+     */
+    default Long getCheckpointedStreamSnapshotAddress() {
+        return (Long) getMetadataMap()
+                .getOrDefault(CHECKPOINTED_STREAM_SNAPSHOT_ADDRESS,
+                        Address.NO_BACKPOINTER);
+    }
+
+    default void setCheckpointedStreamSnapshotAddress(Long startLogAddress) {
+        getMetadataMap().put(CHECKPOINTED_STREAM_SNAPSHOT_ADDRESS, startLogAddress);
+    }
+
     @RequiredArgsConstructor
     public enum LogUnitMetadataType implements ITypedEnum {
         RANK(1, TypeToken.of(DataRank.class)),
@@ -230,7 +244,8 @@ public interface IMetadata {
         CHECKPOINTED_STREAM_START_LOG_ADDRESS(9, TypeToken.of(Long.class)),
         CLIENT_ID(10, TypeToken.of(UUID.class)),
         THREAD_ID(11, TypeToken.of(Long.class)),
-        EPOCH(12, TypeToken.of(Long.class))
+        EPOCH(12, TypeToken.of(Long.class)),
+        CHECKPOINTED_STREAM_SNAPSHOT_ADDRESS(13, TypeToken.of(Long.class))
         ;
         final int type;
         @Getter

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -180,6 +180,9 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
                 setCheckpointedStreamStartLogAddress(
                         Long.parseLong(cp.getDict()
                                 .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)));
+                setCheckpointedStreamSnapshotAddress(
+                        Long.parseLong(cp.getDict()
+                                .get(CheckpointEntry.CheckpointDictKey.SNAPSHOT_ADDRESS)));
             }
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -402,7 +402,6 @@ public abstract class AbstractQueuedStreamView extends
          */
         UUID checkpointSuccessId = null;
         long checkpointSuccessStartAddr = Address.NEVER_READ;
-        long checkpointSuccessEndAddr = Address.NEVER_READ;
         long checkpointSuccessNumEntries = 0L;
         long checkpointSuccessBytes = 0L;
         // No need to keep track of # of DATA entries, use context.resolvedQueue.size()?
@@ -437,7 +436,6 @@ public abstract class AbstractQueuedStreamView extends
 
             checkpointSuccessId = null;
             checkpointSuccessStartAddr = Address.NEVER_READ;
-            checkpointSuccessEndAddr = Address.NEVER_READ;
             checkpointSnapshotAddress = Address.NEVER_READ;
             checkpointSuccessNumEntries = 0;
             checkpointSuccessBytes = 0;

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -464,6 +464,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
             TokenResponse tokResp1 = r.getSequencerView().query(streamId);
             long addr1 = tokResp1.getToken().getSequence();
             mdKV.put(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS, Long.toString(addr1 + 1));
+            mdKV.put(CheckpointEntry.CheckpointDictKey.SNAPSHOT_ADDRESS, Long.toString(addr1 + 1));
             CheckpointEntry cp1 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.START,
                     checkpointAuthor, checkpointId, streamId, mdKV, null);
             sv.append(cp1, null, null);


### PR DESCRIPTION
## Overview

Fill from resolved queue when part of the data is already available, and
follow backpointers strictly on the addresses that are not part of the stream.

Why should this be merged: avoids following backpointer for space of resolved addresses. Improve performance.