### PR TITLE
Socket Buffer Sizing

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
@@ -4,12 +4,14 @@ import com.google.common.collect.ImmutableMap;
 
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.AdaptiveRecvByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.ServerChannel;
+import io.netty.channel.WriteBufferWaterMark;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslContext;
@@ -246,6 +248,9 @@ public class CorfuServerNode implements AutoCloseable {
                 .childOption(ChannelOption.SO_KEEPALIVE, true)
                 .childOption(ChannelOption.SO_REUSEADDR, true)
                 .childOption(ChannelOption.TCP_NODELAY, true)
+                .childOption(ChannelOption.RCVBUF_ALLOCATOR, new AdaptiveRecvByteBufAllocator(64 * 1024,
+                        64 * 1024,  1024 * 1024))
+                .option(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(393216, 524288))
                 .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.WriteBufferWaterMark;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Data;
@@ -401,6 +402,10 @@ public class CorfuRuntime {
                 ImmutableMap.<ChannelOption, Object>builder()
                         .put(ChannelOption.TCP_NODELAY, true)
                         .put(ChannelOption.SO_REUSEADDR, true)
+                        .put(ChannelOption.SO_SNDBUF, 1024 * 1024)
+                        .put(ChannelOption.SO_RCVBUF, 1024 * 1024)
+                        .put(ChannelOption.WRITE_BUFFER_WATER_MARK, new WriteBufferWaterMark(
+                                393216, 524288))
                         .build();
 
         /**

--- a/test/src/test/java/org/corfudb/integration/LargeWriteIT.java
+++ b/test/src/test/java/org/corfudb/integration/LargeWriteIT.java
@@ -31,9 +31,9 @@ public class LargeWriteIT  {
         String connString = "localhost:9000";
         CorfuRuntime rt = new CorfuRuntime(connString).setCacheDisabled(true).connect();
 
-        final int totalNumWrites = 100_000 * 10;
+        final int totalNumWrites = 100_000 * 5;
         final int numWriters = 8;
-        final int payloadSize = 1000;
+        final int payloadSize = 4000;
         final int batchPerThread = 10;
         final int numWritesPerThread = totalNumWrites / numWriters;
         byte[] payload = new byte[payloadSize];
@@ -49,8 +49,6 @@ public class LargeWriteIT  {
                         .getLogUnitClient(connString);
                 CompletableFuture<Boolean> ft = new CompletableFuture<>();
                 ft.complete(true);
-
-
 
                 for (int x = 1; x <= numWritesPerThread; x++) {
                     LogData ld = new LogData(DataType.DATA, payload);

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -46,7 +46,7 @@
 
     <root level="INFO">
         <!--<appender-ref ref="FILE" />-->
-        <!--<appender-ref ref="STDOUT" />-->
+        <appender-ref ref="STDOUT" />
         <!--<appender-ref ref="MetricsRollingFile" />-->
     </root>
 </configuration>


### PR DESCRIPTION
## Overview
The linux defaults are really small, increasing SO buffer sizes can improve performance 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
