### PR TITLE
[Corfu-0.2.3] Porting: Fix Netty channel keep alive NPE

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -591,8 +591,8 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
      * close the channel.
      */
     private void keepAlive() {
-        if (!channel.isOpen()) {
-            log.warn("keepAlive: channel not open, skipping sending keep alive.");
+        if (channel == null || !channel.isOpen()) {
+            log.info("keepAlive: channel not established or not open, skipping sending keep alive.");
             return;
         }
         // Send a keep alive message to server which ignores epoch


### PR DESCRIPTION
# Overview

Porting #2083

When client sending keep alive message, it is possible that the channel
is still not established, which causes a NullPointerException. This patch
adds an additional check to fix NPE.

Why should this be merged: Fix NPE

Related issue(s) (if applicable): #2083

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
