### PR TITLE
Update Netty Version to 4.1.33.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,6 @@
         <module>debian</module>
         <module>generator</module>
         <module>it</module>
-
     </modules>
 
 
@@ -152,7 +151,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
-            <version>4.1.27.Final</version>
+            <version>4.1.33.Final</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Overview

Description:
Updates the Netty Version to 4.1.33.Final.

Why should this be merged: 
To match the version used by CorfuDB's clients.

Related issue(s) (if applicable): #1826 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
