### PR TITLE
Unwrap ExecutionException before re-throwing.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -414,9 +414,13 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
                 .get(parameters.getConnectionTimeout().toMillis(), TimeUnit.MILLISECONDS);
         } catch (InterruptedException e) {
             throw new UnrecoverableCorfuInterruptedError(e);
-        } catch (TimeoutException | ExecutionException e) {
+        } catch (TimeoutException te) {
             CompletableFuture<T> f = new CompletableFuture<>();
-            f.completeExceptionally(e);
+            f.completeExceptionally(te);
+            return f;
+        } catch (ExecutionException ee) {
+            CompletableFuture<T> f = new CompletableFuture<>();
+            f.completeExceptionally(ee.getCause());
             return f;
         }
 


### PR DESCRIPTION
## Overview

Description: Unwrap the ExecutionException before completing the Future exceptionally.

Why should this be merged: Network Exceptions are not recognized as they are wrapped in ExecutionExceptions further wrapped in RuntimeExceptions causing transactions to fail unexpectedly.

Related issue(s) (if applicable): #1863 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
