### PR TITLE
print throwable trace at getPayload

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -80,7 +80,7 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
                                         Serializers.CORFU.deserialize(copyBuf, runtime);
                             } catch (Throwable throwable) {
                                 log.error("Exception caught at address {}, {}, {}",
-                                        getGlobalAddress(), getStreams(), getType());
+                                        getGlobalAddress(), getStreams(), getType(), throwable);
                                 copyBuf.release();
                                 data = null;
                                 throw throwable;


### PR DESCRIPTION
Print the throwable trace to get more information about the error.