### PR TITLE
Add trimmed fields in SMRRecord

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRLogEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRLogEntry.java
@@ -1,6 +1,8 @@
 package org.corfudb.protocols.logprotocol;
 
 import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,8 @@ import java.util.UUID;
 @ToString
 @Slf4j
 public class SMRLogEntry extends LogEntry {
+
+    final static SMRLogEntry TRIMMED_ENTRY = new SMRLogEntry();
 
     // Map from stream-ID to a list of SMR updates to this stream.
     @Getter
@@ -79,7 +83,6 @@ public class SMRLogEntry extends LogEntry {
     void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
         super.deserializeBuffer(b, rt);
         int numStreams = b.readInt();
-        entryMap = new HashMap<>();
 
         for (int i = 0; i < numStreams; i++) {
             UUID streamId = new UUID(b.readLong(), b.readLong());

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRRecord.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRRecord.java
@@ -1,11 +1,15 @@
 package org.corfudb.protocols.logprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.Getter;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
-import lombok.NonNull;
-import lombok.Setter;
 import lombok.ToString;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.NonNull;
+
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.serializer.ISerializer;
@@ -19,7 +23,17 @@ import java.util.Arrays;
 @SuppressWarnings("checkstyle:abbreviation")
 @ToString(callSuper = true)
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class SMRRecord {
+
+    final static SMRRecord TRIMMED_RECORD = SMRRecord.builder().trimmed(true).build();
+
+    /**
+     * A flag indicating whether this SMRRecord is trimmed.
+     */
+    @Getter
+    private boolean trimmed = false;
 
     /**
      * The name of the SMR method. Note that this is limited to the size of a short.
@@ -74,6 +88,12 @@ public class SMRRecord {
     long globalAddress = Address.NON_ADDRESS;
 
     /**
+     * The size in bytes of this SMREntry when serialized.
+     */
+    @Getter
+    private int serializedSize = 0;
+
+    /**
      * Set the upcall result for this entry.
      */
     public void setUpcallResult(Object result) {
@@ -114,6 +134,10 @@ public class SMRRecord {
      * @return an {@code SMRRecord} deserialized from buffer.
      */
     static SMRRecord deserializeFromBuffer(ByteBuf b, CorfuRuntime rt) {
+        boolean trimmed = b.readBoolean();
+        if (trimmed) {
+            return TRIMMED_RECORD;
+        }
         SMRRecord record = new SMRRecord();
         short methodLength = b.readShort();
         byte[] methodBytes = new byte[methodLength];
@@ -129,7 +153,7 @@ public class SMRRecord {
             b.skipBytes(len);
         }
         record.SMRArguments = arguments;
-
+        record.serializedSize = b.readInt();
         return record;
     }
 
@@ -140,6 +164,11 @@ public class SMRRecord {
      * @param b byte buffer to serialize to.
      */
     void serialize(ByteBuf b) {
+        b.writeBoolean(trimmed);
+        if (trimmed) {
+            return;
+        }
+
         b.writeShort(SMRMethod.length());
         b.writeBytes(SMRMethod.getBytes());
         b.writeByte(serializerType.getType());
@@ -154,5 +183,8 @@ public class SMRRecord {
                     b.writeInt(length);
                     b.writerIndex(lengthIndex + length + 4);
                 });
+        // including the size of serializedSize itself.
+        serializedSize = b.readableBytes() + 4;
+        b.writeInt(serializedSize);
     }
 }


### PR DESCRIPTION
## Overview

Add trimmed fields in SMRRecord to indicate being trimmed by LogUnit servers. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
