### PR TITLE
StreamLog refactoring/simplification, exception handling

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -322,7 +322,7 @@ public class CorfuServer {
                     router,
                     (String) opts.get("--address"),
                     port).channel().closeFuture().syncUninterruptibly();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             log.error("CorfuServer: Server exiting due to unrecoverable error: ", e);
             System.exit(EXIT_ERROR_CODE);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
@@ -1,11 +1,21 @@
 package org.corfudb.infrastructure;
 
+import static org.corfudb.infrastructure.utils.Persistence.syncDirectory;
+
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.CacheWriter;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.exceptions.DataCorruptionException;
+import org.corfudb.util.JsonUtils;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
@@ -16,20 +26,6 @@ import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Consumer;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import com.google.common.hash.Hasher;
-import com.google.common.hash.Hashing;
-
-import lombok.extern.slf4j.Slf4j;
-import lombok.Getter;
-
-import org.corfudb.runtime.exceptions.DataCorruptionException;
-import org.corfudb.util.JsonUtils;
-
-import static org.corfudb.infrastructure.utils.Persistence.syncDirectory;
 
 /**
  * Stores data as JSON.
@@ -53,7 +49,7 @@ import static org.corfudb.infrastructure.utils.Persistence.syncDirectory;
 @Slf4j
 public class DataStore implements IDataStore {
 
-    static String EXTENSION = ".ds";
+    static final String EXTENSION = ".ds";
 
     @Getter
     private final Cache<String, Object> cache;
@@ -69,14 +65,13 @@ public class DataStore implements IDataStore {
     /**
      * Return a new DataStore object.
      *
-     * @param opts map of option strings
+     * @param opts        map of option strings
      * @param cleanupTask method to cleanup DataStore files
      */
     public DataStore(@Nonnull Map<String, Object> opts,
                      @Nonnull Consumer<String> cleanupTask) {
 
-        if ((opts.get("--memory") != null && (Boolean) opts.get("--memory"))
-                || opts.get("--log-path") == null) {
+        if ((opts.containsKey("--memory") && (Boolean) opts.get("--memory")) || !opts.containsKey("--log-path")) {
             this.logDirPath = null;
             this.cleanupTask = fileName -> { };
             cache = buildMemoryDs();
@@ -169,7 +164,7 @@ public class DataStore implements IDataStore {
 
     @Override
     public synchronized <T> void put(Class<T> tclass, String prefix, String key, T value) {
-        cache.put(getKey(prefix, key), value);
+        put(new KvRecord<>(prefix, key, tclass), value);
     }
 
     private <T> T load(Class<T> tClass, String key) {
@@ -204,10 +199,25 @@ public class DataStore implements IDataStore {
 
     @Override
     public synchronized <T> T get(Class<T> tclass, String prefix, String key) {
-        String path = getKey(prefix, key);
+        return get(new KvRecord<>(prefix, key, tclass));
+    }
+
+    @Override
+    public synchronized <T> void delete(Class<T> tclass, String prefix, String key) {
+        delete(new KvRecord<>(prefix, key, tclass));
+    }
+
+    @Override
+    public synchronized <T> void put(KvRecord<T> key, T value) {
+        cache.put(key.getFullKeyName(), value);
+    }
+
+    @Override
+    public synchronized <T> T get(KvRecord<T> key) {
+        String path = key.getFullKeyName();
         Object val = cache.get(path, k -> {
             if (!inMem) {
-                T loadedVal = load(tclass, path);
+                T loadedVal = load(key.getDataType(), path);
                 if (loadedVal != null) {
                     return loadedVal;
                 }
@@ -222,11 +232,13 @@ public class DataStore implements IDataStore {
     }
 
     @Override
-    public synchronized <T> void delete(Class<T> tclass, String prefix, String key) {
-        cache.invalidate(getKey(prefix, key));
+    public <T> T get(KvRecord<T> key, T defaultValue) {
+        T value = get(key);
+        return value == null ? defaultValue : value;
     }
 
-    private String getKey(String prefix, String key) {
-        return prefix + "_" + key;
+    @Override
+    public synchronized <T> void delete(KvRecord<T> key) {
+        cache.invalidate(key.getFullKeyName());
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IDataStore.java
@@ -1,6 +1,9 @@
 package org.corfudb.infrastructure;
 
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * Key Value data store abstraction that provides persistence for variables that need
  * retain values across node restarts or need to be accessed by multiple modules/threads.
@@ -11,32 +14,72 @@ package org.corfudb.infrastructure;
  * <p>Created by mdhawan on 7/27/16.
  */
 public interface IDataStore {
+
+    @Deprecated
+    <T> void put(Class<T> tclass, String prefix, String key, T value);
+
+    @Deprecated
+    <T> T get(Class<T> tclass, String prefix, String key);
+
+    @Deprecated
+    <T> void delete(Class<T> tclass, String prefix, String key);
+
     /**
      * Stores a value for a key under a prefix (namespace).
      *
-     * @param tclass the class of the object being stored
-     * @param prefix namespace
-     * @param key    key-value key to store into
+     * @param key record meta information
      * @param value  Immutable value (or a value that won't be changed)
      */
-    public <T> void put(Class<T> tclass, String prefix, String key, T value);
+    <T> void put(KvRecord<T> key, T value);
 
     /**
      * Retrieves the value for a key under a prefix.
      *
-     * @param tclass the class of the object being retrieved
-     * @param prefix namespace
-     * @param key    key-value key to look up
+     * @param key record meta information
      * @return value stored under key
      */
-    public <T> T get(Class<T> tclass, String prefix, String key);
+    <T> T get(KvRecord<T> key);
+
+    /**
+     * Retrieves the value for a key or a default value
+     *
+     * @param key key meta info
+     * @param defaultValue a default value
+     * @param <T>
+     * @return
+     */
+    <T> T get(KvRecord<T> key, T defaultValue);
 
     /**
      * Deletes the value for a key under a prefix.
      *
-     * @param tclass the class of the object being retrieved
-     * @param prefix namespace
-     * @param key    key-value key to delete
+     * @param key record meta information
      */
-    public <T> void delete(Class<T> tclass, String prefix, String key);
+    <T> void delete(KvRecord<T> key);
+
+    /**
+     * Key-value meta information class, provides all the information for saving and getting data from a data store
+     *
+     * @param <T> data type
+     */
+    @AllArgsConstructor
+    @Getter
+    class KvRecord<T> {
+        /**
+         * namespace prefix for a key
+         */
+        private final String prefix;
+        /**
+         * key in a data store
+         */
+        private final String key;
+        /**
+         * The class of the value in a data store
+         */
+        private final Class<T> dataType;
+
+        public String getFullKeyName() {
+            return prefix + "_" + key;
+        }
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -54,6 +54,7 @@ import java.util.regex.Pattern;
  */
 @Slf4j
 public class ServerContext implements AutoCloseable {
+
     // Layout Server
     private static final String PREFIX_EPOCH = "SERVER_EPOCH";
     private static final String KEY_EPOCH = "CURRENT";
@@ -66,10 +67,6 @@ public class ServerContext implements AutoCloseable {
     private static final String PREFIX_LAYOUTS = "LAYOUTS";
 
     // Sequencer Server
-    private static final String PREFIX_TAIL_SEGMENT = "TAIL_SEGMENT";
-    private static final String KEY_TAIL_SEGMENT = "CURRENT";
-    private static final String PREFIX_STARTING_ADDRESS = "STARTING_ADDRESS";
-    private static final String KEY_STARTING_ADDRESS = "CURRENT";
     private static final String KEY_SEQUENCER = "SEQUENCER";
     private static final String PREFIX_SEQUENCER_EPOCH = "EPOCH";
 
@@ -447,30 +444,6 @@ public class ServerContext implements AutoCloseable {
 
     public void setLayoutInHistory(Layout layout) {
         dataStore.put(Layout.class, PREFIX_LAYOUTS, String.valueOf(layout.getEpoch()), layout);
-    }
-
-    public long getTailSegment() {
-        Long tailSegment = dataStore.get(Long.class, PREFIX_TAIL_SEGMENT, KEY_TAIL_SEGMENT);
-        return tailSegment == null ? 0 : tailSegment;
-    }
-
-    public void setTailSegment(long tailSegment) {
-        dataStore.put(Long.class, PREFIX_TAIL_SEGMENT, KEY_TAIL_SEGMENT, tailSegment);
-    }
-
-    /**
-     * Returns the dataStore starting address.
-     *
-     * @return the starting address
-     */
-    public long getStartingAddress() {
-        Long startingAddress = dataStore.get(Long.class, PREFIX_STARTING_ADDRESS,
-                KEY_STARTING_ADDRESS);
-        return startingAddress == null ? 0 : startingAddress;
-    }
-
-    public void setStartingAddress(long startingAddress) {
-        dataStore.put(Long.class, PREFIX_STARTING_ADDRESS, KEY_STARTING_ADDRESS, startingAddress);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogDataStore.java
@@ -1,0 +1,119 @@
+package org.corfudb.infrastructure.log;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.IDataStore;
+import org.corfudb.infrastructure.IDataStore.KvRecord;
+import org.corfudb.runtime.view.Address;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Data access layer for StreamLog.
+ * Keeps stream log related meta information: startingAddress and tailSegment.
+ * Provides access to the stream log related meta information.
+ */
+@Builder
+@Slf4j
+public class StreamLogDataStore {
+    private static final String TAIL_SEGMENT_PREFIX = "TAIL_SEGMENT";
+    public static final String TAIL_SEGMENT_KEY = "CURRENT";
+
+    public static final String STARTING_ADDRESS_PREFIX = "STARTING_ADDRESS";
+    public static final String STARTING_ADDRESS_KEY = "CURRENT";
+
+    public static final KvRecord<Long> TAIL_SEGMENT_RECORD = new KvRecord<>(
+            TAIL_SEGMENT_PREFIX, TAIL_SEGMENT_KEY, Long.class
+    );
+
+    public static final KvRecord<Long> STARTING_ADDRESS_RECORD = new KvRecord<>(
+            STARTING_ADDRESS_PREFIX, STARTING_ADDRESS_KEY, Long.class
+    );
+
+    private static final long ZERO_ADDRESS = 0L;
+
+    @NonNull
+    private final IDataStore dataStore;
+
+    /**
+     * Cached starting address
+     */
+    private final AtomicLong startingAddress = new AtomicLong(Address.NON_ADDRESS);
+    /**
+     * Cached tail segment
+     */
+    private final AtomicLong tailSegment = new AtomicLong(Address.NON_ADDRESS);
+
+    /**
+     * Return current cached tail segment or get the segment from the data store if not initialized
+     *
+     * @return tail segment
+     */
+    public long getTailSegment() {
+        if (tailSegment.get() == Address.NON_ADDRESS) {
+            tailSegment.set(dataStore.get(TAIL_SEGMENT_RECORD, ZERO_ADDRESS));
+        }
+
+        return tailSegment.get();
+    }
+
+    /**
+     * Update current tail segment in the data store
+     *
+     * @param newTailSegment updated tail segment
+     */
+    public void updateTailSegment(long newTailSegment) {
+        if (tailSegment.get() >= newTailSegment) {
+            log.debug("New tail segment less than or equals to the old one: {}. Ignore", newTailSegment);
+            return;
+        }
+
+        log.trace("Update tail segment to: {}", newTailSegment);
+        dataStore.put(TAIL_SEGMENT_RECORD, newTailSegment);
+        tailSegment.set(newTailSegment);
+    }
+
+    /**
+     * Returns the dataStore starting address.
+     *
+     * @return the starting address
+     */
+    public long getStartingAddress() {
+        if (startingAddress.get() == Address.NON_ADDRESS) {
+            startingAddress.set(dataStore.get(STARTING_ADDRESS_RECORD, ZERO_ADDRESS));
+        }
+
+        return startingAddress.get();
+    }
+
+    /**
+     * Update current starting address in the data store
+     *
+     * @param newStartingAddress updated starting address
+     */
+    public void updateStartingAddress(long newStartingAddress) {
+        log.info("Update starting address to: {}", newStartingAddress);
+
+        dataStore.put(STARTING_ADDRESS_RECORD, newStartingAddress);
+        startingAddress.set(newStartingAddress);
+    }
+
+    /**
+     * Reset tail segment
+     */
+    public void resetTailSegment() {
+        log.info("Reset tail segment. Current segment: {}", tailSegment.get());
+        dataStore.put(TAIL_SEGMENT_RECORD, ZERO_ADDRESS);
+        tailSegment.set(ZERO_ADDRESS);
+    }
+
+    /**
+     * Reset starting address
+     */
+    public void resetStartingAddress() {
+        log.info("Reset starting address. Current address: {}", startingAddress.get());
+        dataStore.put(STARTING_ADDRESS_RECORD, ZERO_ADDRESS);
+        startingAddress.set(ZERO_ADDRESS);
+    }
+}

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/log/StreamLogDataStoreTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/log/StreamLogDataStoreTest.java
@@ -1,0 +1,54 @@
+package org.corfudb.infrastructure.log;
+
+import static org.junit.Assert.*;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.DataStore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+public class StreamLogDataStoreTest {
+    private static final long INITIAL_ADDRESS = 0L;
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test
+    public void testGetAndSave() {
+        StreamLogDataStore streamLogDs = getStreamLogDataStore();
+
+        final int tailSegment = 333;
+        streamLogDs.updateTailSegment(tailSegment);
+        assertEquals(tailSegment, streamLogDs.getTailSegment());
+
+        final int startingAddress = 555;
+        streamLogDs.updateStartingAddress(startingAddress);
+        assertEquals(startingAddress, streamLogDs.getStartingAddress());
+    }
+
+    @Test
+    public void testReset() {
+        StreamLogDataStore streamLogDs = getStreamLogDataStore();
+        streamLogDs.resetStartingAddress();
+        assertEquals(INITIAL_ADDRESS, streamLogDs.getStartingAddress());
+
+        streamLogDs.resetTailSegment();
+        assertEquals(INITIAL_ADDRESS, streamLogDs.getTailSegment());
+    }
+
+    private StreamLogDataStore getStreamLogDataStore() {
+        Map<String, Object> opts = new HashMap<>();
+        opts.put("--log-path", tempDir.getRoot().getAbsolutePath());
+
+        DataStore ds = new DataStore(opts, val -> log.info("clean up"));
+
+        return StreamLogDataStore.builder()
+                .dataStore(ds)
+                .build();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/DataCorruptionException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/DataCorruptionException.java
@@ -11,4 +11,16 @@ public class DataCorruptionException extends LogUnitException {
     public DataCorruptionException(String message) {
         super(message);
     }
+
+    public DataCorruptionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public DataCorruptionException(Throwable cause) {
+        super(cause);
+    }
+
+    public DataCorruptionException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/LogUnitException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/LogUnitException.java
@@ -12,4 +12,16 @@ public class LogUnitException extends RuntimeException {
     public LogUnitException(String message) {
         super(message);
     }
+
+    public LogUnitException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public LogUnitException(Throwable cause) {
+        super(cause);
+    }
+
+    public LogUnitException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
 }


### PR DESCRIPTION
## Overview

Description:
 - If can't create stream log directory then throw UnrecoverableException 
 - extract StreamLogDataStore 
 - get  rid of unnecessary variables

Why should this be merged: 
Improving StreamLogFiles by better exception handling, improving/extracting StreamLogDataStore.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
