### PR TITLE
Fix PrefixTrim Bug on Address Maps

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -342,11 +342,11 @@ public class SequencerServer extends AbstractServer {
             // Advance the trim mark, if the new trim request has a higher trim mark.
             trimMark = msg.getPayload();
             cache.invalidateUpTo(trimMark);
-        }
 
-        // Remove trimmed addresses from each address map and set new trim mark
-        for(StreamAddressSpace streamAddressSpace : streamsAddressMap.values()) {
-            streamAddressSpace.trim(trimMark);
+            // Remove trimmed addresses from each address map and set new trim mark
+            for(StreamAddressSpace streamAddressSpace : streamsAddressMap.values()) {
+                streamAddressSpace.trim(trimMark);
+            }
         }
 
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NavigableSet;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.Function;
 
@@ -192,10 +194,8 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
 
     private void processCheckpoint(StreamAddressSpace streamAddressSpace, Function<ILogData, BackpointerOp> filter,
                                    NavigableSet<Long> queue) {
-        List<Long> checkpointAddresses = new ArrayList<>();
+        SortedSet<Long> checkpointAddresses = new TreeSet<>(Collections.reverseOrder());
         streamAddressSpace.getAddressMap().forEach(checkpointAddresses::add);
-        checkpointAddresses.sort(null);
-        Collections.reverse(checkpointAddresses);
 
         // Checkpoint entries will be read in batches of a predefined size,
         // the reason not to read them all in a single call is that:

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.view.stream;
 
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
+import org.corfudb.runtime.view.Address;
 import org.roaringbitmap.longlong.LongIterator;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
@@ -108,6 +109,14 @@ public class StreamAddressSpace {
      * @param trimMark upper limit of addresses to trim
      */
     public void trim(Long trimMark) {
+        if (!Address.isAddress(trimMark)) {
+            // If not valid address return and do not attempt to trim.
+            return;
+        }
+
+        // Note: if a negative value is passed to this API the cardinality
+        // of the bitmap is returned, which would be incorrect as we would
+        // be removing all addresses upon an invalid trim mark.
         long numAddressesToTrim = addressMap.rankLong(trimMark);
 
         if (numAddressesToTrim <= NO_ADDRESSES) {
@@ -116,7 +125,7 @@ public class StreamAddressSpace {
 
         List<Long> addressesToTrim = new ArrayList<>();
         LongIterator it = addressMap.getLongIterator();
-        for (int i=0; i < numAddressesToTrim; i++) {
+        for (int i = 0; i < numAddressesToTrim; i++) {
             addressesToTrim.add(it.next());
         }
 


### PR DESCRIPTION
## Overview

Description: when attempting to trim the bitmaps on a negative value, the rankLong function will return the cardinality of infinity, i.e., the complete address map, thus trimming all addresses from the sequencer (when non should've been trimmed as trim mark was -1). This can lead to potential issues in which a stream cannot be rebuilt as all addresses appear to be trimmed and not covered by a checkpoint. This PR fixes this issue.

Why should this be merged: fix a potential bug detected on an intermittent test failure.
