### PR TITLE
CorfuQueue: Support for custom serializer & Secondary Indexes

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -105,7 +105,7 @@ public class CheckpointWriter<T extends Map> {
 
     @Getter
     @Setter
-    ISerializer serializer = Serializers.JSON;
+    ISerializer serializer = Serializers.getDefaultSerializer();
 
     /** Constructor for Checkpoint Writer for Corfu Maps.
      * @param rt object's runtime

--- a/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
@@ -7,6 +7,7 @@ import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
+import org.corfudb.util.serializer.Serializers;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -119,6 +120,7 @@ public class CorfuGuidGenerator implements OrderedGuidGenerator {
         distributedCounter = rt.getObjectsView().build()
                 .setType(SMRMap.class)
                 .setStreamName(GUID_STREAM_NAME)
+                .setSerializer(Serializers.getDefaultSerializer())
                 .open();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectBuilder.java
@@ -44,7 +44,7 @@ public class ObjectBuilder<T> implements IObjectBuilder<T> {
     String streamName;
 
     @Setter
-    ISerializer serializer = Serializers.JSON;
+    ISerializer serializer = Serializers.getDefaultSerializer();
 
     @Setter
     Set<ObjectOpenOptions> options = EnumSet.noneOf(ObjectOpenOptions.class);

--- a/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
@@ -20,6 +20,13 @@ public class Serializers {
     public static final ISerializer JSON = new JsonSerializer((byte) 2);
     public static final ISerializer PRIMITIVE = new PrimitiveSerializer((byte) 3);
 
+    /**
+     * @return the recommended default serializer used for converting objects into write format.
+     */
+    public static final ISerializer getDefaultSerializer() {
+        return Serializers.JSON;
+    }
+
     private static final Map<Byte, ISerializer> serializersMap;
 
     static {

--- a/test/src/test/java/org/corfudb/CustomSerializer.java
+++ b/test/src/test/java/org/corfudb/CustomSerializer.java
@@ -9,7 +9,7 @@ import org.corfudb.util.serializer.Serializers;
  * This serializer class is to be used only in tests.
  */
 public class CustomSerializer implements ISerializer {
-    ISerializer serializer = Serializers.JSON;
+    ISerializer serializer = Serializers.getDefaultSerializer();
     private final byte type;
 
     public CustomSerializer(byte type) {

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuMapTest.java
@@ -584,7 +584,7 @@ public class CorfuMapTest extends AbstractViewTest {
             Map<String, String> testMap2 = getRuntime().getObjectsView()
                     .build()
                     .setStreamName("A")
-                    .setSerializer(Serializers.JSON)
+                    .setSerializer(Serializers.getDefaultSerializer())
                     .addOption(ObjectOpenOptions.NO_CACHE)
                     .setTypeToken(CorfuTable.<String,String>getMapType())
                     .open();

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import org.corfudb.runtime.collections.CorfuQueue.CorfuQueueRecord;
 import org.corfudb.runtime.collections.CorfuQueue.CorfuRecordId;
 import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
 import java.util.Comparator;
@@ -65,6 +66,21 @@ public class CorfuQueueTest extends AbstractViewTest {
 
         assertThat(records.get(0).compareTo(records2.get(1))).isLessThan(0);
         assertThat(records.get(0).getRecordId().compareTo(records2.get(1).getRecordId())).isLessThan(0);
+    }
+
+    @Test
+    public void queueWithSecondaryIndexCheck() {
+        CorfuQueue<String>
+                corfuQueue = new CorfuQueue<>(getDefaultRuntime(), "test", Serializers.JAVA,
+                CorfuTable.IndexRegistry.empty());
+
+        CorfuRecordId idC = corfuQueue.enqueue("c");
+        CorfuRecordId idB = corfuQueue.enqueue("b");
+        CorfuRecordId idA = corfuQueue.enqueue("a");
+
+        final int expected = 3;
+        List<CorfuQueueRecord<String>> records = corfuQueue.entryList();
+        assertThat(records.size()).isEqualTo(expected);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -581,7 +581,7 @@ public class SMRMapTest extends AbstractViewTest {
             Map<String, String> testMap2 = getRuntime().getObjectsView()
                     .build()
                     .setStreamName("A")
-                    .setSerializer(Serializers.JSON)
+                    .setSerializer(Serializers.getDefaultSerializer())
                     .addOption(ObjectOpenOptions.NO_CACHE)
                     .setTypeToken(new TypeToken<SMRMap<String, String>>() {})
                     .open();

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -283,7 +283,7 @@ public class CorfuSMRObjectProxyTest extends AbstractObjectTest {
         Map<String, String> test2 = r.getObjectsView().build()
                 .setType(SMRMap.class)
                 .setStreamName("test")
-                .setSerializer(Serializers.JSON)
+                .setSerializer(Serializers.getDefaultSerializer())
                 .open();
 
         ObjectsView.ObjectID mapId = new ObjectsView.

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -296,7 +296,7 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
     @Test
     public void customSameHashAlwaysConflicts() {
         // Register a custom hasher which always hashes to an empty byte array
-        Serializers.JSON.registerCustomHasher(CustomSameHashConflictObject.class,
+        Serializers.getDefaultSerializer().registerCustomHasher(CustomSameHashConflictObject.class,
                 o -> new byte[0]);
 
         CustomSameHashConflictObject c1 = new CustomSameHashConflictObject("a", "a");
@@ -336,7 +336,7 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
     public void customHasDoesNotConflict() {
         // Register a custom hasher which always hashes to the two strings together as a
         // byte array
-        Serializers.JSON.registerCustomHasher(CustomSameHashConflictObject.class,
+        Serializers.getDefaultSerializer().registerCustomHasher(CustomSameHashConflictObject.class,
                 o -> {
                     ByteBuffer b = ByteBuffer.wrap(new byte[o.k1.length() + o.k2.length()]);
                     b.put(o.k1.getBytes());


### PR DESCRIPTION
## Overview

Consumers of the CorfuQueue need a way to set a custom serializer based on the integration framework.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
