### PR TITLE
Make ping epoch unaware.

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -21,7 +21,7 @@ import java.lang.reflect.Constructor;
 @AllArgsConstructor
 public enum CorfuMsgType {
     // Base Messages
-    PING(0, TypeToken.of(CorfuMsg.class)),
+    PING(0, TypeToken.of(CorfuMsg.class), true),
     PONG(1, TypeToken.of(CorfuMsg.class), true),
     RESET(2, TypeToken.of(CorfuMsg.class), true),
     SET_EPOCH(3, new TypeToken<CorfuPayloadMsg<Long>>() {}, true),


### PR DESCRIPTION
## Overview

Description: Make ping epoch unaware.
A wrongEpochException means the node is reachable.

Why should this be merged: ForceRemoveNode is not able to find an orchestrator if the only remaining live node is sealed. Making the ping epoch unaware makes it possible to choose an orchestrator and hence trigger the workflow.

Related issue(s) (if applicable): Fixes #1917 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
