### PR TITLE
Persistent back-end for CorfuTable

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -140,6 +140,11 @@
             <version>0.3.0</version>
         </dependency>
         <dependency>
+            <groupId>org.rocksdb</groupId>
+            <artifactId>rocksdbjni</artifactId>
+            <version>6.2.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
             <version>0.7.36</version>

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -1,6 +1,5 @@
 package org.corfudb.runtime.collections;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
@@ -37,7 +36,6 @@ import org.corfudb.annotations.DontInstrument;
 import org.corfudb.annotations.Mutator;
 import org.corfudb.annotations.MutatorAccessor;
 import org.corfudb.annotations.TransactionalMethod;
-import org.corfudb.util.ImmuableListSetWrapper;
 
 /** The CorfuTable implements a simple key-value store.
  *
@@ -223,39 +221,58 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
     }
 
     // The "main" map which contains the primary key-value mappings.
-    private final Map<K,V> mainMap;
+    private final StreamingMap<K,V> mainMap;
     private final Set<Index<K, V, ? extends Comparable>> indexSpec = new HashSet<>();
     private final Map<String, Map<Comparable, Map<K, V>>> secondaryIndexes = new HashMap<>();
 
     /**
-     * Generate a table with a given implementation for the mainMap
+     * Generate a table with a given implementation for the {@link StreamingMap}.
      */
-    public CorfuTable(IndexRegistry<K, V> indices, Map<K, V> mapImpl) {
+    public CorfuTable(IndexRegistry<K, V> indices, StreamingMap<K, V> streamingMap) {
         indices.forEach(index -> {
             secondaryIndexes.put(index.getName().get(), new HashMap<>());
             indexSpec.add(index);
         });
         log.info("CorfuTable: creating CorfuTable with the following indexes: {}",
                 secondaryIndexes.keySet());
-        mainMap = mapImpl;
+        mainMap = streamingMap;
+    }
+
+    /**
+     * Generate a table with a given implementation for the {@link Map}.
+     */
+    public CorfuTable(IndexRegistry<K, V> indices, Map<K, V> mapImpl) {
+        this(indices, new StreamingMapDecorator<>(mapImpl));
     }
 
     /**
      * Generate a table with the given set of indexes.
      */
     public CorfuTable(IndexRegistry<K, V> indices) {
-        this(indices, new HashMap<>());
+        this(indices, new StreamingMapDecorator<>(new HashMap<>()));
+    }
+
+    /**
+     * Generates a table with the given {@link Map} implementation and
+     * without any secondary indexes.
+     */
+    public CorfuTable(Map<K, V> mapImpl) {
+        this(IndexRegistry.empty(), mapImpl);
+    }
+
+    /**
+     * Generates a table with the given {@link StreamingMap} implementation
+     * and without any secondary indexes.
+     */
+    public CorfuTable(StreamingMap<K, V> streamingMap) {
+        this(IndexRegistry.empty(), streamingMap);
     }
 
     /**
      * Default constructor. Generates a table without any secondary indexes.
      */
     public CorfuTable() {
-        this(IndexRegistry.empty(), new HashMap<>());
-    }
-
-    public CorfuTable(Map<K, V> underlying) {
-        this(IndexRegistry.empty(), underlying);
+        this(IndexRegistry.empty(), new StreamingMapDecorator<>(new HashMap<>()));
     }
 
     /** {@inheritDoc} */
@@ -457,24 +474,24 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
      * This method has a memory/CPU advantage over the map iterators as no deep copy
      * is actually performed.
      *
-     * @param p java predicate (function to evaluate)
+     * @param valuePredicate java predicate (function to evaluate)
      * @return a view of the values contained in this map meeting the predicate condition.
      */
     @Accessor
-    public List<V> scanAndFilter(Predicate<? super V> p) {
-        return mainMap.values().parallelStream()
-                                    .filter(p)
-                                    .collect(Collectors.toCollection(ArrayList::new));
+    public List<V> scanAndFilter(Predicate<? super V> valuePredicate) {
+        return mainMap.entryStream()
+                .map(Entry::getValue).filter(valuePredicate)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     /** {@inheritDoc} */
     @Override
     @Accessor
-    public Collection<Map.Entry<K, V>> scanAndFilterByEntry(Predicate<? super Map.Entry<K, V>>
-                                                                    entryPredicate) {
-        return mainMap.entrySet().parallelStream()
-                                    .filter(entryPredicate)
-                                    .collect(Collectors.toCollection(ArrayList::new));
+    public Collection<Map.Entry<K, V>> scanAndFilterByEntry(
+            Predicate<? super Map.Entry<K, V>> entryPredicate) {
+        return mainMap.entryStream()
+                .filter(entryPredicate)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     /** {@inheritDoc} */
@@ -549,14 +566,16 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
     @Override
     @Accessor
     public @Nonnull Set<K> keySet() {
-        return ImmutableSet.copyOf(mainMap.keySet());
+        return mainMap.entryStream().map(Entry::getKey)
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     /** {@inheritDoc} */
     @Override
     @Accessor
     public @Nonnull Collection<V> values() {
-        return ImmutableList.copyOf(mainMap.values());
+        return mainMap.entryStream().map(Entry::getValue)
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     /**
@@ -566,13 +585,16 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
     @Override
     @Accessor
     public @Nonnull Set<Entry<K, V>> entrySet() {
-        List<Entry<K, V>> copy = new ArrayList<>(mainMap.size());
-        for (Map.Entry<K, V> entry : mainMap.entrySet()) {
-            copy.add(new AbstractMap.SimpleImmutableEntry<>(entry.getKey(),
-                    entry.getValue()));
-        }
-        return new ImmuableListSetWrapper<>(copy);
+        return mainMap.entryStream().map(entry ->
+                new AbstractMap.SimpleImmutableEntry<>(entry.getKey(), entry.getValue()))
+                .collect(ImmutableSet.toImmutableSet());
     }
+
+    @Accessor
+    public @Nonnull Stream<Entry<K, V>> entryStream() {
+        return mainMap.entryStream();
+    }
+
 
     /** {@inheritDoc} */
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
@@ -1,0 +1,296 @@
+package org.corfudb.runtime.collections;
+
+import com.google.common.collect.Streams;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.util.serializer.ISerializer;
+import org.rocksdb.RocksDB;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+
+/**
+ * A concrete implementation of {@link StreamingMap} that is capable of storing data
+ * off-heap. The location for the off-heap data is provided by {@link File} dataPath,
+ * while the resource policy (memory and storage limits) are defined in {@link Options}.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+@Slf4j
+public class PersistedStreamingMap<K, V> implements StreamingMap<K, V> {
+
+    private final AtomicInteger dataSetSize = new AtomicInteger();
+    private final CorfuRuntime corfuRuntime;
+    private final ISerializer serializer;
+    private final RocksDB rocksDb;
+
+    public PersistedStreamingMap(@NonNull File dataPath,
+                                 @NonNull Options options,
+                                 @NonNull ISerializer serializer,
+                                 @NonNull CorfuRuntime corfuRuntime) {
+        try {
+            FileUtils.deleteDirectory(dataPath);
+            this.rocksDb = RocksDB.open(options, dataPath.getAbsolutePath());
+        } catch (RocksDBException | IOException e) {
+            throw new UnrecoverableCorfuError(e);
+        }
+        this.serializer = serializer;
+        this.corfuRuntime = corfuRuntime;
+    }
+
+    /**
+     * A Java compatible {@link RocksIterator} implementation
+     */
+    public class RocksDbIterator implements Iterator<Entry<K, V>> {
+        private RocksIterator iterator;
+        private Entry<K, V> current;
+        private Entry<K, V> next;
+
+        public RocksDbIterator(RocksIterator iterator) {
+            this.iterator = iterator;
+        }
+
+        /**
+         * Ensure that this iterator is operating under the correct assumptions.
+         */
+        private void checkInvariants() {
+            // RocksDB does not support multi-threaded access.
+            // If the iterator was created by some thread, it also has to be consumed by it.
+            if (!iterator.isOwningHandle()) {
+                throw new IllegalStateException("Detected multi-threaded access to this iterator.");
+            }
+
+            try {
+                iterator.status();
+            } catch (RocksDBException e) {
+                throw new UnrecoverableCorfuError(
+                        "There was an error reading the persisted map.", e);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean hasNext() {
+            // If we have the next element pipelined, go ahead and return true.
+            if (next != null) {
+                return true;
+            }
+
+            // If the iterator is valid, this means that the next entry exists.
+            checkInvariants();
+            if (iterator.isValid()) {
+                // Go ahead and cache that entry.
+                next = new AbstractMap.SimpleEntry(
+                        serializer.deserialize(Unpooled.wrappedBuffer(iterator.key()), corfuRuntime),
+                        serializer.deserialize(Unpooled.wrappedBuffer(iterator.value()), corfuRuntime));
+                // Advance the underlying iterator.
+                iterator.next();
+            } else {
+                // If there is no more elements to consume, we should release the resources.
+                iterator.close();
+            }
+
+            return next != null;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Entry<K, V> next() {
+            checkInvariants();
+
+            if (hasNext()) {
+                current = next;
+                next = null;
+                return current;
+            } else {
+                throw new NoSuchElementException();
+            }
+
+        }
+    }
+
+    public static byte[] byteArrayFromBuf(final ByteBuf buf) {
+        ByteBuf readOnlyCopy = buf.asReadOnly();
+        readOnlyCopy.resetReaderIndex();
+        byte[] outArray = new byte[readOnlyCopy.readableBytes()];
+        readOnlyCopy.readBytes(outArray);
+        return outArray;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int size() {
+        return dataSetSize.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEmpty() {
+        return dataSetSize.get() == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean containsKey(@NonNull Object key) {
+        ByteBuf payload = Unpooled.buffer();
+        serializer.serialize(key, payload);
+        try {
+            byte[] value = rocksDb.get(payload.array());
+            return value != null;
+        } catch (RocksDBException ex) {
+            throw new UnrecoverableCorfuError(ex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Please use {@link StreamingMap#entryStream()}.
+     */
+    @Override
+    public boolean containsValue(@NonNull Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V get(@NonNull Object key) {
+        ByteBuf keyPayload = Unpooled.buffer();
+        serializer.serialize(key, keyPayload);
+
+        try {
+            byte[] value = rocksDb.get(byteArrayFromBuf(keyPayload));
+            if (value == null) {
+                return null;
+            }
+            return (V) serializer.deserialize(Unpooled.wrappedBuffer(value), corfuRuntime);
+        } catch (RocksDBException ex) {
+            throw new UnrecoverableCorfuError(ex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V put(@NonNull K key, @NonNull V value) {
+        ByteBuf keyPayload = Unpooled.buffer();
+        ByteBuf valuePayload = Unpooled.buffer();
+        serializer.serialize(key, keyPayload);
+        serializer.serialize(value, valuePayload);
+
+        try {
+            rocksDb.put(byteArrayFromBuf(keyPayload), byteArrayFromBuf(valuePayload));
+        } catch (RocksDBException ex) {
+            throw new UnrecoverableCorfuError(ex);
+        }
+
+        dataSetSize.incrementAndGet();
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V remove(@NonNull Object key) {
+        ByteBuf keyPayload = Unpooled.buffer();
+        serializer.serialize(key, keyPayload);
+        try {
+            V value = get(key);
+            if (value != null) {
+                rocksDb.delete(byteArrayFromBuf(keyPayload));
+                dataSetSize.decrementAndGet();
+                return value;
+            } else {
+                return null;
+            }
+        } catch (RocksDBException ex) {
+            throw new UnrecoverableCorfuError(ex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void putAll(@NonNull Map<? extends K, ? extends V> map) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clear() {
+        dataSetSize.set(0);
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<K> keySet() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Please use {@link StreamingMap#entryStream()}.
+     */
+    @Override
+    public Collection<V> values() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Please use {@link StreamingMap#entryStream()}.
+     */
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<Entry<K, V>> entryStream() {
+        final RocksIterator rocksIterator = rocksDb.newIterator();
+        rocksIterator.seekToFirst();
+        return Streams.stream(new RocksDbIterator(rocksIterator));
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMap.java
@@ -1,0 +1,18 @@
+package org.corfudb.runtime.collections;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ *
+ * This interface provides additional functionality not provided by the standard {@link Map}.
+ * In cases when the actual data is not being backed by the heap, {@link Map#values()},
+ * {@link Map#keySet()} or {@link Map#entrySet()} will not suffice, since we cannot guarantee
+ * that the data-set will fit in the memory.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+interface StreamingMap<K, V> extends Map<K, V> {
+    Stream<Map.Entry<K, V>> entryStream();
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
@@ -1,0 +1,127 @@
+package org.corfudb.runtime.collections;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * A decorated map that provides additional functionality defined by the {@link StreamingMap}
+ * interface. Whatever guarantees are being provided the the underlying map implementation
+ * (such as ordering, retrieval complexity...) are also provided by this map.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class StreamingMapDecorator<K, V> implements StreamingMap<K, V> {
+
+    final Map<K, V> mapImpl;
+
+    StreamingMapDecorator(Map<K, V> mapImpl) {
+        this.mapImpl = mapImpl;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<Entry<K, V>> entryStream() {
+        return mapImpl.entrySet().stream().parallel();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int size() {
+        return mapImpl.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEmpty() {
+        return mapImpl.isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean containsKey(Object key) {
+        return mapImpl.containsKey(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean containsValue(Object value) {
+        return mapImpl.containsValue(value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V get(Object key) {
+        return mapImpl.get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V put(K key, V value) {
+        return mapImpl.put(key, value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V remove(Object key) {
+        return mapImpl.remove(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map) {
+        mapImpl.putAll(map);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clear() {
+        mapImpl.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<K> keySet() {
+        return mapImpl.keySet();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<V> values() {
+        return mapImpl.values();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return mapImpl.entrySet();
+    }
+}

--- a/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
@@ -1,0 +1,194 @@
+package org.corfudb.runtime.collections;
+
+import com.google.common.reflect.TypeToken;
+import com.google.gson.Gson;
+import io.netty.buffer.ByteBuf;
+import lombok.Builder;
+import lombok.Data;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.rocksdb.Env;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.SstFileManager;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Disk-backed {@link StreamingMap} tests.
+ */
+public class DiskBackedCorfuClientTest extends AbstractViewTest {
+
+    /**
+     * Single type POJO serializer.
+     */
+    public static class PojoSerializer implements ISerializer {
+        private final Gson gson = new Gson();
+        private final Class<?> clazz;
+        private final int SERIALIZER_OFFSET = 23;  // Random number.
+
+        PojoSerializer(Class<?> clazz) {
+            this.clazz = clazz;
+        }
+
+        @Override
+        public byte getType() {
+            return SERIALIZER_OFFSET;
+        }
+
+        @Override
+        public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+            return gson.fromJson(new String(PersistedStreamingMap.byteArrayFromBuf(b)), clazz);
+        }
+
+        @Override
+        public void serialize(Object o, ByteBuf b) {
+            b.writeBytes(gson.toJson(o).getBytes());
+        }
+    }
+
+    /**
+     * Sample POJO class.
+     */
+    @Data
+    @Builder
+    public static class Pojo {
+        public final String payload;
+    }
+
+    /**
+     * Ensure disk-backed table serialization and deserialization works as expected.
+     *
+     * @throws RocksDBException
+     */
+    @Test
+    public void customSerializer() throws RocksDBException {
+        RocksDB.loadLibrary();
+
+        final File persistedCacheLocation = new File("/tmp/", "diskBackedMap");
+        final Options options =
+                new Options().setCreateIfMissing(true)
+                        // The size is checked either during flush or compaction.
+                        .setWriteBufferSize(FileUtils.ONE_KB);
+
+        CorfuTable<String, Pojo>
+                table = getDefaultRuntime().getObjectsView().build()
+                .setTypeToken(new TypeToken<CorfuTable<String, Pojo>>() {})
+                .setArguments(new PersistedStreamingMap<String, Pojo>(
+                        persistedCacheLocation, options,
+                        new PojoSerializer(Pojo.class), getRuntime()))
+                .setStreamName("diskBackedMap")
+                .open();
+
+        final long ITERATION_COUNT = 100;
+        final int ENTITY_CHAR_SIZE = 100;
+
+        LongStream.rangeClosed(1, ITERATION_COUNT).forEach(idx -> {
+            String key = RandomStringUtils.random(ENTITY_CHAR_SIZE, true, true);
+            Pojo value = Pojo.builder()
+                    .payload(RandomStringUtils.random(ENTITY_CHAR_SIZE, true, true))
+                    .build();
+            table.put(key, value);
+            Pojo persistedValue = table.get(key);
+            Assertions.assertEquals(value, persistedValue);
+        });
+    }
+
+    /**
+     * Ensure that file-system quota is obeyed.
+     *
+     * @throws RocksDBException
+     */
+    @Test
+    public void fileSystemLimit() throws RocksDBException {
+        RocksDB.loadLibrary();
+
+        final File persistedCacheLocation = new File("/tmp/", "diskBackedMap");
+        SstFileManager sstFileManager = new SstFileManager(Env.getDefault());
+        sstFileManager.setMaxAllowedSpaceUsage(FileUtils.ONE_KB);
+        sstFileManager.setCompactionBufferSize(FileUtils.ONE_KB);
+
+        final Options options =
+                new Options().setCreateIfMissing(true)
+                        .setSstFileManager(sstFileManager)
+                        // The size is checked either during flush or compaction.
+                        .setWriteBufferSize(FileUtils.ONE_KB);
+
+        CorfuTable<String, String>
+                table = getDefaultRuntime().getObjectsView().build()
+                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setArguments(new PersistedStreamingMap<String, String>(
+                        persistedCacheLocation, options,
+                        Serializers.JSON, getRuntime()))
+                .setStreamName("diskBackedMap")
+                .open();
+
+        final long ITERATION_COUNT = 100000;
+        final int ENTITY_CHAR_SIZE = 1000;
+
+        assertThatThrownBy(() ->
+                LongStream.rangeClosed(1, ITERATION_COUNT).forEach(idx -> {
+                    String key = RandomStringUtils.random(ENTITY_CHAR_SIZE, true, true);
+                    String value = RandomStringUtils.random(ENTITY_CHAR_SIZE, true, true);
+                    table.put(key, value);
+                    String persistedValue = table.get(key);
+                    Assertions.assertEquals(value, persistedValue);
+                })).isInstanceOf(UnrecoverableCorfuError.class)
+                .hasCauseInstanceOf(RocksDBException.class);
+    }
+
+    /**
+     * Ensure that scan-and-filter works as expected.
+     *
+     * @throws RocksDBException
+     */
+    @Test
+    public void scanAndFilter() throws RocksDBException {
+        RocksDB.loadLibrary();
+
+        final File persistedCacheLocation = new File("/tmp/", "diskBackedMap");
+        final Options options = new Options().setCreateIfMissing(true);
+        final StreamingMap streamingMap = new PersistedStreamingMap<String, String>(
+                persistedCacheLocation, options,
+                new PojoSerializer(String.class), getRuntime());
+        CorfuTable<String, String>
+                table = getDefaultRuntime().getObjectsView().build()
+                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setArguments(streamingMap)
+                .setStreamName("diskBackedMap")
+                .open();
+
+        final long ITERATION_COUNT = 100;
+        final int ENTITY_CHAR_SIZE = 100;
+
+        Map<String, String> correctMap = new HashMap<String, String>();
+        LongStream.rangeClosed(1, ITERATION_COUNT).forEach(idx -> {
+            String key = RandomStringUtils.random(ENTITY_CHAR_SIZE, true, true);
+            String value = RandomStringUtils.random(ENTITY_CHAR_SIZE, true, true);
+            Assertions.assertNotNull(key);
+            Assertions.assertNotNull(value);
+            table.put(key, value);
+            table.get(key).equals(value);
+            correctMap.put(key, value);
+        });
+
+        Assertions.assertEquals(correctMap.size(), table.entryStream().count());
+        table.entryStream().forEach(Assertions::assertNotNull);
+        table.entryStream().map(Map.Entry::getKey).map(correctMap::remove)
+                .forEach(Assertions::assertNotNull);
+        Assertions.assertEquals(0, correctMap.size());
+    }
+}


### PR DESCRIPTION
## Overview

Description:

By default, CorfuTable builds its view in-memory, but in some
circumstances the data set is either too large or it causes
unnecessary memory bloat. This patch addresses this issue by
introducing a feature that lets client offload the data from
heap to disk.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
