### PR TITLE
Fix CI Failures for Master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,8 @@ jobs:
   - stage: code_quality
     name: Code Quality
     script:
+    # Prepare docker image
+    - ./mvnw -pl infrastructure -DskipTests -Pdocker clean package
     - |
       ./mvnw verify -Pit sonar:sonar \
       -Dtest.travisBuild=true \


### PR DESCRIPTION
## Overview
CI jobs that run on the master branch are failing on the universe
tests because the docker image doesn't exist. This patch adds
a package command before the test runs.

Why should this be merged: Fixs CI

Related issue(s) (if applicable):  #1890


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
