### PR TITLE
Make Netty keep alive message ignore epoch, fix Future handling in NettyClientRouter

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -50,8 +50,21 @@ public class BaseServer extends AbstractServer {
      * @param r     The server router.
      */
     @ServerHandler(type = CorfuMsgType.PING)
-    private static void ping(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+    private void ping(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         r.sendResponse(ctx, msg, CorfuMsgType.PONG.msg());
+    }
+
+    /**
+     * Respond to a keep alive message.
+     * Note: this message ignores epoch.
+     *
+     * @param msg   The incoming message
+     * @param ctx   The channel context
+     * @param r     The server router.
+     */
+    @ServerHandler(type = CorfuMsgType.KEEP_ALIVE)
+    private void keepAlive(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+        r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
     }
 
     /**
@@ -84,7 +97,7 @@ public class BaseServer extends AbstractServer {
             long epoch = msg.getPayload();
             log.info("handleMessageSetEpoch: Received SET_EPOCH, moving to new epoch {}", epoch);
             serverContext.setServerEpoch(epoch, r);
-            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
+            r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
         } catch (WrongEpochException e) {
             log.debug("handleMessageSetEpoch: Rejected SET_EPOCH current={}, requested={}",
                     e.getCorrectEpoch(), msg.getPayload());

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -83,6 +83,7 @@ public enum CorfuMsgType {
     LAYOUT_ALREADY_BOOTSTRAP(60, TypeToken.of(CorfuMsg.class), true),
     LAYOUT_PREPARE_ACK(61, new TypeToken<CorfuPayloadMsg<LayoutPrepareResponse>>(){}, true),
     RESTART(62, TypeToken.of(CorfuMsg.class), true),
+    KEEP_ALIVE(63, TypeToken.of(CorfuMsg.class), true),
 
     // Management Messages
     MANAGEMENT_BOOTSTRAP_REQUEST(70, new TypeToken<CorfuPayloadMsg<Layout>>(){}, true),

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -373,7 +373,6 @@ public class CorfuRuntime {
         static final Map<ChannelOption, Object> DEFAULT_CHANNEL_OPTIONS =
                 ImmutableMap.<ChannelOption, Object>builder()
                         .put(ChannelOption.TCP_NODELAY, true)
-                        .put(ChannelOption.SO_KEEPALIVE, true)
                         .put(ChannelOption.SO_REUSEADDR, true)
                         .build();
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -38,6 +38,7 @@ public class BaseClient implements IClient {
 
     /**
      * Ping the endpoint, synchronously.
+     * Note: this ping is epoch aware
      *
      * @return True, if the endpoint was reachable, false otherwise.
      */

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -460,9 +460,15 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         final CompletableFuture<T> cfTimeout =
             CFUtils.within(cfBenchmarked, Duration.ofMillis(timeoutResponse));
         cfTimeout.exceptionally(e -> {
-            outstandingRequests.remove(thisRequest);
-            log.debug("Remove request {} to {} due to timeout! Message:{}",
-                    thisRequest, node, message);
+            // CFUtils.within() can wrap different kinds of exceptions in
+            // CompletionException, just dealing with TimeoutException here since
+            // the router is not aware of it and this::completeExceptionally()
+            // takes care of others. This avoids handling same exception twice.
+            if (e.getCause() instanceof TimeoutException) {
+                outstandingRequests.remove(thisRequest);
+                log.debug("sendMessageAndGetCompletable: Remove request {} to {} due to timeout! Message:{}",
+                        thisRequest, node, message);
+            }
             return null;
         });
         return cfTimeout;
@@ -508,9 +514,8 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      */
     public <T> void completeRequest(long requestId, T completion) {
         CompletableFuture<T> cf;
-        if ((cf = (CompletableFuture<T>) outstandingRequests.get(requestId)) != null) {
+        if ((cf = (CompletableFuture<T>) outstandingRequests.remove(requestId)) != null) {
             cf.complete(completion);
-            outstandingRequests.remove(requestId);
         } else {
             log.warn("Attempted to complete request {}, but request not outstanding!", requestId);
         }
@@ -522,11 +527,12 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      * @param requestID The request to complete.
      * @param cause     The cause to give for the exceptional completion.
      */
-    public void completeExceptionally(long requestID, Throwable cause) {
+    public void completeExceptionally(long requestID, @Nonnull Throwable cause) {
         CompletableFuture cf;
-        if ((cf = outstandingRequests.get(requestID)) != null) {
+        if ((cf = outstandingRequests.remove(requestID)) != null) {
             cf.completeExceptionally(cause);
-            outstandingRequests.remove(requestID);
+            log.debug("completeExceptionally: Remove request {} to {} due to {}.", requestID, node,
+                    cause.getClass().getSimpleName(), cause);
         } else {
             log.warn("Attempted to exceptionally complete request {}, but request not outstanding!",
                 requestID);
@@ -579,17 +585,18 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
     }
 
     /**
-     * Sends a ping to the server so that the pong response will keep
+     * Sends a keep alive message to the server so that the response will keep
      * the channel active in order to avoid a ReadTimeout exception that will
      * close the channel.
      */
     private void keepAlive() {
         if (!channel.isOpen()) {
-            log.warn("keepAlive: channel not open, skipping ping. ");
+            log.warn("keepAlive: channel not open, skipping sending keep alive.");
             return;
         }
-        sendMessageAndGetCompletable(null, new CorfuMsg(CorfuMsgType.PING));
-        log.trace("keepAlive: sending ping to {}", this.channel.remoteAddress());
+        // Send a keep alive message to server which ignores epoch
+        sendMessageAndGetCompletable(null, CorfuMsgType.KEEP_ALIVE.msg());
+        log.trace("keepAlive: sent keep alive to {}", this.channel.remoteAddress());
     }
 
     @Override


### PR DESCRIPTION
## Overview

Description:

- Create a new KeepAlive message which is basically a ping but ignores epoch.
- Fix CompletableFuture exception handling in NettyClientRouter when the exception
is not due to timeout, which results in handling same exception twice.
- Removed client side SO_KEEPALIVE socket option since we already have keep alive mechanism in client side.

Why should this be merged: 

Fixed two issues:
- Keep alive message gets WrongEpochException
- Same CompletableFuture exception handled twice in NettyClientRouter


Related issue(s) (if applicable): #1743


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
