### PR TITLE
Elaborate and cleanup acceptor side of Paxos

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AcceptedData.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AcceptedData.java
@@ -13,7 +13,7 @@ import org.corfudb.runtime.view.Layout;
 @Data
 @ToString
 @AllArgsConstructor
-public class Phase2Data {
+public class AcceptedData {
     Rank rank;
     Layout layout;
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -2,6 +2,15 @@ package org.corfudb.infrastructure;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.ChannelHandlerContext;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.annotation.Nonnull;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
@@ -19,48 +28,48 @@ import org.corfudb.protocols.wireprotocol.LayoutProposeRequest;
 import org.corfudb.protocols.wireprotocol.LayoutProposeResponse;
 import org.corfudb.runtime.view.Layout;
 
-import javax.annotation.Nonnull;
-import java.lang.invoke.MethodHandles;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
 /**
  * The layout server serves layouts, which are used by clients to find the
  * Corfu infrastructure.
  *
- * <p>For replication and high availability, the layout server implements a
- * basic Paxos protocol. The layout server functions as a Paxos acceptor,
+ * <p>For replication and high availability, the layout server implements
+ * Basic Paxos with NACKs. The layout server functions as a Paxos acceptor,
  * and accepts proposals from clients consisting of a rank and desired
- * layout. The protocol consists of three rounds:
+ * value (layout). The protocol consists of three rounds:
  *
  * <p>1)   Prepare(rank) - Clients first contact each server with a rank.
  * If the server responds with ACK, the server promises not to
  * accept any requests with a rank lower than the given rank.
- * If the server responds with LAYOUT_PREPARE_REJECT, the server
- * informs the client of the current high rank and the request is
+ * ACK consists of a triplet (proposed rank, accepted rank, accepted value).
+ * Both accepted rank and the value are optional in case nothing has been accepted.
+ * If the server responds with NACK (LAYOUT_PREPARE_REJECT), the server
+ * informs the client of the current highest proposed rank and the request is
  * rejected.
  *
- * <p>2)   Propose(rank,layout) - Clients then contact each server with
- * the previously prepared rank and the desired layout. If no other
+ * <p>2)   Propose(rank, layout) - Clients then contact each server with
+ * the previously prepared rank and the desired value (layout). If no other
  * client has sent a prepare with a higher rank, the layout is
  * persisted, and the server begins serving that layout to other
  * clients. If the server responds with LAYOUT_PROPOSE_REJECT,
  * either another client has sent a prepare with a higher rank,
  * or this was a propose of a previously accepted rank.
  *
- * <p>3)   Committed(rank, layout) - Clients then send a hint to each layout
- * server that a new rank has been accepted by a quorum of
- * servers.
+ * <p>3)   Committed(rank, layout) - Clients then send a hint to each acceptor
+ * (layout server) that a new proposal has been accepted by a quorum of
+ * servers. Adding phase three to Classic Paxos serves an important purpose
+ * that may not be immediately apparent, namely that the liveness conditions
+ * are no longer necessary for progress. With this variant, Classic Paxos can make
+ * progress provided either a majority of acceptors are up or at least one acceptor
+ * who has been notified of decision is up. As a result, the proposer may return a
+ * decided value after communicating with just one acceptor.
  *
  * <p>Created by mwei on 12/8/15.
  */
-//TODO Finer grained synchronization needed for this class.
 //TODO Need a janitor to cleanup old phases data and to fill up holes in layout history.
 @Slf4j
 public class LayoutServer extends AbstractServer {
+
+    private static final long UNINITIALIZED_RANK = -1L;
 
     @Getter
     private final ServerContext serverContext;
@@ -183,62 +192,146 @@ public class LayoutServer extends AbstractServer {
         }
     }
 
+    private boolean isSameEpoch(
+            long payloadEpoch,
+            @NonNull CorfuPayloadMsg msg,
+            @NonNull ChannelHandlerContext ctx,
+            @NonNull IServerRouter router) {
+        final long serverEpoch = getServerEpoch();
+
+        // Check if the propose is for the correct epoch
+        if (payloadEpoch != serverEpoch) {
+            router.sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
+            log.trace("Incoming message with wrong epoch, got {} expected {}, message was: {}",
+                    payloadEpoch, serverEpoch, msg);
+            return false;
+        }
+
+        return true;
+    }
+
     /**
-     * Accepts a prepare message if the rank is higher than any accepted so far.
+     * Phase I: Prepare
+     *
+     * Each acceptor stores the last promised rank and last accepted proposal. When an
+     * acceptor receives prepare(rank_msg), if rank_msg is the first rank promised or
+     * if rank_msg is greater than the last rank promised, then rank_msg is written to storage and
+     * the acceptor replies with promise(e_msg, rank_acc, value_acc). (rank_acc, value_acc) is the
+     * last accepted proposal (if present).
+     *
+     * Original Algorithm:
+     *
+     * prepare(rank_msg) received from proposer
+     *   if rank_pro = nil ∨ rank_msg ≥ rank_pro then (1)
+     *     rank_pro ← rank_msg
+     *     send promise(rank_msg, rank_acc, value_acc) to proposer
+     *   else
+     *     send no-promise(rank_msg, rank_pro) to proposer
+     *
+     * The only deviation from the original algorithm is (1) where instead of doing
+     * rank_msg ≥ rank_pro, we do rank_msg > rank_pro. This does not have any impact on
+     * correctness.
+     *
+     * Warning: Do not try to change the way the synchronization is done. Paxos is meant to be
+     * a message passing algorithm, meaning that only one message can be processed at
+     * any point in time.
+     *
+     * Please take a look at Technical Report UCAM-CL-TR-935 ISSN 1476-2986 for more information.
      *
      * @param msg corfu message containing LAYOUT_PREPARE
      * @param ctx netty ChannelHandlerContext
      * @param r   server router
      */
-    // TODO this can work under a separate lock for this step as it does not change the global
-    // components
     @ServerHandler(type = CorfuMsgType.LAYOUT_PREPARE)
     public synchronized void handleMessageLayoutPrepare(
             @NonNull CorfuPayloadMsg<LayoutPrepareRequest> msg,
             ChannelHandlerContext ctx,
             @NonNull IServerRouter r) {
 
-        // Check if the prepare is for the correct epoch
+        // Check if the prepare if we are bootstrapped.
         if (!isBootstrapped(msg, ctx, r)) {
             return;
         }
 
         final long payloadEpoch = msg.getPayload().getEpoch();
-        final long serverEpoch = getServerEpoch();
+        final Rank payloadRank = new Rank(msg.getPayload().getRank(), msg.getClientID());
+        final Rank highestProposedRank = getProposedRank(payloadEpoch);
+        final Layout acceptedLayout = getAcceptedLayout(payloadEpoch);
+        final Rank highestAcceptedRank = Optional.ofNullable(getAcceptedRank(payloadEpoch))
+                .orElse(new Rank(UNINITIALIZED_RANK, msg.getClientID()));
 
-        final Rank prepareRank = new Rank(msg.getPayload().getRank(), msg.getClientID());
-        final Rank phase1Rank = getPhase1Rank(payloadEpoch);
-
-        if (payloadEpoch != serverEpoch) {
-            r.sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
-            log.trace("handleMessageLayoutPrepare: Incoming message with wrong epoch, got {}, "
-                            + "expected {}, message was: {}",
-                    msg.getPayload().getEpoch(), serverEpoch, msg);
+        // Check if the prepare is for the correct epoch.
+        if (!isSameEpoch(payloadEpoch, msg, ctx, r)) {
             return;
         }
 
-        Layout proposedLayout = getProposedLayout(payloadEpoch);
-
         // This is a prepare. If the rank is less than or equal to the phase 1 rank, reject.
-        if (phase1Rank != null && prepareRank.lessThanEqualTo(phase1Rank)) {
-            log.debug("handleMessageLayoutPrepare: Rejected phase 1 prepare of rank={}, "
-                    + "phase1Rank={}", prepareRank, phase1Rank);
-            r.sendResponse(ctx, msg, CorfuMsgType.LAYOUT_PREPARE_REJECT.payloadMsg(new
-                    LayoutPrepareResponse(phase1Rank.getRank(), proposedLayout)));
+        if (highestProposedRank == null || payloadRank.greaterThan(highestProposedRank)) {
+            setProposeRank(payloadRank, payloadEpoch);
+            log.debug("Phase I: New proposedRank = {}", getProposedRank(payloadEpoch));
+            r.sendResponse(ctx, msg, CorfuMsgType.LAYOUT_PREPARE_ACK.payloadMsg(new
+                    LayoutPrepareResponse(highestAcceptedRank.getRank(), acceptedLayout)));
         } else {
             // Return the layout with the highest rank proposed before.
-            Rank highestProposedRank = proposedLayout == null ? new Rank(-1L, msg.getClientID())
-                    : getPhase2Rank(payloadEpoch);
-            setPhase1Rank(prepareRank, payloadEpoch);
-            log.debug("handleMessageLayoutPrepare: New phase 1 rank={}", prepareRank);
-            r.sendResponse(ctx, msg, CorfuMsgType.LAYOUT_PREPARE_ACK.payloadMsg(new
-                    LayoutPrepareResponse(highestProposedRank.getRank(), proposedLayout)));
+            log.debug("Phase I: Rejected prepare: payloadRank = {}, proposedRank = {}",
+                    payloadRank, highestProposedRank);
+            r.sendResponse(ctx, msg, CorfuMsgType.LAYOUT_PREPARE_REJECT.payloadMsg(new
+                    LayoutPrepareResponse(highestProposedRank.getRank(), acceptedLayout)));
         }
     }
 
     /**
-     * Accepts a proposal for which it had accepted in the prepare phase.
-     * A minor optimization is to reject any duplicate propose messages.
+     * Phase II: Propose
+     *
+     * Each acceptor receives a propose(rank_msg, value_msg). If rank_msg is the first rank
+     * promised or if it is equal to the last promised rank, then the accepted proposal is
+     * updated and the acceptor replies with accept(rank_msg).
+     *
+     * Note: This implementation of propose deviates from the original Paxos implementation.
+     *
+     * Original Algorithm:
+     *
+     * propose(rank_msg, value_msg) received from proposer
+     *   if rank_pro = nil ∨ rank_msg ≥ rank_pro then
+     *     rank_pro ← rank_msg
+     *     rank_acc ← rank_msg
+     *     value acc ← value_msg,
+     *     send accept(rank_msg) to proposer
+     *   else
+     *     send no-accept(rank_msg, rank_pro) to proposer
+     *
+     * Current Implementation:
+     *
+     * propose(rank_msg, value_msg) received from proposer
+     *
+     *   if rank_pro = nil then (1)
+     *     send no-accept(rank_msg, rank_pro) to proposer
+     *   if rank_pro ≠ rank_msg then (2)
+     *     send no-accept(rank_msg, rank_pro) to proposer
+     *   else (3)
+     *     rank_acc ← rank_msg
+     *     value acc ← value_msg,
+     *     send accept(rank_msg) to proposer
+     *
+     * Technically, Step 1 is not required, since we are already doing an equality check in
+     * Step 2. It is there mostly for clarification reasons.
+     *
+     * Rather than checking in Step 2 if the message rank is greater than or equal to highest
+     * proposed rank, we are only checking for equality, This has an effect on the quorum
+     * intersection between Phase I and II. The implication is that the any acceptor that
+     * accepted a value must have participated in the prepare phase (Phase I) for that exact client
+     * and rank. More formally:
+     * Current Implementation: Q1 \ Q2 = ∅ : |Q1| = |Q1| = n/2 + 1
+     * Original Algorithm:     |Q1 ∩ Q2| = n/2 + 1
+     *
+     * Notice that we are not setting the proposed rank in Step 3. This is not required since we
+     * already know that the message rank is equal to the highest proposed rank.
+     *
+     * Warning: Do not try to change the way the synchronization is done. Paxos is meant to be
+     * a message passing algorithm, meaning that only one message can be processed at
+     * any point in time.
+     *
+     * Please take a look at Technical Report UCAM-CL-TR-935 ISSN 1476-2986 for more information.
      *
      * @param msg corfu message containing LAYOUT_PROPOSE
      * @param ctx netty ChannelHandlerContext
@@ -255,96 +348,34 @@ public class LayoutServer extends AbstractServer {
         }
 
         final long payloadEpoch = msg.getPayload().getEpoch();
-        final long serverEpoch = getServerEpoch();
+        final Rank payloadRank = new Rank(msg.getPayload().getRank(), msg.getClientID());
+        final Rank highestProposedRank = getProposedRank(payloadEpoch);
+        final Layout messageValue = msg.getPayload().getLayout();
 
-        final Rank proposeRank = new Rank(msg.getPayload().getRank(), msg.getClientID());
-        final Rank phase1Rank = getPhase1Rank(payloadEpoch);
-
-        // Check if the propose is for the correct epoch
-        if (payloadEpoch != serverEpoch) {
-            r.sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
-            log.trace("handleMessageLayoutPropose: Incoming message with wrong epoch, got {}, "
-                            + "expected {}, message was: {}", payloadEpoch, serverEpoch, msg);
+        // Check if the prepare is for the correct epoch.
+        if (!isSameEpoch(payloadEpoch, msg, ctx, r)) {
             return;
         }
+
         // This is a propose. If no prepare, reject.
-        if (phase1Rank == null) {
-            log.debug("handleMessageLayoutPropose: Rejected phase 2 propose of rank={}, "
-                    + "phase1Rank=none", proposeRank);
+        if (highestProposedRank == null) {
+            log.debug("Phase II: Rejected propose of rank = {}, proposedRank = none",
+                    highestProposedRank);
             r.sendResponse(ctx, msg, CorfuMsgType.LAYOUT_PROPOSE_REJECT.payloadMsg(new
                     LayoutProposeResponse(-1)));
-            return;
-        }
-        // This is a propose. If the rank in the proposal is less than or equal to the highest yet
-        // observed prepare rank, reject.
-        if (!proposeRank.equals(phase1Rank)) {
-            log.debug("handleMessageLayoutPropose: Rejected phase 2 propose of rank={}, "
-                    + "phase1Rank={}", proposeRank, phase1Rank);
+        } else if (!payloadRank.equals(highestProposedRank)) {
+            log.debug("Phase II: Rejected propose of rank = {}, proposedRank = {}",
+                    payloadRank, highestProposedRank);
             r.sendResponse(ctx, msg, CorfuMsgType.LAYOUT_PROPOSE_REJECT.payloadMsg(new
-                    LayoutProposeResponse(phase1Rank.getRank())));
-            return;
+                    LayoutProposeResponse(highestProposedRank.getRank())));
+        } else {
+            log.debug("Phase II: New acceptedRank = {}, layout = {}",
+                    payloadRank, messageValue);
+            setProposeRank(payloadRank, payloadEpoch);
+            setAcceptedData(new AcceptedData(payloadRank, messageValue), payloadEpoch);
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
         }
-
-        final Rank phase2Rank = getPhase2Rank(payloadEpoch);
-        final Layout proposeLayout = msg.getPayload().getLayout();
-
-        // Make sure that the layout epoch is the same as the LayoutProposeRequest epoch.
-        if (proposeLayout.getEpoch() != payloadEpoch) {
-            log.debug("Phase II error: layout {} and payload {} epoch should be the same",
-                    proposeLayout.getEpoch(), payloadEpoch);
-            r.sendResponse(ctx, msg, CorfuMsgType.LAYOUT_PROPOSE_REJECT.payloadMsg(new
-                    LayoutProposeResponse(phase1Rank.getRank())));
-            return;
-        }
-
-        // In addition, if the rank in the propose message is equal to the current phase 2 rank
-        // (already accepted message), reject.
-        // This can happen in case of duplicate messages.
-        if (proposeRank.equals(phase2Rank)) {
-            log.debug("handleMessageLayoutPropose: Rejected phase 2 propose of rank={}, "
-                    + "phase2Rank={}", proposeRank, phase2Rank);
-            r.sendResponse(ctx, msg, CorfuMsgType.LAYOUT_PROPOSE_REJECT.payloadMsg(new
-                    LayoutProposeResponse(phase2Rank.getRank())));
-            return;
-        }
-
-        log.debug("handleMessageLayoutPropose: New phase 2 rank={}, layout={}",
-                proposeRank, proposeLayout);
-        setPhase2Data(new Phase2Data(proposeRank, proposeLayout), payloadEpoch);
-        r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
     }
-
-
-    /**
-     * Force layout enables the server to bypass consensus
-     * and accept a new layout.
-     *
-     * @param msg              corfu message containing LAYOUT_FORCE
-     * @param ctx              netty ChannelHandlerContext
-     * @param r                server router
-     */
-    private synchronized void forceLayout(@Nonnull CorfuPayloadMsg<LayoutCommittedRequest> msg,
-                                               @Nonnull ChannelHandlerContext ctx,
-                                               @Nonnull IServerRouter r) {
-        final long payloadEpoch = msg.getPayload().getEpoch();
-        final long serverEpoch = getServerEpoch();
-
-        if (payloadEpoch != serverEpoch) {
-            // return can't force old epochs
-            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
-            log.warn("forceLayout: Trying to force a layout with an old epoch. Layout {}, " +
-                    "current epoch {}", payloadEpoch, serverEpoch);
-            return;
-        }
-
-        final Layout msgLayout = msg.getPayload().getLayout();
-
-        setCurrentLayout(msgLayout);
-        serverContext.setServerEpoch(msgLayout.getEpoch(), r);
-        log.warn("forceLayout: Forcing new layout {}", msgLayout);
-        r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
-    }
-
 
     /**
      * Accepts any committed layouts for the current epoch or newer epochs.
@@ -388,6 +419,35 @@ public class LayoutServer extends AbstractServer {
         r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
     }
 
+    /**
+     * Force layout enables the server to bypass consensus
+     * and accept a new layout.
+     *
+     * @param msg              corfu message containing LAYOUT_FORCE
+     * @param ctx              netty ChannelHandlerContext
+     * @param r                server router
+     */
+    private synchronized void forceLayout(@Nonnull CorfuPayloadMsg<LayoutCommittedRequest> msg,
+                                               @Nonnull ChannelHandlerContext ctx,
+                                               @Nonnull IServerRouter r) {
+        final long payloadEpoch = msg.getPayload().getEpoch();
+        final long serverEpoch = getServerEpoch();
+
+        if (payloadEpoch != serverEpoch) {
+            // return can't force old epochs
+            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
+            log.warn("forceLayout: Trying to force a layout with an old epoch. Layout {}, " +
+                    "current epoch {}", payloadEpoch, serverEpoch);
+            return;
+        }
+
+        final Layout msgLayout = msg.getPayload().getLayout();
+
+        setCurrentLayout(msgLayout);
+        serverContext.setServerEpoch(msgLayout.getEpoch(), r);
+        log.warn("forceLayout: Forcing new layout {}", msgLayout);
+        r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
+    }
 
     public Layout getCurrentLayout() {
         Layout layout = serverContext.getCurrentLayout();
@@ -409,18 +469,20 @@ public class LayoutServer extends AbstractServer {
         setLayoutInHistory(layout);
     }
 
-    public Rank getPhase1Rank(long epoch) {
+
+    public Rank getProposedRank(long epoch) {
         return paxosDataStore
                 .getPhase1Rank(epoch)
                 .orElse(null);
     }
 
-    public void setPhase1Rank(Rank rank, long epoch) {
+
+    public void setProposeRank(Rank rank, long epoch) {
         paxosDataStore.setPhase1Rank(rank, epoch);
     }
 
-    public void setPhase2Data(Phase2Data phase2Data, long epoch) {
-        paxosDataStore.setPhase2Data(phase2Data, epoch);
+    public void setAcceptedData(AcceptedData acceptedData, long epoch) {
+        paxosDataStore.setAcceptedData(acceptedData, epoch);
     }
 
     public void setLayoutInHistory(Layout layout) {
@@ -436,10 +498,10 @@ public class LayoutServer extends AbstractServer {
      *
      * @return the phase 2 rank
      */
-    public Rank getPhase2Rank(long epoch) {
+    public Rank getAcceptedRank(long epoch) {
         return paxosDataStore
                 .getPhase2Data(epoch)
-                .map(Phase2Data::getRank)
+                .map(AcceptedData::getRank)
                 .orElse(null);
     }
 
@@ -448,10 +510,11 @@ public class LayoutServer extends AbstractServer {
      *
      * @return the proposed layout
      */
-    public Layout getProposedLayout(long epoch) {
+
+    public Layout getAcceptedLayout(long epoch) {
         return paxosDataStore
                 .getPhase2Data(epoch)
-                .map(Phase2Data::getLayout)
+                .map(AcceptedData::getLayout)
                 .orElse(null);
     }
 
@@ -459,10 +522,10 @@ public class LayoutServer extends AbstractServer {
      * Return accepted data for the given epoch.
      *
      * @param epoch that we are interested in
-     * @return {@link Optional} {@link Phase2Data}
+     * @return {@link Optional} {@link AcceptedData}
      */
     @VisibleForTesting
-    Optional<Phase2Data> getPhase2Data(long epoch) {
+    Optional<AcceptedData> getPhase2Data(long epoch) {
         return paxosDataStore.getPhase2Data(epoch);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/Rank.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/Rank.java
@@ -9,7 +9,13 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Tuple to store the rank and clientId for each round in Paxos.
+ * One important property that a rank must maintain is that each proposer should be given a
+ * disjoint subset of the epochs. This uniqueness is achieved by storing corresponding clientId.
+ *
+ * In other words, exclusive epochs are guaranteed by adding the requirement to promises
+ * that if the rank from the prepare message rank_msg is equal to the last promised rank rank_pro
+ * then the proposer must be the same as the proposer who was previously promised.
+ *
  * Created by mdhawan on 6/28/16.
  */
 @Slf4j
@@ -26,16 +32,45 @@ public class Rank {
      * Compares only the ranks. Does not use clientIds in the comparison.
      *
      * @param other rank to compare against
-     * @return True if this rank is lower than or equal to other rank,
-     *     False otherwise or if other is null
+     * @return True if this rank is lower than the other rank,
+     *         False otherwise or if other is null
      */
-    public boolean lessThanEqualTo(Rank other) {
+    public boolean lessThan(Rank other) {
         if (other == null) {
             return false;
         }
-        if (this == other) {
+
+        return this.rank.compareTo(other.rank) < 0;
+    }
+
+    /**
+     * Compares only the ranks. Does not use clientIds in the comparison.
+     *
+     * @param other rank to compare against
+     * @return True if this rank is greater than or equal to the other rank,
+     *         False otherwise or if other is null
+     */
+    public boolean greaterThan(Rank other) {
+        return this.rank.compareTo(other.rank) > 0;
+    }
+
+    /**
+     * Compare must use clientId (PID) during equality comparison.
+     *
+     * @param other rank to compare against
+     * @return True if this rank is greater than or equal to the other rank,
+     *         False otherwise or if other is null
+     */
+    public boolean greaterThanOrEqual(Rank other) {
+        if (other == null) {
+            return false;
+        }
+
+        // Uniqueness guarantee.
+        if (this.equals(other)) {
             return true;
         }
-        return this.rank.compareTo(other.rank) <= 0;
+
+        return this.rank.compareTo(other.rank) > 0;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/paxos/PaxosDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/paxos/PaxosDataStore.java
@@ -2,8 +2,9 @@ package org.corfudb.infrastructure.paxos;
 
 import lombok.Builder;
 import lombok.NonNull;
+import org.corfudb.infrastructure.AcceptedData;
 import org.corfudb.infrastructure.DataStore;
-import org.corfudb.infrastructure.Phase2Data;
+import org.corfudb.infrastructure.AcceptedData;
 import org.corfudb.infrastructure.Rank;
 
 import java.util.Optional;
@@ -46,27 +47,27 @@ public class PaxosDataStore {
      * @param serverEpoch server epoch
      * @return phase2 data
      */
-    public Optional<Phase2Data> getPhase2Data(long serverEpoch) {
-        Phase2Data rank = dataStore.get(
-                Phase2Data.class,
+    public Optional<AcceptedData> getPhase2Data(long serverEpoch) {
+        AcceptedData acceptedData = dataStore.get(
+                AcceptedData.class,
                 PREFIX_PHASE_2,
                 serverEpoch + KEY_SUFFIX_PHASE_2
         );
 
-        return Optional.ofNullable(rank);
+        return Optional.ofNullable(acceptedData);
     }
 
     /**
      * Saves phase2 data
-     * @param phase2Data phase2 data
+     * @param acceptedData accepted data
      * @param serverEpoch current server epoch
      */
-    public void setPhase2Data(Phase2Data phase2Data, long serverEpoch) {
+    public void setAcceptedData(AcceptedData acceptedData, long serverEpoch) {
         dataStore.put(
-                Phase2Data.class,
+                AcceptedData.class,
                 PREFIX_PHASE_2,
                 serverEpoch + KEY_SUFFIX_PHASE_2,
-                phase2Data
+                acceptedData
         );
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerAssertions.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerAssertions.java
@@ -38,9 +38,9 @@ public class LayoutServerAssertions extends AbstractAssert<LayoutServerAssertion
     public LayoutServerAssertions isPhase1Rank(Rank phase1Rank) {
         isNotNull();
         final long serverEpoch = actual.getServerContext().getServerEpoch();
-        if (!actual.getPhase1Rank(serverEpoch).equals(phase1Rank)) {
+        if (!actual.getProposedRank(serverEpoch).equals(phase1Rank)) {
             failWithMessage("Expected server to be in phase1Rank <%s> but it was in phase1Rank <%s>", phase1Rank,
-                    actual.getPhase1Rank(serverEpoch));
+                    actual.getProposedRank(serverEpoch));
         }
         return this;
     }
@@ -48,9 +48,9 @@ public class LayoutServerAssertions extends AbstractAssert<LayoutServerAssertion
     public LayoutServerAssertions isPhase2Rank(Rank phase2Rank) {
         isNotNull();
         final long serverEpoch = actual.getServerContext().getServerEpoch();
-        if (!actual.getPhase2Rank(serverEpoch).equals(phase2Rank)) {
+        if (!actual.getAcceptedRank(serverEpoch).equals(phase2Rank)) {
             failWithMessage("Expected server to be in phase2Rank <%s> but it was in phase2Rank <%s>", phase2Rank,
-                    actual.getPhase2Rank(serverEpoch));
+                    actual.getAcceptedRank(serverEpoch));
         }
         return this;
     }
@@ -58,9 +58,9 @@ public class LayoutServerAssertions extends AbstractAssert<LayoutServerAssertion
     public LayoutServerAssertions isProposedLayout(Layout layout) {
         isNotNull();
         final long serverEpoch = actual.getServerContext().getServerEpoch();
-        if (!actual.getProposedLayout(serverEpoch).asJSONString().equals(layout.asJSONString())) {
+        if (!actual.getAcceptedLayout(serverEpoch).asJSONString().equals(layout.asJSONString())) {
             failWithMessage("Expected server to have proposedLayout  <%s> but it is <%s>", layout,
-                    actual.getProposedLayout(serverEpoch));
+                    actual.getAcceptedLayout(serverEpoch));
 
         }
         return this;

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -108,7 +108,7 @@ public class LayoutServerTest extends AbstractServerTest {
      * Note: This is in the scope of same epoch.
      */
     @Test
-    public void proposeRejectsAlreadyProposed() {
+    public void proposeAcceptsAlreadyProposed() {
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         long epoch = layout.getEpoch();
         bootstrapServer(layout);
@@ -117,7 +117,7 @@ public class LayoutServerTest extends AbstractServerTest {
         sendPropose(epoch, LOW_RANK, layout);
         Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
         sendPropose(epoch, LOW_RANK, layout);
-        Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.LAYOUT_PROPOSE_REJECT);
+        Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.ACK);
     }
 
     /**
@@ -497,7 +497,7 @@ public class LayoutServerTest extends AbstractServerTest {
         Mockito.doAnswer(invocation -> {
             spyLayoutServer.getServerContext().setServerEpoch(newSealEpoch, router);
             return invocation.callRealMethod();
-        }).when(spyLayoutServer).setPhase2Data(Mockito.any(), Mockito.anyLong());
+        }).when(spyLayoutServer).setAcceptedData(Mockito.any(), Mockito.anyLong());
 
         final long msgRank = 0L;
 

--- a/test/src/test/java/org/corfudb/runtime/clients/LayoutHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LayoutHandlerTest.java
@@ -120,7 +120,7 @@ public class LayoutHandlerTest extends AbstractClientTest {
     }
 
     @Test
-    public void proposeRejectsAlreadyProposed()
+    public void proposeAcceptsAlreadyProposed()
             throws Exception {
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         long epoch = layout.getEpoch();
@@ -136,9 +136,7 @@ public class LayoutHandlerTest extends AbstractClientTest {
             client.propose(epoch, RANK_LOW, layout).get();
         }).hasCauseInstanceOf(OutrankedException.class);
 
-        assertThatThrownBy(() -> {
-            client.propose(epoch, RANK_HIGH, layout).get();
-        }).hasCauseInstanceOf(OutrankedException.class);
+        client.propose(epoch, RANK_HIGH, layout).get();
     }
 
     @Test


### PR DESCRIPTION
The current Paxos implementation deviates form the original algorithm,
and this patch clarifies the differences and its ramifications. It also
does some minor changes to the code in order to aid in readability.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
