### PR TITLE
Logback: migrate to an asynchronous appender

### DIFF
--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true" scanPeriod="30 seconds">
 
+    <!-- https://logback.qos.ch/manual/configuration.html#stopContext -->
+    <shutdownHook/>
+
     <property name="LOG_DIRECTORY" value="/var/log/corfu" />
 
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -20,7 +23,13 @@
         </encoder>
     </appender>
 
+    <!-- https://logback.qos.ch/manual/appenders.html#AsyncAppender -->
+    <appender name="async_file" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="file" />
+        <queueSize>1024</queueSize>
+    </appender>
+
     <root level="info">
-        <appender-ref ref="file"/>
+        <appender-ref ref="async_file"/>
     </root>
 </configuration>


### PR DESCRIPTION
## Overview

Description:
Asynchronous appender is very helpful in case of a slow disk (critical for us) or other cases (see https://logback.qos.ch/manual/appenders.html#AsyncAppender).

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
