### PR TITLE
org.corfudb.util.Sleep refactoring/deprecation

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementAgent.java
@@ -13,6 +13,7 @@ import org.corfudb.util.Sleep;
 import org.corfudb.util.concurrent.SingletonResource;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 import static org.corfudb.infrastructure.RecoveryHandler.runRecoveryReconfiguration;
 
@@ -148,7 +149,7 @@ public class ManagementAgent {
         try {
             while (!shutdown && serverContext.getManagementLayout() == null) {
                 log.warn("initializationTask: Management Server waiting to be bootstrapped");
-                Sleep.MILLISECONDS.sleepRecoverably(CHECK_BOOTSTRAP_INTERVAL.toMillis());
+                TimeUnit.MILLISECONDS.sleep(CHECK_BOOTSTRAP_INTERVAL.toMillis());
             }
         } catch (InterruptedException e) {
             // Due to shutdown, which interrupts this thread
@@ -173,7 +174,7 @@ public class ManagementAgent {
 
                 log.error("initializationTask: Recovery failed {} times. Retrying in {}s.",
                         ++recoveryAttempts, RECOVERY_RETRY_INTERVAL);
-                Sleep.MILLISECONDS.sleepRecoverably(RECOVERY_RETRY_INTERVAL.toMillis());
+                TimeUnit.MILLISECONDS.sleep(RECOVERY_RETRY_INTERVAL.toMillis());
             } catch (InterruptedException e) {
                 // Due to shutdown, which interrupts this thread
                 log.debug("initializationTask: Initialization task interrupted without being recovered");

--- a/runtime/src/main/java/org/corfudb/runtime/BootstrapUtil.java
+++ b/runtime/src/main/java/org/corfudb/runtime/BootstrapUtil.java
@@ -19,6 +19,7 @@ import org.corfudb.util.Sleep;
 
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Utility to bootstrap a cluster.
@@ -131,7 +132,7 @@ public class BootstrapUtil {
                         throw new RetryExhaustedException("Bootstrapping node: retry exhausted");
                     }
                     log.warn("Retrying bootstrap {} times in {}ms.", retry, retryDuration.toMillis());
-                    Sleep.MILLISECONDS.sleepUninterruptibly(retryDuration.toMillis());
+                    Sleep.sleepUninterruptibly(retryDuration);
                 }
             }
 

--- a/runtime/src/main/java/org/corfudb/runtime/RebootUtil.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RebootUtil.java
@@ -11,6 +11,7 @@ import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Sleep;
 
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Utility to Reboot a server which includes reset or restart
@@ -123,7 +124,7 @@ public class RebootUtil {
                     throw new RetryExhaustedException("Rebooting node: retry exhausted");
                 }
                 log.warn("Retrying reboot {} times in {}ms.", retries, retryDuration.toMillis());
-                Sleep.MILLISECONDS.sleepUninterruptibly(retryDuration.toMillis());
+                Sleep.sleepUninterruptibly(retryDuration);
             }
         }
         log.info("Successfully rebooted server:{}", endpoint);

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -29,9 +29,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
+import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 /**
@@ -402,7 +404,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                 MetricsUtils.incConditionalCounter(isMetricsEnabled, counterTxnRetryN, 1);
                 log.debug("Transactional function aborted due to {}, retrying after {} msec",
                         e, sleepTime);
-                Sleep.MILLISECONDS.sleepUninterruptibly(sleepTime);
+                Sleep.sleepUninterruptibly(Duration.ofMillis(sleepTime));
                 sleepTime = min(sleepTime * 2L, maxSleepTime);
                 retries++;
             } catch (Exception e) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.view;
 
 import java.time.Duration;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/NeverHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/NeverHoleFillPolicy.java
@@ -1,5 +1,7 @@
 package org.corfudb.runtime.view.replication;
 
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
@@ -41,7 +43,7 @@ public class NeverHoleFillPolicy implements IHoleFillPolicy {
         do {
             if (tryNum != 0) {
                 log.trace("Peek[{}] Retrying read {}", address, tryNum);
-                Sleep.MILLISECONDS.sleepUninterruptibly(waitMs);
+                Sleep.sleepUninterruptibly(Duration.ofMillis(waitMs));
             }
             data = peekFunction.apply(address);
             tryNum++;

--- a/runtime/src/main/java/org/corfudb/util/retry/ExponentialBackoffRetry.java
+++ b/runtime/src/main/java/org/corfudb/util/retry/ExponentialBackoffRetry.java
@@ -2,6 +2,7 @@ package org.corfudb.util.retry;
 
 import java.time.Duration;
 import java.util.Random;
+import java.util.concurrent.TimeUnit;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -80,7 +81,7 @@ public class ExponentialBackoffRetry<E extends Exception, F extends Exception,
             sleepTime = base + extraWait;
             sleepTime -= sleepTime * randomPart;
         }
-        Sleep.MILLISECONDS.sleepUninterruptibly(sleepTime);
+        Sleep.sleepUninterruptibly(Duration.ofMillis(sleepTime));
     }
 
 }

--- a/runtime/src/main/java/org/corfudb/util/retry/IntervalRetry.java
+++ b/runtime/src/main/java/org/corfudb/util/retry/IntervalRetry.java
@@ -5,6 +5,8 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.util.Sleep;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * This class implements a basic interval-based retry.
  *
@@ -33,7 +35,7 @@ public class IntervalRetry<E extends Exception, F extends Exception,
      */
     @Override
     public void nextWait() throws InterruptedException {
-        Sleep.MILLISECONDS.sleepUninterruptibly(retryInterval);
+        TimeUnit.MILLISECONDS.sleep(retryInterval);
     }
 
 }

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
@@ -150,7 +151,9 @@ public class AbstractIT extends AbstractCorfuTest {
         }
     }
 
-    public void restartServer(CorfuRuntime corfuRuntime, String endpoint) {
+    public void restartServer(
+            CorfuRuntime corfuRuntime, String endpoint) throws InterruptedException {
+
         corfuRuntime.invalidateLayout();
         RuntimeLayout runtimeLayout = corfuRuntime.getLayoutView().getRuntimeLayout();
         try {
@@ -167,7 +170,7 @@ public class AbstractIT extends AbstractCorfuTest {
                     == (runtimeLayout.getLayout().getEpoch() + 1)) {
                 break;
             }
-            Sleep.MILLISECONDS.sleepUninterruptibly(PARAMETERS.TIMEOUT_SHORT);
+            TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
             corfuRuntime.invalidateLayout();
         }
     }
@@ -179,7 +182,9 @@ public class AbstractIT extends AbstractCorfuTest {
      * @param verifier     Layout predicate to test the refreshed layout.
      * @param corfuRuntime corfu runtime.
      */
-    public static void waitForLayoutChange(Predicate<Layout> verifier, CorfuRuntime corfuRuntime) {
+    public static void waitForLayoutChange(
+            Predicate<Layout> verifier, CorfuRuntime corfuRuntime) throws InterruptedException {
+
         corfuRuntime.invalidateLayout();
         Layout refreshedLayout = corfuRuntime.getLayoutView().getLayout();
 
@@ -189,7 +194,7 @@ public class AbstractIT extends AbstractCorfuTest {
             }
             corfuRuntime.invalidateLayout();
             refreshedLayout = corfuRuntime.getLayoutView().getLayout();
-            Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_VERY_SHORT);
+            TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         }
         assertThat(verifier.test(refreshedLayout)).isTrue();
     }
@@ -199,9 +204,9 @@ public class AbstractIT extends AbstractCorfuTest {
      *
      * @param supplier Supplier to test condition
      */
-    public static void waitFor(Supplier<Boolean> supplier) {
+    public static void waitFor(Supplier<Boolean> supplier) throws InterruptedException {
         while (!supplier.get()) {
-            Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_VERY_SHORT);
+            TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         }
     }
 

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -105,7 +105,9 @@ public class ClusterReconfigIT extends AbstractIT {
      * @param epochVerifier Predicate to test the refreshed epoch value.
      * @param corfuRuntime  Runtime.
      */
-    private void waitForEpochChange(Predicate<Long> epochVerifier, CorfuRuntime corfuRuntime) {
+    private void waitForEpochChange(Predicate<Long> epochVerifier, CorfuRuntime corfuRuntime)
+            throws InterruptedException {
+
         corfuRuntime.invalidateLayout();
         Layout refreshedLayout = corfuRuntime.getLayoutView().getLayout();
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
@@ -114,7 +116,7 @@ public class ClusterReconfigIT extends AbstractIT {
             }
             corfuRuntime.invalidateLayout();
             refreshedLayout = corfuRuntime.getLayoutView().getLayout();
-            Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_SHORT);
+            TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
         }
         assertThat(epochVerifier.test(refreshedLayout.getEpoch())).isTrue();
     }
@@ -388,8 +390,7 @@ public class ClusterReconfigIT extends AbstractIT {
      * @param killNode Index of the node to be killed.
      * @throws Exception
      */
-    private void killNodeAndVerifyDataPath(int killNode)
-            throws Exception {
+    private void killNodeAndVerifyDataPath(int killNode) throws Exception {
 
         // Set up cluster of 3 nodes.
         final int PORT_0 = 9000;
@@ -401,7 +402,7 @@ public class ClusterReconfigIT extends AbstractIT {
         List<Process> corfuServers = Arrays.asList(corfuServer_1, corfuServer_2, corfuServer_3);
         final Layout layout = getLayout(3);
         final int retries = 3;
-        Sleep.SECONDS.sleepUninterruptibly(1);
+        TimeUnit.SECONDS.sleep(1);
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
         // Create map and set up daemon writer thread.
@@ -511,7 +512,7 @@ public class ClusterReconfigIT extends AbstractIT {
         shutdownCorfuServer(corfuServer_3);
     }
 
-    private void retryBootstrapOperation(Runnable bootstrapOperation) {
+    private void retryBootstrapOperation(Runnable bootstrapOperation) throws InterruptedException {
         final int retries = 5;
         int retry = retries;
         while (retry-- > 0) {
@@ -519,7 +520,7 @@ public class ClusterReconfigIT extends AbstractIT {
                 bootstrapOperation.run();
                 return;
             } catch (Exception e) {
-                Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_SHORT);
+                TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
             }
         }
         fail();
@@ -691,7 +692,7 @@ public class ClusterReconfigIT extends AbstractIT {
                 // A transaction aborted exception is expected during
                 // some reconfiguration cases.
             }
-            Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_SHORT);
+            TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis());
         }
         assertThat(writeAfterKillNode).isTrue();
 
@@ -905,7 +906,7 @@ public class ClusterReconfigIT extends AbstractIT {
                 break;
             }
             runtime.invalidateLayout();
-            Sleep.sleepUninterruptibly(PARAMETERS.TIMEOUT_VERY_SHORT);
+            TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
         }
 
         assertThat(runtime.getLayoutView().getLayout().getUnresponsiveServers()).isEmpty();
@@ -1037,7 +1038,7 @@ public class ClusterReconfigIT extends AbstractIT {
         List<Process> corfuServers = Arrays.asList(corfuServer_1, corfuServer_2, corfuServer_3);
         final Layout layout = getLayout(3);
         final int retries = 3;
-        Sleep.SECONDS.sleepUninterruptibly(1);
+        TimeUnit.SECONDS.sleep(1);
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
         final int systemDownHandlerLimit = 10;

--- a/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
@@ -93,7 +93,7 @@ public class TransactionStreamIT extends AbstractIT {
                 }
 
                 consumed += entries.size();
-                Sleep.MILLISECONDS.sleepUninterruptibly(pollPeriodMs);
+                TimeUnit.MILLISECONDS.sleep(pollPeriodMs);
             }
 
             return counters;


### PR DESCRIPTION
## Overview
org.corfudb.util.Sleep:
- doesn't provide any advantages over TimeUnit.
- it throws an UnrecoverableCorfuInterruptedError which extends `java.lang.Error` - which is error prone and very bad practice.
- A lot of useless boilerplate (entire functionality already implemented in TimeUnit, `Sleep` just copy\paste some methods from TimeUnit).
- it brings additional complexity and confusion

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
