### PR TITLE
Huge performance impact. Avoid reading entire segment while building address space index

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -52,6 +52,7 @@ message Metadata {
     required sfixed32 payload_checksum = 1;
     required sfixed32 length_checksum = 2;
     required sfixed32 length = 3;
+    optional sfixed64 global_address = 4;
 }
 
 message TrimEntry {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/AddressMetaData.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/AddressMetaData.java
@@ -4,6 +4,7 @@ package org.corfudb.infrastructure.log;
  * Created by maithem on 3/14/17.
  */
 public class AddressMetaData {
+    public final long globalAddress;
     public final int checksum;
     public final int length;
     public final long offset;
@@ -15,7 +16,8 @@ public class AddressMetaData {
      * @param length    length of log data
      * @param offset    file channel offset
      **/
-    public AddressMetaData(int checksum, int length, long offset) {
+    public AddressMetaData(long globalAddress, int checksum, int length, long offset) {
+        this.globalAddress = globalAddress;
         this.checksum = checksum;
         this.length = length;
         this.offset = offset;


### PR DESCRIPTION
## Overview

Description:
When corfu starts it goes through all the segments and builds the address space index for each segment. To build the index it loads all entire database (all the data from disk into memory). 
Also when any segment needs to be loaded we build the index it also loads the entire segment into memory just to build the index. 

Why should this be merged: 
Building index - loads all the data, it dramatically affects performance. 
Adding globalAddress into the index will reduce the data load by 95% when building the index. 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
