### PR TITLE
Lazy Deserialization

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -1,25 +1,29 @@
 package org.corfudb.protocols.logprotocol;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.buffer.ByteBuf;
-
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
-import lombok.Getter;
+import io.netty.buffer.Unpooled;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.Serializers;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.google.common.base.Preconditions.checkState;
 
 
 /**
- * A log entry structure which contains a collection of multiSMRentries,
- * each one contains a list of updates for one object.
+ * A log entry structure which contains a collection of multiSMREntries,
+ * each one contains a list of updates for one object. When a LogEntry is deserialized,
+ * a stream's updates are only deserialized on access. In essence, allowing a stream to
+ * only deserialize its updates. That is, stream updates are lazily deserialized.
  */
 @SuppressWarnings("checkstyle:abbreviation")
 @ToString
@@ -27,94 +31,129 @@ import org.corfudb.util.serializer.Serializers;
 public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
 
     // map from stream-ID to a list of updates encapsulated as MultiSMREntry
-    @Getter
-    public Map<UUID, MultiSMREntry> entryMap = Collections.synchronizedMap(new HashMap<>());
+    private Map<UUID, MultiSMREntry> streamUpdates = new ConcurrentHashMap<>();
+
+    /**
+     * A container to store streams and their payloads (i.e. serialized SMR updates).
+     * This is required to support lazy stream deserialization.
+     */
+    private final Map<UUID, byte[]> streamBuffers = new ConcurrentHashMap<>();
 
     public MultiObjectSMREntry() {
         this.type = LogEntryType.MULTIOBJSMR;
     }
 
-    public MultiObjectSMREntry(Map<UUID, MultiSMREntry> entryMap) {
-        this.type = LogEntryType.MULTIOBJSMR;
-        this.entryMap = entryMap;
-    }
-
-    /** Extract a particular stream's entry from this object.
-     *
-     * @param streamID StreamID
-     * @return the MultiSMREntry corresponding to streamId
-     */
-    protected MultiSMREntry getStreamEntry(UUID streamID) {
-        return getEntryMap().computeIfAbsent(streamID, u -> {
-                    return new MultiSMREntry();
-                }
-        );
-    }
-
     /**
-     * Add one SMR-update to one object's update-list.
-     * @param streamID StreamID
+     * Add one SMR-update to one object's update-list. This method is only called during a
+     * transaction, since only a single thread can execute a transaction at any point in time
+     * synchronization is not required.
+     *
+     * @param streamID    StreamID
      * @param updateEntry SMREntry to add
      */
     public void addTo(UUID streamID, SMREntry updateEntry) {
-        getStreamEntry(streamID).addTo(updateEntry);
+        checkState(streamBuffers.isEmpty(), "Shouldn't be called on a deserialized object");
+        MultiSMREntry multiSMREntry = streamUpdates.computeIfAbsent(streamID, k -> new MultiSMREntry());
+        multiSMREntry.addTo(updateEntry);
     }
 
     /**
-     * merge two MultiObjectSMREntry records.
-     * merging is done object-by-object
+     * merge two MultiObjectSMREntry records. This method is only called during a
+     * transaction, since only a single thread can execute a transaction at any point in time
+     * synchronization is not required.
+     *
      * @param other Object to merge.
      */
     public void mergeInto(MultiObjectSMREntry other) {
+        checkState(streamBuffers.isEmpty(), "Shouldn't be called on a deserialized object");
+
         if (other == null) {
             return;
         }
 
-        other.getEntryMap().forEach((streamID, multiSmrEntry) -> {
-            getStreamEntry(streamID).mergeInto(multiSmrEntry);
+        other.getEntryMap().forEach((otherStreamID, otherMultiSmrEntry) -> {
+            MultiSMREntry multiSMREntry = streamUpdates.computeIfAbsent(otherStreamID, k -> new MultiSMREntry());
+            multiSMREntry.mergeInto(otherMultiSmrEntry);
         });
     }
 
     /**
-     * This function provides the remaining buffer.
+     * This function provides the remaining buffer. Since stream updates
+     * are deserialized on access, this method will only map a stream to
+     * its payload (i.e. updates). The stream updates will be deserialized
+     * on first access.
      *
      * @param b The remaining buffer.
      */
     @Override
-    void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
+    public void deserializeBuffer(ByteBuf b, CorfuRuntime rt) {
         super.deserializeBuffer(b, rt);
+        int numStreams = b.readInt();
+        for (int i = 0; i < numStreams; i++) {
+            UUID streamId = new UUID(b.readLong(), b.readLong());
 
-        int numUpdates = b.readInt();
-        entryMap = new HashMap<>();
-        for (int i = 0; i < numUpdates; i++) {
-            entryMap.put(
-                    new UUID(b.readLong(), b.readLong()),
-                    ((MultiSMREntry) Serializers.CORFU.deserialize(b, rt)));
+            int updateLength = b.readInt();
+            byte[] streamUpdates = new byte[updateLength];
+            b.readBytes(streamUpdates);
+            streamBuffers.put(streamId, streamUpdates);
         }
     }
 
     @Override
     public void serialize(ByteBuf b) {
         super.serialize(b);
-        b.writeInt(entryMap.size());
-        entryMap.entrySet().stream()
+        b.writeInt(streamUpdates.size());
+        streamUpdates.entrySet().stream()
                 .forEach(x -> {
+                    // Stream payload structure
+                    // | stream id | payload size | SMR Update 1 | ... | SMR Update N|
                     b.writeLong(x.getKey().getMostSignificantBits());
                     b.writeLong(x.getKey().getLeastSignificantBits());
-                    Serializers.CORFU.serialize(x.getValue(), b);
+                    int payloadSizeIndex = b.writerIndex();
+                    b.writeInt(0);
+                    int payloadIndex = b.writerIndex();
+                    b.writeInt(x.getValue().getUpdates().size());
+                    x.getValue().getUpdates().stream().forEach(smrEntry -> Serializers.CORFU.serialize(smrEntry, b));
+                    int length = b.writerIndex() - payloadIndex;
+                    b.writerIndex(payloadSizeIndex);
+                    b.writeInt(length);
+                    b.writerIndex(payloadIndex + length);
                 });
     }
 
     /**
      * Get the list of SMR updates for a particular object.
+     *
      * @param id StreamID
      * @return an empty list if object has no updates; a list of updates if exists
      */
     @Override
     public List<SMREntry> getSMRUpdates(UUID id) {
-        MultiSMREntry entry = entryMap.get(id);
-        return entryMap.get(id) == null ? Collections.emptyList() :
-                entry.getUpdates();
+
+        // Since a stream buffer should only be deserialized once and multiple
+        // readers can deserialize different stream updates within the same container,
+        // synchronization on a per-stream basis is required.
+        MultiSMREntry resMultiSmrEntry = streamUpdates.computeIfAbsent(id, k -> {
+            if (!streamBuffers.containsKey(id)) {
+                return null;
+            }
+
+            // The stream exists and it needs to be deserialized
+            byte[] streamUpdatesBuf = streamBuffers.get(id);
+            ByteBuf buf = Unpooled.wrappedBuffer(streamUpdatesBuf);
+            int numUpdates = buf.readInt();
+            List<SMREntry> smrEntries = new ArrayList<>(numUpdates);
+            for (int update = 0; update < numUpdates; update++) {
+                smrEntries.add((SMREntry) Serializers.CORFU.deserialize(buf, null));
+            }
+
+            MultiSMREntry multiSMREntry = new MultiSMREntry(smrEntries);
+            multiSMREntry.setGlobalAddress(getGlobalAddress());
+            streamBuffers.remove(id);
+            return multiSMREntry;
+        });
+
+        return resMultiSmrEntry == null ? Collections.emptyList() : resMultiSmrEntry.getUpdates();
     }
 
     /**
@@ -123,8 +162,31 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
     @Override
     public void setGlobalAddress(long address) {
         super.setGlobalAddress(address);
-        this.getEntryMap().values().forEach(x -> {
-            x.setGlobalAddress(address);
-        });
+        streamUpdates.values().forEach(x -> x.setGlobalAddress(address));
+    }
+
+    /**
+     * Return updates for all streams, note that unlike getSMRUpdates this method
+     * will deserialize all stream updates.
+     */
+    public Map<UUID, MultiSMREntry> getEntryMap() {
+        // Calling getSMRUpdates is required to populate the streamUpdates
+        // from the remaining streamBuffers (i.e. streams that haven't been
+        // accessed and thus haven't been serialized)
+        for (UUID id : new HashSet<>(streamBuffers.keySet())) {
+            getSMRUpdates(id);
+        }
+
+        return this.streamUpdates;
+    }
+
+    @VisibleForTesting
+    Map<UUID, byte[]> getStreamBuffers() {
+        return streamBuffers;
+    }
+
+    @VisibleForTesting
+    Map<UUID, MultiSMREntry> getStreamUpdates() {
+        return streamUpdates;
     }
 }

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
@@ -21,6 +22,7 @@ import org.corfudb.util.serializer.Serializers;
 @SuppressWarnings("checkstyle:abbreviation")
 @ToString(callSuper = true)
 @NoArgsConstructor
+@EqualsAndHashCode
 public class SMREntry extends LogEntry implements ISMRConsumable {
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -74,12 +74,6 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
         return new SerializationHandle(this);
     }
 
-    /**
-     * Return whether or not this entry is a log entry.
-     */
-    default boolean isLogEntry(CorfuRuntime runtime) {
-        return getPayload(runtime) instanceof LogEntry;
-    }
 
     /**
      * Return the payload as a log entry.
@@ -104,13 +98,6 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
             return null;
         }
         return getBackpointerMap().get(streamId);
-    }
-
-    /**
-     * Return if this is the first entry in a particular stream.
-     */
-    default boolean isFirstEntry(UUID streamId) {
-        return getBackpointer(streamId) == -1L;
     }
 
     /**

--- a/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
@@ -40,7 +40,7 @@ public class TransactionStreamIT extends AbstractIT {
     private void ConsumeDelta(Map<UUID, Integer> map, List<ILogData> deltas) {
         for (ILogData ld : deltas) {
             MultiObjectSMREntry multiObjSmr = (MultiObjectSMREntry) ld.getPayload(null);
-            for (Map.Entry<UUID, MultiSMREntry> multiSMREntry : multiObjSmr.entryMap.entrySet()) {
+            for (Map.Entry<UUID, MultiSMREntry> multiSMREntry : multiObjSmr.getEntryMap().entrySet()) {
                 for (SMREntry update : multiSMREntry.getValue().getUpdates()) {
                     int key = (int) update.getSMRArguments()[0];
                     int val = (int) update.getSMRArguments()[1];

--- a/test/src/test/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntryTest.java
+++ b/test/src/test/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntryTest.java
@@ -1,0 +1,98 @@
+package org.corfudb.protocols.logprotocol;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.corfudb.CustomSerializer;
+import org.corfudb.runtime.exceptions.SerializerException;
+import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class MultiObjectSMREntryTest {
+
+    @Test
+    public void testLazyDeserialization() {
+        // This tests exercises the lazy deserialization functionality provided by
+        // MultiObjectSMREntry. It creates an entry with two streams, their updates
+        // are serialized with two different serializers. Only one of the serializers
+        // registered. 
+
+        // Create two updates on two different streams with different serializers
+        MultiObjectSMREntry multiObjSmrEntry = new MultiObjectSMREntry();
+
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+
+        SMREntry update1 = new SMREntry("method1", new Object[]{"arg1"}, Serializers.PRIMITIVE);
+
+        ISerializer customSerializer = new CustomSerializer((byte) (Serializers.SYSTEM_SERIALIZERS_COUNT + 2));
+
+        SMREntry update2 = new SMREntry("method2", new Object[]{"arg1"}, customSerializer);
+
+        multiObjSmrEntry.addTo(id1, update1);
+        multiObjSmrEntry.addTo(id2, update2);
+
+        final long entryAddress = 5;
+
+        // Serialize MultiObjectSMREntry and deserialize it into a new object
+        ByteBuf buf = Unpooled.buffer();
+        multiObjSmrEntry.serialize(buf);
+
+        MultiObjectSMREntry deserializedEntry = (MultiObjectSMREntry) LogEntry.deserialize(buf, null);
+        deserializedEntry.setGlobalAddress(entryAddress);
+
+        // Verify that the buffer cache contains both streams
+        assertThat(deserializedEntry.getStreamBuffers()).containsOnlyKeys(id1, id2);
+
+        // Get updates for stream1 to force deserializing only one stream and verify
+        // that the updates for stream two are not deserialized
+        List<SMREntry> stream1Updates = deserializedEntry.getSMRUpdates(id1);
+        assertThat(stream1Updates).containsExactly(update1);
+        stream1Updates.stream().forEach(entry -> assertThat(entry.getGlobalAddress()).isEqualTo(entryAddress));
+
+        assertThat(deserializedEntry.getStreamBuffers()).containsOnlyKeys(id2);
+        assertThat(deserializedEntry.getStreamUpdates()).containsOnlyKeys(id1);
+
+        // Verify that attempting to deserialize stream2's updates results in an
+        // exception (since the serializer isn't registered)
+        assertThatThrownBy(() -> deserializedEntry.getSMRUpdates(id2)).isInstanceOf(SerializerException.class);
+        assertThatThrownBy(deserializedEntry::getEntryMap).isInstanceOf(SerializerException.class);
+        assertThat(deserializedEntry.getStreamBuffers()).containsOnlyKeys(id2);
+        assertThat(deserializedEntry.getStreamUpdates()).containsOnlyKeys(id1);
+
+        // Register stream2's serializer and verify that its updates can be retrieved
+        Serializers.registerSerializer(customSerializer);
+
+        List<SMREntry> stream2Updates = deserializedEntry.getSMRUpdates(id2);
+        assertThat(stream2Updates).containsExactly(update2);
+        stream2Updates.stream().forEach(entry -> assertThat(entry.getGlobalAddress()).isEqualTo(entryAddress));
+
+        assertThat(deserializedEntry.getStreamBuffers()).isEmpty();
+        assertThat(deserializedEntry.getStreamUpdates()).containsOnlyKeys(id1, id2);
+
+        // Verify that getEntryMap returns all updates and that the MultiSMREntry
+        // structure is correct
+        Map<UUID, MultiSMREntry> allUpdates = deserializedEntry.getEntryMap();
+        assertThat(allUpdates).containsOnlyKeys(id1, id2);
+
+        MultiSMREntry multiSMREntry1 = allUpdates.get(id1);
+        assertThat(multiSMREntry1.getGlobalAddress()).isEqualTo(entryAddress);
+        assertThat(multiSMREntry1.getUpdates()).isEqualTo(Arrays.asList(update1));
+        multiSMREntry1.getUpdates().stream().forEach(entry -> assertThat(entry.getGlobalAddress())
+                .isEqualTo(entryAddress));
+
+        MultiSMREntry multiSMREntry2 = allUpdates.get(id2);
+        assertThat(multiSMREntry2.getGlobalAddress()).isEqualTo(entryAddress);
+        assertThat(multiSMREntry2.getUpdates()).isEqualTo(Arrays.asList(update2));
+        multiSMREntry2.getUpdates().stream().forEach(entry -> assertThat(entry.getGlobalAddress())
+                .isEqualTo(entryAddress));
+    }
+}


### PR DESCRIPTION
## Overview
When a LogEntry is deserialized, stream updates are only deserilized
on access. In essence, allowing a stream to only deserilize its updates.
This is useful when a CorfuRuntime doesn't have the serializers for all
other stream updates within the same LogEntry.
Description:

Why should this be merged: Addresses the problem where a client needs to read stream entries that exist as a part of a bigger transaction, but doesn't have a serilizer for all other streams within the same transaction. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
