### PR TITLE
MultiObjectSMREntry Lazy Evaluation

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
@@ -34,11 +34,6 @@ public class MultiSMREntry extends LogEntry implements ISMRConsumable {
         this.type = LogEntryType.MULTISMR;
     }
 
-    public MultiSMREntry(List<SMREntry> updates) {
-        this.type = LogEntryType.MULTISMR;
-        this.updates = updates;
-    }
-
     public void addTo(SMREntry entry) {
         getUpdates().add(entry);
     }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -66,13 +66,6 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
     }
 
     /**
-     * Return whether or not this entry is a log entry.
-     */
-    default boolean isLogEntry(CorfuRuntime runtime) {
-        return getPayload(runtime) instanceof LogEntry;
-    }
-
-    /**
      * Return the payload as a log entry.
      */
     default LogEntry getLogEntry(CorfuRuntime runtime) {
@@ -95,13 +88,6 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
             return null;
         }
         return getBackpointerMap().get(streamId);
-    }
-
-    /**
-     * Return if this is the first entry in a particular stream.
-     */
-    default boolean isFirstEntry(UUID streamId) {
-        return getBackpointer(streamId) == -1L;
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -428,8 +428,8 @@ public class FastObjectLoader {
 
     private void updateCorfuObjectWithMultiObjSmrEntry(LogEntry logEntry, long globalAddress) {
         MultiObjectSMREntry multiObjectLogEntry = (MultiObjectSMREntry) logEntry;
-        multiObjectLogEntry.getEntryMap().forEach((streamId, multiSmrEntry) -> {
-            multiSmrEntry.getSMRUpdates(streamId).forEach((smrEntry) -> {
+        multiObjectLogEntry.getEntryMap().forEach((streamId, smrEntryList) -> {
+            smrEntryList.forEach((smrEntry) -> {
                 applySmrEntryToStream(streamId, smrEntry, globalAddress);
             });
         });

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -451,9 +451,9 @@ public class Utils {
                 log.info("--------------------------");
             } else if (le.getType() == LogEntry.LogEntryType.MULTIOBJSMR) {
                 log.info("printLogAnatomy: Number of Streams: {}", logData.getStreams().size());
-                ((MultiObjectSMREntry)le).getEntryMap().forEach((stream, multiSmrEntry) -> {
-                    log.info("printLogAnatomy: Number of Entries: {}",
-                            multiSmrEntry.getSMRUpdates(stream).size());
+                ((MultiObjectSMREntry)le).getEntryMap().forEach((stream, smrEntryList) -> {
+                    log.info("printLogAnatomy: Number of Entries({}): {}",
+                            stream, smrEntryList.size());
                 });
                 log.info("--------------------------");
             }

--- a/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
@@ -40,8 +40,8 @@ public class TransactionStreamIT extends AbstractIT {
     private void ConsumeDelta(Map<UUID, Integer> map, List<ILogData> deltas) {
         for (ILogData ld : deltas) {
             MultiObjectSMREntry multiObjSmr = (MultiObjectSMREntry) ld.getPayload(null);
-            for (Map.Entry<UUID, MultiSMREntry> multiSMREntry : multiObjSmr.entryMap.entrySet()) {
-                for (SMREntry update : multiSMREntry.getValue().getUpdates()) {
+            for (Map.Entry<UUID, List<SMREntry>> multiSMREntry : multiObjSmr.entryMap.entrySet()) {
+                for (SMREntry update : multiSMREntry.getValue()) {
                     int key = (int) update.getSMRArguments()[0];
                     int val = (int) update.getSMRArguments()[1];
                     assertThat(key).isEqualTo(val);

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
@@ -60,11 +60,11 @@ public class WriteAfterWriteTransactionContextTest extends AbstractTransactionCo
         MultiObjectSMREntry tx1 = (MultiObjectSMREntry)txns.get(0).getLogEntry
             (getRuntime());
         assertThat(tx1.getEntryMap().size()).isEqualTo(1);
-        MultiSMREntry entryMap = tx1.getEntryMap().entrySet().iterator()
+        List<SMREntry> smrEntries = tx1.getEntryMap().entrySet().iterator()
                                                         .next().getValue();
-        assertThat(entryMap).isNotNull();
-        assertThat(entryMap.getUpdates().size()).isEqualTo(1);
-        SMREntry smrEntry = entryMap.getUpdates().get(0);
+        assertThat(smrEntries).isNotNull();
+        assertThat(smrEntries.size()).isEqualTo(1);
+        SMREntry smrEntry = smrEntries.get(0);
         Object[] args = smrEntry.getSMRArguments();
         assertThat(smrEntry.getSMRMethod()).isEqualTo("put");
         assertThat((String) args[0]).isEqualTo("k");

--- a/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -109,12 +109,12 @@ public class ObjectsViewTest extends AbstractViewTest {
 
         MultiObjectSMREntry tx1 = (MultiObjectSMREntry)txns.get(0).getLogEntry
                 (getRuntime());
-        MultiSMREntry entryMap = tx1.getEntryMap().get(CorfuRuntime.getStreamID(mapA));
-        assertThat(entryMap).isNotNull();
+        List<SMREntry> smrEntries = tx1.getEntryMap().get(CorfuRuntime.getStreamID(mapA));
+        assertThat(smrEntries).isNotNull();
 
-        assertThat(entryMap.getUpdates().size()).isEqualTo(1);
+        assertThat(smrEntries.size()).isEqualTo(1);
 
-        SMREntry smrEntry = entryMap.getUpdates().get(0);
+        SMREntry smrEntry = smrEntries.get(0);
         Object[] args = smrEntry.getSMRArguments();
         assertThat(smrEntry.getSMRMethod()).isEqualTo("put");
         assertThat((String) args[0]).isEqualTo("k");


### PR DESCRIPTION
## Overview
Since getPayload will deserialize all streams in MultiObjectSMREntry, the client needs to register all the corresponding stream's serializers even the ones that it doesn't care about, which can be problematic. This PR, lazily deserializes the MultiObjectSMREntry and therefore a client only needs to register serializers for streams that it opened.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
