### PR TITLE
Change default NO_CONFLICT_KEY constant -- Port

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TokenResponse.java
@@ -17,7 +17,7 @@ import lombok.Data;
 @AllArgsConstructor
 public class TokenResponse implements ICorfuPayload<TokenResponse>, IToken {
 
-    public static byte[] NO_CONFLICT_KEY = new byte[]{};
+    public static byte[] NO_CONFLICT_KEY = new byte[]{ 0 };
     public static UUID NO_CONFLICT_STREAM = new UUID(0, 0);
 
     /**


### PR DESCRIPTION
Change it to a more sensible value byte[]{ 0 }.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
