### PR TITLE
Reduce corfu server logs

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -148,7 +148,7 @@ public class LogUnitServer extends AbstractServer {
      */
     @ServerHandler(type = CorfuMsgType.WRITE)
     public void write(CorfuPayloadMsg<WriteRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
-        log.debug("log write: global: {}, streams: {}", msg.getPayload().getToken(),
+        log.trace("log write: global: {}, streams: {}", msg.getPayload().getToken(),
                 msg.getPayload().getData().getBackpointerMap());
 
         try {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogDataStore.java
@@ -65,7 +65,8 @@ public class StreamLogDataStore {
      */
     public void updateTailSegment(long newTailSegment) {
         if (tailSegment.get() >= newTailSegment) {
-            log.debug("New tail segment less than or equals to the old one: {}. Ignore", newTailSegment);
+            log.trace("New tail segment less than or equals to the old one: {}. Ignore",
+                    newTailSegment);
             return;
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -867,6 +867,8 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             logMetadata.update(entry);
         }
 
+        log.trace("Record saved, address: {}, streams: {}", address, entry.getBackpointerMap());
+
         return new AddressMetaData(metadata.getPayloadChecksum(), metadata.getLength(), channelOffset);
     }
 
@@ -940,7 +942,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         List<LogData> entries = preprocess(range);
 
         if (entries.isEmpty()) {
-            log.info("No entries to write.");
+            log.trace("No entries to write.");
             return;
         }
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
@@ -24,13 +24,13 @@ public class NettyCorfuMessageEncoder extends MessageToByteEncoder<CorfuMsg> {
                           ByteBuf byteBuf) throws Exception {
         try {
             corfuMsg.serialize(byteBuf);
-            if(log.isDebugEnabled()) {
+            if(log.isTraceEnabled()) {
                 long prev = maxValue.get();
                 maxValue.accumulate(byteBuf.readableBytes());
                 long curr = maxValue.get();
                 // The max value has been updated.
                 if (prev < curr) {
-                    log.debug("encode: New max write buffer found {}", curr);
+                    log.trace("encode: New max write buffer found {}", curr);
                 }
             }
 

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/NetworkException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/NetworkException.java
@@ -9,16 +9,28 @@ import org.corfudb.util.NodeLocator;
 public class NetworkException extends RuntimeException {
 
     @Getter
-    NodeLocator node;
+    private final NodeLocator node;
 
+    @Getter
+    private final Type exceptionType;
 
-    public NetworkException(String message, NodeLocator node) {
-        super(message + " [endpoint=" + node.toString() + "]");
+    public static NetworkException buildDisconnected(NodeLocator node){
+        return new NetworkException(Type.DISCONNECTED, node);
+    }
+
+    public NetworkException(Type exceptionType, NodeLocator node) {
+        super(exceptionType.name() + " [endpoint=" + node.toString() + "]");
+        this.exceptionType = exceptionType;
         this.node = node;
     }
 
-    public NetworkException(String message, NodeLocator node, Throwable cause) {
+    public NetworkException(Type exceptionType, String message, NodeLocator node, Throwable cause) {
         super(message + " [endpoint=" + node.toString() + "]", cause);
+        this.exceptionType = exceptionType;
         this.node = node;
+    }
+
+    public enum Type {
+        DISCONNECTED
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -195,9 +195,11 @@ public class TestClientRouter implements IClientRouter {
         // Simulate a "disconnected endpoint"
         if (!connected) {
             log.trace("Disconnected endpoint " + host + ":" + port);
-            throw new NetworkException("Disconnected endpoint", NodeLocator.builder()
-                                                                    .host(host)
-                                                                    .port(port).build());
+            NodeLocator node = NodeLocator.builder()
+                    .host(host)
+                    .port(port)
+                    .build();
+            throw NetworkException.buildDisconnected(node);
         }
 
         // Set up the timer and context to measure request


### PR DESCRIPTION
## Overview

Description:
Reduce corfu server logs

Why should this be merged:
Reduces the number of unnecessary log messages. 
Prevents polluting server logs with exceptions added to the log by NettyClientRouter, but the stack trace can't be used to find a potential issue and the exception will be thrown anyway by the other part.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
