### PR TITLE
ICorfuPayload supports nested containers

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DetectorMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DetectorMsg.java
@@ -1,5 +1,6 @@
 package org.corfudb.protocols.wireprotocol;
 
+import com.google.common.reflect.TypeToken;
 import io.netty.buffer.ByteBuf;
 
 import java.util.Set;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TxResolutionInfo.java
@@ -2,6 +2,7 @@ package org.corfudb.protocols.wireprotocol;
 
 import com.google.common.collect.ImmutableMap;
 
+import com.google.common.reflect.TypeToken;
 import io.netty.buffer.ByteBuf;
 
 import java.util.Collections;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/failuredetector/FailureDetectorMetrics.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/failuredetector/FailureDetectorMetrics.java
@@ -1,5 +1,6 @@
 package org.corfudb.protocols.wireprotocol.failuredetector;
 
+import com.google.common.reflect.TypeToken;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/runtime/src/test/java/org/corfudb/protocols/wireprotocol/ICorfuPayloadTest.java
+++ b/runtime/src/test/java/org/corfudb/protocols/wireprotocol/ICorfuPayloadTest.java
@@ -1,5 +1,7 @@
 package org.corfudb.protocols.wireprotocol;
 
+import com.google.common.collect.Lists;
+import com.google.common.reflect.TypeToken;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.corfudb.protocols.logprotocol.CheckpointEntry.CheckpointEntryType;
@@ -7,11 +9,7 @@ import org.corfudb.protocols.wireprotocol.IMetadata.DataRank;
 import org.corfudb.runtime.view.Layout;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
@@ -29,7 +27,7 @@ public class ICorfuPayloadTest {
     }
 
     @Test
-    public void testBuildPayloadFromBuffer(){
+    public void testBuildPayloadFromBuffer() {
         final int value = 12345;
         ByteBuf payload = Unpooled.buffer().writeInt(value);
         Integer result = ICorfuPayload.fromBuffer(payload, Integer.class);
@@ -38,7 +36,7 @@ public class ICorfuPayloadTest {
     }
 
     @Test
-    public void testSerialize(){
+    public void testSerialize() {
         ByteBuf buf = Unpooled.buffer();
 
         Set<String> payload = new HashSet<>();
@@ -48,6 +46,37 @@ public class ICorfuPayloadTest {
         ICorfuPayload.serialize(buf, payload);
 
         assertThat(ICorfuPayload.setFromBuffer(buf, String.class)).isEqualTo(payload);
+    }
+
+    @Test
+    public void testListSerialize() {
+        ByteBuf buf = Unpooled.buffer();
+
+        List<String> payload = new ArrayList<>();
+        payload.add("value1");
+        payload.add("value2");
+
+        ICorfuPayload.serialize(buf, payload);
+
+        List<String> deserializedList = ICorfuPayload.fromBuffer(buf, new TypeToken<List<String>>(){});
+
+        assertThat(deserializedList).isEqualTo(payload);
+    }
+
+    @Test
+    public void testNestedContainers() {
+        ByteBuf buf = Unpooled.buffer();
+
+        Set<List<String>> payload = new HashSet<>();
+        List<String> list1 = Arrays.asList("value1", "value2");
+        List<String> list2 = Arrays.asList("value3", "value4");
+
+        payload.add(list1);
+        payload.add(list2);
+
+        ICorfuPayload.serialize(buf, payload);
+
+        assertThat(ICorfuPayload.fromBuffer(buf, new TypeToken<Set<List<String>>>(){})).isEqualTo(payload);
     }
 
 }


### PR DESCRIPTION
## Overview

The existing ICorfuPlayload cannot serialize/deserialize nested containers. This patch enable this feature.

Description:

Why should this be merged: 

In the future, GC would write a RPC message to inform LogUnits about garbage collection decision. This message contains nested containers.  

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
