### PR TITLE
Invalidate layout returns CompletableFuture 

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/RemoteMonitoringService.java
@@ -263,10 +263,10 @@ public class RemoteMonitoringService implements MonitoringService {
      */
     private synchronized void runDetectionTasks() {
 
-        CorfuRuntime corfuRuntime = getCorfuRuntime();
-        getCorfuRuntime().invalidateLayout();
-
-        Layout layout = serverContext.saveManagementLayout(corfuRuntime.getLayoutView().getLayout());
+        Layout layout = getCorfuRuntime()
+                .invalidateLayout()
+                .thenApply(serverContext::saveManagementLayout)
+                .join();
 
         if (!canHandleReconfigurations()) {
             log.error("Can't run failure detector. This Server: {}, is not a part of the active layout: {}",


### PR DESCRIPTION
## Overview

Description:
The way how we invalidate (update) the layout right now is pretty inconvenient and completely synchronous (if you want to get updated layout).
This change enables us to invalidate layout asynchronously.
P.S. the old way also still working

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
