### PR TITLE
Freeze segment head for epoch before electing new sequencer.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -366,6 +366,12 @@ public class Layout {
     public enum ReplicationMode {
         CHAIN_REPLICATION {
             @Override
+            public void validateAddressSpaceSeal(LayoutSegment layoutSegment,
+                                                 Map<String, CompletableFuture<Boolean>> completableFutureMap) {
+                SealServersHelper.freezeChainSegment(layoutSegment, completableFutureMap);
+            }
+
+            @Override
             public void validateSegmentSeal(LayoutSegment layoutSegment,
                                             Map<String, CompletableFuture<Boolean>>
                                                     completableFutureMap)
@@ -407,6 +413,12 @@ public class Layout {
             }
         },
         QUORUM_REPLICATION {
+            @Override
+            public void validateAddressSpaceSeal(LayoutSegment layoutSegment,
+                                                 Map<String, CompletableFuture<Boolean>> completableFutureMap) {
+                throw new UnsupportedOperationException("unsupported operation");
+            }
+
             @Override
             public void validateSegmentSeal(LayoutSegment layoutSegment,
                                             Map<String, CompletableFuture<Boolean>>
@@ -470,6 +482,12 @@ public class Layout {
 
         }, NO_REPLICATION {
             @Override
+            public void validateAddressSpaceSeal(LayoutSegment layoutSegment,
+                                                 Map<String, CompletableFuture<Boolean>> completableFutureMap) {
+                throw new UnsupportedOperationException("unsupported operation");
+            }
+
+            @Override
             public void validateSegmentSeal(LayoutSegment layoutSegment,
                                             Map<String, CompletableFuture<Boolean>>
                                                     completableFutureMap)
@@ -502,11 +520,16 @@ public class Layout {
         };
 
         /**
+         * Waits for the particular address space in the segment to be sealed.
+         */
+        public abstract void validateAddressSpaceSeal(LayoutSegment layoutSegment,
+                                                      Map<String, CompletableFuture<Boolean>> completableFutureMap);
+
+        /**
          * Seals the layout segment.
          */
         public abstract void validateSegmentSeal(LayoutSegment layoutSegment,
-                                                 Map<String, CompletableFuture<Boolean>>
-                                                         completableFutureMap)
+                                                 Map<String, CompletableFuture<Boolean>> completableFutureMap)
                 throws QuorumUnreachableException;
 
         /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -427,8 +427,10 @@ public class LayoutManagementView extends AbstractView {
                         || !originalLayout.getPrimarySequencer()
                         .equals(newLayout.getPrimarySequencer())) {
 
-                    //TODO(Maithem) why isn't this getting the tails
-                    // from utils?
+                    // Freeze the addressSpace by sealing the log unit head in all segments for this epoch.
+                    // The log units cannot accept any messages from the previous epoch.
+                    runtime.getLayoutView().getRuntimeLayout(newLayout).freezeSegmentsForEpoch();
+
                     TailsResponse tails = runtime.getAddressSpaceView().getAllTails();
 
                     maxTokenRequested = tails.getLogTail();

--- a/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
@@ -78,6 +78,22 @@ public class RuntimeLayout {
         log.debug("Layout has been sealed successfully.");
     }
 
+    /**
+     * Attempts to freeze the address space so that all in flight messages are completed. This is executed before
+     * the election of a new sequencer. This is different from the seal protocol as this makes a decision of
+     * completion of the reign of the previous sequencer by freezing and ending all it's in-flight tokens and
+     * preparing the logunits for the new sequencer.
+     */
+    public void freezeSegmentsForEpoch() {
+        log.info("Requested to freeze segments for previous epochs. Current layout: {}", layout);
+
+        Map<String, CompletableFuture<Boolean>> resultMap = SealServersHelper.asyncSealServers(this);
+        for (LayoutSegment layoutSegment : layout.getSegments()) {
+            layoutSegment.getReplicationMode().validateAddressSpaceSeal(layoutSegment, resultMap);
+        }
+        log.info("Freeze segments for layout successful : {}", layout);
+    }
+
 
     /**
      * Sender Client Map.


### PR DESCRIPTION
## Overview

Description:
Introduces the address space freeze before a new sequencer is elected. This is different from a seal logically as it is intended to seal the head of the chain as not to allow any in-flight messages from the previous epoch or tokens dispatched by the previous sequencer.
Again, this is not combined with the seal protocol to keep both the algorithms semantically separate for what they are intended.

Why should this be merged: Causes a correctness issue.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
