### PR TITLE
Hide Protobuf Serializer TypeCode.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -75,16 +75,11 @@ public class TableRegistry {
      */
     private final CorfuTable<TableName, CorfuRecord<TableDescriptors, Message>> registryTable;
 
-    /**
-     * Byte code for the Protobuf Serializer.
-     */
-    private static final byte PROTOBUF_SERIALIZER_CODE = (byte) 25;
-
     public TableRegistry(CorfuRuntime runtime) {
         this.runtime = runtime;
         this.classMap = new ConcurrentHashMap<>();
         this.tableMap = new ConcurrentHashMap<>();
-        this.protobufSerializer = new ProtobufSerializer(PROTOBUF_SERIALIZER_CODE, classMap);
+        this.protobufSerializer = new ProtobufSerializer(classMap);
         Serializers.registerSerializer(this.protobufSerializer);
         this.registryTable = this.runtime.getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<TableName, CorfuRecord<TableDescriptors, Message>>>() {

--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -59,11 +59,6 @@ import static org.corfudb.runtime.view.TableRegistry.getTypeUrl;
 public class DynamicProtobufSerializer implements ISerializer {
 
     /**
-     * This is the serializer code used by the ProtobufSerializer.
-     */
-    private static final byte PROTOBUF_SERIALIZER_CODE = (byte) 25;
-
-    /**
      * Type code of the serializer. In this case the code needs to override the code of {@link ProtobufSerializer}.
      */
     @Getter
@@ -86,8 +81,8 @@ public class DynamicProtobufSerializer implements ISerializer {
      */
     private final ConcurrentMap<String, FileDescriptor> fileDescriptorMap = new ConcurrentHashMap<>();
 
-    public DynamicProtobufSerializer(byte type, CorfuRuntime corfuRuntime) {
-        this.type = type;
+    public DynamicProtobufSerializer(CorfuRuntime corfuRuntime) {
+        this.type = ProtobufSerializer.PROTOBUF_SERIALIZER_CODE;
 
         // Create and register a protobuf serializer to read the table registry.
         ISerializer protobufSerializer = createProtobufSerializer();
@@ -125,7 +120,7 @@ public class DynamicProtobufSerializer implements ISerializer {
         // Register the schemas of TableName and TableDescriptors to be able to understand registry table.
         classMap.put(getTypeUrl(TableName.getDescriptor()), TableName.class);
         classMap.put(getTypeUrl(TableDescriptors.getDescriptor()), TableDescriptors.class);
-        return new ProtobufSerializer(PROTOBUF_SERIALIZER_CODE, classMap);
+        return new ProtobufSerializer(classMap);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/util/serializer/ProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/ProtobufSerializer.java
@@ -32,10 +32,13 @@ import org.corfudb.runtime.exceptions.SerializerException;
 public class ProtobufSerializer implements ISerializer {
 
     private final byte type;
+
+    static final byte PROTOBUF_SERIALIZER_CODE = (byte) 25;
+
     private final Map<String, Class<? extends Message>> classMap;
 
-    public ProtobufSerializer(byte type, Map<String, Class<? extends Message>> classMap) {
-        this.type = type;
+    public ProtobufSerializer(Map<String, Class<? extends Message>> classMap) {
+        this.type = PROTOBUF_SERIALIZER_CODE;
         this.classMap = classMap;
     }
 

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -3,8 +3,14 @@ package org.corfudb.integration;
 import com.google.common.reflect.TypeToken;
 import com.google.protobuf.DynamicMessage;
 
-import org.corfudb.runtime.collections.*;
 import org.corfudb.runtime.collections.CorfuDynamicKey;
+import org.corfudb.runtime.collections.CorfuDynamicRecord;
+import org.corfudb.runtime.collections.CorfuRecord;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxBuilder;
 import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.test.SampleSchema.Uuid;
 import org.corfudb.util.serializer.DynamicProtobufSerializer;
@@ -153,8 +159,7 @@ public class CorfuStoreIT extends AbstractIT {
         // Interpret using dynamic messages.
         runtime = createRuntime(singleNodeEndpoint);
 
-        final int code = 25;
-        ISerializer dynamicProtobufSerializer = new DynamicProtobufSerializer((byte) code, runtime);
+        ISerializer dynamicProtobufSerializer = new DynamicProtobufSerializer(runtime);
         Serializers.registerSerializer(dynamicProtobufSerializer);
 
         CorfuTable<CorfuDynamicKey, CorfuDynamicRecord> corfuTable = runtime.getObjectsView().build()


### PR DESCRIPTION
## Overview

Description:
The type code of the protobuf serializer should not be exposed.
This for the following reasons:
- It should be used via the CorfuStore as it handles the initialization.
- DynamicProtobufSerializer depends on this code to override it to be able the deserialize the data.

Why should this be merged: 
To have the code in a single place and avoid developer errors in future.

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
