### PR TITLE
Use JaCoco for Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: required
 dist: xenial
 jdk: openjdk8
 
-script: "mvn cobertura:cobertura"
-
 before_cache:
 - rm -rf $HOME/.m2/repository/org/corfudb
 

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
+                <version>0.8.3</version>
                 <executions>
                     <execution>
                         <id>report-aggregate</id>

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.7.9</version>
+                <version>0.8.3</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
## Overview

Description:

Use Jacoco for code coverage report generation instead of Cobertura.
Update Jacoco version.

Why should this be merged: we need to keep track of code coverage in the project. 
