### PR TITLE
Fix Netty router race and channel leak.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -864,7 +864,9 @@ public class CorfuRuntime {
                         .contains(NodeLocator.getLegacyEndpoint(endpoint)))
                 .forEach(endpoint -> {
                     try {
-                        nodeRouterPool.getNodeRouters().get(endpoint).stop();
+                        // Simply remove the router from the pool and let finalize() method close
+                        // the channel when being GC'ed in order to prevent race conditions where
+                        // someone may still holding this router and planing to send messages.
                         nodeRouterPool.getNodeRouters().remove(endpoint);
                     } catch (Exception e) {
                         log.warn("fetchLayout: Exception in stopping and removing "

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -507,7 +507,7 @@ public class NettyCommTest extends AbstractCorfuTest {
             throw ex;
         } finally {
             try {
-                if (ncr != null) {ncr.stop(true);}
+                if (ncr != null) {ncr.stop();}
             } catch (Exception ex) {
                 log.warn("Error shutting down client...", ex);
             }


### PR DESCRIPTION
## Overview

- Fix a race condition when pruning routers that are not in layout, someone may
still using it which causes a ShutdownException
- Fix a channel leak issue that channels are not closed when stopping routers.

Related issue(s) (if applicable): #1751, #1822 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
