### PR TITLE
Remove Unnecessary Synchronization

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -401,13 +401,13 @@ public class LogUnitServer extends AbstractServer {
      * the read() and append(). Any address that cannot be retrieved should be returned as
      * unwritten (null).
      */
-    private synchronized ILogData handleRetrieval(long address) {
+    private ILogData handleRetrieval(long address) {
         LogData entry = streamLog.read(address);
         log.trace("Retrieved[{} : {}]", address, entry);
         return entry;
     }
 
-    private synchronized void handleEviction(long address, ILogData entry, RemovalCause cause) {
+    private void handleEviction(long address, ILogData entry, RemovalCause cause) {
         log.trace("Eviction[{}]: {}", address, cause);
     }
 


### PR DESCRIPTION
## Overview
Synchronizing on evictions is not necessary and StreamLogFiles::read
is thread-safe.

Why should this be merged: The eviction handler just logs and doesn't require synchronization  

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
