### PR TITLE
Decrease log level for OverwriteException 0.2.3

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -26,6 +26,7 @@ import org.corfudb.protocols.wireprotocol.TailsRequest;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.protocols.wireprotocol.TrimRequest;
 import org.corfudb.protocols.wireprotocol.WriteRequest;
+import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.QuotaExceededException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
@@ -193,6 +194,10 @@ public class BatchProcessor implements AutoCloseable {
                             default:
                                 log.warn("Unknown BatchWriterOperation {}", currOp);
                         }
+                    } catch (OverwriteException ex) {
+                        log.trace("OverwriteException. Batch [queue size={}]. StreamLog: [trim mark: {}].",
+                                operationsQueue.size(), streamLog.getTrimMark(), ex);
+                        currOp.getFutureResult().completeExceptionally(ex);
                     } catch (Exception e) {
                         log.error("Stream log error. Batch [queue size={}]. StreamLog: [trim mark: {}, tails: {}].",
                                 operationsQueue.size(), streamLog.getTrimMark(), streamLog.getAllTails(), e);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -194,12 +194,8 @@ public class BatchProcessor implements AutoCloseable {
                             default:
                                 log.warn("Unknown BatchWriterOperation {}", currOp);
                         }
-                    } catch (OverwriteException ex) {
-                        log.trace("OverwriteException. Batch [queue size={}]. StreamLog: [trim mark: {}].",
-                                operationsQueue.size(), streamLog.getTrimMark(), ex);
-                        currOp.getFutureResult().completeExceptionally(ex);
                     } catch (Exception e) {
-                        log.debug("Stream log error. Batch [queue size={}]. StreamLog: [trim mark: {}].",
+                        log.error("Stream log error. Batch [queue size={}]. StreamLog: [trim mark: {}].",
                                 operationsQueue.size(), streamLog.getTrimMark(), e);
                         currOp.getFutureResult().completeExceptionally(e);
                     }


### PR DESCRIPTION
## Overview

Description:
Descrease log level for OverwriteException 2

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
