### PR TITLE
Make MemoryFootprintIT more reliable by forcing GC first

### DIFF
--- a/test/src/test/java/org/corfudb/integration/MemoryFootprintIT.java
+++ b/test/src/test/java/org/corfudb/integration/MemoryFootprintIT.java
@@ -73,6 +73,9 @@ public class MemoryFootprintIT extends AbstractIT {
                 .setStreamName("volbeat")
                 .open();
 
+        // Force GC first to prevent it from interfering with the size estimates after.
+        System.gc();
+
         // Register memory footprint tracking
         final Gauge<Long> corfuTableSizeGauge = MetricsUtils.addMemoryMeasurerFor(
                 CorfuRuntime.getDefaultMetrics(),


### PR DESCRIPTION
## Overview
Sometimes GC kicks in the middle of the loading in the test causing the after load memory use to show a smaller value than before.
Forcing GC before the test can prevent this discrepancy.
Description:

Why should this be merged: 

Related issue(s) (if applicable): #1922 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc