### PR TITLE
Create a separate docker image for universe solely for testing

### DIFF
--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -44,6 +44,10 @@
                                         <argument>
                                             corfudb/corfu-server:${project.version}
                                         </argument>
+                                        <argument>-t</argument>
+                                        <argument>
+                                            corfudb-universe/corfu-server:${project.version}
+                                        </argument>
                                         <argument>.</argument>
                                     </arguments>
                                 </configuration>

--- a/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
@@ -44,7 +44,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 @Slf4j
 public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, UniverseParams> {
-    private static final String IMAGE_NAME = "corfudb/corfu-server:" + getAppVersion();
+    private static final String IMAGE_NAME = "corfudb-universe/corfu-server:" + getAppVersion();
     private static final String ALL_NETWORK_INTERFACES = "0.0.0.0";
 
     @NonNull


### PR DESCRIPTION
## Overview

Description:
We need to create a separate docker image for universe testing because the docker hub image might collide with the locally cached one. It makes it hard to understand what image is exactly used for universe testing. 
Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
