### PR TITLE
Use global compaction mark instead of per stream to prevent leak.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DataStore.java
@@ -1,7 +1,5 @@
 package org.corfudb.infrastructure;
 
-import static org.corfudb.infrastructure.utils.Persistence.syncDirectory;
-
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.CacheWriter;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -16,16 +14,20 @@ import org.corfudb.util.JsonUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.File;
+import java.io.FileFilter;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.function.Consumer;
+
+import static org.corfudb.infrastructure.utils.Persistence.syncDirectory;
 
 /**
  * Stores data as JSON.
@@ -94,11 +96,11 @@ public class DataStore implements IDataStore {
     }
 
 
-    public static int getChecksum(byte[] bytes) {
+    private static int getChecksum(ByteBuffer buf) {
         Hasher hasher = Hashing.crc32c().newHasher();
-        for (byte a : bytes) {
-            hasher.putByte(a);
-        }
+        buf.mark();
+        hasher.putBytes(buf);
+        buf.reset();
 
         return hasher.hash().asInt();
     }
@@ -126,18 +128,31 @@ public class DataStore implements IDataStore {
                             Path path = Paths.get(logDirPath, dsFileName);
                             Path tmpPath = Paths.get(logDirPath, dsFileName + ".tmp");
 
-                            String jsonPayload = JsonUtils.parser.toJson(value, value.getClass());
-                            byte[] bytes = jsonPayload.getBytes();
+                            ByteBuffer dataBuf;
+                            if (value instanceof ByteBuffer) {
+                                dataBuf = ((ByteBuffer) value);
+                            } else {
+                                String jsonPayload = JsonUtils.parser.toJson(value, value.getClass());
+                                dataBuf = ByteBuffer.wrap(jsonPayload.getBytes());
+                            }
 
-                            ByteBuffer buffer = ByteBuffer.allocate(bytes.length
-                                    + Integer.BYTES);
-                            buffer.putInt(getChecksum(bytes));
-                            buffer.put(bytes);
-                            Files.write(tmpPath, buffer.array(), StandardOpenOption.CREATE,
+                            ByteBuffer checksumBuf = ByteBuffer.allocate(Integer.BYTES);
+                            checksumBuf.putInt(getChecksum(dataBuf));
+                            checksumBuf.flip();
+                            ByteBuffer[] buffers = {checksumBuf, dataBuf};
+
+                            FileChannel writeChannel = FileChannel.open(tmpPath,
+                                    StandardOpenOption.WRITE, StandardOpenOption.CREATE,
                                     StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.SYNC);
+
+                            while (checksumBuf.hasRemaining() || dataBuf.hasRemaining()) {
+                                writeChannel.write(buffers);
+                            }
+
                             Files.move(tmpPath, path, StandardCopyOption.REPLACE_EXISTING,
                                     StandardCopyOption.ATOMIC_MOVE);
                             syncDirectory(logDirPath);
+
                             // Invoking the cleanup on each disk file write is fine for performance
                             // since DataStore files are not supposed to change too frequently
                             cleanupTask.accept(dsFileName);
@@ -167,23 +182,31 @@ public class DataStore implements IDataStore {
         put(new KvRecord<>(prefix, key, tclass), value);
     }
 
+    @SuppressWarnings("unchecked")
     private <T> T load(Class<T> tClass, String key) {
         try {
             Path path = Paths.get(logDirPath, key + EXTENSION);
             if (Files.notExists(path)) {
                 return null;
             }
-            byte[] bytes = Files.readAllBytes(path);
-            ByteBuffer buf = ByteBuffer.wrap(bytes);
-            int checksum = buf.getInt();
-            byte[] strBytes = Arrays.copyOfRange(bytes, 4, bytes.length);
-            if (checksum != getChecksum(strBytes)) {
+
+            FileChannel readChannel = FileChannel.open(path, StandardOpenOption.READ);
+            ByteBuffer dataBuf = ByteBuffer.allocate((int) readChannel.size());
+            readChannel.read(dataBuf);
+            dataBuf.flip();
+
+            int checksum = dataBuf.getInt();
+            if (checksum != getChecksum(dataBuf)) {
                 throw new DataCorruptionException();
             }
 
-            String json = new String(strBytes);
-            T val = JsonUtils.parser.fromJson(json, tClass);
-            return val;
+            if (tClass.equals(ByteBuffer.class)) {
+                return (T) dataBuf;
+            }
+
+            String json = new String(dataBuf.array(), Integer.BYTES, dataBuf.remaining());
+            return JsonUtils.parser.fromJson(json, tClass);
+
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -222,7 +245,6 @@ public class DataStore implements IDataStore {
                     return loadedVal;
                 }
             }
-
             // We need to maintain a path -> null mapping for keys that were loaded, but
             // were empty. This is required to prevent loading an empty key more than once, which is expensive.
             return NullValue.NULL_VALUE;
@@ -240,5 +262,20 @@ public class DataStore implements IDataStore {
     @Override
     public synchronized <T> void delete(KvRecord<T> key) {
         cache.invalidate(key.getFullKeyName());
+    }
+
+    @Override
+    public void deleteFiles(FileFilter fileFilter) {
+        File[] files = new File(logDirPath).listFiles(fileFilter);
+
+        if (files == null) {
+            throw new RuntimeException("DataStore: Failed to list files to delete.");
+        }
+
+        for (File file : files) {
+            if (file.delete()) {
+                log.debug("DataStore: Deleted existing DataStore file: {}", file);
+            }
+        }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IDataStore.java
@@ -4,6 +4,8 @@ package org.corfudb.infrastructure;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.io.FileFilter;
+
 /**
  * Key Value data store abstraction that provides persistence for variables that need
  * retain values across node restarts or need to be accessed by multiple modules/threads.
@@ -56,6 +58,13 @@ public interface IDataStore {
      * @param key record meta information
      */
     <T> void delete(KvRecord<T> key);
+
+    /**
+     * Deletes all datastore files matching the given filter.
+     *
+     * @param fileFilter a file filter function
+     */
+    void deleteFiles(FileFilter fileFilter);
 
     /**
      * Key-value meta information class, provides all the information for saving and getting data from a data store

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -292,7 +292,7 @@ public class LogUnitServer extends AbstractServer {
                 rr.put(address, LogData.getEmpty(address));
             } else {
                 rr.put(address, (LogData) logData);
-                rr.setCompactionMarks(streamLog.getCompactionMarks(logData.getAllStreams()));
+                rr.setCompactionMark(streamLog.getGlobalCompactionMark());
             }
             r.sendResponse(ctx, msg, CorfuMsgType.READ_RESPONSE.payloadMsg(rr));
         } catch (DataCorruptionException e) {
@@ -307,7 +307,6 @@ public class LogUnitServer extends AbstractServer {
         log.trace("multiRead: {}, cacheable: {}", msg.getPayload().getAddresses(), cacheable);
 
         ReadResponse rr = new ReadResponse();
-        Set<UUID> streams = new HashSet<>();
         try {
             for (Long address : msg.getPayload().getAddresses()) {
                 ILogData logData = dataCache.get(address, cacheable);
@@ -315,10 +314,9 @@ public class LogUnitServer extends AbstractServer {
                     rr.put(address, LogData.getEmpty(address));
                 } else {
                     rr.put(address, (LogData) logData);
-                    streams.addAll(logData.getAllStreams());
                 }
             }
-            rr.setCompactionMarks(streamLog.getCompactionMarks(streams));
+            rr.setCompactionMark(streamLog.getGlobalCompactionMark());
             r.sendResponse(ctx, msg, CorfuMsgType.READ_RESPONSE.payloadMsg(rr));
         } catch (DataCorruptionException e) {
             r.sendResponse(ctx, msg, CorfuMsgType.ERROR_DATA_CORRUPTION.msg());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/AbstractLogSegment.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/AbstractLogSegment.java
@@ -220,9 +220,7 @@ public abstract class AbstractLogSegment implements AutoCloseable,
                 throw new FileNotFoundException(filePath);
             }
             return FileChannel.open(
-                    FileSystems.getDefault().getPath(filePath),
-                    EnumSet.of(StandardOpenOption.READ)
-            );
+                    FileSystems.getDefault().getPath(filePath), StandardOpenOption.READ);
         }
 
         try {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/GarbageSizeFirstPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/GarbageSizeFirstPolicy.java
@@ -34,7 +34,7 @@ public class GarbageSizeFirstPolicy extends AbstractCompactionPolicy {
     @Override
     public List<Long> getSegmentsToCompact(List<CompactionMetadata> compactibleSegments) {
         // Force compaction to override the policy if out of disk quota.
-        if (requireForceCompaction(params, fileStore, logSizeQuota)) {
+        if (requireForceCompaction(params, fileStore, logSizeQuota, compactibleSegments)) {
             log.info("Force compaction needed, ignoring compaction policy.");
             return getSegmentsToForceCompact(compactibleSegments);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -1,12 +1,12 @@
 package org.corfudb.infrastructure.log;
 
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.view.Address;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -160,8 +160,8 @@ public class InMemoryStreamLog implements StreamLog {
     }
 
     @Override
-    public Map<UUID, Long> getCompactionMarks(@NonNull Set<UUID> streams) {
-        return Collections.emptyMap();
+    public long getGlobalCompactionMark() {
+        return Address.NON_ADDRESS;
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/SnapshotLengthFirstPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/SnapshotLengthFirstPolicy.java
@@ -40,7 +40,7 @@ public class SnapshotLengthFirstPolicy extends AbstractCompactionPolicy {
     @Override
     public List<Long> getSegmentsToCompact(List<CompactionMetadata> compactibleSegments) {
         // Force compaction to override the policy if out of disk quota.
-        if (requireForceCompaction(params, fileStore, logSizeQuota)) {
+        if (requireForceCompaction(params, fileStore, logSizeQuota, compactibleSegments)) {
             log.info("Force compaction needed, ignoring compaction policy.");
             return getSegmentsToForceCompact(compactibleSegments);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -1,6 +1,5 @@
 package org.corfudb.infrastructure.log;
 
-import lombok.NonNull;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
@@ -13,7 +12,6 @@ import org.corfudb.runtime.exceptions.ValueAdoptedException;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
@@ -53,10 +51,9 @@ public interface StreamLog {
     /**
      * Return the current compaction marks for a list of stream
      *
-     * @param streams set of stream identifiers
      * @return a map of stream to its compaction mark.
      */
-    Map<UUID, Long> getCompactionMarks(@NonNull Set<UUID> streams);
+    long getGlobalCompactionMark();
 
     /**
      * Prefix trim the global log.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogDataStore.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogDataStore.java
@@ -1,27 +1,31 @@
 package org.corfudb.infrastructure.log;
 
 import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
 import org.corfudb.infrastructure.IDataStore;
 import org.corfudb.infrastructure.IDataStore.KvRecord;
+import org.corfudb.runtime.exceptions.SerializerException;
 import org.corfudb.runtime.view.Address;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Data access layer for StreamLog.
- * Keeps stream log related meta information: startingAddress, tailSegment
- * and per-segment per-stream compaction marks.
+ * Keeps stream log related meta information: starting address,
+ * tail segment and global compaction mark.
  * Provides access to the stream log related meta information.
  */
 @Slf4j
-@RequiredArgsConstructor
 public class StreamLogDataStore {
     private static final String TAIL_SEGMENT_PREFIX = "TAIL_SEGMENT";
     private static final String TAIL_SEGMENT_KEY = "CURRENT";
@@ -32,6 +36,8 @@ public class StreamLogDataStore {
     private static final String COMPACTION_MARK_PREFIX = "COMPACTION_MARK";
     private static final String COMPACTION_MARK_KEY = "CURRENT";
 
+    private static final String COMPACTED_ADDRESSES_PREFIX = "COMPACTED_ADDRESSES";
+
     private static final KvRecord<Long> TAIL_SEGMENT_RECORD = new KvRecord<>(
             TAIL_SEGMENT_PREFIX, TAIL_SEGMENT_KEY, Long.class
     );
@@ -40,8 +46,8 @@ public class StreamLogDataStore {
             STARTING_ADDRESS_PREFIX, STARTING_ADDRESS_KEY, Long.class
     );
 
-    private static final KvRecord<Map> COMPACTION_MARK_RECORD = new KvRecord<>(
-            COMPACTION_MARK_PREFIX, COMPACTION_MARK_KEY, Map.class
+    private static final KvRecord<Long> COMPACTION_MARK_RECORD = new KvRecord<>(
+            COMPACTION_MARK_PREFIX, COMPACTION_MARK_KEY, Long.class
     );
 
     private static final long ZERO_ADDRESS = 0L;
@@ -50,126 +56,192 @@ public class StreamLogDataStore {
     private final IDataStore dataStore;
 
     /**
-     * Cached starting address
+     * Cached starting address.
      */
-    private final AtomicLong startingAddress = new AtomicLong(Address.NON_ADDRESS);
-    /**
-     * Cached tail segment
-     */
-    private final AtomicLong tailSegment = new AtomicLong(Address.NON_ADDRESS);
-    /**
-     * Cached stream compaction marks. Any snapshot read on the stream before
-     * compaction mark may result in in-complete history.
-     */
-    private final AtomicReference<Map<UUID, Long>> streamCompactionMarks = new AtomicReference<>(null);
+    private final AtomicLong startingAddress;
 
     /**
-     * Return current cached tail segment or get the segment from the data store if not initialized
+     * Cached tail segment.
+     */
+    private final AtomicLong tailSegment;
+
+    /**
+     * Cached global compaction mark.
+     * Any snapshot read before this may result in in-complete history.
+     */
+    private final AtomicLong globalCompactionMark;
+
+
+    public StreamLogDataStore(IDataStore dataStore) {
+        this.dataStore = dataStore;
+        this.startingAddress =
+                new AtomicLong(dataStore.get(STARTING_ADDRESS_RECORD, ZERO_ADDRESS));
+        this.tailSegment =
+                new AtomicLong(dataStore.get(TAIL_SEGMENT_RECORD, ZERO_ADDRESS));
+        this.globalCompactionMark =
+                new AtomicLong(dataStore.get(COMPACTION_MARK_RECORD, Address.NON_ADDRESS));
+    }
+
+    /**
+     * Return the current tail segment.
      *
      * @return tail segment
      */
     long getTailSegment() {
-        if (tailSegment.get() == Address.NON_ADDRESS) {
-            tailSegment.set(dataStore.get(TAIL_SEGMENT_RECORD, ZERO_ADDRESS));
-        }
-
         return tailSegment.get();
     }
 
     /**
-     * Update current tail segment in the data store
+     * Update current tail segment in the data store.
      *
-     * @param newTailSegment updated tail segment
+     * @param newTailSegment new tail segment to update
      */
     void updateTailSegment(long newTailSegment) {
-        if (tailSegment.get() >= newTailSegment) {
-            log.trace("New tail segment less than or equals to the old one: {}. Ignore", newTailSegment);
-            return;
+        if (updateIfGreater(tailSegment, newTailSegment, TAIL_SEGMENT_RECORD)) {
+            log.debug("Updated tail segment to: {}", newTailSegment);
         }
-
-        log.debug("Update tail segment to: {}", newTailSegment);
-        dataStore.put(TAIL_SEGMENT_RECORD, newTailSegment);
-        tailSegment.set(newTailSegment);
     }
 
     /**
-     * Returns the dataStore starting address.
+     * Reset the current tail segment.
+     */
+    void resetTailSegment() {
+        log.info("Resetting tail segment. Current segment: {}", tailSegment.get());
+        tailSegment.updateAndGet(tail -> {
+            dataStore.put(TAIL_SEGMENT_RECORD, ZERO_ADDRESS);
+            return ZERO_ADDRESS;
+        });
+    }
+
+    /**
+     * Return the current starting address.
      *
      * @return the starting address
      */
     long getStartingAddress() {
-        if (startingAddress.get() == Address.NON_ADDRESS) {
-            startingAddress.set(dataStore.get(STARTING_ADDRESS_RECORD, ZERO_ADDRESS));
-        }
-
         return startingAddress.get();
     }
 
     /**
-     * Update current starting address in the data store
+     * Update current starting address in the data store.
      *
      * @param newStartingAddress updated starting address
      */
     void updateStartingAddress(long newStartingAddress) {
-        log.info("Update starting address to: {}", newStartingAddress);
-
-        dataStore.put(STARTING_ADDRESS_RECORD, newStartingAddress);
-        startingAddress.set(newStartingAddress);
+        if (updateIfGreater(startingAddress, newStartingAddress, STARTING_ADDRESS_RECORD)) {
+            log.debug("Updated starting address to: {}", newStartingAddress);
+        }
     }
 
     /**
-     * Reset tail segment
-     */
-    void resetTailSegment() {
-        log.info("Reset tail segment. Current segment: {}", tailSegment.get());
-        dataStore.put(TAIL_SEGMENT_RECORD, ZERO_ADDRESS);
-        tailSegment.set(ZERO_ADDRESS);
-    }
-
-    /**
-     * Reset starting address
+     * Reset starting address.
      */
     void resetStartingAddress() {
-        log.info("Reset starting address. Current address: {}", startingAddress.get());
-        dataStore.put(STARTING_ADDRESS_RECORD, ZERO_ADDRESS);
-        startingAddress.set(ZERO_ADDRESS);
-    }
-
-    /**
-     * Update current stream compaction marks with a subset of compaction marks.
-     *
-     * @param compactionMarks a subset of compaction marks to update
-     */
-    void updateCompactionMarks(Map<UUID, Long> compactionMarks) {
-        log.debug("Updating stream compaction mark, current: {}", streamCompactionMarks.get());
-        streamCompactionMarks.updateAndGet(cm -> {
-            Map<UUID, Long> newCompactionMarks = new HashMap<>(cm);
-            compactionMarks.forEach((id, addr) -> newCompactionMarks.merge(id, addr, Math::max));
-            dataStore.put(COMPACTION_MARK_RECORD, newCompactionMarks);
-            return newCompactionMarks;
+        log.info("Resetting starting address. Current address: {}", startingAddress.get());
+        startingAddress.updateAndGet(addr -> {
+            dataStore.put(STARTING_ADDRESS_RECORD, ZERO_ADDRESS);
+            return ZERO_ADDRESS;
         });
-        log.debug("Updated stream compaction mark to: {}", streamCompactionMarks.get());
     }
 
     /**
-     * Return current stream compaction marks.
+     * Return the current global compaction marks.
      */
-    @SuppressWarnings("unchecked")
-    Map<UUID, Long> getCompactionMarks() {
-        if (streamCompactionMarks.get() == null) {
-            streamCompactionMarks.getAndUpdate(
-                    cm -> dataStore.get(COMPACTION_MARK_RECORD, Collections.emptyMap()));
+    long getGlobalCompactionMark() {
+        return globalCompactionMark.get();
+    }
+
+    /**
+     * Update the current global compaction mark if the provided address is greater.
+     *
+     * @param newCompactionMark a new address to update current global compaction mark
+     */
+    void updateGlobalCompactionMark(long newCompactionMark) {
+        if (updateIfGreater(globalCompactionMark, newCompactionMark, COMPACTION_MARK_RECORD)) {
+            log.debug("Updated global compaction mark to: {}", newCompactionMark);
+        }
+    }
+
+    /**
+     * Reset global compaction mark.
+     */
+    void resetGlobalCompactionMark() {
+        log.info("Resetting global compaction mark. Current: {}", globalCompactionMark.get());
+        globalCompactionMark.updateAndGet(addr -> {
+            dataStore.put(COMPACTION_MARK_RECORD, Address.NON_ADDRESS);
+            return Address.NON_ADDRESS;
+        });
+    }
+
+    /**
+     * Set the compacted addresses bitmap.
+     *
+     * @param newBitmap new compacted addresses bitmap.
+     */
+    void updateCompactedAddresses(long segment, Roaring64NavigableMap newBitmap) {
+        Roaring64NavigableMap currBitmap = getCompactedAddresses(segment);
+        newBitmap.or(currBitmap);
+
+        newBitmap.runOptimize();
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        DataOutput output = new DataOutputStream(byteStream);
+
+        try {
+            newBitmap.serialize(output);
+            ByteBuffer buffer = ByteBuffer.wrap(byteStream.toByteArray());
+            dataStore.put(getCompactedAddressesRecord(segment), buffer);
+        } catch (IOException ioe) {
+            throw new RuntimeException("Exception when attempting to " +
+                    "serialize compacted addresses bitmap", ioe);
+        } finally {
+            IOUtils.closeQuietly(byteStream);
+        }
+    }
+
+    /**
+     * Get the current compacted addresses bitmap.
+     * Caching is done on upper layer.
+     */
+    Roaring64NavigableMap getCompactedAddresses(long segment) {
+        ByteBuffer buf = dataStore.get(getCompactedAddressesRecord(segment));
+        if (buf == null) {
+            return new Roaring64NavigableMap();
         }
 
-        return streamCompactionMarks.get();
+        ByteArrayInputStream byteStream = new ByteArrayInputStream(
+                buf.array(), buf.position(), buf.remaining());
+        DataInput input = new DataInputStream(byteStream);
+
+        try {
+            Roaring64NavigableMap bitmap = new Roaring64NavigableMap();
+            bitmap.deserialize(input);
+            return bitmap;
+        } catch (IOException ioe) {
+            throw new SerializerException("Exception when attempting to " +
+                    "deserialize compacted addresses bitmap bitmap.", ioe);
+        } finally {
+            IOUtils.closeQuietly(byteStream);
+        }
     }
 
-    /**
-     * Reset stream compaction marks.
-     */
-    void resetCompactionMarks() {
-        log.info("Reset stream compaction marks.");
-        dataStore.put(COMPACTION_MARK_RECORD, Collections.emptyMap());
-        streamCompactionMarks.set(Collections.emptyMap());
+    void resetAllCompactedAddresses() {
+        dataStore.deleteFiles(file -> file.getName().startsWith(COMPACTED_ADDRESSES_PREFIX));
+    }
+
+    private KvRecord<ByteBuffer> getCompactedAddressesRecord(long segment) {
+        return new KvRecord<>(COMPACTED_ADDRESSES_PREFIX, String.valueOf(segment), ByteBuffer.class);
+    }
+
+
+    private boolean updateIfGreater(AtomicLong target, long newAddress, KvRecord<Long> key) {
+        long updatedAddress = target.updateAndGet(curr -> {
+            if (newAddress <= curr) {
+                return curr;
+            }
+            dataStore.put(key, newAddress);
+            return newAddress;
+        });
+
+        return updatedAddress == newAddress;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -9,7 +9,6 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.corfudb.format.Types;
@@ -28,6 +27,8 @@ import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.exceptions.DataCorruptionException;
 import org.corfudb.runtime.exceptions.LogUnitException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.roaringbitmap.longlong.LongIterator;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import javax.annotation.Nullable;
 import java.io.File;
@@ -52,8 +53,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.corfudb.infrastructure.log.StreamLogParams.METADATA_SIZE;
 import static org.corfudb.infrastructure.log.StreamLogParams.VERSION;
@@ -129,7 +128,7 @@ public class StreamLogFiles implements StreamLog {
         logSizeQuota = new ResourceQuota("LogSizeQuota", logSizeLimit);
         logSizeQuota.consume(initialLogSize);
 
-        segmentManager = new SegmentManager(logParams, logDir, logSizeQuota);
+        segmentManager = new SegmentManager(logParams, logDir, logSizeQuota, dataStore);
         segmentManager.deleteExistingCompactionOutputFiles();
 
         verifyLogs();
@@ -213,16 +212,21 @@ public class StreamLogFiles implements StreamLog {
 
         long start = System.currentTimeMillis();
         for (long currentSegment = tailSegment; currentSegment >= startSegment; currentSegment--) {
-            StreamLogSegment streamSegment = segmentManager.getStreamLogSegmentByOridnal(currentSegment);
+            StreamLogSegment streamSegment = segmentManager.getStreamLogSegmentByOrdinal(currentSegment);
 
             for (Long address : streamSegment.getKnownAddresses().keySet()) {
                 LogData logData = read(address);
-                // It is safe to preclude compacted entries when updating stream tails
-                // because each record in it must have been marked garbage by someone
-                // with larger address and still not compacted yet.
-                if (logData.getType() != DataType.COMPACTED) {
-                    logMetadata.update(Collections.singletonList(logData));
-                }
+                logMetadata.update(Collections.singletonList(logData));
+            }
+
+            // Update global tail with compactedAddresses to prevent holes regressing global tail.
+            // It is safe for stream tails and stream address map since holes do not belong to any
+            // stream and if a stream update in a LogData is compacted, it must had been marked
+            // garbage by someone with greater address and still not compacted yet.
+            Roaring64NavigableMap compactedAddresses = streamSegment.getCompactedAddresses();
+            LongIterator iterator = compactedAddresses.getReverseLongIterator();
+            if (iterator.hasNext()) {
+                logMetadata.updateGlobalTail(iterator.next());
             }
 
             // Close and remove the reference of the unprotected segments.
@@ -579,12 +583,8 @@ public class StreamLogFiles implements StreamLog {
     }
 
     @Override
-    public Map<UUID, Long> getCompactionMarks(@NonNull Set<UUID> streams) {
-        Map<UUID, Long> allCompactionMarks = dataStore.getCompactionMarks();
-        return streams
-                .stream()
-                .filter(allCompactionMarks::containsKey)
-                .collect(Collectors.toMap(Function.identity(), allCompactionMarks::get));
+    public long getGlobalCompactionMark() {
+        return dataStore.getGlobalCompactionMark();
     }
 
     @Override
@@ -611,6 +611,8 @@ public class StreamLogFiles implements StreamLog {
 
         dataStore.resetStartingAddress();
         dataStore.resetTailSegment();
+        dataStore.resetGlobalCompactionMark();
+        dataStore.resetAllCompactedAddresses();
         logMetadata = new LogMetadata();
         segmentsToSync.clear();
         logSizeQuota = new ResourceQuota("LogSizeQuota", logSizeLimit);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogParams.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogParams.java
@@ -34,7 +34,7 @@ public class StreamLogParams {
     public boolean verifyChecksum = true;
 
     @Default
-    public int recordsPerSegment = 10_000;
+    public int recordsPerSegment = 20_000;
 
     @Default
     public double logSizeQuotaPercentage = 100.0;
@@ -70,6 +70,9 @@ public class StreamLogParams {
     public double segmentGarbageRatioThreshold = 0.5;
 
     @Default
-    public double segmentGarbageSizeThresholdMB = 200;
+    public double segmentGarbageSizeThresholdMB = 128;
+
+    @Default
+    public double totalGarbageSizeThresholdMB = 5 * 1024;
     // End region
 }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -1,7 +1,6 @@
 package org.corfudb.protocols.wireprotocol;
 
 import com.esotericsoftware.kryo.NotNull;
-import com.google.common.collect.Sets;
 import com.google.common.reflect.TypeToken;
 
 import java.util.Arrays;
@@ -99,25 +98,6 @@ public interface IMetadata {
 
     default void setBackpointerMap(Map<UUID, Long> backpointerMap) {
         getMetadataMap().put(LogUnitMetadataType.BACKPOINTER_MAP, backpointerMap);
-    }
-
-    @SuppressWarnings("unchecked")
-    default Set<UUID> getCompactedStreams() {
-        return (Set<UUID>) getMetadataMap().getOrDefault(LogUnitMetadataType.COMPACTED_STREAMS,
-                Collections.EMPTY_SET);
-    }
-
-    default void setCompactedStreams(Set<UUID> compactedStreams) {
-        getMetadataMap().put(LogUnitMetadataType.COMPACTED_STREAMS, compactedStreams);
-    }
-
-    /**
-     * Get all the streams that belongs to this data including compacted and un-compacted.
-     *
-     * @return a set of all stream identifiers
-     */
-    default Set<UUID> getAllStreams() {
-        return Sets.union(getStreams(), getCompactedStreams());
     }
 
     default void setGlobalAddress(Long address) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -59,8 +59,10 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         return logData;
     }
 
-    public static LogData getCompacted(EnumMap<LogUnitMetadataType, Object> metadataMap) {
-        return new LogData(DataType.COMPACTED, metadataMap);
+    public static LogData getCompacted(long address) {
+        LogData logData = new LogData(DataType.COMPACTED);
+        logData.setGlobalAddress(address);
+        return logData;
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ReadResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ReadResponse.java
@@ -1,15 +1,14 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
+import org.corfudb.runtime.view.Address;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by mwei on 8/15/16.
@@ -23,16 +22,16 @@ public class ReadResponse implements ICorfuPayload<ReadResponse> {
 
     @Setter
     @Getter
-    Map<UUID, Long> compactionMarks;
+    long compactionMark;
 
     public ReadResponse(ByteBuf buf) {
         addresses = ICorfuPayload.mapFromBuffer(buf, Long.class, LogData.class);
-        compactionMarks = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
+        compactionMark = ICorfuPayload.fromBuffer(buf, Long.class);
     }
 
     public ReadResponse() {
         addresses = new HashMap<>();
-        compactionMarks = new HashMap<>();
+        compactionMark = Address.NON_ADDRESS;
     }
 
     public void put(Long address, LogData data) {
@@ -42,6 +41,6 @@ public class ReadResponse implements ICorfuPayload<ReadResponse> {
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, addresses);
-        ICorfuPayload.serialize(buf, compactionMarks);
+        ICorfuPayload.serialize(buf, compactionMark);
     }
 }


### PR DESCRIPTION
## Overview

Using per steam compaction mark has a downside of storing compacted
stream ids in each LogData's metadata, because each read on an address
needs to return the per stream compaction marks on that address, in
this way, we cannot completely remove a LogData which causes a leak.
Using global compaction mark, we only needs to store a bitmap for the
compacted addresses in a segment, which is a smaller overhead, but
sacrifices some versioning ability. This is fine since we have a policy
to ensure compaction mark does not move for a certain amount of time.

This also includes changes in #2134

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
