### PR TITLE
GarbageInformer send garbage information to LogUnits

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRGarbageEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRGarbageEntry.java
@@ -7,6 +7,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collections;
+
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRGarbageRecord.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMRGarbageRecord.java
@@ -24,7 +24,7 @@ public class SMRGarbageRecord {
     private int smrEntrySize;
 
     /**
-     * Constructor for SMREntryGarbageInfo
+     * Constructor for SMRGarbageRecord
      * @param markerAddress The Global address of the SRMRecord that supersedes this SMRRecord.
      * @param smrEntrySize  Serialized size of this SMRRecord in byte.
      */

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -514,6 +514,12 @@ public class CorfuRuntime {
     private final ManagementView managementView = new ManagementView(this);
 
     /**
+     * The hub to disseminate garbage information.
+     */
+    @Getter
+    private final GarbageInformer garbageInformer = new GarbageInformer(this);
+
+    /**
      * List of initial set of layout servers, i.e., servers specified in
      * connection string on bootstrap.
      */
@@ -722,6 +728,7 @@ public class CorfuRuntime {
         // Stopping async task from fetching layout.
         isShutdown = true;
         runtimeExecutor.shutdownNow();
+        garbageInformer.stop();
         if (layout != null) {
             try {
                 layout.cancel(true);
@@ -1057,6 +1064,8 @@ public class CorfuRuntime {
                     .setTimeoutInMinutesForLoading((int) parameters.fastLoaderTimeout.toMinutes());
             fastLoader.loadMaps();
         }
+
+        garbageInformer.start();
 
         return this;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/GarbageInformer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/GarbageInformer.java
@@ -1,0 +1,250 @@
+package org.corfudb.runtime;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.logprotocol.SMRGarbageEntry;
+import org.corfudb.protocols.logprotocol.SMRGarbageRecord;
+import org.corfudb.protocols.logprotocol.SMRRecordLocator;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.runtime.view.Layout;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class GarbageInformer {
+
+    private final static Duration GC_PERIOD = Duration.ofSeconds(15);
+    private final static int RECEIVING_QUEUE_CAPACITY = 5_000;
+    private final static int SENDING_QUEUE_CAPACITY = 20;
+    private final static int BATCH_SIZE = 100;
+
+    private final CorfuRuntime rt;
+
+    // executor to drain garbageReceivingQueue when it is full.
+    private final ExecutorService drainExecutor = Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder().setDaemon(true)
+                    .setNameFormat("GarbageInformerDrain")
+                    .build());
+
+    /**
+     * The queue to receive single garbage decisions from ObjectView
+     */
+    @Getter
+    private final BlockingQueue<SMRGarbageEntry> garbageReceivingQueue =
+            new LinkedBlockingQueue<>(RECEIVING_QUEUE_CAPACITY);
+
+    /**
+     * The queue to sending merged garbage decision to LogUnit servers
+     */
+    @Getter
+    private final BlockingDeque<GarbageBatch> garbageSendingDeque =
+            new LinkedBlockingDeque<>(SENDING_QUEUE_CAPACITY);
+
+    private final ScheduledExecutorService gcScheduler = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder().setDaemon(true)
+                    .setNameFormat("GarbageInformerGC")
+                    .build());
+
+    /**
+     * Constructor
+     *
+     * @param rt Corfu runtime
+     */
+    public GarbageInformer(CorfuRuntime rt) {
+        this.rt = rt;
+    }
+
+    /**
+     * Start to send garbage decisions to LogUnit servers.
+     */
+    public void start() {
+        Random rand = new Random();
+
+        // periodically to drain garbageReceivingQueue and send garbage decisions to LogUnit servers.
+        // Randomized initial delay prevents all runtime send garbage decision simultaneously.
+        gcScheduler.scheduleWithFixedDelay(this::gc,
+                GC_PERIOD.getSeconds() + rand.nextInt((int) GC_PERIOD.getSeconds()),
+                GC_PERIOD.getSeconds(),
+                TimeUnit.SECONDS);
+    }
+
+    /**
+     * Stop to send garbage decisions to LogUnit servers.
+     * This function shuts down the single-threaded executor.
+     */
+    public void stop() {
+        gcScheduler.shutdownNow();
+    }
+
+    /**
+     * Adds a list of SMRRecordLocators whose associated SMRRecords are marked as garbage by the same global address.
+     *
+     * @param markerAddress The global address marks the garbage.
+     * @param locators      A list of locators whose associated SMRRecords are marked as garbage.
+     */
+    public void add(long markerAddress, List<SMRRecordLocator> locators) {
+        // sanity check
+        if (locators.isEmpty()) {
+            return;
+        }
+
+        List<SMRGarbageEntry> garbageEntries = generateGarbageEntries(markerAddress, locators);
+
+        // synchronization to prevent concurrent access to garbageReceivingQueue to maintain order by marker address.
+        synchronized (this) {
+            try {
+                for (SMRGarbageEntry garbageEntry : garbageEntries) {
+                    boolean success = garbageReceivingQueue.offer(garbageEntry);
+                    if (!success) {
+                        drainExecutor.submit(this::gc);
+                        garbageReceivingQueue.put(garbageEntry);
+                    }
+                }
+            } catch (InterruptedException ie) {
+                throw new UnrecoverableCorfuInterruptedError(
+                        "Interrupted during adding locators to GarbageInformer", ie);
+            }
+        }
+    }
+
+    private List<SMRGarbageEntry> generateGarbageEntries(long markerAddress,
+                                                         List<SMRRecordLocator> locators) {
+        Map<Long, SMRGarbageEntry> garbage = new HashMap<>();
+
+        locators.forEach(locator -> {
+            int serializedSize = locator.getSerializedSize();
+            SMRGarbageRecord garbageRecord = new SMRGarbageRecord(markerAddress, serializedSize);
+            long globalAddress = locator.getGlobalAddress();
+
+            garbage.compute(globalAddress, (a, smrGarbageEntry) -> {
+                if (smrGarbageEntry == null) {
+                    smrGarbageEntry = new SMRGarbageEntry();
+                    smrGarbageEntry.setGlobalAddress(a);
+                }
+                smrGarbageEntry.add(locator.getStreamId(), locator.getIndex(), garbageRecord);
+                return smrGarbageEntry;
+            });
+        });
+
+        return new ArrayList<>(garbage.values());
+    }
+
+    /**
+     * Drains garbage decisions from receiving queue and sends them to LogUnit servers.
+     */
+    public synchronized void gc() {
+        // drains sending queue first when it reaches the capacity limit.
+        if (garbageSendingDeque.size() >= SENDING_QUEUE_CAPACITY) {
+            log.debug("GarbageInformer: Drains sending queue");
+            sendGarbage();
+        }
+
+        // If garbageSendingDeque is still full, gives up drain garbageReceivingQueue.
+        if (garbageSendingDeque.size() >= SENDING_QUEUE_CAPACITY) {
+            log.debug("GarbageInformer: Stop drains receiving queue because sending queue is full");
+            return;
+        }
+
+        // TODO(xin): fill lastMarker in future commits.
+        Map<UUID, Long> lastMarkers = new HashMap<>();
+
+        Map<Long, SMRGarbageEntry> addressToGarbage = new HashMap<>();
+
+        List<SMRGarbageEntry> garbageEntries = new ArrayList<>();
+        garbageReceivingQueue.drainTo(garbageEntries, BATCH_SIZE);
+
+        if (garbageEntries.isEmpty()) {
+            log.trace("Garbage Informer has nothing to send");
+            return;
+        }
+
+        for (SMRGarbageEntry garbageEntry : garbageEntries) {
+            long globalAddress = garbageEntry.getGlobalAddress();
+
+            if (!addressToGarbage.containsKey(globalAddress)) {
+                addressToGarbage.put(globalAddress, garbageEntry);
+            } else {
+                addressToGarbage.get(globalAddress).merge(garbageEntry);
+            }
+        }
+
+        GarbageBatch garbageBatch = new GarbageBatch(addressToGarbage.values(), lastMarkers);
+        garbageSendingDeque.offer(garbageBatch);
+        sendGarbage();
+    }
+
+    private void sendGarbage() {
+        GarbageBatch garbageBatch = null;
+        try {
+            while ((garbageBatch = garbageSendingDeque.poll()) != null) {
+                sendGarbageBatch(garbageBatch);
+            }
+        } catch (Exception e) {
+            log.error("GarbageInformer: Caught exception in the write processor.", e);
+            // Adds pending garbage to the head of garbageSendingDeque and waits for another
+            // cycle to send garbage to LogUnit servers.
+            if (garbageBatch != null) {
+                garbageSendingDeque.addFirst(garbageBatch);
+            }
+        }
+    }
+
+    /**
+     * Sends GarbageEntry batch as well as last marker address to LogUnits.
+     */
+    @VisibleForTesting
+    public void sendGarbageBatch(GarbageBatch batch) {
+        rt.getAddressSpaceView().layoutHelper(e -> {
+            Layout layout = e.getLayout();
+            Map<Layout.LayoutStripe, List<SMRGarbageEntry>> stripToGarbageEntries = new HashMap<>();
+
+            // shard SMRGarbageEntries based on stripe.
+            batch.getGarbageEntries().forEach(garbageEntry -> {
+                long globalAddress = garbageEntry.getGlobalAddress();
+                Layout.LayoutStripe strip = layout.getStripe(globalAddress);
+                stripToGarbageEntries.computeIfAbsent(strip, s -> new ArrayList<>()).add(garbageEntry);
+            });
+
+            // send GarbageEntry batch.
+            stripToGarbageEntries.forEach((strip, garbageEntries) ->
+                    rt.getAddressSpaceView().sparseTrim(rt.getLayoutView().getRuntimeLayout(), strip,
+                            garbageEntries)
+            );
+
+            // TODO(xin): Inform LogUnits about the last markers.
+            return null;
+        }, true);
+    }
+
+    /**
+     * Contains a batch of garbageEntries as well as the last marker address.
+     * The batch of garbageEntries and the marker address are sent to LogUnit
+     * servers atomically, i.e. if any of them is failed to send to the LogUnits,
+     * all of them are sent again.
+     */
+    @Data
+    public static class GarbageBatch {
+        final Collection<SMRGarbageEntry> garbageEntries;
+        final Map<UUID, Long> lastMarkers;
+    }
+}
+

--- a/runtime/src/main/java/org/corfudb/runtime/collections/MapLocatorStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/MapLocatorStore.java
@@ -15,7 +15,9 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 class MapLocatorStore<T> implements ILocatorStore<T> {
     // Keys have 1:1 mapping to SMRRecord
-    final private Map<T, SMRRecordLocator> keyToSMRRecordLocator = new ConcurrentHashMap<>();
+    private final Map<T, SMRRecordLocator> keyToSMRRecordLocator = new ConcurrentHashMap<>();
+
+    public static final List<SMRRecordLocator> EMPTY_LIST = new ArrayList<>();
 
     /**
      * {@inheritDoc}
@@ -23,6 +25,9 @@ class MapLocatorStore<T> implements ILocatorStore<T> {
     @Override
     public List<SMRRecordLocator> addUnsafe(@NonNull T key, @NonNull SMRRecordLocator smrRecordLocator) {
         SMRRecordLocator oldSMRRecord = keyToSMRRecordLocator.put(key, smrRecordLocator);
+        if (oldSMRRecord == null) {
+            return EMPTY_LIST;
+        }
         return Arrays.asList(oldSMRRecord);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -12,6 +12,7 @@ import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.GarbageInformer;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
@@ -131,6 +132,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
      * @param garbageFunctionMap  garbageFunctionMap
      * @param undoRecordTargetMap undoRecordTargetMap
      * @param resetSet            resetSet
+     * @param garbageInformer   The hub to disseminate garbage information.
      */
     @Deprecated // TODO: Add replacement method that conforms to style
     @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
@@ -140,7 +142,8 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                              Map<String, IUndoFunction<T>> undoTargetMap,
                              Map<String, IUndoRecordFunction<T>> undoRecordTargetMap,
                              Map<String, IGarbageIdentificationFunction> garbageFunctionMap,
-                             Set<String> resetSet
+                             Set<String> resetSet,
+                             GarbageInformer garbageInformer
     ) {
         this.rt = rt;
         this.streamID = streamID;
@@ -153,7 +156,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         underlyingObject = new VersionLockedObject<T>(this::getNewInstance,
                 new StreamViewSMRAdapter(rt, rt.getStreamsView().getUnsafe(streamID)),
                 upcallTargetMap, undoRecordTargetMap, undoTargetMap,
-                garbageFunctionMap, resetSet);
+                garbageFunctionMap, resetSet, garbageInformer);
 
         metrics = CorfuRuntime.getDefaultMetrics();
         mpObj = CorfuComponent.OBJECT.toString();

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -64,7 +64,8 @@ public class CorfuCompileWrapperBuilder {
                 wrapperObject.getCorfuUndoMap(),
                 wrapperObject.getCorfuUndoRecordMap(),
                 wrapperObject.getCorfuGarbageIdentificationMap(),
-                wrapperObject.getCorfuResetSet()));
+                wrapperObject.getCorfuResetSet(),
+                rt.getGarbageInformer()));
 
         if (wrapperObject instanceof ICorfuSMRProxyWrapper) {
             ((ICorfuSMRProxyWrapper) wrapperObject)

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -6,7 +6,9 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.logprotocol.SMRRecord;
+import org.corfudb.protocols.logprotocol.SMRRecordLocator;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.GarbageInformer;
 import org.corfudb.runtime.exceptions.NoRollbackException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.object.transactions.WriteSetSMRStream;
@@ -17,6 +19,7 @@ import org.corfudb.util.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
@@ -115,6 +118,11 @@ public class VersionLockedObject<T> {
     private final Map<String, IGarbageIdentificationFunction> garbageIdentifyFunctionMap;
 
     /**
+     * The garbage identification decisions are exposed outside runtime via garbageInformer.
+     */
+    private final GarbageInformer garbageInformer;
+
+    /**
      * The reset set for this object.
      */
     private final Set<String> resetSet;
@@ -146,6 +154,7 @@ public class VersionLockedObject<T> {
      * @param garbageTargets    Garbage identification function map for this object.
      * @param undoTargets       Undo functions map.
      * @param resetSet          Reset set for this object.
+     * @param garbageInformer   The hub to disseminate garbage information.
      */
     public VersionLockedObject(Supplier<T> newObjectFn,
                                StreamViewSMRAdapter smrStream,
@@ -153,13 +162,15 @@ public class VersionLockedObject<T> {
                                Map<String, IUndoRecordFunction<T>> undoRecordTargets,
                                Map<String, IUndoFunction<T>> undoTargets,
                                Map<String, IGarbageIdentificationFunction> garbageTargets,
-                               Set<String> resetSet) {
+                               Set<String> resetSet,
+                               GarbageInformer garbageInformer) {
         this.smrStream = smrStream;
 
         this.upcallTargetMap = upcallTargets;
         this.undoRecordFunctionMap = undoRecordTargets;
         this.undoFunctionMap = undoTargets;
         this.garbageIdentifyFunctionMap = garbageTargets;
+        this.garbageInformer = garbageInformer;
         this.resetSet = resetSet;
 
         this.newObjectFn = newObjectFn;
@@ -562,9 +573,9 @@ public class VersionLockedObject<T> {
                 log.trace("Apply[{}] Undo->RESET", this);
             }
         }
-
         // now invoke the upcall
         return target.upcall(object, record.getSMRArguments());
+
     }
 
     /**
@@ -641,6 +652,7 @@ public class VersionLockedObject<T> {
     private void applyUpdateStreamUnsafe(Stream<SMRRecord> smrRecordStream, boolean isOptimistic) {
         // AtomicLong is used as a container to bypass the restriction of lambda expression
         final AtomicLong lastSyncAddress = new AtomicLong(Address.NON_ADDRESS);
+        List<SMRRecordLocator> garbageLocators = new ArrayList<>();
 
         smrRecordStream
                 .forEachOrdered(record -> {
@@ -661,6 +673,12 @@ public class VersionLockedObject<T> {
                             if (lastSyncAddress.get() != Address.NON_ADDRESS &&
                                     record.getGlobalAddress() > lastSyncAddress.get()) {
                                 syncTail = Math.max(syncTail, lastSyncAddress.get());
+
+                                // flush garbage if there is garbage
+                                if (!garbageLocators.isEmpty()) {
+                                    garbageInformer.add(syncTail, garbageLocators);
+                                    garbageLocators.clear();
+                                }
                             }
 
                             // to check whether the SMRRecord is first encountered by VLO
@@ -670,7 +688,8 @@ public class VersionLockedObject<T> {
                                 if (garbageIdentifyFunction != null) {
                                     List<Object> garbage =
                                             garbageIdentifyFunction.identify(record.locator, record.getSMRArguments());
-                                    // TODO(xin): handle garbage
+                                    garbage.forEach(o ->
+                                            garbageLocators.add((SMRRecordLocator) o));
                                 }
 
                                 lastSyncAddress.set(record.getGlobalAddress());
@@ -688,6 +707,11 @@ public class VersionLockedObject<T> {
         // update syncTail after applying all SMRRecords. 
         if (!isOptimistic) {
             syncTail = Math.max(syncTail, lastSyncAddress.get());
+
+            // flush garbage if there is garbage
+            if (!garbageLocators.isEmpty()) {
+                garbageInformer.add(syncTail, garbageLocators);
+            }
         }
     }
 


### PR DESCRIPTION
## Overview

GarbageInformer send garbage information to LogUnits. 

This PR is stack atop https://github.com/CorfuDB/CorfuDB/pull/1911, https://github.com/CorfuDB/CorfuDB/pull/2003, https://github.com/CorfuDB/CorfuDB/pull/2014,  https://github.com/CorfuDB/CorfuDB/pull/2011 and https://github.com/CorfuDB/CorfuDB/pull/1999.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
