### PR TITLE
Console logging compression

### DIFF
--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -11,7 +11,7 @@
             <maxIndex>30</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>100MB</maxFileSize>
+            <maxFileSize>700MB</maxFileSize>
         </triggeringPolicy>
         <encoder>
             <pattern>


### PR DESCRIPTION
## Overview

Description:
Average compression ration for our logs is 1:20.
Change max file size to make average gzipped logs size equals 35mb.
Math:
When log file comes 700mb it gets compressed to ~35-40mb
We can have up to 30 compressed log files
Max total disk space consumed by gzipped logs: 40*30 = 1.2GB
And one, not compressed log file: 700mb.
Total number of uncompressed logs: 700 * 30 + 700 = 22GB.

Previous parameters for a total number of uncompressed logs: 100*30 + 100 = 3GB which is ~ 9 hours in a prod environment.

The diff: 22GB - 3GB = 18GB which is ~ 54 hours in a prod environment.

New settings, total time: ~70 hours. 

P.S. if we get rid of log messages:
1. `Trying connection to layout server...`
2. `log write...`

It should reduce logs about 60-80%.
Then we can count on ~ 300-500 hours of logs.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
