### PR TITLE
Shutdown stale CorfuRuntimes in ITs.

### DIFF
--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -53,7 +53,7 @@ public class AbstractIT extends AbstractCorfuTest {
     private static final int SHUTDOWN_RETRIES = 10;
     private static final long SHUTDOWN_RETRY_WAIT = 500;
 
-    CorfuRuntime runtime;
+    public CorfuRuntime runtime;
 
     public static final Properties PROPERTIES = new Properties();
 

--- a/test/src/test/java/org/corfudb/integration/MemoryFootprintIT.java
+++ b/test/src/test/java/org/corfudb/integration/MemoryFootprintIT.java
@@ -63,7 +63,7 @@ public class MemoryFootprintIT extends AbstractIT {
         Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
 
         // Start a Corfu runtime
-        CorfuRuntime runtime = createRuntime(singleNodeEndpoint);
+        runtime = createRuntime(singleNodeEndpoint);
 
         // Create CorfuTable
         CorfuTable testTable = runtime

--- a/test/src/test/java/org/corfudb/integration/SecurityIT.java
+++ b/test/src/test/java/org/corfudb/integration/SecurityIT.java
@@ -228,6 +228,6 @@ public class SecurityIT extends AbstractIT {
                 .build();
 
         // Connecting to runtime
-        CorfuRuntime.fromParameters(runtimeParameters).connect();
+        runtime = CorfuRuntime.fromParameters(runtimeParameters).connect();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -252,7 +252,7 @@ public class ServerRestartIT extends AbstractIT {
         assertThat(corfuServerProcess.isAlive()).isTrue();
 
         // Initialize Client: Create Runtime (Client)
-        CorfuRuntime runtime = createDefaultRuntime();
+        runtime = createDefaultRuntime();
 
         // Create Maps
         List<Map<String, Integer>> smrMapList = new ArrayList<>();

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -98,11 +98,11 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
         // Create Server & Runtime
         Process server = runDefaultServer();
         // Runtime writers
-        CorfuRuntime rt1 = createDefaultRuntime();
+        runtime = createDefaultRuntime();
 
         try {
             // Write 10K entries on S1 & S2
-            CorfuTable<Integer, String> table1 = rt1.getObjectsView().build()
+            CorfuTable<Integer, String> table1 = runtime.getObjectsView().build()
                     .setTypeToken(new TypeToken<CorfuTable<Integer, String>>() {
                     })
                     .setStreamName(stream1Name)
@@ -113,7 +113,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             }
 
             // Write 10K entries on S2
-            CorfuTable<Integer, String> table2 = rt1.getObjectsView().build()
+            CorfuTable<Integer, String> table2 = runtime.getObjectsView().build()
                     .setTypeToken(new TypeToken<CorfuTable<Integer, String>>() {
                     })
                     .setStreamName(stream2Name)
@@ -124,8 +124,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             }
 
             // Force a hole for S1
-            Token token = rt1.getSequencerView().next(CorfuRuntime.getStreamID(stream1Name)).getToken();
-            rt1.getLayoutView().getRuntimeLayout()
+            Token token = runtime.getSequencerView().next(CorfuRuntime.getStreamID(stream1Name)).getToken();
+            runtime.getLayoutView().getRuntimeLayout()
                     .getLogUnitClient("tcp://localhost:9000")
                     .fillHole(token);
 
@@ -149,7 +149,6 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             assertThat(totalTimeAddressMaps).isLessThanOrEqualTo(totalTimeFollowBackpointers);
         } finally {
-            rt1.shutdown();
             shutdownCorfuServer(server);
         }
     }
@@ -489,6 +488,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
         } finally {
             rt1.shutdown();
             rt2.shutdown();
+            rt3.shutdown();
             shutdownCorfuServer(server);
         }
     }

--- a/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
@@ -11,6 +11,7 @@ import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.Sleep;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +68,7 @@ public class TransactionStreamIT extends AbstractIT {
         final long timeout = 30;
 
         ExecutorService consumer = Executors.newSingleThreadExecutor();
+        List<CorfuRuntime> consumerRts = new ArrayList<>();
 
         // A thread that starts and consumes transaction updates via the Transaction Stream.
         Future<Map<UUID, Integer>> consumerState = consumer.submit(() -> {
@@ -74,6 +76,7 @@ public class TransactionStreamIT extends AbstractIT {
                     .setTransactionLogging(true)
                     .setNumCacheEntries(runtimeCacheSize)
                     .connect();
+            consumerRts.add(consumerRt);
 
             IStreamView txStream = consumerRt.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID);
 
@@ -143,6 +146,8 @@ public class TransactionStreamIT extends AbstractIT {
             assertThat(map.size()).isEqualTo(numWritesPerThread);
         }
 
+        producersRt.shutdown();
+        consumerRts.forEach(CorfuRuntime::shutdown);
         shutdownCorfuServer(server_1);
     }
 }

--- a/test/src/test/java/org/corfudb/util/MemoryFootprintMeasurerIT.java
+++ b/test/src/test/java/org/corfudb/util/MemoryFootprintMeasurerIT.java
@@ -68,7 +68,7 @@ public class MemoryFootprintMeasurerIT extends AbstractIT{
                                                         corfuStringNodePort);
 
         // Start a Corfu runtime
-        CorfuRuntime corfuRuntime = createRuntime(singleNodeEndpoint);
+        runtime = createRuntime(singleNodeEndpoint);
 
         // Create an object be measured
         List<byte[]> arrayList = new ArrayList<>();
@@ -120,7 +120,7 @@ public class MemoryFootprintMeasurerIT extends AbstractIT{
                                                         corfuStringNodePort);
 
         // Start a Corfu runtime
-        CorfuRuntime corfuRuntime = createRuntime(singleNodeEndpoint);
+        runtime = createRuntime(singleNodeEndpoint);
 
         // Create and fill a map that will be used to assess nulling out behavior
         Map<String, String> map1 = new HashMap<>();
@@ -157,5 +157,8 @@ public class MemoryFootprintMeasurerIT extends AbstractIT{
                 map1Measurer.getValue());
         log.info("Size of map2 after at the end of test:{}",
                 map2Measurer.getValue());
+
+        // Assert the server is shutdown
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
     }
 }


### PR DESCRIPTION
## Overview

Description:
Shutdown stale runtimes.

Why should this be merged: 
Stale threads affect other tests.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
