### PR TITLE
Print startup message in logs

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -364,6 +364,7 @@ public class CorfuServer {
     @SuppressWarnings("checkstyle:printLine")
     private static void println(Object line) {
         System.out.println(line);
+        log.info(line.toString());
     }
 
     /**


### PR DESCRIPTION
## Overview
Print startup message in the log also. Right now we print the message only in the console and it can be found in tanuki.log. In our logs we have lack of information when Corfu was started.

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
