### PR TITLE
Use server executor in TestServerRouter

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
@@ -5,6 +5,8 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.junit.Test;
 
+import java.util.concurrent.RejectedExecutionException;
+
 /**
  * Created by mwei on 12/14/15.
  */
@@ -30,7 +32,7 @@ public class BaseServerTest extends AbstractServerTest {
     @Test
     public void shutdownServerDoesNotRespond() {
         getDefaultServer().shutdown();
-        sendMessage(new CorfuMsg(CorfuMsgType.PING));
-        Assertions.assertThat(getLastMessage()).isNull();
+        Assertions.assertThatThrownBy(() -> sendMessage(new CorfuMsg(CorfuMsgType.PING)))
+                .isInstanceOf(RejectedExecutionException.class);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -214,12 +214,10 @@ public class TestClientRouter implements IClientRouter {
         final CompletableFuture<T> cf = new CompletableFuture<>();
         outstandingRequests.put(thisRequest, cf);
         // Evaluate rules.
-        if (rules.stream()
-                .map(x -> x.evaluate(message, this))
-                .allMatch(x -> x)) {
+        if (rules.stream().allMatch(x -> x.evaluate(message, this))) {
             // Write the message out to the channel
-                log.trace(Thread.currentThread().getId() + ":Sent message: {}", message);
-                routeMessage(message);
+            log.trace(Thread.currentThread().getId() + ":Sent message: {}", message);
+            routeMessage(message);
         }
 
         // Generate a benchmarked future to measure the underlying request


### PR DESCRIPTION
## Overview

The TestServerRouter should use server executors to handle requests in
order to simimulate the actual handling logic. Without this, changes
like changing number of server executor threads will not be reflected
in unit tests.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
