### PR TITLE
AddressSpaceView cache fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -39,6 +39,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CompletableFuture;
@@ -757,8 +758,9 @@ public class FastObjectLoader {
                 ContiguousSet<Long> addresses = ContiguousSet.create(
                         Range.closed(lower, upper), DiscreteDomain.longs());
 
-                Map<Long, ILogData> range = runtime.getAddressSpaceView().read(addresses,
-                        RecoveryUtils.fastLoaderReadOptions);
+                Map<Long, ILogData> range = new TreeMap<>(
+                        runtime.getAddressSpaceView().read(addresses,
+                                RecoveryUtils.fastLoaderReadOptions));
 
                 // Sanity
                 for (Map.Entry<Long, ILogData> entry : range.entrySet()) {


### PR DESCRIPTION
When the cache is disabled, entries still end up being cached due to a
bug in AddressSpaceView. This patch fixes that issue and simplifies the
logic.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
