### PR TITLE
Allow StreamView to be consumed directly

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -408,10 +408,10 @@ public abstract class AbstractQueuedStreamView extends
             // Find the checkpoint, if present
             try {
                 if (discoverAddressSpace(checkpointId, context.readCpQueue,
-                        runtime.getSequencerView()
-                                .query(checkpointId),
-                        Address.NEVER_READ, d -> scanCheckpointStream(context, d, maxGlobal),
-                        true, maxGlobal)) {
+                        runtime.getSequencerView().query(checkpointId),
+                        Address.NEVER_READ,
+                        d -> scanCheckpointStream(context, d, maxGlobal),
+                        maxGlobal)) {
                     log.trace("Fill_Read_Queue[{}] Get Stream Address Map using checkpoint with {} entries",
                             this, context.readCpQueue.size());
 
@@ -499,7 +499,7 @@ public abstract class AbstractQueuedStreamView extends
         discoverAddressSpace(context.id, context.readQueue,
                 latestTokenValue,
                 stopAddress,
-                d -> true, false, maxGlobal);
+                d -> true, maxGlobal);
 
         return !context.readCpQueue.isEmpty() || !context.readQueue.isEmpty();
     }
@@ -517,7 +517,6 @@ public abstract class AbstractQueuedStreamView extends
      * @param startAddress read start address (inclusive)
      * @param stopAddress read stop address (exclusive)
      * @param filter filter to apply to data
-     * @param checkpoint true if checkpoint discovery, false otherwise.
      * @param maxGlobal max address to resolve discovery.
      *
      * @return true if addresses were discovered, false, otherwise.
@@ -527,7 +526,6 @@ public abstract class AbstractQueuedStreamView extends
                                                     final long startAddress,
                                                     final long stopAddress,
                                                     final Function<ILogData, Boolean> filter,
-                                                    final boolean checkpoint,
                                                     final long maxGlobal);
 
     protected boolean fillFromResolved(final long maxGlobal,


### PR DESCRIPTION
StremView was originally designed to be consumed only via ObjectsView.
When being consumed directly, the client wants to observe linearizable
sequence of events without any gaps.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
