### PR TITLE
Remove backpointersDisabled

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -86,17 +86,6 @@ public class CorfuRuntime {
         private final long nettyShutdownTimeout = 300;
 
         // region Object Layer Parameters
-        /**
-         * True, if undo logging is disabled.
-         */
-        @Default
-        boolean undoDisabled = false;
-
-        /**
-         * True, if optimistic undo logging is disabled.
-         */
-        @Default
-        boolean optimisticUndoDisabled = false;
 
         /**
          * Max size for a write request.
@@ -195,12 +184,6 @@ public class CorfuRuntime {
          */
         @Default
         boolean followBackpointersEnabled = false;
-
-        /**
-         * Whether or not to disable backpointers.
-         */
-        @Default
-        boolean backpointersDisabled = false;
 
         /**
          * Whether or not hole filling should be disabled.
@@ -1141,20 +1124,6 @@ public class CorfuRuntime {
         parameters.usernameFile = usernameFile;
         parameters.passwordFile = passwordFile;
         parameters.saslPlainTextEnabled = true;
-        return this;
-    }
-
-    /**
-     * Whether or not to disable backpointers
-     *
-     * @param disable True, if the cache should be disabled, false otherwise.
-     * @return A CorfuRuntime to support chaining.
-     * @deprecated Deprecated, set using {@link CorfuRuntimeParameters} instead.
-     */
-    @Deprecated
-    public CorfuRuntime setBackpointersDisabled(boolean disable) {
-        log.warn("setBackpointersDisabled: Deprecated, please set parameters instead");
-        parameters.setBackpointersDisabled(disable);
         return this;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -309,7 +309,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
             }
         }
 
-        if (!runtime.getParameters().isBackpointersDisabled() && d.hasBackpointer(streamId)) {
+        if (d.hasBackpointer(streamId)) {
             long previousAddress = d.getBackpointer(streamId);
             log.trace("getStreamAddressMap[{}]: backpointer for {} points to {}",
                     streamId, startAddress, previousAddress);

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/BackpointerStreamView.java
@@ -142,7 +142,7 @@ public class BackpointerStreamView extends AbstractQueuedStreamView {
 
             log.trace("followBackpointers: calculate the next address");
 
-            if (!runtime.getParameters().isBackpointersDisabled() && d.hasBackpointer(streamId)) {
+            if (d.hasBackpointer(streamId)) {
                 long tmp = d.getBackpointer(streamId);
                 log.trace("followBackpointers: backpointer points to {}", tmp);
                 // if backpointer is a valid log address or Address.NON_EXIST

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuMapTest.java
@@ -277,7 +277,6 @@ public class CorfuMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void loadsFollowedByGetsConcurrentMultiView()
             throws Exception {
-        r.setBackpointersDisabled(true);
         // Increasing hole fill delay to avoid intermittent AppendExceptions.
         final int longHoleFillRetryLimit = 50;
         r.getParameters().setHoleFillRetry(longHoleFillRetryLimit);

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -275,7 +275,6 @@ public class SMRMapTest extends AbstractViewTest {
     @SuppressWarnings("unchecked")
     public void loadsFollowedByGetsConcurrentMultiView()
             throws Exception {
-        r.setBackpointersDisabled(true);
         // Increasing hole fill delay to avoid intermittent AppendExceptions.
         final int longHoleFillRetryLimit = 50;
         r.getParameters().setHoleFillRetry(longHoleFillRetryLimit);

--- a/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/QuorumReplicationStreamViewTest.java
@@ -44,14 +44,6 @@ public class QuorumReplicationStreamViewTest extends StreamViewTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void canReadWriteFromStreamWithoutBackpointers()
-            throws Exception {
-        super.canReadWriteFromStreamWithoutBackpointers();
-    }
-
-
-    @Test
-    @SuppressWarnings("unchecked")
     public void canReadWriteFromCachedStream()
             throws Exception {
         super.canReadWriteFromCachedStream();

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -189,29 +189,6 @@ public class StreamViewTest extends AbstractViewTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    public void canReadWriteFromStreamWithoutBackpointers()
-            throws Exception {
-        r.setBackpointersDisabled(true);
-
-        UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
-        byte[] testPayload = "hello world".getBytes();
-
-        IStreamView sv = r.getStreamsView().get(streamA);
-        scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW, i ->
-                sv.append(testPayload));
-        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_NORMAL);
-
-        scheduleConcurrently(PARAMETERS.NUM_ITERATIONS_LOW, i ->
-                assertThat(sv.next().getPayload(getRuntime()))
-                .isEqualTo("hello world".getBytes()));
-        executeScheduled(PARAMETERS.CONCURRENCY_SOME, PARAMETERS.TIMEOUT_NORMAL);
-        assertThat(sv.next())
-                .isEqualTo(null);
-    }
-
-
-    @Test
-    @SuppressWarnings("unchecked")
     public void canReadWriteFromCachedStream()
             throws Exception {
         CorfuRuntime r = getDefaultRuntime().connect()
@@ -556,10 +533,9 @@ public class StreamViewTest extends AbstractViewTest {
      * @throws InterruptedException
      */
     @Test
-    public void txLogTrim() throws InterruptedException {
+    public void txLogTrim() {
         final CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
                 .builder()
-                .backpointersDisabled(true)
                 .build();
         final CorfuRuntime localRuntime = CorfuRuntime.fromParameters(params)
                 .setTransactionLogging(true)


### PR DESCRIPTION
## Overview
Only one variable is needed to toggle backpointers, so I removed
backpointersDisabled for followBackpointersEnabled.

Why should this be merged: Removes a redundant and confusing option. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
