### PR TITLE
[Corfu-0.2.3] Remove deepSizeOf in CheckpointWriter which causes memory bloat.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -172,10 +172,9 @@ public class CheckpointWriter<T extends Map> {
             appendObjectState(entries);
             finishCheckpoint();
             long cpDuration = System.currentTimeMillis() - start;
-            log.info("appendCheckpoint: completed checkpoint for {}, entries({}), tableSize({}) bytes, " +
+            log.info("appendCheckpoint: completed checkpoint for {}, entries({}), " +
                             "cpSize({}) bytes at snapshot {} in {} ms",
-                    streamId, entries.size(), MetricsUtils.sizeOf.deepSizeOf(entries),
-                    numBytes, snapshotTimestamp, cpDuration);
+                    streamId, entries.size(), numBytes, snapshotTimestamp, cpDuration);
         } finally {
             rt.getObjectsView().TXEnd();
         }


### PR DESCRIPTION
## Overview

CheckpointWriter uses deepSizeOf() to calculate the accurate size
of the checkpointed map as one of the metrics. However this method
would cause a heap memory bloat if the map is large, so removing it.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
