### PR TITLE
Reintroducing the Loading Cache

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -5,7 +5,10 @@ import com.codahale.metrics.MetricRegistry;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.netty.handler.timeout.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.DataType;
@@ -41,6 +44,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 
@@ -55,12 +59,22 @@ public class AddressSpaceView extends AbstractView {
     /**
      * A cache for read results.
      */
-    final Cache<Long, ILogData> readCache = CacheBuilder.newBuilder()
+    final LoadingCache<Long, ILogData> readCache = CacheBuilder.newBuilder()
             .maximumSize(runtime.getParameters().getNumCacheEntries())
             .expireAfterAccess(runtime.getParameters().getCacheExpiryTime(), TimeUnit.SECONDS)
             .expireAfterWrite(runtime.getParameters().getCacheExpiryTime(), TimeUnit.SECONDS)
             .recordStats()
-            .build();
+            .build(new CacheLoader<Long, ILogData>() {
+                @Override
+                public ILogData load(Long value) throws Exception {
+                    return fetch(value);
+                }
+
+                @Override
+                public Map<Long, ILogData> loadAll(Iterable<? extends Long> keys) throws Exception {
+                    return fetchAll((Iterable<Long>) keys, true);
+                }
+            });
 
     /**
      * Constructor for the Address Space View.
@@ -224,35 +238,19 @@ public class AddressSpaceView extends AbstractView {
     public @Nonnull
     ILogData read(long address) {
         if (!runtime.getParameters().isCacheDisabled()) {
-            // The VersionLockedObject and the Transaction layer will generate
-            // undoRecord(s) during a transaction commit, or object sync. These
-            // undo records are stored in transient fields and are not persisted.
-            // A missing undo record can cause a NoRollbackException, thus forcing
-            // a complete object rebuild that generates a "scanning" behavior
-            // which affects the LRU window. In essence, affecting other cache users
-            // and making the VersionLockedObject very sensitive to caching behavior.
-            // A concrete example of this would be unsynchronized readers/writes:
-            // 1. Thread A starts replicating write1
-            // 2. Thread B discovers the write (via stream tail query) and
-            //    tries to read write1
-            // 3. Thread B's read results in a cache miss and the reader thread
-            //    starts loading the value into the cache
-            // 4. Thread A completes its write and caches it with undo records
-            // 5. Thread B finishes loading and caches the loaded value replacing
-            //    the cached value from step 4 (i.e. loss of undo records computed
-            //    by thread A)
-            ILogData data = readCache.getIfPresent(address);
-            if (data == null) {
-                // Loading a value without the cache loader can result in
-                // redundant loading calls (i.e. multiple threads try to
-                // load the same value), but currently a redundant RPC
-                // is much cheaper than the cost of a NoRollBackException, therefore
-                // this trade-off is reasonable
-                final ILogData loadedVal = fetch(address);
-                return readCache.asMap().computeIfAbsent(address, (k) -> loadedVal);
+            try {
+                return readCache.get(address);
+            } catch (ExecutionException | UncheckedExecutionException e) {
+                // Guava wraps the exceptions thrown from the lower layers, therefore
+                // we need to unwrap them before throwing them to the upper layers that
+                // don't understand the guava exceptions
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
+                } else {
+                    throw new RuntimeException(cause);
+                }
             }
-
-            return data;
         }
 
         return fetch(address);
@@ -277,7 +275,7 @@ public class AddressSpaceView extends AbstractView {
         ILogData data = readCache.getIfPresent(nextRead);
         if (data == null) {
             log.trace("predictiveReadRange: request to read {}", addresses);
-            Map<Long, ILogData> mapAddresses = this.read(addresses);
+            Map<Long, ILogData> mapAddresses = this.read(addresses, true);
             data = mapAddresses.get(nextRead);
         }
 
@@ -296,48 +294,23 @@ public class AddressSpaceView extends AbstractView {
      * @param addresses An iterable with addresses to read from
      * @return A result, which be cached.
      */
-    public Map<Long, ILogData> read(Iterable<Long> addresses) {
-        return read(addresses, true);
-    }
-
-    /**
-     * Read the given object from a range of addresses.
-     *
-     * @param addresses An iterable with addresses to read from
-     * @param waitForWrite Flag whether wait for write is required or hole fill directly.
-     * @return A map of read addresses, which will be cached if caching is enabled
-     */
     public Map<Long, ILogData> read(Iterable<Long> addresses, boolean waitForWrite) {
-        Map<Long, ILogData> result = new HashMap<>();
-
-        if (!runtime.getParameters().isCacheDisabled()) {
-            Set<Long> addressesToFetch = new HashSet<>();
-
-            for (Long address : addresses) {
-                ILogData val = readCache.getIfPresent(address);
-                if (val == null) {
-                    addressesToFetch.add(address);
+        if (!runtime.getParameters().isCacheDisabled() && waitForWrite) {
+            try {
+                return readCache.getAll(addresses);
+            } catch (ExecutionException | UncheckedExecutionException e) {
+                Throwable cause = e.getCause();
+                if (cause instanceof RuntimeException) {
+                    throw (RuntimeException) cause;
                 } else {
-                    result.put(address, val);
+                    throw new RuntimeException(cause);
                 }
             }
-
-            // At this point we computed a subset of the addresses that
-            // resulted in a cache miss and need to be fetched
-            if (!addressesToFetch.isEmpty()) {
-                Map<Long, ILogData> fetchedAddresses = fetchAll(addressesToFetch, waitForWrite);
-                for (Map.Entry<Long, ILogData> entry : fetchedAddresses.entrySet()) {
-                    // After fetching a value, we need to insert it in the cache.
-                    // Note that based on code inspection it seems like operations
-                    // on the cache's map view are reflected in the cache's statistics.
-                    result.put(entry.getKey(), readCache.asMap()
-                            .computeIfAbsent(entry.getKey(), (k) -> entry.getValue()));
-                }
-            }
-            return result;
-        } else {
+        } else if (!waitForWrite) {
             return fetchAll(addresses, waitForWrite);
         }
+
+        return fetchAll(addresses, true);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -264,7 +264,7 @@ public abstract class AbstractQueuedStreamView extends
     protected List<ILogData> readAll(@Nonnull List<Long> addresses) {
         try {
             Map<Long, ILogData> dataMap =
-                    runtime.getAddressSpaceView().read(addresses);
+                    runtime.getAddressSpaceView().read(addresses, true);
             return addresses.stream().map(dataMap::get).collect(Collectors.toList());
         } catch (TrimmedException te) {
             processTrimmedException(te);

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -154,7 +154,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         rs.add(ADDRESS_1);
         rs.add(ADDRESS_2);
 
-        Map<Long, ILogData> m = rt.getAddressSpaceView().read(rs);
+        Map<Long, ILogData> m = rt.getAddressSpaceView().read(rs, true);
 
         assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -184,7 +184,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         Range range = Range.closed(ADDRESS_0, ADDRESS_2);
         ContiguousSet<Long> addresses = ContiguousSet.create(range, DiscreteDomain.longs());
 
-        Map<Long, ILogData> m = rt.getAddressSpaceView().read(addresses);
+        Map<Long, ILogData> m = rt.getAddressSpaceView().read(addresses, true);
 
         assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -247,7 +247,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         }
 
         Map<Long, ILogData> readResult = rt.getAddressSpaceView().read(
-                ContiguousSet.create(Range.closed(0L, numAddresses - 1), DiscreteDomain.longs()));
+                ContiguousSet.create(Range.closed(0L, numAddresses - 1), DiscreteDomain.longs()), true);
 
         readResult.forEach((addr, data) ->
                 assertThat(data.getPayload(rt)).isEqualTo((testString + addr).getBytes()));


### PR DESCRIPTION
## Overview
It seems like once we switched to asMap().computeIfAbsent we
started seeing spurious AssertionError. Although the problem
is not completely understood this change is being reverted
until it is investigated further.


Why should this be merged: 

Related issue(s) (if applicable): #1878


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
