### PR TITLE
Add API for Object Layer to identify garbage

### DIFF
--- a/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
+++ b/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
@@ -21,6 +21,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -46,6 +49,7 @@ import javax.tools.Diagnostic;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.ICorfuSMRProxy;
 import org.corfudb.runtime.object.ICorfuSMRUpcallTarget;
+import org.corfudb.runtime.object.IGarbageIdentificationFunction;
 import org.corfudb.runtime.object.IUndoFunction;
 import org.corfudb.runtime.object.IUndoRecordFunction;
 
@@ -571,6 +575,7 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
         addUndoRecordMap(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
         addUndoMap(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
         addResetSet(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
+        addGarbageIdentifyMap(typeSpecBuilder, originalName, interfacesToAdd, methodSet);
 
         typeSpecBuilder
                 .addSuperinterfaces(interfacesToAdd);
@@ -918,6 +923,97 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                 .addStatement("return $L", "undoMap" + CORFUSMR_FIELD)
                 .build());
 
+    }
+
+    /** Use as stateful filter to deduplicate. */
+    public static <T> Predicate<T> distinctByProperty(Function<? super T, ?> propertyFunction) {
+        Set<Object> seen = ConcurrentHashMap.newKeySet();
+        return t -> seen.add(propertyFunction.apply(t));
+    }
+
+    /** Generate the garbage string and associated map for the type. */
+    private void addGarbageIdentifyMap(TypeSpec.Builder typeSpecBuilder, TypeName originalName,
+                               Set<TypeName> interfacesToAdd, Set<SmrMethodInfo> methodSet) {
+        String garbageString = methodSet.stream()
+                .filter(x -> x.method.getAnnotation(MutatorAccessor.class) != null
+                        || x.method.getAnnotation(Mutator.class) != null)
+                .filter(x -> x.method.getAnnotation(MutatorAccessor.class) == null
+                        || !x.method.getAnnotation(MutatorAccessor.class).garbageIdentifyFunction().equals(""))
+                .filter(x -> x.method.getAnnotation(Mutator.class) == null
+                        || !x.method.getAnnotation(Mutator.class).garbageIdentificationFunction().equals(""))
+                .filter(distinctByProperty(x -> getSmrFunctionName(x.method)))
+                .map(x -> {
+                    MutatorAccessor mutatorAccessor = x.method.getAnnotation(MutatorAccessor.class);
+                    Mutator mutator = x.method.getAnnotation(Mutator.class);
+                    String garbageFunction = mutator == null ? mutatorAccessor.garbageIdentifyFunction() :
+                            mutator.garbageIdentificationFunction();
+
+                    Optional<SmrMethodInfo> mi = methodSet.stream()
+                            .filter(y -> y.method.getSimpleName().toString().equals(garbageFunction))
+                            .findFirst();
+
+                    // Don't generate a record since we don't have a matching method
+                    if (!mi.isPresent()) {
+                        messager.printMessage(Diagnostic.Kind.MANDATORY_WARNING,
+                                "No garbage identification method for " + x.method.getSimpleName()
+                                        + " named " + garbageFunction );
+                        return "";
+                    }
+
+                    // Check that the signature matches what we expect. (2+original)
+                    if (mi.get().method.getParameters().size()
+                            != x.method.getParameters().size() + 1) {
+                        messager.printMessage(Diagnostic.Kind.ERROR, "garbage identification method "
+                                + garbageFunction + " contained the wrong number of parameters");
+                        return "";
+                    }
+
+                    // Add the interface, if present.
+                    if (mi.get().interfaceOverride != null) {
+                        interfacesToAdd.add(ParameterizedTypeName
+                                .get(mi.get().interfaceOverride.asType()));
+                    }
+                    String callingConvention = mi.get().interfaceOverride == null ? "this." :
+                            mi.get().interfaceOverride.getSimpleName() + ".super.";
+
+                    //return "";
+
+                    return "\n.put(\"" + getSmrFunctionName(x.method) + "\", "
+                            + "(locator, args) -> {return " + callingConvention
+                            + garbageFunction + "(("
+                            + ParameterizedTypeName.get(mi.get().method.getParameters()
+                            .get(0).asType())
+                            + ") locator"
+                            + IntStream.range(0, x.method.getParameters().size())
+                            .mapToObj(i ->
+                                    ", (" + mi.get().method.getParameters().get(i + 1)
+                                            .asType().toString() + ")"
+                                            + " args[" + i + "]")
+                            .collect(Collectors.joining())
+                            + ");})";
+
+                })
+                .collect(Collectors.joining());
+
+        FieldSpec garbageMap = FieldSpec.builder(ParameterizedTypeName.get(ClassName.get(Map.class),
+                ClassName.get(String.class),
+                ClassName.get(IGarbageIdentificationFunction.class)),
+                "garbageIdentificationMap" + CORFUSMR_FIELD, Modifier.PUBLIC, Modifier.FINAL)
+                .initializer("new $T()$L.build()",
+                        ParameterizedTypeName.get(ClassName.get(ImmutableMap.Builder.class),
+                                ClassName.get(String.class),
+                                ClassName.get(IGarbageIdentificationFunction.class)), garbageString)
+                .build();
+
+        typeSpecBuilder.addField(garbageMap);
+
+        typeSpecBuilder.addMethod(MethodSpec.methodBuilder("getCorfuGarbageIdentificationMap")
+                .addModifiers(Modifier.PUBLIC)
+                .returns(ParameterizedTypeName.get(ClassName.get(Map.class),
+                        ClassName.get(String.class),
+                        ClassName.get(IGarbageIdentificationFunction.class)))
+                .addStatement("return $L", "garbageIdentificationMap" + CORFUSMR_FIELD)
+                .build());
     }
 
     /** Add a conflict field to the method.

--- a/annotations/src/main/java/org/corfudb/annotations/Mutator.java
+++ b/annotations/src/main/java/org/corfudb/annotations/Mutator.java
@@ -51,4 +51,11 @@ public @interface Mutator {
      * @return True, if no upcall should be generated.
      */
     boolean noUpcall() default false;
+
+    /** The name of the garbage identification function which will be called
+     * when syncing up to materialized smr streams.
+     * @return  The name of a garbage identification function.
+     */
+    String garbageIdentificationFunction() default  "";
+
 }

--- a/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
+++ b/annotations/src/main/java/org/corfudb/annotations/MutatorAccessor.java
@@ -50,4 +50,10 @@ public @interface MutatorAccessor {
      * @return True, if no upcall should be generated.
      */
     boolean noUpcall() default false;
+
+    /** The name of the function which will be called when syncing up to the smr
+     * stream backed by the log to identify garbage.
+     * @return  The name of a garbage identification function.
+     */
+    String garbageIdentifyFunction() default  "";
 }

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMR.java
@@ -44,4 +44,12 @@ public interface ICorfuSMR<T> {
     default UUID getCorfuStreamID() {
         return getCorfuSMRProxy().getStreamID();
     }
+
+    /**
+     * Get a map from strings (function names) to garbage identification
+     * methods.
+     * @return The garbage identification map.
+     * */
+    Map<String, IGarbageIdentificationFunction>
+        getCorfuGarbageIdentificationMap();
 }

--- a/annotations/src/main/java/org/corfudb/runtime/object/IGarbageIdentificationFunction.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/IGarbageIdentificationFunction.java
@@ -1,0 +1,17 @@
+package org.corfudb.runtime.object;
+
+import java.util.List;
+
+/** A functional interface which represents a garbage identification function.
+ * Created by Xin on 03/18/19.
+ */
+@FunctionalInterface
+public interface IGarbageIdentificationFunction {
+    /** Identify the garbage of an object.
+     *
+     * @param locator       Locator of the newly applied smr entry.
+     * @param args          The arguments to the mutation.
+     * @return              Array of locations of garbage
+     */
+    List<Object> identify(Object locator, Object[] args);
+}

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRRecord.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRRecord.java
@@ -76,7 +76,7 @@ public class SMRRecord {
     public transient boolean haveUpcallResult = false;
 
     /**
-     * The locator of this instance of SMRRecord in SpaceAddressView.
+     * The locator of this instance of SMRRecord in global log.
      */
     @Getter
     @Setter

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRRecordLocator.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRRecordLocator.java
@@ -25,12 +25,14 @@ public class SMRRecordLocator implements Comparable<SMRRecordLocator>, ICorfuSer
     private long globalAddress;
     private UUID streamId;
     private int index;
+    private int serializedSize;
 
     public void serialize(ByteBuf buf) {
         buf.writeLong(globalAddress);
         buf.writeLong(streamId.getMostSignificantBits());
         buf.writeLong(streamId.getLeastSignificantBits());
         buf.writeInt(index);
+        buf.writeInt(serializedSize);
     }
 
 
@@ -42,6 +44,7 @@ public class SMRRecordLocator implements Comparable<SMRRecordLocator>, ICorfuSer
         long leastSignificantBits = buf.readLong();
         smrRecordLocator.setStreamId(new UUID(mostSignificantBits, leastSignificantBits));
         smrRecordLocator.setIndex(buf.readInt());
+        smrRecordLocator.setSerializedSize(buf.readInt());
 
         return smrRecordLocator;
     }

--- a/runtime/src/main/java/org/corfudb/recovery/RecoveryUtils.java
+++ b/runtime/src/main/java/org/corfudb/recovery/RecoveryUtils.java
@@ -35,18 +35,6 @@ public class RecoveryUtils {
         return new ObjectsView.ObjectID(streamId, type);
     }
 
-    static boolean isCheckPointEntry(ILogData logData) {
-        return logData.hasCheckpointMetadata();
-    }
-
-    static long getSnapShotAddressOfCheckPoint(CheckpointEntry logEntry) {
-        return Long.parseLong(logEntry.getDict().get(SNAPSHOT_ADDRESS));
-    }
-
-    static long getStartAddressOfCheckPoint(ILogData logData) {
-        return logData.getCheckpointedStreamStartLogAddress();
-    }
-
     /**
      * Create a new object SMRMap as recipient of SMRUpdates (if doesn't exist yet)
      */

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -5,9 +5,9 @@ import org.corfudb.annotations.Accessor;
 import org.corfudb.annotations.ConflictParameter;
 import org.corfudb.annotations.Mutator;
 import org.corfudb.annotations.MutatorAccessor;
-import org.corfudb.annotations.DontInstrument;
 
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -73,7 +73,8 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      * <p>Conflicts: this operation produces a conflict with any other
      * operation on the given key.
      */
-    @MutatorAccessor(name = "put", undoFunction = "undoPut", undoRecordFunction = "undoPutRecord")
+    @MutatorAccessor(name = "put", undoFunction = "undoPut", undoRecordFunction = "undoPutRecord",
+            garbageIdentifyFunction = "identifyPutGarbage")
     @Override
     V put(@ConflictParameter K key, V value);
 
@@ -90,10 +91,13 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      * <p>Conflicts: this operation produces a conflict with any other
      * operation on the given key.
      */
-    @Mutator(name = "put", noUpcall = true)
+    @Mutator(name = "put", garbageIdentificationFunction = "identifyPutGarbage", noUpcall = true)
     default void blindPut(@ConflictParameter K key, V value) {
         put(key, value);
     }
+
+    List<Object> identifyPutGarbage(Object locator, K key, V value);
+
 
     /** Generate an undo record for a put, given the previous state of the map
      * and the parameters to the put call.
@@ -133,7 +137,7 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      * operation on the given key.
      */
     @MutatorAccessor(name = "remove", undoFunction = "undoRemove",
-            undoRecordFunction = "undoRemoveRecord")
+            undoRecordFunction = "undoRemoveRecord", garbageIdentifyFunction = "identifyRemoveGarbage")
     @Override
     V remove(@ConflictParameter Object key);
 
@@ -162,6 +166,8 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
             map.put(key, undoRecord);
         }
     }
+
+    List<Object> identifyRemoveGarbage(Object locator, K key);
 
     /**
      * {@inheritDoc}
@@ -231,9 +237,11 @@ public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
      * <p>Conflicts: this operation conflicts with the entire map, since it drops
      * all mappings which are present.
      */
-    @Mutator(name = "clear", reset = true)
+    @Mutator(name = "clear", garbageIdentificationFunction = "identifyClearGarbage", reset = true)
     @Override
     void clear();
+
+    List<Object> identifyClearGarbage(Object locator);
 
     /**
      * {@inheritDoc}

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -129,6 +128,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
      * @param serializer          Serializer used by the SMR entries to serialize the arguments.
      * @param upcallTargetMap     upCallTargetMap
      * @param undoTargetMap       undoTargetMap
+     * @param garbageFunctionMap  garbageFunctionMap
      * @param undoRecordTargetMap undoRecordTargetMap
      * @param resetSet            resetSet
      */
@@ -139,6 +139,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                              Map<String, ICorfuSMRUpcallTarget<T>> upcallTargetMap,
                              Map<String, IUndoFunction<T>> undoTargetMap,
                              Map<String, IUndoRecordFunction<T>> undoRecordTargetMap,
+                             Map<String, IGarbageIdentificationFunction> garbageFunctionMap,
                              Set<String> resetSet
     ) {
         this.rt = rt;
@@ -151,8 +152,8 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         // because the VLO will control access to the stream
         underlyingObject = new VersionLockedObject<T>(this::getNewInstance,
                 new StreamViewSMRAdapter(rt, rt.getStreamsView().getUnsafe(streamID)),
-                upcallTargetMap, undoRecordTargetMap,
-                undoTargetMap, resetSet);
+                upcallTargetMap, undoRecordTargetMap, undoTargetMap,
+                garbageFunctionMap, resetSet);
 
         metrics = CorfuRuntime.getDefaultMetrics();
         mpObj = CorfuComponent.OBJECT.toString();

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -63,6 +63,7 @@ public class CorfuCompileWrapperBuilder {
                 wrapperObject.getCorfuSMRUpcallMap(),
                 wrapperObject.getCorfuUndoMap(),
                 wrapperObject.getCorfuUndoRecordMap(),
+                wrapperObject.getCorfuGarbageIdentificationMap(),
                 wrapperObject.getCorfuResetSet()));
 
         if (wrapperObject instanceof ICorfuSMRProxyWrapper) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
@@ -3,9 +3,11 @@ package org.corfudb.runtime.object;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.corfudb.protocols.logprotocol.SMRRecord;
+import org.corfudb.protocols.logprotocol.SMRRecordLocator;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 
 /**
@@ -73,5 +75,19 @@ public interface ISMRStream {
     @SuppressWarnings("checkstyle:abbreviation")
     default UUID getID() {
         return new UUID(0L, 0L);
+    }
+
+    static void addLocatorToSMRRecords(List<SMRRecord> smrRecords, long globalAddress, UUID streamId) {
+        IntStream.range(0, smrRecords.size()).forEach(i -> {
+            SMRRecord entry = smrRecords.get(i);
+            // It is not necessary to compute locator when it has been computed
+            if (entry.locator == null) {
+                entry.setLocator(new SMRRecordLocator(
+                        globalAddress,
+                        streamId,
+                        i,
+                        entry.getSerializedSize()));
+            }
+        });
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -4,6 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
 import org.corfudb.protocols.logprotocol.SMRRecord;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.NoRollbackException;
@@ -23,10 +24,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 //TODO Discard TransactionStream for building maps but not for constructing tails
 
@@ -107,6 +110,11 @@ public class VersionLockedObject<T> {
     private final Map<String, IUndoFunction<T>> undoFunctionMap;
 
     /**
+     * The garbage identification function map for this object.
+     */
+    private final Map<String, IGarbageIdentificationFunction> garbageIdentifyFunctionMap;
+
+    /**
      * The reset set for this object.
      */
     private final Set<String> resetSet;
@@ -121,6 +129,11 @@ public class VersionLockedObject<T> {
      */
     private final Logger correctnessLogger = LoggerFactory.getLogger("correctness");
 
+    /**
+     * The largest address that the stream is synced to.
+     */
+    private long syncTail = Address.NON_ADDRESS;
+
 
     /**
      * The VersionLockedObject maintains a versioned object which is backed by an ISMRStream,
@@ -130,6 +143,7 @@ public class VersionLockedObject<T> {
      * @param smrStream         Stream View backing this object.
      * @param upcallTargets     UpCall map for this object.
      * @param undoRecordTargets Undo record function map for this object.
+     * @param garbageTargets    Garbage identification function map for this object.
      * @param undoTargets       Undo functions map.
      * @param resetSet          Reset set for this object.
      */
@@ -138,12 +152,14 @@ public class VersionLockedObject<T> {
                                Map<String, ICorfuSMRUpcallTarget<T>> upcallTargets,
                                Map<String, IUndoRecordFunction<T>> undoRecordTargets,
                                Map<String, IUndoFunction<T>> undoTargets,
+                               Map<String, IGarbageIdentificationFunction> garbageTargets,
                                Set<String> resetSet) {
         this.smrStream = smrStream;
 
         this.upcallTargetMap = upcallTargets;
         this.undoRecordFunctionMap = undoRecordTargets;
         this.undoFunctionMap = undoTargets;
+        this.garbageIdentifyFunctionMap = garbageTargets;
         this.resetSet = resetSet;
 
         this.newObjectFn = newObjectFn;
@@ -445,6 +461,7 @@ public class VersionLockedObject<T> {
         object = newObjectFn.get();
         smrStream.reset();
         optimisticStream = null;
+        syncTail = Address.NON_ADDRESS;
     }
 
     /**
@@ -546,7 +563,7 @@ public class VersionLockedObject<T> {
             }
         }
 
-        // Now invoke the upcall
+        // now invoke the upcall
         return target.upcall(object, record.getSMRArguments());
     }
 
@@ -616,25 +633,62 @@ public class VersionLockedObject<T> {
         log.trace("Sync[{}] {}", this, (timestamp == Address.OPTIMISTIC)
                 ? "Optimistic" : "to " + timestamp);
         long syncTo = (timestamp == Address.OPTIMISTIC) ? Address.MAX : timestamp;
-        stream.streamUpTo(syncTo)
-                .forEachOrdered(entry -> {
+
+        Stream<SMRRecord> smrRecordStream = stream.streamUpTo(syncTo);
+        applyUpdateStreamUnsafe(smrRecordStream, timestamp == Address.OPTIMISTIC);
+    }
+
+    private void applyUpdateStreamUnsafe(Stream<SMRRecord> smrRecordStream, boolean isOptimistic) {
+        // AtomicLong is used as a container to bypass the restriction of lambda expression
+        final AtomicLong lastSyncAddress = new AtomicLong(Address.NON_ADDRESS);
+
+        smrRecordStream
+                .forEachOrdered(record -> {
                     try {
-                        Object res = applyUpdateUnsafe(entry);
-                        if (timestamp == Address.OPTIMISTIC) {
-                            entry.setUpcallResult(res);
-                        } else if (pendingUpcalls.contains(entry.getGlobalAddress())) {
-                            log.debug("Sync[{}] Upcall Result {}",
-                                    this, entry.getGlobalAddress());
-                            upcallResults.put(entry.getGlobalAddress(), res == null
-                                    ? NullValue.NULL_VALUE : res);
-                            pendingUpcalls.remove(entry.getGlobalAddress());
+                        Object res = applyUpdateUnsafe(record);
+
+                        if (!isOptimistic) { // materialized log
+                            if (pendingUpcalls.contains(record.getGlobalAddress())) {
+                                log.debug("Sync[{}] Upcall Result {}",
+                                        this, record.getGlobalAddress());
+                                upcallResults.put(record.getGlobalAddress(), res == null
+                                        ? NullValue.NULL_VALUE : res);
+                                pendingUpcalls.remove(record.getGlobalAddress());
+                            }
+
+                            // Record with global address larger than lastSyncAddress indicates that all SMRRecords
+                            // from last global address has been applied. Therefore, syncTail could be updated.
+                            if (lastSyncAddress.get() != Address.NON_ADDRESS &&
+                                    record.getGlobalAddress() > lastSyncAddress.get()) {
+                                syncTail = Math.max(syncTail, lastSyncAddress.get());
+                            }
+
+                            // to check whether the SMRRecord is first encountered by VLO
+                            if (record.getGlobalAddress() > syncTail) {
+                                IGarbageIdentificationFunction garbageIdentifyFunction =
+                                        garbageIdentifyFunctionMap.get(record.getSMRMethod());
+                                if (garbageIdentifyFunction != null) {
+                                    List<Object> garbage =
+                                            garbageIdentifyFunction.identify(record.locator, record.getSMRArguments());
+                                    // TODO(xin): handle garbage
+                                }
+
+                                lastSyncAddress.set(record.getGlobalAddress());
+                            }
                         }
-                        entry.setUpcallResult(res);
+
+                        record.setUpcallResult(res);
                     } catch (Exception e) {
                         log.error("Sync[{}] Error: Couldn't execute upcall due to {}", this, e);
                         throw new UnrecoverableCorfuError(e);
                     }
                 });
+
+
+        // update syncTail after applying all SMRRecords. 
+        if (!isOptimistic) {
+            syncTail = Math.max(syncTail, lastSyncAddress.get());
+        }
     }
 
     /**
@@ -656,10 +710,10 @@ public class VersionLockedObject<T> {
     /** Apply an SMRRecord to the version object, while
      * doing bookkeeping for the underlying stream.
      *
-     * @param entry smr entry
+     * @param updates smr records
      */
-    public void applyUpdateToStreamUnsafe(SMRRecord entry, long globalAddress) {
-        applyUpdateUnsafe(entry);
+    public void applyUpdatesToStreamUnsafe(List<SMRRecord> updates, long globalAddress) {
+        applyUpdateStreamUnsafe(updates.stream(), false);
         seek(globalAddress + 1);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/Transaction.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/Transaction.java
@@ -31,7 +31,7 @@ public class Transaction {
      * The type of context to build.
      */
     @Default
-    final TransactionType type = TransactionType.OPTIMISTIC;;
+    final TransactionType type = TransactionType.OPTIMISTIC;
 
     /**
      * For snapshot transactions, the address the

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -15,13 +15,12 @@ import org.corfudb.runtime.exceptions.QuotaExceededException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.WriteSizeException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
-import org.corfudb.runtime.object.CorfuCompileProxy;
-import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
 import org.corfudb.runtime.object.transactions.Transaction;
 import org.corfudb.runtime.object.transactions.Transaction.TransactionBuilder;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
+
 import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.MetricsUtils;
 

--- a/runtime/src/test/java/org/corfudb/protocols/logprotocol/SMRRecordLocatorTest.java
+++ b/runtime/src/test/java/org/corfudb/protocols/logprotocol/SMRRecordLocatorTest.java
@@ -19,7 +19,9 @@ public class SMRRecordLocatorTest {
         long globalAddress = Address.getMinAddress();
         UUID steramId = UUID.randomUUID();
         int index = 0;
-        SMRRecordLocator locator = new SMRRecordLocator(globalAddress, steramId, index);
+        int serializedSize = 0;
+
+        SMRRecordLocator locator = new SMRRecordLocator(globalAddress, steramId, index, serializedSize);
 
         ByteBuf buf = Unpooled.buffer();
         locator.serialize(buf);

--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -29,9 +29,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -42,8 +39,6 @@ import static org.assertj.core.api.Assertions.catchThrowable;
  * Created by rmichoud on 6/16/17.
  */
 public class FastObjectLoaderTest extends AbstractViewTest {
-    static final int NUMBER_OF_CHECKPOINTS = 20;
-    static final int NUMBER_OF_PUT = 100;
     static final int SOME = 3;
     static final int MORE = 5;
 
@@ -289,55 +284,6 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         CorfuRuntime rt2 = Helpers.createNewRuntimeWithFastLoader(getDefaultConfigurationString());
         assertThatMapsAreBuilt(rt2);
         assertThatObjectCacheIsTheSameSize(getDefaultRuntime(), rt2);
-    }
-
-    /**
-     * Interleaving checkpoint entries and normal entries through multithreading
-     *
-     * @throws Exception
-     */
-    @Test
-    public void canReadWithEntriesInterleavingCPS() throws Exception {
-        populateMaps(SOME, getDefaultRuntime(), CorfuTable.class, true, 1);
-        int mapCount = maps.size();
-
-        ExecutorService checkPointThread = Executors.newFixedThreadPool(1);
-        checkPointThread.execute(() -> {
-            for (int i = 0; i < NUMBER_OF_CHECKPOINTS; i++) {
-                try {
-                    checkPointAll(getDefaultRuntime());
-                } catch (Exception e) {
-
-                }
-            }
-        });
-
-
-        for (int i = 0; i < NUMBER_OF_PUT; i++) {
-            maps.get("Map" + (i % maps.size())).put("k" + Integer.toString(i),
-                    "v" + Integer.toString(i));
-        }
-
-        try {
-            checkPointThread.shutdown();
-            final int timeout = 10;
-            checkPointThread.awaitTermination(timeout, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-
-        }
-
-        CorfuRuntime rt2 = Helpers.createNewRuntimeWithFastLoader(getDefaultConfigurationString());
-        assertThatMapsAreBuilt(rt2);
-        assertThatObjectCacheIsTheSameSize(getDefaultRuntime(), rt2);
-
-
-        // Also test it cans find the tails
-        Map<UUID, Long> streamTails = Helpers.getRecoveryStreamTails(getDefaultConfigurationString());
-        assertThatStreamTailsAreCorrect(streamTails);
-
-        // Need to have checkpoint for each stream
-        assertThat(streamTails.size()).isEqualTo(mapCount * 2);
-
     }
 
     @Test


### PR DESCRIPTION
## Overview

By modifying annotation processor, this patch add APIs for the Object Layer to identify garbage. 

This PR is stack atop https://github.com/CorfuDB/CorfuDB/pull/1911,  https://github.com/CorfuDB/CorfuDB/pull/2014, https://github.com/CorfuDB/CorfuDB/pull/2003, https://github.com/CorfuDB/CorfuDB/pull/2011.

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
