### PR TITLE
Reduced The Sequencer's Memory Overhead

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServerCache.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServerCache.java
@@ -196,11 +196,11 @@ public class SequencerServerCache {
     @EqualsAndHashCode
     public static class ConflictTxStream {
         private final UUID streamId;
-        private final String conflictParam;
+        private final byte[] conflictParam;
 
         public ConflictTxStream(UUID streamId, byte[] conflictParam) {
             this.streamId = streamId;
-            this.conflictParam = Utils.bytesToHex(conflictParam);
+            this.conflictParam = conflictParam;
         }
 
         @Override


### PR DESCRIPTION
## Overview
Instead of converting the conflictParams to strings, its better to
keep them as byte arrays, its more compact.

Why should this be merged: Reduces the sequencer's memory footprint by ~4x

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
