### PR TITLE
@PassThrough bug fix

### DIFF
--- a/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
+++ b/annotationProcessor/src/main/java/org/corfudb/annotations/ObjectAnnotationProcessor.java
@@ -527,13 +527,19 @@ public class ObjectAnnotationProcessor extends AbstractProcessor {
                                 ? "return null; });" : "});"
                         );
                     } else if (smrMethod.getAnnotation(PassThrough.class) != null) {
-                        ms.addStatement("$L super.$L($L)",
+
+                        ms.addStatement((smrMethod.getReturnType().getKind()
+                                        .equals(TypeKind.VOID) ? "" : "return ") + "proxy"
+                                        + CORFUSMR_FIELD + ".passThrough(" + "o" + CORFUSMR_FIELD
+                                        + " -> {$Lo" + CORFUSMR_FIELD + ".$L($L);$L})",
                                 smrMethod.getReturnType().getKind().equals(TypeKind.VOID)
                                         ? "" : "return ",
                                 smrMethod.getSimpleName(),
                                 smrMethod.getParameters().stream()
                                         .map(VariableElement::getSimpleName)
-                                        .collect(Collectors.joining(", "))
+                                        .collect(Collectors.joining(", ")),
+                                smrMethod.getReturnType().getKind().equals(TypeKind.VOID)
+                                        ? "return null;" : ""
                         );
                     } else if (smrMethod.getAnnotation(InterfaceOverride.class) != null) {
                         ms.addStatement("$L$T.super.$L($L)",

--- a/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
+++ b/annotations/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxy.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.object;
 
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /** An interface for accessing a proxy, which
@@ -9,6 +10,16 @@ import java.util.function.Supplier;
  * Created by mwei on 11/10/16.
  */
 public interface ICorfuSMRProxy<T> {
+
+    /**
+     * Pass-through: invoke a method on the object without mutator/accessor
+     * synchronization.
+     *
+     * @param method pass through method to invoke
+     * @param <R>               The type to return.
+     * @return result of the pass through method
+     */
+    <R> R passThrough(Function<T, R> method);
 
     /** Access the state of the object.
      * @param accessMethod      The method to execute when accessing an object.

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -35,6 +35,7 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 /**
@@ -165,6 +166,14 @@ public class CorfuCompileProxy<T> implements ICorfuSMRProxyInternal<T> {
         counterAccessLocked = metrics.counter(mpObj + "access-locked");
         counterTxnRetry1 = metrics.counter(mpObj + "txn-first-retry");
         counterTxnRetryN = metrics.counter(mpObj + "txn-extra-retries");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public  <R> R passThrough(Function<T, R> method) {
+        return underlyingObject.passThrough(method);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -172,6 +172,13 @@ public class VersionLockedObject<T> {
     }
 
     /**
+     * Execute a method on the version locked object without synchronization
+     */
+    public <R> R passThrough(Function<T, R> method) {
+        return method.apply(object);
+    }
+
+    /**
      * Access the internal state of the object, trying first to optimistically access
      * the object, then obtaining a write lock the optimistic access fails.
      *


### PR DESCRIPTION
## Overview

Currently, @PassThrough and @DontInstrument have the same behavior,
but @PassThrough methods should execute against the underlying
object and not the wrapper. This patch fixes the annotation
processor to generate correct pass-through methods.


Why should this be merged: Fixes a bug in the annotation processor, enables some clean ups in #2201 and helps fix #2225

Related issue(s) (if applicable): Enables some clean ups in #2201 and helps fix #2225


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
