### PR TITLE
[Corfu-0.2.3] RemoveNode: prevent unresponsive node elected as new primary sequencer.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -283,6 +283,7 @@ public class LayoutManagementView extends AbstractView {
             LayoutBuilder builder = new LayoutBuilder(currentLayout);
             newLayout = builder.removeLayoutServer(endpoint)
                     .removeSequencerServer(endpoint)
+                    .assignResponsiveSequencerAsPrimary(Collections.emptySet())
                     .removeLogunitServer(endpoint)
                     .removeUnresponsiveServer(endpoint)
                     .setEpoch(currentLayout.getEpoch() + 1)

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutManagementViewTest.java
@@ -8,6 +8,8 @@ import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.Layout.ReplicationMode;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -15,8 +17,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * Created by Maithem on 12/13/17.
  */
 @Slf4j
-public class LayoutManagementViewTest extends AbstractViewTest{
-
+public class LayoutManagementViewTest extends AbstractViewTest {
 
     @Test
     public void removeNodeTest() throws Exception {
@@ -80,13 +81,79 @@ public class LayoutManagementViewTest extends AbstractViewTest{
         // Attempt to remove a node from a two node cluster and verify that remove fails
         // due to an invalid modification (i.e. the remove results in a cluster that doesn't
         // meet the least number of nodes required to maintain redundancy).
-        assertThatThrownBy(() -> {
-                    r.getLayoutManagementView().removeNode(l2,
-                            getEndpoint(SERVERS.PORT_1));
-                }
-        ).isInstanceOf(LayoutModificationException.class);
+        assertThatThrownBy(() -> r.getLayoutManagementView().removeNode(l2, getEndpoint(SERVERS.PORT_1)))
+                .isInstanceOf(LayoutModificationException.class);
 
         // Verify that the epoch hasn't changed
         assertThat(r.getLayoutView().getLayout().getEpoch()).isEqualTo(epoch);
+    }
+
+    /**
+     * Verifies that remove node workflow works correctly and the primary sequencer
+     * elected in the new layout is not any server in the unresponsive set.
+     */
+    @Test
+    public void testRemoveNodeReassignsResponsiveSequencer() throws Exception {
+        // Set up a 3 node cluster, where one server is marked unresponsive.
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
+        addServer(SERVERS.PORT_2);
+
+        Layout l = new TestLayoutBuilder()
+                .setEpoch(1L)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_0)
+                .buildSegment()
+                .setReplicationMode(ReplicationMode.CHAIN_REPLICATION)
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_2)
+                .addToSegment()
+                .addToLayout()
+                .addUnresponsiveServer(SERVERS.PORT_1)
+                .build();
+        bootstrapAllServers(l);
+
+        // Shutdown management agent to prevent healing the unresponsive server.
+        getManagementServer(SERVERS.PORT_0).getManagementAgent().shutdown();
+        getManagementServer(SERVERS.PORT_1).getManagementAgent().shutdown();
+        getManagementServer(SERVERS.PORT_2).getManagementAgent().shutdown();
+
+        CorfuRuntime rt = getRuntime().connect();
+
+        rt.invalidateLayout();
+        Layout layout = new Layout(rt.getLayoutView().getLayout());
+
+        // The expected layout should have primary sequencer that is not in
+        // the unresponsive server set.
+        Layout expectedLayout = new LayoutBuilder(layout)
+                .removeLayoutServer(getEndpoint(SERVERS.PORT_2))
+                .removeSequencerServer(getEndpoint(SERVERS.PORT_2))
+                .removeLogunitServer(getEndpoint(SERVERS.PORT_2))
+                .setEpoch(layout.getEpoch() + 1)
+                .build();
+        expectedLayout.setSequencers(Arrays.asList(SERVERS.ENDPOINT_0, SERVERS.ENDPOINT_1));
+
+        // Remove the primary sequencer node.
+        for (int x = 0; x < runtime.getParameters().getInvalidateRetry(); x++) {
+            try {
+                rt.getLayoutManagementView().removeNode(layout, getEndpoint(SERVERS.PORT_2));
+                rt.invalidateLayout();
+                break;
+            } catch (WrongEpochException e) {
+                // ignore and retry
+            }
+        }
+
+        rt.invalidateLayout();
+        Layout l2 = rt.getLayoutView().getLayout();
+
+        // Verify that the node has been removed from the layout,
+        // and the new layout should has primary sequencer that is not unresponsive.
+        assertThat(l2).isEqualTo(expectedLayout);
     }
 }


### PR DESCRIPTION
# Overview

Porting #1993 

In RemoveNode workflow, when proposing a new layout to be committed, a
server that was marked unresponsive might be elected as the new primary
sequencer, which is incorrect. This patch fixes this issue.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
