### PR TITLE
Get rid of Runtime dependency in payload deserialization.

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowser.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowser.java
@@ -2,17 +2,13 @@ package org.corfudb.browser;
 
 import com.google.common.reflect.TypeToken;
 
-import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.CorfuStoreMetadata.TableName;
-import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.CorfuDynamicKey;
 import org.corfudb.runtime.collections.CorfuDynamicRecord;
@@ -105,7 +101,7 @@ public class CorfuStoreBrowser {
                     new PersistedStreamingMap<>(
                             Paths.get(diskPath),
                             options,
-                            dynamicProtobufSerializer, runtime);
+                            dynamicProtobufSerializer);
             corfuTableBuilder.setArguments(mapSupplier, ICorfuVersionPolicy.MONOTONIC);
         }
 

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
@@ -1,6 +1,11 @@
 package org.corfudb.protocols.logprotocol;
 
 import io.netty.buffer.ByteBuf;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -9,17 +14,10 @@ import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import org.corfudb.runtime.CorfuRuntime;
-
 
 /**
  * Object & serialization methods for in-stream checkpoint
- * summarization of SMR object state.
+ * summary of SMR object state.
  */
 @ToString(callSuper = true)
 @NoArgsConstructor
@@ -123,12 +121,10 @@ public class CheckpointEntry extends LogEntry {
      * should initialize their contents based on the buffer.
      *
      * @param b The remaining buffer.
-     * @param rt The CorfuRuntime used by the SMR object.
-     * @return A CheckpointEntry.
      */
     @Override
-    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
-        super.deserializeBuffer(b, rt);
+    void deserializeBuffer(ByteBuf b) {
+        super.deserializeBuffer(b);
         cpType = CheckpointEntryType.typeMap.get(b.readByte());
         checkpointId = new UUID(b.readLong(), b.readLong());
         streamId = new UUID(b.readLong(), b.readLong());
@@ -143,7 +139,7 @@ public class CheckpointEntry extends LogEntry {
         smrEntries = null;
         byte hasSmrEntries = b.readByte();
         if (hasSmrEntries > 0) {
-            smrEntries = (MultiSMREntry) MultiSMREntry.deserialize(b, runtime);
+            smrEntries = (MultiSMREntry) MultiSMREntry.deserialize(b);
         }
         smrEntriesBytes = b.readInt();
     }

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
@@ -1,39 +1,28 @@
 package org.corfudb.protocols.logprotocol;
 
 import io.netty.buffer.ByteBuf;
-
-import java.util.Arrays;
-import java.util.Map;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.serializer.ICorfuSerializable;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 
 /**
  * Created by mwei on 1/8/16.
  */
-@ToString(exclude = {"runtime"})
 @NoArgsConstructor
 public class LogEntry implements ICorfuSerializable {
 
-    static final Map<Byte, LogEntryType> typeMap =
+    private static final Map<Byte, LogEntryType> typeMap =
             Arrays.stream(LogEntryType.values())
                     .collect(Collectors.toMap(LogEntryType::asByte, Function.identity()));
-
-    /**
-     * The runtime to use.
-     */
-    @Setter
-    protected CorfuRuntime runtime;
 
     /**
      * The type of log entry.
@@ -64,14 +53,13 @@ public class LogEntry implements ICorfuSerializable {
      * @param b The buffer to deserialize.
      * @return A LogEntry.
      */
-    public static ICorfuSerializable deserialize(ByteBuf b, CorfuRuntime rt) {
+    public static ICorfuSerializable deserialize(ByteBuf b) {
         try {
             byte type = b.readByte();
             LogEntryType let = typeMap.get(type);
             LogEntry l = let.entryType.newInstance();
             l.type = let;
-            l.runtime = rt;
-            l.deserializeBuffer(b, rt);
+            l.deserializeBuffer(b);
             return l;
         } catch (InstantiationException | IllegalAccessException ie) {
             throw new RuntimeException("Error deserializing entry", ie);
@@ -84,7 +72,7 @@ public class LogEntry implements ICorfuSerializable {
      *
      * @param b The remaining buffer.
      */
-    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
+    void deserializeBuffer(ByteBuf b) {
         // In the base case, we don't do anything.
     }
 

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -5,7 +5,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.Serializers;
 
 import java.util.Collections;
@@ -16,7 +15,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.google.common.base.Preconditions.checkState;
-
 
 /**
  * A log entry structure which contains a collection of multiSMREntries,
@@ -85,8 +83,8 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
      * @param b The remaining buffer.
      */
     @Override
-    public void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
-        super.deserializeBuffer(b, rt);
+    public void deserializeBuffer(ByteBuf b) {
+        super.deserializeBuffer(b);
         int numStreams = b.readInt();
         for (int i = 0; i < numStreams; i++) {
             UUID streamId = new UUID(b.readLong(), b.readLong());
@@ -136,7 +134,7 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
             // The stream exists and it needs to be deserialized
             byte[] streamUpdatesBuf = streamBuffers.get(id);
             ByteBuf buf = Unpooled.wrappedBuffer(streamUpdatesBuf);
-            MultiSMREntry multiSMREntry = (MultiSMREntry) Serializers.CORFU.deserialize(buf, null);
+            MultiSMREntry multiSMREntry = (MultiSMREntry) Serializers.CORFU.deserialize(buf);
             multiSMREntry.setGlobalAddress(getGlobalAddress());
             streamBuffers.remove(id);
             return multiSMREntry;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
@@ -1,20 +1,17 @@
 package org.corfudb.protocols.logprotocol;
 
 import io.netty.buffer.ByteBuf;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.util.serializer.CorfuSerializer;
+import org.corfudb.util.serializer.Serializers;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.ToString;
-import lombok.extern.slf4j.Slf4j;
-
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.util.serializer.CorfuSerializer;
-import org.corfudb.util.serializer.Serializers;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -56,14 +53,14 @@ public class MultiSMREntry extends LogEntry implements ISMRConsumable {
      * @param b The remaining buffer.
      */
     @Override
-    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
-        super.deserializeBuffer(b, rt);
+    void deserializeBuffer(ByteBuf b) {
+        super.deserializeBuffer(b);
 
         int numUpdates = b.readInt();
         updates = new ArrayList<>();
         for (int i = 0; i < numUpdates; i++) {
             updates.add(
-                    (SMREntry) Serializers.CORFU.deserialize(b, rt));
+                    (SMREntry) Serializers.CORFU.deserialize(b));
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -1,21 +1,19 @@
 package org.corfudb.protocols.logprotocol;
 
 import io.netty.buffer.ByteBuf;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.CorfuSerializer;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
 
 import static com.google.common.base.Preconditions.checkState;
 
@@ -102,8 +100,8 @@ public class SMREntry extends LogEntry implements ISMRConsumable {
      * @param b The remaining buffer.
      */
     @Override
-    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
-        super.deserializeBuffer(b, rt);
+    void deserializeBuffer(ByteBuf b) {
+        super.deserializeBuffer(b);
         short methodLength = b.readShort();
         byte[] methodBytes = new byte[methodLength];
         b.readBytes(methodBytes, 0, methodLength);
@@ -114,7 +112,7 @@ public class SMREntry extends LogEntry implements ISMRConsumable {
         for (byte arg = 0; arg < numArguments; arg++) {
             int len = b.readInt();
             ByteBuf objBuf = b.slice(b.readerIndex(), len);
-            arguments[arg] = serializerType.deserialize(objBuf, rt);
+            arguments[arg] = serializerType.deserialize(objBuf);
             b.skipBytes(len);
         }
         SMRArguments = arguments;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ExceptionMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ExceptionMsg.java
@@ -56,7 +56,7 @@ public class ExceptionMsg implements ICorfuPayload<ExceptionMsg> {
     public ExceptionMsg(ByteBuf b) {
         Throwable t;
         try {
-            t = (Throwable) Serializers.JAVA.deserialize(b, null);
+            t = (Throwable) Serializers.JAVA.deserialize(b);
         } catch (Exception e) {
             t = new DeserializationFailedException();
         }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -2,8 +2,8 @@ package org.corfudb.protocols.wireprotocol;
 
 import org.corfudb.common.compression.Codec;
 import org.corfudb.protocols.logprotocol.LogEntry;
-import org.corfudb.runtime.CorfuRuntime;
 
+import javax.annotation.Nonnull;
 import java.util.UUID;
 
 /**
@@ -16,12 +16,12 @@ import java.util.UUID;
  */
 public interface ILogData extends IMetadata, Comparable<ILogData> {
 
-    Object getPayload(CorfuRuntime t);
+    Object getPayload();
 
     DataType getType();
 
     @Override
-    default int compareTo(ILogData o) {
+    default int compareTo(@Nonnull ILogData o) {
         return getGlobalAddress().compareTo(o.getGlobalAddress());
     }
 
@@ -78,8 +78,8 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
     /**
      * Return the payload as a log entry.
      */
-    default LogEntry getLogEntry(CorfuRuntime runtime) {
-        return (LogEntry) getPayload(runtime);
+    default LogEntry getLogEntry() {
+        return (LogEntry) getPayload();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -14,7 +14,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.compression.Codec;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.LogEntry;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.WriteSizeException;
 import org.corfudb.util.serializer.Serializers;
 
@@ -65,7 +64,7 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
     /**
      * Return the payload.
      */
-    public Object getPayload(CorfuRuntime runtime) {
+    public Object getPayload() {
         Object value = payload.get();
         if (value == null) {
             synchronized (this.payload) {
@@ -86,12 +85,9 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
 
                         final Object actualValue;
                         try {
-                            actualValue =
-                                    Serializers.CORFU.deserialize(serializedBuf, runtime);
-
+                            actualValue = Serializers.CORFU.deserialize(serializedBuf);
                             if (actualValue instanceof LogEntry) {
                                 ((LogEntry) actualValue).setGlobalAddress(getGlobalAddress());
-                                ((LogEntry) actualValue).setRuntime(runtime);
                             }
                             value = actualValue == null ? this.payload : actualValue;
                             this.payload.set(value);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
@@ -4,7 +4,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.util.serializer.ISerializer;
 import org.rocksdb.CompactionOptionsUniversal;
@@ -73,14 +72,12 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
 
     private final ContextAwareMap<K, V> optimisticMap = new StreamingMapDecorator<>();
     private final AtomicInteger dataSetSize = new AtomicInteger();
-    private final CorfuRuntime corfuRuntime;
     private final ISerializer serializer;
     private final RocksDB rocksDb;
 
     public PersistedStreamingMap(@NonNull Path dataPath,
                                  @NonNull Options options,
-                                 @NonNull ISerializer serializer,
-                                 @NonNull CorfuRuntime corfuRuntime) {
+                                 @NonNull ISerializer serializer) {
         try {
             RocksDB.destroyDB(dataPath.toFile().getAbsolutePath(), options);
             this.rocksDb = RocksDB.open(options, dataPath.toFile().getAbsolutePath());
@@ -88,7 +85,6 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
             throw new UnrecoverableCorfuError(e);
         }
         this.serializer = serializer;
-        this.corfuRuntime = corfuRuntime;
     }
 
     /**
@@ -149,7 +145,7 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
             if (value == null) {
                 return null;
             }
-            return (V) serializer.deserialize(Unpooled.wrappedBuffer(value), corfuRuntime);
+            return (V) serializer.deserialize(Unpooled.wrappedBuffer(value));
         } catch (RocksDBException ex) {
             throw new UnrecoverableCorfuError(ex);
         } finally {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/RocksDbEntryIterator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/RocksDbEntryIterator.java
@@ -63,9 +63,9 @@ public class RocksDbEntryIterator<K, V> implements Iterator<Map.Entry<K, V>>, Au
     public boolean hasNext() {
         if (next == null && wrappedRocksIterator.isOpen() && wrappedRocksIterator.isValid()) {
             // Retrieve entry if it exists and move the iterator
-            K key = (K) serializer.deserialize(Unpooled.wrappedBuffer(wrappedRocksIterator.key()), null);
+            K key = (K) serializer.deserialize(Unpooled.wrappedBuffer(wrappedRocksIterator.key()));
             V value = loadValues ? (V) serializer
-                    .deserialize(Unpooled.wrappedBuffer(wrappedRocksIterator.value()), null) : null;
+                    .deserialize(Unpooled.wrappedBuffer(wrappedRocksIterator.value())) : null;
             next = new AbstractMap.SimpleEntry(key, value);
             wrappedRocksIterator.next();
         }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingSubscriptionContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingSubscriptionContext.java
@@ -30,11 +30,6 @@ import org.corfudb.runtime.CorfuRuntime;
 public class StreamingSubscriptionContext {
 
     /**
-     * Corfu Runtime.
-     */
-    private final CorfuRuntime runtime;
-
-    /**
      * StreamListener.
      */
     @Getter
@@ -122,7 +117,6 @@ public class StreamingSubscriptionContext {
     public StreamingSubscriptionContext(@Nonnull CorfuRuntime runtime, @Nonnull StreamListener listener,
             @Nonnull String namespace, @Nonnull List<TableSchema> tableSchemas,
             long startAddress) {
-        this.runtime = runtime;
         this.listener = listener;
         this.namespace = namespace;
         this.tablesOfInterest = tableSchemas.stream().collect(Collectors.toMap(
@@ -182,7 +176,7 @@ public class StreamingSubscriptionContext {
                 return false;
             }
 
-            MultiObjectSMREntry multiObjSMREntry = (MultiObjectSMREntry) logData.getPayload(runtime);
+            MultiObjectSMREntry multiObjSMREntry = (MultiObjectSMREntry) logData.getPayload();
             long epoch = logData.getEpoch();
             //Build the CorfuStreamEntries from the MultiObjectSMREntry.
             CorfuStreamEntries update = new CorfuStreamEntries(multiObjSMREntry.getEntryMap()

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -126,8 +126,7 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
     @Deprecated // TODO: Add replacement method that conforms to style
     @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
     public CorfuCompileProxy(CorfuRuntime rt, UUID streamID, Class<T> type, Object[] args,
-                             ISerializer serializer, ICorfuSMR<T> wrapperObject
-    ) {
+                             ISerializer serializer, ICorfuSMR<T> wrapperObject) {
         this.rt = rt;
         this.streamID = streamID;
         this.type = type;
@@ -136,8 +135,9 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
 
         // Since the VLO is thread safe we don't need to use a thread safe stream implementation
         // because the VLO will control access to the stream
-        underlyingObject = new VersionLockedObject<T>(this::getNewInstance,
-                new StreamViewSMRAdapter(rt, rt.getStreamsView().getUnsafe(streamID)),
+        underlyingObject = new VersionLockedObject<>(
+                this::getNewInstance,
+                new StreamViewSMRAdapter(rt.getStreamsView().getUnsafe(streamID)),
                 wrapperObject);
 
         final MetricRegistry metrics = CorfuRuntime.getDefaultMetrics();

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -291,7 +291,7 @@ public class TableRegistry {
             mapSupplier = () -> new PersistedStreamingMap<>(
                     tableOptions.getPersistentDataPath().get(),
                     PersistedStreamingMap.getPersistedStreamingMapOptions(),
-                    protobufSerializer, this.runtime);
+                    protobufSerializer);
         }
 
         // Open and return table instance.

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
@@ -307,7 +307,7 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
      */
     protected boolean processEntryForContext(final ILogData data) {
         if (data != null) {
-            final Object payload = data.getPayload(runtime);
+            final Object payload = data.getPayload();
         }
         return false;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -645,7 +645,7 @@ public abstract class AbstractQueuedStreamView extends
     protected boolean scanCheckpointStream(final QueuedStreamContext context, ILogData data,
                                            long maxGlobal) {
         if (data.hasCheckpointMetadata()) {
-            CheckpointEntry cpEntry = (CheckpointEntry) data.getPayload(runtime);
+            CheckpointEntry cpEntry = (CheckpointEntry) data.getPayload();
 
             // Consider only checkpoints that are less than maxGlobal
             // Because we are traversing in reverse order END marker of a checkpoint should be found first.

--- a/runtime/src/main/java/org/corfudb/util/serializer/CorfuSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/CorfuSerializer.java
@@ -2,7 +2,6 @@ package org.corfudb.util.serializer;
 
 import io.netty.buffer.ByteBuf;
 import org.corfudb.protocols.logprotocol.LogEntry;
-import org.corfudb.runtime.CorfuRuntime;
 
 /**
  * Created by mwei on 9/29/15.
@@ -30,13 +29,13 @@ public class CorfuSerializer implements ISerializer {
      * @return The deserialized object.
      */
     @Override
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
         if (b.readByte() != corfuPayloadMagic) {
             byte[] bytes = new byte[b.readableBytes()];
             b.readBytes(bytes);
             return bytes;
         }
-        return LogEntry.deserialize(b, rt);
+        return LogEntry.deserialize(b);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -214,7 +214,7 @@ public class DynamicProtobufSerializer implements ISerializer {
      * @return The deserialized object.
      */
     @Override
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
 
         try (ByteBufInputStream bbis = new ByteBufInputStream(b)) {
             MessageType type = MessageType.valueOf(bbis.readInt());

--- a/runtime/src/main/java/org/corfudb/util/serializer/ISerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/ISerializer.java
@@ -55,7 +55,7 @@ public interface ISerializer {
      * @param b The bytebuf to deserialize.
      * @return The deserialized object.
      */
-    Object deserialize(ByteBuf b, CorfuRuntime rt);
+    Object deserialize(ByteBuf b);
 
     /**
      * Serialize an object into a given byte buffer.

--- a/runtime/src/main/java/org/corfudb/util/serializer/JavaSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/JavaSerializer.java
@@ -9,7 +9,6 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.runtime.CorfuRuntime;
 
 
 /**
@@ -35,7 +34,7 @@ public class JavaSerializer implements ISerializer {
      * @return The deserialized object.
      */
     @Override
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
         try (ByteBufInputStream bbis = new ByteBufInputStream(b)) {
             try (ObjectInputStream ois = new ObjectInputStream(bbis)) {
                 return ois.readObject();

--- a/runtime/src/main/java/org/corfudb/util/serializer/JsonSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/JsonSerializer.java
@@ -2,19 +2,14 @@ package org.corfudb.util.serializer;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
-import java.util.UUID;
-
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.object.ICorfuSMR;
 
 /**
  * Created by mwei on 2/10/16.
@@ -23,8 +18,7 @@ import org.corfudb.runtime.object.ICorfuSMR;
 public class JsonSerializer implements ISerializer {
     private final byte type;
 
-    private static final Gson gson = new GsonBuilder()
-            .create();
+    private static final Gson gson = new GsonBuilder().create();
 
     public JsonSerializer(byte type) {
         this.type = type;
@@ -42,27 +36,13 @@ public class JsonSerializer implements ISerializer {
      * @return The deserialized object.
      */
     @Override
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
         int classNameLength = b.readShort();
         byte[] classNameBytes = new byte[classNameLength];
         b.readBytes(classNameBytes, 0, classNameLength);
         String className = new String(classNameBytes);
         if (className.equals("null")) {
             return null;
-        } else if (className.equals("CorfuObject")) {
-            int smrClassNameLength = b.readShort();
-            byte[] smrClassNameBytes = new byte[smrClassNameLength];
-            b.readBytes(smrClassNameBytes, 0, smrClassNameLength);
-            String smrClassName = new String(smrClassNameBytes);
-            try {
-                return rt.getObjectsView().build()
-                        .setStreamID(new UUID(b.readLong(), b.readLong()))
-                        .setType((Class<? extends ICorfuSMR>) Class.forName(smrClassName))
-                        .open();
-            } catch (ClassNotFoundException cnfe) {
-                log.error("Exception during deserialization!", cnfe);
-                throw new RuntimeException(cnfe);
-            }
         } else {
             try (ByteBufInputStream bbis = new ByteBufInputStream(b)) {
                 try (InputStreamReader r = new InputStreamReader(bbis)) {
@@ -84,34 +64,18 @@ public class JsonSerializer implements ISerializer {
     @Override
     public void serialize(Object o, ByteBuf b) {
         String className = o == null ? "null" : o.getClass().getName();
-        if (className.endsWith(ICorfuSMR.CORFUSMR_SUFFIX)) {
-            className = "CorfuObject";
-            byte[] classNameBytes = className.getBytes();
-            b.writeShort(classNameBytes.length);
-            b.writeBytes(classNameBytes);
-            String smrClass = className.split("\\$")[0];
-            byte[] smrClassNameBytes = smrClass.getBytes();
-            b.writeShort(smrClassNameBytes.length);
-            b.writeBytes(smrClassNameBytes);
-            UUID id = ((ICorfuSMR) o).getCorfuStreamID();
-            log.trace("Serializing a CorfuObject of type {} as a stream pointer to {}",
-                    smrClass, id);
-            b.writeLong(id.getMostSignificantBits());
-            b.writeLong(id.getLeastSignificantBits());
-        } else {
-            byte[] classNameBytes = className.getBytes();
-            b.writeShort(classNameBytes.length);
-            b.writeBytes(classNameBytes);
-            if (o == null) {
-                return;
+        byte[] classNameBytes = className.getBytes();
+        b.writeShort(classNameBytes.length);
+        b.writeBytes(classNameBytes);
+        if (o == null) {
+            return;
+        }
+        try (ByteBufOutputStream bbos = new ByteBufOutputStream(b)) {
+            try (OutputStreamWriter osw = new OutputStreamWriter(bbos)) {
+                gson.toJson(o, o.getClass(), osw);
             }
-            try (ByteBufOutputStream bbos = new ByteBufOutputStream(b)) {
-                try (OutputStreamWriter osw = new OutputStreamWriter(bbos)) {
-                    gson.toJson(o, o.getClass(), osw);
-                }
-            } catch (IOException ie) {
-                log.error("Exception during serialization!", ie);
-            }
+        } catch (IOException ie) {
+            log.error("Exception during serialization!", ie);
         }
     }
 }

--- a/runtime/src/main/java/org/corfudb/util/serializer/ProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/ProtobufSerializer.java
@@ -77,7 +77,7 @@ public class ProtobufSerializer implements ISerializer {
      * @return The deserialized object.
      */
     @Override
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
 
         try (ByteBufInputStream bbis = new ByteBufInputStream(b)) {
             MessageType type = MessageType.valueOf(bbis.readInt());

--- a/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
@@ -30,7 +30,7 @@ public class Serializers {
     private static final Map<Byte, ISerializer> serializersMap;
 
     static {
-        serializersMap = new HashMap();
+        serializersMap = new HashMap<>();
         serializersMap.put(CORFU.getType(), CORFU);
         serializersMap.put(JAVA.getType(), JAVA);
         serializersMap.put(JSON.getType(), JSON);

--- a/test/src/test/java/org/corfudb/CustomSerializer.java
+++ b/test/src/test/java/org/corfudb/CustomSerializer.java
@@ -1,7 +1,6 @@
 package org.corfudb;
 
 import io.netty.buffer.ByteBuf;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
 
@@ -20,8 +19,8 @@ public class CustomSerializer implements ISerializer {
         return type;
     }
 
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
-        return serializer.deserialize(b, rt);
+    public Object deserialize(ByteBuf b) {
+        return serializer.deserialize(b);
     }
 
     public void serialize(Object o, ByteBuf b) {

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -62,7 +62,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         Serializers.CORFU.serialize(streamEntry, b);
         long address0 = 0;
         log.append(address0, new LogData(DataType.DATA, b));
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
 
         // Disable checksum, then append and read then same entry
         // An overwrite exception should occur, since we are writing the
@@ -72,7 +72,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
             newLog.append(address0, new LogData(DataType.DATA, b));
         })
                 .isInstanceOf(OverwriteException.class);
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
     }
 
     @Test
@@ -293,7 +293,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         long address0 = 0;
         log.append(address0, new LogData(DataType.DATA, b));
 
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
 
         log.close();
 
@@ -318,7 +318,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         log.append(address0, new LogData(DataType.DATA, b));
         log.append(address1, new LogData(DataType.DATA, b));
 
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
         log.close();
 
         final int OVERWRITE_BYTES = 4;
@@ -371,7 +371,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         for (int x = 0; x < num_entries * num_threads; x++) {
             long address = (long) x;
             LogData data = log.read(address);
-            byte[] bytes = (byte[]) data.getPayload(null);
+            byte[] bytes = (byte[]) data.getPayload();
             assertThat(bytes).isEqualTo(streamEntry);
         }
     }
@@ -644,7 +644,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         // Open the segment again and verify that the entry write can be read (i.e. log file can be
         // parsed correctly).
         log = new StreamLogFiles(getContext(), false);
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
     }
 
     @Test
@@ -700,7 +700,7 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
         log.close();
 
         log = new StreamLogFiles(getContext(), false);
-        assertThat(log.read(address0).getPayload(null)).isEqualTo(streamEntry);
+        assertThat(log.read(address0).getPayload()).isEqualTo(streamEntry);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -834,7 +834,7 @@ public class ClusterReconfigIT extends AbstractIT {
                 .getLogUnitClient("localhost:9002")
                 .readAll(getRangeAddressAsList(startAddress, endAddress))
                 .get().getAddresses().values()) {
-            assertThat(logData.getPayload(runtime))
+            assertThat(logData.getPayload())
                     .isEqualTo(Integer.toString(verificationCounter++).getBytes());
         }
 
@@ -914,7 +914,7 @@ public class ClusterReconfigIT extends AbstractIT {
                 .getLogUnitClient("localhost:9002")
                 .readAll(getRangeAddressAsList(startAddress, endAddress)).get()
                 .getAddresses().values()) {
-            assertThat(logData.getPayload(runtime))
+            assertThat(logData.getPayload())
                     .isEqualTo(Integer.toString(verificationCounter++).getBytes());
         }
 
@@ -1001,7 +1001,7 @@ public class ClusterReconfigIT extends AbstractIT {
         final int startAddress = 0;
         final int endAddress = 3;
         for (int i = startAddress; i <= endAddress; i++) {
-            assertThat(runtime.getAddressSpaceView().read(i).getPayload(runtime))
+            assertThat(runtime.getAddressSpaceView().read(i).getPayload())
                     .isEqualTo(Integer.toString(i).getBytes());
         }
 
@@ -1191,8 +1191,7 @@ public class ClusterReconfigIT extends AbstractIT {
         // Addresses should correspond to: start, continuation and end records. (total 3 records)
         assertThat(checkpointAddressSpace.getAddressMap().getLongCardinality()).isEqualTo(numCheckpointRecordsDefault);
         CheckpointEntry cpEntry = (CheckpointEntry) runtime2.getAddressSpaceView()
-                .read(checkpointAddressSpace.getHighestAddress())
-                .getPayload(runtime2);
+                .read(checkpointAddressSpace.getHighestAddress()).getPayload();
         assertThat(cpEntry.getDict().get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)).
                 isEqualTo(String.valueOf(numEntries));
 

--- a/test/src/test/java/org/corfudb/integration/CmdletIT.java
+++ b/test/src/test/java/org/corfudb/integration/CmdletIT.java
@@ -160,8 +160,8 @@ public class CmdletIT extends AbstractIT {
         String commandAppend = "echo '" + payload2 + "' | " + CORFU_PROJECT_DIR + "bin/corfu_stream -i " + streamA + " -c " + ENDPOINT + " append";
         runCmdletGetOutput(commandAppend);
 
-        assertThat(streamViewA.next().getPayload(runtime)).isEqualTo(payload1.getBytes());
-        assertThat(streamViewA.next().getPayload(runtime)).isEqualTo((payload2 + "\n").getBytes());
+        assertThat(streamViewA.next().getPayload()).isEqualTo(payload1.getBytes());
+        assertThat(streamViewA.next().getPayload()).isEqualTo((payload2 + "\n").getBytes());
         assertThat(streamViewA.next()).isNull();
         shutdownCorfuServer(corfuServerProcess);
     }

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -282,7 +282,7 @@ public class CorfuStoreIT extends AbstractIT {
                 final Options options = new Options().setCreateIfMissing(true);
                 final Supplier<StreamingMap<CorfuDynamicKey, CorfuDynamicRecord>> mapSupplier = () -> new PersistedStreamingMap<>(
                         persistedCacheLocation, options,
-                        dynamicProtobufSerializer, runtimeC);
+                        dynamicProtobufSerializer);
                 corfuTableBuilder.setArguments(mapSupplier, ICorfuVersionPolicy.MONOTONIC);
             }
 

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -889,7 +889,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify checkpoint START_LOG_ADDRESS
             LogEntry cpStart = (CheckpointEntry) runtimeRestart.getAddressSpaceView().read(checkpointStartRecord)
-                    .getPayload(runtimeRestart);
+                    .getPayload();
             assertThat(((CheckpointEntry) cpStart).getDict()
                     .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)).isEqualTo("8");
 
@@ -1158,7 +1158,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify Checkpoint START_LOG_ADDRESS (reading start record)
             // Because the stream was empty, it should force a hole on 0, and this should be the start address
-            LogEntry cpStart = (CheckpointEntry) runtime.getAddressSpaceView().read(1L).getPayload(runtime);
+            LogEntry cpStart = (CheckpointEntry) runtime.getAddressSpaceView().read(1L).getPayload();
             assertThat(((CheckpointEntry) cpStart).getDict()
                     .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)).isEqualTo("0");
 

--- a/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
@@ -39,7 +39,7 @@ public class TransactionStreamIT extends AbstractIT {
      */
     private void ConsumeDelta(Map<UUID, Integer> map, List<ILogData> deltas) {
         for (ILogData ld : deltas) {
-            MultiObjectSMREntry multiObjSmr = (MultiObjectSMREntry) ld.getPayload(null);
+            MultiObjectSMREntry multiObjSmr = (MultiObjectSMREntry) ld.getPayload();
             for (Map.Entry<UUID, MultiSMREntry> multiSMREntry : multiObjSmr.getEntryMap().entrySet()) {
                 for (SMREntry update : multiSMREntry.getValue().getUpdates()) {
                     int key = (int) update.getSMRArguments()[0];

--- a/test/src/test/java/org/corfudb/protocols/logprotocol/LogEntryTest.java
+++ b/test/src/test/java/org/corfudb/protocols/logprotocol/LogEntryTest.java
@@ -32,10 +32,10 @@ public class LogEntryTest {
         Serializers.CORFU.serialize(smr2, buf);
 
         SMREntry.seekToEnd(buf);
-        SMREntry recoveredEntry = (SMREntry) Serializers.CORFU.deserialize(buf, null);
+        SMREntry recoveredEntry = (SMREntry) Serializers.CORFU.deserialize(buf);
         assertThat(recoveredEntry).isEqualTo(smr2);
         buf.resetReaderIndex();
-        recoveredEntry = (SMREntry) Serializers.CORFU.deserialize(buf, null);
+        recoveredEntry = (SMREntry) Serializers.CORFU.deserialize(buf);
         assertThat(recoveredEntry).isEqualTo(smr1);
 
         // Verify that both entries can be skipped
@@ -65,10 +65,10 @@ public class LogEntryTest {
         Serializers.CORFU.serialize(multiSMR2, buf);
 
         MultiSMREntry.seekToEnd(buf);
-        MultiSMREntry recoveredMultiSMR = (MultiSMREntry) Serializers.CORFU.deserialize(buf, null);
+        MultiSMREntry recoveredMultiSMR = (MultiSMREntry) Serializers.CORFU.deserialize(buf);
         assertThat(recoveredMultiSMR).isEqualTo(multiSMR2);
         buf.resetReaderIndex();
-        recoveredMultiSMR = (MultiSMREntry) Serializers.CORFU.deserialize(buf, null);
+        recoveredMultiSMR = (MultiSMREntry) Serializers.CORFU.deserialize(buf);
         assertThat(recoveredMultiSMR).isEqualTo(multiSMR1);
 
         // Verify that both entries can be skipped
@@ -106,7 +106,7 @@ public class LogEntryTest {
         ByteBuf buf = Unpooled.buffer();
         multiObjSmrEntry.serialize(buf);
 
-        MultiObjectSMREntry deserializedEntry = (MultiObjectSMREntry) LogEntry.deserialize(buf, null);
+        MultiObjectSMREntry deserializedEntry = (MultiObjectSMREntry) LogEntry.deserialize(buf);
         deserializedEntry.setGlobalAddress(entryAddress);
 
         // Verify that the buffer cache contains both streams

--- a/test/src/test/java/org/corfudb/runtime/CompressionTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CompressionTest.java
@@ -65,8 +65,7 @@ public class CompressionTest extends AbstractViewTest {
         rt.getAddressSpaceView().invalidateClientCache();
 
         // Read data
-        return rt.getAddressSpaceView().read(address)
-                .getPayload(rt);
+        return rt.getAddressSpaceView().read(address).getPayload();
     }
 
     private List<Codec.Type> getReadersCodec(Codec.Type codec) {

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CPSerializer.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CPSerializer.java
@@ -6,7 +6,6 @@ import com.google.gson.GsonBuilder;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.ISerializer;
 
 import java.io.IOException;
@@ -32,7 +31,7 @@ public class CPSerializer implements ISerializer {
         return type;
     }
 
-    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+    public Object deserialize(ByteBuf b) {
         Type mapType = new TypeToken<Map<String, Long>>(){}.getType();
 
         int classNameLength = b.readShort();

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -74,8 +74,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         // Verify that the start/end records have been written for empty maps
         assertThat(a1).isEqualTo(cpEndAddress);
         // Verify that checkpoint start address is the enforced hole (0L)
-        LogEntry cpStart = (CheckpointEntry) r.getAddressSpaceView().read(1L)
-                .getPayload(r);
+        LogEntry cpStart = (CheckpointEntry) r.getAddressSpaceView().read(1L).getPayload();
         assertThat(((CheckpointEntry) cpStart).getDict()
                 .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)).isEqualTo("0");
     }

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -2,19 +2,15 @@ package org.corfudb.runtime.checkpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.reflect.TypeToken;
 
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -703,7 +699,7 @@ public class CheckpointTest extends AbstractObjectTest {
         Supplier<StreamingMap<String, String>> writerMapSupplier = () ->
                 new PersistedStreamingMap<>(Paths.get(path + tableId + "writer"),
                         PersistedStreamingMap.getPersistedStreamingMapOptions(),
-                        Serializers.JSON, rt);
+                        Serializers.JSON);
 
         CorfuTable<String, String> diskBackedMap = rt.getObjectsView()
                 .build()
@@ -729,7 +725,7 @@ public class CheckpointTest extends AbstractObjectTest {
         Supplier<StreamingMap<String, String>> readerMapSupplier = () ->
                 new PersistedStreamingMap<>(Paths.get(path + tableId + "reader"),
                         PersistedStreamingMap.getPersistedStreamingMapOptions(),
-                        Serializers.JSON, rt);
+                        Serializers.JSON);
 
         CorfuTable<String, String> newDiskBackedMap = newRt.getObjectsView()
                 .build()

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -112,7 +112,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         LogData r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString);
     }
 
@@ -277,7 +277,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         LogData r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString);
 
         byte[] testString2 = "hello world 2".getBytes();
@@ -285,7 +285,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString2);
     }
 
@@ -298,7 +298,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         LogData r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString);
 
         byte[] testString2 = "hello world 2".getBytes();
@@ -312,7 +312,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType())
                 .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString);
     }
 
@@ -323,7 +323,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         client.write(0, new IMetadata.DataRank(1), testString, Collections.emptyMap()).get();
         LogData r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType()) .isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime()))
+        assertThat(r.getPayload())
                 .isEqualTo(testString);
 
         try {
@@ -337,11 +337,11 @@ public class LogUnitHandlerTest extends AbstractClientTest {
             ReadResponse read = ex.getReadResponse();
             LogData log = read.getAddresses().get(0l);
             assertThat(log.getType()).isEqualTo(DataType.DATA);
-            assertThat(log.getPayload(new CorfuRuntime())).isEqualTo(testString);;
+            assertThat(log.getPayload()).isEqualTo(testString);;
         }
         r = client.read(0).get().getAddresses().get(0L);
         assertThat(r.getType()).isEqualTo(DataType.DATA);
-        assertThat(r.getPayload(new CorfuRuntime())).isEqualTo(testString);
+        assertThat(r.getPayload()).isEqualTo(testString);
     }
 
     private ILogData.SerializationHandle createEmptyData(long position, DataType type, IMetadata.DataRank rank) {

--- a/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
@@ -100,7 +100,7 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
         }
 
         @Override
-        public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+        public Object deserialize(ByteBuf b) {
             return gson.fromJson(new String(byteArrayFromBuf(b)), clazz);
         }
 
@@ -124,7 +124,7 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
         final Options options = new Options().setCreateIfMissing(true);
         final Supplier<StreamingMap> mapSupplier = () -> new PersistedStreamingMap<String, String>(
                 persistedCacheLocation, options,
-                new PojoSerializer(String.class), getRuntime());
+                new PojoSerializer(String.class));
         return getDefaultRuntime().getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
                 .setArguments(mapSupplier, ICorfuVersionPolicy.DEFAULT)
@@ -167,7 +167,7 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
                         .setWriteBufferSize(FileUtils.ONE_KB);
 
         final Supplier<StreamingMap> mapSupplier = () -> new PersistedStreamingMap<String, String>(
-                persistedCacheLocation, options, Serializers.JSON, getRuntime());
+                persistedCacheLocation, options, Serializers.JSON);
         final CorfuTable<String, String> table = getDefaultRuntime().getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
                 .setArguments(mapSupplier,ICorfuVersionPolicy.DEFAULT)
@@ -202,7 +202,7 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
                         // The size is checked either during flush or compaction.
                         .setWriteBufferSize(FileUtils.ONE_KB);
         final Supplier<StreamingMap> mapSupplier = () -> new PersistedStreamingMap<String, Pojo>(
-                persistedCacheLocation, options, new PojoSerializer(Pojo.class), getRuntime());
+                persistedCacheLocation, options, new PojoSerializer(Pojo.class));
         CorfuTable<String, Pojo>
                 table = getDefaultRuntime().getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<String, Pojo>>() {})

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
@@ -54,14 +54,12 @@ public class WriteAfterWriteTransactionContextTest extends AbstractTransactionCo
 
         List<ILogData> txns = txStream.remainingUpTo(Long.MAX_VALUE);
         assertThat(txns).hasSize(1);
-        assertThat(txns.get(0).getLogEntry(getRuntime()).getType()).isEqualTo
+        assertThat(txns.get(0).getLogEntry().getType()).isEqualTo
             (LogEntry.LogEntryType.MULTIOBJSMR);
 
-        MultiObjectSMREntry tx1 = (MultiObjectSMREntry)txns.get(0).getLogEntry
-            (getRuntime());
+        MultiObjectSMREntry tx1 = (MultiObjectSMREntry)txns.get(0).getLogEntry();
         assertThat(tx1.getEntryMap().size()).isEqualTo(1);
-        MultiSMREntry entryMap = tx1.getEntryMap().entrySet().iterator()
-                                                        .next().getValue();
+        MultiSMREntry entryMap = tx1.getEntryMap().entrySet().iterator().next().getValue();
         assertThat(entryMap).isNotNull();
         assertThat(entryMap.getUpdates().size()).isEqualTo(1);
         SMREntry smrEntry = entryMap.getUpdates().get(0);

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -110,7 +110,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 "hello world".getBytes());
 
-        assertThat(rt.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(rt.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(rt.getAddressSpaceView().read(0L).containsStream(streamA))
@@ -191,7 +191,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         Token token = new Token(rt.getLayoutView().getLayout().getEpoch(), ADDRESS_0);
         rt.getAddressSpaceView().write(token, testPayload);
 
-        assertThat(rt.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
+        assertThat(rt.getAddressSpaceView().read(ADDRESS_0).getPayload())
                 .isEqualTo("hello world".getBytes());
 
 
@@ -208,11 +208,11 @@ public class AddressSpaceViewTest extends AbstractViewTest {
 
         Map<Long, ILogData> m = rt.getAddressSpaceView().read(rs);
 
-        assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
+        assertThat(m.get(ADDRESS_0).getPayload())
                 .isEqualTo("hello world".getBytes());
-        assertThat(m.get(ADDRESS_1).getPayload(getRuntime()))
+        assertThat(m.get(ADDRESS_1).getPayload())
                 .isEqualTo("1".getBytes());
-        assertThat(m.get(ADDRESS_2).getPayload(getRuntime()))
+        assertThat(m.get(ADDRESS_2).getPayload())
                 .isEqualTo("3".getBytes());
     }
 
@@ -230,7 +230,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         Token token = new Token(rt.getLayoutView().getLayout().getEpoch(), ADDRESS_0);
         rt.getAddressSpaceView().write(token, testPayload);
 
-        assertThat(rt.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
+        assertThat(rt.getAddressSpaceView().read(ADDRESS_0).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         Range range = Range.closed(ADDRESS_0, ADDRESS_2);
@@ -238,7 +238,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
 
         Map<Long, ILogData> m = rt.getAddressSpaceView().read(addresses);
 
-        assertThat(m.get(ADDRESS_0).getPayload(getRuntime()))
+        assertThat(m.get(ADDRESS_0).getPayload())
                 .isEqualTo("hello world".getBytes());
         assertThat(m.get(ADDRESS_1).isHole()).isTrue();
         assertThat(m.get(ADDRESS_2).isHole()).isTrue();
@@ -302,6 +302,6 @@ public class AddressSpaceViewTest extends AbstractViewTest {
                 ContiguousSet.create(Range.closed(0L, numAddresses - 1), DiscreteDomain.longs()));
 
         readResult.forEach((addr, data) ->
-                assertThat(data.getPayload(rt)).isEqualTo((testString + addr).getBytes()));
+                assertThat(data.getPayload()).isEqualTo((testString + addr).getBytes()));
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
@@ -32,7 +32,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L).containsStream(streamA))
@@ -62,7 +62,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
             for (int i = base; i < base + numberRecords; i++) {
-                assertThat(r.getAddressSpaceView().read(i).getPayload(getRuntime()))
+                assertThat(r.getAddressSpaceView().read(i).getPayload())
                         .isEqualTo(Integer.toString(i).getBytes());
             }
         });
@@ -104,7 +104,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L)
@@ -144,7 +144,7 @@ public class ChainReplicationViewTest extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L).containsStream(streamA));

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -227,7 +227,7 @@ public class LayoutViewTest extends AbstractViewTest {
         sv.append(testPayload);
         startReconfigurationLatch.countDown();
         layoutReconfiguredLatch.await();
-        assertThat(sv.next().getPayload(corfuRuntime)).isEqualTo("hello world".getBytes());
+        assertThat(sv.next().getPayload()).isEqualTo("hello world".getBytes());
         assertThat(sv.next()).isEqualTo(null);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -97,11 +97,9 @@ public class ObjectsViewTest extends AbstractViewTest {
                 .TRANSACTION_STREAM_ID);
         List<ILogData> txns = txStream.remainingUpTo(Long.MAX_VALUE);
         assertThat(txns).hasSize(1);
-        assertThat(txns.get(0).getLogEntry(getRuntime()).getType())
-                .isEqualTo(LogEntry.LogEntryType.MULTIOBJSMR);
+        assertThat(txns.get(0).getLogEntry().getType()).isEqualTo(LogEntry.LogEntryType.MULTIOBJSMR);
 
-        MultiObjectSMREntry tx1 = (MultiObjectSMREntry)txns.get(0).getLogEntry
-                (getRuntime());
+        MultiObjectSMREntry tx1 = (MultiObjectSMREntry)txns.get(0).getLogEntry();
         MultiSMREntry entryMap = tx1.getEntryMap().get(CorfuRuntime.getStreamID(mapA));
         assertThat(entryMap).isNotNull();
 

--- a/test/src/test/java/org/corfudb/runtime/view/StateTransferTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StateTransferTest.java
@@ -944,8 +944,7 @@ public class StateTransferTest extends AbstractViewTest {
 
         // Read data to validate we are able to decompress correctly
         for (int i = 0; i < writtenAddressesBatch2; i++) {
-            assertThat(rt.getAddressSpaceView().read(i)
-                    .getPayload(rt)).isEqualTo(DEFAULT_PAYLOAD);
+            assertThat(rt.getAddressSpaceView().read(i).getPayload()).isEqualTo(DEFAULT_PAYLOAD);
         }
 
     }

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -113,7 +113,7 @@ public class StreamViewTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(streamA);
         sv.append(testPayload);
 
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(sv.next())
@@ -178,7 +178,7 @@ public class StreamViewTest extends AbstractViewTest {
                 PARAMETERS.TIMEOUT_NORMAL);
 
         scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW,
-                i -> assertThat(sv.next().getPayload(getRuntime()))
+                i -> assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes()));
         executeScheduled(PARAMETERS.CONCURRENCY_SOME,
                 PARAMETERS.TIMEOUT_NORMAL);
@@ -198,7 +198,7 @@ public class StreamViewTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(streamA);
         sv.append(testPayload);
 
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(sv.next())
@@ -219,24 +219,24 @@ public class StreamViewTest extends AbstractViewTest {
         sv.append("c".getBytes());
 
         // Try reading two entries
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("a".getBytes());
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("b".getBytes());
 
         // Seeking to the beginning
         sv.seek(0);
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("a".getBytes());
 
         // Seeking to the end
         sv.seek(2);
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("c".getBytes());
 
         // Seeking to the middle
         sv.seek(1);
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("b".getBytes());
     }
 
@@ -262,18 +262,18 @@ public class StreamViewTest extends AbstractViewTest {
         sv.next(); // "b"
 
         // Should be now "a"
-        assertThat(sv.previous().getPayload(r))
+        assertThat(sv.previous().getPayload())
                 .isEqualTo("a".getBytes());
 
         // Move forward, should be now "b"
-        assertThat(sv.next().getPayload(r))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("b".getBytes());
 
         sv.next(); // "c"
         sv.next(); // null
 
         // Should be now "b"
-        assertThat(sv.previous().getPayload(r))
+        assertThat(sv.previous().getPayload())
                 .isEqualTo("b".getBytes());
     }
 
@@ -292,7 +292,7 @@ public class StreamViewTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(streamA);
         sv.append(testPayload);
 
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(sv.next())
@@ -314,7 +314,7 @@ public class StreamViewTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(streamA);
         sv.append(testPayload);
 
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(sv.next())
@@ -353,10 +353,10 @@ public class StreamViewTest extends AbstractViewTest {
         sv.append(testPayload2);
 
         //make sure we can still read the stream.
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo(testPayload);
 
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo(testPayload2);
     }
 
@@ -393,7 +393,7 @@ public class StreamViewTest extends AbstractViewTest {
         byte[] payload = "entry1".getBytes();
         assertThat(sv.append(payload)).isEqualTo(pos0);
         assertThat(sv.getCurrentGlobalPosition()).isEqualTo(Address.NON_ADDRESS);
-        assertThat(sv.next().getPayload(r)).isEqualTo(payload);
+        assertThat(sv.next().getPayload()).isEqualTo(payload);
         assertThat(sv.getCurrentGlobalPosition()).isEqualTo(pos0);
         assertThat(sv.previous()).isNull();
         assertThat(sv.getCurrentGlobalPosition()).isEqualTo(Address.NON_ADDRESS);

--- a/test/src/test/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocolTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/AbstractReplicationProtocolTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractReplicationProtocolTest extends AbstractViewTest {
                 .isEqualTo(DataType.DATA);
         assertThat(read.getGlobalAddress())
                 .isEqualTo(0);
-        assertThat(read.getPayload(r))
+        assertThat(read.getPayload())
                 .isEqualTo("hello world".getBytes());
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
@@ -77,7 +77,7 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
         ILogData readResult = runtimeLayout.getLogUnitClient(SERVERS.ENDPOINT_0)
                 .read(0).get().getAddresses().get(0L);
 
-        assertThat(readResult.getPayload(r))
+        assertThat(readResult.getPayload())
             .isEqualTo("incomplete".getBytes());
     }
 
@@ -102,7 +102,7 @@ public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTes
         // reflect the -other- clients value
         ILogData readResult = rp.read(runtimeLayout, 0);
 
-        assertThat(readResult.getPayload(r))
+        assertThat(readResult.getPayload())
                 .isEqualTo("incomplete".getBytes());
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
@@ -124,7 +124,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         LogUnitServerAssertions.assertThat(u0)
                 .isEmptyAtAddress(ADDRESS_0);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("0".getBytes());
 
         LogUnitServerAssertions.assertThat(u1)
@@ -162,7 +162,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         tr = r.getSequencerView().next(streamA);
 
         //make sure we can still read the stream.
-        assertThat(sv.next().getPayload(getRuntime()))
+        assertThat(sv.next().getPayload())
                 .isEqualTo(testPayload);
 
         int address = 0;
@@ -189,7 +189,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
                 testPayload);
         ILogData x = r.getAddressSpaceView().read(0);
         assertNotNull(x.getRank());
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(r))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L).containsStream(streamA))
@@ -222,7 +222,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
             for (int i = base; i < base + numberRecords; i++) {
-                assertThat(r.getAddressSpaceView().read(i).getPayload(getRuntime()))
+                assertThat(r.getAddressSpaceView().read(i).getPayload())
                         .isEqualTo(Integer.toString(i).getBytes());
             }
         });
@@ -249,7 +249,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L)
@@ -275,7 +275,7 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
                 testPayload);
 
-        assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
+        assertThat(r.getAddressSpaceView().read(0L).getPayload())
                 .isEqualTo("hello world".getBytes());
 
         assertThat(r.getAddressSpaceView().read(0L).containsStream(streamA));

--- a/test/src/test/java/org/corfudb/runtime/view/stream/AbstractStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/AbstractStreamViewTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractStreamViewTest extends AbstractViewTest {
         // iterations) appending to it
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             assertThat(sv.hasNext()).isTrue();
-            byte[] payLoad = (byte[]) sv.next().getPayload(runtime);
+            byte[] payLoad = (byte[]) sv.next().getPayload();
             assertThat(new String(payLoad).equals(String.valueOf(i)))
                     .isTrue();
             assertThat(sv.getCurrentGlobalPosition()).isEqualTo(i);
@@ -80,7 +80,7 @@ public abstract class AbstractStreamViewTest extends AbstractViewTest {
         // traverse the stream backwards, while periodically (every ten
         // iterations) appending to it
         for (int i = PARAMETERS.NUM_ITERATIONS_LOW - 1; i >= 0; i--) {
-            byte[] payLoad = (byte[]) sv.current().getPayload(runtime);
+            byte[] payLoad = (byte[]) sv.current().getPayload();
             assertThat(new String(payLoad).equals(String.valueOf(i)))
                     .isTrue();
             assertThat(sv.getCurrentGlobalPosition()).isEqualTo(i);
@@ -116,7 +116,7 @@ public abstract class AbstractStreamViewTest extends AbstractViewTest {
         sv.seek(2);
 
         // The previous entry should be ENTRY_0
-        assertThat((byte[])sv.previous().getPayload(runtime))
+        assertThat((byte[])sv.previous().getPayload())
                 .isEqualTo(ENTRY_0);
     }
 
@@ -145,7 +145,7 @@ public abstract class AbstractStreamViewTest extends AbstractViewTest {
                 sv.append(String.valueOf(i).getBytes());
                 sv.append(String.valueOf(i).getBytes());
             }
-            byte[] payLoad = (byte[]) sv.next().getPayload(runtime);
+            byte[] payLoad = (byte[]) sv.next().getPayload();
             assertThat(new String(payLoad).equals(String.valueOf(i)));
         }
     }
@@ -243,7 +243,7 @@ public abstract class AbstractStreamViewTest extends AbstractViewTest {
 
         int remainingCounter = trimMark + 1;
         for (ILogData data: stream) {
-            byte[] payLoad = (byte[]) data.getPayload(this.getRuntime());
+            byte[] payLoad = (byte[]) data.getPayload();
             assertThat(new String(payLoad)).isEqualTo(String.valueOf(remainingCounter));
             remainingCounter++;
         }
@@ -288,7 +288,7 @@ public abstract class AbstractStreamViewTest extends AbstractViewTest {
         // Traverse stream until syncMark
         for (int i = 0; i < traverseMark; i++) {
             assertThat(sv.hasNext()).isTrue();
-            byte[] payLoad = (byte[]) sv.next().getPayload(runtime);
+            byte[] payLoad = (byte[]) sv.next().getPayload();
             assertThat(new String(payLoad).equals(String.valueOf(i)))
                     .isTrue();
             assertThat(sv.getCurrentGlobalPosition()).isEqualTo(i);


### PR DESCRIPTION
# Overview

For some historical reasons, the deserialization of LogData's payload
depends on CorfuRuntime. This patch gets rid of this dependency.

Related issue(s) (if applicable): #1880


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
