### PR TITLE
Do not use stale conflictKey/conflictStream on overwritten for TXNs.

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenType.java
@@ -9,32 +9,30 @@ import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
-/** An enum for distinguishing different response from the sequencer.
+/**
+ * An enum for distinguishing different response from the sequencer.
  * Created by dalia on 4/8/17.
  */
 @RequiredArgsConstructor
-public enum  TokenType implements ICorfuPayload<TokenType> {
+public enum TokenType implements ICorfuPayload<TokenType> {
 
-    // standard token issue by sequencer
+    // Standard token issue by sequencer or a tail-query response
     NORMAL((byte) 0),
 
-    // response to tail-query (no allocation)
-    QUERY((byte)1),
+    // Token request for optimistic TX-commit rejected due to conflict
+    TX_ABORT_CONFLICT((byte) 1),
 
-    // token request for optimistic TX-commit rejected due to conflict
-    TX_ABORT_CONFLICT((byte)2),
-
-    // token request for optimistic TX-commit rejected due to a
+    // Token request for optimistic TX-commit rejected due to a
     // failover-sequencer lacking conflict-resolution info
-    TX_ABORT_NEWSEQ((byte) 3),
+    TX_ABORT_NEWSEQ((byte) 2),
 
     // Sent when a transaction aborts a transaction due to missing information
     // (required data evicted from cache)
-    TX_ABORT_SEQ_OVERFLOW((byte) 4),
+    TX_ABORT_SEQ_OVERFLOW((byte) 3),
 
     // Sent when a transaction aborts because it has an old version (i.e. older than
     // the trim mark). This is to detect slow transactions
-    TX_ABORT_SEQ_TRIM((byte) 5);
+    TX_ABORT_SEQ_TRIM((byte) 4);
 
     final int val;
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -1,24 +1,14 @@
 package org.corfudb.runtime.view;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
-import org.corfudb.protocols.wireprotocol.TokenType;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.AbortCause;
@@ -29,6 +19,12 @@ import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.Utils;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Created by mwei on 12/11/15.
@@ -95,7 +91,6 @@ public class StreamsView extends AbstractView {
      * unsafe streams will be excluded (because its unsafe for the garbage
      * collector thread to operate on them while being used by a different
      * thread).
-     *
      */
     public void gc(long trimMark) {
         for (IStreamView streamView : getStreamCache().values()) {
@@ -116,96 +111,76 @@ public class StreamsView extends AbstractView {
      *                                     the sequencer.
      */
     public long append(@Nonnull Object object, @Nullable TxResolutionInfo conflictInfo,
-                       @Nonnull CacheOption cacheOption, @Nonnull UUID ... streamIDs) {
+                       @Nonnull CacheOption cacheOption, @Nonnull UUID... streamIDs) {
 
         final LogData ld = new LogData(DataType.DATA, object);
         ld.checkMaxWriteSize(runtime.getParameters().getMaxWriteSize());
 
-        // Go to the sequencer, grab an initial token.
-        TokenResponse tokenResponse = conflictInfo == null
-                ? runtime.getSequencerView().next(streamIDs) // Token w/o conflict info
-                : runtime.getSequencerView().next(conflictInfo, streamIDs); // Token w/ conflict info
-
+        TokenResponse tokenResponse = null;
         for (int x = 0; x < runtime.getParameters().getWriteRetry(); x++) {
+            // Go to the sequencer, grab a token to write.
+            tokenResponse = conflictInfo == null
+                    ? runtime.getSequencerView().next(streamIDs) // Token w/o conflict info
+                    : runtime.getSequencerView().next(conflictInfo, streamIDs); // Token w/ conflict info
 
             // Is our token a valid type?
-            if (tokenResponse.getRespType() == TokenType.TX_ABORT_CONFLICT) {
+            AbortCause abortCause = null;
+            switch (tokenResponse.getRespType()) {
+                case TX_ABORT_CONFLICT:
+                    abortCause = AbortCause.CONFLICT;
+                    break;
+                case TX_ABORT_NEWSEQ:
+                    abortCause = AbortCause.NEW_SEQUENCER;
+                    break;
+                case TX_ABORT_SEQ_OVERFLOW:
+                    abortCause = AbortCause.SEQUENCER_OVERFLOW;
+                    break;
+                case TX_ABORT_SEQ_TRIM:
+                    abortCause = AbortCause.SEQUENCER_TRIM;
+                    break;
+            }
+
+            if (abortCause != null) {
                 throw new TransactionAbortedException(
                         conflictInfo,
                         tokenResponse.getConflictKey(), tokenResponse.getConflictStream(),
-                        tokenResponse.getToken().getSequence(), AbortCause.CONFLICT,
-                        TransactionalContext.getCurrentContext());
-            } else if (tokenResponse.getRespType() == TokenType.TX_ABORT_NEWSEQ) {
-                throw new TransactionAbortedException(
-                        conflictInfo,
-                        tokenResponse.getConflictKey(), tokenResponse.getConflictStream(),
-                        tokenResponse.getToken().getSequence(), AbortCause.NEW_SEQUENCER,
-                        TransactionalContext.getCurrentContext());
-            } else if (tokenResponse.getRespType() == TokenType.TX_ABORT_SEQ_OVERFLOW) {
-                throw new TransactionAbortedException(
-                        conflictInfo,
-                        tokenResponse.getConflictKey(), tokenResponse.getConflictStream(),
-                        tokenResponse.getToken().getSequence(), AbortCause.SEQUENCER_OVERFLOW,
-                        TransactionalContext.getCurrentContext());
-            } else if (tokenResponse.getRespType() == TokenType.TX_ABORT_SEQ_TRIM) {
-                throw new TransactionAbortedException(
-                        conflictInfo,
-                        tokenResponse.getConflictKey(), tokenResponse.getConflictStream(),
-                        tokenResponse.getToken().getSequence(), AbortCause.SEQUENCER_TRIM,
+                        tokenResponse.getToken().getSequence(), abortCause,
                         TransactionalContext.getCurrentContext());
             }
 
-            // Attempt to write to the log
             try {
+                // Attempt to write to the log.
                 runtime.getAddressSpaceView().write(tokenResponse, ld, cacheOption);
-                // If we're here, we succeeded, return the acquired token
+                // If we're here, we succeeded, return the acquired token.
                 return tokenResponse.getSequence();
             } catch (OverwriteException oe) {
-
                 // We were overwritten, get a new token and try again.
                 log.warn("append[{}]: Overwritten after {} retries, streams {}",
-                        tokenResponse.getSequence(),
-                        x,
+                        tokenResponse.getSequence(), x,
                         Arrays.stream(streamIDs).map(Utils::toReadableId).collect(Collectors.toSet()));
 
-                TokenResponse temp;
-                if (conflictInfo == null) {
-                    // Token w/o conflict info
-                    temp = runtime.getSequencerView().next(streamIDs);
-                } else {
-
-                    // On retry, check for conflicts only from the previous
-                    // attempt position
+                if (conflictInfo != null) {
+                    // On retry, check for conflicts only from the previous attempt position,
+                    // otherwise the transaction will always conflict with itself.
                     conflictInfo.setSnapshotTimestamp(tokenResponse.getToken());
-
-                    // Token w/ conflict info
-                    temp = runtime.getSequencerView().next(conflictInfo, streamIDs);
                 }
-
-                // We need to fix the token (to use the stream addresses- may
-                // eventually be deprecated since these are no longer used)
-                tokenResponse = new TokenResponse(
-                        temp.getRespType(), tokenResponse.getConflictKey(),
-                        tokenResponse.getConflictStream(), temp.getToken(),
-                        temp.getBackpointerMap(), Collections.emptyList());
 
             } catch (StaleTokenException se) {
                 // the epoch changed from when we grabbed the token from sequencer
-                log.warn("append[{}]: StaleToken , streams {}", tokenResponse.getSequence(),
+                log.warn("append[{}]: StaleToken, streams {}", tokenResponse.getSequence(),
                         Arrays.stream(streamIDs).map(Utils::toReadableId).collect(Collectors.toSet()));
 
                 throw new TransactionAbortedException(
                         conflictInfo,
                         tokenResponse.getConflictKey(), tokenResponse.getConflictStream(),
-                        tokenResponse.getToken().getSequence(), AbortCause.NEW_SEQUENCER, // in the future,
-                        // perhaps
-                        // define a new AbortCause?
+                        tokenResponse.getToken().getSequence(),
+                        AbortCause.NEW_SEQUENCER, // in the future perhaps define a new AbortCause?
                         TransactionalContext.getCurrentContext());
             }
         }
 
-        log.error("append[{}]: failed after {} retries , streams {}, write size {} bytes",
-                tokenResponse.getSequence(),
+        log.error("append[{}]: failed after {} retries, streams {}, write size {} bytes",
+                tokenResponse == null ? -1 : tokenResponse.getSequence(),
                 runtime.getParameters().getWriteRetry(),
                 Arrays.stream(streamIDs).map(Utils::toReadableId).collect(Collectors.toSet()),
                 ILogData.getSerializedSize(object));
@@ -218,7 +193,7 @@ public class StreamsView extends AbstractView {
      * @see StreamsView#append(Object, TxResolutionInfo, CacheOption, UUID...)
      */
     public long append(@Nonnull Object object, @Nullable TxResolutionInfo conflictInfo,
-                       @Nonnull UUID ... streamIDs) {
-       return append(object, conflictInfo, CacheOption.WRITE_THROUGH, streamIDs);
+                       @Nonnull UUID... streamIDs) {
+        return append(object, conflictInfo, CacheOption.WRITE_THROUGH, streamIDs);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
@@ -30,9 +30,9 @@ public abstract class AbstractTransactionContextTest extends AbstractTransaction
     public ISMRMap<String, String> getMap() {
         if (testMap == null) {
             testMap = (ISMRMap<String, String>) instantiateCorfuObject(
-                    new TypeToken<SMRMap<String, String>>() {
-                    }, "test stream"
-            ) ;
+                    new TypeToken<SMRMap<String, String>>() {},
+                    "test stream"
+            );
         }
         return testMap;
     }


### PR DESCRIPTION
## Overview

- On OverwriteException, StreamsView::append will grab a new token and
retry, but it was still using the conflictKey/conflictStream info from
the stale tokeResponse. In case of transactions and there is a conflict
when we try to re-requst the token, the stale conflictKey/conflictStream
is empty. This patch directly uses the new token and retry.

- Some clean up in StreamsView and TokenType.

Related issue(s) (if applicable): #2042 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
