### PR TITLE
FastObjectLoader fix nextRead offset

### DIFF
--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -558,16 +558,13 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         populateMaps(1, getDefaultRuntime(), CorfuTable.class, false, 2);
 
         // Create a new runtime with fastloader
-        CorfuRuntime rt2 = getNewRuntime(getDefaultNode())
-                .connect();
+        CorfuRuntime rt2 = getNewRuntime(getDefaultNode()).connect();
         FastObjectLoader fsm = new FastObjectLoader(rt2);
         fsm.addStreamToIgnore("Map1");
         fsm.setDefaultObjectsType(CorfuTable.class);
         fsm.loadMaps();
 
         assertThatMapsAreBuiltIgnore(rt2, "Map1");
-
-
     }
 
     @Test(expected = RuntimeException.class)
@@ -575,12 +572,11 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         populateMaps(SOME, getDefaultRuntime(), CorfuTable.class, true, SOME);
 
         // Create a new runtime with fastloader
-        CorfuRuntime rt2 = getNewRuntime(getDefaultNode())
-                .connect();
+        CorfuRuntime rt2 = getNewRuntime(getDefaultNode()).connect();
 
         long firstMileStone = 2;
         FastObjectLoader incrementalLoader = new FastObjectLoader(rt2);
-        incrementalLoader.setNumberOfAttempt(1);
+        incrementalLoader.setNumberOfAttempt(0);
         incrementalLoader.setLogTail(firstMileStone);
         incrementalLoader.setDefaultObjectsType(CorfuTable.class);
         incrementalLoader.loadMaps();
@@ -591,11 +587,10 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         incrementalLoader.setLogHead(firstMileStone + 1);
         incrementalLoader.setLogTail(getDefaultRuntime().getSequencerView().next().getSequence());
         incrementalLoader.loadMaps();
-
     }
 
     @Test
-    public void failWhenTrimHappensWhileFastLoading() throws Exception{
+    public void failWhenTrimHappensWhileFastLoading() throws Exception {
         // 1 tables has 1 entry and 2 tables have 2 entries
         populateMaps(SOME, getDefaultRuntime(), CorfuTable.class, true, 1);
         populateMaps(2, getDefaultRuntime(), CorfuTable.class, false, 1);
@@ -603,15 +598,14 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         Token snapShotAddress = checkPointAll(getDefaultRuntime());
         Helpers.trim(getDefaultRuntime(), snapShotAddress);
 
-        CorfuRuntime rt2 = getNewRuntime(getDefaultNode())
-                .connect();
+        CorfuRuntime rt2 = getNewRuntime(getDefaultNode()).connect();
 
         // Force a read from 0
         FastObjectLoader fsm = new FastObjectLoader(rt2);
         fsm.setLogHead(0L);
         fsm.setDefaultObjectsType(CorfuTable.class);
-        assertThatThrownBy(() ->fsm.loadMaps())
-                .isInstanceOf(TrimmedException.class);
+        fsm.setNumberOfAttempt(0);
+        assertThatThrownBy(fsm::loadMaps).isInstanceOf(RuntimeException.class);
     }
 
     @Test


### PR DESCRIPTION
## Overview


Description:
If FastObjectLoader face TRIMMED message, it starts loading trimmed data again.

Why should this be merged: 
updates logHead up to `trimMark` then the loading process continues from trim mark position

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
