### PR TITLE
Check max write size in stream layer.

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.WriteSizeException;
 import org.corfudb.util.serializer.Serializers;
 
 /**
@@ -256,5 +257,18 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
     @Override
     public String toString() {
         return "LogData[" + getGlobalAddress() + "]";
+    }
+
+    /**
+     * Verify that max payload is enforced for the specified limit.
+     *
+     * @param limit Max write limit.
+     */
+    public void checkMaxWriteSize(int limit) {
+        try (ILogData.SerializationHandle sh = this.getSerializedForm()) {
+            if (limit != 0 && getSizeEstimate() > limit) {
+                throw new WriteSizeException(getSizeEstimate(), limit);
+            }
+        }
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -149,7 +149,12 @@ public class AddressSpaceView extends AbstractView {
      * @throws WrongEpochException  If the token epoch is invalid.
      */
     public void write(@Nonnull IToken token, @Nonnull Object data, @Nonnull CacheOption cacheOption) {
-        final ILogData ld = new LogData(DataType.DATA, data);
+        ILogData ld;
+        if (data instanceof ILogData) {
+            ld = (ILogData) data;
+        } else {
+            ld = new LogData(DataType.DATA, data);
+        }
 
         layoutHelper(e -> {
             Layout l = e.getLayout();

--- a/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
@@ -145,8 +145,7 @@ public class RuntimeLayout {
     public LogUnitClient getLogUnitClient(String endpoint) {
         return ((LogUnitClient) getClient(LogUnitClient.class, endpoint))
                 .setMetricRegistry(getRuntime().getMetrics() != null
-                        ? getRuntime().getMetrics() : CorfuRuntime.getDefaultMetrics())
-                .setMaxWrite(getRuntime().getParameters().getMaxWriteSize());
+                        ? getRuntime().getMetrics() : CorfuRuntime.getDefaultMetrics());
     }
 
     public ManagementClient getManagementClient(String endpoint) {


### PR DESCRIPTION
## Overview

Description:
The max write size is checked at the LogUnitClient after obtaining a token. This causes us to create a lot of holes in case the payload size is large.
Thus the check has been moved to the stream layer.

Why should this be merged: This creates a lot of holes due to large payload sizes.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
