### PR TITLE
CorfuGuidGenerator: Use Parent TransactionType if nested

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
@@ -70,7 +70,6 @@ public class CorfuQueue<E> {
 
         /**
          * @return Return only the unique part of the id without the ordering
-         * (should only be used for testing or validation of CorfuQueue)
          */
         public long getEntryId() {
             return id.getLeastSignificantBits();
@@ -78,7 +77,6 @@ public class CorfuQueue<E> {
 
         /**
          * @return Return only the ordering part of the entry without the id.
-         * (should only be used for testing or validation of CorfuQueue)
          */
         public long getOrdering() {
             return id.getMostSignificantBits();

--- a/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
@@ -5,6 +5,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.transactions.TransactionType;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
 
 import java.util.UUID;
 
@@ -48,11 +49,19 @@ public class CorfuGuidGenerator implements OrderedGuidGenerator {
     }
 
     private long updateInstanceId() {
-        long nextInstanceId = 0L;
+        long nextInstanceId;
         while(true) {
             try {
+                TransactionType txnType;
+                if (TransactionalContext.isInTransaction()) {
+                    txnType = TransactionalContext.getCurrentContext()
+                            .getTransaction().getType();
+                } else { // Pick default type as OPTIMISTIC
+                    txnType = TransactionType.OPTIMISTIC;
+
+                }
                 runtime.getObjectsView().TXBuild()
-                        .type(TransactionType.OPTIMISTIC)
+                        .type(txnType)
                         .build()
                         .begin();
 

--- a/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class CorfuQueueTxTest extends AbstractTransactionsTest {
     @Override
     public void TXBegin() {
-        OptimisticTXBegin();
+        TXBegin(TransactionType.OPTIMISTIC);
     }
 
     public void TXBegin(TransactionType type) {
@@ -38,7 +38,7 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
                 OptimisticTXBegin();
                 return;
             default:
-                throw new IllegalArgumentException("Unsupported TXN type");
+                throw new IllegalArgumentException("Unsupported TXN type:"+type.toString());
         }
     }
 

--- a/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
@@ -7,6 +7,7 @@ import org.corfudb.runtime.collections.CorfuQueue.CorfuRecordId;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.transactions.AbstractTransactionsTest;
+import org.corfudb.runtime.object.transactions.TransactionType;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -24,7 +25,22 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Slf4j
 public class CorfuQueueTxTest extends AbstractTransactionsTest {
     @Override
-    public void TXBegin() { OptimisticTXBegin(); }
+    public void TXBegin() {
+        OptimisticTXBegin();
+    }
+
+    public void TXBegin(TransactionType type) {
+        switch (type){
+            case WRITE_AFTER_WRITE:
+                WWTXBegin();
+                return;
+            case OPTIMISTIC:
+                OptimisticTXBegin();
+                return;
+            default:
+                throw new IllegalArgumentException("Unsupported TXN type");
+        }
+    }
 
     protected final int numIterations = PARAMETERS.NUM_ITERATIONS_LOW;
     protected final Long numConflictKeys = 2L;
@@ -36,7 +52,16 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
      * @throws Exception
      */
     @Test
-    public void queueOrderedByTransaction() throws Exception {
+    public void queueOrderedByOptimisticTxn() throws Exception {
+        queueOrderedByTransaction(TransactionType.OPTIMISTIC);
+    }
+
+    @Test
+    public void queueOrderedByWWTxn() throws Exception {
+        queueOrderedByTransaction(TransactionType.WRITE_AFTER_WRITE);
+    }
+
+    public void queueOrderedByTransaction(TransactionType txnType) throws Exception {
         final int numThreads = PARAMETERS.CONCURRENCY_TWO;
         Map<Long, Long> conflictMap = instantiateCorfuObject(SMRMap.class, "conflictMap");
         CorfuQueue<String>
@@ -60,7 +85,7 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
             for (Long i = 0L; i < numIterations; i++) {
                 String queueData = t.toString() + ":" + i.toString();
                 try {
-                    TXBegin();
+                    TXBegin(txnType);
                     Long coinToss = new Random().nextLong() % numConflictKeys;
                     conflictMap.put(coinToss, coinToss);
                     CorfuRecordId id = corfuQueue.enqueue(queueData);
@@ -68,10 +93,10 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
                     final long streamOffset = TXEnd();
                     validator.add(new Record(id, queueData));
                     log.debug("ENQ:" + id + "=>" + queueData + " at " + streamOffset);
+                    lock.unlock();
                 } catch (TransactionAbortedException txException) {
                     log.debug(queueData + " ---> Abort!!! ");
                     // Half the transactions are expected to abort
-                } finally {
                     lock.unlock();
                 }
             }


### PR DESCRIPTION
We don't allow nesting transactions of different types.
To get around this,
+ use parent transaction type if in one.
+ Separate test cases to validate different transaction types.
+ In CorfuQueue, remove comment that says getEntryId() and getOrdering() should only be used for testing since they are valid uses of the API.

Why should this be merged: 
Related issue(s) (if applicable): #2038 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
