### PR TITLE
Rename SET_EPOCH to SEAL

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BaseServer.java
@@ -102,7 +102,7 @@ public class BaseServer extends AbstractServer {
      * @param ctx The channel context
      * @param r   The server router.
      */
-    @ServerHandler(type = CorfuMsgType.SET_EPOCH)
+    @ServerHandler(type = CorfuMsgType.SEAL)
     public synchronized void handleMessageSetEpoch(@NonNull CorfuPayloadMsg<Long> msg,
                                                    ChannelHandlerContext ctx,
                                                    @NonNull IServerRouter r) {
@@ -114,12 +114,12 @@ public class BaseServer extends AbstractServer {
             } catch (NullPointerException e) {
                 remoteHostAddress = "unavailable";
             }
-            log.info("handleMessageSetEpoch: Received SET_EPOCH from (clientId={}:{}), moving to new epoch {}",
+            log.info("handleMessageSetEpoch: Received SEAL from (clientId={}:{}), moving to new epoch {}",
                     msg.getClientID(), remoteHostAddress, epoch);
             serverContext.setServerEpoch(epoch, r);
             r.sendResponse(ctx, msg, CorfuMsgType.ACK.msg());
         } catch (WrongEpochException e) {
-            log.debug("handleMessageSetEpoch: Rejected SET_EPOCH current={}, requested={}",
+            log.debug("handleMessageSetEpoch: Rejected SEAL current={}, requested={}",
                     e.getCorrectEpoch(), msg.getPayload());
             r.sendResponse(ctx, msg,
                     new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH, e.getCorrectEpoch()));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LayoutServer.java
@@ -354,7 +354,7 @@ public class LayoutServer extends AbstractServer {
      * @param ctx netty ChannelHandlerContext
      * @param r   server router
      */
-    // TODO If a server does not get SET_EPOCH layout commit message cannot reach it
+    // TODO If a server does not get SEAL layout commit message cannot reach it
     // TODO as this message is not set to ignore EPOCH.
     // TODO How do we handle holes in history if we let in layout commit message. Maybe we have a
     // hole filling process

--- a/it/src/test/java/org/corfudb/universe/scenario/ClusterEdgeCases.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/ClusterEdgeCases.java
@@ -41,7 +41,7 @@ public class ClusterEdgeCases extends GenericIntegrationTest {
                 // Forcefully bump up the epoch.
                 runtimeLayout.getBaseClient(
                         originalLayout.getLayoutServers().stream().findFirst().get()
-                ).setRemoteEpoch(originalLayout.getEpoch() + 10);
+                ).sealRemoteServer(originalLayout.getEpoch() + 10);
 
                 {
                     final List<Throwable> exceptions = new ArrayList();

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -24,7 +24,7 @@ public enum CorfuMsgType {
     PING(0, TypeToken.of(CorfuMsg.class), true),
     PONG(1, TypeToken.of(CorfuMsg.class), true),
     RESET(2, TypeToken.of(CorfuMsg.class), true),
-    SET_EPOCH(3, new TypeToken<CorfuPayloadMsg<Long>>() {}, true),
+    SEAL(3, new TypeToken<CorfuPayloadMsg<Long>>() {}, true),
     ACK(4, TypeToken.of(CorfuMsg.class), true),
     WRONG_EPOCH(5, new TypeToken<CorfuPayloadMsg<Long>>() {},  true),
     NACK(6, TypeToken.of(CorfuMsg.class)),

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -15,7 +15,7 @@ import org.corfudb.protocols.wireprotocol.VersionInfo;
  * This is a base client which sends basic messages.
  * It mainly sends PINGs, as well as the ACK/NACKs defined by
  * the Corfu protocol.
- * This is also responsible to send SET_EPOCH messages used to seal the servers with an epoch
+ * This is also responsible to send SEAL messages used to seal the servers with an epoch
  *
  * <p>Created by mwei on 12/9/15.
  */
@@ -57,9 +57,9 @@ public class BaseClient implements IClient {
      * @param newEpoch New Epoch to be set
      * @return Completable future which returns true on successful epoch set.
      */
-    public CompletableFuture<Boolean> setRemoteEpoch(long newEpoch) {
-        CorfuMsg msg = new CorfuPayloadMsg<>(CorfuMsgType.SET_EPOCH, newEpoch).setEpoch(epoch);
-        log.info("setRemoteEpoch: send SET_EPOCH from me(clientId={}) to new epoch {}",
+    public CompletableFuture<Boolean> sealRemoteServer(long newEpoch) {
+        CorfuMsg msg = new CorfuPayloadMsg<>(CorfuMsgType.SEAL, newEpoch).setEpoch(epoch);
+        log.info("sealRemoteServer: send SEAL from me(clientId={}) to new epoch {}",
                 msg.getClientID(), epoch);
         return router.sendMessageAndGetCompletable(msg);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -187,7 +187,7 @@ public class LayoutManagementView extends AbstractView {
 
             // Seal the node to be healed.
             CFUtils.getUninterruptibly(runtime.getLayoutView().getRuntimeLayout(currentLayout)
-                    .getBaseClient(endpoint).setRemoteEpoch(currentLayout.getEpoch()));
+                    .getBaseClient(endpoint).sealRemoteServer(currentLayout.getEpoch()));
 
             // Reset the node to be healed.
             CFUtils.getUninterruptibly(runtime.getLayoutView().getRuntimeLayout(currentLayout)

--- a/runtime/src/main/java/org/corfudb/runtime/view/SealServersHelper.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SealServersHelper.java
@@ -38,7 +38,7 @@ public class SealServersHelper {
         // Seal all servers
         layout.getAllServers().forEach(server -> {
             CompletableFuture<Boolean> cf =
-                    runtimeLayout.getBaseClient(server).setRemoteEpoch(layout.getEpoch());
+                    runtimeLayout.getBaseClient(server).sealRemoteServer(layout.getEpoch());
             resultMap.put(server, cf);
         });
 

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -534,7 +534,7 @@ public class LayoutServerTest extends AbstractServerTest {
     private void commitReturnsAck(LayoutServer s1, Integer reboot, long baseEpoch) {
 
         long newEpoch = baseEpoch + reboot;
-        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.SET_EPOCH, newEpoch));
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.SEAL, newEpoch));
 
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         layout.setEpoch(newEpoch);
@@ -579,7 +579,7 @@ public class LayoutServerTest extends AbstractServerTest {
     }
 
     private void setEpoch(long epoch) {
-        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.SET_EPOCH, epoch));
+        sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.SEAL, epoch));
     }
 
     private void sendPrepare(long epoch, long rank) {

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
@@ -49,14 +49,14 @@ public class TestClientRouterTest extends AbstractCorfuTest {
     @Test
     public void onlyDropEpochChangeMessages() {
         tcr.rules.add(new TestRule()
-                .matches(x -> x.getMsgType().equals(CorfuMsgType.SET_EPOCH))
+                .matches(x -> x.getMsgType().equals(CorfuMsgType.SEAL))
                 .drop());
 
         assertThat(bc.pingSync())
                 .isTrue();
 
         final long NEW_EPOCH = 9L;
-        assertThatThrownBy(() -> bc.setRemoteEpoch(NEW_EPOCH).get())
+        assertThatThrownBy(() -> bc.sealRemoteServer(NEW_EPOCH).get())
                 .hasCauseInstanceOf(TimeoutException.class);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -22,14 +22,12 @@ import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.ISMRMap;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.AbortCause;
-import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.ServerNotReadyException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
 import org.corfudb.runtime.view.ClusterStatusReport.ConnectivityStatus;
 import org.corfudb.runtime.view.ClusterStatusReport.NodeStatus;
 import org.corfudb.runtime.view.stream.IStreamView;
-import org.corfudb.util.Sleep;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -380,7 +378,7 @@ public class ManagementViewTest extends AbstractViewTest {
 
         log.info("Only allow SERVERS.PORT_0 to manage failures. Prevent the other servers from handling failures.");
         TestRule testRule = new TestRule()
-                .matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.SET_EPOCH)
+                .matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.SEAL)
                         || corfuMsg.getMsgType().equals(CorfuMsgType.MANAGEMENT_FAILURE_DETECTED))
                 .drop();
 
@@ -401,7 +399,7 @@ public class ManagementViewTest extends AbstractViewTest {
         log.info("Prevent ENDPOINT_1 from sealing.");
         addClientRule(getManagementServer(SERVERS.PORT_0).getManagementAgent().getCorfuRuntime(),
                 SERVERS.ENDPOINT_1, new TestRule()
-                        .matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.SET_EPOCH))
+                        .matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.SEAL))
                         .drop());
         log.info("Simulate ENDPOINT_2 failure from ENDPOINT_1 (only Management Server)");
         addClientRule(getManagementServer(SERVERS.PORT_1).getManagementAgent().getCorfuRuntime(),
@@ -1443,7 +1441,7 @@ public class ManagementViewTest extends AbstractViewTest {
         managementRuntime1.getParameters().setSystemDownHandlerTriggerLimit(sysDownTriggerLimit);
 
         TestRule testRule = new TestRule()
-                .matches(m -> m.getMsgType().equals(CorfuMsgType.SET_EPOCH))
+                .matches(m -> m.getMsgType().equals(CorfuMsgType.SEAL))
                 .drop();
         addClientRule(managementRuntime0, testRule);
         addClientRule(managementRuntime1, testRule);


### PR DESCRIPTION
## Overview
The set epoch operation is in fact a seal operation. Set epoch
might imply arbitrarily setting an epoch, which is not the case.

Why should this be merged: Improves the nomenclature  

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
