### PR TITLE
Flush Write Buffer

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -902,7 +902,10 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     private static void safeWrite(FileChannel channel, ByteBuffer buf) throws IOException {
         long prev = channel.position();
         try {
-            channel.write(buf);
+            do {
+                channel.write(buf);
+            } while (buf.hasRemaining());
+
         } catch (IOException e) {
             // Write failed restore the channels position, so the subsequent writes
             // can overwrite the failed write.


### PR DESCRIPTION
## Overview
It seems like its possible that FileChannel::write might not write
the complete source buffer, so subsequent write calls should be
called on the remaining bytes in the buffer.

Why should this be merged: A partial buffer write can result in acknowledging a write, we need to make sure to flush the whole buffer before returning. 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
