### PR TITLE
Travis CI Changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,33 +3,24 @@ sudo: required
 dist: trusty
 jdk: oraclejdk8
 
-stages:
-- name: test
-  # Run tests for:
-  # - any branch exclude master branch
-  # - for any PR
-  if: branch != master OR (branch = master AND type = pull_request)
-- name: code_quality
-  if: branch = master AND type != pull_request
-
 before_cache:
 - rm -rf $HOME/.m2/repository/org/corfudb
 
 cache:
   directories:
   - "$HOME/.m2"
-  - "$HOME/.sonar/cache"
 
 before_install: |
   ./mvnw build-helper:parse-version versions:set \
     -DnewVersion=\${parsedVersion.majorVersion}.\${parsedVersion.minorVersion}.\${parsedVersion.incrementalVersion}-${TRAVIS_BUILD_NUMBER} \
     -q
 
+
 install: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -T 1C
 
 jobs:
   include:
-  - stage: test
+  - stage: Tests
     name: Unit Tests
     script:
     - ./mvnw -pl :test clean test -T 1C -Dtest.travisBuild=true
@@ -41,34 +32,15 @@ jobs:
     - ./mvnw -pl infrastructure -DskipTests -Pdocker clean package
     # Run integration tests
     - ./mvnw -pl :universe clean verify -Pit
-    name: Testing Framework Tests
-  - stage: code_quality
-    name: Code Quality
-    script:
-    # Prepare docker image
-    - ./mvnw -pl infrastructure -DskipTests -Pdocker clean package
-    - |
-      ./mvnw verify -Pit sonar:sonar \
-      -Dtest.travisBuild=true \
-      -Dsonar.host.url=https://sonarqube.com \
-      -Dsonar.github.pullRequest=$TRAVIS_PULL_REQUEST \
-      -Dsonar.github.repository=$TRAVIS_REPO_SLUG \
-      -Dsonar.github.oauth=$SONAR_GITHUB_TOKEN \
-      -Dsonar.organization=corfudb \
-      -Dsonar.login=$SONAR_TOKEN \
-      -Dmaven.javadoc.skip=true
-    - bash <(curl -s https://codecov.io/bash)
-    - .travis_scripts/javadocs.sh
+    name: Universe Tests
 
 notifications:
   email:
-  - corfudb-dev@googlegroups.com
-  webhooks:
-    urls:
-    - https://webhooks.gitter.im/e/e26458f01e3586e3c140
-    on_success: always
+    recipients:
+      - corfu-dev@vmware.com
+      - corfudb-dev@googlegroups.com
+    on_success: never
     on_failure: always
-    on_start: true
 
 addons:
   apt:


### PR DESCRIPTION
## Overview
Make travis send email notifications to the corfu-dev mailing lists
when CI fails on the master branch. Also, update the distro to xenial. 

Why should this be merged: Will make it easier to monitor the master branch.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
