### PR TITLE
fix the leaking problem of clear operation

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -550,7 +550,7 @@ public class CorfuTable<K ,V> implements ICorfuMap<K, V> {
 
     @DontInstrument
     protected List<Object> identifyClearGarbage(Object locator) {
-        return new ArrayList<>(locatorStore.clearUnsafe());
+        return new ArrayList<>(locatorStore.clearUnsafe((SMRRecordLocator) locator));
     }
 
     /** {@inheritDoc} */

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ILocatorStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ILocatorStore.java
@@ -20,7 +20,9 @@ public interface ILocatorStore<T> {
 
     /**
      * Clear this store.
+     * @param latestClearLocator
+     *
      * @return stored locators.
      */
-    List<SMRRecordLocator> clearUnsafe();
+    List<SMRRecordLocator> clearUnsafe(@NonNull SMRRecordLocator latestClearLocator);
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
@@ -717,7 +717,7 @@ public class SMRMap<K, V> extends HashMap<K, V> implements ISMRMap<K,V> {
     @DontInstrument
     @Override
     public List<Object> identifyClearGarbage(Object locator) {
-        return new ArrayList<>(locatorStore.clearUnsafe());
+        return new ArrayList<>(locatorStore.clearUnsafe((SMRRecordLocator) locator));
     }
 
     @DontInstrument


### PR DESCRIPTION
Current implementation could not mark clear() operator as garbage. This patch fixes this problem by adding a dedicated variable to track the locator of latest clear() operator. One clear() operator is marked as garbage when a new clear() is encountered.