### PR TITLE
Add checkpointed map size log and fix unit tests.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -141,8 +141,8 @@ public class CheckpointWriter<T extends Map> {
             startCheckpoint(snapshot, vloVersion);
             appendObjectState(entries);
             finishCheckpoint();
-            log.info("appendCheckpoint: completed checkpoint for {} at snapshot {} in {} ms", streamId, snapshot,
-                    System.currentTimeMillis() - start);
+            log.info("appendCheckpoint: completed checkpoint for {}, num of entries {} at snapshot {} in {} ms",
+                    streamId, entries.size(), snapshot, System.currentTimeMillis() - start);
             return snapshot;
         } finally {
             rt.getObjectsView().TXEnd();

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -169,9 +169,12 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
 
     @After
     public void cleanupBuffers() {
-        testServerMap.values().forEach(x -> {
-            x.getLogUnitServer().shutdown();
-            x.getManagementServer().shutdown();
+        testServerMap.values().forEach(server -> {
+            server.getLogUnitServer().shutdown();
+            server.getManagementServer().shutdown();
+            server.getLayoutServer().shutdown();
+            server.getSequencerServer().shutdown();
+            server.getBaseServer().shutdown();
         });
         // Abort any active transactions...
         while (runtime.getObjectsView().TXActive()) {


### PR DESCRIPTION
## Overview

Description:
Add log to print size of map which was checkpointed. This will help detect keys leaking in CorfuTable.

Shut down server thread pools after tests.

Why should this be merged: Debuggability and test performance.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
