### PR TITLE
Validate epoch in FailureDetector

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/ClusterGraph.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/ClusterGraph.java
@@ -132,6 +132,7 @@ public class ClusterGraph {
 
             NodeConnectivity symmetricConnectivity = NodeConnectivity.builder()
                     .endpoint(nodeName)
+                    .epoch(node.getEpoch())
                     .connectivity(ImmutableMap.copyOf(newConnectivity))
                     .type(node.getType())
                     .build();

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterStateAggregatorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterStateAggregatorTest.java
@@ -14,13 +14,15 @@ import java.util.List;
 
 public class ClusterStateAggregatorTest {
 
+    private final long epoch = 1;
+
     @Test
     public void getAggregatedStateSingleNodeCluster() {
         final String localEndpoint = "a";
 
         ClusterState clusterState = ClusterState.buildClusterState(
                 localEndpoint,
-                nodeState("a", OK)
+                nodeState("a", epoch, OK)
         );
 
         List<ClusterState> clusterStates = Arrays.asList(clusterState, clusterState, clusterState);
@@ -40,15 +42,15 @@ public class ClusterStateAggregatorTest {
 
         ClusterState clusterState1 = ClusterState.buildClusterState(
                 localEndpoint,
-                nodeState("a", OK, FAILED, FAILED),
+                nodeState("a", epoch, OK, FAILED, FAILED),
                 NodeState.getUnavailableNodeState("b"),
                 NodeState.getUnavailableNodeState("c")
         );
 
         ClusterState clusterState2 = ClusterState.buildClusterState(
                 localEndpoint,
-                nodeState("a", OK, OK, FAILED),
-                nodeState("b", OK, OK, FAILED),
+                nodeState("a", epoch, OK, OK, FAILED),
+                nodeState("b", epoch, OK, OK, FAILED),
                 NodeState.getUnavailableNodeState("c")
         );
 
@@ -56,7 +58,7 @@ public class ClusterStateAggregatorTest {
         final int counter = 123;
         ClusterState clusterState3 = ClusterState.buildClusterState(
                 localEndpoint,
-                nodeState("a", OK, FAILED, FAILED),
+                nodeState("a", epoch, OK, FAILED, FAILED),
                 NodeState.getUnavailableNodeState("b"),
                 NodeState.getNotReadyNodeState("c", epoch, counter)
         );

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterStateCollectorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterStateCollectorTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class ClusterStateCollectorTest {
+    private final long epoch = 1;
 
     /**
      * Checks the aggregated cluster state.
@@ -38,8 +39,8 @@ public class ClusterStateCollectorTest {
 
         ClusterState predefinedCluster = ClusterState.buildClusterState(
                 localEndpoint,
-                nodeState("a", OK, OK, FAILED),
-                nodeState("b", OK, OK, FAILED),
+                nodeState("a", epoch, OK, OK, FAILED),
+                nodeState("b", epoch, OK, OK, FAILED),
                 NodeState.getUnavailableNodeState("c")
         );
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterStateTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterStateTest.java
@@ -1,0 +1,32 @@
+package org.corfudb.infrastructure.management;
+
+import org.corfudb.protocols.wireprotocol.ClusterState;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.infrastructure.management.NodeStateTestUtil.nodeState;
+import static org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity.ConnectionStatus.OK;
+
+public class ClusterStateTest {
+
+    @Test
+    public void isReady() {
+        final String localEndpoint = "a";
+        final long epoch1 = 1;
+        final long epoch2 = 2;
+
+        ClusterState invalidClusterState = ClusterState.buildClusterState(
+                localEndpoint,
+                nodeState("a", epoch1, OK),
+                nodeState("b", epoch2, OK)
+        );
+        assertThat(invalidClusterState.isReady()).isFalse();
+
+        ClusterState validClusterState = ClusterState.buildClusterState(
+                localEndpoint,
+                nodeState("a", epoch1, OK),
+                nodeState("b", epoch1, OK)
+        );
+        assertThat(validClusterState.isReady()).isTrue();
+    }
+}

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/CompleteGraphAdvisorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/CompleteGraphAdvisorTest.java
@@ -23,6 +23,8 @@ import java.util.Optional;
 
 public class CompleteGraphAdvisorTest {
 
+    private final long epoch = 1;
+
     /**
      * By definition, a fully connected node can not be added to the unresponsive list.
      * Failed connection(s) between unresponsive and fully connected node(s)
@@ -35,9 +37,9 @@ public class CompleteGraphAdvisorTest {
 
         ClusterState clusterState = buildClusterState(
                 localEndpoint,
-                nodeState(A, OK, OK, OK),
-                nodeState(B, OK, OK, FAILED),
-                nodeState(C, OK, FAILED, OK)
+                nodeState(A, epoch, OK, OK, OK),
+                nodeState(B, epoch, OK, OK, FAILED),
+                nodeState(C, epoch, OK, FAILED, OK)
         );
 
         List<String> unresponsiveServers = Collections.singletonList("b");
@@ -52,8 +54,8 @@ public class CompleteGraphAdvisorTest {
 
         ClusterState clusterState = buildClusterState(
                 localEndpoint,
-                nodeState("a", OK, OK, FAILED),
-                nodeState("b", OK, OK, FAILED),
+                nodeState("a", epoch, OK, OK, FAILED),
+                nodeState("b", epoch, OK, OK, FAILED),
                 NodeState.getUnavailableNodeState("c")
         );
 
@@ -70,9 +72,9 @@ public class CompleteGraphAdvisorTest {
 
         ClusterState clusterState = buildClusterState(
                 localEndpoint,
-                nodeState("a", OK, OK, OK),
-                nodeState("b", OK, OK, FAILED),
-                nodeState("c", OK, FAILED, OK)
+                nodeState("a", epoch, OK, OK, OK),
+                nodeState("b", epoch, OK, OK, FAILED),
+                nodeState("c", epoch, OK, FAILED, OK)
         );
 
         List<String> unresponsiveServers = new ArrayList<>();
@@ -93,7 +95,7 @@ public class CompleteGraphAdvisorTest {
         ClusterState clusterState = buildClusterState(
                 localEndpoint,
                 NodeState.getUnavailableNodeState("a"),
-                nodeState("b", OK, OK, OK),
+                nodeState("b", epoch, OK, OK, OK),
                 NodeState.getUnavailableNodeState("c")
         );
 
@@ -117,22 +119,22 @@ public class CompleteGraphAdvisorTest {
 
         ClusterState nodeAClusterState = buildClusterState(
                 "a",
-                nodeState("a", OK, OK, OK),
-                nodeState("b", OK, OK, FAILED),
-                nodeState("c", OK, FAILED, OK)
+                nodeState("a", epoch, OK, OK, OK),
+                nodeState("b", epoch, OK, OK, FAILED),
+                nodeState("c", epoch, OK, FAILED, OK)
         );
 
         ClusterState nodeBClusterState = buildClusterState(
                 "b",
-                nodeState("a", OK, OK, OK),
-                nodeState("b", OK, OK, FAILED),
+                nodeState("a", epoch, OK, OK, OK),
+                nodeState("b", epoch, OK, OK, FAILED),
                 NodeState.getUnavailableNodeState("c")
         );
         ClusterState nodeCClusterState = buildClusterState(
                 "c",
-                nodeState("a", OK, OK, OK),
+                nodeState("a", epoch, OK, OK, OK),
                 NodeState.getUnavailableNodeState("b"),
-                nodeState("c", OK, FAILED, OK)
+                nodeState("c", epoch, OK, FAILED, OK)
         );
 
         List<String> unresponsiveServers = new ArrayList<>();
@@ -158,9 +160,9 @@ public class CompleteGraphAdvisorTest {
 
         ClusterState clusterState = buildClusterState(
                 localEndpoint,
-                nodeState("a", OK, FAILED, OK),
-                nodeState("b", FAILED, OK, OK),
-                nodeState("c", OK, OK, OK)
+                nodeState("a", epoch, OK, FAILED, OK),
+                nodeState("b", epoch, FAILED, OK, OK),
+                nodeState("c", epoch, OK, OK, OK)
         );
 
         List<String> unresponsiveServers = new ArrayList<>();

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/NodeStateTestUtil.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/NodeStateTestUtil.java
@@ -25,7 +25,7 @@ public class NodeStateTestUtil {
         //prevent creating class instances
     }
 
-    public static NodeState nodeState(String endpoint, ConnectionStatus... connectionStates) {
+    public static NodeState nodeState(String endpoint, long epoch, ConnectionStatus... connectionStates) {
         Map<String, ConnectionStatus> connectivity = new HashMap<>();
         for (int i = 0; i < connectionStates.length; i++) {
             connectivity.put(NODE_NAMES.get(i).name(), connectionStates[i]);
@@ -35,6 +35,7 @@ public class NodeStateTestUtil {
                 .endpoint(endpoint)
                 .type(NodeConnectivityType.CONNECTED)
                 .connectivity(ImmutableMap.copyOf(connectivity))
+                .epoch(epoch)
                 .build();
 
         return NodeState.builder()

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/PollReportTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/PollReportTest.java
@@ -16,12 +16,14 @@ import java.time.Duration;
 
 public class PollReportTest {
 
+    private final long epoch = 1;
+
     @Test
     public void testConnectionStatusesOneNode() {
         final String localEndpoint = "a";
 
         ClusterState clusterState = ClusterState.buildClusterState(
-                localEndpoint, nodeState("a", OK)
+                localEndpoint, nodeState("a", epoch, OK)
         );
 
         final long epoch = 1;
@@ -42,7 +44,7 @@ public class PollReportTest {
 
         ClusterState clusterState = ClusterState.buildClusterState(
                 localEndpoint,
-                nodeState("a", OK, FAILED, FAILED),
+                nodeState("a", epoch, OK, FAILED, FAILED),
                 NodeState.getUnavailableNodeState("b"),
                 NodeState.getUnavailableNodeState("c")
         );
@@ -70,8 +72,8 @@ public class PollReportTest {
 
         ClusterState clusterState = ClusterState.buildClusterState(
                 localEndpoint,
-                nodeState("a", OK, FAILED, FAILED),
-                nodeState("b", OK, OK, FAILED),
+                nodeState("a", epoch, OK, FAILED, FAILED),
+                nodeState("b", epoch, OK, OK, FAILED),
                 NodeState.getUnavailableNodeState("c")
         );
 
@@ -94,8 +96,8 @@ public class PollReportTest {
 
         ClusterState clusterState = ClusterState.buildClusterState(
                 localEndpoint,
-                nodeState("a", OK, OK, FAILED),
-                nodeState("b", OK, OK, FAILED),
+                nodeState("a", epoch, OK, OK, FAILED),
+                nodeState("b", epoch, OK, OK, FAILED),
                 NodeState.getUnavailableNodeState("c")
         );
 

--- a/it/src/test/java/org/corfudb/universe/scenario/NodePausedAndPartitionedIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/NodePausedAndPartitionedIT.java
@@ -66,7 +66,7 @@ public class NodePausedAndPartitionedIT extends GenericIntegrationTest {
                 server2.reconnect(Arrays.asList(server0, server1));
                 waitForUnresponsiveServersChange(size -> size == 0, corfuClient);
 
-                waitUninterruptibly(Duration.ofSeconds(20));
+                waitUninterruptibly(Duration.ofSeconds(30));
 
                 // Verify cluster status is STABLE
                 corfuClient.invalidateLayout();

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NodeState.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NodeState.java
@@ -3,8 +3,8 @@ package org.corfudb.protocols.wireprotocol;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NonNull;
 import lombok.ToString;
 import org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity;
@@ -21,7 +21,7 @@ import org.corfudb.runtime.view.Layout;
  * <p>
  * Created by zlokhandwala on 11/2/18.
  */
-@Data
+@Getter
 @Builder
 @AllArgsConstructor
 @EqualsAndHashCode

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/failuredetector/NodeConnectivity.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/failuredetector/NodeConnectivity.java
@@ -31,6 +31,7 @@ public class NodeConnectivity implements ICorfuPayload<NodeConnectivity>, Compar
     @Getter
     @NonNull
     private final String endpoint;
+
     @Getter
     @NonNull
     private final NodeConnectivityType type;
@@ -42,6 +43,9 @@ public class NodeConnectivity implements ICorfuPayload<NodeConnectivity>, Compar
     @NonNull
     private final ImmutableMap<String, ConnectionStatus> connectivity;
 
+    @Getter
+    private final long epoch;
+
     public NodeConnectivity(ByteBuf buf) {
         endpoint = ICorfuPayload.fromBuffer(buf, String.class);
         type = NodeConnectivityType.valueOf(ICorfuPayload.fromBuffer(buf, String.class));
@@ -52,6 +56,7 @@ public class NodeConnectivity implements ICorfuPayload<NodeConnectivity>, Compar
                 //transform map of strings to map of ConnectionStatus-es
                 .forEach((node, status) -> connectivityMap.put(node, ConnectionStatus.valueOf(status)));
         connectivity = ImmutableMap.copyOf(connectivityMap);
+        epoch = ICorfuPayload.fromBuffer(buf, Long.class);
     }
 
     @Override
@@ -63,6 +68,7 @@ public class NodeConnectivity implements ICorfuPayload<NodeConnectivity>, Compar
         connectivity.forEach((node, state) -> connectivityStrings.put(node, state.name()));
 
         ICorfuPayload.serialize(buf, connectivityStrings);
+        ICorfuPayload.serialize(buf, epoch);
     }
 
     /**

--- a/runtime/src/test/java/org/corfudb/protocols/wireprotocol/NodeStateTest.java
+++ b/runtime/src/test/java/org/corfudb/protocols/wireprotocol/NodeStateTest.java
@@ -15,10 +15,13 @@ public class NodeStateTest {
 
     @Test
     public void testSerializeDeserialize() {
+        final long epoch = 1;
+
         NodeConnectivity co = NodeConnectivity.builder()
                 .type(NodeConnectivityType.CONNECTED)
                 .endpoint("localhost:9000")
                 .connectivity(ImmutableMap.of())
+                .epoch(epoch)
                 .build();
 
         NodeState nodeState = NodeState.builder()

--- a/test/src/test/java/org/corfudb/CorfuTestParameters.java
+++ b/test/src/test/java/org/corfudb/CorfuTestParameters.java
@@ -105,7 +105,7 @@ public class CorfuTestParameters {
         TIMEOUT_NORMAL = TRAVIS_BUILD ? Duration.of(20, SECONDS) :
                                         Duration.of(10, SECONDS);
         TIMEOUT_LONG = TRAVIS_BUILD ? Duration.of(2, MINUTES):
-                                        Duration.of(1, MINUTES);
+                                        Duration.of(2, MINUTES);
 
         // Iterations
         NUM_ITERATIONS_VERY_LOW = TRAVIS_BUILD ? 1 : 10;


### PR DESCRIPTION
For proper validation of cluster state in failure detector, ensure that the epoch is uniform

Co-authored-by: xnull xrw.null@gmail.com

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #1846 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc