### PR TITLE
Abstract server state

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -60,12 +60,18 @@ public abstract class AbstractServer {
         }
     }
 
-    protected void setState(ServerState state) {
-        if (getState() == ServerState.SHUTDOWN && state != ServerState.SHUTDOWN) {
-            throw new IllegalStateException("Server is in SHUTDOWN state. Can't be changed");
-        }
+    protected void setState(ServerState newState) {
+        boolean updated = false;
 
-        this.state.set(state);
+        while(!updated){
+            ServerState currState = getState();
+
+            if (currState == ServerState.SHUTDOWN && newState != ServerState.SHUTDOWN) {
+                throw new IllegalStateException("Server is in SHUTDOWN state. Can't be changed");
+            }
+
+            updated = state.compareAndSet(currState, newState);
+        }
     }
 
     public ServerState getState() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -7,6 +7,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 
 /**
  * Created by mwei on 12/4/15.
@@ -61,17 +62,13 @@ public abstract class AbstractServer {
     }
 
     protected void setState(ServerState newState) {
-        boolean updated = false;
-
-        while(!updated){
-            ServerState currState = getState();
-
+        state.updateAndGet(currState -> {
             if (currState == ServerState.SHUTDOWN && newState != ServerState.SHUTDOWN) {
                 throw new IllegalStateException("Server is in SHUTDOWN state. Can't be changed");
             }
 
-            updated = state.compareAndSet(currState, newState);
-        }
+            return newState;
+        });
     }
 
     public ServerState getState() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -84,7 +84,7 @@ public abstract class AbstractServer {
 
     /**
      * The server state.
-     * Represents server in a particular state: READY, NOT_READY, SHUTDOWN etc.
+     * Represents server in a particular state: READY, NOT_READY, SHUTDOWN.
      */
     public enum ServerState {
         READY, NOT_READY, SHUTDOWN

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -60,11 +60,15 @@ public abstract class AbstractServer {
         }
     }
 
-    protected void setState(ServerState state){
+    protected void setState(ServerState state) {
+        if (getState() == ServerState.SHUTDOWN && state != ServerState.SHUTDOWN) {
+            throw new IllegalStateException("Server is in SHUTDOWN state. Can't be changed");
+        }
+
         this.state.set(state);
     }
 
-    public ServerState getState(){
+    public ServerState getState() {
         return state.get();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -27,6 +27,11 @@ public class BaseServer extends AbstractServer {
     private final ExecutorService executor;
 
     @Override
+    public boolean isServerReadyToHandleMsg(CorfuMsg msg) {
+        return getState() == ServerState.READY;
+    }
+
+    @Override
     public ExecutorService getExecutor() {
         return executor;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuMsgHandler.java
@@ -217,11 +217,6 @@ public class CorfuMsgHandler {
         // Register the handler. Depending on metrics collection configuration by MetricsUtil,
         // handler will be instrumented by the metrics context.
         return (msg, ctx, r) -> {
-            if (!server.isServerReadyToHandleMsg(msg)) {
-                r.sendResponse(ctx, msg, CorfuMsgType.NOT_READY.msg());
-                return;
-            }
-
             try (Timer.Context context = MetricsUtils.getConditionalContext(timer)) {
                 handler.handle(msg, ctx, r);
             }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -71,6 +71,11 @@ public class LayoutServer extends AbstractServer {
     private final ExecutorService executor;
 
     @Override
+    public boolean isServerReadyToHandleMsg(CorfuMsg msg) {
+        return getState() == ServerState.READY;
+    }
+
+    @Override
     public ExecutorService getExecutor() {
         return executor;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -288,6 +288,11 @@ public class LogUnitServer extends AbstractServer {
         log.info("LogUnit sealServerWithEpoch: sealed and flushed with epoch {}", epoch);
     }
 
+    @Override
+    public boolean isServerReadyToHandleMsg(CorfuMsg msg) {
+        return getState() == ServerState.READY;
+    }
+
     /**
      * Resets the log unit server via the BatchWriter.
      * Warning: Clears all data.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -94,6 +94,11 @@ public class ManagementServer extends AbstractServer {
     private final Lock healingLock = new ReentrantLock();
 
     @Override
+    public boolean isServerReadyToHandleMsg(CorfuMsg msg) {
+        return getState() == ServerState.READY;
+    }
+
+    @Override
     public ExecutorService getExecutor() {
         return executor;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -152,6 +152,10 @@ public class SequencerServer extends AbstractServer {
 
     @Override
     public boolean isServerReadyToHandleMsg(CorfuMsg msg) {
+        if (getState() != ServerState.READY){
+            return false;
+        }
+
         if ((sequencerEpoch != serverContext.getServerEpoch())
                 && (!msg.getMsgType().equals(CorfuMsgType.BOOTSTRAP_SEQUENCER))) {
             log.warn("Rejecting msg at sequencer : sequencerStateEpoch:{}, serverEpoch:{}, "

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/CorfuAbstractServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/CorfuAbstractServerTest.java
@@ -28,6 +28,11 @@ public class CorfuAbstractServerTest {
             }
 
             @Override
+            public boolean isServerReadyToHandleMsg(CorfuMsg msg) {
+                return getState() == ServerState.READY;
+            }
+
+            @Override
             public ExecutorService getExecutor() {
                 return executor;
             }


### PR DESCRIPTION
## Overview

Description:
A corfu netty server could be in various states. Exposing those states make a server lifecycle unambiguous.  

Why should this be merged: 
Improving/clarify a server lifecycle.

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
