### PR TITLE
Deploy corfu artifact into bintray maven repository

### DIFF
--- a/.travis_scripts/settings.xml
+++ b/.travis_scripts/settings.xml
@@ -1,0 +1,11 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <servers>
+        <server>
+            <id>bintray-corfudb-maven</id>
+            <username>${DEPLOY_USER}</username>
+            <password>${DEPLOY_PASSWORD}</password>
+        </server>
+    </servers>
+</settings>

--- a/annotationProcessor/pom.xml
+++ b/annotationProcessor/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>annotationProcessor</artifactId>
 
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.corfudb</groupId>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>annotations</artifactId>
 
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/cmdlets/pom.xml
+++ b/cmdlets/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>cmdlets</artifactId>
 
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.corfudb</groupId>
@@ -126,9 +130,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <outputFile>
-                        ${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar
-                    </outputFile>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>shaded</shadedClassifierName>
                 </configuration>
             </plugin>
             <plugin>

--- a/debian/pom.xml
+++ b/debian/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>debian</artifactId>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.corfudb</groupId>

--- a/format/pom.xml
+++ b/format/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>format</artifactId>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <!-- external dependencies -->
         <dependency>

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>generator</artifactId>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.corfudb</groupId>

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>infrastructure</artifactId>
 
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
     <build>
         <plugins>
             <!-- Make a folder `target/*-shaded.jar/` with this project and all its dependencies -->
@@ -39,9 +43,8 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <outputFile>
-                        ${project.build.directory}/${project.artifactId}-${project.version}-shaded.jar
-                    </outputFile>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>shaded</shadedClassifierName>
                 </configuration>
             </plugin>
         </plugins>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -12,6 +12,10 @@
     <artifactId>universe</artifactId>
     <packaging>jar</packaging>
 
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.corfudb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -26,20 +26,14 @@
     <url>http://www.corfudb.org</url>
     <description>A cloud scale-consistency platform</description>
 
-    <distributionManagement>
-        <repository>
-            <id>internal.repo</id>
-            <name>Temporary Staging Repository</name>
-            <url>file://${project.build.directory}/mvn-repo</url>
-        </repository>
-    </distributionManagement>
-
     <organization>
         <name>CorfuDB</name>
         <url>http://www.corfudb.org</url>
     </organization>
 
     <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <logback.classic.version>1.2.3</logback.classic.version>
@@ -181,6 +175,14 @@
         </dependency>
     </dependencies>
 
+    <distributionManagement>
+        <repository>
+            <id>bintray-corfudb-maven</id>
+            <name>CorfuDB repository</name>
+            <url>https://api.bintray.com/maven/corfudb/maven/org.corfudb/;publish=1</url>
+        </repository>
+    </distributionManagement>
+
     <profiles>
         <profile>
             <id>it</id>
@@ -241,6 +243,11 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.0.0-M1</version>
+            </plugin>
             <plugin>
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
@@ -310,14 +317,6 @@
                 <configuration>
                     <header>LICENSE.txt</header>
                     <strictCheck>true</strictCheck>
-                </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.1</version>
-                <configuration>
-                    <altDeploymentRepository>internal.repo::default::file://${project.build.directory}/mvn-repo
-                    </altDeploymentRepository>
                 </configuration>
             </plugin>
             <plugin>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>runtime</artifactId>
 
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
     <build>
         <plugins>
             <plugin>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -12,6 +12,10 @@
     <groupId>org.corfudb</groupId>
     <artifactId>samples</artifactId>
 
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
     <dependencies>
     <dependency>
         <groupId>org.corfudb</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -11,6 +11,10 @@
 
     <artifactId>test</artifactId>
 
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.corfudb</groupId>


### PR DESCRIPTION
## Overview

Description:
Deploy Corfu jar artifacts to bintray maven repository.

Why should this be merged: 
This change allows using Corfu easily. 
Can help improve automation and also helps in the following issues/improvements:
 - achieving CD
 - together with "versioning" improves CI and also helps in achieving CD
 - reuse "universe" framework
 - dockerize Corfu
 - get rid of "private" version of Corfu, which simplifies a lot of in a build process 

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
