### PR TITLE
Add an additional cluster type to Universe

### DIFF
--- a/it/src/main/java/org/corfudb/universe/group/Group.java
+++ b/it/src/main/java/org/corfudb/universe/group/Group.java
@@ -3,6 +3,7 @@ package org.corfudb.universe.group;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
+import org.corfudb.universe.group.cluster.Cluster;
 import org.corfudb.universe.node.Node;
 import org.corfudb.universe.node.Node.NodeType;
 import org.corfudb.universe.universe.Universe;
@@ -69,11 +70,15 @@ public interface Group {
 
     <T extends Node> T getNode(String nodeName);
 
-    interface GroupParams {
+    interface GroupParams<T extends NodeParams> {
         String getName();
 
-        <T extends NodeParams> ImmutableSortedSet<T> getNodesParams();
+        Cluster.ClusterType getType();
 
-        NodeType getNodeType();
+        ImmutableSortedSet<T> getNodesParams();
+
+        GroupParams<T> add(T nodeParams);
+
+        String getFullNodeName(String nodeName);
     }
 }

--- a/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCluster.java
@@ -1,0 +1,129 @@
+package org.corfudb.universe.group.cluster;
+
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedSet;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.universe.group.Group;
+import org.corfudb.universe.node.Node;
+import org.corfudb.universe.node.Node.NodeParams;
+import org.corfudb.universe.node.NodeException;
+import org.corfudb.universe.node.client.LocalCorfuClient;
+import org.corfudb.universe.node.server.CorfuServer;
+import org.corfudb.universe.universe.UniverseParams;
+import org.corfudb.common.util.ClassUtils;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static lombok.Builder.Default;
+
+@Slf4j
+public abstract class AbstractCluster<
+        N extends NodeParams,
+        P extends Group.GroupParams<N>,
+        U extends UniverseParams> implements Cluster {
+
+    @Default
+    protected final ConcurrentNavigableMap<String, CorfuServer> nodes = new ConcurrentSkipListMap<>();
+
+    @Getter
+    @NonNull
+    protected final P params;
+
+    @NonNull
+    protected final U universeParams;
+
+    private final ExecutorService executor;
+
+    protected AbstractCluster(P params, U universeParams) {
+        this.params = params;
+        this.universeParams = universeParams;
+        this.executor = Executors.newCachedThreadPool();
+    }
+
+    protected CompletableFuture<Node> deployAsync(Node server) {
+        return CompletableFuture.supplyAsync(server::deploy, executor);
+    }
+
+    protected abstract Node buildServer(N nodeParams);
+
+    /**
+     * Stop the cluster
+     *
+     * @param timeout allowed time to gracefully stop the {@link Group}
+     */
+    @Override
+    public void stop(Duration timeout) {
+        log.info("Stop corfu cluster: {}", params.getName());
+
+        nodes.values().forEach(node -> {
+            try {
+                node.stop(timeout);
+            } catch (Exception e) {
+                log.warn("Can't stop node: {} in group: {}", node.getParams().getName(), getParams().getName(), e);
+            }
+        });
+    }
+
+    /**
+     * Attempt to kills all the nodes in arbitrary order.
+     */
+    @Override
+    public void kill() {
+        nodes.values().forEach(node -> {
+            try {
+                node.kill();
+            } catch (Exception e) {
+                log.warn("Can't kill node: {} in group: {}", node.getParams().getName(), getParams().getName(), e);
+            }
+        });
+    }
+
+    @Override
+    public void destroy() {
+        log.info("Destroy group: {}", params.getName());
+
+        nodes.values().forEach(node -> {
+            try {
+                node.destroy();
+            } catch (NodeException e) {
+                log.warn("Can't destroy node: {} in group: {}", node.getParams().getName(), getParams().getName(), e);
+            }
+        });
+    }
+
+    @Override
+    public Node add(NodeParams nodeParams) {
+        N corfuServerParams = ClassUtils.cast(nodeParams);
+        params.add(corfuServerParams);
+
+        return deployAsync(buildServer(corfuServerParams)).join();
+    }
+
+    @Override
+    public <T extends Node> T getNode(String nodeNameSuffix) {
+        String fullNodeName = params.getFullNodeName(nodeNameSuffix);
+        Optional<Node> node = Optional.ofNullable(nodes.get(fullNodeName));
+
+        if (!node.isPresent()) {
+            throw new NodeException(String.format(
+                    "Node not found. Node name: %s, cluster: %s, cluster nodes: %s",
+                    fullNodeName, params.getName(), nodes.keySet())
+            );
+        }
+
+        return ClassUtils.cast(node.get());
+    }
+
+    @Override
+    public <T extends Node> ImmutableSortedMap<String, T> nodes() {
+        return ClassUtils.cast(ImmutableSortedMap.copyOf(nodes));
+    }
+}

--- a/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCorfuCluster.java
@@ -1,48 +1,27 @@
 package org.corfudb.universe.group.cluster;
 
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.ImmutableSortedSet;
-import lombok.Getter;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.universe.group.Group;
 import org.corfudb.universe.node.Node;
-import org.corfudb.universe.node.Node.NodeParams;
-import org.corfudb.universe.node.NodeException;
 import org.corfudb.universe.node.client.LocalCorfuClient;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.corfudb.universe.node.server.CorfuServerParams;
 import org.corfudb.universe.universe.UniverseException;
 import org.corfudb.universe.universe.UniverseParams;
-import org.corfudb.common.util.ClassUtils;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentNavigableMap;
-import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
-import static lombok.Builder.Default;
-
 @Slf4j
-public abstract class AbstractCorfuCluster<P extends CorfuClusterParams, U extends UniverseParams>
-        implements CorfuCluster {
-    @Default
-    protected final ConcurrentNavigableMap<String, CorfuServer> nodes = new ConcurrentSkipListMap<>();
-    @Getter
-    @NonNull
-    protected final P params;
-    @NonNull
-    protected final U universeParams;
-    private final ExecutorService executor;
+public abstract class AbstractCorfuCluster<U extends UniverseParams> extends AbstractCluster<
+        CorfuServerParams,
+        CorfuClusterParams,
+        U> implements CorfuCluster {
 
-    protected AbstractCorfuCluster(P params, U universeParams) {
-        this.params = params;
-        this.universeParams = universeParams;
-        this.executor = Executors.newCachedThreadPool();
+    public AbstractCorfuCluster(CorfuClusterParams params, U universeParams) {
+        super(params, universeParams);
     }
 
     /**
@@ -53,23 +32,24 @@ public abstract class AbstractCorfuCluster<P extends CorfuClusterParams, U exten
      * @return an instance of {@link AbstractCorfuCluster}
      */
     @Override
-    public AbstractCorfuCluster<P, U> deploy() {
+    public AbstractCorfuCluster deploy() {
         log.info("Deploy corfu cluster. Params: {}", params);
 
-        List<CompletableFuture<CorfuServer>> asyncDeployment = params
-                .getNodesParams()
+        List<CompletableFuture<Node>> asyncDeployment = params
+                .<Node.NodeParams>getNodesParams()
                 .stream()
                 .map(serverParams -> {
-                    CorfuServer server = buildCorfuServer(serverParams);
+                    CorfuServer server = (CorfuServer) buildServer(serverParams);
                     nodes.put(server.getEndpoint(), server);
                     return server;
                 })
-                .map(this::deployCorfuServerAsync)
+                .map(this::deployAsync)
                 .collect(Collectors.toList());
 
         asyncDeployment.stream()
                 .map(CompletableFuture::join)
-                .forEach(server -> log.debug("Corfu server has deployed: {}", server.getParams().getName()));
+                .forEach(server -> log.debug("Corfu server was deployed: {}",
+                        server.getParams().getName()));
 
         try {
             bootstrap();
@@ -78,86 +58,6 @@ public abstract class AbstractCorfuCluster<P extends CorfuClusterParams, U exten
         }
 
         return this;
-    }
-
-    private CompletableFuture<CorfuServer> deployCorfuServerAsync(CorfuServer corfuServer) {
-        return CompletableFuture.supplyAsync(corfuServer::deploy, executor);
-    }
-
-    protected abstract CorfuServer buildCorfuServer(CorfuServerParams nodeParams);
-
-    /**
-     * Stop the cluster
-     *
-     * @param timeout allowed time to gracefully stop the {@link Group}
-     */
-    @Override
-    public void stop(Duration timeout) {
-        log.info("Stop corfu cluster: {}", params.getName());
-
-        nodes.values().forEach(node -> {
-            try {
-                node.stop(timeout);
-            } catch (Exception e) {
-                log.warn("Can't stop node: {} in group: {}", node.getParams().getName(), getParams().getName(), e);
-            }
-        });
-    }
-
-    /**
-     * Attempt to kills all the nodes in arbitrary order.
-     */
-    @Override
-    public void kill() {
-        nodes.values().forEach(node -> {
-            try {
-                node.kill();
-            } catch (Exception e) {
-                log.warn("Can't kill node: {} in group: {}", node.getParams().getName(), getParams().getName(), e);
-            }
-        });
-    }
-
-    @Override
-    public void destroy() {
-        log.info("Destroy group: {}", params.getName());
-
-        nodes.values().forEach(node -> {
-            try {
-                node.destroy();
-            } catch (NodeException e) {
-                log.warn("Can't destroy node: {} in group: {}", node.getParams().getName(), getParams().getName(), e);
-            }
-        });
-    }
-
-    @Override
-    public Node add(NodeParams nodeParams) {
-        CorfuServerParams corfuServerParams = ClassUtils.cast(nodeParams);
-        params.add(corfuServerParams);
-
-        return deployCorfuServerAsync(buildCorfuServer(corfuServerParams))
-                .join();
-    }
-
-    @Override
-    public <T extends Node> T getNode(String nodeNameSuffix) {
-        String fullNodeName = params.getFullNodeName(nodeNameSuffix);
-        Node node = nodes.get(fullNodeName);
-
-        if (node == null) {
-            throw new NodeException(String.format(
-                    "Node not found. Node name: %s, cluster: %s, cluster nodes: %s",
-                    fullNodeName, params.getName(), nodes.keySet())
-            );
-        }
-
-        return ClassUtils.cast(node);
-    }
-
-    @Override
-    public <T extends Node> ImmutableSortedMap<String, T> nodes() {
-        return ClassUtils.cast(ImmutableSortedMap.copyOf(nodes));
     }
 
     @Override

--- a/it/src/main/java/org/corfudb/universe/group/cluster/AbstractSupportCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/AbstractSupportCluster.java
@@ -1,0 +1,85 @@
+package org.corfudb.universe.group.cluster;
+
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.universe.group.Group;
+import org.corfudb.universe.node.Node;
+import org.corfudb.universe.node.server.SupportServer;
+import org.corfudb.universe.node.server.SupportServerParams;
+import org.corfudb.universe.node.server.docker.DockerSupportServer;
+import org.corfudb.universe.universe.UniverseException;
+import org.corfudb.universe.universe.UniverseParams;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+
+import static lombok.Builder.Default;
+
+@Slf4j
+public abstract class AbstractSupportCluster
+        extends AbstractCluster<SupportServerParams, SupportClusterParams, UniverseParams> {
+
+    @Default
+    protected final ConcurrentNavigableMap<
+            String, SupportServer> nodes = new ConcurrentSkipListMap<>();
+
+    @NonNull
+    protected final UniverseParams universeParams;
+
+    @NonNull
+    protected final SupportClusterParams clusterParams;
+
+    private final ExecutorService executor;
+
+    protected AbstractSupportCluster(UniverseParams universeParams, SupportClusterParams monitoringParams) {
+        super(monitoringParams, universeParams);
+        this.universeParams = universeParams;
+        this.clusterParams = monitoringParams;
+        this.executor = Executors.newCachedThreadPool();
+    }
+
+    /**
+     * Deploys a {@link Group}, including the following steps:
+     * a) Deploy the Corfu nodes
+     * b) Bootstrap all the nodes to form a cluster
+     *
+     * @return an instance of {@link AbstractSupportCluster}
+     */
+    @Override
+    public AbstractSupportCluster deploy() {
+        log.info("Deploy monitoring cluster. Params: {}", clusterParams);
+
+        List<CompletableFuture<Node>> asyncMonDeployment = clusterParams
+                .getNodesParams()
+                .stream()
+                .map(serverParams -> {
+                    DockerSupportServer server = (DockerSupportServer) buildServer(serverParams);
+                    nodes.put(server.getParams().getName(), server);
+                    return server;
+                })
+                .map(this::deployMonitoringServerAsync)
+                .collect(Collectors.toList());
+
+        asyncMonDeployment.stream()
+                .map(CompletableFuture::join)
+                .forEach(server -> log.debug("Corfu server was deployed: {}",
+                        server.getParams().getName()));
+
+        try {
+            bootstrap();
+        } catch (Exception ex) {
+            throw new UniverseException("Can't deploy cluster: " + clusterParams.getName(), ex);
+        }
+
+        return this;
+    }
+
+    private CompletableFuture<Node> deployMonitoringServerAsync(Node monitoringServer) {
+        return CompletableFuture.supplyAsync(monitoringServer::deploy, executor);
+    }
+}

--- a/it/src/main/java/org/corfudb/universe/group/cluster/Cluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/Cluster.java
@@ -8,4 +8,8 @@ public interface Cluster extends Group {
      * Bootstrap a {@link Cluster}
      */
     void bootstrap();
+
+    enum ClusterType {
+        CORFU_CLUSTER, SUPPORT_CLUSTER
+    }
 }

--- a/it/src/main/java/org/corfudb/universe/group/cluster/CorfuClusterParams.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/CorfuClusterParams.java
@@ -9,6 +9,7 @@ import lombok.NonNull;
 import lombok.ToString;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.corfudb.universe.group.Group.GroupParams;
+import org.corfudb.universe.group.cluster.Cluster.ClusterType;
 import org.corfudb.universe.node.Node.NodeType;
 import org.corfudb.universe.node.server.CorfuServerParams;
 import org.corfudb.common.util.ClassUtils;
@@ -23,27 +24,36 @@ import java.util.stream.Collectors;
 @Builder
 @EqualsAndHashCode
 @ToString
-public
-class CorfuClusterParams implements GroupParams {
+public class CorfuClusterParams implements GroupParams<CorfuServerParams> {
+
     @Getter
     @Default
     @NonNull
     private String name = RandomStringUtils.randomAlphabetic(6).toLowerCase();
+
     @Default
     @NonNull
     private final SortedSet<CorfuServerParams> nodes = new TreeSet<>();
+
     @Getter
     @Default
     @NonNull
     private NodeType nodeType = NodeType.CORFU_SERVER;
+
     @Default
     @Getter
     @NonNull
     private final int bootStrapRetries = 20;
+
     @Default
     @Getter
     @NonNull
     private final Duration retryDuration = Duration.ofSeconds(3);
+
+    @Override
+    public ClusterType getType() {
+        return ClusterType.CORFU_CLUSTER;
+    }
 
     @Override
     public ImmutableSortedSet<CorfuServerParams> getNodesParams() {
@@ -58,6 +68,7 @@ class CorfuClusterParams implements GroupParams {
         return nodesMap.get(serverName);
     }
 
+    @Override
     public synchronized CorfuClusterParams add(CorfuServerParams nodeParams) {
         nodes.add(ClassUtils.cast(nodeParams));
         return this;

--- a/it/src/main/java/org/corfudb/universe/group/cluster/SupportClusterParams.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/SupportClusterParams.java
@@ -1,0 +1,52 @@
+package org.corfudb.universe.group.cluster;
+
+import com.google.common.collect.ImmutableSortedSet;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.corfudb.universe.group.Group;
+import org.corfudb.universe.group.cluster.Cluster.ClusterType;
+import org.corfudb.universe.node.server.SupportServerParams;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+@Builder
+@EqualsAndHashCode
+@ToString
+public class SupportClusterParams implements Group.GroupParams<SupportServerParams> {
+
+    @Getter
+    @Default
+    @NonNull
+    private final String name = RandomStringUtils.randomAlphabetic(6).toLowerCase();
+
+    @Default
+    @NonNull
+    private final SortedSet<SupportServerParams> nodes = new TreeSet<>();
+
+    @Override
+    public ClusterType getType() {
+        return ClusterType.SUPPORT_CLUSTER;
+    }
+
+    @Override
+    public ImmutableSortedSet<SupportServerParams> getNodesParams() {
+        return ImmutableSortedSet.copyOf(nodes);
+    }
+
+    @Override
+    public Group.GroupParams<SupportServerParams> add(SupportServerParams nodeParams) {
+        nodes.add(nodeParams);
+        return this;
+    }
+
+    public String getFullNodeName(String nodeName) {
+        return name + "-support-" + nodeName;
+    }
+
+}

--- a/it/src/main/java/org/corfudb/universe/group/cluster/docker/DockerCorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/docker/DockerCorfuCluster.java
@@ -11,7 +11,9 @@ import org.corfudb.runtime.view.Layout.LayoutSegment;
 import org.corfudb.universe.group.cluster.AbstractCorfuCluster;
 import org.corfudb.universe.group.cluster.CorfuCluster;
 import org.corfudb.universe.group.cluster.CorfuClusterParams;
+import org.corfudb.universe.group.cluster.SupportClusterParams;
 import org.corfudb.universe.logging.LoggingParams;
+import org.corfudb.universe.node.Node;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.corfudb.universe.node.server.CorfuServerParams;
 import org.corfudb.universe.node.server.docker.DockerCorfuServer;
@@ -27,15 +29,18 @@ import java.util.stream.Collectors;
  * Provides Docker implementation of {@link CorfuCluster}.
  */
 @Slf4j
-public class DockerCorfuCluster extends AbstractCorfuCluster<CorfuClusterParams, UniverseParams> {
+public class DockerCorfuCluster extends AbstractCorfuCluster<UniverseParams> {
     @NonNull
     private final DockerClient docker;
     @NonNull
     private final LoggingParams loggingParams;
+    @NonNull
     private final DockerManager dockerManager;
 
     @Builder
-    public DockerCorfuCluster(DockerClient docker, CorfuClusterParams params, UniverseParams universeParams,
+    public DockerCorfuCluster(DockerClient docker, CorfuClusterParams params,
+                              UniverseParams universeParams,
+                              SupportClusterParams monitoringParams,
                               LoggingParams loggingParams) {
         super(params, universeParams);
         this.docker = docker;
@@ -44,8 +49,7 @@ public class DockerCorfuCluster extends AbstractCorfuCluster<CorfuClusterParams,
     }
 
     @Override
-    protected CorfuServer buildCorfuServer(CorfuServerParams nodeParams) {
-
+    protected Node buildServer(CorfuServerParams nodeParams) {
         return DockerCorfuServer.builder()
                 .universeParams(universeParams)
                 .clusterParams(params)

--- a/it/src/main/java/org/corfudb/universe/group/cluster/docker/DockerSupportCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/docker/DockerSupportCluster.java
@@ -1,0 +1,56 @@
+package org.corfudb.universe.group.cluster.docker;
+
+import com.google.common.collect.ImmutableSortedSet;
+import com.spotify.docker.client.DockerClient;
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.universe.group.cluster.AbstractSupportCluster;
+import org.corfudb.universe.group.cluster.CorfuCluster;
+import org.corfudb.universe.group.cluster.SupportClusterParams;
+import org.corfudb.universe.logging.LoggingParams;
+import org.corfudb.universe.node.Node;
+import org.corfudb.universe.node.server.SupportServerParams;
+import org.corfudb.universe.node.server.docker.DockerSupportServer;
+import org.corfudb.universe.universe.UniverseParams;
+import org.corfudb.universe.util.DockerManager;
+
+/**
+ * Provides Docker implementation of {@link CorfuCluster}.
+ */
+@Slf4j
+public class DockerSupportCluster extends AbstractSupportCluster {
+    @NonNull
+    private final DockerClient docker;
+    @NonNull
+    private final LoggingParams loggingParams;
+    @NonNull
+    private final DockerManager dockerManager;
+
+    @Builder
+    public DockerSupportCluster(DockerClient docker, SupportClusterParams monitoringParams,
+                                UniverseParams universeParams,
+                                LoggingParams loggingParams) {
+        super(universeParams, monitoringParams);
+        this.docker = docker;
+        this.loggingParams = loggingParams;
+        this.dockerManager = DockerManager.builder().docker(docker).build();
+    }
+
+
+    @Override
+    public void bootstrap() {
+        // NOOP
+    }
+
+    @Override
+    protected Node buildServer(SupportServerParams nodeParams) {
+        return DockerSupportServer.builder()
+                .universeParams(universeParams)
+                .clusterParams(params)
+                .params(nodeParams)
+                .docker(docker)
+                .dockerManager(dockerManager)
+                .build();
+    }
+}

--- a/it/src/main/java/org/corfudb/universe/group/cluster/vm/VmCorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/vm/VmCorfuCluster.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.BootstrapUtil;
 import org.corfudb.runtime.view.Layout;
+import org.corfudb.universe.group.Group;
+import org.corfudb.universe.group.cluster.AbstractCluster;
 import org.corfudb.universe.group.cluster.AbstractCorfuCluster;
 import org.corfudb.universe.group.cluster.CorfuCluster;
 import org.corfudb.universe.group.cluster.CorfuClusterParams;
@@ -29,15 +31,17 @@ import java.util.stream.Collectors;
  * Provides VM implementation of a {@link CorfuCluster}.
  */
 @Slf4j
-public class VmCorfuCluster extends AbstractCorfuCluster<CorfuClusterParams, VmUniverseParams> {
+public class VmCorfuCluster extends AbstractCorfuCluster<VmUniverseParams> {
     private final ImmutableMap<String, VirtualMachine> vms;
 
     @Builder
-    protected VmCorfuCluster(CorfuClusterParams params, VmUniverseParams universeParams,
+    protected VmCorfuCluster(CorfuClusterParams corfuClusterParams,
+                             VmUniverseParams universeParams,
                              ImmutableMap<String, VirtualMachine> vms) {
-        super(params, universeParams);
+        super(corfuClusterParams, universeParams);
         this.vms = vms;
     }
+
 
     /**
      * Deploys a Corfu server node according to the provided parameter.
@@ -45,9 +49,9 @@ public class VmCorfuCluster extends AbstractCorfuCluster<CorfuClusterParams, VmU
      * @return an instance of {@link Node}
      */
     @Override
-    protected CorfuServer buildCorfuServer(CorfuServerParams corfuServerParams) {
-        log.info("Deploy corfu server: {}", corfuServerParams);
-        VmCorfuServerParams params = getVmServerParams(corfuServerParams);
+    protected Node buildServer(CorfuServerParams nodeParams) {
+        log.info("Deploy corfu server: {}", nodeParams);
+        VmCorfuServerParams params = getVmServerParams(nodeParams);
 
         VirtualMachine vm = vms.get(params.getVmName());
 

--- a/it/src/main/java/org/corfudb/universe/node/Node.java
+++ b/it/src/main/java/org/corfudb/universe/node/Node.java
@@ -1,10 +1,11 @@
 package org.corfudb.universe.node;
 
+import com.google.common.collect.ComparisonChain;
 import org.corfudb.universe.group.Group;
-import org.corfudb.universe.node.stress.Stress;
 import org.corfudb.universe.universe.Universe;
 
 import java.time.Duration;
+import java.util.Set;
 
 /**
  * Represent nodes within {@link Group}s of {@link Universe}
@@ -18,7 +19,6 @@ public interface Node {
      * @throws NodeException thrown when can not deploy {@link Node}
      */
     Node deploy();
-
     /**
      * Stops a {@link Node} gracefully within the timeout provided to this method.
      *
@@ -43,18 +43,25 @@ public interface Node {
 
     NodeParams getParams();
 
-    Stress getStress();
-
     /**
      * Common interface for the configurations of different implementation of {@link Node}.
      */
-    interface NodeParams<T> extends Comparable<T> {
+    interface NodeParams extends Comparable<NodeParams> {
         String getName();
+
+        default int compareTo(NodeParams other) {
+            return ComparisonChain.start()
+                    .compare(this.getName(), other.getName())
+                    .compare(this.getNodeType(), other.getNodeType())
+                    .result();
+        }
+
+        Set<Integer> getPorts();
 
         NodeType getNodeType();
     }
 
     enum NodeType {
-        CORFU_SERVER, CORFU_CLIENT
+        CORFU_SERVER, CORFU_CLIENT, METRICS_SERVER, SHELL_NODE
     }
 }

--- a/it/src/main/java/org/corfudb/universe/node/client/ClientParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/client/ClientParams.java
@@ -1,5 +1,6 @@
 package org.corfudb.universe.node.client;
 
+import com.google.common.collect.ImmutableSet;
 import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.EqualsAndHashCode;
@@ -7,30 +8,41 @@ import lombok.Getter;
 import lombok.NonNull;
 import org.corfudb.universe.node.Node.NodeParams;
 import org.corfudb.universe.node.Node.NodeType;
+import org.corfudb.universe.node.server.ServerUtil;
 
 import java.time.Duration;
+import java.util.Set;
 
 @Builder
 @Getter
 @EqualsAndHashCode(exclude = {"numRetry", "timeout", "pollPeriod"})
-public class ClientParams implements NodeParams<ClientParams> {
+public class ClientParams implements NodeParams {
+
     @Default
     @NonNull
     private final String name = "corfuClient";
+
     @NonNull
     private final NodeType nodeType = NodeType.CORFU_CLIENT;
+
+    @Default
+    @Getter
+    private final int port = ServerUtil.getRandomOpenPort();
+
     /**
      * Total number of times to retry a workflow if it fails
      */
     @Default
     @NonNull
     private final int numRetry = 5;
+
     /**
      * Total time to wait before the workflow times out
      */
     @Default
     @NonNull
     private final Duration timeout = Duration.ofSeconds(30);
+
     /**
      * Poll period to query the completion of the workflow
      */
@@ -42,7 +54,7 @@ public class ClientParams implements NodeParams<ClientParams> {
     private final int order = 0;
 
     @Override
-    public int compareTo(ClientParams other) {
-        return Integer.compare(order, other.order);
+    public Set<Integer> getPorts() {
+        return ImmutableSet.of();
     }
 }

--- a/it/src/main/java/org/corfudb/universe/node/client/LocalCorfuClient.java
+++ b/it/src/main/java/org/corfudb/universe/node/client/LocalCorfuClient.java
@@ -11,7 +11,6 @@ import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.ManagementView;
 import org.corfudb.runtime.view.ObjectsView;
-import org.corfudb.universe.node.stress.Stress;
 import org.corfudb.util.NodeLocator;
 
 import java.time.Duration;
@@ -27,8 +26,10 @@ import static org.corfudb.runtime.CorfuRuntime.fromParameters;
 @Slf4j
 public class LocalCorfuClient implements CorfuClient {
     private final CorfuRuntime runtime;
+
     @Getter
     private final ClientParams params;
+
     @Getter
     private final ImmutableSortedSet<String> serverEndpoints;
 
@@ -86,11 +87,6 @@ public class LocalCorfuClient implements CorfuClient {
     @Override
     public void destroy() {
         runtime.shutdown();
-    }
-
-    @Override
-    public Stress getStress() {
-        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override

--- a/it/src/main/java/org/corfudb/universe/node/server/AbstractCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/AbstractCorfuServer.java
@@ -13,7 +13,9 @@ import java.io.FileReader;
 import java.io.IOException;
 
 @Slf4j
-public abstract class AbstractCorfuServer<T extends CorfuServerParams, U extends UniverseParams> implements CorfuServer {
+public abstract class AbstractCorfuServer<
+        T extends CorfuServerParams,
+        U extends UniverseParams> implements CorfuServer {
 
     private static final String POM_FILE = "pom.xml";
 

--- a/it/src/main/java/org/corfudb/universe/node/server/SupportServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/SupportServer.java
@@ -1,0 +1,8 @@
+package org.corfudb.universe.node.server;
+
+import org.corfudb.universe.node.Node;
+
+public interface SupportServer extends Node {
+    @Override
+    SupportServer deploy();
+}

--- a/it/src/main/java/org/corfudb/universe/node/server/SupportServerParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/SupportServerParams.java
@@ -1,5 +1,6 @@
 package org.corfudb.universe.node.server;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,19 +16,17 @@ import org.corfudb.universe.node.server.CorfuServer.Persistence;
 import org.slf4j.event.Level;
 
 import java.time.Duration;
+import java.util.Map;
 import java.util.Set;
 
-@Builder(builderMethodName = "serverParamsBuilder")
+@Builder
 @AllArgsConstructor
 @EqualsAndHashCode(exclude = {"logLevel", "stopTimeout"})
 @ToString
-public class CorfuServerParams implements NodeParams {
-    @NonNull
-    private final String streamLogDir = "db";
-
-    @Default
-    @Getter
-    private final int port = ServerUtil.getRandomOpenPort();
+public class SupportServerParams implements NodeParams {
+    private static final Map<NodeType, Integer> PORTS = ImmutableMap.<NodeType, Integer>builder()
+            .put(NodeType.METRICS_SERVER, 9090)
+            .build();
 
     @Default
     @NonNull
@@ -46,11 +45,8 @@ public class CorfuServerParams implements NodeParams {
 
     @NonNull
     @Getter
-    private final NodeType nodeType = NodeType.CORFU_SERVER;
+    private final NodeType nodeType;
 
-    /**
-     * A name of the Corfu cluster
-     */
     @Getter
     @NonNull
     private final String clusterName;
@@ -62,15 +58,11 @@ public class CorfuServerParams implements NodeParams {
 
     @Override
     public String getName() {
-        return clusterName + "-corfu-node" + getPort();
+        return clusterName + "-support-node-" + getNodeType();
     }
 
-    public String getStreamLogDir() {
-        return getName() + "/" + streamLogDir;
-    }
-
-    @Override
     public Set<Integer> getPorts() {
-        return ImmutableSet.of(port);
+        return ImmutableSet.of(PORTS.get(getNodeType()));
     }
+
 }

--- a/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
@@ -36,8 +36,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 /**
  * Implements a docker instance representing a {@link CorfuServer}.
@@ -122,11 +124,6 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
 
         collectLogs();
         dockerManager.destroy(params.getName());
-    }
-
-    @Override
-    public Stress getStress() {
-        throw new UnsupportedOperationException("Not implemented");
     }
 
     /**
@@ -323,7 +320,8 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
 
     private ContainerConfig buildContainerConfig() {
         // Bind ports
-        String[] ports = {String.valueOf(params.getPort())};
+        List<String> ports = params.getPorts().stream()
+                .map(Objects::toString).collect(Collectors.toList());
         Map<String, List<PortBinding>> portBindings = new HashMap<>();
         for (String port : ports) {
             List<PortBinding> hostPorts = new ArrayList<>();
@@ -348,7 +346,7 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
                 .hostConfig(hostConfig)
                 .image(IMAGE_NAME)
                 .hostname(params.getName())
-                .exposedPorts(ports)
+                .exposedPorts(ports.stream().toArray(String[]::new))
                 .cmd("sh", "-c", cmdLine)
                 .build();
     }

--- a/it/src/main/java/org/corfudb/universe/node/server/docker/DockerSupportServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/docker/DockerSupportServer.java
@@ -1,0 +1,179 @@
+package org.corfudb.universe.node.server.docker;
+
+import com.google.common.collect.ImmutableMap;
+import com.spotify.docker.client.DockerClient;
+import com.spotify.docker.client.exceptions.DockerException;
+import com.spotify.docker.client.messages.ContainerConfig;
+import com.spotify.docker.client.messages.ContainerCreation;
+import com.spotify.docker.client.messages.HostConfig;
+import com.spotify.docker.client.messages.PortBinding;
+import groovy.util.logging.Log4j;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NonNull;
+import org.apache.commons.lang.StringUtils;
+import org.corfudb.universe.group.cluster.SupportClusterParams;
+import org.corfudb.universe.node.Node;
+import org.corfudb.universe.node.NodeException;
+import org.corfudb.universe.node.server.SupportServer;
+import org.corfudb.universe.universe.UniverseParams;
+import org.corfudb.universe.util.DockerManager;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+@Log4j
+public class DockerSupportServer<N extends Node.NodeParams> implements SupportServer {
+    private static final String ALL_NETWORK_INTERFACES = "0.0.0.0";
+    private static final Map<NodeType, String> IMAGE_NAME = ImmutableMap.<NodeType, String>builder()
+            .put(NodeType.METRICS_SERVER, "prom/prometheus")
+            .put(NodeType.SHELL_NODE, "ubuntu")
+            .build();
+
+    private static final Map<NodeType, String> CMD = ImmutableMap.<NodeType, String>builder()
+            .put(NodeType.SHELL_NODE, "bash")
+            .build();
+
+    @Getter
+    protected final N params;
+
+    @NonNull
+    @Getter
+    protected final UniverseParams universeParams;
+
+    @NonNull
+    private final DockerClient docker;
+
+    @NonNull
+    private final DockerManager dockerManager;
+
+    @NonNull
+    private final SupportClusterParams clusterParams;
+
+    @NonNull
+    private final AtomicReference<String> ipAddress = new AtomicReference<>();
+
+    @NonNull
+    private final String prometheusConfigPath;
+
+    @Builder
+    public DockerSupportServer(DockerClient docker, DockerManager dockerManager,
+                               N params, String prometheusConfigPath,
+                               SupportClusterParams clusterParams, UniverseParams universeParams) {
+        this.docker = docker;
+        this.dockerManager = dockerManager;
+        this.params = params;
+        this.prometheusConfigPath = prometheusConfigPath;
+        this.clusterParams = clusterParams;
+        this.universeParams = universeParams;
+    }
+
+    @Override
+    public SupportServer deploy() {
+        deployContainer();
+
+        return this;
+    }
+
+    private ContainerConfig buildContainerConfig() {
+        List<String> ports = params.getPorts().stream()
+                .map(Objects::toString).collect(Collectors.toList());
+        Map<String, List<PortBinding>> portBindings = new HashMap<>();
+        for (String port : ports) {
+            List<PortBinding> hostPorts = new ArrayList<>();
+            hostPorts.add(PortBinding.of(ALL_NETWORK_INTERFACES, port));
+            portBindings.put(port, hostPorts);
+        }
+
+        HostConfig.Bind configurationFile =  HostConfig.Bind.builder()
+                .from("/home/nsx/prometheus.yml")
+                .to("/etc/prometheus/prometheus.yml").build();
+        HostConfig hostConfig = HostConfig.builder()
+                .privileged(true)
+                .binds(configurationFile)
+                .portBindings(portBindings)
+                .build();
+
+        ContainerConfig.Builder builder = ContainerConfig.builder();
+        builder.hostConfig(hostConfig)
+                .exposedPorts(ports.stream().toArray(String[]::new))
+                .image(IMAGE_NAME.get(getParams().getNodeType()));
+
+        if (CMD.containsKey(getParams().getNodeType())) {
+            builder.cmd(CMD.get(getParams().getNodeType()));
+        }
+
+        return builder.build();
+    }
+
+    private String deployContainer() {
+        ContainerConfig containerConfig = buildContainerConfig();
+
+        String id;
+        try {
+            ContainerCreation container = docker.createContainer(containerConfig,
+                    params.getName());
+            id = container.id();
+
+            dockerManager.addShutdownHook(clusterParams.getName());
+
+            docker.disconnectFromNetwork(id, "bridge");
+            docker.connectToNetwork(id, docker.inspectNetwork(universeParams.getNetworkName()).id());
+
+            docker.startContainer(id);
+
+            String ipAddr = docker.inspectContainer(id)
+                    .networkSettings().networks()
+                    .values().asList().get(0)
+                    .ipAddress();
+
+            if (StringUtils.isEmpty(ipAddr)) {
+                throw new NodeException("Empty Ip address for container: " + clusterParams.getName());
+            }
+
+            ipAddress.set(ipAddr);
+        } catch (InterruptedException | DockerException e) {
+            throw new NodeException("Can't start a container", e);
+        }
+
+        return id;
+    }
+
+    /**
+     * This method attempts to gracefully stop the Corfu server. After timeout, it will kill the Corfu server.
+     *
+     * @param timeout a duration after which the stop will kill the server
+     * @throws NodeException this exception will be thrown if the server cannot be stopped.
+     */
+    @Override
+    public void stop(Duration timeout) {
+        dockerManager.stop(params.getName(), timeout);
+    }
+
+    /**
+     * Immediately kill the Corfu server.
+     *
+     * @throws NodeException this exception will be thrown if the server can not be killed.
+     */
+    @Override
+    public void kill() {
+        dockerManager.kill(params.getName());
+    }
+
+    /**
+     * Immediately kill and remove the docker container
+     *
+     * @throws NodeException this exception will be thrown if the server can not be killed.
+     */
+    @Override
+    public void destroy() {
+        dockerManager.destroy(params.getName());
+    }
+
+}

--- a/it/src/main/java/org/corfudb/universe/node/server/vm/VmCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/vm/VmCorfuServer.java
@@ -258,11 +258,6 @@ public class VmCorfuServer extends AbstractCorfuServer<VmCorfuServerParams, VmUn
         }
     }
 
-    @Override
-    public Stress getStress() {
-        return stress;
-    }
-
     /**
      * Remove corfu server application dir.
      * AppDir is a directory that contains corfu-infrastructure jar file and could have log files, stream-log files and

--- a/it/src/main/java/org/corfudb/universe/universe/AbstractUniverse.java
+++ b/it/src/main/java/org/corfudb/universe/universe/AbstractUniverse.java
@@ -8,13 +8,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.universe.group.Group;
 import org.corfudb.universe.group.Group.GroupParams;
 import org.corfudb.common.util.ClassUtils;
+import org.corfudb.universe.node.Node;
 
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 @Slf4j
-public abstract class AbstractUniverse<P extends UniverseParams> implements Universe {
+public abstract class AbstractUniverse<
+        N extends Node.NodeParams,
+        P extends UniverseParams> implements Universe {
     @Getter
     @NonNull
     protected final P universeParams;
@@ -44,7 +47,7 @@ public abstract class AbstractUniverse<P extends UniverseParams> implements Univ
                 .forEach(Group::deploy);
     }
 
-    protected abstract Group buildGroup(GroupParams groupParams);
+    protected abstract Group buildGroup(GroupParams<N> groupParams);
 
     @Override
     public ImmutableMap<String, Group> groups() {

--- a/it/src/main/java/org/corfudb/universe/universe/docker/DockerUniverse.java
+++ b/it/src/main/java/org/corfudb/universe/universe/docker/DockerUniverse.java
@@ -5,10 +5,12 @@ import com.spotify.docker.client.messages.NetworkConfig;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.universe.group.Group.GroupParams;
-import org.corfudb.universe.group.cluster.AbstractCorfuCluster;
-import org.corfudb.universe.group.cluster.CorfuClusterParams;
+import org.corfudb.universe.group.cluster.Cluster;
+import org.corfudb.universe.group.cluster.Cluster.ClusterType;
 import org.corfudb.universe.group.cluster.docker.DockerCorfuCluster;
+import org.corfudb.universe.group.cluster.docker.DockerSupportCluster;
 import org.corfudb.universe.logging.LoggingParams;
+import org.corfudb.universe.node.Node;
 import org.corfudb.universe.universe.AbstractUniverse;
 import org.corfudb.universe.universe.Universe;
 import org.corfudb.universe.universe.UniverseException;
@@ -24,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Represents Docker implementation of a {@link Universe}.
  */
 @Slf4j
-public class DockerUniverse extends AbstractUniverse<UniverseParams> {
+public class DockerUniverse extends AbstractUniverse<Node.NodeParams, UniverseParams> {
     /**
      * Docker parameter --network=host doesn't work in mac machines,
      * FakeDns is used to solve the issue, it resolves a dns record (which is a node name) to loopback address always.
@@ -94,9 +96,11 @@ public class DockerUniverse extends AbstractUniverse<UniverseParams> {
     }
 
     @Override
-    protected AbstractCorfuCluster<CorfuClusterParams, UniverseParams> buildGroup(GroupParams groupParams) {
-        switch (groupParams.getNodeType()) {
-            case CORFU_SERVER:
+    protected Cluster buildGroup(GroupParams<Node.NodeParams> groupParams) {
+
+        switch (groupParams.getType()) {
+
+            case CORFU_CLUSTER:
                 groupParams.getNodesParams().forEach(node ->
                         FAKE_DNS.addForwardResolution(node.getName(), InetAddress.getLoopbackAddress())
                 );
@@ -107,8 +111,17 @@ public class DockerUniverse extends AbstractUniverse<UniverseParams> {
                         .loggingParams(loggingParams)
                         .docker(docker)
                         .build();
-            case CORFU_CLIENT:
-                throw new UniverseException("Not implemented corfu client. Group config: " + groupParams);
+            case SUPPORT_CLUSTER:
+                groupParams.getNodesParams().forEach(node ->
+                        FAKE_DNS.addForwardResolution(node.getName(), InetAddress.getLoopbackAddress())
+                );
+
+                return DockerSupportCluster.builder()
+                        .universeParams(universeParams)
+                        .monitoringParams(ClassUtils.cast(groupParams))
+                        .loggingParams(loggingParams)
+                        .docker(docker)
+                        .build();
             default:
                 throw new UniverseException("Unknown node type");
         }


### PR DESCRIPTION
Augment the Universe Framework to support additional cluster types that
can be used for deploying support components, such as monitoring,
tracing and metrics.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
