### PR TITLE
Fix CorfuDynamicMessage equals.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuDynamicMessage.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuDynamicMessage.java
@@ -76,10 +76,10 @@ public class CorfuDynamicMessage {
         // The getAllFields returns a {@link com.google.protobuf.SmallSortedMap}. This map ensures ordering.
         // This is created internally in protobuf from 2 parts an entry list  which is an ArrayList and an overflowMap
         // which is a TreeMap. Both of these guarantee ordering and hence ordering is guaranteed in the iteration.
-        Iterator<Map.Entry<FieldDescriptor, Object>> thisMessage = new ArrayList<>(payload.getAllFields().entrySet())
-                .iterator();
-        Iterator<Map.Entry<FieldDescriptor, Object>> otherMessage = new ArrayList<>(payload.getAllFields().entrySet())
-                .iterator();
+        Iterator<Map.Entry<FieldDescriptor, Object>> thisMessage
+                = new ArrayList<>(payload.getAllFields().entrySet()).iterator();
+        Iterator<Map.Entry<FieldDescriptor, Object>> otherMessage
+                = new ArrayList<>(other.payload.getAllFields().entrySet()).iterator();
 
         while (thisMessage.hasNext()) {
             if (!otherMessage.hasNext()) {

--- a/runtime/src/main/java/org/corfudb/util/serializer/ProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/ProtobufSerializer.java
@@ -33,7 +33,7 @@ public class ProtobufSerializer implements ISerializer {
 
     private final byte type;
 
-    static final byte PROTOBUF_SERIALIZER_CODE = (byte) 25;
+    public static final byte PROTOBUF_SERIALIZER_CODE = (byte) 25;
 
     private final Map<String, Class<? extends Message>> classMap;
 


### PR DESCRIPTION
## Overview

Description:
Fix CorfuDynamicMessage equals.
Validate schema on multiple openTables.

Why should this be merged: 
Fixes an equals bug which causes missing data in CorfuStore.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
