### PR TITLE
Transaction Poller Bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/TransactionPoller.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TransactionPoller.java
@@ -35,16 +35,29 @@ public class TransactionPoller implements Runnable {
     private final List<StreamingSubscriptionContext> streamContexts;
 
     /**
+     * A reference to the transaction stream
+     */
+    private final IStreamView txnStream;
+
+    /**
      * Constructor.
      *
      * @param streams The list of StreamingSubscriptionContexts to process.
      */
     public TransactionPoller(@Nonnull CorfuRuntime runtime,
-            @Nonnull List<StreamingSubscriptionContext> streams) {
+                             @Nonnull List<StreamingSubscriptionContext> streams) {
         this.runtime = runtime;
         this.streamContexts = streams.stream()
                 .sorted(Comparator.comparingLong(sc -> sc.getLastReadAddress()))
                 .collect(Collectors.toList());
+
+        StreamOptions options = StreamOptions.builder()
+                .ignoreTrimmed(true)
+                .cacheEntries(false)
+                .build();
+
+        txnStream = runtime.getStreamsView()
+                .get(ObjectsView.TRANSACTION_STREAM_ID, options);
     }
 
     /**
@@ -69,18 +82,12 @@ public class TransactionPoller implements Runnable {
  
         long lastReadAddress = streamContexts.get(0).getLastReadAddress();
 
-        StreamOptions options = StreamOptions.builder()
-                .ignoreTrimmed(true)
-                .cacheEntries(false)
-                .build();
-        IStreamView txStream = runtime.getStreamsView()
-                .get(ObjectsView.TRANSACTION_STREAM_ID, options);
         log.trace("Seeking txStream to {}", lastReadAddress + 1);
-        txStream.seek(lastReadAddress + 1);
+        txnStream.seek(lastReadAddress + 1);
         log.trace("txStream current global position after seeking {}, hasNext {}",
-                txStream.getCurrentGlobalPosition(), txStream.hasNext());
+                txnStream.getCurrentGlobalPosition(), txnStream.hasNext());
 
-        List<ILogData> updates = txStream.remaining();
+        List<ILogData> updates = txnStream.remaining();
 
         log.trace("{} updates remaining in the txStream", updates.size());
 


### PR DESCRIPTION
## Overview
Every time the transaction poller polls the transaction stream
it will create a new StreamView object, which leaks stream
objects.

Why should this be merged: Fixes a memory leak

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
