### PR TITLE
Add Checkpoint Metadata

### DIFF
--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -35,6 +35,8 @@ message LogEntry {
     optional int64 checkpointedStreamId_least_significant = 14;
     //  Tail of the stream at the time of taking the checkpoint snapshot.
     optional int64 checkpointedStreamStartLogAddress = 15;
+    optional int64 checkpointStartAddress = 19;
+    optional int64 checkpointSnapshotAddress = 20;
 
     // ClientId is the Corfu runtime id that created this LogEntry
     optional int64 clientId_least_significant = 16;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -425,6 +425,9 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
 
             logData.setCheckpointedStreamStartLogAddress(
                     entry.getCheckpointedStreamStartLogAddress());
+
+           logData.setCheckpointStartAddress(entry.getCheckpointStartAddress());
+           logData.setCheckpointSnapshotAddress(entry.getCheckpointSnapshotAddress());
         }
 
         return logData;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
@@ -47,10 +47,11 @@ public class CheckpointEntry extends LogEntry {
     public enum CheckpointDictKey {
         START_TIME(0),
         END_TIME(1),
-        START_LOG_ADDRESS(2),
+        VLO_VERSION(2),
         ENTRY_COUNT(3),
         BYTE_COUNT(4),
-        SNAPSHOT_ADDRESS(5);
+        SNAPSHOT_ADDRESS(5),
+        START_ADDRESS(6);
 
         public final int type;
 
@@ -80,6 +81,9 @@ public class CheckpointEntry extends LogEntry {
 
     @Getter
     UUID streamId;
+
+    @Getter
+    long startAddress;
 
     /** Author/cause/trigger of this checkpoint
      */
@@ -164,8 +168,8 @@ public class CheckpointEntry extends LogEntry {
         super.serialize(b);
 
         if (cpType == CheckpointEntryType.END
-                && getDict().get(CheckpointDictKey.START_LOG_ADDRESS) == null) {
-            throw new IllegalArgumentException(dict.get(CheckpointDictKey.START_LOG_ADDRESS));
+                && getDict().get(CheckpointDictKey.VLO_VERSION) == null) {
+            throw new IllegalArgumentException(dict.get(CheckpointDictKey.VLO_VERSION));
         }
 
         b.writeByte(cpType.asByte());

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -24,10 +24,7 @@ import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.Layout;
 
-import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_ID;
-import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_START_LOG_ADDRESS;
-import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_ID;
-import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_TYPE;
+import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.*;
 
 /**
  * Created by mwei on 9/18/15.
@@ -218,6 +215,32 @@ public interface IMetadata {
         getMetadataMap().put(CHECKPOINTED_STREAM_START_LOG_ADDRESS, startLogAddress);
     }
 
+    /**
+     * Returns the address for the start record of this checkpoint.
+     */
+    default Long getCheckpointStartAddress() {
+        return (Long) getMetadataMap()
+                .getOrDefault(LogUnitMetadataType.CHECKPOINT_START_ADDRESS,
+                        Address.NON_EXIST);
+    }
+
+    default void setCheckpointStartAddress(Long startAddress) {
+        getMetadataMap().put(CHECKPOINT_START_ADDRESS, startAddress);
+    }
+
+    /**
+     * Returns the snapshot address at which this checkpoint was taken.
+     */
+    default Long getCheckpointSnapshotAddress() {
+        return (Long) getMetadataMap()
+                .getOrDefault(CHECKPOINT_SNAPSHOT_ADDRESS,
+                        Address.NON_ADDRESS);
+    }
+
+    default void setCheckpointSnapshotAddress(Long snapshotAddress) {
+        getMetadataMap().put(CHECKPOINT_SNAPSHOT_ADDRESS, snapshotAddress);
+    }
+
     @RequiredArgsConstructor
     public enum LogUnitMetadataType implements ITypedEnum {
         RANK(1, TypeToken.of(DataRank.class)),
@@ -228,6 +251,8 @@ public interface IMetadata {
         CHECKPOINT_ID(7, TypeToken.of(UUID.class)),
         CHECKPOINTED_STREAM_ID(8, TypeToken.of(UUID.class)),
         CHECKPOINTED_STREAM_START_LOG_ADDRESS(9, TypeToken.of(Long.class)),
+        CHECKPOINT_START_ADDRESS(13, TypeToken.of(Long.class)),
+        CHECKPOINT_SNAPSHOT_ADDRESS(14, TypeToken.of(Long.class)),
         CLIENT_ID(10, TypeToken.of(UUID.class)),
         THREAD_ID(11, TypeToken.of(Long.class)),
         EPOCH(12, TypeToken.of(Long.class))

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -187,7 +187,14 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
                 setCheckpointedStreamId(cp.getStreamId());
                 setCheckpointedStreamStartLogAddress(
                         Long.parseLong(cp.getDict()
-                                .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)));
+                                .get(CheckpointEntry.CheckpointDictKey.VLO_VERSION)));
+                if (cp.getCpType() == CheckpointEntry.CheckpointEntryType.END) {
+                    setCheckpointSnapshotAddress(
+                            Long.parseLong(cp.getDict()
+                                    .get(CheckpointEntry.CheckpointDictKey.SNAPSHOT_ADDRESS)));
+                    setCheckpointStartAddress(Long.parseLong(cp.getDict()
+                            .get(CheckpointEntry.CheckpointDictKey.START_ADDRESS)));
+                }
             }
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -637,7 +637,7 @@ public abstract class AbstractQueuedStreamView extends
             if (context.checkpointSuccessId == null &&
                     cpEntry.getCpType() == CheckpointEntry.CheckpointEntryType.END
                     && Long.decode(cpEntry.getDict()
-                    .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)) <= maxGlobal) {
+                    .get(CheckpointEntry.CheckpointDictKey.VLO_VERSION)) <= maxGlobal) {
                 log.trace("Checkpoint[{}] END found at address {} type {} id {} author {}",
                         this, data.getGlobalAddress(), cpEntry.getCpType(),
                         Utils.toReadableId(cpEntry.getCheckpointId()),
@@ -653,7 +653,7 @@ public abstract class AbstractQueuedStreamView extends
                 context.checkpointSuccessBytes += cpEntry.getSmrEntriesBytes();
                 if (cpEntry.getCpType().equals(CheckpointEntry.CheckpointEntryType.START)) {
                     context.checkpointSuccessStartAddr = Long.decode(cpEntry.getDict()
-                            .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS));
+                            .get(CheckpointEntry.CheckpointDictKey.VLO_VERSION));
                     if (cpEntry.getDict().get(CheckpointEntry.CheckpointDictKey
                             .SNAPSHOT_ADDRESS) != null) {
                         context.checkpointSnapshotAddress = Long.decode(cpEntry.getDict()


### PR DESCRIPTION
Include snapshot address and start address as part of the END
record metadata. This information will be used to ease stream's
address space rebuilt on log units.