### PR TITLE
Un-deprecate SMR layer, VLO clean up

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/CheckpointEntry.java
@@ -73,8 +73,7 @@ public class CheckpointEntry extends LogEntry {
      * Unique identifier for this checkpoint.  All entries
      * for the same checkpoint state must use the same ID.
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+    @SuppressWarnings("checkstyle:abbreviation")
     @Getter
     UUID checkpointId;
 
@@ -83,15 +82,13 @@ public class CheckpointEntry extends LogEntry {
 
     /** Author/cause/trigger of this checkpoint
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+    @SuppressWarnings("checkstyle:abbreviation")
     @Getter
     String checkpointAuthorId;
 
     /** Map of checkpoint metadata, see key constants above.
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+    @SuppressWarnings("checkstyle:abbreviation")
     @Getter
     Map<CheckpointDictKey, String> dict;
 

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/ISMRConsumable.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/ISMRConsumable.java
@@ -10,8 +10,7 @@ import java.util.UUID;
  *
  * <p>Created by mwei on 9/20/16.
  */
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 public interface ISMRConsumable {
     List<SMREntry> getSMRUpdates(UUID id);
 }

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -21,8 +21,7 @@ import org.corfudb.util.serializer.Serializers;
  * A log entry structure which contains a collection of multiSMRentries,
  * each one contains a list of updates for one object.
  */
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 @ToString
 @Slf4j
 public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
@@ -22,8 +22,7 @@ import org.corfudb.util.serializer.Serializers;
  * Its primary use case is to allow a single log entry to
  * hold a sequence of updates made by a transaction, which are applied atomically.
  */
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 @ToString
 @Slf4j
 public class MultiSMREntry extends LogEntry implements ISMRConsumable {

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -18,8 +18,7 @@ import org.corfudb.util.serializer.Serializers;
 /**
  * Created by mwei on 1/8/16.
  */
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 @ToString(callSuper = true)
 @NoArgsConstructor
 public class SMREntry extends LogEntry implements ISMRConsumable {
@@ -27,16 +26,14 @@ public class SMREntry extends LogEntry implements ISMRConsumable {
     /**
      * The name of the SMR method. Note that this is limited to the size of a short.
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:MemberName") // Due to deprecation
+    @SuppressWarnings("checkstyle:MemberName")
     @Getter
     private String SMRMethod;
 
     /**
      * The arguments to the SMR method, which could be 0.
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:MemberName") // Due to deprecation
+    @SuppressWarnings("checkstyle:MemberName")
     @Getter
     private Object[] SMRArguments;
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -97,8 +97,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      * The current request ID.
      */
     @Getter
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+    @SuppressWarnings("checkstyle:abbreviation")
     public AtomicLong requestID;
     /**
      * The handlers registered to this router.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/FGMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/FGMap.java
@@ -21,8 +21,7 @@ import sun.misc.CRC16;
 /**
  * Created by mwei on 3/29/16.
  */
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 @CorfuObject(constructorType = ConstructorType.PERSISTED,
         objectType = ObjectType.STATELESS)
 public class FGMap<K, V> extends AbstractCorfuWrapper<FGMap<K,V>> implements Map<K, V> {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -12,8 +12,7 @@ import org.corfudb.annotations.MutatorAccessor;
 /**
  * Created by mwei on 1/9/16.
  */
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 public interface ISMRMap<K, V> extends Map<K, V>, ISMRObject {
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRObject.java
@@ -5,8 +5,7 @@ import org.corfudb.annotations.Accessor;
 /**
  * Created by mwei on 11/12/16.
  */
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 public interface ISMRObject {
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
@@ -26,8 +26,7 @@ import org.corfudb.annotations.TransactionalMethod;
  * Created by mwei on 1/7/16.
  */
 @CorfuObject
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/AbstractCorfuWrapper.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/AbstractCorfuWrapper.java
@@ -27,8 +27,7 @@ public abstract class AbstractCorfuWrapper<T> implements ICorfuSMRProxyWrapper<T
      *
      * @return Returns the StreamID of this Corfu Wrapper.
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+    @SuppressWarnings("checkstyle:abbreviation")
     protected UUID getStreamID() {
         return proxy.getStreamID();
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -33,7 +33,6 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 /**
@@ -79,8 +78,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
     /**
      * The ID of the stream of the log.
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+    @SuppressWarnings("checkstyle:abbreviation")
             UUID streamID;
 
     /**
@@ -297,10 +295,10 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
 
         // Check first if we have the upcall, if we do
         // we can service the request right away.
-        if (underlyingObject.upcallResults.containsKey(timestamp)) {
+        if (underlyingObject.getUpcallResults().containsKey(timestamp)) {
             log.trace("Upcall[{}] {} Direct", this, timestamp);
-            R ret = (R) underlyingObject.upcallResults.get(timestamp);
-            underlyingObject.upcallResults.remove(timestamp);
+            R ret = (R) underlyingObject.getUpcallResults().get(timestamp);
+            underlyingObject.getUpcallResults().remove(timestamp);
             return ret == VersionLockedObject.NullValue.NULL_VALUE ? null : ret;
         }
 
@@ -308,10 +306,10 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
             try {
                 return underlyingObject.update(o -> {
                     o.syncObjectUnsafe(timestamp);
-                    if (o.upcallResults.containsKey(timestamp)) {
+                    if (o.getUpcallResults().containsKey(timestamp)) {
                         log.trace("Upcall[{}] {} Sync'd", this, timestamp);
-                        R ret = (R) o.upcallResults.get(timestamp);
-                        o.upcallResults.remove(timestamp);
+                        R ret = (R) o.getUpcallResults().get(timestamp);
+                        o.getUpcallResults().remove(timestamp);
                         return ret == VersionLockedObject.NullValue.NULL_VALUE ? null : ret;
                     }
 
@@ -362,8 +360,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         }
     }
 
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings({"checkstyle:membername", "checkstyle:abbreviation"}) // Due to deprecation
+    @SuppressWarnings({"checkstyle:membername", "checkstyle:abbreviation"})
     private <R> R TXExecuteInner(Supplier<R> txFunction, boolean isMetricsEnabled) {
         // Don't nest transactions if we are already running in a transaction
         if (TransactionalContext.isInTransaction()) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -27,8 +27,7 @@ public class CorfuCompileWrapperBuilder {
      * @throws IllegalAccessException Illegal Access to the Object.
      * @throws InstantiationException Cannot instantiate the object using the arguments and class.
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+    @SuppressWarnings("checkstyle:abbreviation")
     public static <T> T getWrapper(Class<T> type, CorfuRuntime rt,
                                    UUID streamID, Object[] args,
                                    ISerializer serializer)

--- a/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
@@ -11,8 +11,7 @@ import org.corfudb.util.serializer.ISerializer;
  *
  * <p>Created by mwei on 11/15/16.
  */
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 public interface ICorfuSMRProxyInternal<T> extends ICorfuSMRProxy<T> {
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
@@ -20,8 +20,7 @@ import org.corfudb.protocols.wireprotocol.TokenResponse;
  *
  * <p>Created by mwei on 3/13/17.
  */
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 public interface ISMRStream {
 
 
@@ -71,8 +70,7 @@ public interface ISMRStream {
      *
      * @return The UUID for this stream.
      */
-    @Deprecated // TODO: Add replacement method that conforms to style
-    @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+    @SuppressWarnings("checkstyle:abbreviation")
     default UUID getID() {
         return new UUID(0L, 0L);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
@@ -30,8 +30,7 @@ import org.corfudb.runtime.view.stream.IStreamView;
  *
  * <p>Created by mwei on 3/10/17.
  */
-@Deprecated // TODO: Add replacement method that conforms to style
-@SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
+@SuppressWarnings("checkstyle:abbreviation")
 public class StreamViewSMRAdapter implements ISMRStream {
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.object.transactions;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -58,22 +59,25 @@ import org.corfudb.util.Utils;
  *
  */
 @Slf4j
-@Deprecated
 @SuppressWarnings("checkstyle:abbreviationaswordinname")
 public class WriteSetSMRStream implements ISMRStream {
 
-    List<AbstractTransactionalContext> contexts;
+    private List<AbstractTransactionalContext> contexts;
 
     int currentContext = 0;
 
-    // TODO add comment
-    long currentContextPos;
+    /**
+     * Current position in {@link WriteSetSMRStream#contexts}
+     */
+    private long currentContextPos;
 
-    // TODO add comment
-    long writePos;
+    /**
+     * Current write position in an SMREntry
+     */
+    private long writePos;
 
     // the specific stream-id for which this SMRstream wraps the write-set
-    final UUID id;
+    private final UUID id;
 
     /**
      * Returns a new WriteSetSMRStream containing transactional contexts and stream id.
@@ -167,7 +171,7 @@ public class WriteSetSMRStream implements ISMRStream {
     @Override
     public List<SMREntry> current() {
         if (Address.nonAddress(writePos)) {
-            return null;
+            return new ArrayList<>();
         }
         if (Address.nonAddress(currentContextPos)) {
             currentContextPos = -1;
@@ -184,7 +188,7 @@ public class WriteSetSMRStream implements ISMRStream {
 
         if (writePos <= Address.maxNonAddress()) {
             writePos = Address.maxNonAddress();
-            return null;
+            return new ArrayList<>();
         }
 
         currentContextPos--;

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -119,14 +119,14 @@ public class CompileProxyTest extends AbstractViewTest {
         int beforeSync, afterSync;
 
         // before sync'ing the in-memory object, the in-memory copy does not get updated
-        assertThat(beforeSync = proxy_CORFUSMR.getUnderlyingObject().object.getValue())
+        assertThat(beforeSync = proxy_CORFUSMR.getUnderlyingObject().getObject().getValue())
                 .isEqualTo(INITIAL);
 
         // sync with the stream entry by entry
         for (int timestamp = 1; timestamp <= concurrency; timestamp++) {
             proxy_CORFUSMR.getUnderlyingObject()
                     .syncObjectUnsafe(timestamp);
-            assertThat((afterSync = proxy_CORFUSMR.getUnderlyingObject().object.getValue()))
+            assertThat((afterSync = proxy_CORFUSMR.getUnderlyingObject().getObject().getValue()))
                     .isBetween(0, concurrency);
             assertThat(beforeSync)
                     .isNotEqualTo(afterSync);
@@ -265,7 +265,7 @@ public class CompileProxyTest extends AbstractViewTest {
             } else {
                 // before sync'ing the in-memory object, the in-memory copy does not get updated
                 // check that the in-memory copy is only as up-to-date as the latest 'get()'
-                assertThat(proxy_CORFUSMR.getUnderlyingObject().object.getValue())
+                assertThat(proxy_CORFUSMR.getUnderlyingObject().getObject().getValue())
                         .isEqualTo(lastRead.get());
 
                 // now read, expect to get the latest written
@@ -435,9 +435,9 @@ public class CompileProxyTest extends AbstractViewTest {
         // step 2: check the unsync'ed in-memory object state
         addTestStep((ignored_task_num) -> {
             // before sync'ing the in-memory object, the in-memory copy does not get updated
-            assertThat(proxy_CORFUSMR.getUnderlyingObject().object.getUser().getFirstName())
+            assertThat(proxy_CORFUSMR.getUnderlyingObject().getObject().getUser().getFirstName())
                     .startsWith("E");
-            assertThat(proxy_CORFUSMR.getUnderlyingObject().object.getUser().getLastName())
+            assertThat(proxy_CORFUSMR.getUnderlyingObject().getObject().getUser().getLastName())
                     .startsWith("F");
         });
 


### PR DESCRIPTION
## Overview

Description:
Un-deprecate SMR layer, VLO clean up

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
