### PR TITLE
MultiCheckpointWriter Bug Fix + More Logging

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
@@ -84,12 +84,8 @@ public class MultiCheckpointWriter<T extends Map> {
                     minSnapshot = minCPSnapshot;
                 }
             }
-        } finally {
-            // TODO(Maithem): print cp id?
-            log.trace("appendCheckpoints: finished, author '{}' at min globalAddress {}",
-                    author, minSnapshot);
-            rt.getObjectsView().TXEnd();
         }
+
         final long cpStop = System.currentTimeMillis();
 
         log.info("appendCheckpoints: took {} ms to append {} checkpoints", cpStop - cpStart,

--- a/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
@@ -75,7 +75,7 @@ public class MetricsUtils {
     private static boolean metricsSlf4jReportingEnabled = false;
     private static String mpTrigger = "filter-trigger"; // internal use only
 
-    private static final SizeOf sizeOf = SizeOf.newInstance();
+    public static final SizeOf sizeOf = SizeOf.newInstance();
 
     /**
      * Load metrics properties.


### PR DESCRIPTION
## Overview
The multicheckpointwriter was ending a transaction without starting
one, which this patch removes. Also, added extra stats(i.e. in-memory
size, CP size in bytes)  logging for the checkpoint writer.

Why should this be merged: Bug fix + more stat logging

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
