### PR TITLE
Introducing non-cacheable reads on log unit server.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -1,27 +1,10 @@
 package org.corfudb.infrastructure;
 
-import com.github.benmanes.caffeine.cache.Caffeine;
-import com.github.benmanes.caffeine.cache.LoadingCache;
-import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.google.common.annotations.VisibleForTesting;
-
 import io.netty.channel.ChannelHandlerContext;
-
-import java.lang.invoke.MethodHandles;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
 import org.corfudb.infrastructure.log.InMemoryStreamLog;
 import org.corfudb.infrastructure.log.StreamLog;
 import org.corfudb.infrastructure.log.StreamLogCompaction;
@@ -52,6 +35,17 @@ import org.corfudb.runtime.exceptions.ValueAdoptedException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.Utils;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import static org.corfudb.infrastructure.BatchWriterOperation.Type.LOG_ADDRESS_SPACE_QUERY;
 import static org.corfudb.infrastructure.BatchWriterOperation.Type.PREFIX_TRIM;
@@ -101,7 +95,7 @@ public class LogUnitServer extends AbstractServer {
      * it is not backed by anything, but in a disk implementation it is backed by persistent
      * storage.
      */
-    private final LoadingCache<Long, ILogData> dataCache;
+    private final LogUnitServerCache dataCache;
     private final StreamLog streamLog;
     private final StreamLogCompaction logCleaner;
     private final BatchProcessor batchWriter;
@@ -141,13 +135,8 @@ public class LogUnitServer extends AbstractServer {
             streamLog = new StreamLogFiles(serverContext, config.isNoVerify());
         }
 
+        dataCache = new LogUnitServerCache(config, streamLog);
         batchWriter = new BatchProcessor(streamLog, serverContext.getServerEpoch(), !config.isNoSync());
-
-        dataCache = Caffeine.newBuilder()
-                .<Long, ILogData>weigher((k, v) -> ((LogData) v).getData() == null ? 1 : ((LogData) v).getData().length)
-                .maximumWeight(config.getMaxCacheSize())
-                .removalListener(this::handleEviction)
-                .build(this::handleRetrieval);
 
         logCleaner = new StreamLogCompaction(streamLog, 10, 45, TimeUnit.MINUTES, ServerContext.SHUTDOWN_TIMER);
     }
@@ -297,16 +286,18 @@ public class LogUnitServer extends AbstractServer {
     }
 
     @ServerHandler(type = CorfuMsgType.READ_REQUEST)
-    private void read(CorfuPayloadMsg<ReadRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
+    public void read(CorfuPayloadMsg<ReadRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
         long address = msg.getPayload().getAddress();
-        log.trace("read: {}", msg.getPayload().getAddress());
+        boolean cacheable = msg.getPayload().isCacheReadResult();
+        log.trace("read: {}, cacheable: {}", msg.getPayload().getAddress(), cacheable);
+
         ReadResponse rr = new ReadResponse();
         try {
-            ILogData e = dataCache.get(address);
-            if (e == null) {
+            ILogData logData = dataCache.get(address, cacheable);
+            if (logData == null) {
                 rr.put(address, LogData.getEmpty(address));
             } else {
-                rr.put(address, (LogData) e);
+                rr.put(address, (LogData) logData);
             }
             r.sendResponse(ctx, msg, CorfuMsgType.READ_RESPONSE.payloadMsg(rr));
         } catch (DataCorruptionException e) {
@@ -315,17 +306,18 @@ public class LogUnitServer extends AbstractServer {
     }
 
     @ServerHandler(type = CorfuMsgType.MULTIPLE_READ_REQUEST)
-    private void multiRead(CorfuPayloadMsg<MultipleReadRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
-        log.trace("multiRead: {}", msg.getPayload().getAddresses());
+    public void multiRead(CorfuPayloadMsg<MultipleReadRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
+        boolean cacheable = msg.getPayload().isCacheReadResult();
+        log.trace("multiRead: {}, cacheable: {}", msg.getPayload().getAddresses(), cacheable);
 
         ReadResponse rr = new ReadResponse();
         try {
-            for (Long l : msg.getPayload().getAddresses()) {
-                ILogData e = dataCache.get(l);
-                if (e == null) {
-                    rr.put(l, LogData.getEmpty(l));
+            for (Long address : msg.getPayload().getAddresses()) {
+                ILogData logData = dataCache.get(address, cacheable);
+                if (logData == null) {
+                    rr.put(address, LogData.getEmpty(address));
                 } else {
-                    rr.put(l, (LogData) e);
+                    rr.put(address, (LogData) logData);
                 }
             }
             r.sendResponse(ctx, msg, CorfuMsgType.READ_RESPONSE.payloadMsg(rr));
@@ -429,25 +421,7 @@ public class LogUnitServer extends AbstractServer {
         }
     }
 
-    /**
-     * Retrieve the LogUnitEntry from disk, given an address.
-     *
-     * @param address The address to retrieve the entry from.
-     * @return The log unit entry to retrieve into the cache.
-     * <p>
-     * This function should not care about trimmed addresses, as that is handled in
-     * the read() and append(). Any address that cannot be retrieved should be returned as
-     * unwritten (null).
-     */
-    private ILogData handleRetrieval(long address) {
-        LogData entry = streamLog.read(address);
-        log.trace("Retrieved[{} : {}]", address, entry);
-        return entry;
-    }
 
-    private void handleEviction(long address, ILogData entry, RemovalCause cause) {
-        log.trace("Eviction[{}]: {}", address, cause);
-    }
 
     /**
      * Shutdown the server.
@@ -460,7 +434,7 @@ public class LogUnitServer extends AbstractServer {
     }
 
     @VisibleForTesting
-    public LoadingCache<Long, ILogData> getDataCache() {
+    public LogUnitServerCache getDataCache() {
         return dataCache;
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServerCache.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServerCache.java
@@ -1,0 +1,109 @@
+package org.corfudb.infrastructure;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.google.common.annotations.VisibleForTesting;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.LogUnitServer.LogUnitServerConfig;
+import org.corfudb.infrastructure.log.StreamLog;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.LogData;
+
+/**
+ * LogUnit server cache.
+ * <p>
+ * All reads and writes go through this cache. But in some cases, messages can
+ * specify non-cacheable read/write, then they will not go through this cache.
+ * <p>
+ * Created by WenbinZhu on 5/30/19.
+ */
+@Slf4j
+public class LogUnitServerCache {
+
+    private final LoadingCache<Long, ILogData> dataCache;
+    private final StreamLog streamLog;
+
+    public LogUnitServerCache(LogUnitServerConfig config, StreamLog streamLog) {
+        this.streamLog = streamLog;
+        this.dataCache = Caffeine.newBuilder()
+                .<Long, ILogData>weigher((addr, logData) -> logData.getSizeEstimate())
+                .maximumWeight(config.getMaxCacheSize())
+                .removalListener(this::handleEviction)
+                .build(this::handleRetrieval);
+    }
+
+    /**
+     * Retrieves the LogUnitEntry from disk, given an address.
+     *
+     * @param address the address to retrieve the entry from
+     * @return the log unit entry to retrieve into the cache
+     * <p>
+     * This function should not care about trimmed addresses, as that is handled
+     * in the streamLog. Any address that cannot be retrieved should be returned
+     * as un-written (null).
+     */
+    private ILogData handleRetrieval(long address) {
+        LogData entry = streamLog.read(address);
+        log.trace("handleRetrieval: Retrieved[{} : {}]", address, entry);
+        return entry;
+    }
+
+    private void handleEviction(long address, ILogData entry, RemovalCause cause) {
+        log.trace("handleEviction: Eviction[{}]: {}", address, cause);
+    }
+
+    /**
+     * Returns the log entry form the cache or retrieves it from the underlying storage.
+     * <p>
+     * If the log entry is not cacheable and it does not exist in cache, it will not be
+     * cached when retrieved from the underlying storage.
+     *
+     * @param address   the address of the log entry to retrieve
+     * @param cacheable if the log entry should be cached when retrieved from underlying storage
+     * @return the log entry read from cache or retrieved the underlying storage
+     */
+    public ILogData get(long address, boolean cacheable) {
+        if (!cacheable) {
+            ILogData ld = dataCache.getIfPresent(address);
+            return ld != null ? ld : handleRetrieval(address);
+        }
+
+        return dataCache.get(address);
+    }
+
+    /**
+     * Returns the log entry form the cache or retrieves it from the underlying storage.
+     *
+     * @param address the address of the log entry to retrieve
+     * @return the log entry read from cache or retrieved the underlying storage
+     */
+    public ILogData get(long address) {
+        return get(address, true);
+    }
+
+    /**
+     * Puts the log entry into the cache.
+     * {@link LoadingCache#put(Object, Object)}
+     *
+     * @param address the address to write entry to
+     * @param entry   the log entry to write
+     */
+    public void put(long address, ILogData entry) {
+        log.trace("LogUnitServerCache.put: Cache write[{} : {}]", address, entry);
+        dataCache.put(address, entry);
+    }
+
+    /**
+     * Discards all the entries in the cache.
+     * {@link LoadingCache#invalidateAll()}
+     */
+    public void invalidateAll() {
+        dataCache.invalidateAll();
+    }
+
+    @VisibleForTesting
+    public int getSize() {
+        return dataCache.asMap().size();
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/StateTransfer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/StateTransfer.java
@@ -197,8 +197,8 @@ public class StateTransfer {
 
         long ts1 = System.currentTimeMillis();
 
-        Map<Long, ILogData> dataMap = runtime.getAddressSpaceView()
-                .fetchAll(chunk, true);
+        // Don't cache the read results on server for state transfer.
+        Map<Long, ILogData> dataMap = runtime.getAddressSpaceView().nonCacheFetchAll(chunk, true);
 
         long ts2 = System.currentTimeMillis();
 
@@ -215,8 +215,7 @@ public class StateTransfer {
         }
 
         try {
-
-            // Write segment chunk to the new logunit
+            // Write segment chunk to the new log unit
             ts1 = System.currentTimeMillis();
             boolean transferSuccess = CFUtils.getUninterruptibly(runtime.getLayoutView()
                     .getRuntimeLayout(layout)

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -109,9 +109,7 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      *
      * @return An estimate on the size of this object, in bytes.
      */
-    default int getSizeEstimate() {
-        return 1; // The default is that we don't know, so we return 1.
-    }
+    int getSizeEstimate();
 
     /** Return whether the entry represents a hole or not. */
     default boolean isHole() {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/MultipleReadRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/MultipleReadRequest.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -13,11 +12,15 @@ import java.util.List;
  *
  * Created by maithem on 7/28/17.
  */
-@Data
+@Getter
 @AllArgsConstructor
 public class MultipleReadRequest implements ICorfuPayload<MultipleReadRequest> {
-    @Getter
-    final List<Long> addresses;
+
+    // List of requested addresses to read.
+    private final List<Long> addresses;
+
+    // Whether the read results should be cached on server.
+    private final boolean cacheReadResult;
 
     /**
      * Deserialization Constructor from ByteBuf to ReadRequest.
@@ -26,14 +29,12 @@ public class MultipleReadRequest implements ICorfuPayload<MultipleReadRequest> {
      */
     public MultipleReadRequest(ByteBuf buf) {
         addresses = ICorfuPayload.listFromBuffer(buf, Long.class);
-    }
-
-    public MultipleReadRequest(Long address) {
-        addresses = Collections.singletonList(address);
+        cacheReadResult = buf.readBoolean();
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, addresses);
+        buf.writeBoolean(cacheReadResult);
     }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ReadRequest.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ReadRequest.java
@@ -3,16 +3,20 @@ package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.Getter;
 
 /**
  * Created by mwei on 8/11/16.
  */
-@Data
+@Getter
 @AllArgsConstructor
 public class ReadRequest implements ICorfuPayload<ReadRequest> {
 
-    final long address;
+    // Requested address to read.
+    private final long address;
+
+    // Whether the read result should be cached on server.
+    private final boolean cacheReadResult;
 
     /**
      * Deserialization Constructor from ByteBuf to ReadRequest.
@@ -21,11 +25,13 @@ public class ReadRequest implements ICorfuPayload<ReadRequest> {
      */
     public ReadRequest(ByteBuf buf) {
         address = buf.readLong();
+        cacheReadResult = buf.readBoolean();
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
         buf.writeLong(address);
+        buf.writeBoolean(cacheReadResult);
     }
 
 }

--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -38,7 +38,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -743,9 +742,11 @@ public class FastObjectLoader {
                 final long lower = nextRead;
                 final long upper = Math.min(lower + batchReadSize - 1, logTail);
                 nextRead = upper + 1;
-                Map<Long, ILogData> range =
-                        runtime.getAddressSpaceView().fetchAll(ContiguousSet.create(
-                                Range.closed(lower, upper), DiscreteDomain.longs()), true);
+
+                // Don't cache the read results on server for fast loader
+                ContiguousSet<Long> addresses = ContiguousSet.create(
+                        Range.closed(lower, upper), DiscreteDomain.longs());
+                Map<Long, ILogData> range = runtime.getAddressSpaceView().nonCacheFetchAll(addresses, true);
 
                 // Sanity
                 for (Map.Entry<Long, ILogData> entry : range.entrySet()) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ChainReplicationProtocol.java
@@ -90,13 +90,15 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
      * @param runtimeLayout runtime layout.
      * @param addresses     list of addresses to read.
      * @param waitForWrite  flag whether wait for write is required or hole fill directly.
+     * @param cacheOnServer flag whether the fetch results should be cached on log unit server.
      * @return Map of read addresses.
      */
     @Override
     @Nonnull
     public Map<Long, ILogData> readAll(RuntimeLayout runtimeLayout,
                                        List<Long> addresses,
-                                       boolean waitForWrite) {
+                                       boolean waitForWrite,
+                                       boolean cacheOnServer) {
 
         // A map of log unit server endpoint to addresses it's responsible for
         Map<String, List<Long>> serverAddressMap = new HashMap<>();
@@ -110,7 +112,8 @@ public class ChainReplicationProtocol extends AbstractReplicationProtocol {
 
         // Send read requests to log unit servers in parallel
         List<CompletableFuture<ReadResponse>> futures = serverAddressMap.entrySet().stream()
-                .map(entry -> runtimeLayout.getLogUnitClient(entry.getKey()).readAll(entry.getValue()))
+                .map(entry -> runtimeLayout.getLogUnitClient(entry.getKey())
+                        .readAll(entry.getValue(), cacheOnServer))
                 .collect(Collectors.toList());
 
         // Merge the read responses from different log unit servers

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/IReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/IReplicationProtocol.java
@@ -66,10 +66,14 @@ public interface IReplicationProtocol {
      * @param runtimeLayout the RuntimeLayout stamped with layout to use for the read.
      * @param addresses     a list of addresses to read from.
      * @param waitForWrite  flag whether wait for write is required or hole fill directly.
+     * @param cacheOnServer whether the fetch results should be cached on log unit server.
      * @return a map of addresses to data commit at these address, hole filling if necessary.
      */
     @Nonnull
-    Map<Long, ILogData> readAll(RuntimeLayout runtimeLayout, List<Long> addresses, boolean waitForWrite);
+    Map<Long, ILogData> readAll(RuntimeLayout runtimeLayout,
+                                List<Long> addresses,
+                                boolean waitForWrite,
+                                boolean cacheOnServer);
 
     /**
      * Peek data from a given address.

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocol.java
@@ -109,7 +109,8 @@ public class QuorumReplicationProtocol extends AbstractReplicationProtocol {
     @Nonnull
     public Map<Long, ILogData> readAll(RuntimeLayout runtimeLayout,
                                        List<Long> addresses,
-                                       boolean waitForWrite) {
+                                       boolean waitForWrite,
+                                       boolean cacheOnServer) {
         // TODO: replace this naive implementation
         return addresses.stream()
                 .map(addr -> new SimpleImmutableEntry<>(addr, read(runtimeLayout, addr)))

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -1,20 +1,6 @@
 package org.corfudb.runtime.view.stream;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableSet;
-import java.util.Optional;
-import java.util.TreeSet;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
-
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Range;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
@@ -29,9 +15,18 @@ import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.RuntimeLayout;
-import org.corfudb.runtime.view.replication.ChainReplicationProtocol;
 import org.corfudb.util.Utils;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Optional;
+import java.util.TreeSet;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 /** The abstract queued stream view implements a stream backed by a read queue.

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitCacheTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitCacheTest.java
@@ -1,0 +1,103 @@
+package org.corfudb.infrastructure;
+
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.MultipleReadRequest;
+import org.corfudb.protocols.wireprotocol.RangeWriteMsg;
+import org.corfudb.protocols.wireprotocol.ReadResponse;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.infrastructure.LogUnitServerAssertions.assertThat;
+import static org.corfudb.infrastructure.LogUnitServerTest.waitForLogUnit;
+
+/**
+ * Created by WenbinZhu on 5/30/19.
+ */
+public class LogUnitCacheTest extends AbstractServerTest {
+
+    private static final double MIN_HEAP_RATIO = 0.1;
+    private static final double MAX_HEAP_RATIO = 0.9;
+
+    @Override
+    public AbstractServer getDefaultServer() {
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+
+        return new LogUnitServer(new ServerContextBuilder()
+                .setLogPath(serviceDir)
+                .setMemory(false)
+                .build());
+    }
+
+    /**
+     * Test non-cacheable reads on log unit sever will not affect server cache.
+     */
+    @Test
+    public void checkNonCacheableReads() throws Exception {
+        final int size = 10;
+        final long start = 0L;
+        final long end = start + size;
+
+        LogUnitServer logUnitServer = (LogUnitServer) getDefaultServer();
+        setServer(logUnitServer);
+
+        List<Long> addresses = LongStream.range(start, end).boxed().collect(Collectors.toList());
+        List<LogData> payloads = new ArrayList<>();
+
+        for (long i = start; i < end; i++) {
+            LogData logData = new LogData(DataType.DATA, new Object());
+            logData.setGlobalAddress(i);
+            payloads.add(logData);
+        }
+
+        // Range write is not cached on server.
+        sendMessage(CorfuMsgType.RANGE_WRITE.payloadMsg(new RangeWriteMsg(payloads)));
+        waitForLogUnit(logUnitServer);
+
+        // Non-cacheable reads should not affect the data cache on server.
+        sendMessage(CorfuMsgType.MULTIPLE_READ_REQUEST.payloadMsg(new MultipleReadRequest(addresses, false)));
+        waitForLogUnit(logUnitServer);
+
+        checkReadResponse(getLastPayloadMessageAs(ReadResponse.class), size);
+        assertThat(logUnitServer.getDataCache().getSize()).isEqualTo(0);
+
+        // Cacheable reads should update the data cache on server.
+        sendMessage(CorfuMsgType.MULTIPLE_READ_REQUEST.payloadMsg(new MultipleReadRequest(addresses, true)));
+        waitForLogUnit(logUnitServer);
+
+        checkReadResponse(getLastPayloadMessageAs(ReadResponse.class), size);
+        assertThat(logUnitServer.getDataCache().getSize()).isEqualTo(size);
+    }
+
+    private void checkReadResponse(ReadResponse readResponse, int size) {
+        assertThat(readResponse.getAddresses().size()).isEqualTo(size);
+
+        readResponse.getAddresses().forEach((addr, ld) -> {
+            assertThat(ld).isNotNull();
+        });
+    }
+
+    /**
+     * Test maximum server cache size is correctly set.
+     */
+    @Test
+    public void CheckMaxCacheSizeIsCorrectRatio() {
+        Random r = new Random(System.currentTimeMillis());
+        double randomCacheRatio = MIN_HEAP_RATIO + (MAX_HEAP_RATIO - MIN_HEAP_RATIO) * r.nextDouble();
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+        LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
+                .setLogPath(serviceDir)
+                .setMemory(false)
+                .setCacheSizeHeapRatio(String.valueOf(randomCacheRatio))
+                .build());
+
+        assertThat(s1).hasMaxCorrectCacheSize(randomCacheRatio);
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerAssertions.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerAssertions.java
@@ -75,7 +75,7 @@ public class LogUnitServerAssertions extends AbstractAssert<LogUnitServerAsserti
         return this;
     }
 
-    public LogUnitServerAssertions hasCorrectCacheSize(double ratio) {
+    public LogUnitServerAssertions hasMaxCorrectCacheSize(double ratio) {
         long maxHeapSize = Runtime.getRuntime().maxMemory();
         if(actual.getMaxCacheSize() != (long) (maxHeapSize * ratio)) {
             failWithMessage("Expected cache size <%d> doesn't match allocated cache size <%d>",

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -34,20 +34,17 @@ import static org.junit.Assert.fail;
  */
 public class LogUnitServerTest extends AbstractServerTest {
 
-    private static final double minHeapRatio = 0.1;
-    private static final double maxHeapRatio = 0.9;
-
     @Override
     public AbstractServer getDefaultServer() {
         return new LogUnitServer(new ServerContextBuilder().build());
     }
 
     /**
-     * Waits for the logunit batch writer to drain the operation queue and
+     * Waits for the log unit batch writer to drain the operation queue and
      * reply to all requests.
-     * @param lu logunit to wait for
+     * @param lu log unit to wait for
      */
-    private void waitForLogUnit(LogUnitServer lu) throws Exception {
+    static void waitForLogUnit(LogUnitServer lu) throws Exception {
         lu.getBatchWriter().stopProcessor();
         lu.getBatchWriter().startProcessor();
         lu.stopHandler();
@@ -537,22 +534,6 @@ public class LogUnitServerTest extends AbstractServerTest {
         assertThat(s2)
                 .matchesDataAtAddress(ADDRESS_0, "1".getBytes());
 
-    }
-
-    @Test
-    public void CheckCacheSizeIsCorrectRatio() throws Exception {
-
-        Random r = new Random(System.currentTimeMillis());
-        double randomCacheRatio = minHeapRatio + (maxHeapRatio - minHeapRatio) * r.nextDouble();
-        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
-        LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
-                .setLogPath(serviceDir)
-                .setMemory(false)
-                .setCacheSizeHeapRatio(String.valueOf(randomCacheRatio))
-                .build());
-
-
-        assertThat(s1).hasCorrectCacheSize(randomCacheRatio);
     }
 }
 

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -211,14 +211,14 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         serverRouter.reset();
         serverRouter.addServer(server2);
 
-        assertThat(server2.getDataCache().asMap().size()).isEqualTo(0);
+        assertThat(server2.getDataCache().getSize()).isEqualTo(0);
         byte[] testString = "hello world".getBytes();
         client.write(0, null, testString, Collections.emptyMap()).get();
-        assertThat(server2.getDataCache().asMap().size()).isEqualTo(1);
+        assertThat(server2.getDataCache().getSize()).isEqualTo(1);
         client.flushCache().get();
-        assertThat(server2.getDataCache().asMap().size()).isEqualTo(0);
+        assertThat(server2.getDataCache().getSize()).isEqualTo(0);
         LogData r = client.read(0).get().getAddresses().get(0L);
-        assertThat(server2.getDataCache().asMap().size()).isEqualTo(1);
+        assertThat(server2.getDataCache().getSize()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## Overview

- For batch read scenarios like state transfer and fast loader, caching
the read results on log unit server would pollute the cache. This patch
adds the capability of not caching the read results in these situations.

- Separates log unit cache into a new class for more readability and
    testability.

Why should this be merged: 
Improve performance on log unit server by preventing cache pollution.

Related issue(s) (if applicable): #1841 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
