### PR TITLE
UnsupportedOperationException error handling

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -468,6 +468,10 @@ public class CorfuRuntime {
          */
         @Default
         PriorityLevel priorityLevel = PriorityLevel.NORMAL;
+
+        /** Maximum number of retries before we give up retrying an implicit transaction. */
+        @Default
+        int maxNumOfImplicitTxRetries = 20;
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/AbortCause.java
@@ -15,6 +15,7 @@ public enum AbortCause {
     SIZE_EXCEEDED,
     USER,
     NETWORK,
+    UNSUPPORTED_OPERATION,
     TRIM, /** Aborted because an access to this snapshot resulted in a trim exception. */
     SEQUENCER_OVERFLOW,
     SEQUENCER_TRIM,

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -395,10 +395,20 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
                     }
                 }
 
+                if (e.getAbortCause() == AbortCause.UNSUPPORTED_OPERATION) {
+                    // No need to deal with TransactionalContext in this case.
+                    throw e;
+                }
+
                 if (retries == 1) {
                     MetricsUtils
                             .incConditionalCounter(isMetricsEnabled, counterTxnRetry1, 1);
                 }
+
+                if (retries > rt.getParameters().getMaxNumOfImplicitTxRetries()) {
+                    throw e; // Give up.
+                }
+
                 MetricsUtils.incConditionalCounter(isMetricsEnabled, counterTxnRetryN, 1);
                 log.debug("Transactional function aborted due to {}, retrying after {} msec",
                         e, sleepTime);

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
@@ -41,6 +41,10 @@ public abstract class AbstractTransactionContextTest extends AbstractTransaction
         return getMap().put(key, value);
     }
 
+    String putIfAbsent(String key, String value) {
+        return getMap().putIfAbsent(key, value);
+    }
+
     String get(String key) {
         return getMap().get(key);
     }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/SnapshotTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/SnapshotTransactionContextTest.java
@@ -2,15 +2,18 @@ package org.corfudb.runtime.object.transactions;
 
 import com.google.common.reflect.TypeToken;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.exceptions.AbortCause;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
  * Created by mwei on 11/22/16.
  */
 public class SnapshotTransactionContextTest extends AbstractTransactionContextTest {
+
     @Override
     public void TXBegin() { SnapshotTXBegin(); }
-
 
     @Test
     public void defaultSnapshotTest() {
@@ -102,6 +105,22 @@ public class SnapshotTransactionContextTest extends AbstractTransactionContextTe
         }));
         t(0, this::TXEnd);
         t(0, this::TXEnd);
+    }
 
+
+    /**
+     * Ensure that TransactionAbortedException(AbortCause.UNSUPPORTED_OPERATION) is thrown when
+     * doing a mutation inside of a snapshot read.
+     */
+    @Test
+    public void testUnsupportedOperationException() {
+        try {
+            SnapshotTXBegin();
+            putIfAbsent("k" , "v1");
+            TXEnd();
+            Assert.fail();
+        } catch (TransactionAbortedException e) {
+            Assert.assertTrue(e.getAbortCause() == AbortCause.UNSUPPORTED_OPERATION);
+        }
     }
 }


### PR DESCRIPTION
## Overview

Description:
UnsupportedOperationException error handling

Why should this be merged: 

An AbortedTransaction whose cause is UnsupportedOperationException
should not be retried, but propagated to the consumer.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
