### PR TITLE
Add SMRRecordLocator

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRLogEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRLogEntry.java
@@ -1,8 +1,7 @@
 package org.corfudb.protocols.logprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
+
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRRecord.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRRecord.java
@@ -10,12 +10,15 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.NonNull;
 
+
+import java.util.Arrays;
+
+
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
 
-import java.util.Arrays;
 
 /**
  * Created by mwei on 1/8/16.

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRRecordLocator.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRRecordLocator.java
@@ -1,0 +1,59 @@
+package org.corfudb.protocols.logprotocol;
+
+import io.netty.buffer.ByteBuf;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NonNull;
+
+import org.corfudb.util.serializer.ICorfuSerializable;
+
+import java.util.UUID;
+
+
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@Getter
+@Setter
+public class SMRRecordLocator implements Comparable<SMRRecordLocator>, ICorfuSerializable {
+    private long globalAddress;
+    private UUID streamId;
+    private int index;
+
+    public void serialize(ByteBuf buf) {
+        buf.writeLong(globalAddress);
+        buf.writeLong(streamId.getMostSignificantBits());
+        buf.writeLong(streamId.getLeastSignificantBits());
+        buf.writeInt(index);
+    }
+
+
+    static public SMRRecordLocator deserialize(ByteBuf buf) {
+        SMRRecordLocator smrRecordLocator = new SMRRecordLocator();
+
+        smrRecordLocator.setGlobalAddress(buf.readLong());
+        long mostSignificantBits = buf.readLong();
+        long leastSignificantBits = buf.readLong();
+        smrRecordLocator.setStreamId(new UUID(mostSignificantBits, leastSignificantBits));
+        smrRecordLocator.setIndex(buf.readInt());
+
+        return smrRecordLocator;
+    }
+
+    public int compareTo(@NonNull SMRRecordLocator other) {
+        if (globalAddress != other.globalAddress) {
+            return Long.compare(globalAddress, other.getGlobalAddress());
+        }
+        if (!streamId.equals(other.getStreamId())) {
+            throw new IllegalArgumentException("Can't compare SMRRecordLocator of different streams");
+        }
+
+        return Integer.compare(index, other.getIndex());
+    }
+}

--- a/runtime/src/test/java/org/corfudb/protocols/logprotocol/SMRRecordLocatorTest.java
+++ b/runtime/src/test/java/org/corfudb/protocols/logprotocol/SMRRecordLocatorTest.java
@@ -1,0 +1,30 @@
+package org.corfudb.protocols.logprotocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.corfudb.runtime.view.Address;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by Xin Li on 05/23/19.
+ */
+public class SMRRecordLocatorTest {
+    @Test
+    public void testSMRRecordLocatorSerializeDeserialize() {
+
+        long globalAddress = Address.getMinAddress();
+        UUID steramId = UUID.randomUUID();
+        int index = 0;
+        SMRRecordLocator locator = new SMRRecordLocator(globalAddress, steramId, index);
+
+        ByteBuf buf = Unpooled.buffer();
+        locator.serialize(buf);
+        SMRRecordLocator deserializedLocator = SMRRecordLocator.deserialize(buf);
+
+        assertEquals(locator, deserializedLocator);
+    }
+}


### PR DESCRIPTION
## Overview

Description:

SMRRecordLocator is used to denote the location of a SMRRecord in the global SpaceAddressView.

Why should this be merged: 

SMRRecordLocator will be used by GC to denote the where the garbage is in the global SpaceAddressView. It could also be used by runtime to retrieve data from LogUnit. 
