### PR TITLE
TrimmedException log level message - 0.2.3

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -303,8 +303,11 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                         " stream[{}]", this, startAddress, streamId);
                 return false;
             } else {
-                log.warn("getStreamAddressMap[{}]; Attempting to resolve backpointer for {} but address is trimmed.",
-                        this, startAddress, e);
+                // Info level as trimmedExceptions are handled by upper layers, which accordingly retry
+                // and abort in the case that a stream cannot be resolved from a checkpoint.
+                log.info("getStreamAddressMap[{}]; Attempting to resolve backpointer for {} but address is trimmed. " +
+                                "Looking for a checkpoint.",
+                        this, startAddress);
                 throw e;
             }
         }


### PR DESCRIPTION
Change log level from WARN to INFO and do not print stack trace, as this exception
is properly handled by upper layers and accordingly printed if leading to an actual exception.

Port to corfu-0.2.3