### PR TITLE
CorfuStore: Metadata retains previous values if not set

### DIFF
--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -22,6 +22,7 @@ message LogicalSwitch {
 message ManagedResources {
     optional string create_user = 1;
     optional int64 version = 2 [(org.corfudb.runtime.schema).version = true];
+    optional int64 create_timestamp = 3;
 }
 
 message EventInfo {


### PR DESCRIPTION
Some fields in managedResources are set only at the time the object is created and not really available on updates. This means clients would need to do an explicit get() to retrieve the old value.
This change makes the merging of previous value the default behavior for metadata fields.

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
