### PR TITLE
Hex to table name fix in vlo

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -18,7 +18,7 @@ public class CorfuCompileWrapperBuilder {
      *
      * @param type       Type of SMR object.
      * @param rt         Connected instance of the CorfuRuntime.
-     * @param streamID   StreamID of the SMR Object.
+     * @param streamId   StreamID of the SMR Object.
      * @param args       Arguments passed to instantiate the object.
      * @param serializer Serializer to be used to serialize the object arguments.
      * @param <T>        Type
@@ -27,10 +27,9 @@ public class CorfuCompileWrapperBuilder {
      * @throws IllegalAccessException Illegal Access to the Object.
      * @throws InstantiationException Cannot instantiate the object using the arguments and class.
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+    @SuppressWarnings("checkstyle:abbreviation")
     public static <T> T getWrapper(Class<T> type, CorfuRuntime rt,
-                                   UUID streamID, Object[] args,
+                                   StreamId streamId, Object[] args,
                                    ISerializer serializer)
             throws ClassNotFoundException, IllegalAccessException,
             InstantiationException {
@@ -59,7 +58,7 @@ public class CorfuCompileWrapperBuilder {
 
         // Now we create the proxy, which actually manages
         // instances of this object. The wrapper delegates calls to the proxy.
-        wrapperObject.setCorfuSMRProxy(new CorfuCompileProxy<>(rt, streamID,
+        wrapperObject.setCorfuSMRProxy(new CorfuCompileProxy<>(rt, streamId,
                 type, args, serializer,
                 wrapperObject.getCorfuSMRUpcallMap(),
                 wrapperObject.getCorfuUndoMap(),

--- a/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
@@ -71,9 +71,7 @@ public interface ISMRStream {
      *
      * @return The UUID for this stream.
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
-    default UUID getID() {
-        return new UUID(0L, 0L);
-    }
+    @SuppressWarnings("checkstyle:abbreviation")
+    UUID getID();
+
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamId.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamId.java
@@ -1,0 +1,56 @@
+package org.corfudb.runtime.object;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.util.Utils;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@EqualsAndHashCode
+@ToString
+public class StreamId {
+    @Getter
+    private final UUID id;
+
+    private final Optional<String> name;
+
+    /**
+     * @param id id of the stream
+     */
+    private StreamId(UUID id, Optional<String> name) {
+        this.name = name;
+        this.id = id;
+    }
+
+    /**
+     * Either of the variables should be defined to create a streamId.
+     *
+     * @param streamName name of a stream
+     * @param uuid       id of a stream
+     * @return streamId object
+     * @throws IllegalStateException exception if none are defined
+     */
+    public static StreamId build(Optional<String> streamName, Optional<UUID> uuid) {
+        StreamId streamId;
+
+        if (streamName.isPresent() && uuid.isPresent()) {
+            streamId = new StreamId(uuid.get(), streamName);
+        } else if (streamName.isPresent()) {
+            UUID id = CorfuRuntime.getStreamID(streamName.get());
+            streamId = new StreamId(id, streamName);
+        } else if (uuid.isPresent()) {
+            streamId = new StreamId(uuid.get(), streamName);
+        } else {
+            throw new IllegalArgumentException("Either uuid or streamName should be defined");
+        }
+
+        return streamId;
+    }
+
+    public String getName() {
+        return name.orElse(Utils.toReadableId(id));
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
+import lombok.Getter;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.ISMRConsumable;
 import org.corfudb.protocols.logprotocol.SMREntry;
@@ -44,10 +45,18 @@ public class StreamViewSMRAdapter implements ISMRStream {
      */
     final CorfuRuntime runtime;
 
+    /**
+     * Name of the wrapped stream.
+     */
+    @Getter
+    private final StreamId streamId;
+
+
     public StreamViewSMRAdapter(CorfuRuntime runtime,
-                                IStreamView streamView) {
+                                IStreamView streamView, StreamId streamId) {
         this.runtime = runtime;
         this.streamView = streamView;
+        this.streamId = streamId;
     }
 
     private List<SMREntry> dataAndCheckpointMapper(ILogData logData) {
@@ -112,7 +121,7 @@ public class StreamViewSMRAdapter implements ISMRStream {
      * Returns the list of SMREntries positioned at the previous log position of this stream.
      *
      * @return Returns the list of SMREntries positioned at the previous log position of this
-     *     stream.
+     * stream.
      */
     public List<SMREntry> previous() {
         ILogData data = streamView.previous();

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -11,7 +11,6 @@ import org.corfudb.runtime.object.transactions.WriteSetSMRStream;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.MetricsUtils;
-import org.corfudb.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +80,7 @@ public class VersionLockedObject<T> {
     /**
      * The stream view this object is backed by.
      */
-    private final ISMRStream smrStream;
+    private final StreamViewSMRAdapter smrStream;
 
     /**
      * The optimistic SMR stream on this object, if any.
@@ -474,11 +473,10 @@ public class VersionLockedObject<T> {
     @Override
     public String toString() {
         WriteSetSMRStream optimisticStream = this.optimisticStream;
-
-        return object.getClass().getSimpleName()
-                + "[" + Utils.toReadableId(smrStream.getID()) + "]@"
-                + (getVersionUnsafe() == Address.NEVER_READ ? "NR" : getVersionUnsafe())
-                + (optimisticStream == null ? "" : "+" + optimisticStream.pos());
+        return object.getClass().getSimpleName() +
+                "[" + smrStream.getStreamId().getName() + "]@" +
+                (getVersionUnsafe() == Address.NEVER_READ ? "NR" : getVersionUnsafe()) +
+                (optimisticStream == null ? "" : "+" + optimisticStream.pos());
     }
 
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.view;
 import com.google.common.reflect.TypeToken;
 
 import java.util.EnumSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -14,12 +15,12 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.CorfuCompileWrapperBuilder;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.IObjectBuilder;
+import org.corfudb.runtime.object.StreamId;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
 
@@ -94,20 +95,22 @@ public class ObjectBuilder<T> implements IObjectBuilder<T> {
     @SuppressWarnings("unchecked")
     public T open() {
 
-        if (streamName != null) {
-            streamID = CorfuRuntime.getStreamID(streamName);
-        }
-
         try {
+            StreamId streamIdentity = StreamId.build(
+                    Optional.ofNullable(streamName),
+                    Optional.ofNullable(streamID)
+            );
+
             if (options.contains(ObjectOpenOptions.NO_CACHE)) {
-                return CorfuCompileWrapperBuilder.getWrapper(type, runtime, streamID,
-                        arguments, serializer);
+                return CorfuCompileWrapperBuilder.getWrapper(
+                        type, runtime, streamIdentity, arguments, serializer
+                );
             } else {
-                ObjectsView.ObjectID<T> oid = new ObjectsView.ObjectID(streamID, type);
+                ObjectsView.ObjectID<T> oid = new ObjectsView.ObjectID(streamIdentity.getId(), type);
                 return (T) runtime.getObjectsView().objectCache.computeIfAbsent(oid, x -> {
                             try {
                                 T result = CorfuCompileWrapperBuilder.getWrapper(type, runtime,
-                                        streamID, arguments, serializer);
+                                        streamIdentity, arguments, serializer);
 
                                 // Get object serializer to check if we didn't attempt to set another serializer
                                 // to an already existing map

--- a/runtime/src/test/java/org/corfudb/runtime/object/StreamIdTest.java
+++ b/runtime/src/test/java/org/corfudb/runtime/object/StreamIdTest.java
@@ -1,0 +1,37 @@
+package org.corfudb.runtime.object;
+
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.util.Utils;
+import org.junit.Test;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.Assert.*;
+
+public class StreamIdTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBuildIllegalArguments() {
+        StreamId.build(Optional.empty(), Optional.empty());
+    }
+
+    @Test
+    public void testBuildValidArguments() {
+        String streamName = "test";
+        String id = "098f6bcd-4621-3373-8ade-4e832627b4f6";
+        UUID uuid = CorfuRuntime.getStreamID(streamName);
+
+        StreamId streamId = StreamId.build(Optional.of(streamName), Optional.empty());
+        assertEquals(streamName, streamId.getName());
+        assertEquals(UUID.fromString(id), streamId.getId());
+
+        streamId = StreamId.build(Optional.empty(), Optional.of(uuid));
+        assertEquals(Utils.toReadableId(uuid), streamId.getName());
+        assertEquals(uuid, streamId.getId());
+
+        streamId = StreamId.build(Optional.of(streamName), Optional.of(uuid));
+        assertEquals(streamName, streamId.getName());
+        assertEquals(uuid, streamId.getId());
+    }
+}


### PR DESCRIPTION
## Overview

Description:
When VersionLockedObject's functions throw exceptions, it is not clear looking at the logs during which table the exception is seen. Original stream name should be preserved in that case. 

Why should this be merged: 
It is easier to link the VLO failures to a particular table.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
