### PR TITLE
Corfu deployment: maven silent mode, Quiet output - only show errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
   - stage: Deploy
     name: Deployment
     script:
-    - ./mvnw clean deploy -s .travis_scripts/settings.xml -DskipTests -T 1C
+    - ./mvnw clean deploy -s .travis_scripts/settings.xml -DskipTests -Dmaven.javadoc.skip=true -T 1C -q
 
 notifications:
   email:


### PR DESCRIPTION
## Overview
Corfu deployment: maven silent mode, Quiet output - only show errors

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
