### PR TITLE
Prevent netty channel leak

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/FailureDetector.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/FailureDetector.java
@@ -18,7 +18,6 @@ import org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity.Conne
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.IClientRouter;
 import org.corfudb.runtime.clients.ManagementClient;
-import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.util.CFUtils;
@@ -126,13 +125,9 @@ public class FailureDetector implements IDetector {
         // Set up arrays for routers to the endpoints.
         routerMap = new HashMap<>();
         allServers.forEach(s -> {
-            try {
-                IClientRouter router = corfuRuntime.getRouter(s);
-                router.setTimeoutResponse(period);
-                routerMap.put(s, router);
-            } catch (NetworkException ne) {
-                log.error("Error creating router for {}", s);
-            }
+            IClientRouter router = corfuRuntime.getRouter(s);
+            router.setTimeoutResponse(period);
+            routerMap.put(s, router);
         });
         // Perform polling of all responsive servers.
         return pollRound(layout.getEpoch(), allServers, routerMap, sequencerMetrics, layout);

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -211,8 +211,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         b.channel(parameters.getSocketType().getChannelClass());
         parameters.getNettyChannelOptions().forEach(b::option);
         b.handler(getChannelInitializer());
-        b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS,
-                (int) parameters.getConnectionTimeout().toMillis());
+        b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) timeoutConnect);
 
         // Asynchronously connect, retrying until shut down.
         // Once connected, connectionFuture will be completed.
@@ -335,21 +334,19 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
         });
     }
 
-    /** Connect to a remote server asynchronously.
+    /**
+     * Connect to a remote server asynchronously.
      *
-     * @param bootstrap         The channel boostrap to use
-     * @return                  A {@link ChannelFuture} which is c
+     * @param bootstrap The channel bootstrap to use
      */
-    private ChannelFuture connectAsync(@Nonnull Bootstrap bootstrap) {
+    private void connectAsync(@Nonnull Bootstrap bootstrap) {
         // If shutdown, return a ChannelFuture that is exceptionally completed.
         if (shutdown) {
-            return new DefaultChannelPromise(channel, GlobalEventExecutor.INSTANCE)
-                .setFailure(new ShutdownException("Runtime already shutdown!"));
+            return;
         }
         // Use the bootstrap to create a new channel.
         ChannelFuture f = bootstrap.connect(node.getHost(), node.getPort());
         f.addListener((ChannelFuture cf) -> channelConnectionFutureHandler(cf, bootstrap));
-        return f;
     }
 
     /** Handle when a channel is connected.

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -203,16 +203,7 @@ public class LayoutView extends AbstractView {
     public Layout propose(long epoch, long rank, Layout layout)
             throws QuorumUnreachableException, OutrankedException {
         CompletableFuture<Boolean>[] proposeList = getLayout().getLayoutServers().stream()
-                .map(x -> {
-                    CompletableFuture<Boolean> cf = new CompletableFuture<>();
-                    try {
-                        // Connection to router can cause network exception too.
-                        cf = getRuntimeLayout().getLayoutClient(x).propose(epoch, rank, layout);
-                    } catch (NetworkException e) {
-                        cf.completeExceptionally(e);
-                    }
-                    return cf;
-                })
+                .map(x -> getRuntimeLayout().getLayoutClient(x).propose(epoch, rank, layout))
                 .toArray(CompletableFuture[]::new);
 
         long timeouts = 0L;

--- a/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
@@ -23,11 +23,9 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.IClientRouter;
 import org.corfudb.runtime.clients.LayoutClient;
 import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
-import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.WorkflowException;
 import org.corfudb.runtime.exceptions.WorkflowResultUnknownException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
 import org.corfudb.runtime.view.ClusterStatusReport.ClusterStatusReliability;
 import org.corfudb.runtime.view.ClusterStatusReport.ConnectivityStatus;
@@ -498,18 +496,8 @@ public class ManagementView extends AbstractView {
 
         // Get layout futures for layout requests from all layout servers.
         for (String server : layoutServers) {
-            try {
-                // Router creation can throw a NetworkException.
-                IClientRouter router = runtime.getRouter(server);
-                layoutFuturesMap.put(server,
-                        new LayoutClient(router, Layout.INVALID_EPOCH).getLayout());
-            } catch (NetworkException e) {
-                log.error("getClusterStatus: Exception encountered connecting to {}. ",
-                        server, e);
-                CompletableFuture<Layout> cf = new CompletableFuture<>();
-                cf.completeExceptionally(e);
-                layoutFuturesMap.put(server, cf);
-            }
+            IClientRouter router = runtime.getRouter(server);
+            layoutFuturesMap.put(server, new LayoutClient(router, Layout.INVALID_EPOCH).getLayout());
         }
 
         return layoutFuturesMap;

--- a/runtime/src/main/java/org/corfudb/runtime/view/SealServersHelper.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SealServersHelper.java
@@ -11,7 +11,6 @@ import java.util.function.Predicate;
 
 import lombok.extern.slf4j.Slf4j;
 
-import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.util.CFUtils;
@@ -38,14 +37,8 @@ public class SealServersHelper {
         Map<String, CompletableFuture<Boolean>> resultMap = new HashMap<>();
         // Seal all servers
         layout.getAllServers().forEach(server -> {
-            CompletableFuture<Boolean> cf = new CompletableFuture<>();
-            try {
-                // Creating router can cause NetworkException which should be handled.
-                cf = runtimeLayout.getBaseClient(server).setRemoteEpoch(layout.getEpoch());
-            } catch (NetworkException ne) {
-                cf.completeExceptionally(ne);
-                log.error("Remote seal SET_EPOCH failed for server {} with {}", server, ne);
-            }
+            CompletableFuture<Boolean> cf =
+                    runtimeLayout.getBaseClient(server).setRemoteEpoch(layout.getEpoch());
             resultMap.put(server, cf);
         });
 

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -54,9 +54,12 @@ public class AbstractIT extends AbstractCorfuTest {
     private static final int SHUTDOWN_RETRIES = 10;
     private static final long SHUTDOWN_RETRY_WAIT = 500;
 
+    CorfuRuntime runtime;
+
     public static final Properties PROPERTIES = new Properties();
 
     public static final String TEST_SEQUENCE_LOG_PATH = CORFU_LOG_PATH + File.separator + "testSequenceLog";
+
 
     public AbstractIT() {
         CorfuRuntime.overrideGetRouterFunction = null;
@@ -77,6 +80,7 @@ public class AbstractIT extends AbstractCorfuTest {
      */
     @Before
     public void setUp() throws Exception {
+        runtime = null;
         forceShutdownAllCorfuServers();
         FileUtils.cleanDirectory(new File(CORFU_LOG_PATH));
     }
@@ -89,6 +93,9 @@ public class AbstractIT extends AbstractCorfuTest {
     @After
     public void cleanUp() throws Exception {
         forceShutdownAllCorfuServers();
+        if (runtime != null) {
+            runtime.shutdown();
+        }
     }
 
     public static String getCorfuServerLogPath(String host, int port) {

--- a/test/src/test/java/org/corfudb/integration/CmdletIT.java
+++ b/test/src/test/java/org/corfudb/integration/CmdletIT.java
@@ -148,7 +148,7 @@ public class CmdletIT extends AbstractIT {
 
         corfuServerProcess = new CorfuServerRunner().setPort(PORT).runServer();
         final String streamA = "streamA";
-        CorfuRuntime runtime = createRuntime(ENDPOINT);
+        runtime = createRuntime(ENDPOINT);
         IStreamView streamViewA = runtime.getStreamsView().get(CorfuRuntime.getStreamID(streamA));
 
         String payload1 = "Hello";
@@ -178,7 +178,7 @@ public class CmdletIT extends AbstractIT {
 
         corfuServerProcess = new CorfuServerRunner().setPort(PORT).runServer();
         final String streamA = "streamA";
-        CorfuRuntime runtime = createRuntime(ENDPOINT);
+        runtime = createRuntime(ENDPOINT);
 
         String commandNextToken = CORFU_PROJECT_DIR + "bin/corfu_sequencer -i " + streamA + " -c " + ENDPOINT + " next-token 3";
         runCmdletGetOutput(commandNextToken);
@@ -273,7 +273,7 @@ public class CmdletIT extends AbstractIT {
 
         assertThat(runCmdletGetOutput(command).contains(expectedOutput)).isTrue();
 
-        CorfuRuntime runtime = createRuntime(ENDPOINT);
+        runtime = createRuntime(ENDPOINT);
         IStreamView streamViewA = runtime.getStreamsView().get(CorfuRuntime.getStreamID("streamA"));
         assertThat(streamViewA.hasNext())
                 .isFalse();

--- a/test/src/test/java/org/corfudb/integration/CorfuMsgFilterIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuMsgFilterIT.java
@@ -73,14 +73,14 @@ public class CorfuMsgFilterIT extends AbstractIT {
         final CorfuRuntimeParameters corfuRuntimeParameters = parametersBuilder.build();
 
         // Initialize and connect to a corfuRuntime
-        CorfuRuntime corfuRuntime = CorfuRuntime
+        runtime = CorfuRuntime
                 .fromParameters(corfuRuntimeParameters)
                 .parseConfigurationString(singleNodeEndpoint)
                 .connect();
 
         // Verify
-        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(0L);
-        assertThatThrownBy(() -> corfuRuntime.getLayoutView()
+        assertThat(runtime.getLayoutView().getLayout().getEpoch()).isEqualTo(0L);
+        assertThatThrownBy(() -> runtime.getLayoutView()
                                              .getRuntimeLayout()
                                              .getBaseClient(singleNodeEndpoint)
                                              .ping()
@@ -122,14 +122,14 @@ public class CorfuMsgFilterIT extends AbstractIT {
         final CorfuRuntimeParameters corfuRuntimeParameters = parametersBuilder.build();
 
         // Initialize and connect to a corfuRuntime
-        CorfuRuntime corfuRuntime = CorfuRuntime
+        runtime = CorfuRuntime
                 .fromParameters(corfuRuntimeParameters)
                 .parseConfigurationString(singleNodeEndpoint)
                 .connect();
 
         // Verify
-        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(0L);
-        assertThat(corfuRuntime.getLayoutView()
+        assertThat(runtime.getLayoutView().getLayout().getEpoch()).isEqualTo(0L);
+        assertThat(runtime.getLayoutView()
                                .getRuntimeLayout()
                                .getBaseClient(singleNodeEndpoint)
                                .getVersionInfo().get())
@@ -162,14 +162,14 @@ public class CorfuMsgFilterIT extends AbstractIT {
         final CorfuRuntimeParameters corfuRuntimeParameters = parametersBuilder.build();
 
         // Initialize and connect to a corfuRuntime
-        CorfuRuntime corfuRuntime = CorfuRuntime
+        runtime = CorfuRuntime
                 .fromParameters(corfuRuntimeParameters)
                 .parseConfigurationString(singleNodeEndpoint)
                 .connect();
 
         // Verify
-        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(0L);
-        assertThat(corfuRuntime.getLayoutView()
+        assertThat(runtime.getLayoutView().getLayout().getEpoch()).isEqualTo(0L);
+        assertThat(runtime.getLayoutView()
                 .getRuntimeLayout()
                 .getBaseClient(singleNodeEndpoint)
                 .getVersionInfo().get())
@@ -203,14 +203,14 @@ public class CorfuMsgFilterIT extends AbstractIT {
         final CorfuRuntimeParameters corfuRuntimeParameters = parametersBuilder.build();
 
         // Initialize and connect to a corfuRuntime
-        CorfuRuntime corfuRuntime = CorfuRuntime
+        runtime = CorfuRuntime
                 .fromParameters(corfuRuntimeParameters)
                 .parseConfigurationString(singleNodeEndpoint)
                 .connect();
 
         // Verify
-        assertThat(corfuRuntime.getLayoutView().getLayout().getEpoch()).isEqualTo(0L);
-        assertThat(corfuRuntime.getLayoutView()
+        assertThat(runtime.getLayoutView().getLayout().getEpoch()).isEqualTo(0L);
+        assertThat(runtime.getLayoutView()
                 .getRuntimeLayout()
                 .getBaseClient(singleNodeEndpoint)
                 .getVersionInfo().get())

--- a/test/src/test/java/org/corfudb/integration/Harness.java
+++ b/test/src/test/java/org/corfudb/integration/Harness.java
@@ -269,13 +269,12 @@ public class Harness {
         final CorfuRuntime runtime = new CorfuRuntime(node.getClusterAddress());
 
         if (tlsEnabled) {
-            runtime
-                    .enableTls(runtimePathToKeyStore,
-                               runtimePathToKeyStorePassword,
-                               runtimePathToTrustStore,
-                               runtimePathToTrustStorePassword);
+            runtime.enableTls(
+                    runtimePathToKeyStore,
+                    runtimePathToKeyStorePassword,
+                    runtimePathToTrustStore,
+                    runtimePathToTrustStorePassword);
         }
-        return runtime
-                .connect();
+        return runtime.connect();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/LargeWriteIT.java
+++ b/test/src/test/java/org/corfudb/integration/LargeWriteIT.java
@@ -39,14 +39,14 @@ public class LargeWriteIT extends AbstractIT {
                 .maxWriteSize(maxWriteSize)
                 .build();
 
-        CorfuRuntime rt = CorfuRuntime.fromParameters(params);
-        rt.parseConfigurationString(DEFAULT_ENDPOINT);
-        rt.connect();
+        runtime = CorfuRuntime.fromParameters(params);
+        runtime.parseConfigurationString(DEFAULT_ENDPOINT);
+        runtime.connect();
 
         final int bufSize = maxWriteSize * 2;
 
         // Attempt to write a payload that is greater than the configured limit.
-        assertThatThrownBy(() -> rt.getStreamsView()
+        assertThatThrownBy(() -> runtime.getStreamsView()
                 .get(CorfuRuntime.getStreamID(streamName))
                 .append(new byte[bufSize]))
                 .isInstanceOf(WriteSizeException.class);
@@ -72,24 +72,24 @@ public class LargeWriteIT extends AbstractIT {
                 .maxWriteSize(maxWriteSize)
                 .build();
 
-        CorfuRuntime rt = CorfuRuntime.fromParameters(params);
-        rt.parseConfigurationString(DEFAULT_ENDPOINT);
-        rt.connect();
+        runtime = CorfuRuntime.fromParameters(params);
+        runtime.parseConfigurationString(DEFAULT_ENDPOINT);
+        runtime.connect();
 
         String largePayload = new String(new byte[maxWriteSize * 2]);
 
-        Map<String, String> map = rt.getObjectsView()
+        Map<String, String> map = runtime.getObjectsView()
                 .build()
                 .setType(CorfuTable.class)
                 .setStreamName(tableName)
                 .open();
 
 
-        rt.getObjectsView().TXBegin();
+        runtime.getObjectsView().TXBegin();
         map.put("key1", largePayload);
         boolean aborted = false;
         try {
-            rt.getObjectsView().TXEnd();
+            runtime.getObjectsView().TXEnd();
         } catch (TransactionAbortedException e) {
             aborted = true;
             assertThat(e.getCause()).isInstanceOf(WriteSizeException.class);

--- a/test/src/test/java/org/corfudb/integration/MemoryFootprintIT.java
+++ b/test/src/test/java/org/corfudb/integration/MemoryFootprintIT.java
@@ -63,10 +63,10 @@ public class MemoryFootprintIT extends AbstractIT {
         Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
 
         // Start a Corfu runtime
-        CorfuRuntime corfuRuntime = createRuntime(singleNodeEndpoint);
+        CorfuRuntime runtime = createRuntime(singleNodeEndpoint);
 
         // Create CorfuTable
-        CorfuTable testTable = corfuRuntime
+        CorfuTable testTable = runtime
                 .getObjectsView()
                 .build()
                 .setTypeToken(new TypeToken<CorfuTable<String, Object>>() {})
@@ -113,10 +113,10 @@ public class MemoryFootprintIT extends AbstractIT {
         Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
 
         // Start a Corfu runtime
-        CorfuRuntime corfuRuntime = createRuntime(singleNodeEndpoint);
+        runtime = createRuntime(singleNodeEndpoint);
 
         // Create CorfuTable
-        CorfuTable testTable = corfuRuntime
+        CorfuTable testTable = runtime
                 .getObjectsView()
                 .build()
                 .setTypeToken(new TypeToken<CorfuTable<String, Object>>() {})

--- a/test/src/test/java/org/corfudb/integration/SealIT.java
+++ b/test/src/test/java/org/corfudb/integration/SealIT.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Created by rmichoud on 2/12/17.
  */
 public class SealIT extends AbstractIT {
+
     static String corfuSingleNodeHost;
     static int corfuSingleNodePort;
 
@@ -31,7 +32,7 @@ public class SealIT extends AbstractIT {
         CorfuRuntime cr1 = createDefaultRuntime();
         CorfuRuntime cr2 = createDefaultRuntime();
 
-        Long beforeAddress = cr2.getSequencerView().next().getToken().getSequence();
+        long beforeAddress = cr2.getSequencerView().next().getToken().getSequence();
 
         /* We will trigger a Paxos round, this is what will happen:
          *   1. Set our layout (same than before) with a new Epoch
@@ -72,5 +73,8 @@ public class SealIT extends AbstractIT {
         assertThat(afterAddress).isEqualTo(beforeAddress+1);
 
         assertThat(shutdownCorfuServer(corfuProcess)).isTrue();
+
+        cr1.shutdown();
+        cr2.shutdown();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/SecurityIT.java
+++ b/test/src/test/java/org/corfudb/integration/SecurityIT.java
@@ -112,7 +112,7 @@ public class SecurityIT extends AbstractIT {
         Process corfuServer = runSinglePersistentServerTls();
 
         // Start a Corfu runtime
-        CorfuRuntime corfuRuntime = new CorfuRuntime(singleNodeEndpoint)
+        runtime = new CorfuRuntime(singleNodeEndpoint)
                                     .enableTls(runtimePathToKeyStore,
                                                runtimePathToKeyStorePassword,
                                                runtimePathToTrustStore,
@@ -121,7 +121,7 @@ public class SecurityIT extends AbstractIT {
                                     .connect();
 
         // Create CorfuTable
-        CorfuTable testTable = corfuRuntime
+        CorfuTable testTable = runtime
                 .getObjectsView()
                 .build()
                 .setTypeToken(new TypeToken<CorfuTable<String, Object>>() {})
@@ -173,12 +173,12 @@ public class SecurityIT extends AbstractIT {
                 .build();
 
         // Start a Corfu runtime from parameters
-        CorfuRuntime corfuRuntime = CorfuRuntime
+        runtime = CorfuRuntime
                 .fromParameters(runtimeParameters)
                 .connect();
 
         // Create CorfuTable
-        CorfuTable testTable = corfuRuntime
+        CorfuTable testTable = runtime
                 .getObjectsView()
                 .build()
                 .setTypeToken(new TypeToken<CorfuTable<String, Object>>() {})
@@ -214,7 +214,7 @@ public class SecurityIT extends AbstractIT {
     @Test(expected = UnrecoverableCorfuError.class)
     public void testIncorrectKeyStoreException() throws Exception {
         // Run a corfu server with incorrect truststore
-        Process corfuServer = runSinglePersistentServerTls();
+        runSinglePersistentServerTls();
 
         // Start a Corfu runtime with incorrect truststore
         final CorfuRuntime.CorfuRuntimeParameters runtimeParameters = CorfuRuntime.CorfuRuntimeParameters
@@ -228,8 +228,6 @@ public class SecurityIT extends AbstractIT {
                 .build();
 
         // Connecting to runtime
-        CorfuRuntime corfuRuntime = CorfuRuntime
-                .fromParameters(runtimeParameters)
-                .connect();
+        CorfuRuntime.fromParameters(runtimeParameters).connect();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -207,6 +207,8 @@ public class ServerRestartIT extends AbstractIT {
         } catch (Exception e) {
             throw e;
         }
+
+        runtimeList.forEach(CorfuRuntime::shutdown);
     }
 
 
@@ -424,9 +426,9 @@ public class ServerRestartIT extends AbstractIT {
         UUID streamNameA = CorfuRuntime.getStreamID("mapA");
         UUID streamNameB = CorfuRuntime.getStreamID("mapB");
 
-        CorfuRuntime corfuRuntime = createDefaultRuntime();
-        Map<String, Integer> mapA = createMap(corfuRuntime, "mapA");
-        Map<String, Integer> mapB = createMap(corfuRuntime, "mapB");
+        runtime = createDefaultRuntime();
+        Map<String, Integer> mapA = createMap(runtime, "mapA");
+        Map<String, Integer> mapB = createMap(runtime, "mapB");
 
         for (int i = 0; i < insertions; i++) {
             mapA.put(Integer.toString(i), i);
@@ -440,10 +442,10 @@ public class ServerRestartIT extends AbstractIT {
         final int newMapBStreamTail = 19;
         final int newGlobalTail = 19;
 
-        restartServer(corfuRuntime, DEFAULT_ENDPOINT);
+        restartServer(runtime, DEFAULT_ENDPOINT);
 
-        TokenResponse tokenResponseA = corfuRuntime.getSequencerView().next(streamNameA);
-        TokenResponse tokenResponseB = corfuRuntime.getSequencerView().next(streamNameB);
+        TokenResponse tokenResponseA = runtime.getSequencerView().next(streamNameA);
+        TokenResponse tokenResponseB = runtime.getSequencerView().next(streamNameB);
 
         assertThat(tokenResponseA.getToken().getSequence()).isEqualTo(newGlobalTail + 1);
         assertThat(tokenResponseA.getBackpointerMap().get(streamNameA))
@@ -468,17 +470,17 @@ public class ServerRestartIT extends AbstractIT {
         final int timeToWaitInSeconds = 3;
 
         Process corfuServerProcess = runCorfuServer();
-        final CorfuRuntime corfuRuntime = createDefaultRuntime();
+        runtime = createDefaultRuntime();
 
         // wait for this server long enough to start (by requesting token service)
-        TokenResponse firsttr = corfuRuntime.getSequencerView().next();
+        TokenResponse firsttr = runtime.getSequencerView().next();
 
         assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
 
         corfuServerProcess = runCorfuServer();
 
-        corfuRuntime.invalidateLayout();
-        TokenResponse tr = corfuRuntime.getSequencerView().next();
+        runtime.invalidateLayout();
+        TokenResponse tr = runtime.getSequencerView().next();
 
         assertThat(tr.getEpoch())
                 .isEqualTo(1);
@@ -491,7 +493,7 @@ public class ServerRestartIT extends AbstractIT {
 
         // Should succeed. internally, it will refresh the token.
         CompletableFuture cf = CFUtils.within(CompletableFuture.supplyAsync(() -> {
-            corfuRuntime.getAddressSpaceView().write(mockTr, testPayload);
+            runtime.getAddressSpaceView().write(mockTr, testPayload);
             return true;
         }), Duration.ofSeconds(timeToWaitInSeconds));
 
@@ -526,13 +528,13 @@ public class ServerRestartIT extends AbstractIT {
         long mapBStreamTail = -1;
         long globalTail = -1;
 
-        CorfuRuntime corfuRuntime = createDefaultRuntime();
+        runtime = createDefaultRuntime();
         Random rand = new Random(PARAMETERS.SEED);
 
         for (int r = 0; r < PARAMETERS.NUM_ITERATIONS_LOW; r++) {
 
-            Map<String, Integer> mapA = createMap(corfuRuntime, "mapA");
-            Map<String, Integer> mapB = createMap(corfuRuntime, "mapB");
+            Map<String, Integer> mapA = createMap(runtime, "mapA");
+            Map<String, Integer> mapB = createMap(runtime, "mapB");
 
             // activity (i): map put()'s
             boolean updateMaps = rand.nextBoolean();
@@ -560,20 +562,20 @@ public class ServerRestartIT extends AbstractIT {
                 MultiCheckpointWriter mcw1 = new MultiCheckpointWriter();
                 mcw1.addMap((SMRMap) mapA);
                 mcw1.addMap((SMRMap) mapB);
-                Token checkpointAddress = mcw1.appendCheckpoints(corfuRuntime, "dahlia");
+                Token checkpointAddress = mcw1.appendCheckpoints(runtime, "dahlia");
 
                 // Trim the log
-                corfuRuntime.getAddressSpaceView().prefixTrim(checkpointAddress);
-                corfuRuntime.getAddressSpaceView().gc();
-                corfuRuntime.getAddressSpaceView().invalidateServerCaches();
-                corfuRuntime.getAddressSpaceView().invalidateClientCache();
+                runtime.getAddressSpaceView().prefixTrim(checkpointAddress);
+                runtime.getAddressSpaceView().gc();
+                runtime.getAddressSpaceView().invalidateServerCaches();
+                runtime.getAddressSpaceView().invalidateClientCache();
 
                 System.out.println(r + "..ckpoint and trimmed @" + checkpointAddress);
             } else {
                 System.out.println(r + "..no checkpoint/trim");
             }
 
-            SequencerClient sequencerClient = corfuRuntime
+            SequencerClient sequencerClient = runtime
                     .getLayoutView().getRuntimeLayout()
                     .getSequencerClient(corfuSingleNodeHost + ":" + corfuSingleNodePort);
 
@@ -591,13 +593,13 @@ public class ServerRestartIT extends AbstractIT {
 
 
             // activity (iii) shutdown and restart
-            corfuRuntime.shutdown();
+            runtime.shutdown();
             assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
 
             corfuServerProcess = runCorfuServer();
-            corfuRuntime = createDefaultRuntime();
+            runtime = createDefaultRuntime();
 
-            sequencerClient = corfuRuntime
+            sequencerClient = runtime
                     .getLayoutView().getRuntimeLayout()
                     .getSequencerClient(corfuSingleNodeHost + ":" + corfuSingleNodePort);
 
@@ -626,11 +628,11 @@ public class ServerRestartIT extends AbstractIT {
             boolean restartwithHoles = true; // rand.nextBoolean();
 
             if (restartwithHoles) {
-                corfuRuntime.shutdown();
+                runtime.shutdown();
                 assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
 
                 corfuServerProcess = runCorfuServer();
-                corfuRuntime = createDefaultRuntime();
+                runtime = createDefaultRuntime();
                 System.out.println(r + "..restart with holes");
                 // in this scenario, the globalTail is left unchanged from before,
                 // because we restart without ever having writes use the tokens
@@ -641,14 +643,14 @@ public class ServerRestartIT extends AbstractIT {
 
             // these writes should throw a StaleTokenException if we restarted
             try {
-                corfuRuntime.getAddressSpaceView()
+                runtime.getAddressSpaceView()
                         .write(tokenResponseA.getToken(), "fixed string".getBytes());
             } catch (StaleTokenException se) {
                 assertThat(restartwithHoles).isTrue();
             }
 
             try {
-                corfuRuntime.getAddressSpaceView()
+                runtime.getAddressSpaceView()
                         .write(tokenResponseB.getToken(), "fixed string".getBytes());
             } catch (StaleTokenException se) {
                 assertThat(restartwithHoles).isTrue();
@@ -658,7 +660,6 @@ public class ServerRestartIT extends AbstractIT {
         }
 
         assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
-
     }
 
     private CorfuTable createTable(CorfuRuntime corfuRuntime, CorfuTable.IndexRegistry indexer) {
@@ -685,8 +686,8 @@ public class ServerRestartIT extends AbstractIT {
         Process corfuProcess = runCorfuServer();
 
         // Write 1000 entries.
-        CorfuRuntime rt1 = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
-        CorfuTable<String, String> corfuTable1 = createTable(rt1, new StringIndexer());
+        CorfuRuntime runtime1 = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
+        CorfuTable<String, String> corfuTable1 = createTable(runtime1, new StringIndexer());
         final int num = 1000;
         for (int i = 0; i < num; i++) {
             corfuTable1.put(Integer.toString(i), Integer.toString(i));
@@ -695,34 +696,34 @@ public class ServerRestartIT extends AbstractIT {
         // Checkpoint and trim the log.
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(corfuTable1);
-        Token trimMark = mcw.appendCheckpoints(rt1, "author");
+        Token trimMark = mcw.appendCheckpoints(runtime1, "author");
         Collection<Map.Entry<String, String>> c1a =
                 corfuTable1.getByIndex(StringIndexer.BY_FIRST_LETTER, "9");
         Collection<Map.Entry<String, String>> c1b =
                 corfuTable1.getByIndex(StringIndexer.BY_VALUE, "9");
-        rt1.getAddressSpaceView().prefixTrim(trimMark);
-        rt1.getAddressSpaceView().invalidateClientCache();
-        rt1.getAddressSpaceView().invalidateServerCaches();
-        rt1.getAddressSpaceView().gc();
+        runtime1.getAddressSpaceView().prefixTrim(trimMark);
+        runtime1.getAddressSpaceView().invalidateClientCache();
+        runtime1.getAddressSpaceView().invalidateServerCaches();
+        runtime1.getAddressSpaceView().gc();
 
         // Restart the corfu server.
         assertThat(shutdownCorfuServer(corfuProcess)).isTrue();
         corfuProcess = runCorfuServer();
 
         // Start a new client and verify the index.
-        CorfuRuntime rt2 = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
-        CorfuTable<String, String> corfuTable2 = createTable(rt2, new StringIndexer());
+        CorfuRuntime runtime2 = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
+        CorfuTable<String, String> corfuTable2 = createTable(runtime2, new StringIndexer());
         Collection<Map.Entry<String, String>> c2 =
                 corfuTable2.getByIndex(StringIndexer.BY_FIRST_LETTER, "9");
         assertThat(c1a.size()).isEqualTo(c2.size());
         assertThat(c1a.containsAll(c2)).isTrue();
 
         // Start a new client with cache disabled and fast object loading disabled.
-        CorfuRuntime rt3 = new CorfuRuntime(DEFAULT_ENDPOINT)
+        CorfuRuntime runtime3 = new CorfuRuntime(DEFAULT_ENDPOINT)
                 .setLoadSmrMapsAtConnect(false)
                 .setCacheDisabled(true)
                 .connect();
-        CorfuTable<String, String> corfuTable3 = createTable(rt3, new StringIndexer());
+        CorfuTable<String, String> corfuTable3 = createTable(runtime3, new StringIndexer());
         Collection<Map.Entry<String, String>> c3 =
                 corfuTable3.getByIndex(StringIndexer.BY_VALUE, "9");
         assertThat(c1b.size()).isEqualTo(c3.size());
@@ -730,6 +731,10 @@ public class ServerRestartIT extends AbstractIT {
 
         // Stop the corfu server.
         assertThat(shutdownCorfuServer(corfuProcess)).isTrue();
+
+        runtime1.shutdown();
+        runtime2.shutdown();
+        runtime3.shutdown();
     }
 
     /**
@@ -800,5 +805,9 @@ public class ServerRestartIT extends AbstractIT {
 
         // Stop the corfu server
         assertThat(shutdownCorfuServer(corfuProcess)).isTrue();
+
+        runtime1.shutdown();
+        runtime2.shutdown();
+        runtime3.shutdown();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -10,8 +10,6 @@ import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuTable;
-import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.util.Sleep;
@@ -36,7 +34,7 @@ import java.util.concurrent.CountDownLatch;
 @Slf4j
 public class WorkflowIT extends AbstractIT {
 
-    final String host = "localhost";
+    private final String host = "localhost";
 
     String getConnectionString(int port) {
         return host + ":" + port;
@@ -63,10 +61,10 @@ public class WorkflowIT extends AbstractIT {
         final int n3Port = 9002;
         Process server_3 = runServer(n3Port, false);
 
-        CorfuRuntime n1Rt = new CorfuRuntime(getConnectionString(n1Port))
+        runtime = new CorfuRuntime(getConnectionString(n1Port))
                 .setCacheDisabled(true).connect();
 
-        CorfuTable table = n1Rt.getObjectsView()
+        CorfuTable table = runtime.getObjectsView()
                 .build()
                 .setType(CorfuTable.class)
                 .setStreamName(streamName)
@@ -76,43 +74,43 @@ public class WorkflowIT extends AbstractIT {
             table.put(String.valueOf(x), String.valueOf(x));
         }
 
-        n1Rt.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
+        runtime.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
                 timeout, pollPeriod);
 
         // Wait for servers
         final int clusterSizeN2 = 2;
         waitForLayoutChange(layout -> layout.getAllServers().size() == clusterSizeN2
-                && layout.getSegments().size() == 1, n1Rt);
+                && layout.getSegments().size() == 1, runtime);
 
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
 
-        Token prefix = mcw.appendCheckpoints(n1Rt, "Maithem");
+        Token prefix = mcw.appendCheckpoints(runtime, "Maithem");
 
-        n1Rt.getAddressSpaceView().prefixTrim(prefix);
+        runtime.getAddressSpaceView().prefixTrim(prefix);
 
-        n1Rt.getAddressSpaceView().invalidateClientCache();
-        n1Rt.getAddressSpaceView().invalidateServerCaches();
-        n1Rt.getAddressSpaceView().gc();
+        runtime.getAddressSpaceView().invalidateClientCache();
+        runtime.getAddressSpaceView().invalidateServerCaches();
+        runtime.getAddressSpaceView().gc();
 
         // Add a third node after compaction
-        n1Rt.getManagementView().addNode(getConnectionString(n3Port), workflowNumRetry,
+        runtime.getManagementView().addNode(getConnectionString(n3Port), workflowNumRetry,
                 timeout, pollPeriod);
 
         // Verify that the third node has been added and data can be read back
         final int clusterSizeN3 = 3;
         waitForLayoutChange(layout -> layout.getAllServers().size() == clusterSizeN3
-                && layout.getSegments().size() == 1, n1Rt);
+                && layout.getSegments().size() == 1, runtime);
 
         // Remove node 2
-        n1Rt.getManagementView().removeNode(getConnectionString(n2Port), workflowNumRetry,
+        runtime.getManagementView().removeNode(getConnectionString(n2Port), workflowNumRetry,
                 timeout, pollPeriod);
-        n1Rt.invalidateLayout();
-        assertThat(n1Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
+        runtime.invalidateLayout();
+        assertThat(runtime.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
 
 
         // Remove node 2 again and verify that the epoch doesn't change
-        n1Rt.getManagementView().removeNode(getConnectionString(n2Port), workflowNumRetry,
+        runtime.getManagementView().removeNode(getConnectionString(n2Port), workflowNumRetry,
                 timeout, pollPeriod);
         shutdownCorfuServer(server_2);
 
@@ -120,23 +118,23 @@ public class WorkflowIT extends AbstractIT {
         // the sequencers/layouts/segments nodes include the first and third node
         waitForLayoutChange(layout ->
                 layout.getAllServers().size() == 2
-                        && !layout.getAllServers().contains(getConnectionString(n2Port)), n1Rt);
+                        && !layout.getAllServers().contains(getConnectionString(n2Port)), runtime);
 
         // Force remove node 3
-        n1Rt.getManagementView().forceRemoveNode(getConnectionString(n3Port), workflowNumRetry,
+        runtime.getManagementView().forceRemoveNode(getConnectionString(n3Port), workflowNumRetry,
                 timeout, pollPeriod);
         shutdownCorfuServer(server_3);
 
-        n1Rt.invalidateLayout();
-        assertThat(n1Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(1);
+        runtime.invalidateLayout();
+        assertThat(runtime.getLayoutView().getLayout().getAllServers().size()).isEqualTo(1);
 
         server_2 = runServer(n2Port, false);
         // Re-add node 2
-        n1Rt.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
+        runtime.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
                 timeout, pollPeriod);
 
         waitForLayoutChange(layout -> layout.getAllServers().size() == clusterSizeN2
-                && layout.getSegments().size() == 1, n1Rt);
+                && layout.getSegments().size() == 1, runtime);
 
         for (int x = 0; x < numIter; x++) {
             String v = (String) table.get(String.valueOf(x));
@@ -166,8 +164,8 @@ public class WorkflowIT extends AbstractIT {
         Process p1 = runServer(n1Port, false);
         Process p2 = runServer(n2Port, false);
 
-        CorfuRuntime n0Rt = new CorfuRuntime(getConnectionString(n0Port)).connect();
-        CorfuTable table = n0Rt.getObjectsView().build()
+        runtime = new CorfuRuntime(getConnectionString(n0Port)).connect();
+        CorfuTable table = runtime.getObjectsView().build()
                 .setType(CorfuTable.class)
                 .setStreamName("table1").open();
 
@@ -176,31 +174,31 @@ public class WorkflowIT extends AbstractIT {
             table.put(String.valueOf(x), String.valueOf(x));
         }
 
-        n0Rt.getManagementView().addNode(getConnectionString(n1Port), workflowNumRetry,
+        runtime.getManagementView().addNode(getConnectionString(n1Port), workflowNumRetry,
                 timeout, pollPeriod);
-        n0Rt.invalidateLayout();
+        runtime.invalidateLayout();
 
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
+        assertThat(runtime.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
 
-        n0Rt.getManagementView().forceRemoveNode(getConnectionString(n1Port), workflowNumRetry,
+        runtime.getManagementView().forceRemoveNode(getConnectionString(n1Port), workflowNumRetry,
                 timeout, pollPeriod);
-        n0Rt.invalidateLayout();
+        runtime.invalidateLayout();
 
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN1);
+        assertThat(runtime.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN1);
 
-        n0Rt.getManagementView().addNode(getConnectionString(n1Port), workflowNumRetry,
-                timeout, pollPeriod);
-
-        n0Rt.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
+        runtime.getManagementView().addNode(getConnectionString(n1Port), workflowNumRetry,
                 timeout, pollPeriod);
 
-        n0Rt.invalidateLayout();
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN3);
-
-        n0Rt.getManagementView().removeNode(getConnectionString(n1Port), workflowNumRetry,
+        runtime.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
                 timeout, pollPeriod);
-        n0Rt.invalidateLayout();
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
+
+        runtime.invalidateLayout();
+        assertThat(runtime.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN3);
+
+        runtime.getManagementView().removeNode(getConnectionString(n1Port), workflowNumRetry,
+                timeout, pollPeriod);
+        runtime.invalidateLayout();
+        assertThat(runtime.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN2);
 
         for (int x = 0; x < iter; x++) {
             assertThat(table.get(String.valueOf(x))).isEqualTo(String.valueOf(x));
@@ -226,8 +224,8 @@ public class WorkflowIT extends AbstractIT {
         Process p1 = runServer(n1Port, false);
         Process p2 = runServer(n2Port, false);
 
-        CorfuRuntime n0Rt = new CorfuRuntime(getConnectionString(n0Port)).connect();
-        CorfuTable table = n0Rt.getObjectsView().build()
+        runtime = new CorfuRuntime(getConnectionString(n0Port)).connect();
+        CorfuTable table = runtime.getObjectsView().build()
                 .setType(CorfuTable.class)
                 .setStreamName("table1").open();
 
@@ -236,26 +234,26 @@ public class WorkflowIT extends AbstractIT {
             table.put(String.valueOf(x), String.valueOf(x));
         }
 
-        n0Rt.getManagementView().addNode(getConnectionString(n1Port), workflowNumRetry,
+        runtime.getManagementView().addNode(getConnectionString(n1Port), workflowNumRetry,
                 timeout, pollPeriod);
 
-        n0Rt.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
+        runtime.getManagementView().addNode(getConnectionString(n2Port), workflowNumRetry,
                 timeout, pollPeriod);
 
-        n0Rt.invalidateLayout();
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN3);
+        runtime.invalidateLayout();
+        assertThat(runtime.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN3);
 
         // Kill two nodes from a three node cluster
         shutdownCorfuServer(p1);
         shutdownCorfuServer(p2);
 
         // Force remove the "failed" node
-        n0Rt.getManagementView().forceRemoveNode(getConnectionString(n1Port), workflowNumRetry,
+        runtime.getManagementView().forceRemoveNode(getConnectionString(n1Port), workflowNumRetry,
                 timeout, pollPeriod);
-        n0Rt.getManagementView().forceRemoveNode(getConnectionString(n2Port), workflowNumRetry,
+        runtime.getManagementView().forceRemoveNode(getConnectionString(n2Port), workflowNumRetry,
                 timeout, pollPeriod);
-        n0Rt.invalidateLayout();
-        assertThat(n0Rt.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN1);
+        runtime.invalidateLayout();
+        assertThat(runtime.getLayoutView().getLayout().getAllServers().size()).isEqualTo(clusterSizeN1);
 
         for (int x = 0; x < iter; x++) {
             assertThat(table.get(String.valueOf(x))).isEqualTo(String.valueOf(x));
@@ -285,9 +283,9 @@ public class WorkflowIT extends AbstractIT {
         Node n1 = harness.deployUnbootstrappedNode(PORT_1);
         Node n2 = harness.deployUnbootstrappedNode(PORT_2);
 
-        CorfuRuntime rt = harness.createRuntimeForNode(n0);
+        runtime = harness.createRuntimeForNode(n0);
         final String streamName = "test";
-        CorfuTable<String, Integer> table = rt.getObjectsView()
+        CorfuTable<String, Integer> table = runtime.getObjectsView()
                 .build()
                 .setType(CorfuTable.class)
                 .setStreamName(streamName)
@@ -302,13 +300,13 @@ public class WorkflowIT extends AbstractIT {
         // Checkpoint and trim the entries.
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
-        Token prefixTrimAddress = mcw.appendCheckpoints(rt, "author");
-        rt.getAddressSpaceView().prefixTrim(prefixTrimAddress);
-        rt.getAddressSpaceView().invalidateServerCaches();
-        rt.getAddressSpaceView().invalidateClientCache();
-        rt.getAddressSpaceView().gc();
+        Token prefixTrimAddress = mcw.appendCheckpoints(runtime, "author");
+        runtime.getAddressSpaceView().prefixTrim(prefixTrimAddress);
+        runtime.getAddressSpaceView().invalidateServerCaches();
+        runtime.getAddressSpaceView().invalidateClientCache();
+        runtime.getAddressSpaceView().gc();
 
-        assertThat(rt.getAddressSpaceView().getTrimMark().getSequence()).isEqualTo(entriesCount);
+        assertThat(runtime.getAddressSpaceView().getTrimMark().getSequence()).isEqualTo(entriesCount);
 
         // 2 Checkpoint entries for the start and end.
         // 1000 entries being checkpointed = 20 checkpoint entries due to batch size of 50.
@@ -324,32 +322,32 @@ public class WorkflowIT extends AbstractIT {
         final int retries = 3;
         final Duration timeout = PARAMETERS.TIMEOUT_LONG;
         final Duration pollPeriod = PARAMETERS.TIMEOUT_VERY_SHORT;
-        rt.getManagementView().addNode("localhost:9001", retries, timeout, pollPeriod);
-        rt.getManagementView().addNode("localhost:9002", retries, timeout, pollPeriod);
+        runtime.getManagementView().addNode("localhost:9001", retries, timeout, pollPeriod);
+        runtime.getManagementView().addNode("localhost:9002", retries, timeout, pollPeriod);
 
-        rt.invalidateLayout();
-        Layout layoutAfterAdds = rt.getLayoutView().getLayout();
+        runtime.invalidateLayout();
+        Layout layoutAfterAdds = runtime.getLayoutView().getLayout();
         assertThat(layoutAfterAdds.getSegments().stream()
                 .allMatch(s -> s.getAllLogServers().size() == numNodes)).isTrue();
 
         run(n0.shutdown);
 
-        assertThat(rt.getAddressSpaceView().getTrimMark().getSequence()).isEqualTo(entriesCount);
+        assertThat(runtime.getAddressSpaceView().getTrimMark().getSequence()).isEqualTo(entriesCount);
 
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
-            if (rt.getLayoutView().getLayout().getEpoch() > layoutAfterAdds.getEpoch()) {
+            if (runtime.getLayoutView().getLayout().getEpoch() > layoutAfterAdds.getEpoch()) {
                 break;
             }
-            rt.invalidateLayout();
+            runtime.invalidateLayout();
             Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_SHORT);
         }
 
         // Assert that the new nodes should have the correct trimMark.
-        assertThat(rt.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9001").getTrimMark().get())
+        assertThat(runtime.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9001").getTrimMark().get())
                 .isEqualTo(prefixTrimAddress.getSequence() + 1);
-        assertThat(rt.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9002").getTrimMark().get())
+        assertThat(runtime.getLayoutView().getRuntimeLayout().getLogUnitClient("localhost:9002").getTrimMark().get())
                 .isEqualTo(prefixTrimAddress.getSequence() + 1);
-        assertThat(rt.getAddressSpaceView().getAllTails().getStreamTails().get(CorfuRuntime.getStreamID(streamName)))
+        assertThat(runtime.getAddressSpaceView().getAllTails().getStreamTails().get(CorfuRuntime.getStreamID(streamName)))
                 .isEqualTo(streamTail);
 
         // Shutdown two nodes
@@ -401,12 +399,12 @@ public class WorkflowIT extends AbstractIT {
     public void testRuntimeGCForActiveTransactionsInTrimRangeSingleThread() throws Exception {
         // Run single node server and create runtime
         runDefaultServer();
-        CorfuRuntime corfuRuntime = createDefaultRuntime();
+        runtime = createDefaultRuntime();
 
         final int numDataEntries = 10;
 
         // (1)
-        CorfuTable<Integer, String> table = corfuRuntime.getObjectsView().build()
+        CorfuTable<Integer, String> table = runtime.getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<Integer, String>>() {
                 })
                 .setStreamName("test")
@@ -414,37 +412,37 @@ public class WorkflowIT extends AbstractIT {
 
         // (2)
         for (int i = 0; i < numDataEntries - 2; i++) {
-            corfuRuntime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
+            runtime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
             table.put(i, String.valueOf(i));
-            corfuRuntime.getObjectsView().TXEnd();
+            runtime.getObjectsView().TXEnd();
         }
 
         // (3)
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
-        Token prefixTrim = mcw.appendCheckpoints(corfuRuntime, "author");
+        Token prefixTrim = mcw.appendCheckpoints(runtime, "author");
 
         // (4)
         for (int i = numDataEntries - 2; i < numDataEntries; i++) {
-            corfuRuntime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
+            runtime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
             table.put(i, String.valueOf(i));
-            corfuRuntime.getObjectsView().TXEnd();
+            runtime.getObjectsView().TXEnd();
         }
 
         // (5)
         // Force the global pointer to move back to the space of addresses to be trimmed.
-        corfuRuntime.getObjectsView().TXBuild().type(TransactionType.SNAPSHOT)
+        runtime.getObjectsView().TXBuild().type(TransactionType.SNAPSHOT)
                 .snapshot(new Token(0,1))
                 .build()
                 .begin();
         table.get(0);
-        corfuRuntime.getObjectsView().TXEnd();
+        runtime.getObjectsView().TXEnd();
 
         // (6)
-        corfuRuntime.getAddressSpaceView().prefixTrim(prefixTrim);
+        runtime.getAddressSpaceView().prefixTrim(prefixTrim);
 
         // (7)
-        corfuRuntime.getGarbageCollector().runRuntimeGC();
+        runtime.getGarbageCollector().runRuntimeGC();
 
         // (8)
         assertThat(table).hasSize(numDataEntries);
@@ -453,7 +451,7 @@ public class WorkflowIT extends AbstractIT {
         }
 
         // (9)
-        corfuRuntime.getGarbageCollector().runRuntimeGC();
+        runtime.getGarbageCollector().runRuntimeGC();
 
         // (10)
         // TODO: snapshots transactions after trim/gc only fail if client caches are enabled and we
@@ -529,22 +527,22 @@ public class WorkflowIT extends AbstractIT {
     public void testRuntimeGCForActiveTransactionsInTrimRangeMultiThread() throws Exception {
         // Run single node server and create runtime
         runDefaultServer();
-        CorfuRuntime corfuRuntime = createDefaultRuntime();
+        runtime = createDefaultRuntime();
 
         int initKey = 0;
         final int numDataEntries = 10;
 
         // (1)
-        CorfuTable<Integer, String> table = corfuRuntime.getObjectsView().build()
+        CorfuTable<Integer, String> table = runtime.getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<Integer, String>>() {
                 })
                 .setStreamName("test")
                 .open();
 
         // (2)
-        corfuRuntime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
+        runtime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
         table.put(initKey, String.valueOf(initKey));
-        corfuRuntime.getObjectsView().TXEnd();
+        runtime.getObjectsView().TXEnd();
 
         initKey++;
 
@@ -554,7 +552,7 @@ public class WorkflowIT extends AbstractIT {
 
         Thread t = new Thread(() -> {
             // (3)
-            corfuRuntime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
+            runtime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
             table.put(numDataEntries, String.valueOf(numDataEntries));
                     countDownLatch1.countDown();
             try {
@@ -567,7 +565,7 @@ public class WorkflowIT extends AbstractIT {
             // efficient or there is a bug, further look into this...
             // (7)
             table.get(0);
-            corfuRuntime.getObjectsView().TXEnd();
+            runtime.getObjectsView().TXEnd();
             countDownLatch3.countDown();
         });
         t.start();
@@ -576,32 +574,32 @@ public class WorkflowIT extends AbstractIT {
 
         // (4)
         for (int i = initKey; i < numDataEntries - 2; i++) {
-            corfuRuntime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
+            runtime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
             table.put(i, String.valueOf(i));
-            corfuRuntime.getObjectsView().TXEnd();
+            runtime.getObjectsView().TXEnd();
         }
 
         // (5)
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
-        Token prefixTrim = mcw.appendCheckpoints(corfuRuntime, "author");
+        Token prefixTrim = mcw.appendCheckpoints(runtime, "author");
 
         // (6)
         for (int i = numDataEntries - 2; i < numDataEntries; i++) {
-            corfuRuntime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
+            runtime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
             table.put(i, String.valueOf(i));
-            corfuRuntime.getObjectsView().TXEnd();
+            runtime.getObjectsView().TXEnd();
         }
 
         countDownLatch2.countDown();
         countDownLatch3.await();
 
         // (8)
-        corfuRuntime.getAddressSpaceView().prefixTrim(prefixTrim);
+        runtime.getAddressSpaceView().prefixTrim(prefixTrim);
 
         // (9) Note: run it twice so we enforce the trim at stream layer which is deferred in one cycle
-        corfuRuntime.getGarbageCollector().runRuntimeGC();
-        corfuRuntime.getGarbageCollector().runRuntimeGC();
+        runtime.getGarbageCollector().runRuntimeGC();
+        runtime.getGarbageCollector().runRuntimeGC();
 
         // (10)
         assertThat(table).hasSize(numDataEntries + 1);
@@ -665,12 +663,12 @@ public class WorkflowIT extends AbstractIT {
     public void testRuntimeGCWithStreamWithNoUpdatesAfterCheckpoint() throws Exception {
         // Run single node server and create runtime
         runDefaultServer();
-        CorfuRuntime corfuRuntime = createDefaultRuntime();
+        runtime = createDefaultRuntime();
 
         final int numDataEntries = 5;
 
         // (1) Open table backed by stream 'test'
-        CorfuTable<Integer, String> table = corfuRuntime.getObjectsView().build()
+        CorfuTable<Integer, String> table = runtime.getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<Integer, String>>() {
                 })
                 .setStreamName("test")
@@ -678,42 +676,42 @@ public class WorkflowIT extends AbstractIT {
 
         // (2) Add 5 entries
         for (int i = 0; i < numDataEntries; i++) {
-            corfuRuntime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
+            runtime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
             table.put(i, String.valueOf(i));
-            corfuRuntime.getObjectsView().TXEnd();
+            runtime.getObjectsView().TXEnd();
         }
 
         // (3) Checkpoint 'table'
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
-        Token prefixTrim = mcw.appendCheckpoints(corfuRuntime, "author");
+        Token prefixTrim = mcw.appendCheckpoints(runtime, "author");
 
         // (4) Trim
-        corfuRuntime.getAddressSpaceView().prefixTrim(prefixTrim);
+        runtime.getAddressSpaceView().prefixTrim(prefixTrim);
 
         // (5) Initiate Snapshot Transaction (before runtime GC) should complete as data is kept locally
-        corfuRuntime.getObjectsView().TXBuild().type(TransactionType.SNAPSHOT)
+        runtime.getObjectsView().TXBuild().type(TransactionType.SNAPSHOT)
                 .snapshot(new Token(0,2))
                 .build()
                 .begin();
         table.get(0);
-        corfuRuntime.getObjectsView().TXEnd();
+        runtime.getObjectsView().TXEnd();
 
         // (5) Start optimistic transaction @snapshot(0, 7), read all 5 entries (before runtime GC)
         for(int i = 0; i < numDataEntries; i++) {
-            corfuRuntime.getObjectsView().TXBuild().type(TransactionType.OPTIMISTIC).build().begin();
+            runtime.getObjectsView().TXBuild().type(TransactionType.OPTIMISTIC).build().begin();
             assertThat(table.get(i)).isEqualTo(String.valueOf(i));
-            corfuRuntime.getObjectsView().TXEnd();
+            runtime.getObjectsView().TXEnd();
         }
 
         // (7) Run GC
-        corfuRuntime.getGarbageCollector().runRuntimeGC();
+        runtime.getGarbageCollector().runRuntimeGC();
 
         // (8) Start optimistic transaction @snapshot(0, 7), read all 5 entries (after runtime GC)
         for(int i = 0; i < numDataEntries; i++) {
-            corfuRuntime.getObjectsView().TXBuild().type(TransactionType.OPTIMISTIC).build().begin();
+            runtime.getObjectsView().TXBuild().type(TransactionType.OPTIMISTIC).build().begin();
             assertThat(table.get(i)).isEqualTo(String.valueOf(i));
-            corfuRuntime.getObjectsView().TXEnd();
+            runtime.getObjectsView().TXEnd();
         }
         
         // (9) Snapshot in trimmed addresses (after runtimeGC), should fail as address space has been GC


### PR DESCRIPTION
## Overview

- Properly shutdown the netty routers in BootstapUtil when exception
happens. This prevents channel leakage, which may cause an issue that
after the boostrap finishes and then some server goes down, the leaked
channels are constantly reconnecting every second.

- Integrations tests are not shutting down runtime after tests finish,
which is also leaking channels.

- Removed all NetworkExceptions catches when creating NettyClientRouter,
since it is needed only for legacy versions.

Related issue(s) (if applicable): #1788


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
