### PR TITLE
Improved CheckpointWriter Logging

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -176,8 +176,11 @@ public class CheckpointWriter<T extends Map> {
             startCheckpoint(snapshotTimestamp, vloVersion);
             appendObjectState(entries);
             finishCheckpoint();
-            log.info("appendCheckpoint: completed checkpoint for {}, num of entries {} at snapshot {} in {} ms",
-                    streamId, entries.size(), snapshotTimestamp, System.currentTimeMillis() - start);
+            long cpDuration = System.currentTimeMillis() - start;
+            log.info("appendCheckpoint: completed checkpoint for {}, entries({}), tableSize({}) bytes, " +
+                            "cpSize({}) bytes at snapshot {} in {} ms",
+                    streamId, entries.size(), MetricsUtils.sizeOf.deepSizeOf(entries),
+                    numBytes, snapshotTimestamp, cpDuration);
         } finally {
             rt.getObjectsView().TXEnd();
         }


### PR DESCRIPTION
## Overview
Improved Logging

Added extra stats(i.e. in-memory size, CP size in bytes) logging
for the checkpoint writer.

Why should this be merged: Porting 6d13acee7fbaa59a17a34c6a2245618c844b090c from master