### PR TITLE
Port: Change how we deal with the transaction stream

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -18,6 +18,7 @@ import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.runtime.view.StreamOptions;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
@@ -159,16 +160,32 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                 queue.addAll(streamAddressSpace.copyAddressesToSet(maxGlobal));
 
                 long trimMark = streamAddressSpace.getTrimMark();
+
+                // In case we are dealing with a stream that does not have the checkpoint
+                // capability, check to see if we are trying to access an address that has been
+                // previously trimmed.
+                if (!isCheckpointCapable()
+                        && Address.isAddress(trimMark)
+                        && trimMark > stopAddress) {
+                    String message = String.format("getStreamAddressMap[{%s}] stream has been " +
+                                    "trimmed at address %s and we are trying to access the " +
+                                    "stream starting at address %s. This stream does not have " +
+                                    "the checkpoint capability.", this, trimMark, stopAddress);
+                    log.info(message);
+                    throw new TrimmedException(message);
+                }
+
                 // Address maps might have been trimmed, hence not reflecting all updates to the stream
                 // For this reason, in the case of a valid trim mark, we must be sure this space is
                 // already resolved or loaded by a checkpoint.
-                if (Address.isAddress(trimMark) && !isTrimCoveredByCheckpointOrLocalView(trimMark)) {
+                if (isCheckpointCapable()
+                        && Address.isAddress(trimMark)
+                        && !isTrimCoveredByCheckpointOrLocalView(trimMark)) {
                     String message = String.format("getStreamAddressMap[{%s}] stream has been " +
                                     "trimmed at address %s and this space is not covered by the " +
                                     "loaded checkpoint with start address %s, while accessing the " +
-                                    "stream at version %s. Looking for a new checkpoint.", this,
-                            streamAddressSpace.getTrimMark(),
-                            getCurrentContext().checkpoint.startAddress, maxGlobal);
+                                    "stream at version %s. Looking for a new checkpoint.",this,
+                            trimMark, getCurrentContext().checkpoint.startAddress, maxGlobal);
                     log.info(message);
                     if (getReadOptions().isIgnoreTrim()) {
                         log.debug("getStreamAddressMap[{}]: Ignoring trimmed exception for address[{}].",
@@ -181,7 +198,6 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
         }
 
         addressCount += queue.size();
-
         return !queue.isEmpty();
     }
 
@@ -346,6 +362,15 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
     private boolean isTrimCoveredByCheckpoint(long trimMark) {
         return getCurrentContext().checkpoint.id != null &&
                 getCurrentContext().checkpoint.startAddress >= trimMark;
+    }
+
+    /**
+     * Check to see if the current stream is checkpoint capable.
+     *
+     * @return whether this stream is capable of being checkpointed
+     */
+    private boolean isCheckpointCapable() {
+        return !getId().equals(ObjectsView.TRANSACTION_STREAM_ID);
     }
 
     @Override


### PR DESCRIPTION
The transaction stream it not checkpoint aware, thus, we need to ensure
that address space discovery mechanism takes into account.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
