### PR TITLE
Move Index defintions into a separate class

### DIFF
--- a/generator/src/main/java/org/corfudb/generator/StringIndexer.java
+++ b/generator/src/main/java/org/corfudb/generator/StringIndexer.java
@@ -1,35 +1,34 @@
 package org.corfudb.generator;
 
-import org.corfudb.runtime.collections.CorfuTable;
-import org.corfudb.runtime.collections.CorfuTable.Index;
+import org.corfudb.runtime.collections.Index;
 
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-public class StringIndexer implements CorfuTable.IndexRegistry<String, String> {
+public class StringIndexer implements Index.Registry<String, String> {
 
-    public static final CorfuTable.IndexName BY_VALUE = () -> "BY_VALUE";
-    public static final CorfuTable.IndexName BY_FIRST_CHAR = () -> "BY_FIRST_LETTER";
+    public static final Index.Name BY_VALUE = () -> "BY_VALUE";
+    public static final Index.Name BY_FIRST_CHAR = () -> "BY_FIRST_LETTER";
 
-    private static final CorfuTable.Index<String, String, ? extends Comparable<?>> BY_VALUE_INDEX =
-            new CorfuTable.Index<>(
+    private static final Index.Spec<String, String, ? extends Comparable<?>> BY_VALUE_INDEX =
+            new Index.Spec<>(
                     BY_VALUE,
-                    (CorfuTable.IndexFunction<String, String, String>) (key, val) -> val);
+                    (Index.Function<String, String, String>) (key, val) -> val);
 
-    private static final CorfuTable.Index<String, String, ? extends Comparable<?>> BY_FIRST_CHAR_INDEX =
-            new CorfuTable.Index<>(
+    private static final Index.Spec<String, String, ? extends Comparable<?>> BY_FIRST_CHAR_INDEX =
+            new Index.Spec<>(
                     BY_FIRST_CHAR,
-                    (CorfuTable.IndexFunction<String, String, String>) (key, val) ->
+                    (Index.Function<String, String, String>) (key, val) ->
                             Character.toString(val.charAt(0)));
 
     @Override
-    public Iterator<Index<String, String, ? extends Comparable<?>>> iterator() {
+    public Iterator<Index.Spec<String, String, ? extends Comparable<?>>> iterator() {
         return Stream.of(BY_VALUE_INDEX, BY_FIRST_CHAR_INDEX).iterator();
     }
 
     @Override
-    public Optional<CorfuTable.Index<String, String, ? extends Comparable<?>>> get(CorfuTable.IndexName name) {
+    public Optional<Index.Spec<String, String, ? extends Comparable<?>>> get(Index.Name name) {
         String indexName = (name != null)? name.get() : null;
 
         if (BY_VALUE.get().equals(indexName)) {

--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -18,7 +18,7 @@ import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuTable;
-import org.corfudb.runtime.collections.CorfuTable.IndexRegistry;
+import org.corfudb.runtime.collections.Index;
 import org.corfudb.runtime.collections.SMRMap;
 import org.corfudb.runtime.exceptions.FastObjectLoaderException;
 import org.corfudb.runtime.exceptions.TrimmedException;
@@ -184,7 +184,7 @@ public class FastObjectLoader {
      * @param streamName    Stream name.
      * @param indexRegistry Index Registry.
      */
-    public void addIndexerToCorfuTableStream(String streamName, IndexRegistry indexRegistry) {
+    public void addIndexerToCorfuTableStream(String streamName, Index.Registry indexRegistry) {
         UUID streamId = CorfuRuntime.getStreamID(streamName);
         Builder ob = SMRObject.builder()
                 .runtime(runtime)

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
@@ -4,7 +4,6 @@ import com.google.common.reflect.TypeToken;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.collections.CorfuTable.IndexRegistry;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.CorfuGuidGenerator;
@@ -44,7 +43,7 @@ public class CorfuQueue<E> {
     private final CorfuGuidGenerator guidGenerator;
 
     public CorfuQueue(CorfuRuntime runtime, String streamName, ISerializer serializer,
-                      IndexRegistry<Long, E> indices) {
+                      Index.Registry<Long, E> indices) {
         final Supplier<StreamingMap<Long, E>> mapSupplier =
                 () -> new StreamingMapDecorator<>(new LinkedHashMap<Long, E>());
         this.runtime = runtime;
@@ -58,7 +57,7 @@ public class CorfuQueue<E> {
     }
 
     public CorfuQueue(CorfuRuntime runtime, String streamName) {
-        this(runtime, streamName, Serializers.getDefaultSerializer(), IndexRegistry.empty());
+        this(runtime, streamName, Serializers.getDefaultSerializer(), Index.Registry.empty());
 
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ProtobufIndexer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ProtobufIndexer.java
@@ -6,8 +6,6 @@ import com.google.protobuf.Message;
 
 import org.corfudb.common.util.ClassUtils;
 import org.corfudb.runtime.CorfuOptions;
-import org.corfudb.runtime.collections.CorfuTable.Index;
-import org.corfudb.runtime.collections.CorfuTable.IndexName;
 
 import java.util.HashMap;
 import java.util.Iterator;
@@ -21,22 +19,23 @@ import java.util.Optional;
  *
  * Created by hisundar on 2019-08-12.
  */
-public class ProtobufIndexer implements CorfuTable.IndexRegistry<Message, CorfuRecord<Message, Message>> {
+public class ProtobufIndexer implements Index.Registry<Message, CorfuRecord<Message,
+        Message>> {
 
     private final HashMap<String,
-            Index<Message, CorfuRecord<Message, Message>, ? extends Comparable<?>>>
+            Index.Spec<Message, CorfuRecord<Message, Message>, ? extends Comparable<?>>>
             indices = new HashMap<>();
 
     ProtobufIndexer(Message payloadSchema) {
         payloadSchema.getDescriptorForType().getFields().forEach(this::registerIndices);
     }
 
-    private <T extends Comparable<T>> Index<Message, CorfuRecord<Message, Message>, ? extends Comparable<?>>
+    private <T extends Comparable<T>> Index.Spec<Message, CorfuRecord<Message, Message>, ? extends Comparable<?>>
     getIndex(String indexName, FieldDescriptor fieldDescriptor) {
 
-        return new Index<>(
+        return new Index.Spec<>(
                 () -> indexName,
-                (CorfuTable.IndexFunction<Message, CorfuRecord<Message, Message>, T>)
+                (Index.Function<Message, CorfuRecord<Message, Message>, T>)
                         (key, val) -> ClassUtils.cast(val.getPayload().getField(fieldDescriptor)));
     }
 
@@ -52,12 +51,14 @@ public class ProtobufIndexer implements CorfuTable.IndexRegistry<Message, CorfuR
     }
 
     @Override
-    public Optional<Index<Message, CorfuRecord<Message, Message>, ? extends Comparable<?>>> get(IndexName name) {
+    public Optional<
+            Index.Spec<Message, CorfuRecord<Message, Message>, ? extends Comparable<?>>
+            > get(Index.Name name) {
         return Optional.ofNullable(name).map(indexName -> indices.get(indexName));
     }
 
     @Override
-    public Iterator<Index<Message, CorfuRecord<Message, Message>, ? extends Comparable<?>>> iterator() {
+    public Iterator<Index.Spec<Message, CorfuRecord<Message, Message>, ? extends Comparable<?>>> iterator() {
         return indices.values().iterator();
 
     }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TableOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TableOptions.java
@@ -1,6 +1,5 @@
 package org.corfudb.runtime.collections;
 
-import org.corfudb.runtime.collections.CorfuTable.IndexRegistry;
 import lombok.Builder;
 
 import java.nio.file.Path;
@@ -12,7 +11,7 @@ import java.util.Optional;
 @Builder
 public class TableOptions<K, V> {
 
-    private final IndexRegistry<K, V> indexRegistry;
+    private final Index.Registry<K, V> indexRegistry;
 
     /**
      * If this path is set, {@link CorfuStore} will utilize disk-backed {@link CorfuTable}.

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -31,9 +31,8 @@ import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CheckpointWriter;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
-import org.corfudb.runtime.clients.SequencerClient;
 import org.corfudb.runtime.collections.CorfuTable;
-import org.corfudb.runtime.collections.SMRMap;
+import org.corfudb.runtime.collections.Index;
 import org.corfudb.runtime.collections.StringIndexer;
 import org.corfudb.runtime.collections.StringMultiIndexer;
 import org.corfudb.runtime.exceptions.AbortCause;
@@ -510,7 +509,7 @@ public class ServerRestartIT extends AbstractIT {
         assertThat(shutdownCorfuServer(corfuServerProcess)).isTrue();
     }
 
-    private CorfuTable createTable(CorfuRuntime corfuRuntime, CorfuTable.IndexRegistry indexer) {
+    private CorfuTable createTable(CorfuRuntime corfuRuntime, Index.Registry indexer) {
         return corfuRuntime.getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
                 .setArguments(indexer)

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
@@ -71,7 +71,7 @@ public class CorfuQueueTest extends AbstractViewTest {
     public void queueWithSecondaryIndexCheck() {
         CorfuQueue<String>
                 corfuQueue = new CorfuQueue<>(getDefaultRuntime(), "test", Serializers.JAVA,
-                CorfuTable.IndexRegistry.empty());
+                Index.Registry.empty());
 
         CorfuRecordId idC = corfuQueue.enqueue("c");
         CorfuRecordId idB = corfuQueue.enqueue("b");

--- a/test/src/test/java/org/corfudb/runtime/collections/StringIndexer.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/StringIndexer.java
@@ -5,29 +5,29 @@ import java.util.Iterator;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-public class StringIndexer implements CorfuTable.IndexRegistry<String, String> {
+public class StringIndexer implements Index.Registry<String, String> {
 
-    public static final CorfuTable.IndexName BY_VALUE = () -> "BY_VALUE";
-    public static final CorfuTable.IndexName BY_FIRST_LETTER = () -> "BY_FIRST_LETTER";
+    public static final Index.Name BY_VALUE = () -> "BY_VALUE";
+    public static final Index.Name BY_FIRST_LETTER = () -> "BY_FIRST_LETTER";
 
-    private static final CorfuTable.Index<String, String, ? extends Comparable<?>> BY_VALUE_INDEX =
-            new CorfuTable.Index<>(
+    private static final Index.Spec<String, String, ? extends Comparable<?>> BY_VALUE_INDEX =
+            new Index.Spec<>(
                                    BY_VALUE,
-                                   (CorfuTable.IndexFunction<String, String, String>) (key, val) -> val);
+                                   (Index.Function<String, String, String>) (key, val) -> val);
 
-    private static final CorfuTable.Index<String, String, ? extends Comparable<?>> BY_FIRST_LETTER_INDEX =
-            new CorfuTable.Index<>(
+    private static final Index.Spec<String, String, ? extends Comparable<?>> BY_FIRST_LETTER_INDEX =
+            new Index.Spec<>(
                                    BY_FIRST_LETTER,
-                                   (CorfuTable.IndexFunction<String, String, String>) (key, val) ->
+                                   (Index.Function<String, String, String>) (key, val) ->
                                            Character.toString(val.charAt(0)));
 
     @Override
-    public Iterator<CorfuTable.Index<String, String, ? extends Comparable<?>>> iterator() {
+    public Iterator<Index.Spec<String, String, ? extends Comparable<?>>> iterator() {
         return Stream.of(BY_VALUE_INDEX, BY_FIRST_LETTER_INDEX).iterator();
     }
 
     @Override
-    public Optional<CorfuTable.Index<String, String, ? extends Comparable<?>>> get(CorfuTable.IndexName name) {
+    public Optional<Index.Spec<String, String, ? extends Comparable<?>>> get(Index.Name name) {
         String indexName = (name != null)? name.get() : null;
 
         if (BY_VALUE.get().equals(indexName)) {
@@ -41,17 +41,17 @@ public class StringIndexer implements CorfuTable.IndexRegistry<String, String> {
     }
 
     public static class FailingIndex extends StringIndexer {
-        public static final CorfuTable.IndexName FAILING = () -> "FAILING";
+        public static final Index.Name FAILING = () -> "FAILING";
 
-        private static final CorfuTable.Index<String, String, ? extends Comparable<?>> FAILING_INDEX =
-                new CorfuTable.Index<>(
+        private static final Index.Spec<String, String, ? extends Comparable<?>> FAILING_INDEX =
+                new Index.Spec<>(
                         FAILING,
-                        (CorfuTable.IndexFunction<String, String, String>) (key, value) -> {
+                        (Index.Function<String, String, String>) (key, value) -> {
                             throw new ConcurrentModificationException();
                         });
 
         @Override
-        public Iterator<CorfuTable.Index<String, String, ? extends Comparable<?>>> iterator() {
+        public Iterator<Index.Spec<String, String, ? extends Comparable<?>>> iterator() {
             return Stream.of(FAILING_INDEX, FAILING_INDEX).iterator();
         }
     }

--- a/test/src/test/java/org/corfudb/runtime/collections/StringMultiIndexer.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/StringMultiIndexer.java
@@ -10,19 +10,19 @@ import java.util.Optional;
 /**
  * Created by Sam Behnam on 5/10/18.
  */
-public class StringMultiIndexer implements CorfuTable.IndexRegistry<String, String> {
-    public static final CorfuTable.IndexName BY_EACH_WORD = () -> "BY_EACH_WORD";
+public class StringMultiIndexer implements Index.Registry<String, String> {
+    public static final Index.Name BY_EACH_WORD = () -> "BY_EACH_WORD";
 
-    private static final CorfuTable.Index<String, String, ? extends Comparable<?>> BY_WORD_INDEX =
-            new CorfuTable.Index<>(BY_EACH_WORD,
-                    (CorfuTable.MultiValueIndexFunction<String, String, String>) (key, val) -> keySetOWords(val));
+    private static final Index.Spec<String, String, ? extends Comparable<?>> BY_WORD_INDEX =
+            new Index.Spec<>(BY_EACH_WORD,
+                    (Index.MultiValueFunction<String, String, String>) (key, val) -> keySetOWords(val));
 
     private static Iterable<String> keySetOWords(String val) {
         return new HashSet<>(Arrays.asList(val.split(" ")));
     }
 
     @Override
-    public Optional<CorfuTable.Index<String, String, ? extends Comparable<?>>> get(CorfuTable.IndexName name) {
+    public Optional<Index.Spec<String, String, ? extends Comparable<?>>> get(Index.Name name) {
         String indexName = (name != null) ? name.get() : null;
         if (BY_EACH_WORD.get().equals(indexName)) {
             return Optional.of(BY_WORD_INDEX);
@@ -32,8 +32,8 @@ public class StringMultiIndexer implements CorfuTable.IndexRegistry<String, Stri
     }
 
     @Override
-    public Iterator<CorfuTable.Index<String, String, ? extends Comparable<?>>> iterator() {
-        final List<CorfuTable.Index<String, String, ? extends Comparable<?>>> indices = new ArrayList<>();
+    public Iterator<Index.Spec<String, String, ? extends Comparable<?>>> iterator() {
+        final List<Index.Spec<String, String, ? extends Comparable<?>>> indices = new ArrayList<>();
         indices.add(BY_WORD_INDEX);
         return indices.iterator();
 


### PR DESCRIPTION
In order to accommodate for disk-backed CorfuTable refactoring and to
improve readability, move all index interfaces and definitions out of
CorfuTable and into a separate class.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
