### PR TITLE
Remove Trim Info Log Message - Chatty

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedException.java
@@ -30,6 +30,7 @@ public class TrimmedException extends LogUnitException {
     }
 
     public TrimmedException(List<Long> trimmed) {
+        super(String.format("Trimmed addresses {}", trimmed));
         trimmedAddresses = trimmed;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -181,16 +181,15 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                 if (isCheckpointCapable()
                         && Address.isAddress(trimMark)
                         && !isTrimCoveredByCheckpointOrLocalView(trimMark)) {
-                    String message = String.format("getStreamAddressMap[{%s}] stream has been " +
-                                    "trimmed at address %s and this space is not covered by the " +
-                                    "loaded checkpoint with start address %s, while accessing the " +
-                                    "stream at version %s. Looking for a new checkpoint.",this,
-                            trimMark, getCurrentContext().checkpoint.startAddress, maxGlobal);
-                    log.info(message);
                     if (getReadOptions().isIgnoreTrim()) {
                         log.debug("getStreamAddressMap[{}]: Ignoring trimmed exception for address[{}].",
                                 this, streamAddressSpace.getTrimMark());
                     } else {
+                        String message = String.format("getStreamAddressMap[{%s}] stream has been " +
+                                        "trimmed at address %s and this space is not covered by the " +
+                                        "loaded checkpoint with start address %s, while accessing the " +
+                                        "stream at version %s. Looking for a new checkpoint.",this,
+                                trimMark, getCurrentContext().checkpoint.startAddress, maxGlobal);
                         throw new TrimmedException(message);
                     }
                 }


### PR DESCRIPTION
## Overview

Typically for delta sync the remaining API is called in a very short interval (every 50ms) so printing the trim info log message warning that a checkpoint might not be loaded (which is expected as the stream is forcibly seek to a point and remaining is called from this point onwards) becomes chatty. 