### PR TITLE
Serializer: get rid of Runtime dependency on ILogData::getPayload.

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
@@ -14,7 +14,6 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.corfudb.runtime.CorfuRuntime;
 
 
 /**
@@ -126,12 +125,10 @@ public class CheckpointEntry extends LogEntry {
      * should initialize their contents based on the buffer.
      *
      * @param b The remaining buffer.
-     * @param rt The CorfuRuntime used by the SMR object.
-     * @return A CheckpointEntry.
      */
     @Override
-    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
-        super.deserializeBuffer(b, rt);
+    void deserializeBuffer(ByteBuf b) {
+        super.deserializeBuffer(b);
         cpType = CheckpointEntryType.typeMap.get(b.readByte());
         checkpointId = new UUID(b.readLong(), b.readLong());
         streamId = new UUID(b.readLong(), b.readLong());
@@ -146,7 +143,7 @@ public class CheckpointEntry extends LogEntry {
         smrEntries = null;
         byte hasSmrEntries = b.readByte();
         if (hasSmrEntries > 0) {
-            smrEntries = (MultiSMREntry) MultiSMREntry.deserialize(b, runtime);
+            smrEntries = (MultiSMREntry) MultiSMREntry.deserialize(b);
         }
         smrEntriesBytes = b.readInt();
     }

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
@@ -30,12 +30,6 @@ public class LogEntry implements ICorfuSerializable {
                     .collect(Collectors.toMap(LogEntryType::asByte, Function.identity()));
 
     /**
-     * The runtime to use.
-     */
-    @Setter
-    protected CorfuRuntime runtime;
-
-    /**
      * The type of log entry.
      */
     @Getter
@@ -64,13 +58,12 @@ public class LogEntry implements ICorfuSerializable {
      * @param b The buffer to deserialize.
      * @return A LogEntry.
      */
-    public static ICorfuSerializable deserialize(ByteBuf b, CorfuRuntime rt) {
+    public static ICorfuSerializable deserialize(ByteBuf b) {
         try {
             LogEntryType let = typeMap.get(b.readByte());
             LogEntry l = let.entryType.newInstance();
             l.type = let;
-            l.runtime = rt;
-            l.deserializeBuffer(b, rt);
+            l.deserializeBuffer(b);
             return l;
         } catch (InstantiationException | IllegalAccessException ie) {
             throw new RuntimeException("Error deserializing entry", ie);
@@ -83,7 +76,7 @@ public class LogEntry implements ICorfuSerializable {
      *
      * @param b The remaining buffer.
      */
-    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
+    void deserializeBuffer(ByteBuf b) {
         // In the base case, we don't do anything.
     }
 

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -12,9 +12,7 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.ILogData;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.Serializers;
-
 
 
 /**
@@ -82,15 +80,15 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
      * @param b The remaining buffer.
      */
     @Override
-    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
-        super.deserializeBuffer(b, rt);
+    void deserializeBuffer(ByteBuf b) {
+        super.deserializeBuffer(b);
 
         int numUpdates = b.readInt();
         entryMap = new HashMap<>();
         for (int i = 0; i < numUpdates; i++) {
             entryMap.put(
                     new UUID(b.readLong(), b.readLong()),
-                    ((MultiSMREntry) Serializers.CORFU.deserialize(b, rt)));
+                    ((MultiSMREntry) Serializers.CORFU.deserialize(b)));
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
@@ -12,7 +12,6 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.wireprotocol.ILogData;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.Serializers;
 
 
@@ -54,14 +53,14 @@ public class MultiSMREntry extends LogEntry implements ISMRConsumable {
      * @param b The remaining buffer.
      */
     @Override
-    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
-        super.deserializeBuffer(b, rt);
+    void deserializeBuffer(ByteBuf b) {
+        super.deserializeBuffer(b);
 
         int numUpdates = b.readInt();
         updates = new ArrayList<>();
         for (int i = 0; i < numUpdates; i++) {
             updates.add(
-                    (SMREntry) Serializers.CORFU.deserialize(b, rt));
+                    (SMREntry) Serializers.CORFU.deserialize(b));
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
 
@@ -100,8 +99,8 @@ public class SMREntry extends LogEntry implements ISMRConsumable {
      * @param b The remaining buffer.
      */
     @Override
-    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
-        super.deserializeBuffer(b, rt);
+    void deserializeBuffer(ByteBuf b) {
+        super.deserializeBuffer(b);
         short methodLength = b.readShort();
         byte[] methodBytes = new byte[methodLength];
         b.readBytes(methodBytes, 0, methodLength);
@@ -112,7 +111,7 @@ public class SMREntry extends LogEntry implements ISMRConsumable {
         for (byte arg = 0; arg < numArguments; arg++) {
             int len = b.readInt();
             ByteBuf objBuf = b.slice(b.readerIndex(), len);
-            arguments[arg] = serializerType.deserialize(objBuf, rt);
+            arguments[arg] = serializerType.deserialize(objBuf);
             b.skipBytes(len);
         }
         SMRArguments = arguments;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ExceptionMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ExceptionMsg.java
@@ -56,7 +56,7 @@ public class ExceptionMsg implements ICorfuPayload<ExceptionMsg> {
     public ExceptionMsg(ByteBuf b) {
         Throwable t;
         try {
-            t = (Throwable) Serializers.JAVA.deserialize(b, null);
+            t = (Throwable) Serializers.JAVA.deserialize(b);
         } catch (Exception e) {
             t = new DeserializationFailedException();
         }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -5,7 +5,10 @@ import java.util.UUID;
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.runtime.CorfuRuntime;
 
-/** An interface to log data entries.
+import javax.annotation.Nonnull;
+
+/**
+ * An interface to log data entries.
  * Log data entries represent data stored in the actual log,
  * with convenience methods for software to retrieve the
  * stored information.
@@ -13,12 +16,12 @@ import org.corfudb.runtime.CorfuRuntime;
  */
 public interface ILogData extends IMetadata, Comparable<ILogData> {
 
-    Object getPayload(CorfuRuntime t);
+    Object getPayload();
 
     DataType getType();
 
     @Override
-    default int compareTo(ILogData o) {
+    default int compareTo(@Nonnull ILogData o) {
         return getGlobalAddress().compareTo(o.getGlobalAddress());
     }
 
@@ -69,14 +72,14 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      * Return whether or not this entry is a log entry.
      */
     default boolean isLogEntry(CorfuRuntime runtime) {
-        return getPayload(runtime) instanceof LogEntry;
+        return getPayload() instanceof LogEntry;
     }
 
     /**
      * Return the payload as a log entry.
      */
     default LogEntry getLogEntry(CorfuRuntime runtime) {
-        return (LogEntry) getPayload(runtime);
+        return (LogEntry) getPayload();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -11,7 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.LogEntry;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.WriteSizeException;
 import org.corfudb.util.serializer.Serializers;
 
@@ -58,7 +57,7 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
     /**
      * Return the payload.
      */
-    public Object getPayload(CorfuRuntime runtime) {
+    public Object getPayload() {
         Object value = payload.get();
         if (value == null) {
             synchronized (this.payload) {
@@ -68,12 +67,10 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
                         this.payload.set(null);
                     } else {
                         ByteBuf copyBuf = Unpooled.wrappedBuffer(data);
-                        final Object actualValue =
-                                Serializers.CORFU.deserialize(copyBuf, runtime);
+                        final Object actualValue = Serializers.CORFU.deserialize(copyBuf);
                         // TODO: Remove circular dependency on logEntry.
                         if (actualValue instanceof LogEntry) {
                             ((LogEntry) actualValue).setEntry(this);
-                            ((LogEntry) actualValue).setRuntime(runtime);
                         }
                         value = actualValue == null ? this.payload : actualValue;
                         this.payload.set(value);

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -149,7 +149,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         // Since the VLO is thread safe we don't need to use a thread safe stream implementation
         // because the VLO will control access to the stream
         underlyingObject = new VersionLockedObject<T>(this::getNewInstance,
-                new StreamViewSMRAdapter(rt, rt.getStreamsView().getUnsafe(streamID)),
+                new StreamViewSMRAdapter(rt.getStreamsView().getUnsafe(streamID)),
                 upcallTargetMap, undoRecordTargetMap,
                 undoTargetMap, resetSet);
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
@@ -7,7 +7,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.ISMRConsumable;
 import org.corfudb.protocols.logprotocol.SMREntry;
@@ -37,35 +36,29 @@ public class StreamViewSMRAdapter implements ISMRStream {
     /**
      * The stream view backing this adapter.
      */
-    final IStreamView streamView;
+    private final IStreamView streamView;
 
-    /**
-     * Necessary until the runtime is no longer necessary for deserialization.
-     */
-    final CorfuRuntime runtime;
-
-    public StreamViewSMRAdapter(CorfuRuntime runtime,
-                                IStreamView streamView) {
-        this.runtime = runtime;
+    public StreamViewSMRAdapter(IStreamView streamView) {
         this.streamView = streamView;
     }
 
     private List<SMREntry> dataAndCheckpointMapper(ILogData logData) {
+        Object payload = logData.getPayload();
+
         if (logData.hasCheckpointMetadata()) {
-            // This is a CHECKPOINT record.  Extract the SMREntries, if any.
-            CheckpointEntry cp = (CheckpointEntry) logData.getPayload(runtime);
-            if (cp.getSmrEntries() != null
-                    && cp.getSmrEntries().getUpdates().size() > 0) {
+            // This is a CHECKPOINT record, extract the SMREntries, if any.
+            CheckpointEntry cp = (CheckpointEntry) payload;
+            if (cp.getSmrEntries() != null) {
                 cp.getSmrEntries().getUpdates().forEach(e -> {
-                    e.setRuntime(runtime);
                     e.setEntry(logData);
                 });
                 return cp.getSmrEntries().getUpdates();
-            } else {
-                return (List<SMREntry>) Collections.EMPTY_LIST;
             }
+            return Collections.emptyList();
+        } else if (payload instanceof ISMRConsumable) {
+            return ((ISMRConsumable) payload).getSMRUpdates(streamView.getId());
         } else {
-            return ((ISMRConsumable) logData.getPayload(runtime)).getSMRUpdates(streamView.getId());
+            return Collections.emptyList();
         }
     }
 
@@ -83,8 +76,6 @@ public class StreamViewSMRAdapter implements ISMRStream {
     public List<SMREntry> remainingUpTo(long maxGlobal) {
         return streamView.remainingUpTo(maxGlobal).stream()
                 .filter(m -> m.getType() == DataType.DATA)
-                .filter(m -> m.getPayload(runtime) instanceof ISMRConsumable
-                        || m.hasCheckpointMetadata())
                 .map(this::dataAndCheckpointMapper)
                 .flatMap(List::stream)
                 .collect(Collectors.toList());
@@ -100,8 +91,8 @@ public class StreamViewSMRAdapter implements ISMRStream {
         ILogData data = streamView.current();
         if (data != null) {
             if (data.getType() == DataType.DATA
-                    && data.getPayload(runtime) instanceof ISMRConsumable) {
-                return ((ISMRConsumable) data.getPayload(runtime))
+                    && data.getPayload() instanceof ISMRConsumable) {
+                return ((ISMRConsumable) data.getPayload())
                         .getSMRUpdates(streamView.getId());
             }
         }
@@ -119,8 +110,8 @@ public class StreamViewSMRAdapter implements ISMRStream {
         while (Address.isAddress(streamView.getCurrentGlobalPosition())
                 && data != null) {
             if (data.getType() == DataType.DATA
-                    && data.getPayload(runtime) instanceof ISMRConsumable) {
-                return ((ISMRConsumable) data.getPayload(runtime))
+                    && data.getPayload() instanceof ISMRConsumable) {
+                return ((ISMRConsumable) data.getPayload())
                         .getSMRUpdates(streamView.getId());
             }
             data = streamView.previous();
@@ -149,7 +140,7 @@ public class StreamViewSMRAdapter implements ISMRStream {
     public Stream<SMREntry> streamUpTo(long maxGlobal) {
         return streamView.streamUpTo(maxGlobal)
                 .filter(m -> m.getType() == DataType.DATA)
-                .filter(m -> m.getPayload(runtime) instanceof ISMRConsumable
+                .filter(m -> m.getPayload() instanceof ISMRConsumable
                         || m.hasCheckpointMetadata())
                 .map(this::dataAndCheckpointMapper)
                 .flatMap(List::stream);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -16,7 +16,6 @@ import org.corfudb.protocols.logprotocol.ISMRConsumable;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.Token;
-import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.AppendException;
@@ -342,7 +341,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                     getWriteSetEntryList(x.getStreamID());
             List<SMREntry> entryWrites =
                     ((ISMRConsumable) committedEntry
-                            .getPayload(this.transaction.getRuntime()))
+                            .getPayload())
                     .getSMRUpdates(x.getStreamID());
             if (committedWrites.size()
                     == entryWrites.size()) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
@@ -307,7 +307,7 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
      */
     protected boolean processEntryForContext(final ILogData data) {
         if (data != null) {
-            final Object payload = data.getPayload(runtime);
+            final Object payload = data.getPayload();
         }
         return false;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -1,6 +1,5 @@
 package org.corfudb.runtime.view.stream;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +13,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Range;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
@@ -29,8 +27,6 @@ import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.RuntimeLayout;
-import org.corfudb.runtime.view.replication.ChainReplicationProtocol;
 import org.corfudb.util.Utils;
 
 
@@ -613,8 +609,7 @@ public abstract class AbstractQueuedStreamView extends
     protected BackpointerOp resolveCheckpoint(final QueuedStreamContext context, ILogData data,
                                               long maxGlobal) {
         if (data.hasCheckpointMetadata()) {
-            CheckpointEntry cpEntry = (CheckpointEntry)
-                    data.getPayload(runtime);
+            CheckpointEntry cpEntry = (CheckpointEntry) data.getPayload();
 
             // Select the latest cp that has a snapshot address
             // which is less than maxGlobal

--- a/runtime/src/main/java/org/corfudb/util/serializer/CorfuSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/CorfuSerializer.java
@@ -2,7 +2,6 @@ package org.corfudb.util.serializer;
 
 import io.netty.buffer.ByteBuf;
 import org.corfudb.protocols.logprotocol.LogEntry;
-import org.corfudb.runtime.CorfuRuntime;
 
 /**
  * Created by mwei on 9/29/15.
@@ -30,13 +29,13 @@ public class CorfuSerializer implements ISerializer {
      * @return The deserialized object.
      */
     @Override
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
         if (b.readByte() != corfuPayloadMagic) {
             byte[] bytes = new byte[b.readableBytes()];
             b.readBytes(bytes);
             return bytes;
         }
-        return LogEntry.deserialize(b, rt);
+        return LogEntry.deserialize(b);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/util/serializer/ISerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/ISerializer.java
@@ -55,7 +55,7 @@ public interface ISerializer {
      * @param b The bytebuf to deserialize.
      * @return The deserialized object.
      */
-    Object deserialize(ByteBuf b, CorfuRuntime rt);
+    Object deserialize(ByteBuf b);
 
     /**
      * Serialize an object into a given byte buffer.

--- a/runtime/src/main/java/org/corfudb/util/serializer/JavaSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/JavaSerializer.java
@@ -9,7 +9,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.runtime.CorfuRuntime;
 
 
 /**
@@ -35,7 +34,7 @@ public class JavaSerializer implements ISerializer {
      * @return The deserialized object.
      */
     @Override
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
         try (ByteBufInputStream bbis = new ByteBufInputStream(b)) {
             try (ObjectInputStream ois = new ObjectInputStream(bbis)) {
                 return ois.readObject();

--- a/runtime/src/main/java/org/corfudb/util/serializer/JsonSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/JsonSerializer.java
@@ -13,7 +13,6 @@ import java.io.OutputStreamWriter;
 import java.util.UUID;
 
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.object.ICorfuSMR;
 
 
@@ -39,31 +38,17 @@ public class JsonSerializer implements ISerializer {
     /**
      * Deserialize an object from a given byte buffer.
      *
-     * @param b The bytebuf to deserialize.
+     * @param b The Bytebuf to deserialize.
      * @return The deserialized object.
      */
     @Override
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
         int classNameLength = b.readShort();
         byte[] classNameBytes = new byte[classNameLength];
         b.readBytes(classNameBytes, 0, classNameLength);
         String className = new String(classNameBytes);
         if (className.equals("null")) {
             return null;
-        } else if (className.equals("CorfuObject")) {
-            int smrClassNameLength = b.readShort();
-            byte[] smrClassNameBytes = new byte[smrClassNameLength];
-            b.readBytes(smrClassNameBytes, 0, smrClassNameLength);
-            String smrClassName = new String(smrClassNameBytes);
-            try {
-                return rt.getObjectsView().build()
-                        .setStreamID(new UUID(b.readLong(), b.readLong()))
-                        .setType(Class.forName(smrClassName))
-                        .open();
-            } catch (ClassNotFoundException cnfe) {
-                log.error("Exception during deserialization!", cnfe);
-                throw new RuntimeException(cnfe);
-            }
         } else {
             try (ByteBufInputStream bbis = new ByteBufInputStream(b)) {
                 try (InputStreamReader r = new InputStreamReader(bbis)) {
@@ -85,34 +70,18 @@ public class JsonSerializer implements ISerializer {
     @Override
     public void serialize(Object o, ByteBuf b) {
         String className = o == null ? "null" : o.getClass().getName();
-        if (className.endsWith(ICorfuSMR.CORFUSMR_SUFFIX)) {
-            className = "CorfuObject";
-            byte[] classNameBytes = className.getBytes();
-            b.writeShort(classNameBytes.length);
-            b.writeBytes(classNameBytes);
-            String smrClass = className.split("\\$")[0];
-            byte[] smrClassNameBytes = smrClass.getBytes();
-            b.writeShort(smrClassNameBytes.length);
-            b.writeBytes(smrClassNameBytes);
-            UUID id = ((ICorfuSMR) o).getCorfuStreamID();
-            log.trace("Serializing a CorfuObject of type {} as a stream pointer to {}",
-                    smrClass, id);
-            b.writeLong(id.getMostSignificantBits());
-            b.writeLong(id.getLeastSignificantBits());
-        } else {
-            byte[] classNameBytes = className.getBytes();
-            b.writeShort(classNameBytes.length);
-            b.writeBytes(classNameBytes);
-            if (o == null) {
-                return;
+        byte[] classNameBytes = className.getBytes();
+        b.writeShort(classNameBytes.length);
+        b.writeBytes(classNameBytes);
+        if (o == null) {
+            return;
+        }
+        try (ByteBufOutputStream bbos = new ByteBufOutputStream(b)) {
+            try (OutputStreamWriter osw = new OutputStreamWriter(bbos)) {
+                gson.toJson(o, o.getClass(), osw);
             }
-            try (ByteBufOutputStream bbos = new ByteBufOutputStream(b)) {
-                try (OutputStreamWriter osw = new OutputStreamWriter(bbos)) {
-                    gson.toJson(o, o.getClass(), osw);
-                }
-            } catch (IOException ie) {
-                log.error("Exception during serialization!", ie);
-            }
+        } catch (IOException ie) {
+            log.error("Exception during serialization!", ie);
         }
     }
 }

--- a/runtime/src/main/java/org/corfudb/util/serializer/PrimitiveSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/PrimitiveSerializer.java
@@ -4,18 +4,14 @@ import com.google.common.collect.ImmutableMap;
 import io.netty.buffer.ByteBuf;
 
 import java.lang.reflect.Array;
-import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
-import org.corfudb.runtime.CorfuRuntime;
 
 
 /**
@@ -25,10 +21,10 @@ import org.corfudb.runtime.CorfuRuntime;
 public class PrimitiveSerializer implements ISerializer {
     private final byte type;
 
-    public static final Map<Byte, DeserializerFunction> DeserializerMap =
+    private static final Map<Byte, DeserializerFunction> DeserializerMap =
             Arrays.stream(Primitives.values())
                     .collect(Collectors.toMap(Primitives::getTypeNum, Primitives::getDeserializer));
-    public static final Map<Class, Primitives> SerializerMap = getSerializerMap();
+    private static final Map<Class, Primitives> SerializerMap = getSerializerMap();
 
     public PrimitiveSerializer(byte type) {
         this.type = type;
@@ -51,7 +47,7 @@ public class PrimitiveSerializer implements ISerializer {
     }
 
     @SuppressWarnings("unchecked")
-    static <T, R> void writeArray(T[] o, ByteBuf b, BiFunction<ByteBuf, R, ByteBuf> applyFunc) {
+    private static <T, R> void writeArray(T[] o, ByteBuf b, BiFunction<ByteBuf, R, ByteBuf> applyFunc) {
         int length = Array.getLength(o);
         b.writeInt(length);
         Arrays.stream(o)
@@ -59,8 +55,8 @@ public class PrimitiveSerializer implements ISerializer {
     }
 
     @SuppressWarnings("unchecked")
-    static <T, R> T[] readArray(ByteBuf b, Function<ByteBuf, T> applyFunc,
-                                Function<Integer, T[]> arrayGen) {
+    private static <T> T[] readArray(ByteBuf b, Function<ByteBuf, T> applyFunc,
+                                     Function<Integer, T[]> arrayGen) {
         int length = b.readInt();
         T[] r = arrayGen.apply(length);
         for (int i = 0; i < length; i++) {
@@ -69,13 +65,13 @@ public class PrimitiveSerializer implements ISerializer {
         return r;
     }
 
-    static void writeBytes(Object o, ByteBuf b) {
+    private static void writeBytes(Object o, ByteBuf b) {
         int length = Array.getLength(o);
         b.writeInt(length);
         b.writeBytes((byte[]) o);
     }
 
-    static byte[] readBytes(ByteBuf b, CorfuRuntime rt) {
+    private static byte[] readBytes(ByteBuf b) {
         int length = b.readInt();
         byte[] bytes = new byte[length];
         b.readBytes(bytes, 0, length);
@@ -90,10 +86,10 @@ public class PrimitiveSerializer implements ISerializer {
      */
     @Override
     @SuppressWarnings("unchecked")
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
         byte type = b.readByte();
         DeserializerFunction d = DeserializerMap.get(type);
-        return d.deserialize(b, rt);
+        return d.deserialize(b);
     }
 
     /**
@@ -105,94 +101,45 @@ public class PrimitiveSerializer implements ISerializer {
     @Override
     @SuppressWarnings("unchecked")
     public void serialize(Object o, ByteBuf b) {
-        if (o.getClass().getName().contains("$ByteBuddy$")) {
-            ((SerializerFunction<Object>) Primitives.CORFU_SMR.getSerializer()).serialize(o, b);
-        } else {
-            Primitives p = SerializerMap.get(o.getClass());
-            if (p == null) {
-                throw new RuntimeException("Unsupported class for serialization: " + o.getClass());
-            }
-            b.writeByte(p.getTypeNum());
-            ((SerializerFunction<Object>)p.getSerializer()).serialize(o, b);
+        Primitives p = SerializerMap.get(o.getClass());
+        if (p == null) {
+            throw new RuntimeException("Unsupported class for serialization: " + o.getClass());
         }
+        b.writeByte(p.getTypeNum());
+        ((SerializerFunction<Object>)p.getSerializer()).serialize(o, b);
     }
 
     enum Primitives {
-        BYTE(0, Byte.class, byte.class, (o, b) -> b.writeByte(o), (b, r) -> b.readByte()),
-        SHORT(1, Short.class, short.class, (o, b) -> b.writeShort(o), (b, r) -> b.readShort()),
-        INTEGER(2, Integer.class, int.class, (o, b) -> b.writeInt(o), (b, r) -> b.readInt()),
-        LONG(3, Long.class, long.class, (o, b) -> b.writeLong(o), (b, r) -> b.readLong()),
-        BOOLEAN(4, Boolean.class, boolean.class, (o, b) -> b.writeBoolean(o),
-                (b, r) -> b.readBoolean()),
-        DOUBLE(5, Double.class, double.class, (o, b) -> b.writeDouble(o), (b, r) -> b.readDouble()),
-        FLOAT(6, Float.class, float.class, (o, b) -> b.writeFloat(o), (b, r) -> b.readFloat()),
+        BYTE(0, Byte.class, byte.class, (o, b) -> b.writeByte(o), ByteBuf::readByte),
+        SHORT(1, Short.class, short.class, (o, b) -> b.writeShort(o), ByteBuf::readShort),
+        INTEGER(2, Integer.class, int.class, (o, b) -> b.writeInt(o), ByteBuf::readInt),
+        LONG(3, Long.class, long.class, (o, b) -> b.writeLong(o), ByteBuf::readLong),
+        BOOLEAN(4, Boolean.class, boolean.class, (o, b) -> b.writeBoolean(o), ByteBuf::readBoolean),
+        DOUBLE(5, Double.class, double.class, (o, b) -> b.writeDouble(o), ByteBuf::readDouble),
+        FLOAT(6, Float.class, float.class, (o, b) -> b.writeFloat(o), ByteBuf::readFloat),
         BYTE_ARRAY(7, Byte[].class, byte[].class, PrimitiveSerializer::writeBytes,
-                (DeserializerFunction)PrimitiveSerializer::readBytes),
-        SHORT_ARRAY(8, Short[].class, short[].class, (o, b) -> writeArray(o, b,
-                ByteBuf::writeShort),
-                (b, r) -> readArray(b, ByteBuf::readShort, Short[]::new)),
-        INTEGER_ARRAY(9, Integer[].class, int[].class, (o, b) -> writeArray(o, b,
-                ByteBuf::writeInt),
-                (b, r) -> readArray(b, ByteBuf::readInt, Integer[]::new)),
+                (DeserializerFunction) PrimitiveSerializer::readBytes),
+        SHORT_ARRAY(8, Short[].class, short[].class, (o, b) -> writeArray(o, b, ByteBuf::writeShort),
+                b -> readArray(b, ByteBuf::readShort, Short[]::new)),
+        INTEGER_ARRAY(9, Integer[].class, int[].class, (o, b) -> writeArray(o, b, ByteBuf::writeInt),
+                b -> readArray(b, ByteBuf::readInt, Integer[]::new)),
         LONG_ARRAY(10, Long[].class, long[].class, (o, b) -> writeArray(o, b, ByteBuf::writeLong),
-                (b, r) -> readArray(b, ByteBuf::readLong, Long[]::new)),
-        BOOLEAN_ARRAY(11, Boolean[].class, boolean[].class, (o, b) -> writeArray(o, b,
-                ByteBuf::writeBoolean),
-                (b, r) -> readArray(b, ByteBuf::readBoolean, Boolean[]::new)),
-        DOUBLE_ARRAY(12, Double[].class, double[].class, (o, b) -> writeArray(o, b,
-                ByteBuf::writeDouble),
-                (b, r) -> readArray(b, ByteBuf::readDouble, Double[]::new)),
-        FLOAT_ARRAY(13, Float[].class, float[].class, (o, b) -> writeArray(o, b,
-                ByteBuf::writeFloat),
-                (b, r) -> readArray(b, ByteBuf::readFloat, Float[]::new)),
+                b -> readArray(b, ByteBuf::readLong, Long[]::new)),
+        BOOLEAN_ARRAY(11, Boolean[].class, boolean[].class, (o, b) -> writeArray(o, b, ByteBuf::writeBoolean),
+                b -> readArray(b, ByteBuf::readBoolean, Boolean[]::new)),
+        DOUBLE_ARRAY(12, Double[].class, double[].class, (o, b) -> writeArray(o, b, ByteBuf::writeDouble),
+                b -> readArray(b, ByteBuf::readDouble, Double[]::new)),
+        FLOAT_ARRAY(13, Float[].class, float[].class, (o, b) -> writeArray(o, b, ByteBuf::writeFloat),
+                b -> readArray(b, ByteBuf::readFloat, Float[]::new)),
         STRING(14, String.class, null, (o, b) -> {
             b.writeInt(o.length());
             b.writeBytes(o.getBytes());
-        },
-                (b, r) -> {
-                    int length = b.readInt();
-                    byte[] bs = new byte[length];
-                    b.readBytes(bs, 0, length);
-                    return new String(bs);
-                }),
-        CORFU_SMR(15, Object.class, null, (o, b) -> {
-            String className = o.getClass().toString();
-            className = "CorfuObject";
-            byte[] classNameBytes = className.getBytes();
-            b.writeShort(classNameBytes.length);
-            b.writeBytes(classNameBytes);
-            String smrClass = className.split("\\$")[0];
-            byte[] smrClassNameBytes = smrClass.getBytes();
-            b.writeShort(smrClassNameBytes.length);
-            b.writeBytes(smrClassNameBytes);
-            try {
-                Field f = o.getClass().getDeclaredField("_corfuStreamID");
-                f.setAccessible(true);
-                UUID id = (UUID) f.get(o);
-                log.trace("Serializing a CorfuObject of type {} as a stream pointer to {}",
-                        smrClass, id);
-                b.writeLong(id.getMostSignificantBits());
-                b.writeLong(id.getLeastSignificantBits());
-            } catch (NoSuchFieldException | IllegalAccessException nsfe) {
-                log.error("Error serializing fields");
-                throw new RuntimeException(nsfe);
-            }
-        },
-                (b, r) -> {
-                    int smrClassNameLength = b.readShort();
-                    byte[] smrClassNameBytes = new byte[smrClassNameLength];
-                    b.readBytes(smrClassNameBytes, 0, smrClassNameLength);
-                    String smrClassName = new String(smrClassNameBytes);
-                    try {
-                        return r.getObjectsView().build()
-                                .setStreamID(new UUID(b.readLong(), b.readLong()))
-                                .setType(Class.forName(smrClassName))
-                                .open();
-                    } catch (ClassNotFoundException cnfe) {
-                        log.error("Exception during deserialization!", cnfe);
-                        throw new RuntimeException(cnfe);
-                    }
-                });
+        }, b -> {
+            int length = b.readInt();
+            byte[] bs = new byte[length];
+            b.readBytes(bs, 0, length);
+            return new String(bs);
+        });
 
         @Getter
         public final byte typeNum;
@@ -214,10 +161,9 @@ public class PrimitiveSerializer implements ISerializer {
         }
     }
 
-
     @FunctionalInterface
     interface DeserializerFunction<T> {
-        T deserialize(ByteBuf b, CorfuRuntime r);
+        T deserialize(ByteBuf b);
     }
 
     @FunctionalInterface

--- a/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
@@ -23,7 +23,7 @@ public class Serializers {
     private static final Map<Byte, ISerializer> serializersMap;
 
     static {
-        serializersMap = new HashMap();
+        serializersMap = new HashMap<>();
         serializersMap.put(CORFU.getType(), CORFU);
         serializersMap.put(JAVA.getType(), JAVA);
         serializersMap.put(JSON.getType(), JSON);

--- a/test/src/test/java/org/corfudb/CustomSerializer.java
+++ b/test/src/test/java/org/corfudb/CustomSerializer.java
@@ -1,7 +1,6 @@
 package org.corfudb;
 
 import io.netty.buffer.ByteBuf;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
 
@@ -20,8 +19,8 @@ public class CustomSerializer implements ISerializer {
         return type;
     }
 
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
-        return serializer.deserialize(b, rt);
+    public Object deserialize(ByteBuf b) {
+        return serializer.deserialize(b);
     }
 
     public void serialize(Object o, ByteBuf b) {

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -30,7 +30,6 @@ import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.OverwriteException;
-import org.corfudb.runtime.exceptions.WorkflowException;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
@@ -62,7 +61,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         Serializers.CORFU.serialize(streamEntry, b);
         long address0 = 0;
         log.append(address0, new LogData(DataType.DATA, b));
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
 
         // Disable checksum, then append and read then same entry
         // An overwrite exception should occur, since we are writing the
@@ -72,7 +71,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
             newLog.append(address0, new LogData(DataType.DATA, b));
         })
                 .isInstanceOf(OverwriteException.class);
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
     }
 
     @Test
@@ -293,7 +292,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         long address0 = 0;
         log.append(address0, new LogData(DataType.DATA, b));
 
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
 
         log.close();
 
@@ -318,7 +317,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         log.append(address0, new LogData(DataType.DATA, b));
         log.append(address1, new LogData(DataType.DATA, b));
 
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
         log.close();
 
         final int OVERWRITE_BYTES = 4;
@@ -371,7 +370,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         for (int x = 0; x < num_entries * num_threads; x++) {
             long address = (long) x;
             LogData data = log.read(address);
-            byte[] bytes = (byte[]) data.getPayload(null);
+            byte[] bytes = (byte[]) data.getPayload();
             assertThat(bytes).isEqualTo(streamEntry);
         }
     }
@@ -645,7 +644,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         // Open the segment again and verify that the entry write can be read (i.e. log file can be
         // parsed correctly).
         log = new StreamLogFiles(getContext(), false);
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
     }
 
     @Test
@@ -701,6 +700,6 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         log.close();
 
         log = new StreamLogFiles(getContext(), false);
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -821,7 +821,7 @@ public class ClusterReconfigIT extends AbstractIT {
                 .getLogUnitClient("localhost:9002")
                 .readAll(getRangeAddressAsList(startAddress, endAddress))
                 .get().getAddresses().values()) {
-            assertThat(logData.getPayload(runtime))
+            assertThat(logData.getPayload())
                     .isEqualTo(Integer.toString(verificationCounter++).getBytes());
         }
 
@@ -902,7 +902,7 @@ public class ClusterReconfigIT extends AbstractIT {
                 .getLogUnitClient("localhost:9002")
                 .readAll(getRangeAddressAsList(startAddress, endAddress)).get()
                 .getAddresses().values()) {
-            assertThat(logData.getPayload(runtime))
+            assertThat(logData.getPayload())
                     .isEqualTo(Integer.toString(verificationCounter++).getBytes());
         }
 
@@ -990,7 +990,7 @@ public class ClusterReconfigIT extends AbstractIT {
         final int startAddress = 0;
         final int endAddress = 3;
         for (int i = startAddress; i <= endAddress; i++) {
-            assertThat(runtime.getAddressSpaceView().read(i).getPayload(runtime))
+            assertThat(runtime.getAddressSpaceView().read(i).getPayload())
                     .isEqualTo(Integer.toString(i).getBytes());
         }
 

--- a/test/src/test/java/org/corfudb/integration/CmdletIT.java
+++ b/test/src/test/java/org/corfudb/integration/CmdletIT.java
@@ -162,8 +162,8 @@ public class CmdletIT extends AbstractIT {
         String commandAppend = "echo '" + payload2 + "' | " + CORFU_PROJECT_DIR + "bin/corfu_stream -i " + streamA + " -c " + ENDPOINT + " append";
         runCmdletGetOutput(commandAppend);
 
-        assertThat(streamViewA.next().getPayload(runtime)).isEqualTo(payload1.getBytes());
-        assertThat(streamViewA.next().getPayload(runtime)).isEqualTo((payload2 + "\n").getBytes());
+        assertThat(streamViewA.next().getPayload()).isEqualTo(payload1.getBytes());
+        assertThat(streamViewA.next().getPayload()).isEqualTo((payload2 + "\n").getBytes());
         assertThat(streamViewA.next()).isNull();
         shutdownCorfuServer(corfuServerProcess);
     }

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CPSerializer.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CPSerializer.java
@@ -6,7 +6,6 @@ import com.google.gson.GsonBuilder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.ISerializer;
 
 import java.io.IOException;
@@ -32,7 +31,7 @@ public class CPSerializer implements ISerializer {
         return type;
     }
 
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
         Type mapType = new TypeToken<Map<String, Long>>(){}.getType();
 
         int classNameLength = b.readShort();

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -108,7 +108,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         LogData r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString);
     }
 
@@ -230,7 +230,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         LogData r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString);
 
         byte[] testString2 = "hello world 2".getBytes();
@@ -238,7 +238,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString2);
     }
 
@@ -251,7 +251,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         LogData r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString);
 
         byte[] testString2 = "hello world 2".getBytes();
@@ -265,7 +265,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString);
     }
 
@@ -276,7 +276,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         client.write(0, new IMetadata.DataRank(1), testString, Collections.emptyMap()).get();
         LogData r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType()) .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString);
 
         try {
@@ -290,11 +290,11 @@ public class LogUnitHandlerTest extends AbstractClientTest {
             ReadResponse read = ex.getReadResponse();
             LogData log = read.getAddresses().get(0l);
             assertThat(log.getType()).isEqualTo(DataType.DATA);
-            assertThat(log.getPayload(new CorfuRuntime())).isEqualTo(testString);;
+            assertThat(log.getPayload()).isEqualTo(testString);;
         }
         r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType()).isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime())).isEqualTo(testString);
+        assertThat(r.getPayload()).isEqualTo(testString);
     }
 
     private ILogData.SerializationHandle createEmptyData(long position, DataType type, IMetadata.DataRank rank) {

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -58,7 +58,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 "hello world".getBytes());
 
-        assertThat(rt.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(rt.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(rt.getAddressSpaceView().read(0L).containsStream(streamA))
@@ -139,7 +139,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         Token token = new Token(rt.getLayoutView().getLayout().getEpoch(), ADDRESS_0);
         rt.getAddressSpaceView().write(token, testPayload);
 
-        assertThat(rt.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
+        assertThat(rt.getAddressSpaceView().read(ADDRESS_0).getPayload())
                 .isEqualTo("hello world".getBytes());
 
 
@@ -156,11 +156,11 @@ public class AddressSpaceViewTest extends AbstractViewTest {
 
         Map<Long, ILogData> m = rt.getAddressSpaceView().read(rs, true);
 
-        assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
+        assertThat(m.get(ADDRESS_0).getPayload())
                 .isEqualTo("hello world".getBytes());
-        assertThat(m.get(ADDRESS_1).getPayload(getRuntime()))
+        assertThat(m.get(ADDRESS_1).getPayload())
                 .isEqualTo("1".getBytes());
-        assertThat(m.get(ADDRESS_2).getPayload(getRuntime()))
+        assertThat(m.get(ADDRESS_2).getPayload())
                 .isEqualTo("3".getBytes());
     }
 
@@ -178,7 +178,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         Token token = new Token(rt.getLayoutView().getLayout().getEpoch(), ADDRESS_0);
         rt.getAddressSpaceView().write(token, testPayload);
 
-        assertThat(rt.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
+        assertThat(rt.getAddressSpaceView().read(ADDRESS_0).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         Range range = Range.closed(ADDRESS_0, ADDRESS_2);
@@ -186,7 +186,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
 
         Map<Long, ILogData> m = rt.getAddressSpaceView().read(addresses, true);
 
-        assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
+        assertThat(m.get(ADDRESS_0).getPayload())
                 .isEqualTo("hello world".getBytes());
         assertThat(m.get(ADDRESS_1).isHole()).isTrue();
         assertThat(m.get(ADDRESS_2).isHole()).isTrue();
@@ -250,6 +250,6 @@ public class AddressSpaceViewTest extends AbstractViewTest {
                 ContiguousSet.create(Range.closed(0L, numAddresses - 1), DiscreteDomain.longs()), true);
 
         readResult.forEach((addr, data) ->
-                assertThat(data.getPayload(rt)).isEqualTo((testString + addr).getBytes()));
+                assertThat(data.getPayload()).isEqualTo((testString + addr).getBytes()));
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
@@ -31,7 +31,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L).containsStream(streamA))
@@ -61,7 +61,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
             for (int i = base; i < base + numberRecords; i++) {
-                assertThat(r.getAddressSpaceView().read(i).getPayload(getRuntime()))
+                assertThat(r.getAddressSpaceView().read(i).getPayload())
                         .isEqualTo(Integer.toString(i).getBytes());
             }
         });
@@ -103,7 +103,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L)
@@ -142,7 +142,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L).containsStream(streamA));

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -234,7 +234,7 @@ public class LayoutViewTest extends AbstractViewTest {
         sv.append(testPayload);
         startReconfigurationLatch.countDown();
         layoutReconfiguredLatch.await();
-        assertThat(sv.next().getPayload(corfuRuntime)).isEqualTo("hello world".getBytes());
+        assertThat(sv.next().getPayload()).isEqualTo("hello world".getBytes());
         assertThat(sv.next()).isEqualTo(null);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -15,7 +15,6 @@ import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +48,7 @@ public class StreamViewTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(streamA);
         sv.append(testPayload);
 
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(sv.next())
@@ -109,7 +108,7 @@ public class StreamViewTest extends AbstractViewTest {
                 PARAMETERS.TIMEOUT_NORMAL);
 
         scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW,
-                i -> assertThat(sv.next().getPayload(getRuntime()))
+                i -> assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes()));
         executeScheduled(PARAMETERS.CONCURRENCY_SOME,
                 PARAMETERS.TIMEOUT_NORMAL);
@@ -132,7 +131,7 @@ public class StreamViewTest extends AbstractViewTest {
         executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_NORMAL);
 
         scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW, i ->
-                assertThat(sv.next().getPayload(getRuntime()))
+                assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes()));
         executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_NORMAL);
         assertThat(sv.next())
@@ -152,7 +151,7 @@ public class StreamViewTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(streamA);
         sv.append(testPayload);
 
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(sv.next())
@@ -173,24 +172,24 @@ public class StreamViewTest extends AbstractViewTest {
         sv.append("c".getBytes());
 
         // Try reading two entries
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("a".getBytes());
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("b".getBytes());
 
         // Seeking to the beginning
         sv.seek(0);
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("a".getBytes());
 
         // Seeking to the end
         sv.seek(2);
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("c".getBytes());
 
         // Seeking to the middle
         sv.seek(1);
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("b".getBytes());
     }
 
@@ -272,18 +271,18 @@ public class StreamViewTest extends AbstractViewTest {
         sv.next(); // "b"
 
         // Should be now "a"
-        assertThat(sv.previous().getPayload(r))
+        assertThat(sv.previous().getPayload())
                 .isEqualTo("a".getBytes());
 
         // Move forward, should be now "b"
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("b".getBytes());
 
         sv.next(); // "c"
         sv.next(); // null
 
         // Should be now "b"
-        assertThat(sv.previous().getPayload(r))
+        assertThat(sv.previous().getPayload())
                 .isEqualTo("b".getBytes());
     }
 
@@ -302,7 +301,7 @@ public class StreamViewTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(streamA);
         sv.append(testPayload);
 
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(sv.next())
@@ -324,7 +323,7 @@ public class StreamViewTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(streamA);
         sv.append(testPayload);
 
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(sv.next())
@@ -363,10 +362,10 @@ public class StreamViewTest extends AbstractViewTest {
         sv.append(testPayload2);
 
         //make sure we can still read the stream.
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo(testPayload);
 
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo(testPayload2);
     }
 
@@ -403,7 +402,7 @@ public class StreamViewTest extends AbstractViewTest {
         byte[] payload = "entry1".getBytes();
         assertThat(sv.append(payload)).isEqualTo(pos0);
         assertThat(sv.getCurrentGlobalPosition()).isEqualTo(Address.NON_ADDRESS);
-        assertThat(sv.next().getPayload(r)).isEqualTo(payload);
+        assertThat(sv.next().getPayload()).isEqualTo(payload);
         assertThat(sv.getCurrentGlobalPosition()).isEqualTo(pos0);
         assertThat(sv.previous()).isNull();
         assertThat(sv.getCurrentGlobalPosition()).isEqualTo(Address.NON_ADDRESS);

--- a/test/src/test/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocolTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocolTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractReplicationProtocolTest extends AbstractViewTest {
                 .isEqualTo(DataType.DATA);
         assertThat(read.getGlobalAddress())
                 .isEqualTo(0);
-        assertThat(read.getPayload(r))
+        assertThat(read.getPayload())
                 .isEqualTo("hello world".getBytes());
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
@@ -77,7 +77,7 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
         ILogData readResult = runtimeLayout.getLogUnitClient(SERVERS.ENDPOINT_0)
                 .read(0).get().getAddresses().get(0L);
 
-        assertThat(readResult.getPayload(r))
+        assertThat(readResult.getPayload())
             .isEqualTo("incomplete".getBytes());
     }
 
@@ -102,7 +102,7 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
         // reflect the -other- clients value
         ILogData readResult = rp.read(runtimeLayout, 0);
 
-        assertThat(readResult.getPayload(r))
+        assertThat(readResult.getPayload())
                 .isEqualTo("incomplete".getBytes());
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
@@ -124,7 +124,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         LogUnitServerAssertions.assertThat(u0)
                 .isEmptyAtAddress(ADDRESS_0);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("0".getBytes());
 
         LogUnitServerAssertions.assertThat(u1)
@@ -162,7 +162,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         tr = r.getSequencerView().next(streamA);
 
         //make sure we can still read the stream.
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo(testPayload);
 
         int address = 0;
@@ -189,7 +189,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
                 testPayload);
         ILogData x = r.getAddressSpaceView().read(0);
         assertNotNull(x.getRank());
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(r))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L).containsStream(streamA))
@@ -222,7 +222,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
             for (int i = base; i < base + numberRecords; i++) {
-                assertThat(r.getAddressSpaceView().read(i).getPayload(getRuntime()))
+                assertThat(r.getAddressSpaceView().read(i).getPayload())
                         .isEqualTo(Integer.toString(i).getBytes());
             }
         });
@@ -249,7 +249,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L)
@@ -275,7 +275,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L).containsStream(streamA));

--- a/test/src/test/java/org/corfudb/runtime/view/stream/BackpointerStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/BackpointerStreamViewTest.java
@@ -52,7 +52,7 @@ public class BackpointerStreamViewTest extends AbstractViewTest {
         // iterations) appending to it
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             assertThat(sv.hasNext()).isTrue();
-            byte[] payLoad = (byte[]) sv.next().getPayload(runtime);
+            byte[] payLoad = (byte[]) sv.next().getPayload();
             assertThat(new String(payLoad).equals(String.valueOf(i)))
                     .isTrue();
             assertThat(sv.getCurrentGlobalPosition()).isEqualTo(i);
@@ -68,7 +68,7 @@ public class BackpointerStreamViewTest extends AbstractViewTest {
         // traverse the stream backwards, while periodically (every ten
         // iterations) appending to it
         for (int i = PARAMETERS.NUM_ITERATIONS_LOW - 1; i >= 0; i--) {
-            byte[] payLoad = (byte[]) sv.current().getPayload(runtime);
+            byte[] payLoad = (byte[]) sv.current().getPayload();
             assertThat(new String(payLoad).equals(String.valueOf(i)))
                     .isTrue();
             assertThat(sv.getCurrentGlobalPosition()).isEqualTo(i);
@@ -104,7 +104,7 @@ public class BackpointerStreamViewTest extends AbstractViewTest {
         sv.seek(2);
 
         // The previous entry should be ENTRY_0
-        assertThat((byte[])sv.previous().getPayload(runtime))
+        assertThat((byte[])sv.previous().getPayload())
                 .isEqualTo(ENTRY_0);
     }
 
@@ -133,7 +133,7 @@ public class BackpointerStreamViewTest extends AbstractViewTest {
                 sv.append(String.valueOf(i).getBytes());
                 sv.append(String.valueOf(i).getBytes());
             }
-            byte[] payLoad = (byte[]) sv.next().getPayload(runtime);
+            byte[] payLoad = (byte[]) sv.next().getPayload();
             assertThat(new String(payLoad).equals(String.valueOf(i)));
         }
     }


### PR DESCRIPTION
## Overview

Description:

For some historical reasons, the deserialization of LogData's payload
depends on CorfuRuntime. This patch gets rid of this dependency.

Related issue(s) (if applicable): #1880 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
