### PR TITLE
ILogData: Get rid of backward dependency on LogEntry.

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
@@ -13,15 +13,15 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.Address;
 import org.corfudb.util.serializer.ICorfuSerializable;
 
 
 /**
  * Created by mwei on 1/8/16.
  */
-@ToString(exclude = {"runtime", "entry"})
+@ToString(exclude = {"runtime"})
 @NoArgsConstructor
 public class LogEntry implements ICorfuSerializable {
 
@@ -42,11 +42,11 @@ public class LogEntry implements ICorfuSerializable {
     LogEntryType type;
 
     /**
-     * An underlying log entry, if present.
+     * The global address of this log entry.
      */
     @Getter
     @Setter
-    ILogData entry;
+    long globalAddress = Address.NON_ADDRESS;
 
     /**
      * Constructor for generating LogEntries.

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -121,10 +121,10 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
      * {@inheritDoc}
      */
     @Override
-    public void setEntry(ILogData entry) {
-        super.setEntry(entry);
+    public void setGlobalAddress(long address) {
+        super.setGlobalAddress(address);
         this.getEntryMap().values().forEach(x -> {
-            x.setEntry(entry);
+            x.setGlobalAddress(address);
         });
     }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiSMREntry.java
@@ -73,9 +73,9 @@ public class MultiSMREntry extends LogEntry implements ISMRConsumable {
     }
 
     @Override
-    public void setEntry(ILogData entry) {
-        super.setEntry(entry);
-        this.getUpdates().forEach(x -> x.setEntry(entry));
+    public void setGlobalAddress(long address) {
+        super.setGlobalAddress(address);
+        this.getUpdates().forEach(x -> x.setGlobalAddress(address));
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -1,14 +1,16 @@
 package org.corfudb.protocols.wireprotocol;
 
-import java.util.UUID;
-
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.runtime.CorfuRuntime;
 
-/** An interface to log data entries.
+import java.util.UUID;
+
+/**
+ * An interface to log data entries.
  * Log data entries represent data stored in the actual log,
  * with convenience methods for software to retrieve the
  * stored information.
+ *
  * Created by mwei on 8/17/16.
  */
 public interface ILogData extends IMetadata, Comparable<ILogData> {
@@ -22,26 +24,33 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
         return getGlobalAddress().compareTo(o.getGlobalAddress());
     }
 
-    /** This class provides a serialization handle, which
+    /**
+     * This class provides a serialization handle, which
      * manages the lifetime of the serialized copy of this
      * entry.
      */
     class SerializationHandle implements AutoCloseable {
 
-        /** A reference to the log data. */
+        /**
+         * A reference to the log data.
+         */
         final ILogData data;
 
-        /** Explicitly request the serialized form of this log data
+        /**
+         * Explicitly request the serialized form of this log data
          * which only exists for the lifetime of this handle.
-         * @return  The serialized form of this handle.
+         *
+         * @return The serialized form of this handle.
          */
         public ILogData getSerialized() {
             return data;
         }
 
-        /** Create a new serialized handle with a reference
+        /**
+         * Create a new serialized handle with a reference
          * to the log data.
-         * @param data  The log data to manage.
+         *
+         * @param data The log data to manage.
          */
         public SerializationHandle(ILogData data) {
             this.data = data;
@@ -111,23 +120,37 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
      */
     int getSizeEstimate();
 
-    /** Return whether the entry represents a hole or not. */
+    /**
+     * Assign a given token to this log data.
+     *
+     * @param token the token to use
+     */
+    void useToken(IToken token);
+
+    /**
+     * Return whether the entry represents a hole or not.
+     */
     default boolean isHole() {
         return getType() == DataType.HOLE;
     }
 
-    /** Return whether the entry represents an empty entry or not. */
+    /**
+     * Return whether the entry represents an empty entry or not.
+     */
     default boolean isEmpty() {
         return getType() == DataType.EMPTY;
     }
 
-    /** Return true if and only if the entry represents a trimmed address.*/
+    /**
+     * Return true if and only if the entry represents a trimmed address.
+     */
     default boolean isTrimmed() {
         return getType() == DataType.TRIMMED;
     }
 
     /**
      * Return the serialized size of an object
+     *
      * @param obj the entry's payload object
      * @return size of serialized buffer
      */
@@ -137,18 +160,6 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
         int size = ld.getSizeEstimate();
         ld.releaseBuffer();
         return size;
-    }
-
-    /** Assign a given token to this log data.
-     *
-     * @param token     The token to use.
-     */
-    default void useToken(IToken token) {
-        setGlobalAddress(token.getSequence());
-        setEpoch(token.getEpoch());
-        if (token.getBackpointerMap().size() > 0) {
-            setBackpointerMap(token.getBackpointerMap());
-        }
     }
 
     default void setId(UUID clientId) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -47,7 +47,7 @@ public interface IMetadata {
      */
     @SuppressWarnings("unchecked")
     default Set<UUID> getStreams() {
-        return (Set<UUID>) ((Map<UUID, Long>)getMetadataMap().getOrDefault(
+        return ((Map<UUID, Long>) getMetadataMap().getOrDefault(
                 LogUnitMetadataType.BACKPOINTER_MAP, Collections.emptyMap())).keySet();
     }
 
@@ -131,12 +131,8 @@ public interface IMetadata {
      */
     @SuppressWarnings("unchecked")
     default Long getGlobalAddress() {
-        if (getMetadataMap() == null
-                || getMetadataMap().get(LogUnitMetadataType.GLOBAL_ADDRESS) == null) {
-            return -1L;
-        }
         return Optional.ofNullable((Long) getMetadataMap()
-                .get(LogUnitMetadataType.GLOBAL_ADDRESS)).orElse((long) -1);
+                .get(LogUnitMetadataType.GLOBAL_ADDRESS)).orElse(Address.NON_ADDRESS);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -314,7 +314,7 @@ public class FastObjectLoader {
      * @return if the entry is already part of the checkpoint we started from.
      */
     private boolean entryAlreadyContainedInCheckpoint(UUID streamId, SMREntry entry) {
-        return streamsMetaData.containsKey(streamId) && entry.getEntry().getGlobalAddress() <
+        return streamsMetaData.containsKey(streamId) && entry.getGlobalAddress() <
                 streamsMetaData.get(streamId).getHeadAddress();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
@@ -56,7 +56,7 @@ public class StreamViewSMRAdapter implements ISMRStream {
                     && cp.getSmrEntries().getUpdates().size() > 0) {
                 cp.getSmrEntries().getUpdates().forEach(e -> {
                     e.setRuntime(runtime);
-                    e.setEntry(logData);
+                    e.setGlobalAddress(logData.getGlobalAddress());
                 });
                 return cp.getSmrEntries().getUpdates();
             } else {


### PR DESCRIPTION
## Overview

- LogEntry is the payload of LogData, however LogEntry also contains a
reference to LogData, which undermines readability and is error prone.
This is also unnecessary because the only reason to have this backward
dependency is LogEntry needs to know about the global address inside
LogData, which is consumed by VLO. This patch removed this dependency
by setting globalAddress directly.

- This is also a prerequisite a following patch that unifies SMREntry, MultiSMREntry
and MultiObjectSMREntry.

Related issue(s) (if applicable): #2080 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
