### PR TITLE
CorfuGuidGenerator: Prevent transactional aborts

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
@@ -46,7 +46,7 @@ public class CorfuQueue<E> {
                 .setStreamName(streamName)
                 .setArguments(CorfuTable.IndexRegistry.empty(), new LinkedHashMap<Long, E>())
                 .open();
-        guidGenerator = new CorfuGuidGenerator(runtime);
+        guidGenerator = CorfuGuidGenerator.getInstance(runtime);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.view;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
@@ -7,6 +8,7 @@ import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -14,40 +16,127 @@ import java.util.UUID;
  * with weak comparable ordering with minimal distributed state sync.
  * On startup increment a globally unique id via Corfu Object.
  * Use this id with locally incrementing values to return unique ids.
- * Higher bits are made of an UTC timestamp while lower bits carry the
- * counter.
  *
  * Created by Sundar Sridharan on 5/22/19.
  */
+
+class CorfuGuid {
+    public static final int MAX_CORRECTION = 0xF;
+    private final long timestamp;
+    private final int driftCorrection;
+    private final int resolutionCorrection;
+    @Getter
+    private final long uniqueInstanceId;
+
+    CorfuGuid(long UTCtimestamp, int driftCorrection,
+              int resolutionCorrection, long uniqueInstanceId) {
+        this.timestamp = UTCtimestamp;
+        this.driftCorrection = driftCorrection;
+        this.resolutionCorrection = resolutionCorrection;
+        this.uniqueInstanceId = uniqueInstanceId;
+    }
+
+    private static final long TIMESTAMP_MSB_MASK = 0x000000FFffFF0000L;
+    private static final long TIMESTAMP_LSB_MASK = 0x000000000000FFffL;
+    private static final long INSTANCE_ID_MASK   = 0x000000000000FFffL;
+    private static final int CORRECTION_MASK     = MAX_CORRECTION;
+
+    private static final long TIMESTAMP_MSB_SHIFT = 24;
+    private static final long DRIFT_ADJUST_SHIFT  = 36;
+    private static final long TIMESTAMP_LSB_SHIFT = 20;
+    private static final long INSTANCE_ID_SHIFT   = 4;
+
+    /**
+     * Construct the CorfuGuid with the UTC + GloballyUniqueCounter + Corrections
+     * There are 2 types of corrections necessary to ensure uniqueness:
+     * 1. UTC wall clock time can drift backwards - Drift Adjust.
+     * 2. UTC resolution may be coarse if many threads try to generate a
+     *    guid simultaneously - Resolution Adjust.
+     *
+     * Can tolerate up to 16 NTP time adjustments without global state sync.
+     * Can tolerate up to 65 seconds of time drifts without loss of ordering.
+     * +---------------+--------------+---------------+-------------+-------------------+
+     * | Timestamp MSB | Drift Adjust | Timestamp LSB | Instance ID | Resolution Adjust |
+     * +---------------+--------------+---------------+-------------+-------------------+
+     * <----24 bits----><----4 bits---><----16 bits---><---16 bits--><-------4 bits----->
+     * @return - build the guid out of the timestamp from parts as shown above
+     */
+    public long getLong() {
+        final long timestampMSB     = timestamp & TIMESTAMP_MSB_MASK;
+        final long driftAdjust      = driftCorrection & CORRECTION_MASK;
+        final long timestampLSB     = timestamp & TIMESTAMP_LSB_MASK;
+        final long instanceId       = uniqueInstanceId & INSTANCE_ID_MASK;
+        final long resolutionAdjust = resolutionCorrection & CORRECTION_MASK;
+
+        return ((timestampMSB     << TIMESTAMP_MSB_SHIFT) |
+                (driftAdjust      << DRIFT_ADJUST_SHIFT)  |
+                (timestampLSB     << TIMESTAMP_LSB_SHIFT) |
+                (instanceId       << INSTANCE_ID_SHIFT)   |
+                resolutionAdjust);
+    }
+
+    CorfuGuid(long encodedTs) {
+        long currentTimestamp = System.currentTimeMillis();
+        final long timestampMSB = (encodedTs >> TIMESTAMP_MSB_SHIFT) & TIMESTAMP_MSB_MASK;
+        final long timestampLSB = (encodedTs >> TIMESTAMP_LSB_SHIFT) & TIMESTAMP_LSB_MASK;
+        timestamp = (currentTimestamp & (~(TIMESTAMP_MSB_MASK | TIMESTAMP_LSB_MASK)))
+                | timestampMSB  | timestampLSB;
+        driftCorrection = (int)((encodedTs >> DRIFT_ADJUST_SHIFT) & CORRECTION_MASK);
+        uniqueInstanceId = (int)((encodedTs >> INSTANCE_ID_SHIFT) & INSTANCE_ID_MASK);
+        resolutionCorrection = (int)(encodedTs & CORRECTION_MASK);
+    }
+
+    public String toString() {
+        return String.format("%s: drift: %d resolution: %d instanceId %d",
+                Instant.ofEpochMilli(timestamp).toString(),
+                driftCorrection, resolutionCorrection, uniqueInstanceId);
+    }
+}
+
 @Slf4j
 public class CorfuGuidGenerator implements OrderedGuidGenerator {
-    private final static int TIMESTAMP_SHIFT            = 24;
-    private final static int INSTANCE_ID_SHIFT          = 8;
-    private final static int MAX_TIMESTAMP_CORRECTION   = 0xFF;
-    private final static int MAX_INSTANCE_ID            = 0xFFff;
-
     private final String GUID_STREAM_NAME = "CORFU_GUID_COUNTER_STREAM";
     private final Integer GUID_STREAM_KEY = 0xdeadbeef;
 
     private final SMRMap<Integer, Long> distributedCounter;
+
     private final CorfuRuntime runtime;
+
 
     /**
      * Initialize timestamp & correction to MAX to force an update on the instance id on first call.
      * This prevents the instance id from bumping up if there are no calls made to this class.
      */
-    private long timestampCorrection = MAX_TIMESTAMP_CORRECTION;
+    private int driftCorrection = CorfuGuid.MAX_CORRECTION;
+    private int resolutionCorrection = CorfuGuid.MAX_CORRECTION;
     private long previousTimestamp = Long.MAX_VALUE;
     private long instanceId = 0L;
 
-    public CorfuGuidGenerator(CorfuRuntime rt) {
+    private static CorfuGuidGenerator singletonCorfuGuidGenerator;
+
+    private CorfuGuidGenerator(CorfuRuntime rt) {
         runtime = rt;
         distributedCounter = rt.getObjectsView().build()
-                               .setType(SMRMap.class)
-                               .setStreamName(GUID_STREAM_NAME)
-                               .open();
+                .setType(SMRMap.class)
+                .setStreamName(GUID_STREAM_NAME)
+                .open();
     }
 
+    public synchronized static CorfuGuidGenerator getInstance(CorfuRuntime rt) {
+        if (singletonCorfuGuidGenerator == null) {
+            singletonCorfuGuidGenerator = new CorfuGuidGenerator(rt);
+        }
+        return singletonCorfuGuidGenerator;
+    }
+
+    @Override
+    public UUID nextUUID() {
+        throw new UnsupportedOperationException("Not supported yet");
+    }
+
+    /** Sync up with the distributed state using a Corfu Transaction
+     * Synchronous Network RPCs among other overheads
+     **/
     private long updateInstanceId() {
         long nextInstanceId;
         while(true) {
@@ -80,60 +169,55 @@ public class CorfuGuidGenerator implements OrderedGuidGenerator {
     }
 
     /**
-     * +----------------+--------------------+------------+
-     * |  UTC Timestamp | Unique Instance ID | Correction |
-     * +----------------+--------------------+------------+
-     * <----5 bytes----><------2 bytes------><---1 byte--->
-     *
      * @return a globally unique id with minimal distributed sync up
      */
     @Override
     public long nextLong() {
-        long currentTimestamp = getCorrectedTimestamp();
-        return (currentTimestamp << TIMESTAMP_SHIFT) |
-                ((instanceId & MAX_INSTANCE_ID) << INSTANCE_ID_SHIFT) |
-                (timestampCorrection & MAX_TIMESTAMP_CORRECTION);
+        return getCorrectedTimestamp().getLong();
     }
 
     /**
-     * +-------------------++--------------+------------+
-     * | UTC Timestamp     || Instance Id  | Correction |
-     * +-------------------++--------------+------------+
-     * <------8 byte-------><---7 byte------><--1 byte-->
+     * 1. Get Current timestamp and compare it with previous timestamp
+     *   -> if time has drifted backwards bump up driftCorrection
+     *     -> if driftCorrection has maxed out, bump up instance Id (loss of ordering)
+     *   -> if time is same as previous
+     *    -> bump up resolutionCorrection
+     *     -> if resolutionCorrection has maxed out, bump up instance Id (possible loss of ordering)
      *
-     * @return a higher resolution UUID with a timestamp built in.
+     * @return Parts of the Guid with best effort global ordering in parts
      */
-    @Override
-    public UUID nextUUID() {
-        long currentTimestamp = getCorrectedTimestamp();
-        return new UUID(currentTimestamp,
-                (instanceId << INSTANCE_ID_SHIFT) | (timestampCorrection & MAX_TIMESTAMP_CORRECTION));
-
-    }
-
-    /**
-     * Ensure that timestamp is monotonically increasing and if not,
-     * 1. First bump up the correction
-     * 2. If correction has also rolled over, bump up instance id
-     *
-     * @return currentTimestamp but with side-effects to object state
-     */
-    private synchronized long getCorrectedTimestamp() {
+    private synchronized CorfuGuid getCorrectedTimestamp() {
         long currentTimestamp = System.currentTimeMillis();
-        if (currentTimestamp <= previousTimestamp) {
-            timestampCorrection++;
-            if (timestampCorrection > MAX_TIMESTAMP_CORRECTION) {
-                timestampCorrection = 0;
-                log.info("updateInstanceId: CorfuGuidGenerator corrected timestamp "+
-                                MAX_TIMESTAMP_CORRECTION+
-                                " times!"+
+        if (currentTimestamp == previousTimestamp) {
+            resolutionCorrection++;
+            // If more than 16 concurrent threads are calling this api, we can hit this.
+            // Simple solution is to make the last thread wait a few microseconds.
+            // This avoids an transactional call.
+            if (resolutionCorrection > CorfuGuid.MAX_CORRECTION) {
+                while (currentTimestamp == previousTimestamp) {
+                    currentTimestamp = System.currentTimeMillis();
+                }
+                resolutionCorrection = 0;
+            }
+        } else {
+            resolutionCorrection = 0;
+        }
+
+        if (currentTimestamp < previousTimestamp) {
+            driftCorrection++;
+            if (driftCorrection > CorfuGuid.MAX_CORRECTION) {
+                log.info("updateInstanceId: Time went backward too many times "+
                                 " timestamp={} previousTimestamp={} correction={} instanceId={}",
-                        currentTimestamp, previousTimestamp, timestampCorrection, instanceId);
+                        currentTimestamp, previousTimestamp, driftCorrection, instanceId);
+                driftCorrection = 0;
                 updateInstanceId();
             }
         }
         previousTimestamp = currentTimestamp;
-        return currentTimestamp;
+        return new CorfuGuid(currentTimestamp, driftCorrection, resolutionCorrection, instanceId);
     }
 
+    public String toString(long encodedTs) {
+        return new CorfuGuid(encodedTs).toString();
+    }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/CorfuGuidGeneratorTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/CorfuGuidGeneratorTest.java
@@ -2,6 +2,9 @@ package org.corfudb.runtime.view;
 
 import org.junit.Test;
 
+import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.UUID;
 
@@ -18,27 +21,18 @@ public class CorfuGuidGeneratorTest extends AbstractViewTest {
     @Test
     public void areUniqueAndOrderedLong() {
         final int iterations = PARAMETERS.NUM_ITERATIONS_MODERATE;
-        OrderedGuidGenerator guidGenerator = new CorfuGuidGenerator(getDefaultRuntime().connect());
+        CorfuGuidGenerator guidGenerator = CorfuGuidGenerator.getInstance(getDefaultRuntime().connect());
         long lastValue = 0;
         HashSet<Long> uniq = new HashSet<>(iterations);
         for (int i = 0; i < iterations; i++) {
             long current = guidGenerator.nextLong();
+            CorfuGuid ts = new CorfuGuid(current);
+            // Each time validate that number of transactions made is kept minimal.
+            assertThat(ts.getUniqueInstanceId()).isLessThan(PARAMETERS.NUM_ITERATIONS_LOW);
+            assertThat(guidGenerator.toString(current)).isNotNull();
+            // Validate uniqueness
             assertThat(uniq).doesNotContain(current);
-            assertThat(current).isGreaterThan(lastValue);
-            lastValue = current;
-            uniq.add(current);
-        }
-    }
-
-    @Test
-    public void areUniqueAndOrderedUUID() {
-        final int iterations = PARAMETERS.NUM_ITERATIONS_MODERATE;
-        OrderedGuidGenerator guidGenerator = new CorfuGuidGenerator(getDefaultRuntime().connect());
-        UUID lastValue = new UUID(0,0);
-        HashSet<UUID> uniq = new HashSet<>(iterations);
-        for (int i = 0; i < iterations; i++) {
-            UUID current = guidGenerator.nextUUID();
-            assertThat(uniq).doesNotContain(current);
+            // Validate monotonic increasing order
             assertThat(current).isGreaterThan(lastValue);
             lastValue = current;
             uniq.add(current);


### PR DESCRIPTION
If CorfuQueue is used in a highly concurrent environment, it
causes the correction to quickly overflow and bump up the instance id.
Bumping up the instance id is really a corfu transaction.
If this transaction is nested, it aborts the parent transaction.
To avoid this, keep the use of transactions to an absolute minimum.
Make CorfuGuids tolerant of NTP time drifts upto 16 per minute

Why should this be merged: 

Related issue(s) (if applicable): #2152 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
