### PR TITLE
Make (Multi)CheckpointWriter consume StreamingMap

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/MultiCheckpointWriter.java
@@ -5,7 +5,9 @@ import com.codahale.metrics.Timer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.collections.ISMRMap;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuSMR;
@@ -23,7 +25,7 @@ import java.util.UUID;
  * Checkpoint multiple SMRMaps serially as a prerequisite for a later log trim.
  */
 @Slf4j
-public class MultiCheckpointWriter<T extends Map> {
+public class MultiCheckpointWriter<T extends StreamingMap> {
     @Getter
     private List<ICorfuSMR<T>> maps = new ArrayList<>();
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ContextAwareMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ContextAwareMap.java
@@ -1,0 +1,32 @@
+package org.corfudb.runtime.collections;
+
+import org.corfudb.runtime.object.ICorfuExecutionContext;
+
+/**
+ * A flavour of {@link StreamingMap} that is {@link ICorfuExecutionContext} aware
+ * and {@link AutoCloseable}.
+ *
+ * @param <K> key type
+ * @param <V> value type
+ */
+public interface ContextAwareMap<K, V> extends StreamingMap<K, V>, AutoCloseable {
+
+    /**
+     * Return an optional implementation of the {@link StreamingMap} that
+     * is used only during optimistic (non-committed) operations.
+     *
+     * It is the responsibility of the data-structure to query this map during
+     * any sort of access operations.
+     *
+     * @return {@link StreamingMap} representing non-committed changes
+     */
+    default ContextAwareMap<K, V> getOptimisticMap() {
+        return this;
+    }
+
+    /**
+     * Relinquish any resources associated with this object.
+     */
+    default void close() {
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -62,8 +62,8 @@ import org.corfudb.runtime.object.ICorfuVersionPolicy;
  */
 @Slf4j
 @CorfuObject
-public class CorfuTable<K ,V>
-        implements ICorfuMap<K, V>, ICorfuSMR<CorfuTable<K ,V>>, AutoCloseable {
+public class CorfuTable<K ,V> implements
+        ICorfuTable<K, V>, ICorfuSMR<CorfuTable<K, V>> {
 
     /**
      * Denotes a function that supplies the unique name of an index registered to
@@ -205,13 +205,13 @@ public class CorfuTable<K ,V>
     }
 
     // The "main" map which contains the primary key-value mappings.
-    private final StreamingMap<K,V> mainMap;
+    private final ContextAwareMap<K,V> mainMap;
     private final Set<Index<K, V, ? extends Comparable>> indexSpec;
     private final Map<String, Map<Comparable, Map<K, V>>> secondaryIndexes;
     private final CorfuTable<K, V> optimisticTable;
     private final VersionPolicy versionPolicy;
 
-    public CorfuTable(StreamingMap<K,V> mainMap,
+    public CorfuTable(ContextAwareMap<K,V> mainMap,
                       Set<Index<K, V, ? extends Comparable>> indexSpec,
                       Map<String, Map<Comparable, Map<K, V>>> secondaryIndexe,
                       CorfuTable<K, V> optimisticTable) {
@@ -227,7 +227,7 @@ public class CorfuTable<K ,V>
      * specification.
      */
     public CorfuTable(IndexRegistry<K, V> indices,
-                      Supplier<StreamingMap<K, V>> streamingMapSupplier,
+                      Supplier<ContextAwareMap<K, V>> streamingMapSupplier,
                       VersionPolicy versionPolicy) {
         this.indexSpec = new HashSet<>();
         this.secondaryIndexes = new HashMap<>();
@@ -251,7 +251,7 @@ public class CorfuTable<K ,V>
      * {@link IndexRegistry}.
      */
     public CorfuTable(IndexRegistry<K, V> indices,
-                      Supplier<StreamingMap<K, V>> streamingMapSupplier) {
+                      Supplier<ContextAwareMap<K, V>> streamingMapSupplier) {
         this(indices, streamingMapSupplier, ICorfuVersionPolicy.DEFAULT);
     }
 
@@ -259,7 +259,7 @@ public class CorfuTable<K ,V>
      * Generate a table with a given implementation for the {@link StreamingMap},
      * and {@link VersionPolicy}.
      */
-    public CorfuTable(Supplier<StreamingMap<K, V>> streamingMapSupplier,
+    public CorfuTable(Supplier<ContextAwareMap<K, V>> streamingMapSupplier,
                       VersionPolicy versionPolicy) {
         this(IndexRegistry.empty(), streamingMapSupplier, versionPolicy);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ICorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ICorfuTable.java
@@ -4,8 +4,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.function.Predicate;
 
-public interface ICorfuMap<K, V>
-    extends Map<K, V> {
+public interface ICorfuTable<K, V>
+        extends StreamingMap<K, V> {
 
     /** Insert a key-value pair into a map, overwriting any previous mapping.
      *
@@ -35,5 +35,5 @@ public interface ICorfuMap<K, V>
      * @return a view of the entries contained in this map meeting the predicate condition.
      */
     Collection<Map.Entry<K, V>> scanAndFilterByEntry(Predicate<? super Entry<K, V>>
-                                                                    entryPredicate);
+                                                             entryPredicate);
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ISMRMap.java
@@ -6,14 +6,16 @@ import java.util.Map;
 import java.util.Set;
 import org.corfudb.annotations.Accessor;
 import org.corfudb.annotations.ConflictParameter;
+import org.corfudb.annotations.DontInstrument;
 import org.corfudb.annotations.Mutator;
 import org.corfudb.annotations.MutatorAccessor;
+import org.corfudb.runtime.object.ICorfuSMR;
 
 /**
  * Created by mwei on 1/9/16.
  */
 @SuppressWarnings("checkstyle:abbreviation")
-public interface ISMRMap<K, V> extends Map<K, V> {
+public interface ISMRMap<K, V> extends StreamingMap<K, V> {
 
     /**
      * {@inheritDoc}
@@ -273,5 +275,4 @@ public interface ISMRMap<K, V> extends Map<K, V> {
     @Accessor
     @Override
     Set<Entry<K, V>> entrySet();
-
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
@@ -38,13 +38,13 @@ import java.util.stream.Stream;
  * @param <V> value type
  */
 @Slf4j
-public class PersistedStreamingMap<K, V> implements StreamingMap<K, V> {
+public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
 
     static {
         RocksDB.loadLibrary();
     }
 
-    private final StreamingMap<K, V> optimisticMap = new StreamingMapDecorator<>();
+    private final ContextAwareMap<K, V> optimisticMap = new StreamingMapDecorator<>();
     private final AtomicInteger dataSetSize = new AtomicInteger();
     private final CorfuRuntime corfuRuntime;
     private final ISerializer serializer;
@@ -308,7 +308,7 @@ public class PersistedStreamingMap<K, V> implements StreamingMap<K, V> {
      * {@inheritDoc}
      */
     @Override
-    public StreamingMap<K, V> getOptimisticMap() {
+    public ContextAwareMap<K, V> getOptimisticMap() {
         return optimisticMap;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/SMRMap.java
@@ -17,6 +17,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.corfudb.annotations.Accessor;
 import org.corfudb.annotations.CorfuObject;
@@ -706,5 +707,13 @@ public class SMRMap<K, V>
     @Override
     public SMRMap<K, V> getContext(ICorfuExecutionContext.Context context) {
         return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Stream<Entry<K, V>> entryStream() {
+        return entrySet().stream();
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMap.java
@@ -13,7 +13,7 @@ import java.util.stream.Stream;
  * @param <K> key type
  * @param <V> value type
  */
-public interface StreamingMap<K, V> extends Map<K, V>, AutoCloseable {
+public interface StreamingMap<K, V> extends Map<K, V> {
 
     /**
      * Present the content of a {@link StreamingMap} via the {@link Stream} interface.
@@ -21,23 +21,4 @@ public interface StreamingMap<K, V> extends Map<K, V>, AutoCloseable {
      * @return stream of entries
      */
     Stream<Map.Entry<K, V>> entryStream();
-
-    /**
-     * Return an optional implementation of the {@link StreamingMap} that
-     * is used only during optimistic (non-committed) operations.
-     *
-     * It is the responsibility of the data-structure to query this map during
-     * any sort of access operations.
-     *
-     * @return {@link StreamingMap} representing non-committed changes
-     */
-    default StreamingMap<K, V> getOptimisticMap() {
-        return this;
-    }
-
-    /**
-     * Relinquish any resources associated with this object.
-     */
-    default void close() {
-    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
  * @param <K> key type
  * @param <V> value type
  */
-public class StreamingMapDecorator<K, V> implements StreamingMap<K, V> {
+public class StreamingMapDecorator<K, V> implements ContextAwareMap<K, V> {
 
     final Map<K, V> mapImpl;
 

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -11,9 +11,9 @@ import org.apache.commons.io.FileUtils;
 import org.corfudb.AbstractCorfuTest;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.RuntimeLayout;
-import org.corfudb.util.Sleep;
 import org.junit.After;
 import org.junit.Before;
 
@@ -305,8 +305,8 @@ public class AbstractIT extends AbstractCorfuTest {
         return rt;
     }
 
-    public static Map<String, Integer> createMap(CorfuRuntime rt, String streamName) {
-        Map<String, Integer> map = rt.getObjectsView()
+    public static StreamingMap<String, Integer> createMap(CorfuRuntime rt, String streamName) {
+        StreamingMap<String, Integer> map = rt.getObjectsView()
                 .build()
                 .setStreamName(streamName)
                 .setTypeToken(new TypeToken<SMRMap<String, Integer>>() {})

--- a/test/src/test/java/org/corfudb/integration/LogSizeQuotaIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogSizeQuotaIT.java
@@ -8,6 +8,7 @@ import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.QuotaExceededException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
@@ -118,7 +119,7 @@ public class LogSizeQuotaIT extends AbstractIT {
         privilegedRt.connect();
 
 
-        Map<String, String> map2 = privilegedRt.getObjectsView()
+        StreamingMap<String, String> map2 = privilegedRt.getObjectsView()
                 .build()
                 .setStreamName("s1")
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -12,6 +12,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
@@ -532,13 +533,13 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             final int sizeMap1 = 4;
             final int sizeMap2 = 6;
 
-            Map<String, String> map1 = defaultRT.getObjectsView().build()
+            StreamingMap<String, String> map1 = defaultRT.getObjectsView().build()
                     .setTypeToken(new TypeToken<SMRMap<String, String>>() {
                     })
                     .setStreamName("stream1")
                     .open();
 
-            Map<String, String> map2 = defaultRT.getObjectsView().build()
+            StreamingMap<String, String> map2 = defaultRT.getObjectsView().build()
                     .setTypeToken(new TypeToken<SMRMap<String, String>>() {
                     })
                     .setStreamName("stream2")
@@ -638,7 +639,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             final long snapshotAddress = 9L;
             final int sizeAtSnapshot = 6;
 
-            Map<String, String> map1 = writeRuntime.getObjectsView().build()
+            StreamingMap<String, String> map1 = writeRuntime.getObjectsView().build()
                     .setTypeToken(new TypeToken<SMRMap<String, String>>() {
                     })
                     .setStreamName("stream1")
@@ -724,8 +725,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(runtime);
 
             // Open mapA (S1) and mapB (S2)
-            Map<String, Integer> mapA = createMap(runtime, stream1);
-            Map<String, Integer> mapB = createMap(runtime, stream2);
+            StreamingMap<String, Integer> mapA = createMap(runtime, stream1);
+            StreamingMap<String, Integer> mapB = createMap(runtime, stream2);
 
             // Write 8 entries to mapA
             for (int i = 0; i < insertions - insertionsB; i++) {
@@ -837,8 +838,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(runtime);
 
             // Open mapA
-            Map<String, Integer> mapA = createMap(runtime, streamNameA);
-            Map<String, Integer> mapB = createMap(runtime, streamNameB);
+            StreamingMap<String, Integer> mapA = createMap(runtime, streamNameA);
+            StreamingMap<String, Integer> mapB = createMap(runtime, streamNameB);
 
             // Write 9 entries to mapA
             for (int i = 0; i < insertions - 1; i++) {
@@ -944,8 +945,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(runtime);
 
             // Open mapA
-            Map<String, Integer> mapA = createMap(runtime, streamNameA);
-            Map<String, Integer> mapB = createMap(runtime, streamNameB);
+            StreamingMap<String, Integer> mapA = createMap(runtime, streamNameA);
+            StreamingMap<String, Integer> mapB = createMap(runtime, streamNameB);
 
             // Write 9 entries to mapA
             for (int i = 0; i < insertions; i++) {
@@ -1048,8 +1049,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Instantiate streamA and streamB as maps
             final String streamA = "streamA";
             final String streamB = "streamB";
-            Map<String, Integer> mA = createMap(runtime, streamA);
-            Map<String, Integer> mB = createMap(runtime, streamB);
+            StreamingMap<String, Integer> mA = createMap(runtime, streamA);
+            StreamingMap<String, Integer> mB = createMap(runtime, streamB);
 
             // Write 10 Entries to streamA
             for (int i = 0; i < numEntries; i++) {
@@ -1143,7 +1144,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
         try {
             // Instantiate streamA as map
             final String streamA = "streamA";
-            Map<String, Integer> map = createMap(runtime, streamA);
+            StreamingMap<String, Integer> map = createMap(runtime, streamA);
 
             // Start a CheckpointWriter for streamA (empty)
             CheckpointWriter cpwA = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(streamA),
@@ -1257,7 +1258,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
         try {
             // Instantiate streamA as map
             final String streamA = "streamA";
-            Map<String, Integer> mA = createMap(runtime, streamA);
+            StreamingMap<String, Integer> mA = createMap(runtime, streamA);
 
             UUID streamID = CorfuRuntime.getStreamID(streamA);
             UUID checkpointId = CorfuRuntime.getCheckpointStreamIdFromId(streamID);

--- a/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
+++ b/test/src/test/java/org/corfudb/recovery/FastObjectLoaderTest.java
@@ -15,6 +15,7 @@ import org.corfudb.runtime.clients.LogUnitClient;
 import org.corfudb.runtime.clients.SequencerClient;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.collections.StringIndexer;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.VersionLockedObject;
@@ -52,7 +53,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
 
 
     private int key_count = 0;
-    private Map<String, Map> maps = new HashMap<>();
+    private Map<String, StreamingMap> maps = new HashMap<>();
 
     private <T extends Map<String, String>, ICorfuExecutionContext> void populateMapWithNextKey(T map) {
         map.put("key" + key_count, "value" + key_count);
@@ -67,7 +68,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         }
         for (int i = 0; i < numMaps; i++) {
             String mapName = "Map" + i;
-            Map currentMap = maps.computeIfAbsent(mapName, (k) ->
+            StreamingMap currentMap = maps.computeIfAbsent(mapName, (k) ->
                     Helpers.createMap(k, rt, type)
             );
 
@@ -369,7 +370,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
     public void canFindTailsWithFailedCheckpoint() throws Exception {
         CorfuRuntime rt1 = getDefaultRuntime();
         String streamName = "Map1";
-        Map<String, String> map = Helpers.createMap(streamName, rt1);
+        StreamingMap<String, String> map = Helpers.createMap(streamName, rt1);
         map.put("k1", "v1");
 
         UUID stream1 = CorfuRuntime.getStreamID(streamName);
@@ -386,7 +387,7 @@ public class FastObjectLoaderTest extends AbstractViewTest {
         long streamTail = getDefaultRuntime().getSequencerView().query(stream1);
         try {
             cpw.startCheckpoint(snapshot, streamTail);
-            cpw.appendObjectState(map.entrySet());
+            cpw.appendObjectState(map.entryStream());
         } finally {
             getDefaultRuntime().getObjectsView().TXEnd();
         }

--- a/test/src/test/java/org/corfudb/recovery/Helpers.java
+++ b/test/src/test/java/org/corfudb/recovery/Helpers.java
@@ -8,6 +8,7 @@ import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.VersionLockedObject;
@@ -29,12 +30,13 @@ public class Helpers{
         return data.getSerializedForm();
     }
 
-    static Map<String, String> createMap(String streamName, CorfuRuntime cr) {
+    static StreamingMap<String, String> createMap(String streamName, CorfuRuntime cr) {
         return createMap(streamName, cr, SMRMap.class);
     }
 
-    static <T extends ICorfuSMR> Map<String, String> createMap(String streamName, CorfuRuntime cr, Class<T> type) {
-        return (Map<String, String>) cr.getObjectsView().build()
+    static <T extends ICorfuSMR> StreamingMap<
+            String, String> createMap(String streamName, CorfuRuntime cr, Class<T> type) {
+        return (StreamingMap<String, String>) cr.getObjectsView().build()
                 .setStreamName(streamName)
                 .setType(type)
                 .open();

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -27,6 +27,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
@@ -247,7 +248,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         final Long fudgeFactor = 75L;
         final int smallBatchSize = 4;
 
-        Map<String, Long> m = instantiateMap(streamName);
+        StreamingMap<String, Long> m = instantiateMap(streamName);
         for (int i = 0; i < numKeys; i++) {
             m.put(keyPrefix + Integer.toString(i), (long) i);
         }
@@ -280,7 +281,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         long streamTail = r.getSequencerView().query(streamId);
         try {
             cpw.startCheckpoint(snapshot, streamTail);
-            cpw.appendObjectState(m.entrySet());
+            cpw.appendObjectState(m.entryStream());
             cpw.finishCheckpoint();
 
             // Instantiate new runtime & map.  All map entries (except 'just one more')
@@ -460,7 +461,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         }
     }
 
-    private Map<String, Long> instantiateMap(String streamName) {
+    private StreamingMap<String, Long> instantiateMap(String streamName) {
         Serializers.registerSerializer(serializer);
         return r.getObjectsView()
                 .build()
@@ -655,7 +656,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
 
         // Open map.
         final String streamA = "streamA";
-        Map<String, Long> mA = instantiateMap(streamA);
+        StreamingMap<String, Long> mA = instantiateMap(streamA);
 
         // (1) Write 25 Entries
         for (int i = 0; i < numEntries; i++) {
@@ -705,11 +706,11 @@ public class CheckpointSmokeTest extends AbstractViewTest {
 
         // Open map A
         final String streamA = "streamA";
-        Map<String, Long> mA = instantiateMap(streamA);
+        StreamingMap<String, Long> mA = instantiateMap(streamA);
 
         // Open map B
         final String streamB = "streamB";
-        Map<String, Long> mB = instantiateMap(streamB);
+        StreamingMap<String, Long> mB = instantiateMap(streamB);
 
         // Write numEntries Entries to mA
         for (int i = 0; i < numEntries; i++) {

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -16,6 +16,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.clients.TestRule;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.TrimmedException;
@@ -633,7 +634,7 @@ public class CheckpointTest extends AbstractObjectTest {
         CorfuRuntime runtime = getARuntime();
 
         try {
-            Map<String, Long> testMap = rt.getObjectsView().build()
+            StreamingMap<String, Long> testMap = rt.getObjectsView().build()
                     .setTypeToken(new TypeToken<SMRMap<String, Long>>() {
                     })
                     .setStreamName(streamName)

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTrimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTrimTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.view.AbstractViewTest;
@@ -65,7 +66,7 @@ public class CheckpointTrimTest extends AbstractViewTest {
      */
     @Test
     public void ensureMCWUsesRealTail() throws Exception {
-        Map<String, String> map = getDefaultRuntime().getObjectsView().build()
+        StreamingMap<String, String> map = getDefaultRuntime().getObjectsView().build()
                 .setTypeToken(new TypeToken<SMRMap<String, String>>() {
                 })
                 .setStreamName("test")

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -8,6 +8,7 @@ import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuSMR;
@@ -407,7 +408,7 @@ public class StreamViewTest extends AbstractViewTest {
     @Test
     public void testPreviousWithStreamCheckpoint() throws Exception {
         String stream = "stream1";
-        Map<String, String> map = r.getObjectsView()
+        StreamingMap<String, String> map = r.getObjectsView()
                 .build()
                 .setStreamName(stream)
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})


### PR DESCRIPTION
In order for checkpointing to work with large (disk-backed) tables,
(Multi)CheckpointWriter needs to consume the streaming interface.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
