### PR TITLE
Message epoch validation on prefixTrim.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -229,12 +229,19 @@ public class LogUnitServer extends AbstractServer {
         }
     }
 
+    /**
+     * Perform a prefix trim.
+     * Here the token is not used as is to perform the trim as the epoch at which the checkpoint was completed
+     * might be old. Hence, we use the msg epoch to perform the trim. This should be safe provided that the
+     * trim is performed only on the token provided by the CheckpointWriter which ensures that the checkpoint
+     * was persisted. Using any other address to perform a trim can cause data loss.
+     */
     @ServerHandler(type = CorfuMsgType.PREFIX_TRIM)
     private void prefixTrim(CorfuPayloadMsg<TrimRequest> msg, ChannelHandlerContext ctx,
                             IServerRouter r) {
         try {
             TrimRequest req = msg.getPayload();
-            batchWriter.prefixTrim(req.getAddress());
+            batchWriter.prefixTrim(new Token(msg.getEpoch(), req.getAddress().getSequence()));
             r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
         } catch (TrimmedException ex) {
             r.sendResponse(ctx, msg, CorfuMsgType.ERROR_TRIMMED.msg());

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TailsResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TailsResponse.java
@@ -1,12 +1,15 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+
+import java.util.Map;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import org.corfudb.runtime.view.Layout;
 
 /**
  *
@@ -18,19 +21,24 @@ import java.util.UUID;
 
 @Data
 @RequiredArgsConstructor
+@AllArgsConstructor
 public class TailsResponse implements ICorfuPayload<TailsResponse> {
+
+    long epoch = Layout.INVALID_EPOCH;
 
     final long logTail;
 
     final Map<UUID, Long> streamTails;
 
     public TailsResponse(ByteBuf buf) {
+        epoch = ICorfuPayload.fromBuffer(buf, Long.class);
         logTail = ICorfuPayload.fromBuffer(buf, Long.class);
         streamTails = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, epoch);
         ICorfuPayload.serialize(buf, logTail);
         ICorfuPayload.serialize(buf, streamTails);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -374,19 +374,11 @@ public class AddressSpaceView extends AbstractView {
                 Sleep.sleepUninterruptibly(retryRate);
             } catch (WrongEpochException wee) {
                 long serverEpoch = wee.getCorrectEpoch();
-                // Retry if wrongEpochException corresponds to message epoch (only)
-                if (address.getEpoch() == serverEpoch) {
-                    long runtimeEpoch = runtime.getLayoutView().getLayout().getEpoch();
-                    log.warn("prefixTrim[{}]: wrongEpochException, runtime is in epoch {}, " +
-                            "while server is in epoch {}. Invalidate layout for this client " +
-                            "and retry, attempt: {}/{}", address, runtimeEpoch, serverEpoch, x+1, numRetries);
-                    runtime.invalidateLayout();
-                } else {
-                    // wrongEpochException corresponds to a stale trim address (prefix trim token on the wrong epoch)
-                    log.error("prefixTrim[{}]: stale prefix trim. Prefix trim on wrong epoch {}, " +
-                            "while server on epoch {}", address, address.getEpoch(), serverEpoch);
-                    throw wee;
-                }
+                long runtimeEpoch = runtime.getLayoutView().getLayout().getEpoch();
+                log.warn("prefixTrim[{}]: wrongEpochException, runtime is in epoch {}, while server is in epoch {}. "
+                                + "Invalidate layout for this client and retry, attempt: {}/{}",
+                        address, runtimeEpoch, serverEpoch, x + 1, numRetries);
+                runtime.invalidateLayout();
             }
         }
     }

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -471,7 +471,7 @@ public class Utils {
      * @param responses a set of tail responses
      * @return An max-aggregation of all tails
      */
-    static TailsResponse getTails(Set<TailsResponse> responses) {
+    static TailsResponse getTails(Set<TailsResponse> responses, long epoch) {
         long globalTail = Address.NON_ADDRESS;
         Map<UUID, Long> globalStreamTails = new HashMap<>();
 
@@ -483,7 +483,8 @@ public class Utils {
                 globalStreamTails.put(stream.getKey(), Math.max(streamTail, stream.getValue()));
             }
         }
-        return new TailsResponse(globalTail, globalStreamTails);
+        // All epochs should be equal as all the tails are queried using a single runtime layout.
+        return new TailsResponse(epoch, globalTail, globalStreamTails);
     }
 
     /**
@@ -516,6 +517,6 @@ public class Utils {
             throw new UnsupportedOperationException();
         }
 
-        return getTails(luResponses);
+        return getTails(luResponses, layout.getEpoch());
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -67,7 +67,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(CorfuRuntime.getStreamID("S1"));
         final int objSize = 100;
         long a1 = sv.append(new byte[objSize]);
-        final long cpEndAddress = 2L;
+        final long cpEndAddress = 0L;
         // Verify that the start/end records have been written for empty maps
         assertThat(a1).isEqualTo(cpEndAddress);
     }
@@ -300,6 +300,19 @@ public class CheckpointSmokeTest extends AbstractViewTest {
      *  destroyed (logically, not physically) by the CP, so we have
      *  to use a different position 'history' for our assertion
      *  check.
+     *
+     * +-----------------------------------------------------------------+
+     * | 0  | 1  | 2  | 3 | 4 | 5  | 6 | 7  | 8 | 9  | 10 | 11 | 12 | 13 |
+     * +-----------------------------------------------------------------+
+     * | F0 | F1 | F2 | S | C | M0 | C | M1 | C | M2 | E  | L0 | L1 | L2 |
+     * +-----------------------------------------------------------------+
+     * F : First batch of entries.
+     * S : Start of checkpoint.
+     * C : Continuation of checkpoints
+     * M : Middle batch of entries.
+     * E : End of checkpoints
+     * L : Last batch of entries.
+     *
      */
     @Test
     public void checkpointWriterInterleavedTest() throws Exception {


### PR DESCRIPTION
## Overview

Description: Avoid batch writer validating the token epoch on prefix trim. This is to prevent rejecting the trim request for an address with an old epoch. The address in its completeness is a valid address with the old epoch. As long as the address is generated by the CheckpointWriter after persisting the checkpoint, the trim on this address should be processed.

Why should this be merged: We invalidate a valid trim request on an older address.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
