### PR TITLE
Fix a flaky integration test

### DIFF
--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -60,6 +60,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class ClusterReconfigIT extends AbstractIT {
 
     private static String corfuSingleNodeHost;
+    private final int basePort = 9000;
+    private final int retries = 10;
 
     @Before
     public void loadProperties() {
@@ -84,8 +86,6 @@ public class ClusterReconfigIT extends AbstractIT {
         testStatus += "SEED=" + Long.toHexString(SEED);
         return new Random(SEED);
     }
-
-    final int basePort = 9000;
 
     private Layout getLayout(int numNodes) {
         List<String> servers = new ArrayList<>();
@@ -367,7 +367,6 @@ public class ClusterReconfigIT extends AbstractIT {
     public void rebootUtilTest() throws Exception {
         final int PORT_0 = 9000;
         final String SERVER_0 = "localhost:" + PORT_0;
-        final int retries = 3;
 
         // Start testing restart utility
         Process corfuServer = runPersistentServer(corfuSingleNodeHost, PORT_0, true);
@@ -408,7 +407,6 @@ public class ClusterReconfigIT extends AbstractIT {
         Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
         List<Process> corfuServers = Arrays.asList(corfuServer_1, corfuServer_2, corfuServer_3);
         final Layout layout = getLayout(3);
-        final int retries = 3;
         TimeUnit.SECONDS.sleep(1);
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
@@ -508,7 +506,6 @@ public class ClusterReconfigIT extends AbstractIT {
         Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
         final Layout layout = getLayout(3);
 
-        final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
         runtime = createDefaultRuntime();
@@ -520,7 +517,6 @@ public class ClusterReconfigIT extends AbstractIT {
     }
 
     private void retryBootstrapOperation(Runnable bootstrapOperation) throws InterruptedException {
-        final int retries = 5;
         int retry = retries;
         while (retry-- > 0) {
             try {
@@ -545,7 +541,6 @@ public class ClusterReconfigIT extends AbstractIT {
         final int PORT_0 = 9000;
         Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
         final Layout layout = getLayout(1);
-        final int retries = 5;
 
         IClientRouter router = new NettyClientRouter(NodeLocator
                 .parseString(corfuSingleNodeHost + ":" + PORT_0),
@@ -576,7 +571,6 @@ public class ClusterReconfigIT extends AbstractIT {
         final int PORT_0 = 9000;
         Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
         final Layout layout = getLayout(1);
-        final int retries = 3;
 
         IClientRouter router = new NettyClientRouter(NodeLocator
                 .parseString(corfuSingleNodeHost + ":" + PORT_0),
@@ -606,7 +600,6 @@ public class ClusterReconfigIT extends AbstractIT {
         final int PORT_0 = 9000;
         Process corfuServer_1 = runPersistentServer(corfuSingleNodeHost, PORT_0, false);
         final Layout layout = getLayout(1);
-        final int retries = 3;
 
         IClientRouter router = new NettyClientRouter(NodeLocator
                 .parseString(corfuSingleNodeHost + ":" + PORT_0),
@@ -652,7 +645,6 @@ public class ClusterReconfigIT extends AbstractIT {
         Process corfuServer_2 = runPersistentServer(corfuSingleNodeHost, PORT_1, false);
         Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
         final Layout layout = getLayout(3);
-        final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
         // Create map and set up daemon writer thread.
@@ -802,7 +794,6 @@ public class ClusterReconfigIT extends AbstractIT {
         Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
         final Layout layout = getLayout(3);
 
-        final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
         runtime = createDefaultRuntime();
@@ -872,7 +863,6 @@ public class ClusterReconfigIT extends AbstractIT {
         final int nodesCount = 3;
         final Layout layout = getLayout(3);
 
-        final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
         runtime = createDefaultRuntime();
@@ -950,7 +940,6 @@ public class ClusterReconfigIT extends AbstractIT {
         Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
         final Layout layout = getLayout(3);
 
-        final int retries = 3;
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 
         final int systemDownHandlerLimit = 10;
@@ -1044,7 +1033,6 @@ public class ClusterReconfigIT extends AbstractIT {
         Process corfuServer_3 = runPersistentServer(corfuSingleNodeHost, PORT_2, false);
         List<Process> corfuServers = Arrays.asList(corfuServer_1, corfuServer_2, corfuServer_3);
         final Layout layout = getLayout(3);
-        final int retries = 3;
         TimeUnit.SECONDS.sleep(1);
         BootstrapUtil.bootstrap(layout, retries, PARAMETERS.TIMEOUT_SHORT);
 


### PR DESCRIPTION
Depending on the available resources, the total number of retries in
ClusterReconfigIT is sometimes not sufficient.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
