### PR TITLE
Replace null with empty collections

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -17,8 +17,8 @@ import lombok.Data;
 @AllArgsConstructor
 public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
 
-    public static byte[] NO_CONFLICT_KEY = new byte[]{};
-    public static UUID NO_CONFLICT_STREAM = new UUID(0, 0);
+    public static final byte[] NO_CONFLICT_KEY = new byte[]{};
+    public static final UUID NO_CONFLICT_STREAM = new UUID(0, 0);
 
     /**
      * Constructor for TokenResponse.

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -2,18 +2,6 @@ package org.corfudb.runtime.object;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.protocols.logprotocol.SMREntry;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.exceptions.NoRollbackException;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
-import org.corfudb.runtime.object.transactions.WriteSetSMRStream;
-import org.corfudb.runtime.view.Address;
-import org.corfudb.util.CorfuComponent;
-import org.corfudb.util.MetricsUtils;
-import org.corfudb.util.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.ListIterator;
@@ -26,6 +14,20 @@ import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.NoRollbackException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.object.transactions.WriteSetSMRStream;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.util.CorfuComponent;
+import org.corfudb.util.MetricsUtils;
+import org.corfudb.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import lombok.extern.slf4j.Slf4j;
 
 //TODO Discard TransactionStream for building maps but not for constructing tails
 
@@ -580,7 +582,7 @@ public class VersionLockedObject<T> {
 
         List<SMREntry> entries = stream.current();
 
-        while (entries != null) {
+        while (entries != null && !entries.isEmpty()) {
             if (entries.stream().allMatch(x -> x.isUndoable())) {
                 // start from the end, process one at a time
                 ListIterator<SMREntry> it =

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -7,13 +7,13 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import lombok.extern.slf4j.Slf4j;
-
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.object.ISMRStream;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.Utils;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Created by mwei on 3/13/17.
@@ -66,10 +66,8 @@ public class WriteSetSMRStream implements ISMRStream {
 
     int currentContext = 0;
 
-    // TODO add comment
     long currentContextPos;
 
-    // TODO add comment
     long writePos;
 
     // the specific stream-id for which this SMRstream wraps the write-set
@@ -156,7 +154,7 @@ public class WriteSetSMRStream implements ISMRStream {
                 entryList.add(writeSet.get((int) j));
                 writePos++;
             }
-            if (writeSet.size() > 0) {
+            if (!writeSet.isEmpty()) {
                 currentContext = i;
                 currentContextPos = writeSet.size() - 1;
             }
@@ -167,7 +165,7 @@ public class WriteSetSMRStream implements ISMRStream {
     @Override
     public List<SMREntry> current() {
         if (Address.nonAddress(writePos)) {
-            return null;
+            return Collections.emptyList();
         }
         if (Address.nonAddress(currentContextPos)) {
             currentContextPos = -1;
@@ -184,7 +182,7 @@ public class WriteSetSMRStream implements ISMRStream {
 
         if (writePos <= Address.maxNonAddress()) {
             writePos = Address.maxNonAddress();
-            return null;
+            return Collections.emptyList();
         }
 
         currentContextPos--;

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/IReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/IReplicationProtocol.java
@@ -1,10 +1,11 @@
 package org.corfudb.runtime.view.replication;
 
-import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import javax.annotation.Nonnull;
 
 import org.corfudb.protocols.wireprotocol.ILogData;
@@ -70,9 +71,9 @@ public interface IReplicationProtocol {
      */
     default @Nonnull
             Map<Long, ILogData> readAll(RuntimeLayout runtimeLayout, List<Long> globalAddresses) {
-        return globalAddresses.parallelStream()
-                .map(a -> new AbstractMap.SimpleImmutableEntry<>(a, read(runtimeLayout, a)))
-                .collect(Collectors.toMap(r -> r.getKey(), r -> r.getValue()));
+        return globalAddresses
+                .parallelStream()
+                .collect(Collectors.toMap(Function.identity(), a -> read(runtimeLayout, a)));
     }
 
     /** Read data from a range.
@@ -91,9 +92,9 @@ public interface IReplicationProtocol {
      */
     default @Nonnull
     Map<Long, ILogData> readRange(RuntimeLayout runtimeLayout, Set<Long> globalAddresses) {
-        return globalAddresses.parallelStream()
-                .map(a -> new AbstractMap.SimpleImmutableEntry<>(a, read(runtimeLayout, a)))
-                .collect(Collectors.toMap(r -> r.getKey(), r -> r.getValue()));
+        return globalAddresses
+                .parallelStream()
+                .collect(Collectors.toMap(Function.identity(),a -> read(runtimeLayout, a)));
     }
 
     /** Peek data from a given address.
@@ -127,9 +128,9 @@ public interface IReplicationProtocol {
      */
     default @Nonnull Map<Long, ILogData> peekAll(RuntimeLayout runtimeLayout,
                                                  Set<Long> globalAddresses) {
-        return globalAddresses.parallelStream()
-                .map(a -> new AbstractMap.SimpleImmutableEntry<>(a, peek(runtimeLayout, a)))
-                .collect(Collectors.toMap(r -> r.getKey(), r -> r.getValue()));
+        return globalAddresses
+                .parallelStream()
+                .collect(Collectors.toMap(Function.identity(), a -> peek(runtimeLayout, a)));
     }
 
 }

--- a/test/src/test/java/org/corfudb/integration/CmdletIT.java
+++ b/test/src/test/java/org/corfudb/integration/CmdletIT.java
@@ -1,6 +1,14 @@
 package org.corfudb.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStreamReader;
+import java.util.Collections;
 import java.util.UUID;
+
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
@@ -8,14 +16,6 @@ import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Ignore;
 import org.junit.Test;
-
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.InputStreamReader;
-import java.util.Collections;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for clojure cmdlets.
@@ -39,7 +39,7 @@ public class CmdletIT extends AbstractIT {
                         0L,
                         -1L,
                         Collections.singletonList(new Layout.LayoutStripe(Collections.singletonList(ENDPOINT))))),
-                Collections.EMPTY_LIST,
+                Collections.emptyList(),
                 0L,
                 UUID.randomUUID());
     }


### PR DESCRIPTION
## Overview

Description:
Replace returning null with empty collections
Make constants final
Combine nested if loops

Why should this be merged: 
Avoid returning nulls
Constants should be final

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
