### PR TITLE
Restore fault detection interval to 1 second

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -187,7 +187,7 @@ public class ManagementAgent {
         // Start monitoring services that deals with failure and healing detection.
         if (!shutdown) {
             localMonitoringService.start(METRICS_POLL_INTERVAL);
-            remoteMonitoringService.start(METRICS_POLL_INTERVAL);
+            remoteMonitoringService.start(POLICY_EXECUTE_INTERVAL);
         }
     }
 


### PR DESCRIPTION
## Overview

Restore fault detection interval to 1 second which was previously using.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
