### PR TITLE
DynamicProtobufSerializer: Debug message for serializer error

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -133,8 +133,9 @@ public class BatchProcessor implements AutoCloseable {
                     streamLog.sync(true);
                     break;
                 } else if (streamLog.quotaExceeded() && currOp.getMsg().getPriorityLevel() != PriorityLevel.HIGH) {
-                    // TODO(Maithem): should the exception include the used/limit metrics?
-                    currOp.getFutureResult().completeExceptionally(new QuotaExceededException());
+                    currOp.getFutureResult().completeExceptionally(
+                            new QuotaExceededException("Quota of "
+                                    + streamLog.quotaLimitInBytes() + " bytes"));
                     log.warn("batchprocessor: quota exceeded, dropping msg {}", currOp.getMsg());
                 } else if (currOp.getType() == Type.SEAL && currOp.getMsg().getEpoch() >= sealEpoch) {
                     log.info("batchWriteProcessor: updating from {} to {}", sealEpoch, currOp.getMsg().getEpoch());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -140,4 +140,12 @@ public interface StreamLog {
     default boolean quotaExceeded() {
         return false;
     }
+
+    /**
+     * Query the exact Quota value in bytes
+     * @return the quota set in bytes
+     */
+    default long quotaLimitInBytes() {
+        return Long.MAX_VALUE;
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -8,6 +8,7 @@ import com.google.protobuf.AbstractMessage;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.netty.buffer.Unpooled;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -279,6 +280,11 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
     @Override
     public boolean quotaExceeded() {
         return !logSizeQuota.hasAvailable();
+    }
+
+    @Override
+    public long quotaLimitInBytes() {
+        return logSizeQuota.getLimit();
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/QuotaExceededException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/QuotaExceededException.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class QuotaExceededException extends RuntimeException {
     public QuotaExceededException(String msg) {
-        super(msg);
+        super("Disk usage has exceeded the quota set, system is now in read-only mode. "
+                + msg);
     }
 }

--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -151,6 +151,13 @@ public class DynamicProtobufSerializer implements ISerializer {
             return fileDescriptorMap.get(name);
         }
 
+        if (!fdProtoMap.containsKey(name)) {
+            log.error("DynamicProtobufSerializer failed to deserialize unknown file {}",
+                    name);
+            log.error(this.toString());
+            throw new SerializerException(
+                    "DynamicProtobufSerializer file " + name + " was never seen in registry");
+        }
         List<FileDescriptor> fileDescriptorList = new ArrayList<>();
         for (String s : fdProtoMap.get(name).getDependencyList()) {
             FileDescriptor descriptor = getDescriptor(s);
@@ -283,6 +290,27 @@ public class DynamicProtobufSerializer implements ISerializer {
             log.error("Exception during serialization!", ie);
             throw new SerializerException(ie);
         }
+    }
+
+    public String toString() {
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("\n---------messageFdProtoNameMap Messages:---------\n");
+        for (Map.Entry<String, String> mname: messagesFdProtoNameMap.entrySet()) {
+            stringBuilder.append("Message: "+ mname.getKey()+ " in file "+ mname.getValue()+"\n");
+        }
+
+        stringBuilder.append("\n-------fdProtoMap FileDescriptors:--------------\n");
+        for (Map.Entry<String, FileDescriptorProto> fdProto: fdProtoMap.entrySet()) {
+            stringBuilder.append("File: " + fdProto.getKey());
+            stringBuilder.append(" ===> (FileDescriptorProto follows...)\n");
+            stringBuilder.append(fdProto.getValue());
+        }
+
+        stringBuilder.append("\n---------fileDescriptorCache FileDescriptors----------\n");
+        for (Map.Entry<String, FileDescriptor> fds: fileDescriptorMap.entrySet()) {
+            stringBuilder.append("File: "+ fds.getKey() + " ==> " + fds.getValue() + "\n");
+        }
+        return stringBuilder.toString();
     }
 }
 

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
@@ -10,6 +10,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
 import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.test.SampleSchema;
 import org.corfudb.test.SampleSchema.EventInfo;
 import org.corfudb.test.SampleSchema.Uuid;
 import org.junit.Test;
@@ -204,6 +205,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                 .isEqualTo(ManagedResources.newBuilder()
                         .setCreateUser("user_1")
                         .setCreateTimestamp(0L)
+                        .setNestedType(SampleSchema.NestedTypeA.newBuilder().build())
                         .setVersion(expectedVersion++).build());
 
         // Set the version field to the correct value 1 and expect that no exception is thrown
@@ -217,6 +219,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                 .isEqualTo(ManagedResources.newBuilder()
                         .setCreateUser("user_2")
                         .setCreateTimestamp(0L)
+                        .setNestedType(SampleSchema.NestedTypeA.newBuilder().build())
                         .setVersion(expectedVersion++).build());
 
         // Now do an updated without setting the version field, and it should not get validated!
@@ -230,6 +233,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                 .isEqualTo(ManagedResources.newBuilder()
                         .setCreateUser("user_2")
                         .setCreateTimestamp(0L)
+                        .setNestedType(SampleSchema.NestedTypeA.newBuilder().build())
                         .setVersion(expectedVersion).build());
 
         corfuStore.tx(nsxManager).delete(tableName, key1).commit();
@@ -245,6 +249,7 @@ public class CorfuStoreTest extends AbstractViewTest {
         assertThat(corfuStore.openTable(nsxManager, tableName).get(key1).getMetadata())
                 .isEqualTo(ManagedResources.newBuilder(user_2)
                         .setCreateTimestamp(0L)
+                        .setNestedType(SampleSchema.NestedTypeA.newBuilder().build())
                         .setVersion(expectedVersion).build());
 
         // Validate that if Metadata schema is specified, a null metadata is not acceptable

--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -4,6 +4,7 @@ package org.corfudb.test;
 option java_package = "org.corfudb.test";
 
 import "corfu_options.proto";
+import "google/protobuf/descriptor.proto";
 import "sample_appliance.proto";
 
 message FirewallRule {
@@ -23,6 +24,7 @@ message ManagedResources {
     optional string create_user = 1;
     optional int64 version = 2 [(org.corfudb.runtime.schema).version = true];
     optional int64 create_timestamp = 3;
+    optional NestedTypeA nested_type = 4;
 }
 
 message EventInfo {
@@ -36,4 +38,23 @@ message EventInfo {
 message Uuid {
     optional uint64 msb = 1;
     optional uint64 lsb = 2;
+}
+
+message NestedTypeA {
+    repeated NestedTypeB tag = 1;
+}
+
+message NestedTypeB {
+    option (org.corfudb.test.mgoptions).skip_snapshot = true;
+    optional string something = 1;
+    optional string something2 = 2;
+}
+
+message ManagedResourceOptionsMsg {
+    optional bool skip_snapshot = 1;
+
+}
+
+extend google.protobuf.MessageOptions {
+    optional ManagedResourceOptionsMsg mgoptions = 54312;
 }


### PR DESCRIPTION
## Overview

If a table was opened with a different type but carries entries of different types, then we should be able to catch and log this error.
## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
