### PR TITLE
Add logging for Data Corruption Exceptions

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -286,7 +286,8 @@ public class LogUnitServer extends AbstractServer {
             }
             r.sendResponse(ctx, msg, CorfuMsgType.READ_RESPONSE.payloadMsg(rr));
         } catch (DataCorruptionException e) {
-            r.sendResponse(ctx, msg, CorfuMsgType.ERROR_DATA_CORRUPTION.msg());
+            log.error("Data corruption exception while reading address {}", address, e);
+            r.sendResponse(ctx, msg, CorfuMsgType.ERROR_DATA_CORRUPTION.payloadMsg(address));
         }
     }
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -77,7 +77,7 @@ public enum CorfuMsgType {
     ERROR_RANK(54, TypeToken.of(CorfuMsg.class)),
     ERROR_NOENTRY(55, TypeToken.of(CorfuMsg.class)),
     RANGE_WRITE(56, new TypeToken<CorfuPayloadMsg<RangeWriteMsg>>(){}),
-    ERROR_DATA_CORRUPTION(57, TypeToken.of(CorfuMsg.class)),
+    ERROR_DATA_CORRUPTION(57, new TypeToken<CorfuPayloadMsg<Long>>(){}),
     ERROR_DATA_OUTRANKED(58, TypeToken.of(CorfuMsg.class)),
     ERROR_VALUE_ADOPTED(59,new TypeToken<CorfuPayloadMsg<ReadResponse>>() {}),
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitHandler.java
@@ -11,6 +11,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.KnownAddressResponse;
+import org.corfudb.protocols.wireprotocol.ReadRequest;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
@@ -179,9 +180,10 @@ public class LogUnitHandler implements IClient, IHandler<LogUnitClient> {
      * @param r   Router
      */
     @ClientHandler(type = CorfuMsgType.ERROR_DATA_CORRUPTION)
-    private static Object handleReadDataCorruption(CorfuMsg msg,
+    private static Object handleReadDataCorruption(CorfuPayloadMsg<Long> msg,
                                                    ChannelHandlerContext ctx, IClientRouter r) {
-        throw new DataCorruptionException();
+        long read = msg.getPayload().longValue();
+        throw new DataCorruptionException(String.format("Encountered corrupted data while reading %s", read));
     }
 
     /**


### PR DESCRIPTION
Why should this be merged: if we receive a DataCorruptionException on the client side, we are unable to track the actual address that led to this exception. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
