### PR TITLE
Expose client metrics for external consumption

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/servers/PrometheusMetricsServer.java
+++ b/common/src/main/java/org/corfudb/common/metrics/servers/PrometheusMetricsServer.java
@@ -70,6 +70,7 @@ public class PrometheusMetricsServer implements MetricsServer {
     public static class Config {
         private final int port;
         private final boolean enabled;
+        public static final Boolean ENABLED = true;
         public static final String METRICS_PARAM = "--metrics";
         public static final String METRICS_PORT_PARAM = "--metrics-port";
 

--- a/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCorfuCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCorfuCluster.java
@@ -71,7 +71,7 @@ public abstract class AbstractCorfuCluster<U extends UniverseParams> extends Abs
     public LocalCorfuClient getLocalCorfuClient() {
         return LocalCorfuClient.builder()
                 .serverEndpoints(getClusterLayoutServers())
-                .metricsPort(Optional.empty())
+                .prometheusMetricsPort(Optional.empty())
                 .build()
                 .deploy();
     }
@@ -79,7 +79,7 @@ public abstract class AbstractCorfuCluster<U extends UniverseParams> extends Abs
     @Override
     public LocalCorfuClient getLocalCorfuClient(int metricsPort) {
         return LocalCorfuClient.builder()
-                .metricsPort(Optional.of(metricsPort))
+                .prometheusMetricsPort(Optional.of(metricsPort))
                 .serverEndpoints(getClusterLayoutServers())
                 .build()
                 .deploy();

--- a/it/src/main/java/org/corfudb/universe/node/client/LocalCorfuClient.java
+++ b/it/src/main/java/org/corfudb/universe/node/client/LocalCorfuClient.java
@@ -38,7 +38,7 @@ public class LocalCorfuClient implements CorfuClient {
     @Builder
     public LocalCorfuClient(ClientParams params,
                             ImmutableSortedSet<String> serverEndpoints,
-                            Optional<Integer> metricsPort) {
+                            Optional<Integer> prometheusMetricsPort) {
         this.params = params;
         this.serverEndpoints = serverEndpoints;
 
@@ -53,6 +53,7 @@ public class LocalCorfuClient implements CorfuClient {
                 .layoutServers(layoutServers)
                 .systemDownHandler(this::systemDownHandler);
 
+        prometheusMetricsPort.map(port -> parametersBuilder.prometheusMetricsPort(port));
         this.runtime = fromParameters(parametersBuilder.build());
     }
 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -53,6 +53,11 @@
     <dependencies>
         <dependency>
             <groupId>org.corfudb</groupId>
+            <artifactId>corfudb-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.corfudb</groupId>
             <artifactId>format</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -62,9 +67,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-        <groupId>org.corfudb</groupId>
-        <artifactId>annotationProcessor</artifactId>
-        <version>${project.version}</version>
+            <groupId>org.corfudb</groupId>
+            <artifactId>annotationProcessor</artifactId>
+            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/MetricsUtils.java
@@ -25,6 +25,9 @@ import java.lang.management.ManagementFactory;
 import java.lang.ref.WeakReference;
 import java.util.concurrent.TimeUnit;
 
+import org.corfudb.common.metrics.MetricsServer;
+import org.corfudb.common.metrics.servers.PrometheusMetricsServer;
+import org.corfudb.common.metrics.servers.PrometheusMetricsServer.Config;
 import org.ehcache.sizeof.SizeOf;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +61,8 @@ public class MetricsUtils {
     private static final String PROPERTY_JMX_REPORTING = "corfu.metrics.jmxreporting";
     private static final String PROPERTY_JVM_METRICS_COLLECTION = "corfu.metrics.jvm";
     private static final String PROPERTY_LOG_INTERVAL = "corfu.metrics.log.interval";
-    private static final String PROPERTY_METRICS_COLLECTION = "corfu.metrics.collection";
+    private static final String PROPERTY_LOCAL_METRICS_COLLECTION =
+            "corfu.local.metrics.collection";
 
     private static final String ADDRESS_SPACE_METRIC_PREFIX = "corfu.runtime.as-view";
     private static final MetricFilter ADDRESS_SPACE_FILTER =
@@ -69,6 +73,7 @@ public class MetricsUtils {
     private static String metricsCsvFolder;
     @Getter
     private static boolean metricsCollectionEnabled = false;
+    private static boolean metricsLocalCollectionEnabled = false;
     private static boolean metricsCsvReportingEnabled = false;
     private static boolean metricsJmxReportingEnabled = false;
     private static boolean metricsJvmCollectionEnabled = false;
@@ -76,6 +81,7 @@ public class MetricsUtils {
     private static final String mpTrigger = "filter-trigger"; // internal use only
 
     public static final SizeOf sizeOf = SizeOf.newInstance();
+    public static final int NO_METRICS_PORT = -1;
 
     /**
      * Load metrics properties.
@@ -116,7 +122,8 @@ public class MetricsUtils {
      * -Dcorfu.metrics.log.interval=60}
      */
     private static void loadVmProperties() {
-        metricsCollectionEnabled = Boolean.valueOf(System.getProperty(PROPERTY_METRICS_COLLECTION));
+        metricsLocalCollectionEnabled = Boolean.valueOf(System.getProperty(
+                PROPERTY_LOCAL_METRICS_COLLECTION));
 
         metricsJmxReportingEnabled = Boolean.valueOf(System.getProperty(PROPERTY_JMX_REPORTING));
         metricsJvmCollectionEnabled = Boolean.valueOf(System.getProperty(PROPERTY_JVM_METRICS_COLLECTION));
@@ -157,23 +164,39 @@ public class MetricsUtils {
 
         loadVmProperties();
 
-        if (metricsCollectionEnabled) {
+        if (metricsLocalCollectionEnabled) {
             setupCsvReporting(metrics);
             setupJvmMetrics(metrics);
             setupJmxReporting(metrics);
             setupSlf4jReporting(metrics);
-            log.info("Corfu metrics collection and all reporting types are enabled");
-        } else {
-            log.info("Corfu metrics collection and all reporting types are disabled");
+
+            metricsCollectionEnabled = true;
+            log.info("Corfu CSV metrics collection and all reporting types are enabled");
         }
+    }
+    /**
+     * Start metrics reporting via Prometheus.
+     *
+     * @param metricRegistry Metrics registry
+     * @param prometheusMetricsPort port on which statistics should be exported
+     */
+    public static void metricsReportingSetup(@NonNull MetricRegistry metricRegistry,
+                                              int prometheusMetricsPort) {
+        Config config = new Config(prometheusMetricsPort, Config.ENABLED);
+        MetricsServer server = new PrometheusMetricsServer(config, metricRegistry);
+        server.start();
+
+        metricsCollectionEnabled = true;
+        log.info("Metrics exporting via Prometheus has been enabled at port {}.",
+                prometheusMetricsPort);
     }
 
     // If enabled, setup jmx reporting
-    private static void setupJmxReporting(MetricRegistry metrics) {
+    private static void setupJmxReporting(MetricRegistry metricRegistry) {
         if (!metricsJmxReportingEnabled) return;
 
         // This filters noisy addressSpace metrics to have a clean JMX reporting
-        JmxReporter jmxReporter = JmxReporter.forRegistry(metrics)
+        JmxReporter jmxReporter = JmxReporter.forRegistry(metricRegistry)
                 .convertDurationsTo(TimeUnit.MICROSECONDS)
                 .convertRatesTo(TimeUnit.SECONDS)
                 .inDomain(CORFU_METRICS)


### PR DESCRIPTION
Allow the client to set a CorfuRuntime parameter that will allow
metrics to be consumed via an external agent.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
