### PR TITLE
Change how we initialize wrapper objects

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -135,6 +135,11 @@
             <version>3.1.0</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.9</version>
+        </dependency>
+        <dependency>
             <groupId>org.ehcache</groupId>
             <artifactId>sizeof</artifactId>
             <version>0.3.0</version>

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -1,9 +1,11 @@
 package org.corfudb.runtime.object;
 
-import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.util.UUID;
 
+import lombok.NonNull;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.util.ReflectionUtils;
 import org.corfudb.util.serializer.ISerializer;
 
 /**
@@ -12,6 +14,7 @@ import org.corfudb.util.serializer.ISerializer;
  * <p>Created by mwei on 11/11/16.
  */
 public class CorfuCompileWrapperBuilder {
+
 
     /**
      * Returns a wrapper for the underlying SMR Object
@@ -32,29 +35,14 @@ public class CorfuCompileWrapperBuilder {
                                    UUID streamID, Object[] args,
                                    ISerializer serializer)
             throws ClassNotFoundException, IllegalAccessException,
-            InstantiationException {
+            InstantiationException, InvocationTargetException {
         // Do we have a compiled wrapper for this type?
         Class<ICorfuSMR<T>> wrapperClass = (Class<ICorfuSMR<T>>)
                 Class.forName(type.getName() + ICorfuSMR.CORFUSMR_SUFFIX);
 
         // Instantiate a new instance of this class.
-        ICorfuSMR<T> wrapperObject = null;
-        if (args == null || args.length == 0) {
-            wrapperObject = wrapperClass.newInstance();
-        } else {
-            // This loop is not ideal, but the easiest way to get around Java
-            // boxing, which results in primitive constructors not matching.
-            for (Constructor<?> constructor : wrapperClass
-                    .getDeclaredConstructors()) {
-                try {
-                    wrapperObject = (ICorfuSMR<T>) constructor
-                            .newInstance(args);
-                    break;
-                } catch (Exception e) {
-                    // just keep trying until one works.
-                }
-            }
-        }
+        ICorfuSMR<T> wrapperObject = (ICorfuSMR<T>) ReflectionUtils.
+                            findMatchingConstructor(wrapperClass.getDeclaredConstructors(), args);
 
         // Now we create the proxy, which actually manages
         // instances of this object. The wrapper delegates calls to the proxy.

--- a/runtime/src/main/java/org/corfudb/util/ReflectionUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/ReflectionUtils.java
@@ -1,13 +1,21 @@
 package org.corfudb.util;
 
 import com.google.common.collect.ImmutableMap;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ClassUtils;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -92,38 +100,94 @@ public class ReflectionUtils {
                 .toArray(Class[]::new);
     }
 
-    public static <T> T newInstanceFromUnknownArgumentTypes(Class<T> cls, Object[] args) {
-        try {
-            return cls.getDeclaredConstructor(getArgumentTypesFromArgumentList(args))
-                    .newInstance(args);
-        } catch (InstantiationException | InvocationTargetException | IllegalAccessException ie) {
-            throw new RuntimeException(ie);
-        } catch (NoSuchMethodException nsme) {
-            // Now we need to find a matching primitive type.
-            // We can maybe cheat by running through all the constructors until we get what we want
-            // due to autoboxing
-            Constructor[] ctors = Arrays.stream(cls.getDeclaredConstructors())
-                    .filter(c -> c.getParameterTypes().length == args.length)
-                    .toArray(Constructor[]::new);
-            for (Constructor<?> ctor : ctors) {
-                try {
-                    return (T) ctor.newInstance(args);
-                } catch (Exception e) {
-                    // silently drop exceptions since we are brute forcing here...
-                }
+    /**
+     * Given the constructor arguments and the desired class type, find
+     * the closest matching constructor. For example, if a wrapper
+     * class contains two constructors, Constructor(A) and Constructor(B),
+     * and the constructor argument is of type B, where B inherits from A,
+     * instantiate the object via Constructor(B) since it is closes with
+     * respect to type hierarchy.
+     *
+     * @param constructors   Object constructors.
+     * @param args           Constructor arguments.
+     * @param <T>            Type
+     * @return instantiated  wrapper class.
+     *
+     * @throws IllegalAccessException should not be thrown
+     * @throws InvocationTargetException should not be thrown
+     * @throws InstantiationException should not be thrown
+     */
+    public static <T> Object findMatchingConstructor(
+            @NonNull Constructor[] constructors, @NonNull Object[] args)
+            throws IllegalAccessException, InvocationTargetException, InstantiationException {
+        // Figure out the argument types.
+        final List<Class> argTypes = Arrays
+                .stream(args).map(Object::getClass)
+                .collect(Collectors.toList());
+        // Filter out the constructors that do not have the same arity.
+        final List<Constructor> constructorCandidates = Arrays.stream(constructors)
+                .filter(constructor -> constructor.getParameterTypes().length == args.length)
+                .collect(Collectors.toList());
+
+        Map<Integer, Constructor> matchingConstructors = new HashMap<>();
+        for (Constructor candidate: constructorCandidates) {
+            final List<Class> parameterTypes = Arrays.asList(candidate.getParameterTypes());
+            final List<Integer> resolutionList = new LinkedList<>();
+            // Compare each argument type with the corresponding constructor parameter type.
+            for (int idx = 0; idx < parameterTypes.size(); idx++) {
+                final Class<?> parameterType = parameterTypes.get(idx);
+                final Class<?> argumentType = argTypes.get(idx);
+                // If we are able to match the argument type with the constructor parameter
+                // increment the hierarchy depth, signaling the distance between the
+                // argument type and the parameter type in terms of type hierarchy.
+                resolutionList.add(maxDepth(parameterType, argumentType, 0));
             }
 
-            String argTypes = Arrays.stream(args)
-                    .map(Object::getClass)
-                    .map(Object::toString)
-                    .collect(Collectors.joining(", "));
+            // If any of the argument types has type distance of zero, this means
+            // that we are unable to match the current constructor with the given arguments.
+            if (resolutionList.stream().anyMatch(depth -> depth == 0)) {
+                continue;
+            }
 
-            String availableCtors = Arrays.stream(ctors)
-                    .map(Constructor::toString)
-                    .collect(Collectors.joining(", "));
+            // Put all matching constructors in a map in form of:
+            // (L1 Norm (Distance) -> Constructor)
+            matchingConstructors.put(
+                    resolutionList.stream().reduce(0, Integer::sum),
+                    candidate);
+        }
 
-            throw new RuntimeException("Couldn't find a matching ctor for "
-                    + argTypes + "; available ctors are " + availableCtors);
+        // Instantiate the wrapper object with a constructor that has the lowest L1 norm.
+        return matchingConstructors.entrySet().stream()
+                .min(Map.Entry.comparingByKey()).orElseThrow(
+                        () -> new IllegalStateException("No matching constructors found."))
+                .getValue().newInstance(args);
+    }
+
+    /**
+     * Return the distance between two types with respect to their inheritance.
+     *
+     * @param parameterType type associated with the constructor definition
+     * @param argumentType type associated with the provided argument
+     * @param currentDepth recursive parameter
+     * @return 0 if if one Class cannot be assigned to a variable of another Class.
+     *         Positive integer otherwise.
+     */
+    private static int maxDepth(Class parameterType, Class argumentType, int currentDepth) {
+        if (!ClassUtils.isAssignable(argumentType, parameterType, true)) {
+            return currentDepth;
+        } else {
+            final int newDepth = currentDepth + 1;
+            final List<Integer> results = new ArrayList<>();
+            final Class[] interfaces = argumentType.getInterfaces();
+            final Class superClass = argumentType.getSuperclass();
+
+            Arrays.stream(interfaces) // Check the interface hierarchy recursively.
+                    .forEach(clazz -> results.add(maxDepth(parameterType, clazz, newDepth)));
+            Optional.ofNullable(superClass) // Check the concrete hierarchy recursively.
+                    .map(clazz -> results.add(maxDepth(parameterType, clazz, newDepth)));
+            return results.stream()
+                    .max(Comparator.comparing(Integer::valueOf))
+                    .orElse(newDepth);
         }
     }
 

--- a/test/src/test/java/org/corfudb/runtime/object/ObjectBuilderTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/ObjectBuilderTest.java
@@ -1,0 +1,92 @@
+package org.corfudb.runtime.object;
+
+import org.corfudb.runtime.collections.ISMRObject;
+import org.corfudb.util.ReflectionUtils;
+import org.junit.Test;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Tests related to {@link ISMRObject} creation.
+ */
+public class ObjectBuilderTest {
+
+    public interface BaseInterface { }
+    public interface ChildInterface extends BaseInterface { }
+
+    static class ChildImpl implements ChildInterface { }
+
+    static class Base { }
+    static class Child extends Base { }
+
+    public static class ExampleInterface {
+        public ExampleInterface(ChildInterface base) {
+            // NOOP.
+        }
+
+        public ExampleInterface(BaseInterface base) {
+            throw new IllegalStateException("Not suppose to be called");
+        }
+    }
+
+    public static class Example {
+        public Example() {
+            // NOOP.
+        }
+
+        public Example(Base base) {
+            throw new IllegalStateException("Not suppose to be called");
+        }
+
+        public Example(Child base) {
+            // NOOP.
+        }
+    }
+
+    /**
+     * Make sure that the correct constructor is being used
+     * in case of constructor overloading.
+     *
+     * @throws IllegalAccessException should not be thrown
+     * @throws InstantiationException should not be thrown
+     * @throws InvocationTargetException should not be thrown
+     */
+    @Test
+    public void constructorMatching()
+            throws IllegalAccessException, InstantiationException, InvocationTargetException {
+        Object[] args = { new Child() };
+        ReflectionUtils.findMatchingConstructor(
+                Example.class.getDeclaredConstructors(), args);
+    }
+
+    /**
+     * Make sure that the correct constructor is being used
+     * in case of constructor overloading (interface version).
+     *
+     * @throws IllegalAccessException should not be thrown
+     * @throws InstantiationException should not be thrown
+     * @throws InvocationTargetException should not be thrown
+     */
+    @Test
+    public void constructorInterfaceMatching()
+            throws IllegalAccessException, InstantiationException, InvocationTargetException {
+        Object[] args = { new ChildImpl() };
+        ReflectionUtils.findMatchingConstructor(
+                ExampleInterface.class.getDeclaredConstructors(), args);
+    }
+
+    /**
+     * Make sure that the correct constructor is being used
+     * in case of a zero-arg constructor.
+     *
+     * @throws IllegalAccessException should not be thrown
+     * @throws InstantiationException should not be thrown
+     * @throws InvocationTargetException should not be thrown
+     */
+    @Test
+    public void noArgeConstructorMatch()
+            throws IllegalAccessException, InstantiationException, InvocationTargetException {
+        Object[] args = { };
+        ReflectionUtils.findMatchingConstructor(
+                Example.class.getDeclaredConstructors(), args);
+    }
+}


### PR DESCRIPTION
Previously, we were initializing a wrapper object with any constructor
that would match the given arguments. This approach is not sufficient
when constructor type parameters are polymorphic, since the wrong
constructor might get called.

Please take a look at Java Specification 15.12.2.5. for more
information.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
