### PR TITLE
Add SMREntry garbage pointer types

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/ISMRGarbageInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/ISMRGarbageInfo.java
@@ -1,0 +1,73 @@
+package org.corfudb.protocols.logprotocol;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * ISMRGarbageInfo maintains the positions and other information of garbage-identified {@link SMREntry}s inside one
+ * AddressSpaceView log data. The garbage information would be consumed by LogUnit servers to reclaim disk space and
+ * other housekeeping tasks, e.g. tracking the lower bound of snapshot address for transactions due to the loss of
+ * some versions. Each ISMRGarbageInfo instance is wrapped in one {@link org.corfudb.protocols.wireprotocol.LogData}
+ * instance whose address is the same as that of the associated log data having SMREntries.
+ *
+ * <p>One log data contains one or multiple SMREntries, depending on the type of {@link ISMRConsumable} instance
+ * wrapped in the log data. Each concrete implementation of ISMRGarbageInfo corresponds to one concrete
+ * implementation of ISMRConsumable. <p/>
+ *
+ * Created by Xin Li at 06/03/19.
+ */
+public interface ISMRGarbageInfo {
+    Map<Integer, SMREntryGarbageInfo> EMPTY = new ConcurrentHashMap<>();
+
+    /**
+     * Get the garbage information about a specified SMREntry.
+     * @param streamId stream ID that the interested SMREntry is from.
+     * @param index    per-stream index of the interested SMREntry.
+     * @return         if the SMREntry is identified as garbage, return the garbage information; otherwise return null.
+     */
+    Optional<SMREntryGarbageInfo> getGarbageInfo(UUID streamId, int index);
+
+    /**
+     * Get all the garbage information of a stream.
+     * @param streamId stream ID.
+     * @return         a map whose key is the per-stream index of garbage-identified SMREntries.
+     */
+    Map<Integer, SMREntryGarbageInfo> getAllGarbageInfo(UUID streamId);
+
+    /**
+     * Get the total serialized size of all garbage-identified SMREntries in the associated log data.
+     * @return size in Byte.
+     */
+    int getGarbageSize();
+
+    /**
+     * Add information about one garbage-identified SMREntry.
+     * @param streamId             stream ID the SMREntry belongs to.
+     * @param index                per-stream index of the SMREntry in the associated log data.
+     * @param smrEntryGarbageInfo  garbage information about the SMREntry.
+     */
+    void add(UUID streamId, int index, SMREntryGarbageInfo smrEntryGarbageInfo);
+
+    /**
+     * Remove information about one garbage-identified SMREntry.
+     * @param streamId stream ID the SMREntry belongs to.
+     * @param index    per-stream index of the SMREntry in the associated log data.
+     */
+    void remove(UUID streamId, int index);
+
+    /**
+     * Merge garbage information from another ISMRGarbageInfo instance.
+     * @param other another ISMRGarbageInfo instance.
+     * @return deduplicated garbage information.
+     */
+    ISMRGarbageInfo merge(ISMRGarbageInfo other);
+
+    /**
+     * Test if the other object instance equals this instance.
+     * @param other another object.
+     * @return true if equals
+     */
+    boolean equals(Object other);
+}

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
@@ -115,7 +115,12 @@ public class LogEntry implements ICorfuSerializable {
         SMR(1, SMREntry.class),
         MULTIOBJSMR(7, MultiObjectSMREntry.class),
         MULTISMR(8, MultiSMREntry.class),
-        CHECKPOINT(10, CheckpointEntry.class);
+        CHECKPOINT(10, CheckpointEntry.class),
+
+        // SMREntryGarbageInfo
+        SMR_GARBAGE(11, SMREntryGarbageInfo.class),
+        MULTISMR_GARBAGE(12, MultiSMREntryGarbageInfo.class),
+        MULTIOBJSMR_GARBAGE(13, MultiObjectSMREntryGarbageInfo.class);
 
         public final int type;
         public final Class<? extends LogEntry> entryType;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntryGarbageInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntryGarbageInfo.java
@@ -1,0 +1,155 @@
+package org.corfudb.protocols.logprotocol;
+
+import io.netty.buffer.ByteBuf;
+import lombok.Getter;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.util.serializer.Serializers;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * MultiObjectSMREntryGarbageInfo maintains garbage information of one MultiObjectSMREntry.
+ *
+ * Created by Xin at 06/05/2019.
+ */
+public class MultiObjectSMREntryGarbageInfo extends LogEntry implements ISMRGarbageInfo{
+
+    /**
+     * A map to maintain information about garbage-identified SMREntry inside MultiObjectSMREntry. The key of the map
+     * is the stream id.
+     */
+    @Getter
+    private final Map<UUID, MultiSMREntryGarbageInfo> streamIdToGarbageMap = new ConcurrentHashMap<>();
+
+    public MultiObjectSMREntryGarbageInfo() {
+        super(LogEntryType.MULTIOBJSMR_GARBAGE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<SMREntryGarbageInfo> getGarbageInfo(UUID streamId, int index) {
+        if (!streamIdToGarbageMap.containsKey(streamId)) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(streamIdToGarbageMap.get(streamId).getGarbageMap().get(index));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<Integer, SMREntryGarbageInfo> getAllGarbageInfo(UUID streamId) {
+        if (streamIdToGarbageMap.containsKey(streamId)) {
+            return streamIdToGarbageMap.get(streamId).getAllGarbageInfo(streamId);
+        } else {
+            return ISMRGarbageInfo.EMPTY;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getGarbageSize() {
+        return streamIdToGarbageMap.values().stream()
+                .map(MultiSMREntryGarbageInfo::getGarbageSize)
+                .reduce(0, (a, b) -> a + b);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void remove(UUID streamId, int index) {
+        if (streamIdToGarbageMap.containsKey(streamId)) {
+            streamIdToGarbageMap.get(streamId).remove(streamId, index);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ISMRGarbageInfo merge(ISMRGarbageInfo other) {
+        if (other instanceof MultiObjectSMREntryGarbageInfo) {
+            MultiObjectSMREntryGarbageInfo deduplicatedGCInfo = new MultiObjectSMREntryGarbageInfo();
+
+            ((MultiObjectSMREntryGarbageInfo) other).getStreamIdToGarbageMap().forEach((streamId, garbageMap) -> {
+                // disregard empty gc info
+                if (garbageMap.getAllGarbageInfo(streamId).size() > 0) {
+                    if (streamIdToGarbageMap.containsKey(streamId)) {
+                        MultiSMREntryGarbageInfo perStreamDeduplicatedGCInfo =
+                                (MultiSMREntryGarbageInfo) streamIdToGarbageMap.get(streamId).merge(garbageMap);
+                        // disregard if on new gc info is merged
+                        if (perStreamDeduplicatedGCInfo.getGarbageMap().size() > 0) {
+                            deduplicatedGCInfo.add(streamId, perStreamDeduplicatedGCInfo);
+                        }
+                    } else {
+                        deduplicatedGCInfo.add(streamId, garbageMap);
+                        this.add(streamId, garbageMap);
+                    }
+                }
+            });
+
+            return deduplicatedGCInfo;
+        } else {
+            throw new IllegalArgumentException("Different types of ISMRGarbageInfo cannot merge.");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void add(UUID streamId, int index, SMREntryGarbageInfo smrEntryGarbageInfo) {
+        if (!streamIdToGarbageMap.containsKey(streamId)) {
+            streamIdToGarbageMap.put(streamId, new MultiSMREntryGarbageInfo());
+        }
+
+        streamIdToGarbageMap.get(streamId).add(index, smrEntryGarbageInfo);
+    }
+
+    void add(UUID streamId, MultiSMREntryGarbageInfo multiSMREntryGarbageInfo) {
+        streamIdToGarbageMap.put(streamId, multiSMREntryGarbageInfo);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof MultiObjectSMREntryGarbageInfo) {
+            return streamIdToGarbageMap.equals(((MultiObjectSMREntryGarbageInfo) other).getStreamIdToGarbageMap());
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void serialize(ByteBuf b) {
+        super.serialize(b);
+        b.writeInt(streamIdToGarbageMap.size());
+        streamIdToGarbageMap.forEach((streamId, garbageMap) -> {
+            b.writeLong(streamId.getMostSignificantBits());
+            b.writeLong(streamId.getLeastSignificantBits());
+            Serializers.CORFU.serialize(garbageMap, b);
+        });
+    }
+
+    @Override
+    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
+        super.deserializeBuffer(b, rt);
+        int numEntries = b.readInt();
+        streamIdToGarbageMap.clear();
+
+        for (int i = 0; i < numEntries; i++) {
+            streamIdToGarbageMap.put(
+                    new UUID(b.readLong(), b.readLong()),
+                    ((MultiSMREntryGarbageInfo) Serializers.CORFU.deserialize(b, rt))
+            );
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntryGarbageInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntryGarbageInfo.java
@@ -1,0 +1,139 @@
+package org.corfudb.protocols.logprotocol;
+
+import io.netty.buffer.ByteBuf;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.util.serializer.Serializers;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * MultiSMREntryGarbageInfo maintains garbage information of one MultiSMREntry.
+ *
+ * Created by Xin at 06/05/2019.
+ */
+@ToString(callSuper = true)
+public class MultiSMREntryGarbageInfo extends LogEntry implements ISMRGarbageInfo{
+
+    /**
+     * A map to maintain information about garbage-identified SMREntry inside MultiSMREntry. The key of the map is
+     * the index of the SMREntry inside the original MultiSMREntry.
+     */
+    @Getter
+    private final Map<Integer, SMREntryGarbageInfo> garbageMap = new ConcurrentHashMap<>();
+
+    /**
+     * Constructor.
+     */
+    public MultiSMREntryGarbageInfo() {
+        super(LogEntryType.MULTISMR_GARBAGE);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<SMREntryGarbageInfo> getGarbageInfo(UUID streamId, int index) {
+        // streamId is disregarded
+        return Optional.ofNullable(garbageMap.get(index));
+    }
+
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<Integer, SMREntryGarbageInfo> getAllGarbageInfo(UUID streamId) {
+        // streamId is disregarded
+        return garbageMap;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getGarbageSize() {
+        return garbageMap.values().stream()
+                .map(SMREntryGarbageInfo::getGarbageSize)
+                .reduce(0, (a, b) -> a + b);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void remove(UUID streamId, int index) {
+        garbageMap.remove(index);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ISMRGarbageInfo merge(ISMRGarbageInfo other) {
+        if (other instanceof MultiSMREntryGarbageInfo) {
+            MultiSMREntryGarbageInfo deduplicatedGCInfo = new MultiSMREntryGarbageInfo();
+            ((MultiSMREntryGarbageInfo) other).getGarbageMap().forEach((index, smrEntryGarbageInfo) -> {
+                if (!garbageMap.containsKey(index)) {
+                    garbageMap.put(index, smrEntryGarbageInfo);
+                    deduplicatedGCInfo.add(index, smrEntryGarbageInfo);
+                }
+            });
+            return deduplicatedGCInfo;
+        } else {
+            throw new IllegalArgumentException("Different types of ISMRGarbageInfo cannot merge.");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void add(UUID streamId, int index, SMREntryGarbageInfo smrEntryGarbageInfo) {
+        // streamId is disregarded.
+        add(index, smrEntryGarbageInfo);
+    }
+
+    void add(int index, SMREntryGarbageInfo smrEntryGarbageInfo) {
+        garbageMap.put(index, smrEntryGarbageInfo);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof MultiSMREntryGarbageInfo) {
+            return garbageMap.equals(((MultiSMREntryGarbageInfo) other).getGarbageMap());
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void serialize(ByteBuf b) {
+        super.serialize(b);
+        b.writeInt(garbageMap.size());
+        garbageMap.forEach((streamId, smrEntryGarbageInfo) -> {
+            b.writeInt(streamId);
+            Serializers.CORFU.serialize(smrEntryGarbageInfo, b);
+        });
+    }
+
+    @Override
+    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
+        super.deserializeBuffer(b, rt);
+        int numEntries = b.readInt();
+        garbageMap.clear();
+
+        for (int i = 0; i < numEntries; i++) {
+            garbageMap.put(b.readInt(), (SMREntryGarbageInfo) Serializers.CORFU.deserialize(b, rt));
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntryGarbageInfo.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntryGarbageInfo.java
@@ -1,0 +1,131 @@
+package org.corfudb.protocols.logprotocol;
+
+
+import io.netty.buffer.ByteBuf;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.corfudb.runtime.CorfuRuntime;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * SMREntryGarbageInfo maintains garbage information of one SMREntry. This SMREntry could be stand-alone or a part of
+ * MultiSMREntry. The existence of SMREntryGarbageInfo itself indicates the associated SMREntry has been identified
+ * as garbage. SMREntryGarbageInfo could be used individually or composites more complicated ISMRGarbageInfo.
+ */
+@ToString(callSuper = true)
+@NoArgsConstructor
+public class SMREntryGarbageInfo extends LogEntry implements ISMRGarbageInfo {
+
+    /**
+     * Global address that detected the associated SMREntry as garbage.
+     */
+    @Getter
+    private long detectorAddress;
+
+    /**
+     * The size of the associated SMREntry in Byte.
+     */
+    private int smrEntrySize;
+
+    /**
+     * Constructor for SMREntryGarbageInfo
+     * @param detectorAddress
+     * @param smrEntrySize
+     */
+    public SMREntryGarbageInfo(long detectorAddress, int smrEntrySize) {
+        super(LogEntryType.SMR_GARBAGE);
+        this.detectorAddress = detectorAddress;
+        this.smrEntrySize = smrEntrySize;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Optional<SMREntryGarbageInfo> getGarbageInfo(UUID streamId, int index) {
+        // both streamId and index are not checked
+        return Optional.of(this);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<Integer, SMREntryGarbageInfo> getAllGarbageInfo(UUID streamId) {
+        // streamId is disregarded
+        Map<Integer, SMREntryGarbageInfo> garbageInfo = new ConcurrentHashMap<>();
+        garbageInfo.put(0, this);
+        return garbageInfo;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int getGarbageSize() {
+        return smrEntrySize;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * SMREntryGarbageInfo does not support this operation.
+     */
+    @Override
+    public void remove(UUID streamId, int index) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * SMREntryGarbageInfo does not support this operation.
+     */
+    @Override
+    public ISMRGarbageInfo merge(ISMRGarbageInfo other) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * SMREntryGarbageInfo does not support this operation.
+     */
+    @Override
+    public void add(UUID streamId, int index, SMREntryGarbageInfo smrEntryGarbageInfo) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object other) {
+        if (other instanceof SMREntryGarbageInfo) {
+            return ((SMREntryGarbageInfo) other).detectorAddress == detectorAddress
+                    && ((SMREntryGarbageInfo) other).getGarbageSize() == smrEntrySize;
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public void serialize(ByteBuf b) {
+        super.serialize(b);
+        b.writeLong(detectorAddress);
+        b.writeInt(smrEntrySize);
+    }
+
+    @Override
+    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
+        super.deserializeBuffer(b, rt);
+        detectorAddress = b.readLong();
+        smrEntrySize = b.readInt();
+    }
+
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/DataType.java
@@ -19,7 +19,8 @@ public enum DataType implements ICorfuPayload<DataType> {
     EMPTY(1, true),
     HOLE(2, true),
     TRIMMED(3, true),
-    RANK_ONLY(4, true);
+    RANK_ONLY(4, true),
+    GARBAGE(5, true);
 
     final int val;
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -6,6 +6,7 @@ import io.netty.buffer.Unpooled;
 import java.util.EnumMap;
 import java.util.concurrent.atomic.AtomicReference;
 
+import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -130,7 +131,7 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
      */
     public LogData(ByteBuf buf) {
         type = ICorfuPayload.fromBuffer(buf, DataType.class);
-        if (type == DataType.DATA) {
+        if (type == DataType.DATA || type == DataType.GARBAGE) {
             data = ICorfuPayload.fromBuffer(buf, byte[].class);
         } else {
             data = null;
@@ -211,7 +212,7 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
 
     void doSerializeInternal(ByteBuf buf) {
         ICorfuPayload.serialize(buf, type);
-        if (type == DataType.DATA) {
+        if (type == DataType.DATA || type == DataType.GARBAGE) {
             if (data == null) {
                 int lengthIndex = buf.writerIndex();
                 buf.writeInt(0);

--- a/runtime/src/test/java/org/corfudb/protocols/logprotocol/LogEntryTest.java
+++ b/runtime/src/test/java/org/corfudb/protocols/logprotocol/LogEntryTest.java
@@ -1,0 +1,149 @@
+package org.corfudb.protocols.logprotocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+
+public class LogEntryTest {
+    private static UUID streamId;
+
+    private static SMREntry smrEntry;
+    private static MultiSMREntry multiSMREntry;
+    private static MultiObjectSMREntry multiObjectSMREntry;
+
+    private static SMREntryGarbageInfo smrEntryGarbageInfo;
+    private static MultiSMREntryGarbageInfo multiSMREntryGarbageInfo;
+    private static MultiObjectSMREntryGarbageInfo multiObjectSMREntryGarbageInfo;
+
+    @BeforeClass
+    public static void setUpLogEntryInstances() {
+        String smrMethod = "put";
+        Object[] smrArguments = new Object[]{"a"};
+        ISerializer serializerType = Serializers.JSON;
+        streamId = UUID.randomUUID();
+
+        smrEntry = new SMREntry(smrMethod, smrArguments, serializerType);
+        multiSMREntry = new MultiSMREntry();
+        multiSMREntry.addTo(smrEntry);
+        multiObjectSMREntry = new MultiObjectSMREntry();
+        multiObjectSMREntry.addTo(streamId, smrEntry);
+
+        long detectedAddress = 0L;
+        int smrEntrySize = 0;
+
+        smrEntryGarbageInfo = new SMREntryGarbageInfo(detectedAddress, smrEntrySize);
+        multiSMREntryGarbageInfo = new MultiSMREntryGarbageInfo();
+        multiSMREntryGarbageInfo.add(streamId, 0, smrEntryGarbageInfo);
+        multiObjectSMREntryGarbageInfo = new MultiObjectSMREntryGarbageInfo();
+        multiObjectSMREntryGarbageInfo.add(streamId, 0, smrEntryGarbageInfo);
+    }
+
+    @Test
+    public void testSMREntrySerializeDeserialize() {
+        ByteBuf buf = Unpooled.buffer();
+        smrEntry.serialize(buf);
+
+        // TODO(Xin): runtime is not used in the test. Future patch will eliminate the dependency on runtime.
+        SMREntry deserializedSMREntry = (SMREntry) LogEntry.deserialize(buf, null);
+
+        assertSMRConsumableEquals(smrEntry, deserializedSMREntry, UUID.randomUUID());
+    }
+
+    @Test
+    public void testMultiSMREntrySerializeDeserialize() {
+        ByteBuf buf = Unpooled.buffer();
+        multiSMREntry.serialize(buf);
+
+        // TODO(Xin): runtime is not used in the test. Future patch will eliminate the dependency on runtime.
+        MultiSMREntry deserializedMultiSMREntry = (MultiSMREntry) LogEntry.deserialize(buf, null);
+
+        assertSMRConsumableEquals(multiSMREntry, deserializedMultiSMREntry, streamId);
+    }
+
+    @Test
+    public void testMultiObjectSMREntrySerializeDeserialize() {
+        ByteBuf buf = Unpooled.buffer();
+        multiObjectSMREntry.serialize(buf);
+
+        // TODO(Xin): runtime is not used in the test. Future patch will eliminate the dependency on runtime.
+        MultiObjectSMREntry deserializedMultiObjectSMREntry = (MultiObjectSMREntry) LogEntry.deserialize(buf, null);
+
+        assertSMRConsumableEquals(multiObjectSMREntry, deserializedMultiObjectSMREntry, streamId);
+    }
+
+    @Test
+    public void testSMREntryGarbageInfoSerializeDeserialize() {
+        ByteBuf buf = Unpooled.buffer();
+        smrEntryGarbageInfo.serialize(buf);
+
+        // TODO(Xin): runtime is not used in the test. Future patch will eliminate the dependency on runtime.
+        SMREntryGarbageInfo deserializedSMREntryGarbageInfo = (SMREntryGarbageInfo) LogEntry.deserialize(buf, null);
+        assertSMRGarbageInfoEquals(smrEntryGarbageInfo, deserializedSMREntryGarbageInfo);
+    }
+
+    @Test
+    public void testMultiSMREntryGarbageInfoSerializeDeserialize() {
+        ByteBuf buf = Unpooled.buffer();
+        multiSMREntryGarbageInfo.serialize(buf);
+
+        // TODO(Xin): runtime is not used in the test. Future patch will eliminate the dependency on runtime.
+        MultiSMREntryGarbageInfo deserializedMultiSMREntryGarbageInfo =
+                (MultiSMREntryGarbageInfo) LogEntry.deserialize(buf, null);
+        assertSMRGarbageInfoEquals(multiSMREntryGarbageInfo, deserializedMultiSMREntryGarbageInfo);
+    }
+
+    @Test
+    public void testMultiSMRObjectEntryGarbageInfoSerializeDeserialize() {
+        ByteBuf buf = Unpooled.buffer();
+        multiObjectSMREntryGarbageInfo.serialize(buf);
+
+        // TODO(Xin): runtime is not used in the test. Future patch will eliminate the dependency on runtime.
+        MultiObjectSMREntryGarbageInfo deserializedSMRMultiObjectEntryGarbageInfo =
+                (MultiObjectSMREntryGarbageInfo) LogEntry.deserialize(buf, null);
+        assertSMRGarbageInfoEquals(multiObjectSMREntryGarbageInfo, deserializedSMRMultiObjectEntryGarbageInfo);
+    }
+
+
+    private void assertSMRConsumableEquals(ISMRConsumable expectSMRConsumable, ISMRConsumable testedSMRConsumable,
+                                          UUID streamId) {
+        List<SMREntry> expectedUpdates = expectSMRConsumable.getSMRUpdates(streamId);
+        List<SMREntry> testedUpdates = testedSMRConsumable.getSMRUpdates(streamId);
+
+        Assert.assertEquals(expectedUpdates.size(), testedUpdates.size());
+
+        for (int i = 0; i < expectedUpdates.size(); ++i) {
+            SMREntry expectedSMREntry = expectedUpdates.get(i);
+            SMREntry testedSMREntry = testedUpdates.get(i);
+
+            Assert.assertEquals(expectedSMREntry.getSMRMethod(), testedSMREntry.getSMRMethod());
+            Assert.assertEquals(expectedSMREntry.getSMRArguments(), testedSMREntry.getSMRArguments());
+            Assert.assertEquals(expectedSMREntry.getSerializerType(), testedSMREntry.getSerializerType());
+        }
+    }
+
+    private void assertSMRGarbageInfoEquals(ISMRGarbageInfo expectedSMRGarbageInfo,
+                                            ISMRGarbageInfo testedSMRGarbageInfo) {
+        Map<Integer, SMREntryGarbageInfo> expectedGarbageMap = expectedSMRGarbageInfo.getAllGarbageInfo(streamId);
+        Map<Integer, SMREntryGarbageInfo> testedGarbageMap = testedSMRGarbageInfo.getAllGarbageInfo(streamId);
+
+        Assert.assertEquals(expectedGarbageMap.size(), testedGarbageMap.size());
+
+        for (int index : expectedGarbageMap.keySet()) {
+            SMREntryGarbageInfo expectedGarbageInfo = expectedGarbageMap.get(index);
+
+            Assert.assertTrue(testedGarbageMap.containsKey(index));
+            SMREntryGarbageInfo testedGarbageInfo = testedGarbageMap.get(index);
+
+            Assert.assertEquals(expectedGarbageInfo.getDetectorAddress(), testedGarbageInfo.getDetectorAddress());
+        }
+    }
+}

--- a/runtime/src/test/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntryGarbageInfoTest.java
+++ b/runtime/src/test/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntryGarbageInfoTest.java
@@ -1,0 +1,92 @@
+package org.corfudb.protocols.logprotocol;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class MultiObjectSMREntryGarbageInfoTest {
+    private static UUID streamId1 = UUID.randomUUID();
+    private static long address1_1 = 1L;
+    private static int size1_1 = 100;
+    private static int index1_1 = 0;
+
+    private static UUID streamId2 = UUID.randomUUID();
+    private static long address2_1 = 1L;
+    private static int size2_1 = 200;
+    private static int index2_1 = 2;
+    private static long address2_2 = 2L;
+    private static int size2_2 = 300;
+    private static int index2_2 = 5;
+
+    private void setUpInstance(MultiObjectSMREntryGarbageInfo gcInfo) {
+        SMREntryGarbageInfo smrEntryGarbageInfo1_1 = new SMREntryGarbageInfo(address1_1, size1_1);
+        SMREntryGarbageInfo smrEntryGarbageInfo2_1 = new SMREntryGarbageInfo(address2_1, size2_1);
+        SMREntryGarbageInfo smrEntryGarbageInfo2_2 = new SMREntryGarbageInfo(address2_2, size2_2);
+
+        gcInfo.add(streamId1, index1_1, smrEntryGarbageInfo1_1);
+        gcInfo.add(streamId2, index2_1, smrEntryGarbageInfo2_1);
+        gcInfo.add(streamId2, index2_2, smrEntryGarbageInfo2_2);
+    }
+
+    @Test
+    public void testGetGarbageSize() {
+        MultiObjectSMREntryGarbageInfo gcInfo = new MultiObjectSMREntryGarbageInfo();
+        setUpInstance(gcInfo);
+        Assert.assertEquals(size1_1 + size2_1 + size2_2, gcInfo.getGarbageSize());
+    }
+
+    @Test
+    public void testEquals() {
+        MultiObjectSMREntryGarbageInfo gcInfo = new MultiObjectSMREntryGarbageInfo();
+        setUpInstance(gcInfo);
+
+        MultiObjectSMREntryGarbageInfo empty = new MultiObjectSMREntryGarbageInfo();
+        Assert.assertNotEquals(empty, gcInfo);
+
+        MultiObjectSMREntryGarbageInfo other = new MultiObjectSMREntryGarbageInfo();
+        other.add(streamId1, index1_1, new SMREntryGarbageInfo(address1_1, size1_1));
+        other.add(streamId2, index2_1, new SMREntryGarbageInfo(address2_1, size2_1));
+        other.add(streamId2, index2_2, new SMREntryGarbageInfo(address2_2, size2_2));
+
+        Assert.assertEquals(other, gcInfo);
+    }
+
+    @Test
+    public void testMerge() {
+        MultiObjectSMREntryGarbageInfo gcInfo = new MultiObjectSMREntryGarbageInfo();
+        setUpInstance(gcInfo);
+
+        MultiObjectSMREntryGarbageInfo other = new MultiObjectSMREntryGarbageInfo();
+
+        long address1_2 = 3L;
+        int size1_2 = 100;
+        int index1_2 = 3;
+        other.add(streamId1, index1_1, new SMREntryGarbageInfo(address1_1, size1_1));
+        other.add(streamId1, index1_2, new SMREntryGarbageInfo(address1_2, size1_2));
+
+        other.add(streamId2, index2_1, new SMREntryGarbageInfo(address2_1, size2_1));
+
+        UUID streamId3 = UUID.randomUUID();
+        long address3_1 = 5L;
+        int size3_1 = 100;
+        int index3_1 = 0;
+        other.add(streamId3, index3_1, new SMREntryGarbageInfo(address3_1, size3_1));
+
+        MultiObjectSMREntryGarbageInfo deduplicatedGCInfo = (MultiObjectSMREntryGarbageInfo) gcInfo.merge(other);
+
+        MultiObjectSMREntryGarbageInfo expectedGCInfoAfterMerge = new MultiObjectSMREntryGarbageInfo();
+        expectedGCInfoAfterMerge.add(streamId1, index1_1, new SMREntryGarbageInfo(address1_1, size1_1));
+        expectedGCInfoAfterMerge.add(streamId1, index1_2, new SMREntryGarbageInfo(address1_2, size1_2));
+        expectedGCInfoAfterMerge.add(streamId2, index2_1, new SMREntryGarbageInfo(address2_1, size2_1));
+        expectedGCInfoAfterMerge.add(streamId2, index2_2, new SMREntryGarbageInfo(address2_2, size2_2));
+        expectedGCInfoAfterMerge.add(streamId3, index3_1, new SMREntryGarbageInfo(address3_1, size3_1));
+        Assert.assertEquals(expectedGCInfoAfterMerge, gcInfo);
+
+        MultiObjectSMREntryGarbageInfo expectedDeduplicatedGCInfo = new MultiObjectSMREntryGarbageInfo();
+        expectedDeduplicatedGCInfo.add(streamId1, index1_2, new SMREntryGarbageInfo(address1_2, size1_2));
+        expectedDeduplicatedGCInfo.add(streamId3, index3_1, new SMREntryGarbageInfo(address3_1, size3_1));
+        Assert.assertEquals(expectedDeduplicatedGCInfo, deduplicatedGCInfo);
+    }
+
+}

--- a/runtime/src/test/java/org/corfudb/protocols/wireprotocol/LogDataTest.java
+++ b/runtime/src/test/java/org/corfudb/protocols/wireprotocol/LogDataTest.java
@@ -1,0 +1,52 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.protocols.logprotocol.SMREntryGarbageInfo;
+import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LogDataTest {
+    @Test
+    public void testSMRPayloadSerializeDeserialize() {
+        String smrMethod = "put";
+        Object[] smrArguments = new Object[] {"a"};
+        ISerializer iSerializer = Serializers.JSON;
+
+        SMREntry smrEntry = new SMREntry(smrMethod, smrArguments, iSerializer);
+        LogData logData = new LogData(DataType.DATA, smrEntry);
+        ByteBuf buf = Unpooled.buffer();
+        logData.doSerialize(buf);
+        LogData deserializedLogData = new LogData(buf);
+
+        // TODO(Xin): runtime is not used in the test. Future patch will eliminate the dependency on runtime.
+        SMREntry deserializedSMREntry = (SMREntry) deserializedLogData.getPayload(null);
+
+        Assert.assertEquals(smrEntry.getSMRMethod(), deserializedSMREntry.getSMRMethod());
+        Assert.assertEquals(smrEntry.getSMRArguments(), deserializedSMREntry.getSMRArguments());
+        Assert.assertEquals(smrEntry.getSerializerType(), deserializedSMREntry.getSerializerType());
+    }
+
+    @Test
+    public void testGarbagePayloadSerializeDeserialize() {
+        Long detectedAddress = 0L;
+        int smrEntrySize = 0;
+
+        SMREntryGarbageInfo smrEntryGarbageInfo = new SMREntryGarbageInfo(detectedAddress, smrEntrySize);
+        LogData logData = new LogData(DataType.GARBAGE, smrEntryGarbageInfo);
+        ByteBuf buf = Unpooled.buffer();
+        logData.doSerialize(buf);
+        LogData deserializedLogData = new LogData(buf);
+
+        // TODO(Xin): runtime is not used in the test. Future patch will eliminate the dependency on runtime.
+        SMREntryGarbageInfo deserializedSMREntryGarbageInfo =
+                (SMREntryGarbageInfo) deserializedLogData.getPayload(null);
+
+
+        Assert.assertEquals(detectedAddress, (Long) deserializedSMREntryGarbageInfo.getDetectorAddress());
+        Assert.assertEquals(smrEntrySize, deserializedSMREntryGarbageInfo.getGarbageSize());
+    }
+}


### PR DESCRIPTION
## Overview

Add data structure to represent which SMREntries in the AddressSpaceView are identified as garbage. 

Description:

The data structure would be used by the runtime to send garbage information to the LogUnit servers. 

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
