### PR TITLE
Log Unit Trim Mark Rebuilt Fix

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -35,12 +35,14 @@ import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.ValueAdoptedException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.Utils;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -454,6 +456,16 @@ public class LogUnitServer extends AbstractServer {
     void stopHandler() throws Exception {
         executor.shutdown();
         executor.awaitTermination(ServerContext.SHUTDOWN_TIMER.toMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    @VisibleForTesting
+    StreamAddressSpace getStreamAddressSpace(UUID streamID) {
+        return streamLog.getStreamsAddressSpace().getAddressMap().get(streamID);
+    }
+
+    @VisibleForTesting
+    void prefixTrim(long trimAddress) {
+        streamLog.prefixTrim(trimAddress);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -424,6 +424,20 @@ public class SequencerServer extends AbstractServer {
             // Reset streams address map
             this.streamsAddressMap = new HashMap<>();
             this.streamsAddressMap.putAll(addressSpaceMap);
+
+            for (Map.Entry<UUID, StreamAddressSpace> streamAddressSpace : this.streamsAddressMap.entrySet()) {
+                log.info("Stream[{}] set to last trimmed address {} and {} addresses in the range [{}-{}], " +
+                                "on sequencer reset.",
+                        Utils.toReadableId(streamAddressSpace.getKey()),
+                        streamAddressSpace.getValue().getTrimMark(),
+                        streamAddressSpace.getValue().getAddressMap().getLongCardinality(),
+                        streamAddressSpace.getValue().getLowestAddress(),
+                        streamAddressSpace.getValue().getHighestAddress());
+                if (log.isTraceEnabled()) {
+                    log.trace("Stream[{}] address map on sequencer reset: {}",
+                            Utils.toReadableId(streamAddressSpace.getKey()), streamAddressSpace.getValue().getAddressMap());
+                }
+            }
         }
 
         // Update epochRangeLowerBound if the bootstrap epoch is not consecutive.
@@ -437,6 +451,7 @@ public class SequencerServer extends AbstractServer {
 
         log.info("Sequencer reset with token = {}, size {} streamTailToGlobalTailMap = {}, sequencerEpoch = {}",
                 globalLogTail, streamTailToGlobalTailMap.size(), streamTailToGlobalTailMap, sequencerEpoch);
+
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -74,6 +74,9 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
             log.warn("prefixTrim: Ignoring repeated trim {}", address);
         } else {
             startingAddress = address + 1;
+
+            // Trim address space maps.
+            logMetadata.prefixTrim(address);
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -28,6 +28,9 @@ import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.util.Utils;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -186,7 +189,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                         continue;
                     }
                     LogData logEntry = read(address);
-                    logMetadata.update(logEntry);
+                    logMetadata.update(logEntry, true, getTrimMark());
                 }
             } finally {
                 segment.close();
@@ -290,6 +293,9 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         dataStore.updateStartingAddress(newStartingAddress);
         syncTailSegment(address);
         log.debug("Trimmed prefix, new starting address {}", newStartingAddress);
+
+        // Trim address space maps.
+        logMetadata.prefixTrim(address);
     }
 
     private boolean isTrimmed(long address) {

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -541,7 +541,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         // 1. Entry in Address 0
         LogData ldOne = getLogDataWithoutId(addressOne);
         Map<UUID, Long> backpointerMap = new HashMap<>();
-        backpointerMap.put(streamId, Address.NON_ADDRESS);
+        backpointerMap.put(streamId, Address.NON_EXIST);
         ldOne.setBackpointerMap(backpointerMap);
         client.write(ldOne);
 
@@ -555,7 +555,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         // Get Stream's Address Space
         CompletableFuture<StreamsAddressResponse> cf = client.getLogAddressSpace();
         StreamAddressSpace addressSpace = cf.get().getAddressMap().get(streamId);
-        assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_ADDRESS);
+        assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
         assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(numEntries);
         assertThat(addressSpace.getAddressMap().contains(addressOne));
 
@@ -563,7 +563,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         CompletableFuture<StreamsAddressResponse> cfLog = client.getLogAddressSpace();
         StreamsAddressResponse response = cfLog.get();
         addressSpace = response.getAddressMap().get(streamId);
-        assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_ADDRESS);
+        assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
         assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(numEntries);
         assertThat(addressSpace.getAddressMap().contains(addressOne));
         assertThat(response.getLogTail()).isEqualTo(addressTwo);


### PR DESCRIPTION
## Overview

Description:

Rebuild streams address space from log units assuming data can
be randomly written (i.e., not written in sequential order).

Why should this be merged: This removes the assumption that data is retrieved in order and fixes the issue of false trim marks, which lead to trimmed exceptions, when data is actually present.
