### PR TITLE
Seq mem improvement

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServerCache.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServerCache.java
@@ -196,11 +196,11 @@ public class SequencerServerCache {
     @EqualsAndHashCode
     public static class ConflictTxStream {
         private final UUID streamId;
-        private final String conflictParam;
+        private final byte[] conflictParam;
 
         public ConflictTxStream(UUID streamId, byte[] conflictParam) {
             this.streamId = streamId;
-            this.conflictParam = Utils.bytesToHex(conflictParam);
+            this.conflictParam = conflictParam;
         }
 
         @Override


### PR DESCRIPTION
## Overview
Porting from master

Reduced The Sequencer's Memory Overhead

Instead of converting the conflictParams to strings, its better to
keep them as byte arrays, its more compact.

commit bb154e5d0cab965bd0f174896107892ee1c1799d