### PR TITLE
Correct CheckpointWriter return Token

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -314,23 +314,19 @@ public class SequencerServer extends AbstractServer {
                                   ChannelHandlerContext ctx, IServerRouter r) {
         TokenRequest req = msg.getPayload();
         List<UUID> streams = req.getStreams();
-        List<Long> streamTails;
+        Map<UUID, Long> streamTails;
         Token token;
         if (req.getStreams().isEmpty()) {
             // Global tail query
             token = new Token(sequencerEpoch, globalLogTail - 1);
-            streamTails = Collections.emptyList();
-        } else if (req.getStreams().size() == 1) {
-            // single stream query
-            token = new Token(sequencerEpoch, streamTailToGlobalTailMap.getOrDefault(streams.get(0), Address.NON_EXIST));
-            streamTails = Collections.emptyList();
+            streamTails = Collections.emptyMap();
         } else {
-            // multiple stream query, the token is populated with the global tail and the tail queries are stored in
-            // streamTails
+            // multiple or single stream query, the token is populated with the global tail
+            // and the tail queries are stored in streamTails
             token = new Token(sequencerEpoch, globalLogTail - 1);
-            streamTails = new ArrayList<>(streams.size());
+            streamTails = new HashMap<>(streams.size());
             for (UUID stream : streams) {
-                streamTails.add(streamTailToGlobalTailMap.getOrDefault(stream, Address.NON_EXIST));
+                streamTails.put(stream, streamTailToGlobalTailMap.getOrDefault(stream, Address.NON_EXIST));
             }
         }
 
@@ -559,7 +555,7 @@ public class SequencerServer extends AbstractServer {
                     txResolutionResponse.getTokenType(),
                     txResolutionResponse.getConflictingKey(),
                     txResolutionResponse.getConflictingStream(),
-                    newToken, Collections.emptyMap(), Collections.emptyList())));
+                    newToken, Collections.emptyMap(), Collections.emptyMap())));
             return;
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -206,6 +206,13 @@ public class CorfuRuntime {
         int trimRetry = 2;
 
         /**
+         * The total number of retries the checkpointer will attempt on sequencer failover to
+         * prevent epoch regressions. This is independent of the number of streams to be checkpointed.
+         */
+        @Default
+        int checkpointRetries = 5;
+
+        /**
          * Stream Batch Size: number of addresses to fetch in advance when stream address discovery mechanism
          * relies on address maps instead of follow backpointers, i.e., followBackpointersEnabled = false;
          */

--- a/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
@@ -5,6 +5,7 @@ import com.codahale.metrics.Timer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.util.CorfuComponent;
@@ -45,7 +46,6 @@ public class MultiCheckpointWriter<T extends Map> {
         }
     }
 
-
     /** Checkpoint multiple SMRMaps. Since this method is Map specific
      *  then the keys are unique and the order doesn't matter.
      *
@@ -53,11 +53,11 @@ public class MultiCheckpointWriter<T extends Map> {
      * @param author Author's name, stored in checkpoint metadata
      * @return Global log address of the first record of
      */
-
     public Token appendCheckpoints(CorfuRuntime rt, String author) {
+        int numRetries = rt.getParameters().getCheckpointRetries();
+        int retry = 0;
         log.info("appendCheckpoints: appending checkpoints for {} maps", maps.size());
 
-        // TODO(Maithem) should we throw an exception if a new min is not discovered
         Token minSnapshot = Token.UNINITIALIZED;
 
         final long cpStart = System.currentTimeMillis();
@@ -71,17 +71,32 @@ public class MultiCheckpointWriter<T extends Map> {
                                 .getSerializer();
                 cpw.setSerializer(serializer);
 
-                Token minCPSnapshot = cpw.appendCheckpoint();
+                Token minCPSnapshot = Token.UNINITIALIZED;
+                while (retry < numRetries) {
+                    try {
+                        minCPSnapshot = cpw.appendCheckpoint();
+                        break;
+                    } catch (WrongEpochException wee) {
+                        log.info("Epoch changed to {} during append checkpoint snapshot resolution. Sequencer" +
+                                " failover can lead to potential epoch regression, retry {}/{}", wee.getCorrectEpoch(),
+                                retry, numRetries);
+                        retry++;
+                        if (retry == numRetries) {
+                            String msg = String.format("Epochs changed during checkpoint cycle, " +
+                                    "over more than %s times. Potential sequencer regressions can lead to data loss. " +
+                                    "Aborting.", numRetries);
+                            throw new IllegalStateException(msg);
+                        }
+                    }
+                }
 
                 if (minSnapshot == Token.UNINITIALIZED) {
                     minSnapshot = minCPSnapshot;
-                } else if (minSnapshot.getEpoch() != minCPSnapshot.getEpoch()) {
-                    String msg = String.format("Epoch changed during GC cycle from %s to %s", minSnapshot,
-                            minCPSnapshot);
+                } else if (minCPSnapshot.compareTo(minSnapshot) < 0) {
+                    // Given that the snapshot returned by appendCheckpoint is a global snapshot that shouldn't regress.
+                    String msg = String.format("Potential epoch regression. Subsequent checkpoint returned a greater" +
+                            "snapshot {} than previous {}.", minCPSnapshot, minSnapshot);
                     throw new IllegalStateException(msg);
-                } else if (Token.min(minCPSnapshot, minSnapshot) == minCPSnapshot) {
-                    // Adopt the new min
-                    minSnapshot = minCPSnapshot;
                 }
             }
         } finally {

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -193,7 +194,7 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         for (int x = 0; x < rt.getParameters().getTrimRetry(); x++) {
             // Linearize this read against a timestamp
             final long timestamp = rt.getSequencerView()
-                            .query(getStreamID()).getToken().getSequence();
+                            .query(getStreamID());
             log.debug("Access[{}] conflictObj={} version={}", this, conflictObject, timestamp);
 
             try {
@@ -268,9 +269,9 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
     @Override
     public void sync() {
         // Linearize this read against a timestamp
-        final Token timestamp =
-                rt.getSequencerView()
-                        .query(getStreamID()).getToken();
+        TokenResponse response = rt.getSequencerView()
+                .query(new UUID[]{getStreamID()});
+        final Token timestamp = new Token(response.getEpoch(), response.getStreamTail(getStreamID()));
 
         log.debug("Sync[{}] {}", this, timestamp);
         // Acquire locks and perform read.

--- a/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
@@ -80,13 +80,26 @@ public class SequencerView extends AbstractView {
     }
 
     /**
+     * Return the tail of a specific stream.
+     *
+     * @param streamId the stream to query
+     * @return the stream tail
+     */
+    public long query(UUID streamId) {
+        try (Timer.Context context = MetricsUtils.getConditionalContext(sequencerQuery)) {
+                return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
+                        .nextToken(Arrays.asList(streamId), 0))).getStreamTail(streamId);
+        }
+    }
+
+    /**
      * Return the next token in the sequencer for a particular stream.
      *
      * @param streamIds The stream IDs to retrieve from.
      * @return The first token retrieved.
      */
     public TokenResponse next(UUID ... streamIds) {
-        try (Timer.Context context = MetricsUtils.getConditionalContext(sequencerNextOneStream)){
+        try (Timer.Context context = MetricsUtils.getConditionalContext(sequencerNextOneStream)) {
             return layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
                     .nextToken(Arrays.asList(streamIds), 1)));
         }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -410,7 +410,7 @@ public abstract class AbstractQueuedStreamView extends
             try {
                 if (discoverAddressSpace(checkpointId, context.readCpQueue,
                         runtime.getSequencerView()
-                                .query(checkpointId).getToken().getSequence(),
+                                .query(checkpointId),
                         Address.NEVER_READ, d -> scanCheckpointStream(context, d, maxGlobal),
                         true, maxGlobal)) {
                     log.trace("Fill_Read_Queue[{}] Get Stream Address Map using checkpoint with {} entries",
@@ -458,8 +458,7 @@ public abstract class AbstractQueuedStreamView extends
             // belong to our stream.
             // For these reasons, we will keep this as the high boundary and prune
             // our discovered space of addresses up to maxGlobal.
-            latestTokenValue = runtime.getSequencerView().query(context.id)
-                    .getToken().getSequence();
+            latestTokenValue = runtime.getSequencerView().query(context.id);
             log.trace("Fill_Read_Queue[{}] Fetched tail {} from sequencer", this, latestTokenValue);
         }
 
@@ -593,7 +592,7 @@ public abstract class AbstractQueuedStreamView extends
     @Override
     public boolean getHasNext(QueuedStreamContext context) {
         return  !context.readQueue.isEmpty()
-                || runtime.getSequencerView().query(context.id).getToken().getSequence()
+                || runtime.getSequencerView().query(context.id)
                 > context.getGlobalPointer();
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -103,9 +103,9 @@ public class SequencerServerTest extends AbstractServerTest {
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                     new TokenRequest(0L, Collections.singletonList(streamA))));
-            Token checkTokenA = getLastPayloadMessageAs(TokenResponse.class).getToken();
+            long checkTokenA = getLastPayloadMessageAs(TokenResponse.class).getStreamTail(streamA);
 
-            assertThat(thisTokenA)
+            assertThat(thisTokenA.getSequence())
                     .isEqualTo(checkTokenA);
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
@@ -114,20 +114,20 @@ public class SequencerServerTest extends AbstractServerTest {
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                     new TokenRequest(0L, Collections.singletonList(streamB))));
-            Token checkTokenB = getLastPayloadMessageAs(TokenResponse.class).getToken();
+            long checkTokenB = getLastPayloadMessageAs(TokenResponse.class).getStreamTail(streamB);
 
-            assertThat(thisTokenB)
+            assertThat(thisTokenB.getSequence())
                     .isEqualTo(checkTokenB);
 
             sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                     new TokenRequest(0L, Collections.singletonList(streamA))));
-            Token checkTokenA2 = getLastPayloadMessageAs(TokenResponse.class).getToken();
+            long checkTokenA2 = getLastPayloadMessageAs(TokenResponse.class).getStreamTail(streamA);
 
             assertThat(checkTokenA2)
                     .isEqualTo(checkTokenA);
 
             assertThat(thisTokenB.getSequence())
-                    .isGreaterThan(checkTokenA2.getSequence());
+                    .isGreaterThan(checkTokenA);
         }
     }
 
@@ -230,16 +230,16 @@ public class SequencerServerTest extends AbstractServerTest {
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(0L, Collections.singletonList(streamA))));
-        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getSequence()).isEqualTo(newTailA);
+        assertThat(getLastPayloadMessageAs(TokenResponse.class).getStreamTail(streamA)).isEqualTo(newTailA);
 
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(0L, Collections.singletonList(streamB))));
-        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getSequence()).isEqualTo(newTailB);
+        assertThat(getLastPayloadMessageAs(TokenResponse.class).getStreamTail(streamB)).isEqualTo(newTailB);
 
         // We should have the same value than before
         sendMessage(new CorfuPayloadMsg<>(CorfuMsgType.TOKEN_REQ,
                 new TokenRequest(0L, Collections.singletonList(streamC))));
-        assertThat(getLastPayloadMessageAs(TokenResponse.class).getToken().getSequence()).isEqualTo(newTailC);
+        assertThat(getLastPayloadMessageAs(TokenResponse.class).getStreamTail(streamC)).isEqualTo(newTailC);
     }
 
 
@@ -284,7 +284,7 @@ public class SequencerServerTest extends AbstractServerTest {
         assertThat(getLastPayloadMessageAs(TokenResponse.class))
                 .isEqualTo(new TokenResponse(TokenType.NORMAL, TokenResponse.NO_CONFLICT_KEY,
                         TokenResponse.NO_CONFLICT_STREAM, new Token(newEpoch, num - 1),
-                        Collections.emptyMap(), Collections.emptyList()));
+                        Collections.emptyMap(), Collections.emptyMap()));
     }
 
 }

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -247,9 +247,7 @@ public class ClusterReconfigIT extends AbstractIT {
      */
     private void verifyData(CorfuRuntime corfuRuntime) throws Exception {
 
-        TokenResponse tokenResponse = corfuRuntime.getSequencerView()
-                .query(CorfuRuntime.getStreamID("test"));
-        long lastAddress = tokenResponse.getSequence();
+        long lastAddress = corfuRuntime.getSequencerView().query(CorfuRuntime.getStreamID("test"));
 
         Map<Long, LogData> map_0 = getAllNonEmptyData(corfuRuntime, "localhost:9000", lastAddress);
         Map<Long, LogData> map_1 = getAllNonEmptyData(corfuRuntime, "localhost:9001", lastAddress);
@@ -1177,7 +1175,7 @@ public class ClusterReconfigIT extends AbstractIT {
 
         // Verify sequencer has the correct steam tail.
         assertThat(runtime2.getLayoutView().getLayout().getPrimarySequencer()).isNotEqualTo(getServerEndpoint(PORT_0));
-        assertThat(runtime2.getSequencerView().query(streamId).getSequence()).isEqualTo(numEntries - 1);
+        assertThat(runtime2.getSequencerView().query(streamId)).isEqualTo(numEntries - 1);
 
         CorfuTable<String, String> table2 = runtime2.getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})

--- a/test/src/test/java/org/corfudb/integration/CmdletIT.java
+++ b/test/src/test/java/org/corfudb/integration/CmdletIT.java
@@ -183,8 +183,7 @@ public class CmdletIT extends AbstractIT {
         String commandNextToken = CORFU_PROJECT_DIR + "bin/corfu_sequencer -i " + streamA + " -c " + ENDPOINT + " next-token 3";
         runCmdletGetOutput(commandNextToken);
 
-        Token token = runtime.getSequencerView()
-                .query(CorfuRuntime.getStreamID(streamA)).getToken();
+        Token token = runtime.getSequencerView().query().getToken();
 
         String commandLatest = CORFU_PROJECT_DIR + "bin/corfu_sequencer -i " + streamA + " -c " + ENDPOINT + " latest";
         String output = runCmdletGetOutput(commandLatest);

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -859,12 +859,12 @@ public class ServerRestartIT extends AbstractIT {
             // Checkpoint Writer 2
             CheckpointWriter cpw2 = new CheckpointWriter(r, CorfuRuntime.getStreamID("test"),
                     "checkpointer-2", corfuTable1);
-            Token cp2Token = cpw2.appendCheckpoint(new Token(0, snapshotAddress2 - 1));
+            Token cp2Token = cpw2.appendCheckpoint(new Token(0, snapshotAddress2 - 1), (long) snapshotAddress2 - 1);
 
             // Checkpoint Writer 1
             CheckpointWriter cpw1 = new CheckpointWriter(r, CorfuRuntime.getStreamID("test"),
                     "checkpointer-1", corfuTable1);
-            cpw1.appendCheckpoint(new Token(0, snapshotAddress1 - 1));
+            cpw1.appendCheckpoint(new Token(0, snapshotAddress1 - 1), (long) snapshotAddress1 - 1);
 
             // Trim @snapshotAddress=15 (Checkpoint Writer 2)
             r.getAddressSpaceView().prefixTrim(cp2Token);

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -741,12 +741,12 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Start checkpoint with snapshot time 9 for mapA
             CheckpointWriter cpw = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(stream1),
                     "checkpointer-test", mapA);
-            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress));
+            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress), (long) snapshotAddress);
 
             // Start checkpoint with snapshot time 9 for mapB
             CheckpointWriter cpwB = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(stream2),
                     "checkpointer-test", mapB);
-            cpwB.appendCheckpoint(new Token(0, snapshotAddress));
+            cpwB.appendCheckpoint(new Token(0, snapshotAddress), (long) snapshotAddress);
 
             // Trim the log
             runtime.getAddressSpaceView().prefixTrim(cpAddress);
@@ -863,7 +863,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // we're interested in verifying the behaviour of streamA with end address != trim address.
             CheckpointWriter cpw = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(streamNameA),
                     "checkpoint-test", mapA);
-            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress));
+            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress), (long) snapshotAddress);
 
             // Trim the log
             runtime.getAddressSpaceView().prefixTrim(cpAddress);
@@ -962,7 +962,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Checkpoint A with snapshot @ 9
             CheckpointWriter cpw = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(streamNameA),
                     "checkpointer-test", mapA);
-            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress - 1));
+            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress - 1), (long) snapshotAddress - 1);
 
             // Trim the log
             runtime.getAddressSpaceView().prefixTrim(cpAddress);

--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -126,7 +126,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
     private void assertThatStreamTailsAreCorrect(Map<UUID, Long> streamTails) {
         maps.keySet().forEach((streamName) -> {
             UUID id = CorfuRuntime.getStreamID(streamName);
-            long tail = getDefaultRuntime().getSequencerView().query(id).getToken().getSequence();
+            long tail = getDefaultRuntime().getSequencerView().query(id);
             if (streamTails.containsKey(id)) {
                 assertThat(streamTails.get(id)).isEqualTo(tail);
             }
@@ -381,9 +381,9 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         Token snapshot = TransactionalContext
                 .getCurrentContext()
                 .getSnapshotTimestamp();
-        Token streamTail = getDefaultRuntime().getSequencerView().query(stream1).getToken();
+        long streamTail = getDefaultRuntime().getSequencerView().query(stream1);
         try {
-            cpw.startCheckpoint(snapshot, streamTail.getSequence());
+            cpw.startCheckpoint(snapshot, streamTail);
             cpw.appendObjectState(map.entrySet());
         } finally {
             getDefaultRuntime().getObjectsView().TXEnd();
@@ -655,8 +655,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
 
 
         UUID transactionStreams = rt1.getObjectsView().TRANSACTION_STREAM_ID;
-        long tailTransactionStream = rt1.getSequencerView().query(transactionStreams).
-                getToken().getSequence();
+        long tailTransactionStream = rt1.getSequencerView().query(transactionStreams);
 
         // Also recover the Transaction Stream
         assertThat(streamTails.size()).isEqualTo(mapCount + 1);

--- a/test/src/test/java/org/corfudb/runtime/clients/SequencerHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/SequencerHandlerTest.java
@@ -82,17 +82,17 @@ public class SequencerHandlerTest extends AbstractClientTest {
         UUID streamB = UUID.nameUUIDFromBytes("streamB".getBytes());
         client.nextToken(Collections.singletonList(streamA), 1).get();
         Token tokenA = client.nextToken(Collections.singletonList(streamA), 1).get().getToken();
-        Token tokenA2 = client.nextToken(Collections.singletonList(streamA), 0).get().getToken();
-        assertThat(tokenA)
+        long tokenA2 = client.nextToken(Collections.singletonList(streamA), 0).get().getStreamTail(streamA);
+        assertThat(tokenA.getSequence())
                 .isEqualTo(tokenA2);
-        Token tokenB = client.nextToken(Collections.singletonList(streamB), 0).get().getToken();
+        long tokenB = client.nextToken(Collections.singletonList(streamB), 0).get().getStreamTail(streamB);
         assertThat(tokenB)
                 .isNotEqualTo(tokenA2);
         Token tokenB2 = client.nextToken(Collections.singletonList(streamB), 1).get().getToken();
-        Token tokenB3 = client.nextToken(Collections.singletonList(streamB), 0).get().getToken();
-        assertThat(tokenB2)
+        long tokenB3 = client.nextToken(Collections.singletonList(streamB), 0).get().getStreamTail(streamB);
+        assertThat(tokenB2.getSequence())
                 .isEqualTo(tokenB3);
-        Token tokenA3 = client.nextToken(Collections.singletonList(streamA), 0).get().getToken();
+        long tokenA3 = client.nextToken(Collections.singletonList(streamA), 0).get().getStreamTail(streamA);
         assertThat(tokenA3)
                 .isEqualTo(tokenA2);
     }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -887,12 +887,12 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
 
         // Hole fill the address that the transaction is about to commit, to
         // create an OverwriteException and retry. The retry should succeed.
-        long currentTail = rt.getSequencerView().query().getToken().getSequence();
+        long currentTail = rt.getSequencerView().query().getSequence();
         rt.getAddressSpaceView().read(currentTail + 1);
 
         assertThatCode(this::TXEnd).doesNotThrowAnyException();
 
-        assertThat(rt.getSequencerView().query().getToken().getSequence()).isEqualTo(currentTail + 2);
+        assertThat(rt.getSequencerView().query().getSequence()).isEqualTo(currentTail + 2);
         assertThat(get("k1")).isEqualTo("v1");
         assertThat(get("k2")).isEqualTo("v2");
     }

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -95,8 +95,6 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
     /** Test Endpoint hostname. */
     private final static String testHostname = "tcp://test";
 
-    private boolean followBackpointers = false;
-
     /** Initialize the AbstractViewTest. */
     public AbstractViewTest() {
         this(false);

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -1,15 +1,23 @@
 package org.corfudb.runtime.view;
 
 import java.util.UUID;
+
+import com.google.common.reflect.TypeToken;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.TestLayoutBuilder;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.WrongClusterException;
 import org.corfudb.runtime.view.stream.IStreamView;
+import org.corfudb.util.NodeLocator;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -22,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.corfudb.test.TestUtils.waitForLayoutChange;
 
 /**
  * Created by mwei on 1/6/16.
@@ -659,5 +668,171 @@ public class LayoutViewTest extends AbstractViewTest {
         Layout alreadyProposedLayout3 = corfuRuntime1.getLayoutView().prepare(l.getEpoch(), rank3);
         assertThat(alreadyProposedLayout3).isEqualTo(l2);
 
+    }
+
+    /**
+     * Test that checkpoint writer can overcome sequencer regressions.
+     *
+     * Note: The checkpointer handles sequencer regressions by forcing a read on the snapshot address,
+     * hence, materializing the log until that point. However, there is a time difference between the moment the
+     * snapshot is acquired and the read is performed, which could also lead to sequencer regression.
+     * This test aims to evaluate this very specific case, i.e., whenever the failover occurs
+     * between the token query and the actual read of global tail.
+     *
+     * Steps followed in this test:
+     *
+     * 1. Write 2 entries to streamA
+     * 2. Request 2 tokens for streamB (do not write - space 2-3 will be the space for token regression)
+     * 3. Start checkpoint (global tail = 3, streamA tail = 1)
+     * 4. Insert rule in the runtime to induce sequencer failover right before the checkpoint read request (read on 3)
+     *    is issued.
+     *    This will make sequencer regress to token 1 (last observed update, losing tokens 2 and 3 issued for streamB).
+     *    Also, insert a new write to streamA (token = 2, modifying the state of streamA for snapshot 3) on
+     *    sequencer regression.
+     * 5. Complete checkpoint.
+     * 6. Write entries post-checkpoint to streamA.
+     * 7. Trim.
+     * 8. Instantiate fresh runtime and verify that no data is lost (new entry on regressed space, which is trimmed)
+     */
+    @Test
+    public void testCheckpointWriterSequencerRegressionInMiddleOfCheckpoint() {
+        final int numEntries = 2;
+        final String streamA = "streamA";
+        final String streamB = "streamB";
+
+        // Start a 3 node Cluster
+        addServer(SERVERS.PORT_0);
+        addServer(SERVERS.PORT_1);
+        addServer(SERVERS.PORT_2);
+
+        Layout l1 = new TestLayoutBuilder()
+                .setEpoch(0L)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addLayoutServer(SERVERS.PORT_1)
+                .addLayoutServer(SERVERS.PORT_2)
+                .addSequencer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_1)
+                .addSequencer(SERVERS.PORT_2)
+                .buildSegment()
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addLogUnit(SERVERS.PORT_1)
+                .addLogUnit(SERVERS.PORT_2)
+                .addToSegment()
+                .addToLayout()
+                .build();
+        bootstrapAllServers(l1);
+
+        getManagementServer(SERVERS.PORT_0).getManagementAgent().getRemoteMonitoringService()
+                .getFailureDetector().setFailureThreshold(1);
+        getManagementServer(SERVERS.PORT_1).getManagementAgent().getRemoteMonitoringService()
+                .getFailureDetector().setFailureThreshold(1);
+        getManagementServer(SERVERS.PORT_2).getManagementAgent().getRemoteMonitoringService()
+                .getFailureDetector().setFailureThreshold(1);
+
+        NodeLocator nodeLocator1 = NodeLocator.builder()
+                .host("test")
+                .port(SERVERS.PORT_1)
+                .build();
+
+        CorfuRuntime rt = getNewRuntime(getDefaultNode())
+                .connect();
+
+        // Open map A from rt
+        Map<String, Long> mA = rt.getObjectsView()
+                .build()
+                .setStreamName(streamA)
+                .setTypeToken(new TypeToken<SMRMap<String, Long>>() {
+                })
+                .open();
+
+        // Open map B from rt
+        Map<String, Long> mB = rt.getObjectsView()
+                .build()
+                .setStreamName(streamA)
+                .setTypeToken(new TypeToken<SMRMap<String, Long>>() {
+                })
+                .open();
+
+        // Runtime for Checkpoint
+        CorfuRuntime rtCp = getNewRuntime(nodeLocator1).connect();
+
+        final int[] readRequest = {0};
+
+        // Rule for Checkpoint Runtime - Induce sequencer failover right before the first read request
+        // issued by the checkpointer.
+        TestRule waitLayoutChange = new TestRule().matches(corfuMsg -> {
+            if(corfuMsg.getMsgType().equals(CorfuMsgType.READ_REQUEST) && readRequest[0] == 0) {
+                readRequest[0]++;
+                // Sequencer Failover
+                induceSequencerFailure();
+                System.out.println("Wait for layout to change (sequencer failover)");
+                waitForLayoutChange(layout ->
+                        layout.getEpoch() > 0L && !layout.getPrimarySequencer().equals(SERVERS.ENDPOINT_0), rtCp);
+                System.out.println("Layout change observed for sequencer failover");
+
+                // Write on StreamA after failover (move tail within the same space of last snapshot - regression)
+                System.out.println("Start write on space of sequencer regression.");
+                mA.put(String.valueOf(numEntries), (long) numEntries);
+                System.out.println("Finished critical write.");
+            }
+            return true;
+        });
+        addClientRule(rtCp, waitLayoutChange);
+
+        // Write numEntries to streamA
+        for (int i = 0; i < numEntries; i++) {
+            mA.put(String.valueOf(i), (long) i);
+        }
+
+        Token tk;
+        // Request numEntries tokens for streamB (do not actually write - regression will happen on these positions)
+        for (int i = numEntries; i < numEntries*2; i++) {
+            tk = rt.getSequencerView().next(CorfuRuntime.getStreamID(streamB)).getToken();
+            assertThat(tk.getSequence()).isEqualTo((long) i);
+        }
+
+        // MultiCheckpointWriter
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap(mA);
+        Token minSnapshot = mcw.appendCheckpoints(rtCp, "test-author");
+        assertThat(minSnapshot.getSequence()).isEqualTo((long) numEntries);
+        clearClientRules(rtCp);
+
+        // Add entries to MapA after checkpoint, to guarantee the regular stream is also loaded.
+        for (int i = numEntries+1; i < numEntries*2 + 1; i++) {
+            mA.put(String.valueOf(i), (long) i);
+        }
+
+        // Trim
+        rt.getAddressSpaceView().prefixTrim(minSnapshot);
+
+        // Instantiate new runtime, so we load from checkpoint and ensure no data loss on regressed space
+        CorfuRuntime rt2 = getNewRuntime(nodeLocator1).connect();
+
+        Map<String, Long> mA2 = rt2.getObjectsView()
+                .build()
+                .setStreamName(streamA)
+                .setTypeToken(new TypeToken<SMRMap<String, Long>>() {
+                })
+                .open();
+
+        assertThat(mA2.size()).isEqualTo(numEntries*2 + 1);
+        for (int i = 0; i < numEntries*2 + 1; i++) {
+            assertThat(mA2.get(String.valueOf(i))).isEqualTo((long) i);
+        }
+
+        final long checkpointStartRecordAddress = 4L;
+        CheckpointEntry entry = (CheckpointEntry) rt2.getAddressSpaceView()
+                .read(checkpointStartRecordAddress)
+                .getPayload(rt2);
+        assertThat(entry.getDict().get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS))
+                .isEqualTo(String.valueOf(numEntries));
+    }
+
+    private void induceSequencerFailure() {
+        // induce a failure to the server on PORT_0, where the current sequencer is active
+        getManagementServer(SERVERS.PORT_0).shutdown();
+        addServerRule(SERVERS.PORT_0, new TestRule().always().drop());
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.view;
 import lombok.Getter;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.junit.Test;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
@@ -30,6 +31,7 @@ public class SequencerViewTest extends AbstractViewTest {
     public void canQueryMultipleStreams() {
         CorfuRuntime r = getDefaultRuntime();
 
+        final int totalStreams = 3;
         UUID stream1 = UUID.randomUUID();
         UUID stream2 = UUID.randomUUID();
         UUID stream3 = UUID.randomUUID();
@@ -39,8 +41,11 @@ public class SequencerViewTest extends AbstractViewTest {
         assertThat(r.getSequencerView().next(stream2).getToken())
                 .isEqualTo(new Token( 0l, 1l));
 
-        assertThat(r.getSequencerView().query(stream1, stream2, stream3).getStreamTails())
-                .containsExactly(0l, 1l, Address.NON_EXIST);
+        TokenResponse response = r.getSequencerView().query(stream1, stream2, stream3);
+        assertThat(response.getStreamTailsCount()).isEqualTo(totalStreams);
+        assertThat(response.getStreamTail(stream1)).isEqualTo(0l);
+        assertThat(response.getStreamTail(stream2)).isEqualTo(1l);
+        assertThat(response.getStreamTail(stream3)).isEqualTo(Address.NON_EXIST);
     }
 
     @Test
@@ -69,14 +74,14 @@ public class SequencerViewTest extends AbstractViewTest {
 
         assertThat(r.getSequencerView().next(streamA).getToken())
                 .isEqualTo(new Token(0L, 0L));
-        assertThat(r.getSequencerView().query(streamA).getToken())
-                .isEqualTo(new Token(0L, 0L));
+        assertThat(r.getSequencerView().query(streamA))
+                .isEqualTo(0L);
         assertThat(r.getSequencerView().next(streamB).getToken())
                 .isEqualTo(new Token(0L, 1L));
-        assertThat(r.getSequencerView().query(streamB).getToken())
-                .isEqualTo(new Token(0L, 1L));
-        assertThat(r.getSequencerView().query(streamA).getToken())
-                .isEqualTo(new Token(0L, 0L));
+        assertThat(r.getSequencerView().query(streamB))
+                .isEqualTo(1L);
+        assertThat(r.getSequencerView().query(streamA))
+                .isEqualTo(0L);
     }
 
     @Test
@@ -87,11 +92,11 @@ public class SequencerViewTest extends AbstractViewTest {
 
         assertThat(r.getSequencerView().next(streamA).getBackpointerMap())
                 .containsEntry(streamA, Address.NON_EXIST);
-        assertThat(r.getSequencerView().query(streamA).getBackpointerMap())
+        assertThat(r.getSequencerView().query(new UUID[] {streamA}).getBackpointerMap())
                 .isEmpty();
         assertThat(r.getSequencerView().next(streamB).getBackpointerMap())
                 .containsEntry(streamB, Address.NON_EXIST);
-        assertThat(r.getSequencerView().query(streamB).getBackpointerMap())
+        assertThat(r.getSequencerView().query(new UUID[] {streamB}).getBackpointerMap())
                 .isEmpty();
         assertThat(r.getSequencerView().next(streamA).getBackpointerMap())
                 .containsEntry(streamA, 0L);

--- a/test/src/test/java/org/corfudb/runtime/view/StateTransferTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StateTransferTest.java
@@ -187,8 +187,7 @@ public class StateTransferTest extends AbstractViewTest {
         assertThat(clusterStatusReliability).isEqualTo(ClusterStatusReliability.STRONG_QUORUM);
         assertThat(corfuRuntime.getLayoutView().getLayout()).isEqualTo(expectedLayout);
 
-        TokenResponse tokenResponse = corfuRuntime.getSequencerView().query(CorfuRuntime.getStreamID("test"));
-        long lastAddress = tokenResponse.getSequence();
+        long lastAddress = corfuRuntime.getSequencerView().query(CorfuRuntime.getStreamID("test"));
 
         Map<Long, LogData> map_0 = getAllNonEmptyData(corfuRuntime, SERVERS.ENDPOINT_0, lastAddress);
         Map<Long, LogData> map_2 = getAllNonEmptyData(corfuRuntime, SERVERS.ENDPOINT_2, lastAddress);
@@ -331,9 +330,7 @@ public class StateTransferTest extends AbstractViewTest {
         // Verify sequencers in the layout and their order
         assertThat(actualLayout.getSequencers()).containsExactly(expectedNodes);
 
-        final TokenResponse tokenResponse = rt.getSequencerView().query(CorfuRuntime.getStreamID(
-                "test"));
-        final long lastAddress = tokenResponse.getSequence();
+        final long lastAddress = rt.getSequencerView().query(CorfuRuntime.getStreamID("test"));
 
         // Verify Nodes' data
         Map<Long, LogData> map_0 = getAllNonEmptyData(rt, SERVERS.ENDPOINT_0, lastAddress);

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -471,7 +471,8 @@ public class StreamViewTest extends AbstractViewTest {
 
         map.put("k1", "k1");
 
-        Token baseVersion = r.getSequencerView().query(CorfuRuntime.getStreamID(stream)).getToken();
+        UUID streamId = CorfuRuntime.getStreamID(stream);
+        long baseVersion = r.getSequencerView().query(streamId);
 
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(map);
@@ -505,11 +506,11 @@ public class StreamViewTest extends AbstractViewTest {
         assertThat(sv.getCurrentGlobalPosition()).isEqualTo(finalVersion.getSequence());
         assertThat(sv.previous()).isNotNull();
         assertThat(sv.previous()).isNull();
-        assertThat(sv.getCurrentGlobalPosition()).isEqualTo(baseVersion.getSequence());
+        assertThat(sv.getCurrentGlobalPosition()).isEqualTo(baseVersion);
         // Calling previous on a stream when the pointer points to a a base checkpoint
         // should throw a TrimmedException
         assertThatThrownBy(() -> sv.previous()).isInstanceOf(TrimmedException.class);
-        assertThat(sv.getCurrentGlobalPosition()).isEqualTo(baseVersion.getSequence());
+        assertThat(sv.getCurrentGlobalPosition()).isEqualTo(baseVersion);
     }
 
     /**
@@ -587,7 +588,7 @@ public class StreamViewTest extends AbstractViewTest {
         assertThatThrownBy(() -> txStream.remaining()).isInstanceOf(TrimmedException.class);
 
         // Ensure that we can recover.
-        txStream.seek(localRuntime.getSequencerView().query().getToken().getSequence());
+        txStream.seek(localRuntime.getSequencerView().query().getSequence());
         txStream.remaining();
     }
 }


### PR DESCRIPTION
## Overview

Description:

Return snapshot address at the time of checkpoint instead of stream tail address.

Why should this be merged: The checkpointing task will limit the trim task for those cases in which a stream has not observed updates for a while. In other words, the checkpointWriter token could remain the same for multiple checkpoint cycles if the tail has not progressed, preventing trim from happening. In this change, we correctly retrieve the actual snapshot as the checkpoint token and set the start log address as the stream's latest observed tail. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
