### PR TITLE
Prevent NPE in LocalMonitoringService

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LocalMonitoringService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LocalMonitoringService.java
@@ -38,7 +38,7 @@ class LocalMonitoringService implements MonitoringService {
                            @NonNull SingletonResource<CorfuRuntime> runtimeSingletonResource) {
         this.serverContext = serverContext;
         this.runtimeSingletonResource = runtimeSingletonResource;
-        sequencerMetricsHolder = new AtomicReference<>();
+        sequencerMetricsHolder = new AtomicReference<>(UNKNOWN);
 
         this.pollingService = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder()


### PR DESCRIPTION
## Overview

Description:
`sequencerMetricsHolder` can potentially return null. Added predefined value in a constructor 

Why should this be merged: 

Related issue(s) (if applicable): #2035


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
