### PR TITLE
Persistent back-end for CorfuTable

### DIFF
--- a/benchmarks/src/jmh/java/org/corfudb/benchmarks/runtime/collections/state/EhCacheState.java
+++ b/benchmarks/src/jmh/java/org/corfudb/benchmarks/runtime/collections/state/EhCacheState.java
@@ -8,6 +8,7 @@ import org.corfudb.benchmarks.runtime.collections.helper.CorfuTableBenchmarkHelp
 import org.corfudb.benchmarks.runtime.collections.helper.ValueGenerator.StaticValueGenerator;
 import org.corfudb.benchmarks.util.SizeUnit;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.StreamingMapDecorator;
 import org.ehcache.PersistentCacheManager;
 import org.ehcache.config.ResourcePools;
 import org.ehcache.config.builders.CacheManagerBuilder;
@@ -47,7 +48,8 @@ public abstract class EhCacheState {
         EhCacheMap<Integer, String> underlyingMap = getEhCacheMap();
 
         StaticValueGenerator valueGenerator = new StaticValueGenerator(dataSize);
-        CorfuTable<Integer, String> table = new CorfuTable<>(underlyingMap);
+        CorfuTable<Integer, String> table = new CorfuTable<>(
+                () -> new StreamingMapDecorator<>(underlyingMap));
 
         helper = CorfuTableBenchmarkHelper.builder()
                 .underlyingMap(underlyingMap)

--- a/benchmarks/src/jmh/java/org/corfudb/benchmarks/runtime/collections/state/HashMapState.java
+++ b/benchmarks/src/jmh/java/org/corfudb/benchmarks/runtime/collections/state/HashMapState.java
@@ -6,6 +6,7 @@ import org.corfudb.benchmarks.runtime.collections.helper.CorfuTableBenchmarkHelp
 import org.corfudb.benchmarks.runtime.collections.helper.ValueGenerator.StaticValueGenerator;
 import org.corfudb.benchmarks.util.SizeUnit;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.StreamingMapDecorator;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -24,7 +25,8 @@ public abstract class HashMapState {
 
         StaticValueGenerator valueGenerator = new StaticValueGenerator(dataSize);
         HashMap<Integer, String> underlyingMap = new HashMap<>();
-        CorfuTable<Integer, String> table = new CorfuTable<>(underlyingMap);
+        CorfuTable<Integer, String> table = new CorfuTable<>(
+                () -> new StreamingMapDecorator<>(underlyingMap));
 
         helper = CorfuTableBenchmarkHelper.builder()
                 .underlyingMap(underlyingMap)

--- a/benchmarks/src/jmh/java/org/corfudb/benchmarks/runtime/collections/state/RocksDbState.java
+++ b/benchmarks/src/jmh/java/org/corfudb/benchmarks/runtime/collections/state/RocksDbState.java
@@ -8,6 +8,7 @@ import org.corfudb.benchmarks.runtime.collections.helper.CorfuTableBenchmarkHelp
 import org.corfudb.benchmarks.runtime.collections.helper.ValueGenerator.StaticValueGenerator;
 import org.corfudb.benchmarks.util.SizeUnit;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.StreamingMapDecorator;
 import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -49,7 +50,8 @@ public abstract class RocksDbState {
         cleanDbDir();
         RocksDbMap<Integer, String> rocksMap = getRocksDbMap().init();
 
-        CorfuTable<Integer, String> table = new CorfuTable<>(rocksMap);
+        CorfuTable<Integer, String> table = new CorfuTable<>(
+                () -> new StreamingMapDecorator<>(rocksMap));
         StaticValueGenerator valueGenerator = new StaticValueGenerator(dataSize);
 
         helper = CorfuTableBenchmarkHelper.builder()

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -145,6 +145,11 @@
             <version>0.3.0</version>
         </dependency>
         <dependency>
+            <groupId>org.rocksdb</groupId>
+            <artifactId>rocksdbjni</artifactId>
+            <version>6.2.4</version>
+        </dependency>
+        <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
             <version>0.7.36</version>

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Supplier;
 
 /**
  * Persisted Queue supported by CorfuDB using distributed State Machine Replication.
@@ -44,11 +45,13 @@ public class CorfuQueue<E> {
 
     public CorfuQueue(CorfuRuntime runtime, String streamName, ISerializer serializer,
                       IndexRegistry<Long, E> indices) {
+        final Supplier<StreamingMap<Long, E>> mapSupplier =
+                () -> new StreamingMapDecorator<>(new LinkedHashMap<Long, E>());
         this.runtime = runtime;
         corfuTable = runtime.getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<Long, E>>() {})
                 .setStreamName(streamName)
-                .setArguments(indices, new LinkedHashMap<Long, E>())
+                .setArguments(indices, mapSupplier)
                 .setSerializer(serializer)
                 .open();
         guidGenerator = CorfuGuidGenerator.getInstance(runtime);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -58,7 +58,7 @@ import org.corfudb.util.ImmuableListSetWrapper;
  */
 @Slf4j
 @CorfuObject
-public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
+public class CorfuTable<K ,V> implements ICorfuMap<K, V>, AutoCloseable {
 
     /**
      * Denotes a function that supplies the unique name of an index registered to
@@ -203,59 +203,44 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
             return new TypeToken<CorfuTable<K, V>>() {};
     }
 
-    /**
-     * The interface for a projection function.
-     *
-     * <p> NOTE: The projection function MUST return a new (preferably immutable) collection,
-     * the collection of entries passed during this function are NOT safe to use
-     * outside the context of this function.
-     *
-     * @param <K>   The type of the key used in projection.
-     * @param <V>   The type of the value used in projection.
-     * @param <I>   The type of the index used in projection.
-     * @param <P>   The type of the projection returned.
-     */
-    @FunctionalInterface
-    public interface ProjectionFunction<K, V, I, P> {
-        @Nonnull
-        Stream<P> generateProjection(I index,
-                                     @Nonnull Stream<Map.Entry<K, V>> entryStream);
-    }
-
     // The "main" map which contains the primary key-value mappings.
-    private final Map<K,V> mainMap;
+    private final StreamingMap<K,V> mainMap;
     private final Set<Index<K, V, ? extends Comparable>> indexSpec = new HashSet<>();
     private final Map<String, Map<Comparable, Map<K, V>>> secondaryIndexes = new HashMap<>();
 
     /**
-     * Generate a table with a given implementation for the mainMap
+     * Generate a table with a given implementation for the {@link StreamingMap}.
      */
-    public CorfuTable(IndexRegistry<K, V> indices, Map<K, V> mapImpl) {
+    public CorfuTable(IndexRegistry<K, V> indices,
+                      Supplier<StreamingMap<K, V>> streamingMapSupplier) {
         indices.forEach(index -> {
             secondaryIndexes.put(index.getName().get(), new HashMap<>());
             indexSpec.add(index);
         });
         log.info("CorfuTable: creating CorfuTable with the following indexes: {}",
                 secondaryIndexes.keySet());
-        mainMap = mapImpl;
+        mainMap = streamingMapSupplier.get();
     }
 
     /**
      * Generate a table with the given set of indexes.
      */
-    public CorfuTable(IndexRegistry<K, V> indices) {
-        this(indices, new HashMap<>());
+    public CorfuTable(IndexRegistry<K, V> indexRegistry) {
+        this(indexRegistry, () -> new StreamingMapDecorator<>(new HashMap<>()));
     }
 
+    /**
+     * Generates a table with the given {@link Map} implementation and
+     * without any secondary indexes.
+     */
+    public CorfuTable(Supplier<StreamingMap<K, V>> streamingMapSupplier) {
+        this(IndexRegistry.empty(), streamingMapSupplier);
+    }
     /**
      * Default constructor. Generates a table without any secondary indexes.
      */
     public CorfuTable() {
-        this(IndexRegistry.empty(), new HashMap<>());
-    }
-
-    public CorfuTable(Map<K, V> underlying) {
-        this(IndexRegistry.empty(), underlying);
+        this(IndexRegistry.empty());
     }
 
     /** {@inheritDoc} */
@@ -457,24 +442,24 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
      * This method has a memory/CPU advantage over the map iterators as no deep copy
      * is actually performed.
      *
-     * @param p java predicate (function to evaluate)
+     * @param valuePredicate java predicate (function to evaluate)
      * @return a view of the values contained in this map meeting the predicate condition.
      */
     @Accessor
-    public List<V> scanAndFilter(Predicate<? super V> p) {
-        return mainMap.values().parallelStream()
-                                    .filter(p)
-                                    .collect(Collectors.toCollection(ArrayList::new));
+    public List<V> scanAndFilter(Predicate<? super V> valuePredicate) {
+        return mainMap.entryStream()
+                .map(Entry::getValue).filter(valuePredicate)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     /** {@inheritDoc} */
     @Override
     @Accessor
-    public Collection<Map.Entry<K, V>> scanAndFilterByEntry(Predicate<? super Map.Entry<K, V>>
-                                                                    entryPredicate) {
-        return mainMap.entrySet().parallelStream()
-                                    .filter(entryPredicate)
-                                    .collect(Collectors.toCollection(ArrayList::new));
+    public Collection<Map.Entry<K, V>> scanAndFilterByEntry(
+            Predicate<? super Map.Entry<K, V>> entryPredicate) {
+        return mainMap.entryStream()
+                .filter(entryPredicate)
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     /** {@inheritDoc} */
@@ -549,14 +534,16 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
     @Override
     @Accessor
     public @Nonnull Set<K> keySet() {
-        return ImmutableSet.copyOf(mainMap.keySet());
+        return mainMap.entryStream().map(Entry::getKey)
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     /** {@inheritDoc} */
     @Override
     @Accessor
     public @Nonnull Collection<V> values() {
-        return ImmutableList.copyOf(mainMap.values());
+        return mainMap.entryStream().map(Entry::getValue)
+                .collect(ImmutableSet.toImmutableSet());
     }
 
     /**
@@ -566,13 +553,21 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
     @Override
     @Accessor
     public @Nonnull Set<Entry<K, V>> entrySet() {
-        List<Entry<K, V>> copy = new ArrayList<>(mainMap.size());
-        for (Map.Entry<K, V> entry : mainMap.entrySet()) {
-            copy.add(new AbstractMap.SimpleImmutableEntry<>(entry.getKey(),
-                    entry.getValue()));
-        }
-        return new ImmuableListSetWrapper<>(copy);
+        return new ImmuableListSetWrapper(mainMap.entryStream().map(entry ->
+                new AbstractMap.SimpleImmutableEntry<>(entry.getKey(), entry.getValue()))
+                .collect(ImmutableList.toImmutableList()));
     }
+
+    /**
+     * Present the content of a {@link CorfuTable} via the {@link Stream} interface.
+     *
+     * @return stream of entries
+     */
+    @Accessor
+    public @Nonnull Stream<Entry<K, V>> entryStream() {
+        return mainMap.entryStream();
+    }
+
 
     /** {@inheritDoc} */
     @Override
@@ -789,4 +784,12 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
         secondaryIndexes.clear();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @DontInstrument
+    @Override
+    public void close() {
+        this.mainMap.close();
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
@@ -1,0 +1,341 @@
+package org.corfudb.runtime.collections;
+
+import com.google.common.collect.Streams;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.util.serializer.ISerializer;
+import org.rocksdb.RocksDB;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * A concrete implementation of {@link StreamingMap} that is capable of storing data
+ * off-heap. The location for the off-heap data is provided by {@link File} dataPath,
+ * while the resource policy (memory and storage limits) are defined in {@link Options}.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+@Slf4j
+public class PersistedStreamingMap<K, V> implements StreamingMap<K, V> {
+
+    static {
+        RocksDB.loadLibrary();
+    }
+
+    private static final List<PersistedStreamingMap> openedResources = new ArrayList<>();
+
+    private final AtomicInteger dataSetSize = new AtomicInteger();
+    private final CorfuRuntime corfuRuntime;
+    private final ISerializer serializer;
+    private final RocksDB rocksDb;
+
+    public PersistedStreamingMap(@NonNull Path dataPath,
+                                 @NonNull Options options,
+                                 @NonNull ISerializer serializer,
+                                 @NonNull CorfuRuntime corfuRuntime) {
+        try {
+            RocksDB.destroyDB(dataPath.toFile().getAbsolutePath(), options);
+            this.rocksDb = RocksDB.open(options, dataPath.toFile().getAbsolutePath());
+        } catch (RocksDBException e) {
+            throw new UnrecoverableCorfuError(e);
+        }
+        this.serializer = serializer;
+        this.corfuRuntime = corfuRuntime;
+        openedResources.add(this);
+    }
+
+    /**
+     * A Java compatible {@link RocksIterator} implementation
+     */
+    public class RocksDbIterator implements Iterator<Entry<K, V>> {
+        private RocksIterator iterator;
+        private Entry<K, V> current;
+        private Entry<K, V> next;
+
+        RocksDbIterator(RocksIterator iterator) {
+            this.iterator = iterator;
+        }
+
+        /**
+         * Ensure that this iterator is operating under the correct assumptions.
+         */
+        private void checkInvariants() {
+            // RocksDB does not support multi-threaded access.
+            // If the iterator was created by some thread, it also has to be consumed by it.
+            if (!iterator.isOwningHandle()) {
+                throw new IllegalStateException("Detected multi-threaded access to this iterator.");
+            }
+
+            try {
+                iterator.status();
+            } catch (RocksDBException e) {
+                throw new UnrecoverableCorfuError(
+                        "There was an error reading the persisted map.", e);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean hasNext() {
+            // If we have the next element pipelined, go ahead and return true.
+            if (next != null) {
+                return true;
+            }
+
+            // If the iterator is valid, this means that the next entry exists.
+            checkInvariants();
+            if (iterator.isValid()) {
+                // Go ahead and cache that entry.
+                next = new AbstractMap.SimpleEntry(
+                        serializer.deserialize(Unpooled.wrappedBuffer(iterator.key()), corfuRuntime),
+                        serializer.deserialize(Unpooled.wrappedBuffer(iterator.value()), corfuRuntime));
+                // Advance the underlying iterator.
+                iterator.next();
+            } else {
+                // If there is no more elements to consume, we should release the resources.
+                iterator.close();
+            }
+
+            return next != null;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Entry<K, V> next() {
+            if (hasNext()) {
+                current = next;
+                next = null;
+                return current;
+            } else {
+                throw new NoSuchElementException();
+            }
+
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int size() {
+        return dataSetSize.get();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEmpty() {
+        return dataSetSize.get() == 0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean containsKey(@NonNull Object key) {
+        final ByteBuf keyPayload = Unpooled.buffer();
+        serializer.serialize(key, keyPayload);
+        try {
+            byte[] value = rocksDb.get(
+                    keyPayload.array(), keyPayload.arrayOffset(), keyPayload.readableBytes());
+            return value != null;
+        } catch (RocksDBException ex) {
+            throw new UnrecoverableCorfuError(ex);
+        } finally {
+            keyPayload.release();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Please use {@link StreamingMap#entryStream()}.
+     */
+    @Override
+    public boolean containsValue(@NonNull Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V get(@NonNull Object key) {
+        final ByteBuf keyPayload = Unpooled.buffer();
+        serializer.serialize(key, keyPayload);
+
+        try {
+            byte[] value = rocksDb.get(
+                    keyPayload.array(), keyPayload.arrayOffset(), keyPayload.readableBytes());
+            if (value == null) {
+                return null;
+            }
+            return (V) serializer.deserialize(Unpooled.wrappedBuffer(value), corfuRuntime);
+        } catch (RocksDBException ex) {
+            throw new UnrecoverableCorfuError(ex);
+        } finally {
+            keyPayload.release();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V put(@NonNull K key, @NonNull V value) {
+        final ByteBuf keyPayload = Unpooled.buffer();
+        final ByteBuf valuePayload = Unpooled.buffer();
+        serializer.serialize(key, keyPayload);
+        serializer.serialize(value, valuePayload);
+
+        // Only increment the count if the value is not present. In other words,
+        // increment the count if this is an update operation.
+        final boolean keyExists = rocksDb.keyMayExist(keyPayload.array(),
+                keyPayload.arrayOffset(), keyPayload.readableBytes(), new StringBuilder());
+        if (!keyExists) {
+            dataSetSize.incrementAndGet();
+        }
+
+        try {
+            rocksDb.put(
+                    keyPayload.array(), keyPayload.arrayOffset(), keyPayload.readableBytes(),
+                    valuePayload.array(), valuePayload.arrayOffset(), valuePayload.readableBytes());
+        } catch (RocksDBException ex) {
+            throw new UnrecoverableCorfuError(ex);
+        } finally {
+            keyPayload.release();
+            valuePayload.release();
+        }
+
+        return value;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V remove(@NonNull Object key) {
+        final ByteBuf keyPayload = Unpooled.buffer();
+        serializer.serialize(key, keyPayload);
+        try {
+            V value = get(key);
+            if (value != null) {
+                rocksDb.delete(
+                        keyPayload.array(), keyPayload.arrayOffset(), keyPayload.readableBytes());
+                dataSetSize.decrementAndGet();
+                return value;
+            } else {
+                return null;
+            }
+        } catch (RocksDBException ex) {
+            throw new UnrecoverableCorfuError(ex);
+        } finally {
+            keyPayload.release();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void putAll(@NonNull Map<? extends K, ? extends V> map) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clear() {
+        entryStream().map(Entry::getKey).forEach(this::remove);
+        dataSetSize.set(0);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<K> keySet() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Please use {@link StreamingMap#entryStream()}.
+     */
+    @Override
+    public Collection<V> values() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Please use {@link StreamingMap#entryStream()}.
+     */
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<Entry<K, V>> entryStream() {
+        final RocksIterator rocksIterator = rocksDb.newIterator();
+        rocksIterator.seekToFirst();
+        return Streams.stream(new RocksDbIterator(rocksIterator));
+    }
+
+    /**
+     * Close the underlying database.
+     */
+    private void closeRocksDb() {
+        this.rocksDb.close();
+    }
+
+    /**
+     * Close the underlying database and remove it from the opened resources.
+     */
+    @Override
+    public void close() {
+        closeRocksDb();
+        openedResources.remove(this);
+    }
+
+    /**
+     * Close all known instances of {@link PersistedStreamingMap} that are still open.
+     */
+    public static void closeAll() {
+        openedResources.forEach(PersistedStreamingMap::closeRocksDb);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMap.java
@@ -1,0 +1,30 @@
+package org.corfudb.runtime.collections;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ *
+ * This interface provides additional functionality not provided by the standard {@link Map}.
+ * In cases when the actual data is not being backed by the heap, {@link Map#values()},
+ * {@link Map#keySet()} or {@link Map#entrySet()} will not suffice, since we cannot guarantee
+ * that the data-set will fit in the memory.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public interface StreamingMap<K, V> extends Map<K, V>, AutoCloseable {
+
+    /**
+     * Present the content of a {@link StreamingMap} via the {@link Stream} interface.
+     *
+     * @return stream of entries
+     */
+    Stream<Map.Entry<K, V>> entryStream();
+
+    /**
+     * Relinquish any resources associated with this object.
+     */
+    default void close() {
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
@@ -1,0 +1,132 @@
+package org.corfudb.runtime.collections;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * A decorated map that provides additional functionality defined by the {@link StreamingMap}
+ * interface. Whatever guarantees are being provided the the underlying map implementation
+ * (such as ordering, retrieval complexity...) are also provided by this map.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public class StreamingMapDecorator<K, V> implements StreamingMap<K, V> {
+
+    final Map<K, V> mapImpl;
+
+    public StreamingMapDecorator() {
+        this(new HashMap<>());
+    }
+
+    public StreamingMapDecorator(Map<K, V> mapImpl) {
+        this.mapImpl = mapImpl;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<Entry<K, V>> entryStream() {
+        return mapImpl.entrySet().stream().parallel();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int size() {
+        return mapImpl.size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEmpty() {
+        return mapImpl.isEmpty();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean containsKey(Object key) {
+        return mapImpl.containsKey(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean containsValue(Object value) {
+        return mapImpl.containsValue(value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V get(Object key) {
+        return mapImpl.get(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V put(K key, V value) {
+        return mapImpl.put(key, value);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public V remove(Object key) {
+        return mapImpl.remove(key);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void putAll(Map<? extends K, ? extends V> map) {
+        mapImpl.putAll(map);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clear() {
+        mapImpl.clear();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<K> keySet() {
+        return mapImpl.keySet();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<V> values() {
+        return mapImpl.values();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+        return mapImpl.entrySet();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -12,6 +12,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -67,7 +68,8 @@ public class Table<K extends Message, V extends Message, M extends Message> {
                  @Nonnull final V valueSchema,
                  @Nullable final M metadataSchema,
                  @Nonnull final CorfuRuntime corfuRuntime,
-                 @Nonnull final ISerializer serializer) {
+                 @Nonnull final ISerializer serializer,
+                 @Nonnull final Supplier<StreamingMap<K, V>> streamingMapSupplier) {
 
         this.corfuRuntime = corfuRuntime;
         this.namespace = namespace;
@@ -83,7 +85,7 @@ public class Table<K extends Message, V extends Message, M extends Message> {
                 .setTypeToken(CorfuTable.<K, CorfuRecord<V, M>>getTableType())
                 .setStreamName(this.fullyQualifiedTableName)
                 .setSerializer(serializer)
-                .setArguments(new ProtobufIndexer(valueSchema))
+                .setArguments(new ProtobufIndexer(valueSchema), streamingMapSupplier)
                 .open();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TableOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TableOptions.java
@@ -3,6 +3,10 @@ package org.corfudb.runtime.collections;
 import org.corfudb.runtime.collections.CorfuTable.IndexRegistry;
 import lombok.Builder;
 
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Optional;
+
 /**
  * Created by zlokhandwala on 2019-08-09.
  */
@@ -10,4 +14,13 @@ import lombok.Builder;
 public class TableOptions<K, V> {
 
     private final IndexRegistry<K, V> indexRegistry;
+
+    /**
+     * If this path is set, {@link CorfuStore} will utilize disk-backed {@link CorfuTable}.
+     */
+    private final Path persistentDataPath;
+
+    public Optional<Path> getPersistentDataPath() {
+        return Optional.ofNullable(persistentDataPath);
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -34,8 +34,7 @@ public class CorfuCompileWrapperBuilder {
     public static <T> T getWrapper(Class<T> type, CorfuRuntime rt,
                                    UUID streamID, Object[] args,
                                    ISerializer serializer)
-            throws ClassNotFoundException, IllegalAccessException,
-            InstantiationException, InvocationTargetException {
+            throws Exception {
         // Do we have a compiled wrapper for this type?
         Class<ICorfuSMR<T>> wrapperClass = (Class<ICorfuSMR<T>>)
                 Class.forName(type.getName() + ICorfuSMR.CORFUSMR_SUFFIX);
@@ -43,6 +42,10 @@ public class CorfuCompileWrapperBuilder {
         // Instantiate a new instance of this class.
         ICorfuSMR<T> wrapperObject = (ICorfuSMR<T>) ReflectionUtils.
                             findMatchingConstructor(wrapperClass.getDeclaredConstructors(), args);
+
+        if (wrapperObject instanceof AutoCloseable) {
+            ((AutoCloseable) wrapperObject).close();
+        }
 
         // Now we create the proxy, which actually manages
         // instances of this object. The wrapper delegates calls to the proxy.

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -444,11 +444,22 @@ public class VersionLockedObject<T> {
         return optimisticStream != null && optimisticStream.pos() != Address.NEVER_READ;
     }
 
+    private void closeObject() {
+        if (object instanceof AutoCloseable) {
+            try {
+                ((AutoCloseable) object).close();
+            } catch (Exception ex) {
+                throw new UnrecoverableCorfuError(ex);
+            }
+        }
+    }
+
     /**
      * Reset this object to the uninitialized state.
      */
     public void resetUnsafe() {
         log.debug("Reset[{}]", this);
+        closeObject();
         object = newObjectFn.get();
         smrStream.reset();
         optimisticStream = null;
@@ -549,6 +560,7 @@ public class VersionLockedObject<T> {
                 // we can safely get a new instance, and add the
                 // previous instance to the undo log.
                 entry.setUndoRecord(object);
+                closeObject();
                 object = newObjectFn.get();
                 log.trace("Apply[{}] Undo->RESET", this);
             }

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -1,17 +1,19 @@
 package org.corfudb.runtime.view;
 
 import com.google.common.reflect.TypeToken;
-import com.google.protobuf.DescriptorProtos;
 import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Message;
-
 import java.lang.reflect.InvocationTargetException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.corfudb.runtime.CorfuRuntime;
@@ -19,12 +21,18 @@ import org.corfudb.runtime.CorfuStoreMetadata.TableDescriptors;
 import org.corfudb.runtime.CorfuStoreMetadata.TableName;
 import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.PersistedStreamingMap;
+import org.corfudb.runtime.collections.StreamingMap;
+import org.corfudb.runtime.collections.StreamingMapDecorator;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.ProtobufSerializer;
 import org.corfudb.util.serializer.Serializers;
+import org.rocksdb.CompactionOptionsUniversal;
+import org.rocksdb.CompressionType;
+import org.rocksdb.Options;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -231,6 +239,37 @@ public class TableRegistry {
     }
 
     /**
+     * A set of options defined for disk-backed {@link CorfuTable}.
+     *
+     * For a set of options that dictate RocksDB memory usage can be found here:
+     * https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
+     *
+     * Block Cache:  Which can be set via Options::setTableFormatConfig.
+     *               Out of box, RocksDB will use LRU-based block cache
+     *               implementation with 8MB capacity.
+     * Index/Filter: Is a function of the block cache. Generally it infates
+     *               the block cache by about 50%. The exact number can be
+     *               retrieved via "rocksdb.estimate-table-readers-mem"
+     *               property.
+     * Write Buffer: Also known as memtable is defined by the ColumnFamilyOptions
+     *               option. The default is 64 MB.
+     */
+    private Options getPersistentMapOptions() {
+        final int maxSizeAmplificationPercent = 50;
+        final Options options = new Options();
+
+        options.setCreateIfMissing(true);
+        options.setCompressionType(CompressionType.LZ4_COMPRESSION);
+
+        // Set a threshold at which full compaction will be triggered.
+        // This is important as it purges tombstoned entries.
+        final CompactionOptionsUniversal compactionOptions = new CompactionOptionsUniversal();
+        compactionOptions.setMaxSizeAmplificationPercent(maxSizeAmplificationPercent);
+        options.setCompactionOptionsUniversal(compactionOptions);
+        return options;
+    }
+
+    /**
      * Opens a Corfu table with the specified options.
      *
      * @param namespace    Namespace of the table.
@@ -253,7 +292,7 @@ public class TableRegistry {
                              @Nonnull final Class<K> kClass,
                              @Nonnull final Class<V> vClass,
                              @Nullable final Class<M> mClass,
-                             @Nonnull final TableOptions tableOptions)
+                             @Nonnull final TableOptions<K, V> tableOptions)
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
 
         // Register the schemas to schema table.
@@ -270,6 +309,13 @@ public class TableRegistry {
         }
 
         String fullyQualifiedTableName = getFullyQualifiedTableName(namespace, tableName);
+        Supplier<StreamingMap<K, V>> mapSupplier = () -> new StreamingMapDecorator();
+        if (tableOptions.getPersistentDataPath().isPresent()) {
+            mapSupplier = () -> new PersistedStreamingMap<>(
+                    tableOptions.getPersistentDataPath().get(),
+                    getPersistentMapOptions(),
+                    protobufSerializer, this.runtime);
+        }
 
         // Open and return table instance.
         Table<K, V, M> table = new Table<>(
@@ -278,7 +324,8 @@ public class TableRegistry {
                 defaultValueMessage,
                 defaultMetadataMessage,
                 this.runtime,
-                this.protobufSerializer);
+                this.protobufSerializer,
+                mapSupplier);
         tableMap.put(fullyQualifiedTableName, (Table<Message, Message, Message>) table);
 
         registerTable(namespace, tableName, kClass, vClass, mClass);

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -59,6 +59,12 @@
             <version>1.14</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>net.jqwik</groupId>
+            <artifactId>jqwik</artifactId>
+            <version>1.2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
By default, CorfuTable builds its view in-memory, but in some
circumstances the data set is either too large or it causes
unnecessary memory bloat. This patch addresses this issue by
introducing a feature that lets client offload the data from
heap to disk.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
