### PR TITLE
Fail LogUnitServer startup if log directory is read-only

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -2,10 +2,12 @@ package org.corfudb.infrastructure;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
 import org.corfudb.infrastructure.log.StreamLogFiles;
 import org.corfudb.protocols.wireprotocol.*;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
@@ -13,6 +15,7 @@ import org.junit.Test;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Random;
 import java.util.HashMap;
@@ -21,6 +24,7 @@ import java.util.UUID;
 
 import static org.corfudb.infrastructure.LogUnitServerAssertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
 
 /**
  * Created by mwei on 2/4/16.
@@ -139,6 +143,55 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .matchesDataAtAddress(LOW_ADDRESS, low_payload.getBytes())
                 .matchesDataAtAddress(MID_ADDRESS, mid_payload.getBytes())
                 .matchesDataAtAddress(HIGH_ADDRESS, high_payload.getBytes());
+    }
+
+    /**
+     * Test that corfu refuses to start if the filesystem/directory is/becomes read-only
+     *
+     * @throws Exception
+     */
+    @Test
+    public void cantOpenReadOnlyLogFiles() throws Exception {
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+
+        LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
+                .setLogPath(serviceDir)
+                .setMemory(false)
+                .build());
+
+        this.router.reset();
+        this.router.addServer(s1);
+
+        final long LOW_ADDRESS = 0L; final String low_payload = "0";
+        final long MID_ADDRESS = 100L; final String mid_payload = "100";
+        final long HIGH_ADDRESS = 10000000L; final String high_payload = "100000";
+        final String streamName = "a";
+        //write at 0, 100 & 10_000_000
+        rawWrite(LOW_ADDRESS, low_payload, streamName);
+        rawWrite(MID_ADDRESS, mid_payload, streamName);
+        rawWrite(HIGH_ADDRESS, high_payload, streamName);
+
+        s1.shutdown();
+
+        try {
+            File serviceDirectory = new File(serviceDir);
+            serviceDirectory.setWritable(false);
+        } catch(SecurityException e) {
+            fail("Should not hit security exception"+e.toString());
+        }
+
+        try {
+            LogUnitServer s2 = new LogUnitServer(new ServerContextBuilder()
+                    .setLogPath(serviceDir)
+                    .setMemory(false)
+                    .build());
+            fail("Should have failed to startup in read-only mode");
+        } catch (UnrecoverableCorfuError e) {
+            // Correctly failed to open on read-only directory
+        }
+        // In case the directory is re-used for other tests, restore its write permissions.
+        File serviceDirectory = new File(serviceDir);
+        serviceDirectory.setWritable(true);
     }
 
     protected void rawWrite(long addr, String s, String streamName) {


### PR DESCRIPTION
LogUnitServer should not come up on a read-only directory, because
it would later fail log writes. This could result in clustering
and availability issues.

Co-authored-by: xnull <xrw.null@gmail.com>
Issue: #1859

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
