### PR TITLE
Revamp secondary index logic

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/collections/StringIndexer.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/StringIndexer.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.collections;
 
+import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -39,4 +40,19 @@ public class StringIndexer implements CorfuTable.IndexRegistry<String, String> {
         }
     }
 
+    public static class FailingIndex extends StringIndexer {
+        public static final CorfuTable.IndexName FAILING = () -> "FAILING";
+
+        private static final CorfuTable.Index<String, String, ? extends Comparable<?>> FAILING_INDEX =
+                new CorfuTable.Index<>(
+                        FAILING,
+                        (CorfuTable.IndexFunction<String, String, String>) (key, value) -> {
+                            throw new ConcurrentModificationException();
+                        });
+
+        @Override
+        public Iterator<CorfuTable.Index<String, String, ? extends Comparable<?>>> iterator() {
+            return Stream.of(FAILING_INDEX, FAILING_INDEX).iterator();
+        }
+    }
 }


### PR DESCRIPTION
This patch simplifies the logic associated with secondary index
extraction. It also makes failures that arise due to improper index
function implementation more explicit.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
