### PR TITLE
Lazy Deserialization Part 2

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/LogEntry.java
@@ -66,7 +66,8 @@ public class LogEntry implements ICorfuSerializable {
      */
     public static ICorfuSerializable deserialize(ByteBuf b, CorfuRuntime rt) {
         try {
-            LogEntryType let = typeMap.get(b.readByte());
+            byte type = b.readByte();
+            LogEntryType let = typeMap.get(type);
             LogEntry l = let.entryType.newInstance();
             l.type = let;
             l.runtime = rt;

--- a/runtime/src/main/java/org/corfudb/util/serializer/CorfuSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/CorfuSerializer.java
@@ -12,7 +12,7 @@ public class CorfuSerializer implements ISerializer {
     private final byte type;
 
     /* The magic that denotes this is a corfu payload */
-    final byte corfuPayloadMagic = 0x42;
+    public static final byte corfuPayloadMagic = 0x42;
 
     public CorfuSerializer(byte type) {
         this.type = type;


### PR DESCRIPTION
## Overview
PR #2192 changed the serialization format of MultiObjectSMREntry.
In order to avoid data migration, this patch reverts those format
changes. Those changes are convienent, but not necessary to
implement lazy deserialization. This patch does that: lazy
deserialization without format changes.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
