### PR TITLE
Rename TestRule to CorfuTestRule

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -9,7 +9,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.runtime.clients.TestChannelContext;
-import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.clients.CorfuTestRule;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +33,7 @@ public class TestServerRouter implements IServerRouter {
     @Getter
     public List<AbstractServer> servers;
 
-    public List<TestRule> rules;
+    public List<CorfuTestRule> rules;
 
     AtomicLong requestCounter;
 

--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -4,7 +4,7 @@ import org.assertj.core.api.Assertions;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 
 import org.corfudb.runtime.clients.LogUnitClient;
-import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.clients.CorfuTestRule;
 import org.corfudb.runtime.exceptions.unrecoverable.SystemUnavailableError;
 
 import org.corfudb.runtime.exceptions.WrongEpochException;
@@ -148,7 +148,7 @@ public class CorfuRuntimeTest extends AbstractViewTest {
 
         // Server2 is sealed but will not be able to commit the layout.
         addClientRule(rt, SERVERS.ENDPOINT_2,
-                new TestRule().always().drop());
+                new CorfuTestRule().always().drop());
 
 
         rt.getLayoutView().updateLayout(currentLayout, 0);
@@ -169,9 +169,9 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         // Server 0 and Server 1 are not able to respond to layout request
         // Reduce their timeout to speed up the test.
         addClientRule(rt, SERVERS.ENDPOINT_0,
-                new TestRule().always().drop());
+                new CorfuTestRule().always().drop());
         addClientRule(rt, SERVERS.ENDPOINT_1,
-                new TestRule().always().drop());
+                new CorfuTestRule().always().drop());
 
         rt.getRouter(SERVERS.ENDPOINT_0).setTimeoutResponse(1);
         rt.getRouter(SERVERS.ENDPOINT_1).setTimeoutResponse(1);

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -14,7 +14,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
-import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.clients.CorfuTestRule;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
@@ -390,7 +390,7 @@ public class CheckpointTest extends AbstractObjectTest {
         final int mapSize = PARAMETERS.NUM_ITERATIONS_LOW;
         CorfuRuntime rt = getARuntime();
 
-        TestRule dropSequencerTrim = new TestRule()
+        CorfuTestRule dropSequencerTrim = new CorfuTestRule()
                 .matches(corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.SEQUENCER_TRIM_REQ))
                 .drop();
         addClientRule(rt, dropSequencerTrim);

--- a/test/src/test/java/org/corfudb/runtime/clients/CorfuTestRule.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/CorfuTestRule.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
 /**
  * Created by mwei on 6/29/16.
  */
-public class TestRule {
+public class CorfuTestRule {
 
     // conditions
     private boolean always = false;
@@ -29,7 +29,7 @@ public class TestRule {
     /**
      * Always evaluate this rule.
      */
-    public TestRule always() {
+    public CorfuTestRule always() {
         this.always = true;
         return this;
     }
@@ -39,7 +39,7 @@ public class TestRule {
      *
      * @param transformation A function which transforms the supplied message.
      */
-    public TestRule transform(Consumer<CorfuMsg> transformation) {
+    public CorfuTestRule transform(Consumer<CorfuMsg> transformation) {
         transformer = transformation;
         return this;
     }
@@ -47,7 +47,7 @@ public class TestRule {
     /**
      * Drop this message.
      */
-    public TestRule drop() {
+    public CorfuTestRule drop() {
         this.drop = true;
         return this;
     }
@@ -55,7 +55,7 @@ public class TestRule {
     /**
      * Drop this message on even matches (first match is even)
      */
-    public TestRule dropEven() {
+    public CorfuTestRule dropEven() {
         this.dropEven = true;
         return this;
     }
@@ -63,7 +63,7 @@ public class TestRule {
     /**
      * Drop this message on odd matches
      */
-    public TestRule dropOdd() {
+    public CorfuTestRule dropOdd() {
         this.dropOdd = true;
         return this;
     }
@@ -74,7 +74,7 @@ public class TestRule {
      * @param injectBefore A function which takes the CorfuMsg the rule is being
      *                     applied to and returns a CorfuMsg to be injected.
      */
-    public TestRule injectBefore(Function<CorfuMsg, CorfuMsg> injectBefore) {
+    public CorfuTestRule injectBefore(Function<CorfuMsg, CorfuMsg> injectBefore) {
         this.injectBefore = injectBefore;
         return this;
     }
@@ -85,7 +85,7 @@ public class TestRule {
      * @param matcher A function that takes a CorfuMsg and returns true if the
      *                message matches.
      */
-    public TestRule matches(Function<CorfuMsg, Boolean> matcher) {
+    public CorfuTestRule matches(Function<CorfuMsg, Boolean> matcher) {
         this.matcher = matcher;
         return this;
     }

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -91,7 +91,7 @@ public class TestClientRouter implements IClientRouter {
     @Setter
     public long timeoutRetry = PARAMETERS.TIMEOUT_SHORT.toMillis();
 
-    public List<TestRule> rules;
+    public List<CorfuTestRule> rules;
 
     /** The server router endpoint this client should route to. */
     TestServerRouter serverRouter;

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
@@ -38,7 +38,7 @@ public class TestClientRouterTest extends AbstractCorfuTest {
         assertThat(bc.pingSync())
                 .isTrue();
 
-        tcr.rules.add(new TestRule()
+        tcr.rules.add(new CorfuTestRule()
                 .always()
                 .drop());
 
@@ -48,7 +48,7 @@ public class TestClientRouterTest extends AbstractCorfuTest {
 
     @Test
     public void onlyDropEpochChangeMessages() {
-        tcr.rules.add(new TestRule()
+        tcr.rules.add(new CorfuTestRule()
                 .matches(x -> x.getMsgType().equals(CorfuMsgType.SEAL))
                 .drop());
 

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -7,7 +7,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
-import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.clients.CorfuTestRule;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -150,7 +149,7 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
                 .setType(SMRMap.class)
                 .open();
         // Add rule to force a read on the assigned token before actually writing to that position
-        TestRule testRule = new TestRule()
+        CorfuTestRule testRule = new CorfuTestRule()
                 .matches(m -> {
                     if (m.getMsgType().equals(CorfuMsgType.WRITE)) {
                         rtReader.getStreamsView().get(streamID).next();
@@ -193,7 +192,7 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
         int[] retry = new int[1];
         retry[0] = 0;
         // Add rule to force a read on the assigned token before actually writing to that position
-        TestRule testRule = new TestRule()
+        CorfuTestRule testRule = new CorfuTestRule()
                 .matches(m -> {
                     if (m.getMsgType().equals(CorfuMsgType.WRITE) && retry[0] < rtSlowWriter.getParameters().getWriteRetry()) {
                         rtIntersect.getAddressSpaceView().write(new Token(0, retry[0]), "hello world".getBytes());
@@ -232,7 +231,7 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
         int[] retry = new int[1];
         retry[0] = 0;
         // Add rule to force a read on the assigned token before actually writing to that position
-        TestRule testRule = new TestRule()
+        CorfuTestRule testRule = new CorfuTestRule()
                 .matches(m -> {
                     if (m.getMsgType().equals(CorfuMsgType.WRITE)) {
                         rtPropagateWrite.getAddressSpaceView().write(new Token(0, 0), "hello world".getBytes());

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -34,7 +34,7 @@ import org.corfudb.runtime.clients.LogUnitHandler;
 import org.corfudb.runtime.clients.ManagementHandler;
 import org.corfudb.runtime.clients.SequencerHandler;
 import org.corfudb.runtime.clients.TestClientRouter;
-import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.clients.CorfuTestRule;
 import org.corfudb.runtime.exceptions.OutrankedException;
 
 import org.corfudb.util.NodeLocator;
@@ -424,7 +424,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
      *
      * @param rule  The rule to install
      */
-    public void addClientRule(TestRule rule) {
+    public void addClientRule(CorfuTestRule rule) {
         addClientRule(getRuntime(), rule);
     }
 
@@ -433,7 +433,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
      * @param r     The runtime to install the rule to
      * @param rule  The rule to install.
      */
-    public void addClientRule(CorfuRuntime r, TestRule rule) {
+    public void addClientRule(CorfuRuntime r, CorfuTestRule rule) {
         runtimeRouterMap.get(r).values().forEach(x -> x.rules.add(rule));
     }
 
@@ -443,7 +443,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
      * @param clientRouterEndpoint  The Client router endpoint to install the rule to
      * @param rule                  The rule to install.
      */
-    public void addClientRule(CorfuRuntime r, String clientRouterEndpoint, TestRule rule) {
+    public void addClientRule(CorfuRuntime r, String clientRouterEndpoint, CorfuTestRule rule) {
         runtimeRouterMap.get(r).get(clientRouterEndpoint).rules.add(rule);
     }
 
@@ -460,7 +460,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
      * @param port  The port of the server to install the rule to.
      * @param rule  The rule to install.
      */
-    public void addServerRule(int port, TestRule rule) {
+    public void addServerRule(int port, CorfuTestRule rule) {
         getServer(port).getServerRouter().rules.add(rule);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutSealTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutSealTest.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.clients.CorfuTestRule;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.junit.Test;
 
@@ -146,9 +146,9 @@ public class LayoutSealTest extends AbstractViewTest {
         RuntimeLayout runtimeLayout = getRuntimeLayout(Layout.ReplicationMode.CHAIN_REPLICATION);
         Layout l = runtimeLayout.getLayout();
 
-        addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_1, new TestRule().drop().always());
-        addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_3, new TestRule().drop().always());
-        addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_4, new TestRule().drop().always());
+        addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_1, new CorfuTestRule().drop().always());
+        addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_3, new CorfuTestRule().drop().always());
+        addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_4, new CorfuTestRule().drop().always());
 
         l.setEpoch(l.getEpoch() + 1);
         assertThatThrownBy(runtimeLayout::sealMinServerSet)
@@ -190,7 +190,7 @@ public class LayoutSealTest extends AbstractViewTest {
         Layout l = runtimeLayout.getLayout();
 
         addClientRule(runtimeLayout.getRuntime(), SERVERS.ENDPOINT_3,
-                new TestRule().drop().always());
+                new CorfuTestRule().drop().always());
 
         l.setEpoch(l.getEpoch() + 1);
         assertThatThrownBy(runtimeLayout::sealMinServerSet)

--- a/test/src/test/java/org/corfudb/runtime/view/StateTransferTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StateTransferTest.java
@@ -32,9 +32,8 @@ import org.corfudb.infrastructure.orchestrator.actions.RestoreRedundancyMergeSeg
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
-import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.clients.CorfuTestRule;
 import org.corfudb.runtime.view.ClusterStatusReport.ClusterStatus;
 import org.corfudb.runtime.view.ClusterStatusReport.ClusterStatusReliability;
 import org.corfudb.runtime.view.ClusterStatusReport.ConnectivityStatus;
@@ -233,7 +232,7 @@ public class StateTransferTest extends AbstractViewTest {
         addServer(SERVERS.PORT_1);
         addServer(SERVERS.PORT_2);
 
-        addServerRule(SERVERS.PORT_2, new TestRule().matches(
+        addServerRule(SERVERS.PORT_2, new CorfuTestRule().matches(
                 msg -> !msg.getMsgType().equals(CorfuMsgType.LAYOUT_BOOTSTRAP)
                         && !msg.getMsgType().equals(CorfuMsgType.MANAGEMENT_BOOTSTRAP_REQUEST))
                 .drop());
@@ -394,7 +393,7 @@ public class StateTransferTest extends AbstractViewTest {
                 .build();
 
         // Drop read responses to make sure state transfer will fail if it happens
-        addServerRule(SERVERS.PORT_1, new TestRule().matches(m ->
+        addServerRule(SERVERS.PORT_1, new CorfuTestRule().matches(m ->
                 m.getMsgType().equals(CorfuMsgType.READ_RESPONSE)).drop());
 
         bootstrapAllServers(layout);
@@ -480,7 +479,7 @@ public class StateTransferTest extends AbstractViewTest {
 
         // STEP 1.
         // Rule added to fail the state transfer on the last range write.
-        addClientRule(corfuRuntime, SERVERS.ENDPOINT_1, new TestRule().matches(
+        addClientRule(corfuRuntime, SERVERS.ENDPOINT_1, new CorfuTestRule().matches(
                 corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.RANGE_WRITE)
                         && allowedWrites.decrementAndGet() < 0)
                 .drop());
@@ -510,7 +509,7 @@ public class StateTransferTest extends AbstractViewTest {
 
         // STEP 2.
         // Rule added to fail the state transfer on the last range write.
-        addClientRule(corfuRuntime, SERVERS.ENDPOINT_1, new TestRule().matches(
+        addClientRule(corfuRuntime, SERVERS.ENDPOINT_1, new CorfuTestRule().matches(
                 corfuMsg -> corfuMsg.getMsgType().equals(CorfuMsgType.KNOWN_ADDRESS_REQUEST))
                 .drop());
 
@@ -523,7 +522,7 @@ public class StateTransferTest extends AbstractViewTest {
         // STEP 3.
         // Rule added to count the number of range writes transferred.
         AtomicInteger rangeWrites = new AtomicInteger();
-        addClientRule(corfuRuntime, SERVERS.ENDPOINT_1, new TestRule().matches(
+        addClientRule(corfuRuntime, SERVERS.ENDPOINT_1, new CorfuTestRule().matches(
                 corfuMsg -> {
                     if (corfuMsg.getMsgType().equals(CorfuMsgType.RANGE_WRITE)) {
                         rangeWrites.incrementAndGet();


### PR DESCRIPTION
## Overview

Description:
Rename TestRule to CorfuTestRule to avoid class name conflicts in a private project.
Bazel/IntellijIDEA are confuzed by the name.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
