### PR TITLE
Upgrade Travis Image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 sudo: required
-dist: trusty
-jdk: oraclejdk8
+dist: xenial
+jdk: openjdk8
 
 before_cache:
 - rm -rf $HOME/.m2/repository/org/corfudb


### PR DESCRIPTION
## Overview
Upgarde from trust to xenial.

Why should this be merged:  
Xenial has open ssl 2.0.1+ which is required by netty-tcnative


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
