### PR TITLE
Refactor Network Stretching logic out of FailureDetector

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
@@ -11,14 +11,13 @@ import org.corfudb.infrastructure.management.ClusterAdvisor;
 import org.corfudb.infrastructure.management.ClusterAdvisorFactory;
 import org.corfudb.infrastructure.management.ClusterStateContext;
 import org.corfudb.infrastructure.management.ClusterType;
-import org.corfudb.infrastructure.management.IDetector;
+import org.corfudb.infrastructure.management.FailureDetector;
 import org.corfudb.infrastructure.management.PollReport;
 import org.corfudb.infrastructure.management.ReconfigurationEventHandler;
 import org.corfudb.infrastructure.management.failuredetector.ClusterGraph;
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.protocols.wireprotocol.NodeState;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics;
-import org.corfudb.protocols.wireprotocol.SequencerMetrics.SequencerStatus;
 import org.corfudb.protocols.wireprotocol.failuredetector.FailureDetectorMetrics;
 import org.corfudb.protocols.wireprotocol.failuredetector.FailureDetectorMetrics.FailureDetectorAction;
 import org.corfudb.protocols.wireprotocol.failuredetector.NodeRank;
@@ -70,7 +69,7 @@ public class RemoteMonitoringService implements MonitoringService {
      * Detectors to be used to detect failures and healing.
      */
     @Getter
-    private final IDetector failureDetector;
+    private final FailureDetector failureDetector;
 
     /**
      * Detection Task Scheduler Service
@@ -150,7 +149,7 @@ public class RemoteMonitoringService implements MonitoringService {
     RemoteMonitoringService(@NonNull ServerContext serverContext,
                             @NonNull SingletonResource<CorfuRuntime> runtimeSingletonResource,
                             @NonNull ClusterStateContext clusterContext,
-                            @NonNull IDetector failureDetector,
+                            @NonNull FailureDetector failureDetector,
                             @NonNull LocalMonitoringService localMonitoringService) {
         this.serverContext = serverContext;
         this.runtimeSingletonResource = runtimeSingletonResource;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/FailureDetector.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/FailureDetector.java
@@ -1,7 +1,10 @@
 package org.corfudb.infrastructure.management;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
@@ -19,6 +22,7 @@ import org.corfudb.util.CFUtils;
 import org.corfudb.util.Sleep;
 
 import javax.annotation.Nonnull;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -26,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -52,49 +55,16 @@ public class FailureDetector implements IDetector {
     @Setter
     private int failureThreshold = 3;
 
-    /**
-     * Max duration for the responseTimeouts of the routers in milliseconds.
-     * In the worst case scenario or in case of failed servers, their response timeouts will be
-     * set to a maximum value of maxPeriodDuration.
-     */
-    @Getter
-    @Setter
-    private long maxPeriodDuration = 5_000L;
-
-    /**
-     * Minimum duration for the responseTimeouts of the routers in milliseconds.
-     * Under ideal conditions the routers will have a response timeout set to this.
-     */
-    @Getter
-    @Setter
-    private long initPeriodDuration = 2_000L;
-
-    /**
-     * Response timeout for every router.
-     */
-    @Getter
-    private long period = initPeriodDuration;
-
-    /**
-     * Poll interval between iterations in a pollRound in milliseconds.
-     */
-    @Getter
-    @Setter
-    private long initialPollInterval = 1_000;
-
-    /**
-     * Increments in which the period moves towards the maxPeriodDuration in every failed
-     * iteration provided in milliseconds.
-     */
-    @Getter
-    @Setter
-    private long periodDelta = 1_000L;
-
     @NonNull
     private final HeartbeatCounter heartbeatCounter;
 
     @NonNull
     private final String localEndpoint;
+
+    @NonNull
+    @Default
+    @Setter
+    private NetworkStretcher networkStretcher = NetworkStretcher.builder().build();
 
     public FailureDetector(HeartbeatCounter heartbeatCounter, String localEndpoint) {
         this.heartbeatCounter = heartbeatCounter;
@@ -122,11 +92,15 @@ public class FailureDetector implements IDetector {
         routerMap = new HashMap<>();
         allServers.forEach(s -> {
             IClientRouter router = corfuRuntime.getRouter(s);
-            router.setTimeoutResponse(period);
+            router.setTimeoutResponse(networkStretcher.getCurrentPeriod().toMillis());
             routerMap.put(s, router);
         });
+
         // Perform polling of all responsive servers.
-        return pollRound(layout.getEpoch(), allServers, routerMap, sequencerMetrics, layout);
+        return pollRound(
+                layout.getEpoch(), allServers, routerMap, sequencerMetrics,
+                layout.getActiveLayoutServers()
+        );
     }
 
     /**
@@ -145,9 +119,10 @@ public class FailureDetector implements IDetector {
      *
      * @return Poll Report with detected failed nodes and out of phase epoch nodes.
      */
-    private PollReport pollRound(
+    @VisibleForTesting
+    PollReport pollRound(
             long epoch, Set<String> allServers, Map<String, IClientRouter> router,
-            SequencerMetrics sequencerMetrics, Layout layout) {
+            SequencerMetrics sequencerMetrics, ImmutableList<String> responsiveServers) {
 
         if (failureThreshold < 1) {
             throw new IllegalStateException("Invalid failure threshold");
@@ -155,15 +130,23 @@ public class FailureDetector implements IDetector {
 
         List<PollReport> reports = new ArrayList<>();
         for (int iteration = 0; iteration < failureThreshold; iteration++) {
-            long pollIterationStartTime = System.nanoTime();
-
-            PollReport currReport = pollIteration(allServers, router, epoch, sequencerMetrics, layout);
+            PollReport currReport = pollIteration(
+                    allServers, router, epoch, sequencerMetrics, responsiveServers
+            );
             reports.add(currReport);
 
-            long pollInterval = modifyIterationTimeouts(router, currReport, pollIterationStartTime);
+            Duration restInterval = networkStretcher.getRestInterval(currReport.getElapsedTime());
+            if (!currReport.getFailedNodes().isEmpty()) {
+                networkStretcher.modifyIterationTimeouts();
+
+                Set<String> allReachableNodes = currReport.getAllReachableNodes();
+                tuneRoutersResponseTimeout(
+                        router, allReachableNodes, networkStretcher.getCurrentPeriod()
+                );
+            }
 
             // Sleep for the provided poll interval before starting the next iteration
-            Sleep.MILLISECONDS.sleepUninterruptibly(pollInterval);
+            Sleep.sleepUninterruptibly(restInterval);
         }
 
         //Aggregation step
@@ -180,6 +163,7 @@ public class FailureDetector implements IDetector {
             connectedNodesAggregated.addAll(report.getReachableNodes());
             failedNodesAggregated.addAll(report.getFailedNodes());
         });
+
         failedNodesAggregated.removeAll(connectedNodesAggregated);
 
         Set<String> allConnectedNodes = Sets.union(connectedNodesAggregated, wrongEpochsAggregated.keySet());
@@ -195,39 +179,17 @@ public class FailureDetector implements IDetector {
                 .clusterStates(clusterStates)
                 .build();
 
+        Duration totalElapsedTime = reports.stream()
+                .map(PollReport::getElapsedTime)
+                .reduce(Duration.ZERO, Duration::plus);
+
         return PollReport.builder()
                 .pollEpoch(epoch)
-                .responsiveServers(layout.getActiveLayoutServers())
+                .elapsedTime(totalElapsedTime)
+                .responsiveServers(responsiveServers)
                 .wrongEpochs(ImmutableMap.copyOf(wrongEpochsAggregated))
                 .clusterState(aggregator.getAggregatedState())
                 .build();
-    }
-
-    /**
-     * Tune timeouts after each poll iteration, according to list of failed and connected nodes
-     *
-     * @param router     client router
-     * @param currReport current poll report
-     * @return updated poll interval
-     */
-    private long modifyIterationTimeouts(Map<String, IClientRouter> router, PollReport currReport,
-                                         long pollIterationStartTime) {
-        long pollInterval = initialPollInterval;
-
-        Set<String> allReachableNodes = currReport.getAllReachableNodes();
-
-        if (!currReport.getFailedNodes().isEmpty()) {
-            // Increase the inter iteration sleep time by increasing poll interval if the
-            // period time increases
-            long iterationElapsedTime = TimeUnit.MILLISECONDS.convert(
-                    System.nanoTime() - pollIterationStartTime,
-                    TimeUnit.NANOSECONDS
-            );
-            pollInterval = Math.max(initialPollInterval, period - iterationElapsedTime);
-            period = getIncreasedPeriod();
-            tuneRoutersResponseTimeout(router, allReachableNodes, period);
-        }
-        return pollInterval;
     }
 
     /**
@@ -239,12 +201,17 @@ public class FailureDetector implements IDetector {
      * @param allConnectedNodes all connected nodes
      */
     private void tunePollReportTimeouts(
-            Map<String, IClientRouter> clientRouters, Set<String> failedNodes, Set<String> allConnectedNodes) {
-        period = Math.max(initPeriodDuration, period - periodDelta);
-        tuneRoutersResponseTimeout(clientRouters, allConnectedNodes, period);
+            Map<String, IClientRouter> clientRouters, Set<String> failedNodes,
+            Set<String> allConnectedNodes) {
+
+        networkStretcher.modifyDecreasedPeriod();
+        tuneRoutersResponseTimeout(
+                clientRouters, allConnectedNodes, networkStretcher.getCurrentPeriod()
+        );
+
         // Reset the timeout of all the failed nodes to the max value to set a longer
         // timeout period to detect their response.
-        tuneRoutersResponseTimeout(clientRouters, failedNodes, maxPeriodDuration);
+        tuneRoutersResponseTimeout(clientRouters, failedNodes, networkStretcher.getMaxPeriod());
     }
 
     /**
@@ -258,18 +225,20 @@ public class FailureDetector implements IDetector {
      * - calculate if current layout slot is unfilled
      * - build poll report
      *
-     * @param allServers       all servers in the cluster
-     * @param clientRouters    client clientRouters
-     * @param epoch            current epoch
-     * @param sequencerMetrics metrics
-     * @param layout           current layout
+     * @param allServers        all servers in the cluster
+     * @param clientRouters     client clientRouters
+     * @param epoch             current epoch
+     * @param sequencerMetrics  metrics
+     * @param responsiveServers all responsive servers in a cluster
      * @return a poll report
      */
     private PollReport pollIteration(
             Set<String> allServers, Map<String, IClientRouter> clientRouters, long epoch,
-            SequencerMetrics sequencerMetrics, Layout layout) {
+            SequencerMetrics sequencerMetrics, ImmutableList<String> responsiveServers) {
 
         log.trace("Poll iteration. Epoch: {}", epoch);
+
+        long start = System.currentTimeMillis();
 
         ClusterStateCollector clusterCollector = ClusterStateCollector.builder()
                 .localEndpoint(localEndpoint)
@@ -280,11 +249,14 @@ public class FailureDetector implements IDetector {
         //Cluster state internal map.
         ClusterState clusterState = clusterCollector.collectClusterState(epoch, sequencerMetrics);
 
+        Duration elapsedTime = Duration.ofMillis(System.currentTimeMillis() - start);
+
         return PollReport.builder()
                 .pollEpoch(epoch)
-                .responsiveServers(layout.getActiveLayoutServers())
+                .responsiveServers(responsiveServers)
                 .wrongEpochs(clusterCollector.collectWrongEpochs())
                 .clusterState(clusterState)
+                .elapsedTime(elapsedTime)
                 .build();
     }
 
@@ -323,27 +295,19 @@ public class FailureDetector implements IDetector {
     }
 
     /**
-     * Function to increment the existing response timeout period.
-     *
-     * @return The new calculated timeout value.
-     */
-    private long getIncreasedPeriod() {
-        return Math.min(maxPeriodDuration, period + periodDelta);
-    }
-
-    /**
      * Set the timeoutResponse for all the routers connected to the given endpoints with the
      * given value.
      *
      * @param endpoints Router endpoints.
      * @param timeout   New timeout value.
      */
-    private void tuneRoutersResponseTimeout(Map<String, IClientRouter> clientRouters, Set<String> endpoints, long timeout) {
+    private void tuneRoutersResponseTimeout(
+            Map<String, IClientRouter> clientRouters, Set<String> endpoints, Duration timeout) {
 
         log.trace("Tuning router timeout responses for endpoints:{} to {}ms", endpoints, timeout);
         endpoints.forEach(server -> {
             if (clientRouters.get(server) != null) {
-                clientRouters.get(server).setTimeoutResponse(timeout);
+                clientRouters.get(server).setTimeoutResponse(timeout.toMillis());
             }
         });
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/NetworkStretcher.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/NetworkStretcher.java
@@ -1,0 +1,105 @@
+package org.corfudb.infrastructure.management;
+
+import com.google.common.annotations.VisibleForTesting;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Getter;
+
+import java.time.Duration;
+import java.util.Set;
+
+/**
+ * NetworkStretcher increases or decreases the timeout intervals for polling based on
+ * whether the poll was unsuccessful or successful respectively.
+ */
+@Builder
+public class NetworkStretcher {
+    /**
+     * Max duration for the responseTimeouts of the routers.
+     * In the worst case scenario or in case of failed servers, their response timeouts will be
+     * set to a maximum value of maxPeriod.
+     */
+    @Getter
+    @Default
+    private final Duration maxPeriod = Duration.ofSeconds(5);
+
+    @Getter
+    @Default
+    private final Duration minPeriod = Duration.ofSeconds(2);
+
+    /**
+     * Response timeout for every router.
+     */
+    @Getter
+    @Default
+    private Duration currentPeriod = Duration.ofSeconds(2);
+
+    /**
+     * Poll interval between iterations in a pollRound
+     */
+    @Default
+    private final Duration initialPollInterval = Duration.ofSeconds(1);
+
+    /**
+     * Increments in which the period moves towards the maxPeriod in every failed
+     * iteration provided.
+     */
+    @Default
+    private final Duration periodDelta = Duration.ofSeconds(1);
+
+    /**
+     * Function to increment the existing response timeout period.
+     *
+     * @return The new calculated timeout value.
+     */
+    @VisibleForTesting
+    Duration getIncreasedPeriod() {
+        Duration increasedPeriod = currentPeriod.plus(periodDelta);
+        if (increasedPeriod.toMillis() > maxPeriod.toMillis()){
+            return maxPeriod;
+        }
+
+        return increasedPeriod;
+    }
+
+    /**
+     * Function to decrement the existing response timeout period.
+     *
+     * @return The new calculated timeout value.
+     */
+    private Duration getDecreasedPeriod() {
+        Duration decreasedPeriod = currentPeriod.minus(periodDelta);
+
+        if (decreasedPeriod.toMillis() < minPeriod.toMillis()) {
+            return minPeriod;
+        }
+
+        return decreasedPeriod;
+    }
+
+    /**
+     * Tune timeouts after each poll iteration, according to list of failed and connected nodes
+     *
+     */
+    public void modifyIterationTimeouts() {
+        currentPeriod = getIncreasedPeriod();
+    }
+
+    /**
+     * Calculates rest interval according to the time already spent on network calls
+     * @param elapsedTime time already spent by making network calls
+     * @return rest interval
+     */
+    public Duration getRestInterval(Duration elapsedTime){
+
+        Duration restInterval = currentPeriod.minus(elapsedTime);
+        if (restInterval.toMillis() < initialPollInterval.toMillis()){
+            restInterval = initialPollInterval;
+        }
+        return restInterval;
+    }
+
+    public void modifyDecreasedPeriod() {
+        currentPeriod = getDecreasedPeriod();
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/PollReport.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/PollReport.java
@@ -13,6 +13,7 @@ import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.Layout;
 
+import java.time.Duration;
 import java.util.Set;
 
 /**
@@ -46,6 +47,12 @@ public class PollReport {
      */
     @NonNull
     private final ImmutableList<String> responsiveServers;
+
+    /**
+     * Time spent on collecting this report
+     */
+    @NonNull
+    private final Duration elapsedTime;
 
     /**
      * Returns all connected nodes to the current node including nodes with higher epoch.

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/FailureDetectorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/FailureDetectorTest.java
@@ -1,0 +1,47 @@
+package org.corfudb.infrastructure.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.corfudb.infrastructure.management.ClusterStateContext.HeartbeatCounter;
+import org.corfudb.protocols.wireprotocol.SequencerMetrics;
+import org.corfudb.runtime.clients.IClientRouter;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FailureDetectorTest {
+
+    @Test
+    public void testPollRound() {
+        final String endpoint = "a";
+        NetworkStretcher ns = NetworkStretcher.builder()
+                .initialPollInterval(Duration.ofMillis(100))
+                .currentPeriod(Duration.ofMillis(100))
+                .maxPeriod(Duration.ofMillis(200))
+                .periodDelta(Duration.ofMillis(50))
+                .build();
+        FailureDetector failureDetector = new FailureDetector(new HeartbeatCounter(), endpoint);
+        failureDetector.setNetworkStretcher(ns);
+
+        long epoch = 1;
+        ImmutableSet<String> allServers = ImmutableSet.of("a", "b", "c");
+        Map<String, IClientRouter> routerMap = new HashMap<>();
+        SequencerMetrics metrics = SequencerMetrics.READY;
+        ImmutableList<String> responsiveServers = ImmutableList.of("a", "b");
+
+        long start = System.currentTimeMillis();
+        PollReport report = failureDetector.pollRound(
+                epoch, allServers, routerMap, metrics, responsiveServers
+        );
+        Duration time = Duration.ofMillis(System.currentTimeMillis() - start);
+        assertThat(time).isGreaterThan(Duration.ofMillis(450));
+        assertThat(time).isLessThan(Duration.ofSeconds(2));
+
+        assertThat(report.getReachableNodes()).isEmpty();
+        assertThat(report.getFailedNodes()).containsExactly("a", "b", "c");
+    }
+}

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/NetworkStretcherTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/NetworkStretcherTest.java
@@ -1,0 +1,73 @@
+package org.corfudb.infrastructure.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import java.time.Duration;
+
+public class NetworkStretcherTest {
+
+    @Test
+    public void testIncreasedPeriod() {
+        NetworkStretcher ns = NetworkStretcher.builder().build();
+        assertThat(ns.getIncreasedPeriod()).isEqualTo(Duration.ofSeconds(3));
+    }
+
+    /**
+     * Tests that timeout does increase (stretch) by a second on failures.
+     * Tests that timeout can't go above 5 second max.
+     */
+    @Test
+    public void modifyIterationTimeouts() {
+        NetworkStretcher ns = NetworkStretcher.builder().build();
+
+        ns.modifyIterationTimeouts();
+        assertThat(ns.getCurrentPeriod()).isEqualTo(Duration.ofSeconds(3));
+
+        ns.modifyIterationTimeouts();
+        assertThat(ns.getCurrentPeriod()).isEqualTo(Duration.ofSeconds(4));
+
+        ns.modifyIterationTimeouts();
+        assertThat(ns.getCurrentPeriod()).isEqualTo(Duration.ofSeconds(5));
+
+        ns.modifyIterationTimeouts();
+        assertThat(ns.getCurrentPeriod()).isEqualTo(Duration.ofSeconds(5));
+
+        ns.modifyDecreasedPeriod();
+        assertThat(ns.getCurrentPeriod()).isEqualTo(Duration.ofSeconds(4));
+
+        ns.modifyDecreasedPeriod();
+        assertThat(ns.getCurrentPeriod()).isEqualTo(Duration.ofSeconds(3));
+
+        ns.modifyDecreasedPeriod();
+        assertThat(ns.getCurrentPeriod()).isEqualTo(Duration.ofSeconds(2));
+
+        ns.modifyDecreasedPeriod();
+        assertThat(ns.getCurrentPeriod()).isEqualTo(Duration.ofSeconds(2));
+
+        ns.modifyIterationTimeouts();
+        assertThat(ns.getCurrentPeriod()).isEqualTo(Duration.ofSeconds(3));
+    }
+
+    @Test
+    public void testRestInterval(){
+        NetworkStretcher ns = NetworkStretcher.builder()
+                .currentPeriod(Duration.ofSeconds(2))
+                .initialPollInterval(Duration.ofSeconds(1))
+                .build();
+
+        Duration elapsedTime1 = Duration.ofMillis(500);
+        Duration restInterval = ns.getRestInterval(elapsedTime1);
+        assertThat(restInterval.toMillis()).isEqualTo(1500);
+
+        Duration elapsedTime2 = Duration.ofMillis(800);
+        restInterval = ns.getRestInterval(elapsedTime2);
+        assertThat(restInterval.toMillis()).isEqualTo(1200);
+
+        Duration elapsedTime3 = Duration.ofMillis(1200);
+        restInterval = ns.getRestInterval(elapsedTime3);
+        assertThat(restInterval.toMillis()).isEqualTo(1000);
+    }
+}
+

--- a/it/src/test/java/org/corfudb/universe/scenario/HandOfGodIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/HandOfGodIT.java
@@ -73,7 +73,7 @@ public class HandOfGodIT extends GenericIntegrationTest {
                 ClusterStatusReport clusterStatusReport = corfuClient.getManagementView().getClusterStatus();
                 assertThat(clusterStatusReport.getClusterStatus()).isEqualTo(ClusterStatus.STABLE);
 
-                ScenarioUtils.waitUninterruptibly(Duration.ofSeconds(10));
+                ScenarioUtils.waitUninterruptibly(Duration.ofSeconds(20));
 
                 // Verify data path working
                 for (int i = 0; i < DEFAULT_TABLE_ITER; i++) {

--- a/it/src/test/java/org/corfudb/universe/scenario/NodeDownAndPartitionedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/NodeDownAndPartitionedIT.java
@@ -70,7 +70,7 @@ public class NodeDownAndPartitionedIT extends GenericIntegrationTest {
 
                 // Verify cluster status is STABLE
                 corfuClient.invalidateLayout();
-                waitUninterruptibly(Duration.ofSeconds(5));
+                waitUninterruptibly(Duration.ofSeconds(20));
                 clusterStatusReport = corfuClient.getManagementView().getClusterStatus();
                 assertThat(clusterStatusReport.getClusterStatus()).isEqualTo(ClusterStatus.STABLE);
 

--- a/it/src/test/java/org/corfudb/universe/scenario/RotateLinkFailureIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/RotateLinkFailureIT.java
@@ -111,7 +111,7 @@ public class RotateLinkFailureIT extends GenericIntegrationTest {
                 );
 
                 log.info("Verify data path working fine");
-                waitUninterruptibly(Duration.ofSeconds(10));
+                waitUninterruptibly(Duration.ofSeconds(20));
                 for (int i = 0; i < DEFAULT_TABLE_ITER; i++) {
                     assertThat(table.get(String.valueOf(i))).isEqualTo(String.valueOf(i));
                 }

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -13,6 +13,7 @@ import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.infrastructure.TestServerRouter;
 import org.corfudb.infrastructure.management.FailureDetector;
+import org.corfudb.infrastructure.management.NetworkStretcher;
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
@@ -241,14 +242,17 @@ public class ManagementViewTest extends AbstractViewTest {
 
     private void setAggressiveDetectorTimeouts(int... managementServersPorts) {
         Arrays.stream(managementServersPorts).forEach(port -> {
-            FailureDetector failureDetector = (FailureDetector) getManagementServer(port)
+            NetworkStretcher stretcher = NetworkStretcher.builder()
+                    .periodDelta(PARAMETERS.TIMEOUT_VERY_SHORT)
+                    .maxPeriod(PARAMETERS.TIMEOUT_VERY_SHORT)
+                    .initialPollInterval(PARAMETERS.TIMEOUT_VERY_SHORT)
+                    .build();
+
+            FailureDetector failureDetector = getManagementServer(port)
                     .getManagementAgent()
                     .getRemoteMonitoringService()
                     .getFailureDetector();
-            failureDetector.setInitPeriodDuration(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            failureDetector.setPeriodDelta(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            failureDetector.setMaxPeriodDuration(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            failureDetector.setInitialPollInterval(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+            failureDetector.setNetworkStretcher(stretcher);
         });
     }
 


### PR DESCRIPTION
Add NetworkStretcher unit tests.

Co-authored-by: xnull <xrw.null@gmail.com>

## Overview

Description:

Why should this be merged: Refactors the NetworkStretcher out of FailureDetector since it allows better unit testing.

Related issue(s) (if applicable): #1846 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
