### PR TITLE
Fix garbage segment append: first dedup, then persist and finally merge.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/CompactionMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/CompactionMetadata.java
@@ -11,7 +11,7 @@ import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.view.Address;
 
-import java.util.List;
+import java.util.Collection;
 
 /**
  * Per-segment metadata for compaction.
@@ -62,7 +62,7 @@ class CompactionMetadata {
      *
      * @param entries entries appended to log which contains size information
      */
-    void updateTotalPayloadSize(List<LogData> entries) {
+    void updateTotalPayloadSize(Collection<LogData> entries) {
         for (LogData logData : entries) {
             if (logData.getType() == DataType.COMPACTED) {
                 continue;
@@ -95,7 +95,7 @@ class CompactionMetadata {
      * @param garbageEntries garbage entries appended to log,
      *                       which contains garbage size information
      */
-    void updateGarbageSize(List<SMRGarbageEntry> garbageEntries) {
+    void updateGarbageSize(Collection<SMRGarbageEntry> garbageEntries) {
         for (SMRGarbageEntry garbageEntry : garbageEntries) {
             updateBoundedGarbageSize(garbageEntry);
             updateTotalGarbageSize(garbageEntry);


### PR DESCRIPTION
## Overview

Fix garbage segment append: first dedup, then persist and finally merge.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
