### PR TITLE
Cache-After-Write Race + Data Loss Bug (#1805)

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/StateTransfer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/StateTransfer.java
@@ -81,7 +81,7 @@ public class StateTransfer {
             long ts1 = System.currentTimeMillis();
 
             Map<Long, ILogData> dataMap = runtime.getAddressSpaceView()
-                    .cacheFetch(ContiguousSet.create(
+                    .fetchRange(ContiguousSet.create(
                             Range.closed(chunkStart, chunkEnd),
                             DiscreteDomain.longs()));
 

--- a/runtime/src/main/java/org/corfudb/recovery/RecoveryUtils.java
+++ b/runtime/src/main/java/org/corfudb/recovery/RecoveryUtils.java
@@ -90,7 +90,7 @@ public class RecoveryUtils {
      */
     static Map<Long, ILogData> getLogData(CorfuRuntime runtime, long start, long end) {
         return runtime.getAddressSpaceView().
-                cacheFetch(ContiguousSet.create(Range.closedOpen(start, end), DiscreteDomain.longs()));
+                fetchRange(ContiguousSet.create(Range.closedOpen(start, end), DiscreteDomain.longs()));
     }
 
     /** Deserialize a logData by getting the logEntry

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -4,11 +4,9 @@ import static org.corfudb.util.Utils.getTails;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;
-import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import io.netty.handler.timeout.TimeoutException;
 
@@ -19,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
@@ -47,6 +44,8 @@ import org.corfudb.util.CFUtils;
 import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.Sleep;
 
+import java.util.HashSet;
+
 
 /**
  * A view of the address space implemented by Corfu.
@@ -59,22 +58,12 @@ public class AddressSpaceView extends AbstractView {
     /**
      * A cache for read results.
      */
-    final LoadingCache<Long, ILogData> readCache = CacheBuilder.newBuilder()
+    final Cache<Long, ILogData> readCache = CacheBuilder.newBuilder()
             .maximumSize(runtime.getParameters().getNumCacheEntries())
             .expireAfterAccess(runtime.getParameters().getCacheExpiryTime(), TimeUnit.SECONDS)
             .expireAfterWrite(runtime.getParameters().getCacheExpiryTime(), TimeUnit.SECONDS)
             .recordStats()
-            .build(new CacheLoader<Long, ILogData>() {
-                @Override
-                public ILogData load(Long value) throws Exception {
-                    return cacheFetch(value);
-                }
-
-                @Override
-                public Map<Long, ILogData> loadAll(Iterable<? extends Long> keys) throws Exception {
-                    return cacheFetch((Iterable<Long>) keys);
-                }
-            });
+            .build();
 
     /**
      * Constructor for the Address Space View.
@@ -233,31 +222,42 @@ public class AddressSpaceView extends AbstractView {
      * @param address An address to read from.
      * @return A result, which be cached.
      */
-    public @Nonnull ILogData read(long address) {
+    public @Nonnull
+    ILogData read(long address) {
         if (!runtime.getParameters().isCacheDisabled()) {
-            ILogData data;
-            try {
-                data = readCache.get(address);
-            } catch (ExecutionException | UncheckedExecutionException e) {
-                // Guava wraps the exceptions thrown from the lower layers, therefore
-                // we need to unwrap them before throwing them to the upper layers that
-                // don't understand the guava exceptions
-                Throwable cause = e.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
-                } else {
-                    throw new RuntimeException(cause);
-                }
+            // The VersionLockedObject and the Transaction layer will generate
+            // undoRecord(s) during a transaction commit, or object sync. These
+            // undo records are stored in transient fields and are not persisted.
+            // A missing undo record can cause a NoRollbackException, thus forcing
+            // a complete object rebuild that generates a "scanning" behavior
+            // which affects the LRU window. In essence, affecting other cache users
+            // and making the VersionLockedObject very sensitive to caching behavior.
+            // A concrete example of this would be unsynchronized readers/writes:
+            // 1. Thread A starts replicating write1
+            // 2. Thread B discovers the write (via stream tail query) and
+            //    tries to read write1
+            // 3. Thread B's read results in a cache miss and the reader thread
+            //    starts loading the value into the cache
+            // 4. Thread A completes its write and caches it with undo records
+            // 5. Thread B finishes loading and caches the loaded value replacing
+            //    the cached value from step 4 (i.e. loss of undo records computed
+            //    by thread A)
+            ILogData data = readCache.getIfPresent(address);
+            if (data == null) {
+                // Loading a value without the cache loader can result in
+                // redundant loading calls (i.e. multiple threads try to
+                // load the same value), but currently a redundant RPC
+                // is much cheaper than the cost of a NoRollBackException, therefore
+                // this trade-off is reasonable
+                final ILogData loadedVal = fetch(address);
+                data = readCache.asMap().computeIfAbsent(address, (k) -> loadedVal);
+                return data;
+            } else {
+                return data;
             }
-            if (data == null || data.getType() == DataType.EMPTY) {
-                throw new RuntimeException("Unexpected return of empty data at address "
-                        + address + " on read");
-            } else if (data.isTrimmed()) {
-                throw new TrimmedException();
-            }
-            return data;
+        } else {
+            return fetch(address);
         }
-        return fetch(address);
     }
 
     /**
@@ -267,29 +267,35 @@ public class AddressSpaceView extends AbstractView {
      * @return A result, which be cached.
      */
     public Map<Long, ILogData> read(Iterable<Long> addresses) {
-        Map<Long, ILogData> addressesMap;
         if (!runtime.getParameters().isCacheDisabled()) {
-            try {
-                addressesMap = readCache.getAll(addresses);
-            } catch (ExecutionException | UncheckedExecutionException e) {
-                Throwable cause = e.getCause();
-                if (cause instanceof RuntimeException) {
-                    throw (RuntimeException) cause;
+            Map<Long, ILogData> result = new HashMap<>();
+            Set<Long> addressesToFetch = new HashSet<>();
+
+            for (Long address : addresses) {
+                ILogData val = readCache.getIfPresent(address);
+                if (val == null) {
+                    addressesToFetch.add(address);
                 } else {
-                    throw new RuntimeException(cause);
+                    result.put(address, val);
                 }
             }
-        } else {
-            addressesMap = this.cacheFetch(addresses);
-        }
 
-        for (ILogData logData : addressesMap.values()) {
-            if (logData.isTrimmed()) {
-                throw new TrimmedException();
+            // At this point we computed a subset of the addresses that
+            // resulted in a cache miss and need to be fetched
+            if (!addressesToFetch.isEmpty()) {
+                Map<Long, ILogData> fetchedAddresses = fetchAll(addressesToFetch);
+                for (Map.Entry<Long, ILogData> entry : fetchedAddresses.entrySet()) {
+                    // After fetching a value, we need to insert it in the cache.
+                    // Note that based on code inspection it seems like operations
+                    // on the cache's map view are reflected in the cache's statistics.
+                    result.put(entry.getKey(), readCache.asMap()
+                            .computeIfAbsent(entry.getKey(), (k) -> entry.getValue()));
+                }
             }
+            return result;
+        } else {
+            return fetchAll(addresses);
         }
-
-        return addressesMap;
     }
 
     /**
@@ -424,30 +430,14 @@ public class AddressSpaceView extends AbstractView {
     }
 
     /**
-     * Fetch an address for insertion into the cache.
-     *
-     * @param address An address to read from.
-     * @return A result to be cached. If the readresult is empty,
-     *         This entry will be scheduled to self invalidate.
-     */
-    private @Nonnull ILogData cacheFetch(long address) {
-        log.trace("CacheMiss[{}]", address);
-        ILogData result = fetch(address);
-        if (result.getType() == DataType.EMPTY) {
-            throw new RuntimeException("Unexpected empty return at " +  address + " from fetch");
-        }
-        return result;
-    }
-
-    /**
      * Fetch a collection of addresses for insertion into the cache.
      *
      * @param addresses collection of addresses to read from.
      * @return A result to be cached
      */
     public @Nonnull
-    Map<Long, ILogData> cacheFetch(Iterable<Long> addresses) {
-        Map<Long, ILogData> allAddresses = new HashMap<>();
+    Map<Long, ILogData> fetchAll(Iterable<Long> addresses) {
+        Map<Long, ILogData> result = new HashMap<>();
 
         Iterable<List<Long>> batches = Iterables.partition(addresses,
             runtime.getParameters().getBulkReadSize());
@@ -455,7 +445,7 @@ public class AddressSpaceView extends AbstractView {
         for (List<Long> batch : batches) {
             try {
                 //doesn't handle the case where some address have a different replication mode
-                allAddresses.putAll(layoutHelper(e -> e.getLayout()
+                result.putAll(layoutHelper(e -> e.getLayout()
                         .getReplicationMode(batch.iterator().next())
                         .getReplicationProtocol(runtime)
                         .readAll(e, batch)));
@@ -466,20 +456,46 @@ public class AddressSpaceView extends AbstractView {
             }
         }
 
-        return allAddresses;
+        for (Long address : result.keySet()) {
+            checkLogData(address, result.get(address));
+        }
+        return result;
     }
 
     /**
-     * Fetch a collection of addresses.
+     * Fetch a range of addresses.
      *
      * @param addresses collection of addresses to read from.
      * @return A result to be cached
      */
     public @Nonnull
-    Map<Long, ILogData> cacheFetch(Set<Long> addresses) {
-        return layoutHelper(e -> e.getLayout().getReplicationMode(addresses.iterator().next())
+    Map<Long, ILogData> fetchRange(Set<Long> addresses) {
+        Map<Long, ILogData> result = layoutHelper(e -> e.getLayout().getReplicationMode(addresses.iterator().next())
                 .getReplicationProtocol(runtime)
                 .readRange(e, addresses));
+
+        for (Long address : result.keySet()) {
+            checkLogData(address, result.get(address));
+        }
+        return result;
+    }
+
+    /**
+     * Checks whether a log entry is valid or not. If a read
+     * returns null, Empty, or trimmed an exception will be
+     * thrown.
+     * @param address The address being checked
+     * @param logData the IlogData at the address being checked
+     */
+    private void checkLogData(long address, ILogData logData) {
+        if (logData == null || logData.getType() == DataType.EMPTY) {
+            throw new RuntimeException("Unexpected return of empty data at address "
+                    + address + " on read");
+        }
+
+        if (logData.isTrimmed()) {
+            throw new TrimmedException();
+        }
     }
 
     /**
@@ -490,14 +506,17 @@ public class AddressSpaceView extends AbstractView {
      */
     public @Nonnull
     ILogData fetch(final long address) {
-        return layoutHelper(e -> e.getLayout().getReplicationMode(address)
+        ILogData result = layoutHelper(e -> e.getLayout().getReplicationMode(address)
                 .getReplicationProtocol(runtime)
                 .read(e, address)
         );
+
+        checkLogData(address, result);
+        return result;
     }
 
     @VisibleForTesting
-    LoadingCache<Long, ILogData> getReadCache() {
+    Cache<Long, ILogData> getReadCache() {
         return readCache;
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
@@ -136,7 +136,7 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
                             .getLogUnitClient(startAddress, numUnits - 1).read(address))
                             .getAddresses().get(address);
                     // if value is null, fill the hole and get the value.
-                    if (value == null) {
+                    if (value == null || value.isEmpty()) {
                         holeFill(runtimeLayout, address);
                         value = peek(runtimeLayout, address);
                     }
@@ -145,7 +145,6 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
 
             returnResult.put(entry.getKey(), value);
         }
-
         return returnResult;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/IReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/IReplicationProtocol.java
@@ -89,13 +89,7 @@ public interface IReplicationProtocol {
      * @return                      A map of addresses to committed
      *                              addresses, hole filling if necessary.
      */
-    default @Nonnull
-    Map<Long, ILogData> readRange(RuntimeLayout runtimeLayout, Set<Long> globalAddresses) {
-        return globalAddresses.parallelStream()
-                .map(a -> new AbstractMap.SimpleImmutableEntry<>(a, read(runtimeLayout, a)))
-                .collect(Collectors.toMap(r -> r.getKey(), r -> r.getValue()));
-    }
-
+    Map<Long, ILogData> readRange(RuntimeLayout runtimeLayout, Set<Long> globalAddresses);
     /** Peek data from a given address.
      *
      * <p>This function -may- return null if there was no entry

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
@@ -7,13 +7,17 @@
 package org.corfudb.runtime.view.replication;
 
 import java.time.Duration;
+import java.util.AbstractMap;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
+import com.google.common.collect.Range;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
@@ -39,6 +43,8 @@ import org.corfudb.util.Holder;
 import org.corfudb.util.retry.ExponentialBackoffRetry;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.RetryNeededException;
+
+import javax.annotation.Nonnull;
 
 /**
  * Created by kspirov on 4/23/17.
@@ -96,6 +102,12 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
         } catch (RuntimeException e) {
             throw e;
         }
+    }
+
+    @Override
+    public Map<Long, ILogData> readRange(RuntimeLayout runtimeLayout, Set<Long> globalAddresses) {
+        return globalAddresses.parallelStream()
+                .collect(Collectors.toMap(addr -> addr, addr -> read(runtimeLayout, addr)));
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.view;
 
+import com.google.common.cache.Cache;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
@@ -107,7 +108,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
 
         // Verify that write to address 0 is cached and that the write to address 1 isn't cached
 
-        LoadingCache<Long, ILogData> clientCache = r.getAddressSpaceView().getReadCache();
+        Cache<Long, ILogData> clientCache = r.getAddressSpaceView().getReadCache();
 
         assertThat(clientCache.getIfPresent(0L)).isNotNull();
         assertThat(clientCache.getIfPresent(1L)).isNull();


### PR DESCRIPTION
While a thread writes (i.e. replicate), other threads within the
same client can read the write from the server before it gets
cached. This results in losing undo records and thus causes
objects to experience NoRollBackException.

Porting #1805 from master to corfu-0.2.2

Furthermore, this patch also fixes a correctness bug introduced
in 2ab39da845ba3e40a66e31ad550d54d59e3db103 where empty log
slots are ignored and not hole filled.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
