### PR TITLE
CorfuStore: auto retry on SEQUENCER_OVERFLOW transaction aborts

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -131,12 +131,12 @@ public class CorfuStore {
      * @param namespace Namespace of the tables involved in the transaction.
      * @return Returns a transaction builder instance.
      */
-    @Nonnull
-    public TxBuilder tx(@Nonnull final String namespace) {
-        return new TxBuilder(
-                this.runtime.getObjectsView(),
-                this.runtime.getTableRegistry(),
-                namespace);
+    public TxBuilder tx(final String namespace) {
+        return TxBuilder.builder()
+                .objectsView(runtime.getObjectsView())
+                .tableRegistry(runtime.getTableRegistry())
+                .namespace(namespace)
+                .build();
     }
 
     /**

--- a/test/src/test/java/org/corfudb/infrastructure/CorfuServerNodeTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CorfuServerNodeTest.java
@@ -1,7 +1,5 @@
 package org.corfudb.infrastructure;
 
-import com.codahale.metrics.MetricRegistry;
-
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.protocols.wireprotocol.PriorityLevel;
 import org.corfudb.runtime.CorfuRuntime;

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
@@ -383,3 +383,4 @@ public class CorfuStoreTest extends AbstractViewTest {
         return FileDescriptor.buildFrom(map.get(name), fileDescriptors);
     }
 }
+


### PR DESCRIPTION
## Overview

For high concurrency use cases where only new keys are getting inserted transactionally the current cache eviction (LFU) in sequencer server can cause transaction aborts which can be consumed and retried internally in CorfuStore.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
