### PR TITLE
CorfuGuidGenerator: Use SequencerServer to make unique ordered tokens

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuCounter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuCounter.java
@@ -1,0 +1,26 @@
+package org.corfudb.runtime.collections;
+
+import org.corfudb.annotations.CorfuObject;
+import org.corfudb.annotations.DontInstrument;
+import org.corfudb.annotations.MutatorAccessor;
+
+@CorfuObject
+public class CorfuCounter {
+    private long counter;
+
+    public CorfuCounter() {
+        counter = 0L;
+    }
+
+    @MutatorAccessor(name="next", undoFunction = "prev")
+    public Long next() {
+        counter = counter+1;
+        return counter;
+    }
+
+    @DontInstrument
+    protected Long prev(CorfuCounter corfuCounter) {
+        corfuCounter.counter = corfuCounter.counter-1;
+        return corfuCounter.counter;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
@@ -1,0 +1,130 @@
+package org.corfudb.runtime.view;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.object.transactions.TransactionType;
+
+import java.util.UUID;
+
+/**
+ * Globally Unique Identity generator that returns ids
+ * with weak comparable ordering with minimal distributed state sync.
+ * On startup increment a globally unique id via Corfu Object.
+ * Use this id with locally incrementing values to return unique ids.
+ * Higher bits are made of an UTC timestamp while lower bits carry the
+ * counter.
+ *
+ * Created by Sundar Sridharan on 5/22/19.
+ */
+@Slf4j
+public class CorfuGuidGenerator implements OrderedGuidGenerator {
+    private final static int TIMESTAMP_SHIFT            = 24;
+    private final static int INSTANCE_ID_SHIFT          = 8;
+    private final static int MAX_TIMESTAMP_CORRECTION   = 0xFF;
+    private final static int MAX_INSTANCE_ID            = 0xFFff;
+
+    private final String GUID_STREAM_NAME = "CORFU_GUID_COUNTER_STREAM";
+    private final Integer GUID_STREAM_KEY = 0xdeadbeef;
+
+    private final SMRMap<Integer, Long> distributedCounter;
+    private final CorfuRuntime runtime;
+
+    /**
+     * Initialize timestamp & correction to MAX to force an update on the instance id on first call.
+     * This prevents the instance id from bumping up if there are no calls made to this class.
+     */
+    private long timestampCorrection = MAX_TIMESTAMP_CORRECTION;
+    private long previousTimestamp = Long.MAX_VALUE;
+    private long instanceId = 0L;
+
+    public CorfuGuidGenerator(CorfuRuntime rt) {
+        runtime = rt;
+        distributedCounter = rt.getObjectsView().build()
+                               .setType(SMRMap.class)
+                               .setStreamName(GUID_STREAM_NAME)
+                               .open();
+    }
+
+    private long updateInstanceId() {
+        long nextInstanceId = 0L;
+        while(true) {
+            try {
+                runtime.getObjectsView().TXBuild()
+                        .type(TransactionType.OPTIMISTIC)
+                        .build()
+                        .begin();
+
+                nextInstanceId = distributedCounter.getOrDefault(GUID_STREAM_KEY, 1L) + 1;
+                distributedCounter.put(GUID_STREAM_KEY, nextInstanceId);
+
+                runtime.getObjectsView().TXEnd();
+                break;
+            } catch (TransactionAbortedException e) {
+                log.error("updateInstanceId: Transaction aborted while updating GUID counter", e);
+            }
+        }
+
+        instanceId = nextInstanceId;
+        return nextInstanceId;
+    }
+
+    /**
+     * +----------------+--------------------+------------+
+     * |  UTC Timestamp | Unique Instance ID | Correction |
+     * +----------------+--------------------+------------+
+     * <----5 bytes----><------2 bytes------><---1 byte--->
+     *
+     * @return a globally unique id with minimal distributed sync up
+     */
+    @Override
+    public long nextLong() {
+        long currentTimestamp = getCorrectedTimestamp();
+        return (currentTimestamp << TIMESTAMP_SHIFT) |
+                ((instanceId & MAX_INSTANCE_ID) << INSTANCE_ID_SHIFT) |
+                (timestampCorrection & MAX_TIMESTAMP_CORRECTION);
+    }
+
+    /**
+     * +-------------------++--------------+------------+
+     * | UTC Timestamp     || Instance Id  | Correction |
+     * +-------------------++--------------+------------+
+     * <------8 byte-------><---7 byte------><--1 byte-->
+     *
+     * @return a higher resolution UUID with a timestamp built in.
+     */
+    @Override
+    public UUID nextUUID() {
+        long currentTimestamp = getCorrectedTimestamp();
+        return new UUID(currentTimestamp,
+                (instanceId << INSTANCE_ID_SHIFT) | (timestampCorrection & MAX_TIMESTAMP_CORRECTION));
+
+    }
+
+    /**
+     * Ensure that timestamp is monotonically increasing and if not,
+     * 1. First bump up the correction
+     * 2. If correction has also rolled over, bump up instance id
+     *
+     * @return currentTimestamp but with side-effects to object state
+     */
+    private synchronized long getCorrectedTimestamp() {
+        long currentTimestamp = System.currentTimeMillis();
+        if (currentTimestamp <= previousTimestamp) {
+            timestampCorrection++;
+            if (timestampCorrection > MAX_TIMESTAMP_CORRECTION) {
+                timestampCorrection = 0;
+                log.info("updateInstanceId: CorfuGuidGenerator corrected timestamp "+
+                                MAX_TIMESTAMP_CORRECTION+
+                                " times!"+
+                                " timestamp={} previousTimestamp={} correction={} instanceId={}",
+                        currentTimestamp, previousTimestamp, timestampCorrection, instanceId);
+                updateInstanceId();
+            }
+        }
+        previousTimestamp = currentTimestamp;
+        return currentTimestamp;
+    }
+
+}

--- a/test/src/test/java/org/corfudb/runtime/view/CorfuGuidGeneratorTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/CorfuGuidGeneratorTest.java
@@ -8,37 +8,41 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
+ * Validate that Corfu token based Guid Generator satisfies the following two criteria:
+ * 1. The guids are unique.
+ * 2. The guids are monotonically increasing.
  * Created by Sundar Sridharan on May 23, 2019.
  */
-public class SnowflakeGuidGeneratorTest {
+public class CorfuGuidGeneratorTest extends AbstractViewTest {
 
     @Test
     public void areUniqueAndOrderedLong() {
-        final int iterations = 1000;
-        OrderedGuidGenerator guidGenerator = new SnowflakeGuidGenerator(System.identityHashCode(this));
+        final int iterations = PARAMETERS.NUM_ITERATIONS_MODERATE;
+        OrderedGuidGenerator guidGenerator = new CorfuGuidGenerator(getDefaultRuntime().connect());
         long lastValue = 0;
         HashSet<Long> uniq = new HashSet<>(iterations);
         for (int i = 0; i < iterations; i++) {
             long current = guidGenerator.nextLong();
+            assertThat(uniq).doesNotContain(current);
             assertThat(current).isGreaterThan(lastValue);
             lastValue = current;
-            assertThat(uniq).doesNotContain(current);
             uniq.add(current);
         }
     }
 
     @Test
     public void areUniqueAndOrderedUUID() {
-        final int iterations = 1000;
-        OrderedGuidGenerator guidGenerator = new SnowflakeGuidGenerator(System.identityHashCode(this));
+        final int iterations = PARAMETERS.NUM_ITERATIONS_MODERATE;
+        OrderedGuidGenerator guidGenerator = new CorfuGuidGenerator(getDefaultRuntime().connect());
         UUID lastValue = new UUID(0,0);
         HashSet<UUID> uniq = new HashSet<>(iterations);
         for (int i = 0; i < iterations; i++) {
             UUID current = guidGenerator.nextUUID();
+            assertThat(uniq).doesNotContain(current);
             assertThat(current).isGreaterThan(lastValue);
             lastValue = current;
-            assertThat(uniq).doesNotContain(current);
             uniq.add(current);
         }
     }
 }
+


### PR DESCRIPTION
A simple counter within the Sequence server that issues
ordered guids (OGUIDs) tokens by simply incrementing a counter
and shipping it with the epoch.
If the Sequence server restarts or regresses, the epoch will tick up
to guarantee ordering and global uniqueness.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
