### PR TITLE
Memory Size Based Eviction

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -152,10 +152,16 @@ public class CorfuRuntime {
         boolean cacheDisabled = false;
 
         /**
-         * The maximum size of the cache, in bytes.
+         * The maximum number of entries in the cache.
          */
         @Default
-        long numCacheEntries = 5000;
+        long maxCacheEntries;
+
+        /**
+         * The max in-memory size of the cache in bytes
+         */
+        @Default
+        long maxCacheWeight;
 
         /**
          * Sets expireAfterAccess and expireAfterWrite in seconds.
@@ -1178,19 +1184,6 @@ public class CorfuRuntime {
     public CorfuRuntime setHoleFillingDisabled(boolean disable) {
         log.warn("setHoleFillingDisabled: Deprecated, please set parameters instead");
         parameters.setHoleFillingDisabled(disable);
-        return this;
-    }
-
-    /**
-     * Set the number of cache entries.
-     *
-     * @param numCacheEntries The number of cache entries.
-     * @deprecated Deprecated, set using {@link CorfuRuntimeParameters} instead.
-     */
-    @Deprecated
-    public CorfuRuntime setNumCacheEntries(long numCacheEntries) {
-        log.warn("setNumCacheEntries: Deprecated, please set parameters instead");
-        parameters.setNumCacheEntries(numCacheEntries);
         return this;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -31,6 +31,7 @@ import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.CorfuComponent;
+import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Sleep;
 import org.corfudb.util.Utils;
 
@@ -63,19 +64,44 @@ public class AddressSpaceView extends AbstractView {
     /**
      * A cache for read results.
      */
-    final Cache<Long, ILogData> readCache = CacheBuilder.newBuilder()
-            .maximumSize(runtime.getParameters().getNumCacheEntries())
-            .expireAfterAccess(runtime.getParameters().getCacheExpiryTime(), TimeUnit.SECONDS)
-            .expireAfterWrite(runtime.getParameters().getCacheExpiryTime(), TimeUnit.SECONDS)
-            .removalListener(this::handleEviction)
-            .recordStats()
-            .build();
+    final Cache<Long, ILogData> readCache;
+
+    final private long cacheKeySize = MetricsUtils.sizeOf.deepSizeOf(new Long(0));
+
+    final private long defaultMaxCacheEntries = 5000;
 
     /**
      * Constructor for the Address Space View.
      */
     public AddressSpaceView(@Nonnull final CorfuRuntime runtime) {
         super(runtime);
+
+        CacheBuilder cacheBuilder = CacheBuilder.newBuilder();
+
+        long maxCacheEntries = runtime.getParameters().getMaxCacheEntries();
+        long maxCacheWeight = runtime.getParameters().getMaxCacheWeight();
+
+        if (maxCacheEntries != 0) {
+            cacheBuilder.maximumSize(runtime.getParameters().getMaxCacheEntries());
+        }
+
+        if (maxCacheWeight != 0) {
+            cacheBuilder.maximumWeight(runtime.getParameters().getMaxCacheWeight());
+            cacheBuilder.weigher((k, v) -> (int) (cacheKeySize + MetricsUtils.sizeOf.deepSizeOf(v)));
+        }
+
+        if (maxCacheEntries == 0 && maxCacheWeight == 0) {
+            // If cache weight/size are not set, then we default to using
+            // size based cache
+            cacheBuilder.maximumSize(defaultMaxCacheEntries);
+        }
+
+        readCache = cacheBuilder.expireAfterAccess(runtime.getParameters().getCacheExpiryTime(), TimeUnit.SECONDS)
+                .expireAfterWrite(runtime.getParameters().getCacheExpiryTime(), TimeUnit.SECONDS)
+                .removalListener(this::handleEviction)
+                .recordStats()
+                .build();
+
         MetricRegistry metrics = CorfuRuntime.getDefaultMetrics();
         final String pfx = String.format("%s0x%x.cache.", CorfuComponent.ADDRESS_SPACE_VIEW.toString(),
                                          this.hashCode());

--- a/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
@@ -75,7 +75,7 @@ public class MetricsUtils {
     private static boolean metricsSlf4jReportingEnabled = false;
     private static String mpTrigger = "filter-trigger"; // internal use only
 
-    private static final SizeOf sizeOf = SizeOf.newInstance();
+    public static final SizeOf sizeOf = SizeOf.newInstance();
 
     /**
      * Load metrics properties.

--- a/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
@@ -72,10 +72,17 @@ public class TransactionStreamIT extends AbstractIT {
 
         // A thread that starts and consumes transaction updates via the Transaction Stream.
         Future<Map<UUID, Integer>> consumerState = consumer.submit(() -> {
-            CorfuRuntime consumerRt = new CorfuRuntime(DEFAULT_ENDPOINT)
+
+            CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
+                    .builder()
+                    .maxCacheEntries(runtimeCacheSize)
+                    .build();
+
+            CorfuRuntime consumerRt = CorfuRuntime.fromParameters(params)
+                    .parseConfigurationString(DEFAULT_ENDPOINT)
                     .setTransactionLogging(true)
-                    .setNumCacheEntries(runtimeCacheSize)
                     .connect();
+
             consumerRts.add(consumerRt);
 
             IStreamView txStream = consumerRt.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID);
@@ -102,9 +109,14 @@ public class TransactionStreamIT extends AbstractIT {
 
         ExecutorService producers = Executors.newFixedThreadPool(numWriters);
 
-        CorfuRuntime producersRt = new CorfuRuntime(DEFAULT_ENDPOINT)
+        CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
+                .builder()
+                .maxCacheEntries(runtimeCacheSize)
+                .build();
+
+        CorfuRuntime producersRt = CorfuRuntime.fromParameters(params)
+                .parseConfigurationString(DEFAULT_ENDPOINT)
                 .setTransactionLogging(true)
-                .setNumCacheEntries(runtimeCacheSize)
                 .connect();
 
         // Spawn writers, where each thread creates a table and starts


### PR DESCRIPTION
## Overview
Added weight(i.e. in-memory size) based eviction for the
AddressSpaceView cache.

Why should this be merged: Makes it easier to tune the cache for some workloads 

Related issue(s) (if applicable): #1980


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
