### PR TITLE
Creating a common corfu module

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>corfu</artifactId>
+        <groupId>org.corfudb</groupId>
+        <version>0.2.3-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>corfudb-common</artifactId>
+
+    <properties>
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
+</project>

--- a/common/src/main/java/org/corfudb/common/result/Result.java
+++ b/common/src/main/java/org/corfudb/common/result/Result.java
@@ -1,4 +1,4 @@
-package org.corfudb.util.result;
+package org.corfudb.common.result;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -126,6 +126,11 @@
     <dependencies>
         <dependency>
             <groupId>org.corfudb</groupId>
+            <artifactId>corfudb-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.corfudb</groupId>
             <artifactId>runtime</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.common.result.Result;
 import org.corfudb.infrastructure.management.ClusterAdvisor;
 import org.corfudb.infrastructure.management.ClusterAdvisorFactory;
 import org.corfudb.infrastructure.management.ClusterStateContext;
@@ -27,7 +28,6 @@ import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterrupte
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.util.LambdaUtils;
 import org.corfudb.util.concurrent.SingletonResource;
-import org.corfudb.util.result.Result;
 
 import java.time.Duration;
 import java.util.Collections;

--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,7 @@
     <modules>
         <module>infrastructure</module>
         <module>runtime</module>
+        <module>common</module>
         <module>format</module>
         <module>cmdlets</module>
         <module>test</module>


### PR DESCRIPTION
A `common` Corfu module contains common and generic functionality which can be used by any other module.
It should be used to keep classes like:
 1. Utility classes, like DateUtils, UUIDUtils, JsonUtils, CFUtils, Result and so on.
 2. Common communication primitives, like netty client handler specific to Corfu
 3. Common enums used on infrastructure and client side.
 4. Common classes used by corfu-client-api and corfu-runtime 
and so on.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
