### PR TITLE
Reduce stream interface

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -601,39 +601,7 @@ public abstract class AbstractQueuedStreamView extends
      */
     @Override
     public void close() {}
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public synchronized long find(long globalAddress, SearchDirection direction) {
-        final QueuedStreamContext context = getCurrentContext();
-        // First, check if we have resolved up to the given address
-        if (context.maxResolution < globalAddress) {
-            // If not we need to read to that position
-            // to resolve all the addresses.
-            remainingUpTo(globalAddress + 1);
-        }
-
-        // Now we can do the search.
-        // First, check for inclusive searches.
-        if (direction.isInclusive()
-                && context.resolvedQueue.contains(globalAddress)) {
-            return globalAddress;
-        }
-        // Next, check all elements excluding
-        // in the correct direction.
-        Long result;
-        if (direction.isForward()) {
-            result = context.resolvedQueue.higher(globalAddress);
-        }  else {
-            result = context.resolvedQueue.lower(globalAddress);
-        }
-
-        // Convert the address to never read if there was no result.
-        return result == null ? Address.NOT_FOUND : result;
-    }
-
+    
     // Keeps the latest valid checkpoint (based on the snapshot it covers)
     private StreamCheckpoint latestValidCheckpoint = new StreamCheckpoint();
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/IStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/IStreamView.java
@@ -49,40 +49,6 @@ public interface IStreamView extends
      */
     void seek(long globalAddress);
 
-    /** An enum representing search directions. */
-    @RequiredArgsConstructor
-    enum SearchDirection {
-        /** Search forward. */
-        FORWARD(false, true),
-        /** Search forward, including address given. */
-        FORWARD_INCLUSIVE(true, true),
-        /** Search backwards. */
-        REVERSE(false, false),
-        /** Search backwards, including address given. */
-        REVERSE_INCLUSIVE(true, false);
-
-        /** Whether the address given should be included
-         * in the search.
-         */
-        @Getter
-        final boolean inclusive;
-
-        /** True if the search is forward, false otherwise. */
-        @Getter
-        final boolean forward;
-    }
-
-    /** Find the global address of the next entry in this stream,
-     * in the direction given.
-     *
-     * @param globalAddress     The global address to start searching from.
-     * @param direction         The direction to search.
-     * @return                  The global address of the next entry in the
-     *                          stream, or Address.NOT_FOUND if no entry
-     *                          was found.
-     */
-    long find(long globalAddress, SearchDirection direction);
-
     /** Append an object to the stream, returning the global address
      * it was written at.
      * <p>

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/ThreadSafeStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/ThreadSafeStreamView.java
@@ -61,11 +61,6 @@ public class ThreadSafeStreamView implements IStreamView {
     }
 
     @Override
-    public synchronized long find(long globalAddress, SearchDirection direction) {
-        return stream.find(globalAddress, direction);
-    }
-
-    @Override
     public synchronized long append(Object object,
                 Function<TokenResponse, Boolean> acquisitionCallback,
                 Function<TokenResponse, Boolean> deacquisitionCallback) {

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
@@ -57,13 +57,6 @@ public class QuorumReplicationStreamViewTest extends StreamViewTest {
     }
 
     @Test
-    public void canFindInStream()
-            throws Exception
-    {
-        super.canFindInStream();
-    }
-
-    @Test
     public void canDoPreviousOnStream()
             throws Exception
     {

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -242,62 +242,6 @@ public class StreamViewTest extends AbstractViewTest {
     }
 
     @Test
-    public void canFindInStream()
-            throws Exception
-    {
-        CorfuRuntime r = getDefaultRuntime().connect();
-        IStreamView svA = r.getStreamsView().get(
-                CorfuRuntime.getStreamID("stream  A"));
-        IStreamView svB = r.getStreamsView().get(
-                CorfuRuntime.getStreamID("stream  B"));
-
-        // Append some entries
-        final long A_GLOBAL = 0;
-        svA.append("a".getBytes());
-        final long B_GLOBAL = 1;
-        svB.append("b".getBytes());
-        final long C_GLOBAL = 2;
-        svA.append("c".getBytes());
-        final long D_GLOBAL = 3;
-        svB.append("d".getBytes());
-        final long E_GLOBAL = 4;
-        svA.append("e".getBytes());
-
-        // See if we can find entries:
-        // Should find entry "c"
-        assertThat(svA.find(B_GLOBAL,
-                IStreamView.SearchDirection.FORWARD))
-                .isEqualTo(C_GLOBAL);
-        // Should find entry "a"
-        assertThat(svA.find(B_GLOBAL,
-                IStreamView.SearchDirection.REVERSE))
-                .isEqualTo(A_GLOBAL);
-        // Should find entry "e"
-        assertThat(svA.find(E_GLOBAL,
-                IStreamView.SearchDirection.FORWARD_INCLUSIVE))
-                .isEqualTo(E_GLOBAL);
-        // Should find entry "c"
-        assertThat(svA.find(C_GLOBAL,
-                IStreamView.SearchDirection.REVERSE_INCLUSIVE))
-                .isEqualTo(C_GLOBAL);
-
-        // From existing to existing:
-        // Should find entry "b"
-        assertThat(svB.find(D_GLOBAL,
-                IStreamView.SearchDirection.REVERSE))
-                .isEqualTo(B_GLOBAL);
-        // Should find entry "d"
-        assertThat(svB.find(B_GLOBAL,
-                IStreamView.SearchDirection.FORWARD))
-                .isEqualTo(D_GLOBAL);
-
-        // Bounds:
-        assertThat(svB.find(D_GLOBAL,
-                IStreamView.SearchDirection.FORWARD))
-                .isEqualTo(Address.NOT_FOUND);
-    }
-
-    @Test
     public void canDoPreviousOnStream()
             throws Exception
     {


### PR DESCRIPTION
## Overview
Removed unnecessary APIs.

Why should this be merged: less code, reduced complexity. 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
