### PR TITLE
[Do not review] Bug Fix Stream Address Space Rebuilt Log Unit

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -134,7 +134,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                                            final NavigableSet<Long> queue,
                                            final long startAddress,
                                            final long stopAddress,
-                                           final Function<ILogData, BackpointerOp> filter,
+                                           final Function<ILogData, Boolean> filter,
                                            final boolean checkpoint,
                                            final long maxGlobal) {
         // Sanity check: startAddress must be a valid address and greater than stopAddress.
@@ -162,7 +162,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                                     "trimmed at address %s and this space is not covered by the " +
                                     "loaded checkpoint with start address %s, while accessing the " +
                                     "stream at version %s", this, streamAddressSpace.getTrimMark(),
-                            getCurrentContext().checkpointSuccessStartAddr, maxGlobal);
+                            getCurrentContext().checkpoint.checkpointSuccessStartAddr, maxGlobal);
                     log.warn(message);
                     if (options.ignoreTrimmed) {
                         log.warn("getStreamAddressMap[{}]: Ignoring trimmed exception for address[{}].",
@@ -179,7 +179,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
         return !queue.isEmpty();
     }
 
-    private void processCheckpoint(StreamAddressSpace streamAddressSpace, Function<ILogData, BackpointerOp> filter,
+    private void processCheckpoint(StreamAddressSpace streamAddressSpace, Function<ILogData, Boolean> filter,
                                    NavigableSet<Long> queue) {
         SortedSet<Long> checkpointAddresses = new TreeSet<>(Collections.reverseOrder());
         streamAddressSpace.getAddressMap().forEach(checkpointAddresses::add);
@@ -207,10 +207,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
             try {
                 List<ILogData> entries = readAll(batch);
                 for (ILogData data : entries) {
-                    checkpointResolved = filterCheckpointEntry(data, filter, queue);
-                    if (checkpointResolved) {
-                        break;
-                    }
+                    filter.apply(data);
                 }
             } catch (TrimmedException te) {
                 // Read one entry at a time for the last failed batch, this way we might load
@@ -220,6 +217,10 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                 checkpointResolved = processCheckpointBatchByEntry(batch, filter, queue);
             }
         }
+
+        // Select correct checkpoint - Highest
+        List<Long> checkpointEntries = selectCheckpoint(getCurrentContext());
+        queue.addAll(checkpointEntries);
     }
 
     /**
@@ -233,7 +234,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
      *         False, otherwise.
      */
     private boolean processCheckpointBatchByEntry(List<Long> batch,
-                                                  Function<ILogData, BackpointerOp> filter,
+                                                  Function<ILogData, Boolean> filter,
                                                   NavigableSet<Long> queue) {
         long lastReadAddress = Address.NON_ADDRESS;
         try {
@@ -241,7 +242,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
             for (long address : batch) {
                 lastReadAddress = address;
                 ILogData data = read(address);
-                checkpointResolved = filterCheckpointEntry(data, filter, queue);
+                checkpointResolved = filter.apply(data);
                 if (checkpointResolved) {
                     // Return if checkpoint has already been resolved (reached stop).
                     return true;
@@ -254,32 +255,6 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                         " stream[{}]", this, lastReadAddress, id);
             } else {
                 throw ste;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Applies filter to checkpoint entry and indicates if the checkpoint has been completely resolved
-     * (i.e., reached the stop point).
-     *
-     * @param data checkpoint data entry.
-     * @param filter filter to apply to checkpoint.
-     * @param queue read queue.
-     * @return True, if checkpoint reached stop point (resolved)
-     *         False, if checkpoint resolution needs to continue.
-     */
-    private boolean filterCheckpointEntry(ILogData data, Function<ILogData, BackpointerOp> filter,
-                                          NavigableSet<Long> queue) {
-        BackpointerOp op = filter.apply(data);
-        if (op == BackpointerOp.INCLUDE || op == BackpointerOp.INCLUDE_STOP) {
-            log.trace("filterCheckpointEntry[{}]: Adding checkpoint address[{}] to queue",
-                    this, data.getGlobalAddress());
-            queue.add(data.getGlobalAddress());
-            // Check if we need to stop
-            if (op == BackpointerOp.INCLUDE_STOP) {
-                return true;
             }
         }
 
@@ -355,13 +330,13 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
     }
 
     private boolean isTrimResolvedLocally(long trimMark) {
-        return getCurrentContext().checkpointSuccessId == null
+        return getCurrentContext().checkpoint.checkpointSuccessId == null
                 && getCurrentContext().resolvedQueue.contains(trimMark);
     }
 
     private boolean isTrimCoveredByCheckpoint(long trimMark) {
-        return getCurrentContext().checkpointSuccessId != null &&
-                getCurrentContext().checkpointSuccessStartAddr >= trimMark;
+        return getCurrentContext().checkpoint.checkpointSuccessId != null &&
+                getCurrentContext().checkpoint.checkpointSuccessStartAddr >= trimMark;
     }
 
     @Override

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -405,7 +405,9 @@ public class AbstractIT extends AbstractCorfuTest {
          * @throws IOException
          */
         public Process runServer() throws IOException {
-            final String serverConsoleLogPath = CORFU_LOG_PATH + File.separator + host + "_" + port + "_consolelog";
+            //final String serverConsoleLogPath = CORFU_LOG_PATH + File.separator + host + "_" + port + "_consolelog";
+
+            final String serverConsoleLogPath = "/Users/amartinezman/Desktop" + File.separator + host + "_" + port + "_consolelog";
 
             File logPath = new File(getCorfuServerLogPath(host, port));
             if (!logPath.exists()) {

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -619,5 +619,62 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         mA2.put("a", 2l);
         rt2.getObjectsView().TXEnd();
     }
+
+
+    /**
+     * This test verifies that a stream is rebuilt from a checkpoint, whenever two valid checkpoints exist, but the
+     * latest checkpoint is performed on an earlier snapshot, while the log is trimmed on the snapshot of the earliest
+     * checkpoint.
+     *
+     * 1. Write 25 entries to stream A.
+     * 2. Start a checkpoint (CP2) at snapshot 15, complete it.
+     * 3. Start a checkpoint (CP1) at snapshot 10, complete it.
+     * 4. Trim on token for CP2 (snapshot = 15).
+     * 5. New runtime instantiate stream A (do a mutation to force to load from checkpoint).
+     */
+    @Test
+    public void testUnorderedCheckpoints() throws Exception {
+        final int numEntries = 25;
+        final int snapshotAddress1 = 10;
+        final int snapshotAddress2 = 15;
+
+        // Open map.
+        final String streamA = "streamA";
+        Map<String, Long> mA = instantiateMap(streamA);
+
+        // (1) Write 25 Entries
+        for (int i = 0; i < numEntries; i++) {
+            mA.put(String.valueOf(i), (long) i);
+        }
+
+        // Checkpoint Writer 2 @15
+        CheckpointWriter cpw2 = new CheckpointWriter(r, CorfuRuntime.getStreamID(streamA), "checkpointer-2", mA);
+        Token cp2Token = cpw2.appendCheckpoint(new Token(0, snapshotAddress2 - 1));
+
+        // Checkpoint Writer 1 @10
+        CheckpointWriter cpw1 = new CheckpointWriter(r, CorfuRuntime.getStreamID(streamA), "checkpointer-1", mA);
+        cpw1.appendCheckpoint(new Token(0, snapshotAddress1 - 1));
+
+        // Trim @snapshotAddress=15
+        r.getAddressSpaceView().prefixTrim(cp2Token);
+
+        // New Runtime
+        CorfuRuntime rt2 = getNewRuntime(getDefaultNode()).connect();
+        Map<String, Long> mA2 = rt2.getObjectsView()
+                .build()
+                .setStreamName(streamA)
+                .setTypeToken(new TypeToken<SMRMap<String, Long>>() {
+                })
+                .setSerializer(serializer)
+                .open();
+
+        // Access / Mutate map - It should be built from the earliest checkpoint (CP2)
+        // without throwing a TransactionAbortedException - Cause TRIM
+        rt2.getObjectsView().TXBegin();
+        mA2.put("a", 1l);
+        rt2.getObjectsView().TXEnd();
+
+        assertThat(mA2).hasSize(numEntries + 1);
+    }
 }
 

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -45,7 +45,7 @@
 
 
     <root level="INFO">
-        <!--<appender-ref ref="FILE" />-->
+        <appender-ref ref="FILE" />
         <!--<appender-ref ref="STDOUT" />-->
         <!--<appender-ref ref="MetricsRollingFile" />-->
     </root>


### PR DESCRIPTION
On server restart, stream's address spaces are rebuilt (stream addresses and trim mark). A stream's trim mark was being initialized with the value NON_EXIST (-6) if it appeared before an actual checkpoint entry, and computed as the min of all backpointers. Because it was initialized with -6, this would always be the minimum value. This would make stream trim marks hold the wrong value for cases in which regular entries appear before a checkpoint, until a next trim comes in. This commit corrects this bug, setting the proper trim mark and a test is included.

This change also considers the case of multiple checkpoints running at the same time for address space rebuilt.