### PR TITLE
Log stacktrace on CorfuCompileProxy failures. Access/Update only log …

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -184,7 +184,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 return TransactionalContext.getCurrentContext()
                         .access(this, accessMethod, conflictObject);
             } catch (Exception e) {
-                log.error("Access[{}] Exception: {}", this, e);
+                log.error("Access[{}]", this, e);
                 this.abortTransaction(e);
             }
         }
@@ -237,7 +237,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 return TransactionalContext.getCurrentContext()
                         .logUpdate(this, entry, conflictObject);
             } catch (Exception e) {
-                log.warn("Update[{}] Exception: {}", this, e);
+                log.warn("Update[{}]", this, e);
                 this.abortTransaction(e);
             }
         }


### PR DESCRIPTION
…the exception name omitting the stack trace. We should log both.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
