### PR TITLE
Avoid batch writer epoch validation on prefixTrim.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchWriter.java
@@ -106,13 +106,14 @@ public class BatchWriter<K, V> implements CacheWriter<K, V>, AutoCloseable {
     /**
      * Trim addresses from log up to a prefix.
      *
-     * @param address prefix address to trim to (inclusive)
+     * @param address  prefix address to trim to (inclusive).
+     * @param msgEpoch Message epoch.
      */
-    public void prefixTrim(@Nonnull Token address) {
+    public void prefixTrim(long address, long msgEpoch) {
         try {
-            CompletableFuture<Void> cf = new CompletableFuture();
+            CompletableFuture<Void> cf = new CompletableFuture<>();
             operationsQueue.add(new BatchWriterOperation(BatchWriterOperation.Type.PREFIX_TRIM,
-                    address.getSequence(), null, address.getEpoch(), null, cf));
+                    address, null, msgEpoch, null, cf));
             cf.get();
         } catch (Exception e) {
             if (e.getCause() instanceof RuntimeException) {

--- a/it/src/test/resources/logback-test.xml
+++ b/it/src/test/resources/logback-test.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %highlight(%-5level) | %20.20thread{20} | %50.50(%logger.%M:%L) | %msg%n%xException
+            </pattern>
+        </encoder>
+    </appender>
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>${user.home}/corfudb.log</file>
+        <encoder>
+            <pattern>
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %highlight(%-5level) | %20.20thread{20} | %50.50(%logger.%M:%L) | %msg%n%xException
+            </pattern>
+        </encoder>
+    </appender>
+    <appender name="MetricsRollingFile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>/tmp/log/corfu-metrics.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>/var/log/corfu-metrics.%i.log</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>10</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>100MB</maxFileSize>
+        </triggeringPolicy>
+
+        <encoder>
+            <pattern>%d %highlight(%-5level) - %msg%n %ex{short}</pattern>
+        </encoder>
+    </appender>
+
+    <!-- Control logging levels for individual components here. -->
+    <logger name="org.corfudb.runtime.object" level="INFO"/>
+    <logger name="org.corfudb.runtime.clients" level="INFO"/>
+    <logger name="org.corfudb.infrastructure" level="INFO"/>
+    <logger name="io.netty.util" level="INFO"/>
+    <logger name="io.netty.util.internal" level="INFO"/>
+    <logger name="io.netty.buffer" level="INFO"/>
+
+    <logger name="org.corfudb.metricsdata" level="INFO">
+        <!--<appender-ref ref="MetricsRollingFile" />-->
+    </logger>
+
+
+    <root level="INFO">
+        <!--<appender-ref ref="FILE" />-->
+        <!--<appender-ref ref="STDOUT" />-->
+        <!--<appender-ref ref="MetricsRollingFile" />-->
+    </root>
+</configuration>

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TailsResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/TailsResponse.java
@@ -1,12 +1,15 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
+
+import java.util.Map;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
+import org.corfudb.runtime.view.Layout;
 
 /**
  *
@@ -18,19 +21,24 @@ import java.util.UUID;
 
 @Data
 @RequiredArgsConstructor
+@AllArgsConstructor
 public class TailsResponse implements ICorfuPayload<TailsResponse> {
+
+    long epoch = Layout.INVALID_EPOCH;
 
     final long logTail;
 
     final Map<UUID, Long> streamTails;
 
     public TailsResponse(ByteBuf buf) {
+        epoch = ICorfuPayload.fromBuffer(buf, Long.class);
         logTail = ICorfuPayload.fromBuffer(buf, Long.class);
         streamTails = ICorfuPayload.mapFromBuffer(buf, UUID.class, Long.class);
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, epoch);
         ICorfuPayload.serialize(buf, logTail);
         ICorfuPayload.serialize(buf, streamTails);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -14,6 +14,7 @@ import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
+import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.CacheOption;
 import org.corfudb.runtime.view.StreamsView;
 import org.corfudb.util.CorfuComponent;
@@ -122,12 +123,22 @@ public class CheckpointWriter<T extends Map> {
     }
 
     /**
-     * @return List of global addresses of all entries for this checkpoint.
+     * @return Token at which the snapshot for this checkpoint was taken.
      */
     public Token appendCheckpoint() {
         long start = System.currentTimeMillis();
+
+        // Queries the sequencer for the global log tail. We then read the global log tail to
+        // persist the entry on the logunit in turn preventing from a new sequencer from
+        // regressing tokens.
+        Token markerToken = rt.getSequencerView().query().getToken();
+        if (Address.nonAddress(markerToken.getSequence())) {
+            return markerToken;
+        }
+        rt.getAddressSpaceView().read(markerToken.getSequence());
         rt.getObjectsView().TXBuild()
                 .type(TransactionType.SNAPSHOT)
+                .snapshot(markerToken)
                 .build()
                 .begin();
         try (Timer.Context context = MetricsUtils.getConditionalContext(appendCheckpointTimer)) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -368,19 +368,11 @@ public class AddressSpaceView extends AbstractView {
                 Sleep.sleepUninterruptibly(retryRate);
             } catch (WrongEpochException wee) {
                 long serverEpoch = wee.getCorrectEpoch();
-                // Retry if wrongEpochException corresponds to message epoch (only)
-                if (address.getEpoch() == serverEpoch) {
-                    long runtimeEpoch = runtime.getLayoutView().getLayout().getEpoch();
-                    log.warn("prefixTrim[{}]: wrongEpochException, runtime is in epoch {}, " +
-                            "while server is in epoch {}. Invalidate layout for this client " +
-                            "and retry, attempt: {}/{}", address, runtimeEpoch, serverEpoch, x+1, numRetries);
-                    runtime.invalidateLayout();
-                } else {
-                    // wrongEpochException corresponds to a stale trim address (prefix trim token on the wrong epoch)
-                    log.error("prefixTrim[{}]: stale prefix trim. Prefix trim on wrong epoch {}, " +
-                            "while server on epoch {}", address, address.getEpoch(), serverEpoch);
-                    throw wee;
-                }
+                long runtimeEpoch = runtime.getLayoutView().getLayout().getEpoch();
+                log.warn("prefixTrim[{}]: wrongEpochException, runtime is in epoch {}, while server is in epoch {}. "
+                                + "Invalidate layout for this client and retry, attempt: {}/{}",
+                        address, runtimeEpoch, serverEpoch, x + 1, numRetries);
+                runtime.invalidateLayout();
             }
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -23,7 +23,9 @@ import org.corfudb.runtime.exceptions.LayoutModificationException;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.RecoveryException;
+import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.util.CFUtils;
+import org.corfudb.util.Utils;
 
 /**
  * A view of the Layout Manager to manage reconfigurations of the Corfu Cluster.
@@ -430,9 +432,11 @@ public class LayoutManagementView extends AbstractView {
                         || !originalLayout.getPrimarySequencer()
                         .equals(newLayout.getPrimarySequencer())) {
 
-                    //TODO(Maithem) why isn't this getting the tails
-                    // from utils?
-                    TailsResponse tails = runtime.getAddressSpaceView().getAllTails();
+                    // The tails query and the sequencer recovery must be performed on the same
+                    // epoch. If they are not, we lose the atomicity of bootstrapping the sequencer
+                    // which can lead to data operations across epochs leaking into the
+                    // Address space causing inconsistencies and data loss.
+                    TailsResponse tails = Utils.getTails(newLayout, runtime);
 
                     maxTokenRequested = tails.getLogTail();
                     streamTails = tails.getStreamTails();

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -471,7 +471,7 @@ public class Utils {
      * @param responses a set of tail responses
      * @return An max-aggregation of all tails
      */
-    static TailsResponse getTails(Set<TailsResponse> responses) {
+    static TailsResponse getTails(Set<TailsResponse> responses, long epoch) {
         long globalTail = Address.NON_ADDRESS;
         Map<UUID, Long> globalStreamTails = new HashMap<>();
 
@@ -483,7 +483,8 @@ public class Utils {
                 globalStreamTails.put(stream.getKey(), Math.max(streamTail, stream.getValue()));
             }
         }
-        return new TailsResponse(globalTail, globalStreamTails);
+        // All epochs should be equal as all the tails are queried using a single runtime layout.
+        return new TailsResponse(epoch, globalTail, globalStreamTails);
     }
 
     /**
@@ -516,6 +517,6 @@ public class Utils {
             throw new UnsupportedOperationException();
         }
 
-        return getTails(luResponses);
+        return getTails(luResponses, layout.getEpoch());
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -67,7 +67,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         IStreamView sv = r.getStreamsView().get(CorfuRuntime.getStreamID("S1"));
         final int objSize = 100;
         long a1 = sv.append(new byte[objSize]);
-        final long cpEndAddress = 2L;
+        final long cpEndAddress = 0L;
         // Verify that the start/end records have been written for empty maps
         assertThat(a1).isEqualTo(cpEndAddress);
     }
@@ -300,6 +300,19 @@ public class CheckpointSmokeTest extends AbstractViewTest {
      *  destroyed (logically, not physically) by the CP, so we have
      *  to use a different position 'history' for our assertion
      *  check.
+     *
+     * +-----------------------------------------------------------------+
+     * | 0  | 1  | 2  | 3 | 4 | 5  | 6 | 7  | 8 | 9  | 10 | 11 | 12 | 13 |
+     * +-----------------------------------------------------------------+
+     * | F0 | F1 | F2 | S | C | M0 | C | M1 | C | M2 | E  | L0 | L1 | L2 |
+     * +-----------------------------------------------------------------+
+     * F : First batch of entries.
+     * S : Start of checkpoint.
+     * C : Continuation of checkpoints
+     * M : Middle batch of entries.
+     * E : End of checkpoints
+     * L : Last batch of entries.
+     *
      */
     @Test
     public void checkpointWriterInterleavedTest() throws Exception {

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -1474,6 +1474,7 @@ public class ManagementViewTest extends AbstractViewTest {
         runtime_1.getLayoutView().getRuntimeLayout(layout_2).sealMinServerSet();
         runtime_1.getLayoutView().updateLayout(layout_2, 1L);
         runtime_1.getLayoutManagementView().reconfigureSequencerServers(layout_1, layout_2, false);
+        waitForLayoutChange(layout -> layout.getEpoch() == layout_2.getEpoch(), runtime_1);
 
         clearClientRules(runtime_1);
 


### PR DESCRIPTION
## Overview

Description:

Backport of #1775 to corfu-0.2.2. This change allows prefix trim on different epochs. This change is required to avoid partition full issues found in earliest versions of Corfu due to trim failures.

## Checklist (Definition of Done):

- [x ] There are no TODOs left in the code
- [x ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x ] Change is covered by automated tests
- [x ] Public API has Javadoc
