### PR TITLE
Retry getStreamAddressSpace if disconnected from cluster.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
@@ -109,10 +109,10 @@ public class SequencerView extends AbstractView {
      * @return address space for each stream in the request.
      */
     public Map<UUID, StreamAddressSpace> getStreamsAddressSpace(List<StreamAddressRange> streamsAddressesRange) {
-        try (Timer.Context context = MetricsUtils.getConditionalContext(sequencerNextOneStream)){
+        try (Timer.Context context = MetricsUtils.getConditionalContext(sequencerNextOneStream)) {
             StreamsAddressResponse streamsAddressResponse = layoutHelper(e ->
                     CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
-                    .getStreamsAddressSpace(streamsAddressesRange)), true);
+                            .getStreamsAddressSpace(streamsAddressesRange)));
             return streamsAddressResponse.getAddressMap();
         }
     }

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -35,6 +35,7 @@ import org.corfudb.runtime.clients.ManagementHandler;
 import org.corfudb.runtime.clients.SequencerHandler;
 import org.corfudb.runtime.clients.TestClientRouter;
 import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.util.NodeLocator;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -329,6 +330,21 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
                     .getFailureDetector();
             failureDetector.setNetworkStretcher(stretcher);
         });
+    }
+
+    /**
+     * Increment the cluster layout epoch by 1.
+     *
+     * @return New committed layout
+     * @throws OutrankedException If layout proposal is outranked.
+     */
+    Layout incrementClusterEpoch(CorfuRuntime corfuRuntime) throws OutrankedException {
+        corfuRuntime.invalidateLayout();
+        Layout layout = new Layout(corfuRuntime.getLayoutView().getLayout());
+        layout.setEpoch(layout.getEpoch() + 1);
+        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealMinServerSet();
+        corfuRuntime.getLayoutView().updateLayout(layout, 1L);
+        return layout;
     }
 
     /** Get a default CorfuRuntime. The default CorfuRuntime is connected to a single-node

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1580,21 +1580,6 @@ public class ManagementViewTest extends AbstractViewTest {
     }
 
     /**
-     * Increment the cluster layout epoch by 1.
-     *
-     * @return New committed layout
-     * @throws OutrankedException If layout proposal is outranked.
-     */
-    private Layout incrementClusterEpoch() throws OutrankedException {
-        corfuRuntime.invalidateLayout();
-        Layout layout = new Layout(corfuRuntime.getLayoutView().getLayout());
-        layout.setEpoch(layout.getEpoch() + 1);
-        corfuRuntime.getLayoutView().getRuntimeLayout(layout).sealMinServerSet();
-        corfuRuntime.getLayoutView().updateLayout(layout, 1L);
-        return layout;
-    }
-
-    /**
      * Test scenario where the sequencer bootstrap triggers cache cleanup causing maxConflictWildcard to be reset.
      * The runtime requests for 2 tokens but persists only 1 log entry. On an epoch change, the failover sequencer
      * (in this case, itself) is bootstrapped by running the fastObjectLoader.
@@ -1624,8 +1609,8 @@ public class ManagementViewTest extends AbstractViewTest {
                 .matches(corfuMsg -> corfuMsg.getMsgType() == CorfuMsgType.BOOTSTRAP_SEQUENCER).drop());
 
         // Increment the sequencer epoch twice so that a full sequencer bootstrap is required.
-        incrementClusterEpoch();
-        Layout layout = incrementClusterEpoch();
+        incrementClusterEpoch(corfuRuntime);
+        Layout layout = incrementClusterEpoch(corfuRuntime);
 
         // Clear rules to now allow sequencer bootstrap.
         clearClientRules(getManagementServer(SERVERS.PORT_0).getManagementAgent().getCorfuRuntime());


### PR DESCRIPTION
## Overview

Description:
Retry getStreamAddressSpace if client disconnected from cluster, stamped with an incorrect epoch or server not ready.

Why should this be merged: 
We should not expose exceptions to the client and retry until systemDownHandler is invoked (if registered) or indefinitely.

Added a test ```checkStreamAddressSpaceAcrossEpochs``` to check streamAddressSpace accross epochs.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
