### PR TITLE
Dont Instrument unmapSecondaryIndexes

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -465,12 +465,9 @@ public class CorfuTable<K ,V>
     @Override
     @Mutator(name = "put", noUpcall = true)
     public void insert(@ConflictParameter K key, V value) {
-        V previous = mainMap.put(key, value);
-        // If we have index functions, update the secondary indexes.
-        if (!secondaryIndexes.isEmpty()) {
-            unmapSecondaryIndexes(key, previous);
-            mapSecondaryIndexes(key, value);
-        }
+        // This is just a stub, the annotation processor will generate an update with
+        // put(key, value), since this method doesn't require an upcall therefore no
+        // operations are needed to be executed on the internal data structure
     }
 
     /**
@@ -532,8 +529,9 @@ public class CorfuTable<K ,V>
     @Override
     @Mutator(name = "remove", noUpcall = true)
     public void delete(@ConflictParameter K key) {
-        V previous =  mainMap.remove(key);
-        unmapSecondaryIndexes(key, previous);
+        // This is just a stub, the annotation processor will generate an update with
+        // remove(key), since this method doesn't require an upcall therefore no
+        // operations are needed to be executed on the internal data structure
     }
 
     /** {@inheritDoc} */
@@ -746,6 +744,7 @@ public class CorfuTable<K ,V>
      * @param key   The primary key (index) for the mapping.
      * @param value The value to unmap.
      */
+    @DontInstrument
     @SuppressWarnings("unchecked")
     protected void unmapSecondaryIndexes(K key, V value) {
         if (value == null) {
@@ -783,6 +782,7 @@ public class CorfuTable<K ,V>
      * @param key   the primary key associated with the indexing.
      * @param value the value to map.
      */
+    @DontInstrument
     @SuppressWarnings("unchecked")
     protected void mapSecondaryIndexes(K key, V value) {
         if (value == null) {
@@ -815,6 +815,7 @@ public class CorfuTable<K ,V>
     /**
      *  Disable all secondary indices for this table. Only used during error-recovery.
      */
+    @DontInstrument
     protected void clearIndex() {
         indexSpec.clear();
         secondaryIndexes.clear();

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -90,7 +90,9 @@ public interface ISMRMap<K, V> extends Map<K, V> {
      */
     @Mutator(name = "put", noUpcall = true)
     default void blindPut(@ConflictParameter K key, V value) {
-        put(key, value);
+        // This is just a stub, the annotation processor will generate an update with
+        // put(key, value), since this method doesn't require an upcall therefore no
+        // operations are needed to be executed on the internal data structure
     }
 
     /** Generate an undo record for a put, given the previous state of the map


### PR DESCRIPTION
## Overview
The unmapSecondaryIndexes is not an SMRAcessor, so the annotation
processor shouldn't generator an accessor method for it.

Why should this be merged: prevents the annotation processor of generating an accessor in CorfuTable$CORFUSMR


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
