### PR TITLE
Fix VM cloning in the Universe Framework

### DIFF
--- a/it/src/main/java/org/corfudb/universe/scenario/fixture/Fixtures.java
+++ b/it/src/main/java/org/corfudb/universe/scenario/fixture/Fixtures.java
@@ -183,7 +183,7 @@ public interface Fixtures {
             universe = VmUniverseParams.builder()
                     .vSphereUrl(vmProperties.getProperty("vsphere.url"))
                     .networkName(vmProperties.getProperty("vm.network"))
-                    .templateVMName("corfu-server")
+                    .templateVMName("debian-buster-thin-provisioned")
                     .credentials(credentialParams)
                     .cleanUpEnabled(true);
         }


### PR DESCRIPTION
Leveraging a new template and also disable unnecessary
VM customizations.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
