### PR TITLE
Streaming API needs to operate on a snapshot

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -39,7 +39,7 @@ import org.corfudb.annotations.MutatorAccessor;
 import org.corfudb.annotations.PassThrough;
 import org.corfudb.annotations.TransactionalMethod;
 import org.corfudb.runtime.object.ICorfuSMR;
-import org.corfudb.util.ImmuableListSetWrapper;
+import org.corfudb.util.ImmutableListSetWrapper;
 import org.corfudb.runtime.object.ICorfuExecutionContext;
 import org.corfudb.runtime.object.ICorfuVersionPolicy;
 
@@ -587,9 +587,7 @@ public class CorfuTable<K ,V> implements
     @Override
     @Accessor
     public @Nonnull Set<Entry<K, V>> entrySet() {
-        return new ImmuableListSetWrapper(mainMap.entryStream().map(entry ->
-                new AbstractMap.SimpleImmutableEntry<>(entry.getKey(), entry.getValue()))
-                .collect(ImmutableList.toImmutableList()));
+        return ImmutableListSetWrapper.fromMap(mainMap);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
@@ -9,6 +9,7 @@ import org.apache.commons.io.FileUtils;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.util.serializer.ISerializer;
+import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDBException;
@@ -317,7 +318,12 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
      */
     @Override
     public Stream<Entry<K, V>> entryStream() {
-        final RocksIterator rocksIterator = rocksDb.newIterator();
+        final ReadOptions readOptions = new ReadOptions();
+        // If ReadOptions.snapshot is given, the iterator will return data as of the snapshot.
+        // If it is nullptr, the iterator will read from an implicit snapshot as of the time the
+        // iterator is created. The implicit snapshot is preserved by pinning resource.
+        readOptions.setSnapshot(null);
+        final RocksIterator rocksIterator = rocksDb.newIterator(readOptions);
         rocksIterator.seekToFirst();
         return Streams.stream(new RocksDbIterator(rocksIterator));
     }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
@@ -1,5 +1,7 @@
 package org.corfudb.runtime.collections;
 
+import org.corfudb.util.ImmutableListSetWrapper;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +33,7 @@ public class StreamingMapDecorator<K, V> implements ContextAwareMap<K, V> {
      */
     @Override
     public Stream<Entry<K, V>> entryStream() {
-        return mapImpl.entrySet().stream().parallel();
+        return ImmutableListSetWrapper.fromMap(mapImpl).stream().parallel();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/util/ImmutableListSetWrapper.java
+++ b/runtime/src/main/java/org/corfudb/util/ImmutableListSetWrapper.java
@@ -1,9 +1,16 @@
 package org.corfudb.util;
 
+import com.google.common.collect.ImmutableList;
+import lombok.NonNull;
+
 import javax.annotation.Nonnull;
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.AbstractSet;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.function.Consumer;
@@ -14,13 +21,19 @@ import java.util.stream.Stream;
  * An immutable set implementation that is backed by a list. This type is useful when
  * we have lists that we know conform to the set constraints, but creating the set is
  * too expensive.
- *
  */
+public class ImmutableListSetWrapper<E> extends AbstractSet<E> implements Set<E> {
+    private final List<E> internalList;
 
-public class ImmuableListSetWrapper<E> implements Set<E> {
-    final List<E> internalList;
+    public static <K, V> ImmutableListSetWrapper<Entry<K, V>> fromMap(@NonNull Map<K, V> original) {
+        return new ImmutableListSetWrapper<>(original
+                .entrySet()
+                .stream()
+                .map(entry -> new SimpleImmutableEntry<>(entry.getKey(), entry.getValue()))
+                .collect(ImmutableList.toImmutableList()));
+    }
 
-    public ImmuableListSetWrapper(@Nonnull List<E> internalList) {
+    public ImmutableListSetWrapper(@Nonnull List<E> internalList) {
         this.internalList = internalList;
     }
 

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -9,7 +9,9 @@ import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
@@ -233,4 +235,17 @@ public class CorfuTableTest extends AbstractViewTest {
                 .containsExactly("a");
     }
 
+    /**
+     * Ensure that {@link StreamingMap#entryStream()} always operates on a snapshot.
+     * If it does not, this test will throw {@link ConcurrentModificationException}.
+     */
+    @Test
+    public void snapshotInvariant() {
+        final int NUM_WRITES = 10;
+        final ContextAwareMap<Integer, Integer> map = new StreamingMapDecorator<>();
+        IntStream.range(0, NUM_WRITES).forEach(num -> map.put(num, num));
+
+        final Stream<Map.Entry<Integer, Integer>> result = map.entryStream();
+        result.forEach(e -> map.put(new Random().nextInt(), 0));
+    }
 }


### PR DESCRIPTION
When multiple threads are operating on the same table, and one of them
is utilizing the streaming API, ConcurrentModificationException will
occur since the Stream was operating on a shared reference.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
