### PR TITLE
Build stream trim mark from checkpoint

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -189,8 +189,7 @@ public class BatchProcessor implements AutoCloseable {
                         }
                     } catch (Exception e) {
                         log.error("Stream log error. Batch [queue size={}]. StreamLog: [trim mark: {}, tails: {}].",
-                                operationsQueue.size(), streamLog.getTrimMark(), streamLog.getAllTails(), e
-                        );
+                                operationsQueue.size(), streamLog.getTrimMark(), streamLog.getAllTails(), e);
                         currOp.getFutureResult().completeExceptionally(e);
                     }
                     res.add(currOp);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -354,6 +354,8 @@ public class SequencerServer extends AbstractServer {
             }
         }
 
+        log.debug("trimCache: global trim {}, streamsAddressSpace {}", trimMark, streamsAddressMap);
+
         r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -15,6 +15,7 @@ import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.view.Address;
 
 /**
  * This class implements the StreamLog interface using a Java hash map.
@@ -48,7 +49,7 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
             }
 
             logCache.put(entry.getGlobalAddress(), entry);
-            logMetadata.update(entry);
+            logMetadata.update(entry, false);
         }
     }
 
@@ -62,7 +63,7 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
             throwLogUnitExceptionsIfNecessary(address, entry);
         }
         logCache.put(address, entry);
-        logMetadata.update(entry);
+        logMetadata.update(entry, false);
     }
 
     private boolean isTrimmed(long address) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure.log;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.runtime.view.Address;
@@ -44,92 +45,103 @@ public class LogMetadata {
 
     public void update(List<LogData> entries) {
         for (LogData entry : entries) {
-            update(entry);
+            update(entry, false);
         }
     }
 
-    public void update(LogData entry) {
-        update(entry, false, Address.NON_ADDRESS);
-    }
-
-    public void update(LogData entry, boolean initialize, long globalTrimMark) {
+    public void update(LogData entry, boolean initialize) {
         long entryAddress = entry.getGlobalAddress();
+        // Update log tail
         updateGlobalTail(entryAddress);
+        // For every stream present in entry update stream tail
         for (UUID streamId : entry.getStreams()) {
-            // Update stream tails
-            long currentStreamTail = streamTails.getOrDefault(streamId, Address.NON_ADDRESS);
-            streamTails.put(streamId, Math.max(currentStreamTail, entryAddress));
-
-            // Update stream address map (used for sequencer recovery)
-            // Since entries might have been written in random order
-            // We update the trim mark to be the min of all backpointer addresses.
-            streamsAddressSpaceMap.computeIfAbsent(streamId, k ->
-                    new StreamAddressSpace(Address.NON_EXIST, new Roaring64NavigableMap()));
-
-            streamsAddressSpaceMap.compute(streamId, (id, addressSpace) -> {
-                // If restarting the log unit, i.e., scanning all records in the log for initialization,
-                // update the stream trim mark as we read (as entries might not be ordered).
-                // Otherwise, i.e., on log updates (writes) we should not consider this data point for setting
-                // the stream trim mark, as data might not be written in order, hence, we could have invalid
-                // states of the actual address map. In the case of log updates, the trim mark will be set
-                // as prefix trims are performed.
-                if (addressSpace == null) {
-                    long streamTrimMark = Address.NON_EXIST;
-                    if (initialize) {
-                        streamTrimMark = getStreamTrimMark(Long.MAX_VALUE,
-                                entry.getBackpointer(streamId), globalTrimMark);
-                    }
-                    Roaring64NavigableMap addressMap = new Roaring64NavigableMap();
-                    addressMap.addLong(entryAddress);
-                    return new StreamAddressSpace(streamTrimMark, addressMap);
-                }
-
-                if (initialize) {
-                    long streamTrimMark = getStreamTrimMark(addressSpace.getTrimMark(),
-                            entry.getBackpointer(streamId), globalTrimMark);
-                    addressSpace.setTrimMark(streamTrimMark);
-                }
-
-                addressSpace.addAddress(entryAddress);
-                return addressSpace;
-            });
+            updateStreamSpace(streamId, entryAddress);
         }
 
-        // We should also consider checkpoint metadata while updating the tails.
-        // This is important because there could be streams that have checkpoint
-        // data on the checkpoint stream, but not entries on the regular stream.
-        // If those streams are not updated, then clients would observe those
+        // We should also consider checkpoint metadata while updating the tails and stream trim mark.
+        // This is important because there could be streams which data is completely checkpointed,
+        // i.e., no actual entries on the regular stream but only on the checkpoint stream.
+        // If those streams are not updated with this info, then clients would observe those
         // streams as empty, which is not correct.
         if (entry.hasCheckpointMetadata()) {
-            UUID streamId = entry.getCheckpointedStreamId();
-            long streamTailAtCP = entry.getCheckpointedStreamStartLogAddress();
-
-            if (Address.isAddress(streamTailAtCP)) {
-                // TODO(Maithem) This is needed to filter out checkpoints of empty streams,
-                // if the map has an entry (streamId, Address.Non_ADDRESS), then
-                // when the sequencer services queries on that stream it will
-                // "think" that the tail is not empty and return Address.Non_ADDRESS
-                // instead of NON_EXIST. The sequencer, should handle both cases,
-                // but that can be addressed in another issue.
-                long currentStreamTail = streamTails.getOrDefault(streamId, Address.NON_ADDRESS);
-                streamTails.put(streamId, Math.max(currentStreamTail, streamTailAtCP));
-
-                // The trim mark is part of the address space information and is also required
-                // so clients can observe updates to streams that have been completely checkpointed.
-                // If we hit a checkpoint and the stream is not present in the map, the checkpointed
-                // address is the last trimmed address for this stream.
-                streamsAddressSpaceMap.putIfAbsent(streamId,
-                        new StreamAddressSpace(streamTailAtCP, new Roaring64NavigableMap()));
-            }
+            updateFromCheckpoint(entry, initialize);
         }
     }
 
-    private long getStreamTrimMark(long currentTrimMark, long backpointer, long globalTrimMark) {
-        long streamTrimMark = Long.min(currentTrimMark, backpointer);
-        if (streamTrimMark > globalTrimMark) {
-            streamTrimMark = globalTrimMark;
+    /**
+     * Updates relevant info of a stream's space, concretely:
+     * 1. Stream's tail, i.e., the last observed address for the stream.
+     * 2. Stream's address space, i.e., space of all observed updates for the stream.
+     *
+     * @param streamId stream identifier.
+     * @param entryAddress stream address.
+     */
+    private void updateStreamSpace(UUID streamId, long entryAddress) {
+        // Update stream tails
+        long currentStreamTail = streamTails.getOrDefault(streamId, Address.NON_ADDRESS);
+        streamTails.put(streamId, Math.max(currentStreamTail, entryAddress));
+
+        // Update stream address space (used for sequencer recovery), add this entry as a valid address for this stream.
+        streamsAddressSpaceMap.compute(streamId, (id, addressSpace) -> {
+            if (addressSpace == null) {
+                Roaring64NavigableMap addressMap = new Roaring64NavigableMap();
+                addressMap.addLong(entryAddress);
+                // Note: stream trim mark is initialized to -6
+                // its value will be computed as checkpoints for this stream are found in the log.
+                // The presence of a checkpoint provides a valid trim mark for a stream.
+                return new StreamAddressSpace(Address.NON_EXIST, addressMap);
+            }
+            addressSpace.addAddress(entryAddress);
+            return addressSpace;
+        });
+    }
+
+    /**
+     * Update's relevant info of a stream's space from a checkpoint, concretely:
+     * 1. Stream tail for those stream's that have all updates within a checkpoint.
+     * 2. Stream trim mark, i.e., last observed address for a stream subsumed by a checkpoint.
+     *
+     * @param entry log entry
+     * @param initialize true, if called on log unit initialization (full scan)
+     *                   false, otherwise.
+     */
+    private void updateFromCheckpoint(LogData entry, boolean initialize) {
+        UUID streamId = entry.getCheckpointedStreamId();
+        long lastUpdateToStream = entry.getCheckpointedStreamStartLogAddress();
+
+        if (Address.isAddress(lastUpdateToStream)) {
+            // 1. Update stream tail
+            long currentStreamTail = streamTails.getOrDefault(streamId, Address.NON_ADDRESS);
+            streamTails.put(streamId, Math.max(currentStreamTail, lastUpdateToStream));
+
+            // 2. Update stream trim mark
+            // This is only required on initialization as on all other paths trim mark will be set by
+            // explicit trimming.
+            if (initialize) {
+                // The trim mark is part of the address space information and is also required
+                // so clients can observe updates to streams that have been completely checkpointed.
+                // For instance, an empty address space with a stream trim mark != -6, requires data to be
+                // loaded from a checkpoint (vs. no data ever written to this stream).
+
+                // If we hit a checkpoint END record we can use this info to compute the stream trim mark,
+                // i.e., last observed update to the stream that has already been checkpointed, hence
+                // can be safely trimmed from the log.
+                if (entry.getCheckpointType() == CheckpointEntry.CheckpointEntryType.END) {
+                    streamsAddressSpaceMap.compute(streamId, (id, addressSpace) -> {
+                        if (addressSpace == null) {
+                            // If this entry still does not exist, means no updates have been observed for
+                            // this stream yet. We can initialize the trim mark to the last observed update by the
+                            // checkpoint. If further entries are observed they will be added to the address space.
+                            return new StreamAddressSpace(lastUpdateToStream, new Roaring64NavigableMap());
+                        }
+                        // We will hold the maximum of these observed updates as the stream trim mark (highest
+                        // checkpointed address), as this guarantees data is available in a checkpoint (safe trim mark).
+                        addressSpace.setTrimMark(Long.max(addressSpace.getTrimMark(), lastUpdateToStream));
+                        return addressSpace;
+                    });
+                }
+            }
         }
-        return streamTrimMark;
     }
 
     public void updateGlobalTail(long newTail) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -176,8 +176,11 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         long tailSegment = dataStore.getTailSegment();
 
         long start = System.currentTimeMillis();
-        for (long currentSegment = startingSegment; currentSegment <= tailSegment; currentSegment++) {
-            // TODO(Maithem): factor out getSegmentHandleForAddress to allow getting segments by segment number
+        // Scan the log in reverse, this will ease stream trim mark resolution (as we require the
+        // END records of a checkpoint which are always the last entry in this stream)
+        // Note: if a checkpoint END record is not found (i.e., incomplete) this data is not considered
+        // for stream trim mark computation.
+        for (long currentSegment = tailSegment; currentSegment >= startingSegment; currentSegment--) {
             SegmentHandle segment = getSegmentHandleForAddress(currentSegment * RECORDS_PER_LOG_FILE + 1);
             try {
                 for (Long address : segment.getKnownAddresses().keySet()) {
@@ -186,7 +189,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                         continue;
                     }
                     LogData logEntry = read(address);
-                    logMetadata.update(logEntry, true, getTrimMark());
+                    logMetadata.update(logEntry, true);
                 }
             } finally {
                 segment.close();
@@ -196,7 +199,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
         // Open segment will add entries to the writeChannels map, therefore we need to clear it
         writeChannels.clear();
         long end = System.currentTimeMillis();
-        log.info("initializeStreamTails: took {} ms to load {}", end - start, logMetadata);
+        log.info("initializeStreamTails: took {} ms to load {}, log start {}", end - start, logMetadata, getTrimMark());
     }
 
     /**
@@ -948,7 +951,7 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
             safeWrite(segment.getWriteChannel(), record);
             channelsToSync.add(segment.getWriteChannel());
             syncTailSegment(address);
-            logMetadata.update(entry);
+            logMetadata.update(entry, false);
         }
 
         return new AddressMetaData(metadata.getPayloadChecksum(), metadata.getLength(), channelOffset);

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
@@ -188,4 +188,9 @@ public class StreamAddressSpace {
 
         return addressMap.getReverseLongIterator().next();
     }
+
+    @Override
+    public String toString() {
+        return String.format("[%s, %s]@%s", getLowestAddress(), getHighestAddress(), trimMark);
+    }
 }

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -8,6 +8,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -39,6 +40,7 @@ import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.CFUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -840,10 +842,10 @@ public class ServerRestartIT extends AbstractIT {
         CorfuRuntime rt2 = null;
         CorfuRuntime rt3 = null;
 
-        try {
-            // Start server
-            Process corfuProcess = runCorfuServer();
+        // Start server
+        Process corfuProcess = runCorfuServer();
 
+        try {
             r = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
 
             // Open map.
@@ -894,7 +896,77 @@ public class ServerRestartIT extends AbstractIT {
             if (r != null) r.shutdown();
             if (rt2 != null) rt2.shutdown();
             if (rt3 != null) rt3.shutdown();
+
+            shutdownCorfuServer(corfuProcess);
         }
     }
 
+    /**
+     * Check streamAddressSpace rebuilt from log unit
+     * when stream has been previously checkpointed and trimmed.
+     **/
+    @Test
+    public void checkStreamAddressSpaceRebuiltWithTrim() throws Exception {
+        final int numEntries = 10;
+
+        final List<Long> expectedAddresses = new ArrayList<>(
+                Arrays.asList(13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L));
+
+        CorfuRuntime r = null;
+        CorfuRuntime runtimeRestart = null;
+
+        // Start server
+        Process corfuProcess = runCorfuServer();
+
+        try {
+            // Start runtime
+            r = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
+
+            // Open map
+            CorfuTable<String, String> mapTest = createTable(r, new StringMultiIndexer());
+
+            // Write numEntries to map
+            for (int i = 0; i < numEntries; i++) {
+                mapTest.put(String.valueOf(i), String.valueOf(i));
+            }
+
+            // Checkpoint
+            MultiCheckpointWriter cpw = new MultiCheckpointWriter();
+            cpw.addMap(mapTest);
+            Token cpAddress = cpw.appendCheckpoints(r, "cp-test");
+
+            // Trim the log
+            r.getAddressSpaceView().prefixTrim(cpAddress);
+            r.getAddressSpaceView().gc();
+            r.getAddressSpaceView().invalidateServerCaches();
+            r.getAddressSpaceView().invalidateClientCache();
+
+            // Write another numEntries to map
+            for (int i = numEntries; i < numEntries * 2; i++) {
+                mapTest.put(String.valueOf(i), String.valueOf(i));
+            }
+
+            //Restart the corfu server
+            assertThat(shutdownCorfuServer(corfuProcess)).isTrue();
+            corfuProcess = runCorfuServer();
+
+            // Start NEW runtime
+            runtimeRestart = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
+
+            // Fetch Address Space for the given stream
+            StreamAddressSpace addressSpace = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+                    .getAddressMap()
+                    .get(CorfuRuntime.getStreamID("test"));
+
+            // Verify address space and trim mark is properly set for the given stream.
+            assertThat(addressSpace.getTrimMark()).isEqualTo(cpAddress.getSequence());
+
+            assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(expectedAddresses.size());
+            expectedAddresses.forEach(address -> assertThat(addressSpace.getAddressMap().contains(address)).isTrue());
+        } finally {
+            if (r != null) r.shutdown();
+            if (runtimeRestart != null) runtimeRestart.shutdown();
+            shutdownCorfuServer(corfuProcess);
+        }
+    }
 }

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -3,11 +3,14 @@ package org.corfudb.integration;
 import com.google.common.reflect.TypeToken;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.CheckpointWriter;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.object.transactions.TransactionType;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -676,6 +679,326 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
         } finally {
             writeRuntime.shutdown();
             readRuntime.shutdown();
+            shutdownCorfuServer(server);
+        }
+    }
+
+    /**
+     *
+     * In this test we want to verify stream's address space rebuilt from log unit given that a valid checkpoint
+     * appears after entries to the regular stream. We aim to validate trim mark is properly set despite ordering.
+     *
+     * Test Case 0:
+     *
+     *         S1  S1  S1      S1  S2  S2        S1  S1  S1  S1    S1    S1   S1   S1  CP-S1 snapshot @9
+     *       +---------------------------    +-----------------------------------------------+-------+
+     *       | 0 | 1 | 2 | ..| 7 | 8 | 9 |    | 10 | 6 | 7 | 8 | ..... | 11 | 19 | 20 | 21 | 22 | 23 | ...
+     *       +---------------------------    +-----------------------------------------------+-------+
+     *                                   ^
+     *                                  TRIM
+     **/
+    @Test
+    public void testStreamRebuilt() throws Exception {
+
+        List<CorfuRuntime> runtimes = new ArrayList<>();
+
+        final int insertions = 10;
+        final int insertionsB = 2;
+        final String stream1 = "mapA";
+        final String stream2 = "mapB";
+        final int snapshotAddress = 9;
+
+        // Run Corfu Server
+        Process server = runDefaultServer();
+
+        try {
+            runtime = createDefaultRuntime();
+            runtimes.add(runtime);
+
+            // Open mapA (S1) and mapB (S2)
+            Map<String, Integer> mapA = createMap(runtime, stream1);
+            Map<String, Integer> mapB = createMap(runtime, stream2);
+
+            // Write 8 entries to mapA
+            for (int i = 0; i < insertions - insertionsB; i++) {
+                mapA.put(String.valueOf(i), i);
+            }
+
+            // Write 2 entries to mapB
+            for (int i = 0; i < insertionsB; i++) {
+                mapB.put(String.valueOf(i), i);
+            }
+
+            // Write 10 more entries to streamA (emulating writes that came in between the time a snapshot was taken
+            // for a checkpoint and actual checkpoint entries were written)
+            for (int i = insertions; i < insertions * 2; i++) {
+                mapA.put(String.valueOf(i), i);
+            }
+
+            // Start checkpoint with snapshot time 9 for mapA
+            CheckpointWriter cpw = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(stream1),
+                    "checkpointer-test", mapA);
+            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress));
+
+            // Start checkpoint with snapshot time 9 for mapB
+            CheckpointWriter cpwB = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(stream2),
+                    "checkpointer-test", mapB);
+            cpwB.appendCheckpoint(new Token(0, snapshotAddress));
+
+            // Trim the log
+            runtime.getAddressSpaceView().prefixTrim(cpAddress);
+            runtime.getAddressSpaceView().gc();
+            runtime.getAddressSpaceView().invalidateServerCaches();
+            runtime.getAddressSpaceView().invalidateClientCache();
+
+            // Restart the server
+            assertThat(shutdownCorfuServer(server)).isTrue();
+            server = runDefaultServer();
+
+            // Start new runtime
+            CorfuRuntime runtimeRestart = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
+            runtimes.add(runtimeRestart);
+
+            // Fetch Address Space for the given stream S1
+            StreamAddressSpace addressSpaceA = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+                    .getAddressMap()
+                    .get(CorfuRuntime.getStreamID(stream1));
+
+            // Verify address space and trim mark is properly set for the given stream (should be 7 which  is the start log address
+            // for the existing checkpoint)
+            assertThat(addressSpaceA.getTrimMark()).isEqualTo(cpAddress.getSequence() - insertionsB);
+            assertThat(addressSpaceA.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+
+            // Fetch Address Space for the given stream S2
+            StreamAddressSpace addressSpaceB = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+                    .getAddressMap()
+                    .get(CorfuRuntime.getStreamID(stream2));
+
+            // Verify address space and trim mark is properly set for the given stream (should be 7 which  is the start log address
+            // for the existing checkpoint)
+            assertThat(addressSpaceB.getTrimMark()).isEqualTo(snapshotAddress);
+            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(0);
+
+            // Open mapB after restart (verify it loads from checkpoint)
+            Map<String, Integer> mapBRestart = createMap(runtimeRestart, stream2);
+            assertThat(mapBRestart).hasSize(insertionsB);
+        } finally {
+            runtimes.forEach(CorfuRuntime::shutdown);
+            shutdownCorfuServer(server);
+        }
+    }
+
+
+    /**
+     *
+     *  In this test we want to verify stream's address space rebuilt from log unit given that a hole is the first
+     *  valid address for a stream after a trim (i.e., backpointer is lost) and a checkpoint is present.
+     *
+     * Test Case 1:
+     *
+     *         S1  S1  S1   S1   S1  S2        S1       S1  S1  S1    S1    S1   S1   S1     CP-S1 snapshot @9
+     *       +-------------------------    +-----------------------------------------------+--------------+
+     *       | 0 | 1 | 2 | ... | 8 | 9 |    | 10 (hole) | 6 | 7 | 8 | ..... | 11 | 19 | 20 | 21 | 22 | 23 |
+     *       +-------------------------    +-----------------------------------------------+--------------+
+     *                                ^
+     *                              TRIM
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testStreamRebuiltWithHoleAsFirstEntryAfterTrim() throws Exception {
+
+        List<CorfuRuntime> runtimes = new ArrayList<>();
+
+        final int insertions = 10;
+        final String streamNameA = "mapA";
+        final String streamNameB = "mapB";
+        final int snapshotAddress = 10;
+
+        // Run Corfu Server
+        Process server = runDefaultServer();
+
+        try {
+            runtime = createDefaultRuntime();
+            runtimes.add(runtime);
+
+            // Open mapA
+            Map<String, Integer> mapA = createMap(runtime, streamNameA);
+            Map<String, Integer> mapB = createMap(runtime, streamNameB);
+
+            // Write 9 entries to mapA
+            for (int i = 0; i < insertions - 1; i++) {
+                mapA.put(String.valueOf(i), i);
+            }
+
+            mapB.put("a", 0);
+
+            // Force a hole for streamA
+            Token token = runtime.getSequencerView().next(CorfuRuntime.getStreamID(streamNameA)).getToken();
+            LogData hole = LogData.getHole(token);
+            runtime.getLayoutView().getRuntimeLayout()
+                    .getLogUnitClient("tcp://localhost:9000")
+                    .write(hole);
+
+            // Write 10 more entries to streamA (emulating writes that came in between the time a snapshot was taken
+            // for a checkpoint and actual checkpoint entries were written)
+            for (int i = insertions; i < insertions * 2; i++) {
+                mapA.put(String.valueOf(i), i);
+            }
+
+            // Start checkpoint with snapshot time (right before the hole) - Ignore the fact the entry from streamB is lost
+            // we're interested in verifying the behaviour of streamA with end address != trim address.
+            CheckpointWriter cpw = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(streamNameA),
+                    "checkpoint-test", mapA);
+            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress - 1));
+
+            // Trim the log
+            runtime.getAddressSpaceView().prefixTrim(cpAddress);
+            runtime.getAddressSpaceView().gc();
+            runtime.getAddressSpaceView().invalidateServerCaches();
+            runtime.getAddressSpaceView().invalidateClientCache();
+
+            // Restart the server
+            assertThat(shutdownCorfuServer(server)).isTrue();
+            server = runDefaultServer();
+
+            // Start NEW runtime
+            CorfuRuntime runtimeRestart = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
+            runtimes.add(runtimeRestart);
+
+            // Fetch Address Space for the given stream
+            StreamAddressSpace addressSpaceA = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+                    .getAddressMap()
+                    .get(CorfuRuntime.getStreamID(streamNameA));
+
+            // Verify address space and trim mark is properly set for the given stream.
+            assertThat(addressSpaceA.getTrimMark()).isEqualTo(cpAddress.getSequence() - 1);
+            assertThat(addressSpaceA.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+
+            // Open mapA after restart (verify it loads from checkpoint)
+            Map<String, Integer> mapARestart = createMap(runtimeRestart, streamNameA);
+            assertThat(mapARestart).hasSize(insertions * 2 - 1);
+        } finally {
+            runtimes.forEach(CorfuRuntime::shutdown);
+            shutdownCorfuServer(server);
+        }
+    }
+
+
+    /**
+     *
+     *   In this test we want to verify stream's address space rebuilt from log unit given that a hole is the first
+     *   valid address for a stream after a trim (i.e., backpointer is lost) and no checkpoint is present, i.e.,
+     *   S2 was never written to before the checkpoint.
+     *
+     * Test Case 2:
+     *
+     *         S1  S1  S1   S1   S1  S1        S2       S2   S2  S2    S2    S2   S2
+     *       +-------------------------     +---------------------------------------+
+     *       | 0 | 1 | 2 | ... | 8 | 9 |    | 10 (hole) | 11 | 12 | 13 | ..... | 19 |
+     *       +-------------------------     +---------------------------------------+
+     *                                ^
+     *                              TRIM
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testStreamRebuiltWithHoleAsFirstEntryAfterTrimNoCP() throws Exception {
+
+        List<CorfuRuntime> runtimes = new ArrayList<>();
+
+        final int insertions = 10;
+        final String streamNameA = "mapA";
+        final String streamNameB = "mapB";
+        final int snapshotAddress = 10;
+
+        // Run Corfu Server
+        Process server = runDefaultServer();
+
+        try {
+            runtime = createDefaultRuntime();
+            runtimes.add(runtime);
+
+            // Open mapA
+            Map<String, Integer> mapA = createMap(runtime, streamNameA);
+            Map<String, Integer> mapB = createMap(runtime, streamNameB);
+
+            // Write 9 entries to mapA
+            for (int i = 0; i < insertions; i++) {
+                mapA.put(String.valueOf(i), i);
+            }
+
+            // Force a hole for streamB
+            Token token = runtime.getSequencerView().next(CorfuRuntime.getStreamID(streamNameB)).getToken();
+            LogData hole = LogData.getHole(token);
+            runtime.getLayoutView().getRuntimeLayout()
+                    .getLogUnitClient("tcp://localhost:9000")
+                    .write(hole);
+
+            // Write 10 entries to stream B
+            for (int i = 0; i < insertions; i++) {
+                mapB.put(String.valueOf(i), i);
+            }
+
+            // Checkpoint A with snapshot @ 9
+            CheckpointWriter cpw = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(streamNameA),
+                    "checkpointer-test", mapA);
+            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress - 1));
+
+            // Trim the log
+            runtime.getAddressSpaceView().prefixTrim(cpAddress);
+            runtime.getAddressSpaceView().gc();
+            runtime.getAddressSpaceView().invalidateServerCaches();
+            runtime.getAddressSpaceView().invalidateClientCache();
+
+            // Before restarting the server instantiate new runtime and open map to validate it
+            // is correctly built from checkpoint.
+            CorfuRuntime rt2 = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
+            runtimes.add(rt2);
+
+            // Fetch Address Space for the given stream
+            StreamAddressSpace addressSpaceB = rt2.getAddressSpaceView().getLogAddressSpace()
+                    .getAddressMap()
+                    .get(CorfuRuntime.getStreamID(streamNameB));
+
+            // Verify address space and trim mark is properly set for the given stream.
+            assertThat(addressSpaceB.getTrimMark()).isEqualTo(Address.NON_EXIST);
+            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+
+            // Open mapB new runtime
+            Map<String, Integer> mapBNewRuntime = createMap(rt2, streamNameB);
+            assertThat(mapBNewRuntime).hasSize(insertions);
+
+            // Open mapA new runtime
+            Map<String, Integer> mapANewRuntime = createMap(rt2, streamNameA);
+            assertThat(mapANewRuntime).hasSize(insertions);
+
+            // Restart the server
+            assertThat(shutdownCorfuServer(server)).isTrue();
+            server = runDefaultServer();
+
+            // Start NEW runtime
+            CorfuRuntime runtimeRestart = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
+            runtimes.add(runtimeRestart);
+
+            // Fetch Address Space for the given stream
+            addressSpaceB = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+                    .getAddressMap()
+                    .get(CorfuRuntime.getStreamID(streamNameB));
+
+            // Verify address space and trim mark is properly set for the given stream.
+            assertThat(addressSpaceB.getTrimMark()).isEqualTo(Address.NON_EXIST);
+            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+
+            // Open mapB after restart
+            Map<String, Integer> mapBRestart = createMap(runtimeRestart, streamNameB);
+            assertThat(mapBRestart).hasSize(insertions);
+
+            // Open mapA after restart
+            Map<String, Integer> mapARestart = createMap(runtimeRestart, streamNameA);
+            assertThat(mapARestart).hasSize(insertions);
+        } finally {
+            runtimes.forEach(CorfuRuntime::shutdown);
             shutdownCorfuServer(server);
         }
     }

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -464,6 +464,9 @@ public class CheckpointSmokeTest extends AbstractViewTest {
                 l, l, true, true, true);
     }
 
+    long addr1;
+    long startAddress;
+
     private void writeCheckpointRecords(UUID streamId, String checkpointAuthor, UUID checkpointId,
                                         Object[] objects, Runnable l1, Runnable l2,
                                         boolean write1, boolean write2, boolean write3)
@@ -485,7 +488,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
             mdKV.put(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS, Long.toString(addr1 + 1));
             CheckpointEntry cp1 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.START,
                     checkpointAuthor, checkpointId, streamId, mdKV, null);
-            sv.append(cp1, null, null);
+            startAddress = sv.append(cp1, null, null);
         }
 
         // Interleaving opportunity #1


### PR DESCRIPTION
Simplifying stream address rebuilt on log unit restart. This change also considers the case of multiple checkpoints running at the same time for address space rebuilt.