### PR TITLE
NoRollBack Debug Information

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/NoRollbackException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/NoRollbackException.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.exceptions;
 
 import java.util.Optional;
 
+import lombok.Getter;
 import org.corfudb.protocols.logprotocol.SMREntry;
 
 /**
@@ -9,15 +10,20 @@ import org.corfudb.protocols.logprotocol.SMREntry;
  */
 public class NoRollbackException extends RuntimeException {
 
+    @Getter
+    private final long undoableEntryVersion;
+
     public NoRollbackException(long rollbackVersion) {
         super("Can't roll back due to non-undoable exception "
                 + " but need "
                 + rollbackVersion + " so can't undo");
+        undoableEntryVersion = rollbackVersion;
     }
 
     public NoRollbackException(long address, long rollbackVersion) {
         super("Could only roll back to " + address + " but need "
                 + rollbackVersion + " so can't undo");
+        undoableEntryVersion = address;
     }
 
     public NoRollbackException(Optional<SMREntry> entry, long address, long rollbackVersion) {
@@ -28,5 +34,6 @@ public class NoRollbackException extends RuntimeException {
                 + address
                 + " but need "
                 + rollbackVersion + " so can't undo");
+        undoableEntryVersion = address;
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -9,6 +9,7 @@ import org.corfudb.runtime.exceptions.NoRollbackException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.object.transactions.WriteSetSMRStream;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.AddressSpaceView;
 import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Utils;
@@ -325,7 +326,8 @@ public class VersionLockedObject<T> {
                     try {
                         rollbackObjectUnsafe(timestamp);
                     } catch (NoRollbackException nre) {
-                        log.warn("SyncObjectUnsafe[{}] to {} failed {}", this, timestamp, nre);
+                        log.warn("SyncObjectUnsafe[{}] to {} failed {}, cause {}", this, timestamp, nre,
+                                AddressSpaceView.removalCauseCache.getIfPresent(nre.getUndoableEntryVersion()));
                         resetUnsafe();
                     }
                 }
@@ -354,7 +356,9 @@ public class VersionLockedObject<T> {
                         return;
                     }
                 } catch (NoRollbackException nre) {
-                    log.warn("Rollback[{}] to {} failed {}", this, timestamp, nre);
+                    log.warn("Rollback[{}] to {} failed {}, cause {}", this, timestamp, nre,
+                            AddressSpaceView.removalCauseCache.getIfPresent(nre.getUndoableEntryVersion()));
+
                     resetUnsafe();
                 }
             }


### PR DESCRIPTION
## Overview
Added extra logging to show the cause of a NoRollBackException.

Why should this be merged: Currently its not possible to know why NoRollBackException(NRE)
happen, this patch introduces extra metadata tracking to also log the cause of the
NRE. The metadata is tracked using a cache, so the cause of the NRE can be determined
as long as the cause exists in the cache.  

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
