### PR TITLE
Don't add fully connected node into unresponsive list if there is failed node

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/CompleteGraphAdvisor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/CompleteGraphAdvisor.java
@@ -76,7 +76,7 @@ public class CompleteGraphAdvisor implements ClusterAdvisor {
             return Optional.empty();
         }
 
-        Optional<NodeRank> maybeFailedNode = symmetric.findFailedNode();
+        Optional<NodeRank> maybeFailedNode = symmetric.findFailedNode(unresponsiveServers);
         if (!maybeFailedNode.isPresent()) {
             return Optional.empty();
         }
@@ -140,6 +140,7 @@ public class CompleteGraphAdvisor implements ClusterAdvisor {
 
     /**
      * Returns a new cluster graph from the cluster state
+     *
      * @param clusterState a cluster state
      * @return a transformed cluster graph
      */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/ClusterGraph.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/ClusterGraph.java
@@ -109,8 +109,8 @@ public class ClusterGraph {
 
                         //If current node is not the local node and another node is unavailable we don't change
                         // the adjacent node connectivity matrix, we leave it as is
-                        if (adjNode.getType() == NodeConnectivityType.UNAVAILABLE){
-                            if (!isLocalNode(node)){
+                        if (adjNode.getType() == NodeConnectivityType.UNAVAILABLE) {
+                            if (!isLocalNode(node)) {
                                 newConnectivity.put(adjNodeName, node.getConnectionStatus(adjNodeName));
                                 return;
                             }
@@ -124,7 +124,7 @@ public class ClusterGraph {
                         //Symmetric failure - connection successful only if both nodes connected status is true
                         //in the other case - make the failure symmetric
                         ConnectionStatus status = ConnectionStatus.OK;
-                        if (EnumSet.of(nodeConnection, oppositeNodeConnection).contains(ConnectionStatus.FAILED)){
+                        if (EnumSet.of(nodeConnection, oppositeNodeConnection).contains(ConnectionStatus.FAILED)) {
                             status = ConnectionStatus.FAILED;
                         }
                         newConnectivity.put(adjNodeName, status);
@@ -161,7 +161,7 @@ public class ClusterGraph {
      * Note: it's not required to choose a particular one for entire cluster to add a node to unresponsive list.
      * In a partitioned scenario, a minority side can choose to have a decision maker
      * just that it's decisions will not be used as it does not have consensus
-     *
+     * <p>
      * The decision maker always exists. There is always at least the local node,
      * it always has at least one successful connection to itself.
      * We also have two additional checks to prevent all possible incorrect ways. Decision maker not found if:
@@ -198,7 +198,7 @@ public class ClusterGraph {
      *
      * @return failed node
      */
-    public Optional<NodeRank> findFailedNode() {
+    public Optional<NodeRank> findFailedNode(List<String> unresponsiveServers) {
         log.trace("Looking for failed node");
 
         NavigableSet<NodeRank> nodes = getNodeRanks();
@@ -209,6 +209,24 @@ public class ClusterGraph {
 
         NodeRank last = nodes.last();
         if (last.getNumConnections() == graph.size()) {
+            return Optional.empty();
+        }
+
+        //If the node is connected to all alive nodes (nodes not in unresponsive list)
+        // in the cluster, that node can't be a failed node.
+        // We can't rely on information from nodes in unresponsive list.
+        Optional<NodeRank> fullyConnected = findFullyConnectedNode(
+                last.getEndpoint(),
+                unresponsiveServers
+        );
+
+        //check if failed node is fully connected
+        boolean isFailedNodeFullyConnected = fullyConnected
+                .map(fcNode -> fcNode.equals(last))
+                .orElse(false);
+
+        if (isFailedNodeFullyConnected) {
+            log.trace("Fully connected node can't be a failed node");
             return Optional.empty();
         }
 
@@ -226,26 +244,41 @@ public class ClusterGraph {
         log.trace("Find responsive node. Unresponsive nodes: {}", unresponsiveNodes);
 
         NodeConnectivity node = getNodeConnectivity(endpoint);
-        for (String adjacent : node.getConnectivity().keySet()) {
-            //if adjacent node is unresponsive then then exclude it from  fully connected graph
-            if (unresponsiveNodes.contains(adjacent)) {
-                continue;
-            }
 
-            NodeConnectivity adjacentNode = getNodeConnectivity(adjacent);
-
-            //if adjacent node is unavailable then exclude it from  fully connected graph
-            if (adjacentNode.getType() == NodeConnectivityType.UNAVAILABLE) {
-                continue;
-            }
-
-            if (adjacentNode.getConnectionStatus(endpoint) != ConnectionStatus.OK) {
-                log.trace("Fully connected node not found");
+        switch (node.getType()) {
+            case NOT_READY:
+            case UNAVAILABLE:
+                log.trace("Not connected node: {}", endpoint);
                 return Optional.empty();
-            }
-        }
+            case CONNECTED:
+                for (String adjacent : node.getConnectivity().keySet()) {
+                    //if adjacent node is unresponsive then exclude it from fully connected graph
+                    if (unresponsiveNodes.contains(adjacent)) {
+                        continue;
+                    }
 
-        return Optional.of(new NodeRank(endpoint, getNodeConnectivity(endpoint).getConnected()));
+                    NodeConnectivity adjacentNode = getNodeConnectivity(adjacent);
+
+                    //if adjacent node is unavailable then exclude it from  fully connected graph
+                    if (adjacentNode.getType() == NodeConnectivityType.UNAVAILABLE) {
+                        continue;
+                    }
+
+                    if (adjacentNode.getConnectionStatus(endpoint) != ConnectionStatus.OK) {
+                        log.trace("Fully connected node not found");
+                        return Optional.empty();
+                    }
+                }
+
+                NodeRank rank = new NodeRank(
+                        endpoint,
+                        getNodeConnectivity(endpoint).getConnected()
+                );
+
+                return Optional.of(rank);
+            default:
+                throw new IllegalStateException("Unknown node state");
+        }
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/ClusterGraph.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/failuredetector/ClusterGraph.java
@@ -196,6 +196,7 @@ public class ClusterGraph {
      * Collect all node ranks in a graph and choose the node with smallest number of successful connections and
      * with highest name (sorted alphabetically)
      *
+     * @param unresponsiveServers list of unresponsive nodes in the layout
      * @return failed node
      */
     public Optional<NodeRank> findFailedNode(List<String> unresponsiveServers) {

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterGraphTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterGraphTest.java
@@ -1,12 +1,16 @@
 package org.corfudb.infrastructure.management;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.corfudb.infrastructure.management.NodeStateTestUtil.A;
+import static org.corfudb.infrastructure.management.NodeStateTestUtil.B;
+import static org.corfudb.infrastructure.management.NodeStateTestUtil.C;
 import static org.corfudb.infrastructure.management.failuredetector.ClusterGraph.ClusterGraphHelper.cluster;
 import static org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity.ConnectionStatus.FAILED;
 import static org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity.ConnectionStatus.OK;
 import static org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity.connectivity;
 import static org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity.unavailable;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -14,8 +18,8 @@ import org.corfudb.infrastructure.management.failuredetector.ClusterGraph;
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.protocols.wireprotocol.NodeState;
 import org.corfudb.protocols.wireprotocol.NodeState.HeartbeatTimestamp;
-import org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics;
+import org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity;
 import org.corfudb.protocols.wireprotocol.failuredetector.NodeRank;
 import org.corfudb.runtime.view.Layout;
 import org.junit.Test;
@@ -30,142 +34,146 @@ public class ClusterGraphTest {
         NodeState a = NodeState.builder()
                 .sequencerMetrics(SequencerMetrics.READY)
                 .heartbeat(new HeartbeatTimestamp(0, 0))
-                .connectivity(connectivity("a", ImmutableMap.of("a", OK, "b", OK, "c", FAILED)))
+                .connectivity(connectivity(A, ImmutableMap.of(A, OK, B, OK, C, FAILED)))
                 .build();
 
         NodeState b = NodeState.builder()
                 .sequencerMetrics(SequencerMetrics.READY)
                 .heartbeat(new HeartbeatTimestamp(0, 0))
-                .connectivity(connectivity("b", ImmutableMap.of("a", OK, "b", OK, "c", FAILED)))
+                .connectivity(connectivity(B, ImmutableMap.of(A, OK, B, OK, C, FAILED)))
                 .build();
 
-        NodeState c = unavailableNodeState("c");
+        NodeState c = unavailableNodeState(C);
 
-        ImmutableMap<String, NodeState> nodes = ImmutableMap.of("a", a, "b", b, "c", c);
+        ImmutableMap<String, NodeState> nodes = ImmutableMap.of(A, a, B, b, C, c);
         ClusterState clusterState = ClusterState.builder()
-                .localEndpoint("a")
+                .localEndpoint(A)
                 .nodes(nodes)
                 .build();
 
-        ClusterGraph graph = ClusterGraph.toClusterGraph(clusterState, "a");
+        ClusterGraph graph = ClusterGraph.toClusterGraph(clusterState, A);
 
         assertEquals(graph.size(), nodes.size());
     }
 
     @Test
     public void testToSymmetricForTwoNodes() {
-        NodeConnectivity a = connectivity("a", ImmutableMap.of("a", OK, "b", FAILED));
-        NodeConnectivity b = connectivity("b", ImmutableMap.of("a", OK, "b", OK));
+        NodeConnectivity a = connectivity(A, ImmutableMap.of(A, OK, B, FAILED));
+        NodeConnectivity b = connectivity(B, ImmutableMap.of(A, OK, B, OK));
 
-        ClusterGraph graph = cluster("a", a, b);
+        ClusterGraph graph = cluster(A, a, b);
         ClusterGraph symmetric = graph.toSymmetric();
 
-        assertEquals(FAILED, graph.getNodeConnectivity("a").getConnectionStatus("b"));
-        assertEquals(OK, graph.getNodeConnectivity("b").getConnectionStatus("a"));
+        assertEquals(FAILED, graph.getNodeConnectivity(A).getConnectionStatus(B));
+        assertEquals(OK, graph.getNodeConnectivity(B).getConnectionStatus(A));
 
-        assertEquals(FAILED, symmetric.getNodeConnectivity("a").getConnectionStatus("b"));
-        assertEquals(FAILED, symmetric.getNodeConnectivity("b").getConnectionStatus("a"));
+        assertEquals(FAILED, symmetric.getNodeConnectivity(A).getConnectionStatus(B));
+        assertEquals(FAILED, symmetric.getNodeConnectivity(B).getConnectionStatus(A));
     }
 
     @Test
     public void testToSymmetricForThreeNodes() {
-        NodeConnectivity a = connectivity("a", ImmutableMap.of("a", OK, "b", FAILED, "c", FAILED));
-        NodeConnectivity b = connectivity("b", ImmutableMap.of("a", OK, "b", OK, "c", OK));
-        NodeConnectivity c = connectivity("c", ImmutableMap.of("a", OK, "b", FAILED, "c", OK));
+        NodeConnectivity a = connectivity(A, ImmutableMap.of(A, OK, B, FAILED, C, FAILED));
+        NodeConnectivity b = connectivity(B, ImmutableMap.of(A, OK, B, OK, C, OK));
+        NodeConnectivity c = connectivity(C, ImmutableMap.of(A, OK, B, FAILED, C, OK));
 
-        ClusterGraph symmetric = cluster("a", a, b, c).toSymmetric();
-        assertEquals(FAILED, symmetric.getNodeConnectivity("b").getConnectionStatus("a"));
-        assertEquals(FAILED, symmetric.getNodeConnectivity("c").getConnectionStatus("a"));
+        ClusterGraph symmetric = cluster(A, a, b, c).toSymmetric();
+        assertEquals(FAILED, symmetric.getNodeConnectivity(B).getConnectionStatus(A));
+        assertEquals(FAILED, symmetric.getNodeConnectivity(C).getConnectionStatus(A));
 
-        symmetric = cluster("b", a, b, c).toSymmetric();
-        assertEquals(FAILED, symmetric.getNodeConnectivity("b").getConnectionStatus("a"));
-        assertEquals(FAILED, symmetric.getNodeConnectivity("c").getConnectionStatus("a"));
+        symmetric = cluster(B, a, b, c).toSymmetric();
+        assertEquals(FAILED, symmetric.getNodeConnectivity(B).getConnectionStatus(A));
+        assertEquals(FAILED, symmetric.getNodeConnectivity(C).getConnectionStatus(A));
 
-        symmetric = cluster("c", a, b, c).toSymmetric();
-        assertEquals(FAILED, symmetric.getNodeConnectivity("b").getConnectionStatus("a"));
-        assertEquals(FAILED, symmetric.getNodeConnectivity("c").getConnectionStatus("a"));
+        symmetric = cluster(C, a, b, c).toSymmetric();
+        assertEquals(FAILED, symmetric.getNodeConnectivity(B).getConnectionStatus(A));
+        assertEquals(FAILED, symmetric.getNodeConnectivity(C).getConnectionStatus(A));
     }
 
     @Test
     public void testToSymmetricForThreeNodesWithUnavailableNodeB() {
-        NodeConnectivity a = connectivity("a", ImmutableMap.of("a", OK, "b", FAILED, "c", FAILED));
-        NodeConnectivity b = unavailable("b");
-        NodeConnectivity c = connectivity("c", ImmutableMap.of("a", OK, "b", OK, "c", OK));
+        NodeConnectivity a = connectivity(A, ImmutableMap.of(A, OK, B, FAILED, C, FAILED));
+        NodeConnectivity b = unavailable(B);
+        NodeConnectivity c = connectivity(C, ImmutableMap.of(A, OK, B, OK, C, OK));
 
-        ClusterGraph graph = cluster("a", a, b, c);
+        ClusterGraph graph = cluster(A, a, b, c);
         ClusterGraph symmetric = graph.toSymmetric();
 
-        NodeConnectivity symmetricNodeA = symmetric.getNodeConnectivity("a");
-        assertEquals(OK, symmetricNodeA.getConnectionStatus("a"));
-        assertEquals(FAILED, symmetricNodeA.getConnectionStatus("b"));
-        assertEquals(FAILED, symmetricNodeA.getConnectionStatus("c"));
+        NodeConnectivity symmetricNodeA = symmetric.getNodeConnectivity(A);
+        assertEquals(OK, symmetricNodeA.getConnectionStatus(A));
+        assertEquals(FAILED, symmetricNodeA.getConnectionStatus(B));
+        assertEquals(FAILED, symmetricNodeA.getConnectionStatus(C));
 
-        assertThatThrownBy(() -> symmetric.getNodeConnectivity("b").getConnectionStatus("a"))
+        assertThatThrownBy(() -> symmetric.getNodeConnectivity(B).getConnectionStatus(A))
                 .isInstanceOf(IllegalStateException.class);
 
-        assertEquals(FAILED, symmetric.getNodeConnectivity("c").getConnectionStatus("a"));
-        assertEquals(OK, symmetric.getNodeConnectivity("c").getConnectionStatus("b"));
-        assertEquals(OK, symmetric.getNodeConnectivity("c").getConnectionStatus("c"));
+        assertEquals(FAILED, symmetric.getNodeConnectivity(C).getConnectionStatus(A));
+        assertEquals(OK, symmetric.getNodeConnectivity(C).getConnectionStatus(B));
+        assertEquals(OK, symmetric.getNodeConnectivity(C).getConnectionStatus(C));
     }
 
     @Test
     public void testDecisionMaker() {
-        NodeConnectivity a = connectivity("a", ImmutableMap.of("a", OK, "b", OK, "c", OK));
-        NodeConnectivity b = connectivity("b", ImmutableMap.of("a", FAILED, "b", OK, "c", OK));
-        NodeConnectivity c = connectivity("c", ImmutableMap.of("a", OK, "b", FAILED, "c", OK));
+        NodeConnectivity a = connectivity(A, ImmutableMap.of(A, OK, B, OK, C, OK));
+        NodeConnectivity b = connectivity(B, ImmutableMap.of(A, FAILED, B, OK, C, OK));
+        NodeConnectivity c = connectivity(C, ImmutableMap.of(A, OK, B, FAILED, C, OK));
 
-        ClusterGraph graph = cluster("a", a, b, c);
+        ClusterGraph graph = cluster(A, a, b, c);
         Optional<NodeRank> decisionMaker = graph.toSymmetric().getDecisionMaker();
 
         assertTrue(decisionMaker.isPresent());
-        assertEquals(decisionMaker.get(), new NodeRank("a", 2));
+        assertEquals(decisionMaker.get(), new NodeRank(A, 2));
     }
 
     @Test
     public void testFailedNode() {
-        NodeConnectivity a = connectivity("a", ImmutableMap.of("a", OK, "b", OK, "c", OK));
-        NodeConnectivity b = connectivity("b", ImmutableMap.of("a", FAILED, "b", OK, "c", OK));
-        NodeConnectivity c = connectivity("c", ImmutableMap.of("a", OK, "b", FAILED, "c", OK));
+        ClusterGraph graph = cluster(
+                A,
+                connectivity(A, ImmutableMap.of(A, OK, B, OK, C, OK)),
+                connectivity(B, ImmutableMap.of(A, FAILED, B, OK, C, OK)),
+                connectivity(C, ImmutableMap.of(A, OK, B, FAILED, C, OK))
+        );
 
-        ClusterGraph graph = cluster("a", a, b, c);
-        Optional<NodeRank> failedNode = graph.toSymmetric().findFailedNode();
-
+        Optional<NodeRank> failedNode = graph.toSymmetric().findFailedNode(Collections.emptyList());
         assertTrue(failedNode.isPresent());
-        assertEquals(failedNode.get(), new NodeRank("b", 1));
+        assertEquals(failedNode.get(), new NodeRank(B, 1));
+
+        failedNode = graph.findFailedNode(Collections.singletonList(B));
+        assertFalse(failedNode.isPresent());
     }
 
     @Test
     public void testFindFullyConnectedResponsiveNodes() {
         ClusterGraph graph = cluster(
-                "a",
-                connectivity("a", ImmutableMap.of("a", OK, "b", FAILED, "c", OK)),
-                unavailable("b"),
-                connectivity("c", ImmutableMap.of("a", OK, "b", FAILED, "c", OK))
+                A,
+                connectivity(A, ImmutableMap.of(A, OK, B, FAILED, C, OK)),
+                unavailable(B),
+                connectivity(C, ImmutableMap.of(A, OK, B, FAILED, C, OK))
         );
         graph = graph.toSymmetric();
 
-        Optional<NodeRank> responsiveNode = graph.findFullyConnectedNode("c", Collections.singletonList("b"));
+        Optional<NodeRank> responsiveNode = graph.findFullyConnectedNode(C, Collections.singletonList(B));
         assertTrue(responsiveNode.isPresent());
-        assertEquals(new NodeRank("c", 2), responsiveNode.get());
+        assertEquals(new NodeRank(C, 2), responsiveNode.get());
 
-        responsiveNode = graph.findFullyConnectedNode("c", Collections.singletonList("c"));
+        responsiveNode = graph.findFullyConnectedNode(C, Collections.singletonList(C));
 
         assertTrue(responsiveNode.isPresent());
-        assertEquals("c", responsiveNode.get().getEndpoint());
+        assertEquals(C, responsiveNode.get().getEndpoint());
         assertEquals(2, responsiveNode.get().getNumConnections());
 
         graph = cluster(
-                "a",
-                connectivity("a", ImmutableMap.of("a", OK, "b", FAILED, "c", OK)),
-                connectivity("b", ImmutableMap.of("a", FAILED, "b", OK, "c", FAILED)),
-                connectivity("c", ImmutableMap.of("a", OK, "b", FAILED, "c", OK))
+                A,
+                connectivity(A, ImmutableMap.of(A, OK, B, FAILED, C, OK)),
+                connectivity(B, ImmutableMap.of(A, FAILED, B, OK, C, FAILED)),
+                connectivity(C, ImmutableMap.of(A, OK, B, FAILED, C, OK))
         );
         graph = graph.toSymmetric();
 
-        responsiveNode = graph.findFullyConnectedNode("c", Collections.singletonList("b"));
+        responsiveNode = graph.findFullyConnectedNode(C, Collections.singletonList(B));
 
         assertTrue(responsiveNode.isPresent());
-        assertEquals(new NodeRank("c", 2), responsiveNode.get());
+        assertEquals(new NodeRank(C, 2), responsiveNode.get());
     }
 
     private NodeState unavailableNodeState(String endpoint) {

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/NodeStateTestUtil.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/NodeStateTestUtil.java
@@ -14,9 +14,12 @@ import java.util.List;
 import java.util.Map;
 
 public class NodeStateTestUtil {
-    private static final List<String> NODE_NAMES = Arrays.asList(
-            "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"
-    );
+
+    private static final List<NodeName> NODE_NAMES = Arrays.asList(NodeName.values());
+
+    public static final String A = NodeName.a.name();
+    public static final String B = NodeName.b.name();
+    public static final String C = NodeName.c.name();
 
     private NodeStateTestUtil() {
         //prevent creating class instances
@@ -25,7 +28,7 @@ public class NodeStateTestUtil {
     public static NodeState nodeState(String endpoint, ConnectionStatus... connectionStates) {
         Map<String, ConnectionStatus> connectivity = new HashMap<>();
         for (int i = 0; i < connectionStates.length; i++) {
-            connectivity.put(NODE_NAMES.get(i), connectionStates[i]);
+            connectivity.put(NODE_NAMES.get(i).name(), connectionStates[i]);
         }
 
         NodeConnectivity nodeConnectivity = NodeConnectivity.builder()
@@ -39,5 +42,9 @@ public class NodeStateTestUtil {
                 .heartbeat(new HeartbeatTimestamp(0, 0))
                 .connectivity(nodeConnectivity)
                 .build();
+    }
+
+    public enum NodeName {
+        a, b, c, d, e, f, g, h, i, j, k
     }
 }


### PR DESCRIPTION
## Overview

Description:
Failed connection(s) between unresponsive and fully connected node(s) can't be used to determine if a fully connected node is failed. 

If a failed node already added in the unresponsive list then a fully connected node can't be added into the unresponsive list because we cannot believe to the cluster state, based on information about the connection between the failed node and fully connected node. 
Which means the failed node is already in the unresponsive list, we don't need to add the fully connected node also into the unresponsive list.  

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
