### PR TITLE
[Port 0.2.3] Remove the log line "Runtime cache disabled.." to stop flooding

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -318,11 +318,6 @@ public class AddressSpaceView extends AbstractView {
      * configurations
      */
     private boolean cacheReadRequest(ReadOptions options) {
-        if (runtime.getParameters().isCacheDisabled() && options.isClientCacheable()) {
-            // TODO(Maithem): We can remove this once we have multi-level caches
-            log.warn("read: Runtime cache is disabled, but read request is requesting to cache");
-        }
-
         return !runtime.getParameters().isCacheDisabled() && options.isClientCacheable();
     }
 

--- a/test/src/test/java/org/corfudb/CorfuTestParameters.java
+++ b/test/src/test/java/org/corfudb/CorfuTestParameters.java
@@ -104,7 +104,7 @@ public class CorfuTestParameters {
                                         Duration.of(1, SECONDS);
         TIMEOUT_NORMAL = TRAVIS_BUILD ? Duration.of(20, SECONDS) :
                                         Duration.of(10, SECONDS);
-        TIMEOUT_LONG = TRAVIS_BUILD ? Duration.of(2, MINUTES):
+        TIMEOUT_LONG = TRAVIS_BUILD ? Duration.of(5, MINUTES):
                                         Duration.of(2, MINUTES);
 
         // Iterations


### PR DESCRIPTION
Avoid flooding of checkpointer logs