### PR TITLE
Simplify OverWriteException Handling

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -392,7 +392,10 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         LogData logData = new LogData(org.corfudb.protocols.wireprotocol
                 .DataType.typeMap.get((byte) entry.getDataType().getNumber()), data);
 
-        logData.setBackpointerMap(getUUIDLongMap(entry.getBackpointersMap()));
+        Map<UUID, Long> backpointersMap = getUUIDLongMap(entry.getBackpointersMap());
+        if (!backpointersMap.isEmpty()) {
+            logData.setBackpointerMap(backpointersMap);
+        }
         logData.setGlobalAddress(entry.getGlobalAddress());
         logData.setRank(createDataRank(entry));
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -66,13 +66,6 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
     }
 
     /**
-     * Return whether or not this entry is a log entry.
-     */
-    default boolean isLogEntry(CorfuRuntime runtime) {
-        return getPayload(runtime) instanceof LogEntry;
-    }
-
-    /**
      * Return the payload as a log entry.
      */
     default LogEntry getLogEntry(CorfuRuntime runtime) {
@@ -95,13 +88,6 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
             return null;
         }
         return getBackpointerMap().get(streamId);
-    }
-
-    /**
-     * Return if this is the first entry in a particular stream.
-     */
-    default boolean isFirstEntry(UUID streamId) {
-        return getBackpointer(streamId) == -1L;
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -158,14 +158,6 @@ public interface IMetadata {
         return new Token(getEpoch(), getGlobalAddress());
     }
 
-    default void clearCommit() {
-        getMetadataMap().put(LogUnitMetadataType.COMMIT, false);
-    }
-
-    default void setCommit() {
-        getMetadataMap().put(LogUnitMetadataType.COMMIT, true);
-    }
-
     default boolean hasCheckpointMetadata() {
         return getCheckpointType() != null && getCheckpointId() != null;
     }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -21,8 +21,6 @@ import org.corfudb.util.serializer.Serializers;
 @Slf4j
 public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
 
-    public final static LogData EMPTY = new LogData(DataType.EMPTY);
-
     public static final int NOT_KNOWN = -1;
 
     @Getter
@@ -243,16 +241,17 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
             return false;
         } else {
             LogData other = (LogData) o;
-            if (compareTo(other) == 0) {
-                boolean sameClientId = getClientId() == null ? other.getClientId() == null :
-                        getClientId().equals(other.getClientId());
-                boolean sameThreadId = getThreadId() == null ? other.getThreadId() == null :
-                        getThreadId().equals(other.getThreadId());
 
-                return sameClientId && sameThreadId;
-            }
+            boolean equalLd;
 
-            return false;
+            acquireBuffer();
+            other.acquireBuffer();
+            // This will implicitly check the payload and the LogData metadata
+            equalLd = this.serializedCache.equals(other.serializedCache);
+            releaseBuffer();
+            other.releaseBuffer();
+
+            return equalLd;
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/OverwriteCause.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/OverwriteCause.java
@@ -6,16 +6,12 @@ import lombok.Getter;
 public enum OverwriteCause {
     /** Indicates this address has been already written by a hole.*/
     HOLE(0),
-    /** Indicates this address has been already written and it is 'potentially' the same data
-     * (i.e., based on data length). The client will drive final verification. This intends to be
-     * a hint so verification is only driven in very specific cases.*/
+    /** Indicates this address has been already written and it is the same data..*/
     SAME_DATA(1),
-    /** Indicates this address has been already written and it is a different data (derived from the length).*/
+    /** Indicates this address has been already written and it is a different data.*/
     DIFF_DATA(2),
     /** Indicates this address was already trimmed.*/
-    TRIM(3),
-    /** Indicates there is no actual cause for the overwrite, hence no overwrite exception has occurred. */
-    NONE(4);
+    TRIM(3);
 
     private int id;
     OverwriteCause(int i) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -171,18 +171,13 @@ public class AddressSpaceView extends AbstractView {
                         .getReplicationProtocol(runtime)
                         .write(e, ld);
             } catch (OverwriteException ex) {
-                if (ex.getOverWriteCause() == OverwriteCause.SAME_DATA){
-                    // If we have an overwrite exception with the SAME_DATA cause, it means that the
-                    // server suspects our data has already been written, in this case we need to
-                    // validate the state of the write.
-                    validateStateOfWrittenEntry(token.getSequence(), ld);
-                } else {
-                    // If we have an Overwrite exception with a different cause than SAME_DATA
-                    // we do not need to validate the state of the write, as we know we have been
-                    // certainly overwritten either by other data, by a hole or the address was trimmed.
-                    // Large writes are also rejected right away.
-                    throw ex;
+                if (ex.getOverWriteCause() == OverwriteCause.SAME_DATA) {
+                    // Ignore OverwriteException if the conflicting write is equal This can
+                    // happen when a hole filler thread competes with the main writer
+                    return null;
                 }
+
+                throw ex;
             } catch (WriteSizeException we) {
                 throw we;
             } catch (RuntimeException re) {


### PR DESCRIPTION
## Overview
The OverwriteCause can be misleading and it is not needed, this
patch restores the over write handling without using the
OverwriteCause.

Why should this be merged: The OverwriteCause.SAME_DATA just checks the buffer size of LogData, it doesn't check if the data is equal despite the name. It's also not needed.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
