### PR TITLE
Handle Serializer not present

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/SerializerException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/SerializerException.java
@@ -1,0 +1,16 @@
+package org.corfudb.runtime.exceptions;
+
+/**
+ * Created by annym on 04/12/19
+ */
+public class SerializerException extends RuntimeException {
+
+    /**
+     * Constructor for SerializerException specifying serializer type.
+     *
+     * @param type serializer type not found for client.
+     */
+    public SerializerException(Byte type) {
+        super("Serializer type code " + type.intValue() + " not found.");
+    }
+}

--- a/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.exceptions.SerializerException;
 
 
 /**
@@ -38,10 +39,16 @@ public class Serializers {
      */
     public static ISerializer getSerializer(Byte type) {
         if (type <= SYSTEM_SERIALIZERS_COUNT) {
-            return serializersMap.get(type);
-        } else {
+            if (serializersMap.containsKey(type)) {
+                return serializersMap.get(type);
+            }
+        } else if (customSerializers.containsKey(type)) {
             return customSerializers.get(type);
         }
+
+        log.error("Serializer with type code {} not found. Please check custom serializers " +
+                "for this client.", type.intValue());
+        throw new SerializerException(type);
     }
 
     /**


### PR DESCRIPTION
## Overview

Description:

If a client does not have the serializer required to access data from a given map, it would currently throw a NullPointerException and fail to open a map with no clear cause.

Why should this be merged: this change set properly handles this error and informs the client on the missing serializer.

Related issue(s) (if applicable): #1835 
