### PR TITLE
Do not depend on mutable state for Paxos

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
 import lombok.NonNull;
@@ -22,6 +23,7 @@ import javax.annotation.Nonnull;
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -137,17 +139,19 @@ public class LayoutServer extends AbstractServer {
         if (!isBootstrapped(msg, ctx, r)) {
             return;
         }
-        long epoch = msg.getPayload();
-        if (epoch <= serverContext.getServerEpoch()) {
+
+        final long msgEpoch = msg.getPayload();
+        final long serverEpoch = getServerEpoch();
+
+        if (msgEpoch <= serverEpoch) {
             r.sendResponse(ctx, msg, new LayoutMsg(getCurrentLayout(), CorfuMsgType
                     .LAYOUT_RESPONSE));
         } else {
             // else the client is somehow ahead of the server.
             //TODO figure out a strategy to deal with this situation
-            long serverEpoch = serverContext.getServerEpoch();
             r.sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
             log.warn("handleMessageLayoutRequest: Message Epoch {} ahead of Server epoch {}",
-                    epoch, serverEpoch);
+                    msgEpoch, serverEpoch);
         }
     }
 
@@ -198,12 +202,14 @@ public class LayoutServer extends AbstractServer {
         if (!isBootstrapped(msg, ctx, r)) {
             return;
         }
-        Rank prepareRank = new Rank(msg.getPayload().getRank(), msg.getClientID());
-        Rank phase1Rank = getPhase1Rank();
-        Layout proposedLayout = getProposedLayout();
 
-        long serverEpoch = getServerEpoch();
-        if (msg.getPayload().getEpoch() != serverEpoch) {
+        final long payloadEpoch = msg.getPayload().getEpoch();
+        final long serverEpoch = getServerEpoch();
+
+        final Rank prepareRank = new Rank(msg.getPayload().getRank(), msg.getClientID());
+        final Rank phase1Rank = getPhase1Rank(payloadEpoch);
+
+        if (payloadEpoch != serverEpoch) {
             r.sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
             log.trace("handleMessageLayoutPrepare: Incoming message with wrong epoch, got {}, "
                             + "expected {}, message was: {}",
@@ -211,6 +217,7 @@ public class LayoutServer extends AbstractServer {
             return;
         }
 
+        Layout proposedLayout = getProposedLayout(payloadEpoch);
 
         // This is a prepare. If the rank is less than or equal to the phase 1 rank, reject.
         if (phase1Rank != null && prepareRank.lessThanEqualTo(phase1Rank)) {
@@ -221,9 +228,9 @@ public class LayoutServer extends AbstractServer {
         } else {
             // Return the layout with the highest rank proposed before.
             Rank highestProposedRank = proposedLayout == null ? new Rank(-1L, msg.getClientID())
-                    : getPhase2Rank();
-            setPhase1Rank(prepareRank);
-            log.debug("handleMessageLayoutPrepare: New phase 1 rank={}", getPhase1Rank());
+                    : getPhase2Rank(payloadEpoch);
+            setPhase1Rank(prepareRank, payloadEpoch);
+            log.debug("handleMessageLayoutPrepare: New phase 1 rank={}", prepareRank);
             r.sendResponse(ctx, msg, CorfuMsgType.LAYOUT_PREPARE_ACK.payloadMsg(new
                     LayoutPrepareResponse(highestProposedRank.getRank(), proposedLayout)));
         }
@@ -246,17 +253,18 @@ public class LayoutServer extends AbstractServer {
         if (!isBootstrapped(msg, ctx, r)) {
             return;
         }
-        Rank proposeRank = new Rank(msg.getPayload().getRank(), msg.getClientID());
-        Rank phase1Rank = getPhase1Rank();
 
-        long serverEpoch = getServerEpoch();
+        final long payloadEpoch = msg.getPayload().getEpoch();
+        final long serverEpoch = getServerEpoch();
+
+        final Rank proposeRank = new Rank(msg.getPayload().getRank(), msg.getClientID());
+        final Rank phase1Rank = getPhase1Rank(payloadEpoch);
 
         // Check if the propose is for the correct epoch
-        if (msg.getPayload().getEpoch() != serverEpoch) {
+        if (payloadEpoch != serverEpoch) {
             r.sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
             log.trace("handleMessageLayoutPropose: Incoming message with wrong epoch, got {}, "
-                            + "expected {}, message was: {}",
-                    msg.getPayload().getEpoch(), serverEpoch, msg);
+                            + "expected {}, message was: {}", payloadEpoch, serverEpoch, msg);
             return;
         }
         // This is a propose. If no prepare, reject.
@@ -276,8 +284,19 @@ public class LayoutServer extends AbstractServer {
                     LayoutProposeResponse(phase1Rank.getRank())));
             return;
         }
-        Rank phase2Rank = getPhase2Rank();
-        Layout proposeLayout = msg.getPayload().getLayout();
+
+        final Rank phase2Rank = getPhase2Rank(payloadEpoch);
+        final Layout proposeLayout = msg.getPayload().getLayout();
+
+        // Make sure that the layout epoch is the same as the LayoutProposeRequest epoch.
+        if (proposeLayout.getEpoch() != payloadEpoch) {
+            log.debug("Phase II error: layout {} and payload {} epoch should be the same",
+                    proposeLayout.getEpoch(), payloadEpoch);
+            r.sendResponse(ctx, msg, CorfuMsgType.LAYOUT_PROPOSE_REJECT.payloadMsg(new
+                    LayoutProposeResponse(phase1Rank.getRank())));
+            return;
+        }
+
         // In addition, if the rank in the propose message is equal to the current phase 2 rank
         // (already accepted message), reject.
         // This can happen in case of duplicate messages.
@@ -289,9 +308,9 @@ public class LayoutServer extends AbstractServer {
             return;
         }
 
-        log.debug("handleMessageLayoutPropose: New phase 2 rank={},  layout={}",
+        log.debug("handleMessageLayoutPropose: New phase 2 rank={}, layout={}",
                 proposeRank, proposeLayout);
-        setPhase2Data(new Phase2Data(proposeRank, proposeLayout));
+        setPhase2Data(new Phase2Data(proposeRank, proposeLayout), payloadEpoch);
         r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
     }
 
@@ -307,19 +326,22 @@ public class LayoutServer extends AbstractServer {
     private synchronized void forceLayout(@Nonnull CorfuPayloadMsg<LayoutCommittedRequest> msg,
                                                @Nonnull ChannelHandlerContext ctx,
                                                @Nonnull IServerRouter r) {
-        LayoutCommittedRequest req = msg.getPayload();
+        final long payloadEpoch = msg.getPayload().getEpoch();
+        final long serverEpoch = getServerEpoch();
 
-        if (req.getEpoch() != getServerEpoch()) {
+        if (payloadEpoch != serverEpoch) {
             // return can't force old epochs
             r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
             log.warn("forceLayout: Trying to force a layout with an old epoch. Layout {}, " +
-                    "current epoch {}", req.getLayout(), getServerEpoch());
+                    "current epoch {}", payloadEpoch, serverEpoch);
             return;
         }
 
-        setCurrentLayout(req.getLayout());
-        serverContext.setServerEpoch(req.getLayout().getEpoch(), r);
-        log.warn("forceLayout: Forcing new layout {}", req.getLayout());
+        final Layout msgLayout = msg.getPayload().getLayout();
+
+        setCurrentLayout(msgLayout);
+        serverContext.setServerEpoch(msgLayout.getEpoch(), r);
+        log.warn("forceLayout: Forcing new layout {}", msgLayout);
         r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
     }
 
@@ -347,19 +369,22 @@ public class LayoutServer extends AbstractServer {
             return;
         }
 
-        Layout commitLayout = msg.getPayload().getLayout();
         if (!isBootstrapped(msg, ctx, r)) {
             return;
         }
-        long serverEpoch = getServerEpoch();
-        if (msg.getPayload().getEpoch() < serverEpoch) {
+
+        final long payloadEpoch = msg.getPayload().getEpoch();
+        final long serverEpoch = getServerEpoch();
+        final Layout msgLayout = msg.getPayload().getLayout();
+
+        if (payloadEpoch < serverEpoch) {
             r.sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, serverEpoch));
             return;
         }
 
-        setCurrentLayout(commitLayout);
-        serverContext.setServerEpoch(msg.getPayload().getEpoch(), r);
-        log.info("New layout committed: {}", commitLayout);
+        setCurrentLayout(msgLayout);
+        serverContext.setServerEpoch(payloadEpoch, r);
+        log.info("New layout committed: {}", msgLayout);
         r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
     }
 
@@ -384,18 +409,18 @@ public class LayoutServer extends AbstractServer {
         setLayoutInHistory(layout);
     }
 
-    public Rank getPhase1Rank() {
+    public Rank getPhase1Rank(long epoch) {
         return paxosDataStore
-                .getPhase1Rank(getServerEpoch())
+                .getPhase1Rank(epoch)
                 .orElse(null);
     }
 
-    public void setPhase1Rank(Rank rank) {
-        paxosDataStore.setPhase1Rank(rank, getServerEpoch());
+    public void setPhase1Rank(Rank rank, long epoch) {
+        paxosDataStore.setPhase1Rank(rank, epoch);
     }
 
-    public void setPhase2Data(Phase2Data phase2Data) {
-        paxosDataStore.setPhase2Data(phase2Data, getServerEpoch());
+    public void setPhase2Data(Phase2Data phase2Data, long epoch) {
+        paxosDataStore.setPhase2Data(phase2Data, epoch);
     }
 
     public void setLayoutInHistory(Layout layout) {
@@ -411,9 +436,9 @@ public class LayoutServer extends AbstractServer {
      *
      * @return the phase 2 rank
      */
-    public Rank getPhase2Rank() {
+    public Rank getPhase2Rank(long epoch) {
         return paxosDataStore
-                .getPhase2Data(getServerEpoch())
+                .getPhase2Data(epoch)
                 .map(Phase2Data::getRank)
                 .orElse(null);
     }
@@ -423,10 +448,21 @@ public class LayoutServer extends AbstractServer {
      *
      * @return the proposed layout
      */
-    public Layout getProposedLayout() {
+    public Layout getProposedLayout(long epoch) {
         return paxosDataStore
-                .getPhase2Data(getServerEpoch())
+                .getPhase2Data(epoch)
                 .map(Phase2Data::getLayout)
                 .orElse(null);
+    }
+
+    /**
+     * Return accepted data for the given epoch.
+     *
+     * @param epoch that we are interested in
+     * @return {@link Optional} {@link Phase2Data}
+     */
+    @VisibleForTesting
+    Optional<Phase2Data> getPhase2Data(long epoch) {
+        return paxosDataStore.getPhase2Data(epoch);
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerAssertions.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerAssertions.java
@@ -27,36 +27,40 @@ public class LayoutServerAssertions extends AbstractAssert<LayoutServerAssertion
 
     public LayoutServerAssertions isInEpoch(long epoch) {
         isNotNull();
-        if (actual.getServerContext().getServerEpoch() != epoch) {
-            failWithMessage("Expected server to be in epoch <%d> but it was in epoch <%d>", epoch,
-                    actual.getServerContext().getServerEpoch());
+        final long serverEpoch = actual.getServerContext().getServerEpoch();
+        if (serverEpoch != epoch) {
+            failWithMessage("Expected server to be in epoch <%d> but it was in epoch <%d>",
+                    epoch, serverEpoch);
         }
         return this;
     }
 
     public LayoutServerAssertions isPhase1Rank(Rank phase1Rank) {
         isNotNull();
-        if (!actual.getPhase1Rank().equals(phase1Rank)) {
+        final long serverEpoch = actual.getServerContext().getServerEpoch();
+        if (!actual.getPhase1Rank(serverEpoch).equals(phase1Rank)) {
             failWithMessage("Expected server to be in phase1Rank <%s> but it was in phase1Rank <%s>", phase1Rank,
-                    actual.getPhase1Rank());
+                    actual.getPhase1Rank(serverEpoch));
         }
         return this;
     }
 
     public LayoutServerAssertions isPhase2Rank(Rank phase2Rank) {
         isNotNull();
-        if (!actual.getPhase2Rank().equals(phase2Rank)) {
+        final long serverEpoch = actual.getServerContext().getServerEpoch();
+        if (!actual.getPhase2Rank(serverEpoch).equals(phase2Rank)) {
             failWithMessage("Expected server to be in phase2Rank <%s> but it was in phase2Rank <%s>", phase2Rank,
-                    actual.getPhase2Rank());
+                    actual.getPhase2Rank(serverEpoch));
         }
         return this;
     }
 
     public LayoutServerAssertions isProposedLayout(Layout layout) {
         isNotNull();
-        if (!actual.getProposedLayout().asJSONString().equals(layout.asJSONString())) {
+        final long serverEpoch = actual.getServerContext().getServerEpoch();
+        if (!actual.getProposedLayout(serverEpoch).asJSONString().equals(layout.asJSONString())) {
             failWithMessage("Expected server to have proposedLayout  <%s> but it is <%s>", layout,
-                    actual.getProposedLayout());
+                    actual.getProposedLayout(serverEpoch));
 
         }
         return this;

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -1,10 +1,10 @@
 package org.corfudb.infrastructure;
 
-
 import static org.corfudb.infrastructure.LayoutServerAssertions.assertThat;
 
 import java.util.UUID;
 
+import io.netty.channel.ChannelHandlerContext;
 import lombok.extern.slf4j.Slf4j;
 
 import org.assertj.core.api.Assertions;
@@ -17,8 +17,7 @@ import org.corfudb.protocols.wireprotocol.LayoutPrepareRequest;
 import org.corfudb.protocols.wireprotocol.LayoutProposeRequest;
 import org.corfudb.runtime.view.Layout;
 import org.junit.Test;
-
-//import static org.assertj.core.api.Assertions.assertThat;
+import org.mockito.Mockito;
 
 /**
  * Created by mwei on 12/14/15.

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure;
 
 import static org.corfudb.infrastructure.LayoutServerAssertions.assertThat;
 
+import java.io.File;
 import java.util.UUID;
 
 import io.netty.channel.ChannelHandlerContext;
@@ -247,7 +248,7 @@ public class LayoutServerTest extends AbstractServerTest {
         sendPrepare(newEpoch, 1);
         Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.LAYOUT_PREPARE_ACK);
         assertThat(s1).isPhase1Rank(new Rank(1L, AbstractServerTest.testClientId));
-       //shutdown this instance of server
+        //shutdown this instance of server
         s1.shutdown();
         //bring up a new instance of server with the previously persisted data
         LayoutServer s2 = getDefaultServer(serviceDir);
@@ -347,7 +348,7 @@ public class LayoutServerTest extends AbstractServerTest {
         assertThat(s2).isPhase1Rank(new Rank(HIGH_RANK, AbstractServerTest.testClientId));
 
         //new LAYOUT_PROPOSE message with a lower phase2 rank should be rejected
-        sendPropose(newEpoch,  HIGH_RANK - 1, newLayout);
+        sendPropose(newEpoch, HIGH_RANK - 1, newLayout);
         Assertions.assertThat(getLastMessage().getMsgType()).isEqualTo(CorfuMsgType.LAYOUT_PROPOSE_REJECT);
 
 
@@ -461,6 +462,73 @@ public class LayoutServerTest extends AbstractServerTest {
             commitReturnsAck(s2, i, NEW_EPOCH + 1);
             s2.shutdown();
         }
+    }
+
+    /**
+     * Make sure that Paxos decisions are not based on
+     * mutable state that can be changed out of band.
+     */
+    @Test
+    public void testChangeEpochInPhase2ByBaseServer() {
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+        LayoutServer layoutServer = getDefaultServer(serviceDir);
+
+        //  Spy on the LayoutServer which will let us trigger race conditions.
+        LayoutServer spyLayoutServer = Mockito.spy(layoutServer);
+
+        // Bootstrap the layout server.
+        Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
+        spyLayoutServer.setCurrentLayout(layout);
+
+        // Create a new layout (data) for the propose phase (Phase II).
+        Layout newLayout = TestLayoutBuilder.single(SERVERS.PORT_0);
+        newLayout.setEpoch(layout.getEpoch() + 1L);
+
+        // Mock all RPC calls.
+        IServerRouter router = Mockito.mock(IServerRouter.class);
+        ChannelHandlerContext context = Mockito.mock(ChannelHandlerContext.class);
+        Mockito.doAnswer(invocation -> null)
+                .when(router).sendResponse(Mockito.any(), Mockito.any(), Mockito.any());
+
+        final long newSealEpoch = newLayout.getEpoch() + 1L;
+
+        // Trigger a race condition by bumping the server epoch just before
+        // Paxos is about to persist the accepted data.
+        Mockito.doAnswer(invocation -> {
+            spyLayoutServer.getServerContext().setServerEpoch(newSealEpoch, router);
+            return invocation.callRealMethod();
+        }).when(spyLayoutServer).setPhase2Data(Mockito.any(), Mockito.anyLong());
+
+        final long msgRank = 0L;
+
+        spyLayoutServer.getServerContext().setServerEpoch(newLayout.getEpoch(), router);
+
+        // Run the prepare phase (Phase I).
+        LayoutPrepareRequest prepareRequest = new LayoutPrepareRequest(
+                newLayout.getEpoch(), msgRank);
+        CorfuPayloadMsg<LayoutPrepareRequest> prepareRequestMsg =
+                new CorfuPayloadMsg<>(CorfuMsgType.LAYOUT_PREPARE, prepareRequest);
+        spyLayoutServer.handleMessageLayoutPrepare(prepareRequestMsg, context, router);
+
+        // Run the propose phase (Phase II). This function call will in turn call
+        // LayoutServer:::setPhase2Data(...) which has been instrumented
+        // with Mockito.doAnswer(...) to bump up the epoch.
+        LayoutProposeRequest proposeRequest = new LayoutProposeRequest(
+                newLayout.getEpoch(), msgRank, newLayout);
+        CorfuPayloadMsg<LayoutProposeRequest> layoutProposeRequestMsg =
+                new CorfuPayloadMsg<>(CorfuMsgType.LAYOUT_PROPOSE, proposeRequest);
+        spyLayoutServer.handleMessageLayoutPropose(layoutProposeRequestMsg, context, router);
+
+        // Make sure the epoch has actually changed.
+        Assertions.assertThat(newSealEpoch)
+                .isEqualTo(spyLayoutServer.getServerContext().getServerEpoch());
+
+        // Make sure no data has been accepted for the new epoch.
+        Assertions.assertThat(spyLayoutServer.getPhase2Data(newSealEpoch).isPresent())
+                .isFalse();
+        // Make sure no data has been accepted for the correct epoch.
+        Assertions.assertThat(spyLayoutServer.getPhase2Data(newLayout.getEpoch()).isPresent())
+                .isTrue();
     }
 
     private void commitReturnsAck(LayoutServer s1, Integer reboot, long baseEpoch) {


### PR DESCRIPTION
Within Paxos, avoid relying on mutable state (server epoch to be more
precise), since this can lead to wrong data being persisted and agreed
upon.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
