### PR TITLE
Support retries on TrimmedExceptions for non-tx operations

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -302,28 +302,38 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
             return ret == VersionLockedObject.NullValue.NULL_VALUE ? null : ret;
         }
 
-        try {
-            return underlyingObject.update(o -> {
-                o.syncObjectUnsafe(timestamp);
-                if (o.upcallResults.containsKey(timestamp)) {
-                    log.trace("Upcall[{}] {} Sync'd", this, timestamp);
-                    R ret = (R) o.upcallResults.get(timestamp);
-                    o.upcallResults.remove(timestamp);
-                    return ret == VersionLockedObject.NullValue.NULL_VALUE ? null : ret;
-                }
+        for (int x = 0; x < rt.getParameters().getTrimRetry(); x++) {
+            try {
+                return underlyingObject.update(o -> {
+                    o.syncObjectUnsafe(timestamp);
+                    if (o.upcallResults.containsKey(timestamp)) {
+                        log.trace("Upcall[{}] {} Sync'd", this, timestamp);
+                        R ret = (R) o.upcallResults.get(timestamp);
+                        o.upcallResults.remove(timestamp);
+                        return ret == VersionLockedObject.NullValue.NULL_VALUE ? null : ret;
+                    }
 
-                // The version is already ahead, but we don't have the result.
-                // The only way to get the correct result
-                // of the upcall would be to rollback. For now, we throw an exception
-                // since this is generally not expected. --- and probably a bug if it happens.
-                throw new RuntimeException("Attempted to get the result "
-                        + "of an upcall@" + timestamp + " but we are @"
-                        + underlyingObject.getVersionUnsafe()
-                        + " and we don't have a copy");
-            });
-        } catch (TrimmedException ex) {
-            throw new TrimmedUpcallException(timestamp);
+                    // The version is already ahead, but we don't have the result.
+                    // The only way to get the correct result
+                    // of the upcall would be to rollback. For now, we throw an exception
+                    // since this is generally not expected. --- and probably a bug if it happens.
+                    throw new RuntimeException("Attempted to get the result "
+                            + "of an upcall@" + timestamp + " but we are @"
+                            + underlyingObject.getVersionUnsafe()
+                            + " and we don't have a copy");
+                });
+            } catch (TrimmedException ex) {
+                log.warn("getUpcallResultInner: Encountered a trim exception while accessing version {} on attempt {}",
+                        timestamp, x);
+                // We encountered a TRIM during sync, reset the object
+                underlyingObject.update(o -> {
+                    o.resetUnsafe();
+                    return null;
+                });
+            }
         }
+
+        throw new TrimmedUpcallException(timestamp);
     }
 
     /**


### PR DESCRIPTION
## Overview

Description: retry on trim exceptions for non-tx operations (e.g., remove / put)

Why should this be merged: for non-tx operations we directly throw TrimmedExceptions instead of attempting to rebuild from checkpoint.