### PR TITLE
Compaction mark in read response

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ReadResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ReadResponse.java
@@ -4,10 +4,12 @@ import io.netty.buffer.ByteBuf;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
+import lombok.Setter;
 
 /**
  * Created by mwei on 8/15/16.
@@ -19,12 +21,18 @@ public class ReadResponse implements ICorfuPayload<ReadResponse> {
     @Getter
     Map<Long, LogData> addresses;
 
+    @Setter
+    @Getter
+    Map<UUID, Long> compactionMarks;
+
     public ReadResponse(ByteBuf buf) {
         addresses = ICorfuPayload.mapFromBuffer(buf, Long.class, LogData.class);
+        compactionMarks = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
     }
 
     public ReadResponse() {
-        addresses = new HashMap<Long, LogData>();
+        addresses = new HashMap<>();
+        compactionMarks = new HashMap<>();
     }
 
     public void put(Long address, LogData data) {
@@ -34,5 +42,6 @@ public class ReadResponse implements ICorfuPayload<ReadResponse> {
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, addresses);
+        ICorfuPayload.serialize(buf, compactionMarks);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
@@ -42,6 +43,13 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
      * The runtime the stream view was created with.
      */
     final CorfuRuntime runtime;
+
+    /**
+     * The compaction mark of this stream.
+     */
+    @Getter
+    @Setter
+    volatile long compactionMark = Address.NON_ADDRESS;
 
     /**
      * An ordered set of stream contexts, which store information

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/IStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/IStreamView.java
@@ -232,4 +232,16 @@ public interface IStreamView extends
      * @return total number of updates belonging to this stream.
      */
     long getTotalUpdates();
+
+    /**
+     * Get the compaction mark of this stream.
+     * @return compaction mark.
+     */
+    long getCompactionMark();
+
+    /**
+     * Set the compaction mark of this stream.
+     * @param compactionMark updated compaction mark address.  
+     */
+    void setCompactionMark(long compactionMark);
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/ThreadSafeStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/ThreadSafeStreamView.java
@@ -112,6 +112,16 @@ public class ThreadSafeStreamView implements IStreamView {
         return stream.getTotalUpdates();
     }
 
+    @Override
+    public long getCompactionMark() {
+        return stream.getCompactionMark();
+    }
+
+    @Override
+    public void setCompactionMark(long compactionMark) {
+        stream.setCompactionMark(compactionMark);
+    }
+
     @VisibleForTesting
     IStreamView getUnderlyingStream() {
         return stream;


### PR DESCRIPTION
## Overview

This patch add a new field in the ReadResponse such that the runtime could get the newest compaction mark from LogUnit servers when reading data.

Description:

Why should this be merged: 

Compaction mark is the hint to the runtime about when the versioning is lost in the LogUnit Servers. With that information, the runtime could decide to abort a TX/access if the snapshot time is smaller than the compaction mark. 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
