### PR TITLE
Avoid wait after holeFill in range read.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -142,6 +142,11 @@ public class CorfuRuntime {
         @Default Duration holeFillRetryThreshold = Duration.ofSeconds(1L);
 
         /**
+         * Time limit after which the reader gives up and fills the hole.
+         */
+        @Default Duration holeFillTimeout = Duration.ofSeconds(10);
+
+        /**
          * Whether or not to disable the cache.
          */
         @Default

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -394,7 +394,7 @@ public class Layout {
                     return new ChainReplicationProtocol(new NeverHoleFillPolicy(100));
                 } else {
                     return new ChainReplicationProtocol(
-                            new ReadWaitHoleFillPolicy(r.getParameters().getRequestTimeout(),
+                            new ReadWaitHoleFillPolicy(r.getParameters().getHoleFillTimeout(),
                                     r.getParameters().getHoleFillRetryThreshold()));
                 }
             }
@@ -437,7 +437,7 @@ public class Layout {
                     return new QuorumReplicationProtocol(new NeverHoleFillPolicy(100));
                 } else {
                     return new QuorumReplicationProtocol(
-                            new ReadWaitHoleFillPolicy(r.getParameters().getRequestTimeout(),
+                            new ReadWaitHoleFillPolicy(r.getParameters().getHoleFillTimeout(),
                                     r.getParameters().getHoleFillRetryThreshold()));
                 }
             }

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
@@ -81,32 +81,32 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
      */
     @Override
     public Map<Long, ILogData> readAll(RuntimeLayout runtimeLayout, List<Long> globalAddresses) {
-        long startAddress = globalAddresses.iterator().next();
-        int numUnits = runtimeLayout.getLayout().getSegmentLength(startAddress);
-        log.trace("readAll[{}]: chain {}/{}", globalAddresses, numUnits, numUnits);
-
-        Map<Long, LogData> logResult = CFUtils.getUninterruptibly(
-                runtimeLayout
-                        .getLogUnitClient(startAddress, numUnits - 1)
-                        .read(globalAddresses)).getAddresses();
-
-        //in case of a hole, do a normal read and use its hole fill policy
-        Map<Long, ILogData> returnResult = new TreeMap<>();
-        for (Map.Entry<Long, LogData> entry : logResult.entrySet()) {
-            ILogData value = entry.getValue();
-            if (value == null || value.isEmpty()) {
-                value = read(runtimeLayout, entry.getKey());
-            }
-
-            returnResult.put(entry.getKey(), value);
-        }
-
-        return returnResult;
+        Range<Long> range = Range.encloseAll(globalAddresses);
+        return readRange(runtimeLayout, range, true);
     }
+
+
 
     @Override
     public Map<Long, ILogData> readRange(RuntimeLayout runtimeLayout, Set<Long> globalAddresses) {
         Range<Long> range = Range.encloseAll(globalAddresses);
+        return readRange(runtimeLayout, range, true);
+    }
+
+    /**
+     * Reads a range of addresses from the Chain of log unit servers. This method optimizes for the time to wait to
+     * hole fill in case an empty address is encountered.
+     * If the waitForWrite flag is set to true, when an empty address is encountered, it waits for the hole to be
+     * filled. All subsequent empty addresses are hole filled directly and the reader does not wait.
+     * In case the flag is set to false, none of the reads wait for write completion and the empty address is hole
+     * filled right away.
+     *
+     * @param runtimeLayout Runtime layout.
+     * @param range         Range of addresses to read.
+     * @param waitForWrite  Flag whether wait for write is required or hole fill directly.
+     * @return Map of read addresses.
+     */
+    public Map<Long, ILogData> readRange(RuntimeLayout runtimeLayout, Range<Long> range, boolean waitForWrite) {
         long startAddress = range.lowerEndpoint();
         long endAddress = range.upperEndpoint();
         int numUnits = runtimeLayout.getLayout().getSegmentLength(startAddress);
@@ -117,12 +117,30 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
                         .getLogUnitClient(startAddress, numUnits - 1)
                         .read(range)).getAddresses();
 
-        //in case of a hole, do a normal read and use its hole fill policy
+        // In case of holes, use the standard backoff policy for hole fill for
+        // the first entry in the list. All subsequent holes in the list can
+        // be hole filled without waiting as we have already waited for the first
+        // hole.
+        boolean wait = !waitForWrite;
         Map<Long, ILogData> returnResult = new TreeMap<>();
         for (Map.Entry<Long, LogData> entry : logResult.entrySet()) {
+            long address = entry.getKey();
             ILogData value = entry.getValue();
             if (value == null || value.isEmpty()) {
-                value = read(runtimeLayout, entry.getKey());
+                if (!wait) {
+                    value = read(runtimeLayout, address);
+                    wait = true;
+                } else {
+                    // try to read the value
+                    value = CFUtils.getUninterruptibly(runtimeLayout
+                            .getLogUnitClient(startAddress, numUnits - 1).read(address))
+                            .getAddresses().get(address);
+                    // if value is null, fill the hole and get the value.
+                    if (value == null) {
+                        holeFill(runtimeLayout, address);
+                        value = peek(runtimeLayout, address);
+                    }
+                }
             }
 
             returnResult.put(entry.getKey(), value);

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.view.stream;
 
 import com.google.common.annotations.VisibleForTesting;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
@@ -11,6 +12,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 
+import com.google.common.collect.Range;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
@@ -25,7 +27,9 @@ import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.RuntimeLayout;
 import org.corfudb.runtime.view.StreamOptions;
+import org.corfudb.runtime.view.replication.ChainReplicationProtocol;
 import org.corfudb.util.Utils;
 
 
@@ -194,6 +198,38 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
         }
     }
 
+    /**
+     * Reads data from an address in the address space. It will give the writer a chance to complete based on the time
+     * when the reads of which this individual read is a step started. If the reads have been going on for longer than
+     * the grace period given for a writer to complete a write, the subsequent individual read calls will immediately
+     * fill the hole on absence of data at the given address.
+     *
+     * @param address       Address to read.
+     * @param readStartTime Start time of the range of reads.
+     * @return ILogData at the address.
+     */
+    private ILogData read(final long address, long readStartTime) {
+        if (System.currentTimeMillis() - readStartTime < runtime.getParameters().getHoleFillTimeout().toMillis()) {
+            try {
+                return runtime.getAddressSpaceView().read(address);
+            } catch (TrimmedException te) {
+                processTrimmedException(te);
+                throw te;
+            }
+        } else {
+            RuntimeLayout runtimeLayout = runtime.getLayoutView().getRuntimeLayout();
+            ChainReplicationProtocol replicationProtocol = (ChainReplicationProtocol) runtime
+                    .getLayoutView()
+                    .getLayout()
+                    .getReplicationMode(address)
+                    .getReplicationProtocol(runtime);
+            return replicationProtocol
+                    .readRange(runtimeLayout, Range.encloseAll(Arrays.asList(address)), false)
+                    .get(address);
+
+        }
+    }
+
     @Nonnull
     @Override
     protected List<ILogData> readAll(@Nonnull List<Long> addresses) {
@@ -267,6 +303,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                                       final Function<ILogData, BackpointerOp> filter) {
         log.trace("followBackpointers: streamId[{}], queue[{}], startAddress[{}], stopAddress[{}]," +
                 "filter[{}]", streamId, queue, startAddress, stopAddress, filter);
+        long readStartTime = System.currentTimeMillis();
         // Whether or not we added entries to the queue.
         boolean entryAdded = false;
         // The current address which we are reading from.
@@ -282,7 +319,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             ILogData d;
             try {
                 log.trace("followBackpointers: readAddress[{}]", currentAddress);
-                d = read(currentAddress);
+                d = read(currentAddress, readStartTime);
             } catch (TrimmedException e) {
                 if (options.ignoreTrimmed) {
                     log.warn("followBackpointers: Ignoring trimmed exception for address[{}]," +
@@ -327,7 +364,8 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                     singleStep = false;
                     if (!startingSingleStep) {
                         // A started single step period finishes here, refresh flag for next cycle.
-                        log.info("followBackpointers[{}]: Found backpointer for this stream at address {}. Stop single step downgrade.");
+                        log.info("followBackpointers[{}]: Found backpointer for this stream at address {}."
+                                + "Stop single step downgrade.", this, currentAddress);
                         startingSingleStep = true;
                     }
                 }
@@ -336,7 +374,8 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             if (singleStep) {
                 if (startingSingleStep) {
                     startingSingleStep = false;
-                    log.info("followBackpointers[{}]: Found hole at address {}. Starting single step downgrade.", this, currentAddress);
+                    log.info("followBackpointers[{}]: Found hole at address {}. Starting single step downgrade.",
+                            this, currentAddress);
                 }
                 // backpointers failed, so we're
                 // downgrading to a linear scan


### PR DESCRIPTION
## Overview

Description:
Wait for only one address in range before hole fills instead of all addresses.
Change hole fills timeout from 5 to 10 seconds.

Why should this be merged: Time spent after acquiring the token and before writing was not considered in hole fill timeout.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
