### PR TITLE
Check nested transaction type mismatch upon txn begin

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -593,6 +593,20 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
                 .containsEntry("k", "v1");
     }
 
+    /**
+     * This test makes sure that nested transactions have same txn type
+     * by checking that if nested transaction has a different type than
+     * the parent transaction, an exception is thrown when the nested
+     * transaction starts.
+     */
+    @Test
+    public void nestedTransactionsHaveSameType() {
+        t(1, this::OptimisticTXBegin);
+        t(1, this::WWTXBegin).assertThrows().isInstanceOf(IllegalArgumentException.class);
+        t(1, this::SnapshotTXBegin).assertThrows().isInstanceOf(IllegalArgumentException.class);
+        t(1, this::TXEnd);
+    }
+
     /** This test makes sure that a single thread can read
      * its own nested transactions after they have committed,
      * and that nested transactions are committed with the


### PR DESCRIPTION
## Overview

- Currently when starting nested transactions, client can bypass the txn
type inheritance, and start nested transactions with different types,
which could violate txn semantics. This patch enforces a txn type check
upon transaction start.

Related issue(s) (if applicable): #1796 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
