### PR TITLE
Change how we detect unfilled slots/registers

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterStateCollector.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/ClusterStateCollector.java
@@ -45,7 +45,8 @@ public class ClusterStateCollector {
      * @return cluster state
      */
     public ClusterState collectClusterState(
-            long epoch, Set<String> unresponsiveNodes, SequencerMetrics sequencerMetrics) {
+            long epoch, ImmutableList<String> unresponsiveNodes,
+            SequencerMetrics sequencerMetrics) {
 
         Map<String, NodeState> nodeStates = new HashMap<>();
 
@@ -55,7 +56,7 @@ public class ClusterStateCollector {
         return ClusterState.builder()
                 .localEndpoint(localEndpoint)
                 .nodes(ImmutableMap.copyOf(nodeStates))
-                .unresponsiveNodes(ImmutableList.copyOf(unresponsiveNodes))
+                .unresponsiveNodes(unresponsiveNodes)
                 .build();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/PollReport.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/PollReport.java
@@ -6,14 +6,16 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import lombok.Builder;
 import lombok.Builder.Default;
-import lombok.Data;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.Layout;
 
 import java.time.Duration;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -22,9 +24,10 @@ import java.util.Set;
  * take appropriate action.
  * Created by zlokhandwala on 3/21/17.
  */
-@Data
 @Builder
 @Slf4j
+@Getter
+@ToString
 public class PollReport {
 
     @Default
@@ -43,10 +46,10 @@ public class PollReport {
     private final ClusterState clusterState;
 
     /**
-     * List of responsive servers in a current layout
+     * List of responsive servers that successfully responded to our ping
      */
     @NonNull
-    private final ImmutableList<String> responsiveServers;
+    private final ImmutableList<String> pingResponsiveServers;
 
     /**
      * Time spent on collecting this report
@@ -83,23 +86,34 @@ public class PollReport {
     }
 
     /**
-     * All active Layout servers have been sealed but there is no client to take this forward and
-     * fill the slot by proposing a new layout. This is determined by the outOfPhaseEpochNodes map.
+     * Check to see if the current epoch/register has been decided/filled. We do this by
+     * comparing the epoch of the latest committed layout and the epoch associated with the
+     * {@link WrongEpochException}.
      *
-     * @return True if latest layout slot is vacant.
+     * @return Optional.of(epoch) if latest layout slot is vacant, Optional.none() otherwise.
      */
-    public boolean isCurrentLayoutSlotUnFilled() {
-        log.trace("isCurrentLayoutSlotUnFilled. Wrong epochs: {}, active servers: {}",
-                wrongEpochs, responsiveServers
+    public Optional<Long> getLayoutSlotUnFilled(@NonNull Layout latestCommittedLayout) {
+        log.trace("getLayoutSlotUnFilled. Wrong epochs: {}, latest layout epoch: {}",
+                wrongEpochs, latestCommittedLayout.getEpoch()
         );
 
-        // Check if all active layout servers are present in the outOfPhaseEpochNodes map.
-        boolean result = wrongEpochs.keySet().containsAll(responsiveServers);
-
-        if (result) {
-            log.info("Current layout slot is empty. Filling slot with current layout. " +
-                    "Wrong epochs: {}, active layout servers: {}", wrongEpochs, responsiveServers);
+        long maxOutOfPhaseEpoch = wrongEpochs.values().stream()
+                .max(Long::compare)
+                .orElse(latestCommittedLayout.getEpoch());
+        if (maxOutOfPhaseEpoch > latestCommittedLayout.getEpoch()) {
+            return Optional.of(maxOutOfPhaseEpoch);
         }
-        return result;
+
+        return Optional.empty();
+    }
+
+
+    /**
+     * Check to see if all responsive servers from this {@link PollReport} have been sealed.
+     *
+     * @return true if all responsive servers have been sealed.
+     */
+    public boolean areAllResponsiveServersSealed() {
+        return wrongEpochs.isEmpty() || wrongEpochs.size() == pingResponsiveServers.size();
     }
 }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/CorfuAbstractServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/CorfuAbstractServerTest.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure;
 
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -53,6 +54,6 @@ public class CorfuAbstractServerTest {
                 mock(IServerRouter.class)
         );
 
-        verify(handler, times(0));
+        verify(handler, times(0)).handle(any(), any(), any());
     }
 }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterStateCollectorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterStateCollectorTest.java
@@ -72,7 +72,7 @@ public class ClusterStateCollectorTest {
                 .build();
 
         ClusterState clusterState = collector.collectClusterState(
-                1, Collections.emptySet(), SequencerMetrics.UNKNOWN
+                1, ImmutableList.of(), SequencerMetrics.UNKNOWN
         );
 
         NodeState localNodeState = clusterState.getNode(localEndpoint).get();

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterStateTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/ClusterStateTest.java
@@ -1,12 +1,21 @@
 package org.corfudb.infrastructure.management;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import org.corfudb.protocols.wireprotocol.ClusterState;
+import org.corfudb.protocols.wireprotocol.NodeState;
+import org.corfudb.protocols.wireprotocol.SequencerMetrics;
+import org.corfudb.runtime.view.Layout;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.infrastructure.management.NodeStateTestUtil.A;
+import static org.corfudb.infrastructure.management.NodeStateTestUtil.B;
+import static org.corfudb.infrastructure.management.NodeStateTestUtil.C;
 import static org.corfudb.infrastructure.management.NodeStateTestUtil.nodeState;
 import static org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity.ConnectionStatus.OK;
+import static org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity.connectivity;
+import static org.junit.Assert.assertEquals;
 
 public class ClusterStateTest {
 
@@ -31,5 +40,40 @@ public class ClusterStateTest {
                 nodeState("b", epoch1, OK)
         );
         assertThat(validClusterState.isReady()).isTrue();
+    }
+
+    /**
+     * Ensure that {@link ClusterState#getPingResponsiveNodes()} returns all nodes that have
+     * responded to our ping, despite the face that all nodes are marked as unresponsive by the
+     * current layout and one of the nodes responded with WrongEpochException.
+     */
+    @Test
+    public void testTransformation() {
+        NodeState a = NodeState.builder()
+                .sequencerMetrics(SequencerMetrics.READY)
+                .heartbeat(new NodeState.HeartbeatTimestamp(0, 0))
+                .connectivity(connectivity(A, ImmutableMap.of(A, OK, B, OK, C, OK)))
+                .build();
+
+        NodeState b = NodeState.builder()
+                .sequencerMetrics(SequencerMetrics.READY)
+                .heartbeat(new NodeState.HeartbeatTimestamp(0, 0))
+                .connectivity(connectivity(B, ImmutableMap.of(A, OK, B, OK, C, OK)))
+                .build();
+
+        NodeState c = NodeState.builder()
+                .sequencerMetrics(SequencerMetrics.READY)
+                .heartbeat(new NodeState.HeartbeatTimestamp(Layout.INVALID_EPOCH, 0))
+                .connectivity(connectivity(B, ImmutableMap.of(A, OK, B, OK, C, OK)))
+                .build();
+
+        ImmutableMap<String, NodeState> nodes = ImmutableMap.of(A, a, B, b, C, c);
+        ClusterState clusterState = ClusterState.builder()
+                .localEndpoint(A)
+                .nodes(nodes)
+                .unresponsiveNodes(ImmutableList.copyOf(nodes.keySet()))
+                .build();
+
+        assertEquals(clusterState.getPingResponsiveNodes().size(), nodes.size());
     }
 }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/PollReportTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/PollReportTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.corfudb.infrastructure.management.NodeStateTestUtil.nodeState;
 import static org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity.ConnectionStatus.FAILED;
 import static org.corfudb.protocols.wireprotocol.failuredetector.NodeConnectivity.ConnectionStatus.OK;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -13,9 +15,8 @@ import java.time.Duration;
 
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.protocols.wireprotocol.NodeState;
+import org.corfudb.runtime.view.Layout;
 import org.junit.Test;
-
-import java.time.Duration;
 
 public class PollReportTest {
 
@@ -32,7 +33,7 @@ public class PollReportTest {
         final long epoch = 1;
         final Duration duration = Duration.ofSeconds(1);
         PollReport pollReport = PollReport.builder()
-                .responsiveServers(ImmutableList.of("a"))
+                .pingResponsiveServers(ImmutableList.of("a"))
                 .wrongEpochs(ImmutableMap.of("a", epoch))
                 .clusterState(clusterState)
                 .elapsedTime(Duration.ZERO)
@@ -57,7 +58,7 @@ public class PollReportTest {
         final long epoch = 1;
         final Duration duration = Duration.ofSeconds(1);
         PollReport pollReport = PollReport.builder()
-                .responsiveServers(ImmutableList.of("a", "b", "c"))
+                .pingResponsiveServers(ImmutableList.of("a", "b", "c"))
                 .wrongEpochs(ImmutableMap.of("b", epoch))
                 .clusterState(clusterState)
                 .elapsedTime(Duration.ZERO)
@@ -87,7 +88,7 @@ public class PollReportTest {
         final long epoch = 1;
         final Duration duration = Duration.ofSeconds(1);
         PollReport pollReport = PollReport.builder()
-                .responsiveServers(ImmutableList.of("a", "b", "c"))
+                .pingResponsiveServers(ImmutableList.of("a", "b", "c"))
                 .wrongEpochs(ImmutableMap.of("b", epoch))
                 .clusterState(clusterState)
                 .elapsedTime(Duration.ZERO)
@@ -111,14 +112,15 @@ public class PollReportTest {
         );
 
         final long epoch = 1;
-        final Duration duration = Duration.ofSeconds(1);
         PollReport pollReport = PollReport.builder()
-                .responsiveServers(ImmutableList.of("a", "b"))
+                .pingResponsiveServers(ImmutableList.of("a", "b", "c"))
                 .wrongEpochs(ImmutableMap.of("a", epoch, "b", epoch, "c", epoch))
                 .clusterState(clusterState)
                 .elapsedTime(Duration.ZERO)
                 .build();
 
-        assertThat(pollReport.isCurrentLayoutSlotUnFilled()).isTrue();
+        Layout latestCommitted = mock(Layout.class);
+        when(latestCommitted.getEpoch()).thenReturn(epoch - 1);
+        assertThat(pollReport.getLayoutSlotUnFilled(latestCommitted)).isPresent();
     }
 }

--- a/it/src/test/java/org/corfudb/universe/scenario/ClusterEdgeCases.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/ClusterEdgeCases.java
@@ -1,0 +1,103 @@
+package org.corfudb.universe.scenario;
+
+import org.assertj.core.api.Assertions;
+import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.RuntimeLayout;
+import org.corfudb.universe.GenericIntegrationTest;
+import org.corfudb.universe.group.cluster.CorfuCluster;
+import org.corfudb.universe.node.client.CorfuClient;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+/**
+ * A set of tests that deal with edge-case reconfiguration scenarios.
+ */
+public class ClusterEdgeCases extends GenericIntegrationTest {
+    /**
+     * The test will forcefully bump up one of the LayoutServer epochs, thus emulating
+     * a partial seal. The cluster should recover and all nodes should reach the same layout.
+     */
+    @Test(timeout = 300000)
+    public void wrongEpochRecovery() {
+        getScenario().describe((fixture, testCase) -> {
+            final CorfuCluster corfuCluster =
+                    universe.getGroup(fixture.getCorfuCluster().getName());
+            final CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
+
+            testCase.it("Should fail one link and then heal", data -> {
+                final Layout originalLayout = corfuClient.getRuntime().getLayoutView().getLayout();
+                final RuntimeLayout runtimeLayout = corfuClient.getRuntime()
+                        .getLayoutView()
+                        .getRuntimeLayout(originalLayout);
+
+                // Forcefully bump up the epoch.
+                runtimeLayout.getBaseClient(
+                        originalLayout.getLayoutServers().stream().findFirst().get()
+                ).setRemoteEpoch(originalLayout.getEpoch() + 10);
+
+                {
+                    final List<Throwable> exceptions = new ArrayList();
+                    final List<Layout> layouts = new ArrayList();
+
+                    Stream<CompletableFuture<Layout>> layoutFutures = originalLayout
+                            .getLayoutServers().stream()
+                            .map(server -> runtimeLayout.getLayoutClient(server).getLayout());
+
+                    // Make sure we actually get the WrongEpochException.
+                    layoutFutures.forEach(future -> {
+                        try {
+                            layouts.add(future.get());
+                        } catch (InterruptedException e) {
+                            Assertions.fail("Test interrupted.");
+                        } catch (ExecutionException e) {
+                            exceptions.add(e.getCause());
+                        }
+                    });
+
+                    Assertions.assertThat(layouts.size()).isEqualTo(1);
+                    Assertions.assertThat(exceptions.size())
+                            .isEqualTo(originalLayout.getLayoutServers().size()- 1);
+                    exceptions.forEach(ex -> Assert.assertTrue(ex instanceof WrongEpochException));
+                }
+
+                // Wait for the cluster to heal and stabilize.
+                while (true) {
+                    try {
+                        TimeUnit.SECONDS.sleep(1);
+                    } catch (InterruptedException e) {
+                        Assertions.fail("Test interrupted.");
+                    }
+
+                    Stream<CompletableFuture<Layout>> layoutFutures = originalLayout
+                            .getLayoutServers().stream()
+                            .map(server -> runtimeLayout.getLayoutClient(server).getLayout());
+
+                    final List<Layout> layouts = new ArrayList();
+
+                    layoutFutures.forEach(future -> {
+                        try {
+                            layouts.add(future.get());
+                        } catch (InterruptedException e) {
+                            Assertions.fail("Test interrupted.");
+                        } catch (ExecutionException ignored) {
+                        }
+                    });
+
+                    if (layouts.size() == originalLayout.getLayoutServers().size()) {
+                        break; // The cluster was able to recover from the partial seal.
+                    }
+                }
+            });
+
+            corfuClient.shutdown();
+        });
+    }
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClusterState.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClusterState.java
@@ -109,6 +109,10 @@ public class ClusterState {
         return nodeState.getConnectivity();
     }
 
+    public ImmutableList<String> getPingResponsiveNodes(){
+        return ImmutableList.copyOf(getLocalNodeConnectivity().getConnectedNodes());
+    }
+
     public static ClusterState buildClusterState(
             String localEndpoint, ImmutableList<String> unresponsiveServers, NodeState... states) {
 


### PR DESCRIPTION
Rather than relying on a responsive server set, base the decision
on the latest committed layout and the highest WrongEpochException.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
