### PR TITLE
VLO clean up: return an empty list instead of null

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/NoRollbackException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/NoRollbackException.java
@@ -10,23 +10,25 @@ import org.corfudb.protocols.logprotocol.SMREntry;
 public class NoRollbackException extends RuntimeException {
 
     public NoRollbackException(long rollbackVersion) {
-        super("Can't roll back due to non-undoable exception "
-                + " but need "
-                + rollbackVersion + " so can't undo");
+        super(String.format(
+                "Can't roll back due to non-undoable exception but need %d so can't undo",
+                rollbackVersion)
+        );
     }
 
     public NoRollbackException(long address, long rollbackVersion) {
-        super("Could only roll back to " + address + " but need "
-                + rollbackVersion + " so can't undo");
+        super(String.format(
+                "Could only roll back to %d but need %d so can't undo",
+                address,
+                rollbackVersion)
+        );
     }
 
     public NoRollbackException(Optional<SMREntry> entry, long address, long rollbackVersion) {
-        super("Can't roll back due to " +
-                (entry.isPresent() ?
-                entry.get().getSMRMethod() : "Unknown Entry")
-                + "@"
-                + address
-                + " but need "
-                + rollbackVersion + " so can't undo");
+        super(String.format("Can't roll back due to %s@%d but need %d so can't undo",
+                entry.map(SMREntry::getSMRMethod).orElse("Unknown Entry"),
+                address,
+                rollbackVersion)
+        );
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
@@ -1,13 +1,5 @@
 package org.corfudb.runtime.object;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import com.google.common.annotations.VisibleForTesting;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.ISMRConsumable;
 import org.corfudb.protocols.logprotocol.SMREntry;
@@ -17,6 +9,14 @@ import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.IStreamView;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * StreamViewSMRAdapter wraps a stream and implements the ISMRStream API over
@@ -97,14 +97,13 @@ public class StreamViewSMRAdapter implements ISMRStream {
      */
     public List<SMREntry> current() {
         ILogData data = streamView.current();
-        if (data != null) {
-            if (data.getType() == DataType.DATA
-                    && data.getPayload(runtime) instanceof ISMRConsumable) {
-                return ((ISMRConsumable) data.getPayload(runtime))
-                        .getSMRUpdates(streamView.getId());
-            }
+        if (data == null
+                || data.getType() != DataType.DATA
+                || !(data.getPayload(runtime) instanceof ISMRConsumable)) {
+            return new ArrayList<>();
         }
-        return null;
+
+        return ((ISMRConsumable) data.getPayload(runtime)).getSMRUpdates(streamView.getId());
     }
 
     /**
@@ -124,7 +123,8 @@ public class StreamViewSMRAdapter implements ISMRStream {
             }
             data = streamView.previous();
         }
-        return null;
+
+        return new ArrayList<>();
     }
 
     public long pos() {

--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
@@ -10,7 +10,6 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.IStreamView;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -100,7 +99,7 @@ public class StreamViewSMRAdapter implements ISMRStream {
         if (data == null
                 || data.getType() != DataType.DATA
                 || !(data.getPayload(runtime) instanceof ISMRConsumable)) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         return ((ISMRConsumable) data.getPayload(runtime)).getSMRUpdates(streamView.getId());
@@ -124,7 +123,7 @@ public class StreamViewSMRAdapter implements ISMRStream {
             data = streamView.previous();
         }
 
-        return new ArrayList<>();
+        return Collections.emptyList();
     }
 
     public long pos() {

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -575,11 +575,10 @@ public class VersionLockedObject<T> {
 
         List<SMREntry> entries = stream.current();
 
-        while (entries != null) {
+        while (!entries.isEmpty()) {
             if (entries.stream().allMatch(SMREntry::isUndoable)) {
                 // start from the end, process one at a time
-                ListIterator<SMREntry> it =
-                        entries.listIterator(entries.size());
+                ListIterator<SMREntry> it = entries.listIterator(entries.size());
                 while (it.hasPrevious()) {
                     applyUndoRecordUnsafe(it.previous());
                 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -369,13 +369,10 @@ public abstract class AbstractTransactionalContext implements
     }
 
     int getWriteSetEntrySize(UUID id) {
-        List<SMREntry> entries = getWriteSetInfo().getWriteSet().getSMRUpdates(id);
-
-        if (entries == null) {
-            return 0;
-        } else {
-            return entries.size();
-        }
+        return getWriteSetInfo()
+                .getWriteSet()
+                .getSMRUpdates(id)
+                .size();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -1,6 +1,5 @@
 package org.corfudb.runtime.object.transactions;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
@@ -171,7 +170,7 @@ public class WriteSetSMRStream implements ISMRStream {
     @Override
     public List<SMREntry> current() {
         if (Address.nonAddress(writePos)) {
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         if (Address.nonAddress(currentContextPos)) {
@@ -190,7 +189,7 @@ public class WriteSetSMRStream implements ISMRStream {
 
         if (writePos <= Address.maxNonAddress()) {
             writePos = Address.maxNonAddress();
-            return new ArrayList<>();
+            return Collections.emptyList();
         }
 
         currentContextPos--;

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -173,9 +173,11 @@ public class WriteSetSMRStream implements ISMRStream {
         if (Address.nonAddress(writePos)) {
             return new ArrayList<>();
         }
+
         if (Address.nonAddress(currentContextPos)) {
             currentContextPos = -1;
         }
+
         return Collections.singletonList(contexts
                 .get(currentContext)
                 .getWriteSetEntryList(id)


### PR DESCRIPTION
## Overview

Description:
VLO clean up: return an empty list instead of null

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
