### PR TITLE
Non-Cachable Streams

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/StateTransfer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/StateTransfer.java
@@ -17,6 +17,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.RetryExhaustedException;
 import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.ReadOptions;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.retry.ExponentialBackoffRetry;
 import org.corfudb.util.retry.IRetry;
@@ -41,6 +42,13 @@ public class StateTransfer {
 
     // Maximum number of retries after which the Overwrite Exception is rethrown.
     private static final int OVERWRITE_RETRIES = 3;
+
+    // Default read options for the state read calls
+    private static ReadOptions readOptions = ReadOptions.builder()
+            .waitForHole(true)
+            .clientCacheable(false)
+            .serverCacheable(false)
+            .build();
 
     /**
      * Fetch and propagate the trimMark to the new/healing nodes. Else, a FastLoader reading from
@@ -198,7 +206,7 @@ public class StateTransfer {
         long ts1 = System.currentTimeMillis();
 
         // Don't cache the read results on server for state transfer.
-        Map<Long, ILogData> dataMap = runtime.getAddressSpaceView().nonCacheFetchAll(chunk, true);
+        Map<Long, ILogData> dataMap = runtime.getAddressSpaceView().read(chunk, readOptions);
 
         long ts2 = System.currentTimeMillis();
 

--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -26,6 +26,7 @@ import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterrupte
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.ObjectBuilder;
+import org.corfudb.runtime.view.ReadOptions;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.Utils;
 import org.corfudb.util.serializer.ISerializer;
@@ -752,7 +753,9 @@ public class FastObjectLoader {
                 // Don't cache the read results on server for fast loader
                 ContiguousSet<Long> addresses = ContiguousSet.create(
                         Range.closed(lower, upper), DiscreteDomain.longs());
-                Map<Long, ILogData> range = runtime.getAddressSpaceView().nonCacheFetchAll(addresses, true);
+
+                Map<Long, ILogData> range = runtime.getAddressSpaceView().read(addresses,
+                        RecoveryUtils.fastLoaderReadOptions);
 
                 // Sanity
                 for (Map.Entry<Long, ILogData> entry : range.entrySet()) {

--- a/runtime/src/main/java/org/corfudb/recovery/RecoveryUtils.java
+++ b/runtime/src/main/java/org/corfudb/recovery/RecoveryUtils.java
@@ -8,6 +8,7 @@ import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.view.ObjectBuilder;
 import org.corfudb.runtime.view.ObjectsView;
+import org.corfudb.runtime.view.ReadOptions;
 import org.corfudb.util.serializer.ISerializer;
 
 import java.util.UUID;
@@ -18,6 +19,13 @@ import static org.corfudb.protocols.logprotocol.CheckpointEntry.CheckpointDictKe
  * Created by rmichoud on 6/22/17.
  */
 public class RecoveryUtils {
+
+    // Default read options used by the fast object loader logic
+    public static ReadOptions fastLoaderReadOptions = ReadOptions.builder()
+            .clientCacheable(false)
+            .serverCacheable(false)
+            .waitForHole(true)
+            .build();
 
     private RecoveryUtils() {
         // prevent instantiation of this class
@@ -70,7 +78,7 @@ public class RecoveryUtils {
         if (loadInCache) {
             return runtime.getAddressSpaceView().read(address);
         } else {
-            return runtime.getAddressSpaceView().fetch(address);
+            return runtime.getAddressSpaceView().read(address, fastLoaderReadOptions);
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/ReadOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ReadOptions.java
@@ -1,0 +1,45 @@
+package org.corfudb.runtime.view;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+
+/**
+ * When the client issues a read, the request traverses multiple layers and different configurations
+ * can be set for that read requests. This ReadOptions objects enables different configurations per
+ * read request.
+ *
+ * <p>Created by Maithem on 7/9/19.</p>
+ */
+
+@Builder(toBuilder=true)
+@Data
+public class ReadOptions {
+    /**
+     * Ignore trimmed exceptions encountered while syncing
+     */
+    @Getter
+    @Builder.Default
+    final boolean ignoreTrim = false;
+
+    /**
+     * The readers behavior when a hole is encountered
+     */
+    @Getter
+    @Builder.Default
+    private final boolean waitForHole = true;
+
+    /**
+     * Whether to cache the read on the client side
+     */
+    @Getter
+    @Builder.Default
+    private final boolean clientCacheable = true;
+
+    /**
+     * Cache hint for the server to determine whether to cache the read request or not
+     */
+    @Getter
+    @Builder.Default
+    private final boolean serverCacheable = true;
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamOptions.java
@@ -1,35 +1,27 @@
 package org.corfudb.runtime.view;
 
+import lombok.Builder;
+import lombok.Getter;
+
 /**
  * Created by maithem on 6/20/17.
  */
+@Builder
 public class StreamOptions {
-    public static StreamOptions DEFAULT = new StreamOptions(false);
+    public static StreamOptions DEFAULT = StreamOptions.builder()
+            .ignoreTrimmed(false)
+            .cacheEntries(true)
+            .build();
 
-    public final boolean ignoreTrimmed;
+    /**
+     * Ignore trimmed exceptions encountered while syncing
+     */
+    @Getter
+    final boolean ignoreTrimmed;
 
-    public StreamOptions(boolean ignoreTrimmed) {
-        this.ignoreTrimmed = ignoreTrimmed;
-    }
-
-    public static StreamOptionsBuilder builder() {
-        return new StreamOptionsBuilder();
-    }
-
-    public static class StreamOptionsBuilder {
-        private boolean ignoreTrimmed;
-
-        public StreamOptionsBuilder() {
-
-        }
-
-        public StreamOptionsBuilder ignoreTrimmed(boolean ignore) {
-            this.ignoreTrimmed = ignore;
-            return this;
-        }
-
-        public StreamOptions build() {
-            return new StreamOptions(ignoreTrimmed);
-        }
-    }
+    /**
+     * Cache this stream's entries
+     */
+    @Getter
+    final boolean cacheEntries;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamOptions.java
@@ -4,6 +4,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 /**
+ * Options for the stream layer to configure a stream's caching/read behavior.
+ *
  * Created by maithem on 6/20/17.
  */
 @Builder
@@ -17,11 +19,13 @@ public class StreamOptions {
      * Ignore trimmed exceptions encountered while syncing
      */
     @Getter
-    final boolean ignoreTrimmed;
+    @Builder.Default
+    private final boolean ignoreTrimmed = false;
 
     /**
      * Cache this stream's entries
      */
     @Getter
-    final boolean cacheEntries;
+    @Builder.Default
+    private final boolean cacheEntries = true;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -45,14 +45,8 @@ public class StreamsView extends AbstractView {
     @Getter
     Multimap<UUID, IStreamView> streamCache = Multimaps.synchronizedMultimap(HashMultimap.create());
 
-    /**
-     * Max write size.
-     */
-    final int maxWrite;
-
     public StreamsView(final CorfuRuntime runtime) {
         super(runtime);
-        maxWrite = runtime.getParameters().getMaxWriteSize();
     }
 
     /**
@@ -125,7 +119,7 @@ public class StreamsView extends AbstractView {
                        @Nonnull CacheOption cacheOption, @Nonnull UUID ... streamIDs) {
 
         final LogData ld = new LogData(DataType.DATA, object);
-        ld.checkMaxWriteSize(maxWrite);
+        ld.checkMaxWriteSize(runtime.getParameters().getMaxWriteSize());
 
         // Go to the sequencer, grab an initial token.
         TokenResponse tokenResponse = conflictInfo == null

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -265,7 +265,7 @@ public abstract class AbstractQueuedStreamView extends
     protected List<ILogData> readAll(@Nonnull List<Long> addresses) {
         try {
             Map<Long, ILogData> dataMap =
-                    runtime.getAddressSpaceView().read(addresses, options.ignoreTrimmed);
+                    runtime.getAddressSpaceView().read(addresses, options.isIgnoreTrimmed());
             // If trimmed exceptions are ignored, the data retrieved by the read API might not correspond
             // to all requested addresses, for this reason we must filter out data entries not included (null).
             // Also, we need to preserve ordering for checkpoint logic.

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.view.stream;
 
 import com.google.common.annotations.VisibleForTesting;
 import lombok.Data;
+import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
@@ -16,6 +17,7 @@ import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.ReadOptions;
 import org.corfudb.runtime.view.StreamOptions;
 import org.corfudb.util.Utils;
 
@@ -52,8 +54,8 @@ import java.util.stream.Collectors;
 public abstract class AbstractQueuedStreamView extends
         AbstractContextStreamView<AbstractQueuedStreamView
                 .QueuedStreamContext> {
-
-    final StreamOptions options;
+    @Getter
+    private final ReadOptions readOptions;
 
     /** Create a new queued stream view.
      *
@@ -62,9 +64,12 @@ public abstract class AbstractQueuedStreamView extends
      */
     public AbstractQueuedStreamView(final CorfuRuntime runtime,
                                     final UUID streamId,
-                                    StreamOptions options) {
+                                    StreamOptions streamOptions) {
         super(runtime, streamId, QueuedStreamContext::new);
-        this.options = options;
+        this.readOptions = ReadOptions.builder()
+                .clientCacheable(streamOptions.isCacheEntries())
+                .ignoreTrim(streamOptions.isIgnoreTrimmed())
+                .build();
     }
 
     /** Add the given address to the resolved queue of the
@@ -246,15 +251,18 @@ public abstract class AbstractQueuedStreamView extends
      * @param readStartTime start time of the range of reads.
      * @return log data at the address.
      */
+    @Deprecated
     protected ILogData read(final long address, long readStartTime) {
         try {
             if (System.currentTimeMillis() - readStartTime <
                     runtime.getParameters().getHoleFillTimeout().toMillis()) {
-                return runtime.getAddressSpaceView().read(address);
+                return runtime.getAddressSpaceView().read(address, readOptions);
             }
-            return runtime.getAddressSpaceView()
-                    .read(Collections.singleton(address), false, false)
-                    .get(address);
+
+            ReadOptions options = readOptions.toBuilder()
+                    .waitForHole(false)
+                    .build();
+            return runtime.getAddressSpaceView().read(address, options);
         } catch (TrimmedException te) {
             processTrimmedException(te);
             throw te;
@@ -265,7 +273,7 @@ public abstract class AbstractQueuedStreamView extends
     protected List<ILogData> readAll(@Nonnull List<Long> addresses) {
         try {
             Map<Long, ILogData> dataMap =
-                    runtime.getAddressSpaceView().read(addresses, options.isIgnoreTrimmed());
+                    runtime.getAddressSpaceView().read(addresses, readOptions);
             // If trimmed exceptions are ignored, the data retrieved by the read API might not correspond
             // to all requested addresses, for this reason we must filter out data entries not included (null).
             // Also, we need to preserve ordering for checkpoint logic.
@@ -548,7 +556,7 @@ public abstract class AbstractQueuedStreamView extends
      **/
     protected ILogData read(final long address) {
         try {
-            return runtime.getAddressSpaceView().read(address);
+            return runtime.getAddressSpaceView().read(address, readOptions);
         } catch (TrimmedException te) {
             processTrimmedException(te);
             throw te;
@@ -568,7 +576,7 @@ public abstract class AbstractQueuedStreamView extends
      */
     protected @Nonnull ILogData read(long nextRead, @Nonnull final NavigableSet<Long> addresses) {
         try {
-            return runtime.getAddressSpaceView().read(nextRead, addresses, false);
+            return runtime.getAddressSpaceView().read(nextRead, addresses, readOptions);
         } catch (TrimmedException te) {
             processTrimmedException(te);
             throw te;

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -103,7 +103,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                 // we force trimmedExceptions to be thrown by lower layers, and handle ignoreTrimmed at this layer.
                 // Note that lower layers will cache the valid entries, to optimize read performance.
 
-                if (!options.ignoreTrimmed) {
+                if (!options.isIgnoreTrimmed()) {
                     throw te;
                 }
 
@@ -170,7 +170,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                             streamAddressSpace.getTrimMark(),
                             getCurrentContext().checkpoint.startAddress, maxGlobal);
                     log.info(message);
-                    if (options.ignoreTrimmed) {
+                    if (options.isIgnoreTrimmed()) {
                         log.debug("getStreamAddressMap[{}]: Ignoring trimmed exception for address[{}].",
                                 this, streamAddressSpace.getTrimMark());
                     } else {
@@ -256,7 +256,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
             }
         } catch (TrimmedException ste) {
             // The valid checkpoint has been trimmed.
-            if (options.ignoreTrimmed) {
+            if (options.isIgnoreTrimmed()) {
                 log.debug("processCheckpointBatchByEntry[{}]: Ignoring trimmed exception for address[{}]," +
                         " stream[{}]", this, lastReadAddress, id);
             } else {
@@ -296,7 +296,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
         try {
             d = read(startAddress);
         } catch (TrimmedException e) {
-            if (options.ignoreTrimmed) {
+            if (options.isIgnoreTrimmed()) {
                 log.debug("isAddressToBackpointerResolved[{}]: Ignoring trimmed exception for address[{}]," +
                         " stream[{}]", this, startAddress, streamId);
                 return false;

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -103,7 +103,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                 // we force trimmedExceptions to be thrown by lower layers, and handle ignoreTrimmed at this layer.
                 // Note that lower layers will cache the valid entries, to optimize read performance.
 
-                if (!options.isIgnoreTrimmed()) {
+                if (!getReadOptions().isIgnoreTrim()) {
                     throw te;
                 }
 
@@ -170,7 +170,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                             streamAddressSpace.getTrimMark(),
                             getCurrentContext().checkpoint.startAddress, maxGlobal);
                     log.info(message);
-                    if (options.isIgnoreTrimmed()) {
+                    if (getReadOptions().isIgnoreTrim()) {
                         log.debug("getStreamAddressMap[{}]: Ignoring trimmed exception for address[{}].",
                                 this, streamAddressSpace.getTrimMark());
                     } else {
@@ -256,7 +256,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
             }
         } catch (TrimmedException ste) {
             // The valid checkpoint has been trimmed.
-            if (options.isIgnoreTrimmed()) {
+            if (getReadOptions().isIgnoreTrim()) {
                 log.debug("processCheckpointBatchByEntry[{}]: Ignoring trimmed exception for address[{}]," +
                         " stream[{}]", this, lastReadAddress, id);
             } else {
@@ -296,7 +296,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
         try {
             d = read(startAddress);
         } catch (TrimmedException e) {
-            if (options.isIgnoreTrimmed()) {
+            if (getReadOptions().isIgnoreTrim()) {
                 log.debug("isAddressToBackpointerResolved[{}]: Ignoring trimmed exception for address[{}]," +
                         " stream[{}]", this, startAddress, streamId);
                 return false;

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -56,7 +56,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             try {
                 ld = read(thisRead);
             } catch (TrimmedException te) {
-                if (!options.ignoreTrimmed) {
+                if (!options.isIgnoreTrimmed()) {
                     throw te;
                 }
 
@@ -113,7 +113,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                 log.trace("followBackpointers: readAddress[{}]", currentAddress);
                 d = read(currentAddress, readStartTime);
             } catch (TrimmedException e) {
-                if (options.ignoreTrimmed) {
+                if (options.isIgnoreTrimmed()) {
                     log.warn("followBackpointers: Ignoring trimmed exception for address[{}]," +
                             " stream[{}]", currentAddress, id);
                     return !queue.isEmpty();

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -56,7 +56,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
             try {
                 ld = read(thisRead);
             } catch (TrimmedException te) {
-                if (!options.isIgnoreTrimmed()) {
+                if (!getReadOptions().isIgnoreTrim()) {
                     throw te;
                 }
 
@@ -113,7 +113,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
                 log.trace("followBackpointers: readAddress[{}]", currentAddress);
                 d = read(currentAddress, readStartTime);
             } catch (TrimmedException e) {
-                if (options.isIgnoreTrimmed()) {
+                if (getReadOptions().isIgnoreTrim()) {
                     log.warn("followBackpointers: Ignoring trimmed exception for address[{}]," +
                             " stream[{}]", currentAddress, id);
                     return !queue.isEmpty();

--- a/test/src/test/java/org/corfudb/runtime/view/stream/AbstractStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/AbstractStreamViewTest.java
@@ -274,7 +274,9 @@ public abstract class AbstractStreamViewTest extends AbstractViewTest {
             throws InterruptedException {
 
         CorfuRuntime runtime = getDefaultRuntime();
-        StreamOptions options = new StreamOptions(ignoreTrimmed);
+        StreamOptions options = StreamOptions.builder()
+                .ignoreTrimmed(ignoreTrimmed)
+                .build();
         IStreamView sv = runtime.getStreamsView().get(CorfuRuntime.getStreamID("streamA"), options);
         final long epoch = 0L;
         final Duration waitForTrim = Duration.ofSeconds(5);


### PR DESCRIPTION
## Overview
Allow certain streams to not be cached.

Why should this be merged: Some access patterns are pure consumers, once a stream entry is read it is no longer needed, if its cached it can pollute the AddressSpace cache and compete with transaction workloads ( that need the cache).   

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
