### PR TITLE
Streams view bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
+++ b/runtime/src/main/java/org/corfudb/recovery/FastObjectLoader.java
@@ -519,7 +519,7 @@ public class FastObjectLoader {
     private void cleanUpForRetry() {
         runtime.getAddressSpaceView().invalidateClientCache();
         runtime.getObjectsView().getObjectCache().clear();
-        runtime.getStreamsView().getStreamCache().clear();
+        runtime.getStreamsView().clear();
 
         // Re ask for the Head, if it changes while we were trying.
         findAndSetLogHead();

--- a/test/src/test/java/org/corfudb/runtime/view/StreamsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamsViewTest.java
@@ -1,0 +1,45 @@
+package org.corfudb.runtime.view;
+
+import org.corfudb.runtime.view.stream.IStreamView;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Created by Maithem on 12/18/19.
+ */
+public class StreamsViewTest extends AbstractViewTest {
+
+    @Before
+    public void setRuntime() {
+        getDefaultRuntime().connect();
+    }
+
+    @Test
+    public void testStreamsViewClear() {
+        UUID id1 = UUID.randomUUID();
+        UUID id2 = UUID.randomUUID();
+        IStreamView sv1 = getRuntime().getStreamsView().get(id1);
+        IStreamView sv2 = getRuntime().getStreamsView().get(id1);
+        IStreamView sv3 = getRuntime().getStreamsView().get(id2);
+        IStreamView sv4 = getRuntime().getStreamsView().getUnsafe(id2);
+        assertThat(getRuntime().getStreamsView().getOpenedStreams()).containsExactly(sv1, sv2, sv3);
+        getRuntime().getStreamsView().clear();
+        assertThat(getRuntime().getStreamsView().getOpenedStreams()).isEmpty();
+    }
+
+    @Test
+    public void testConcurrentOpenGC() throws Exception {
+        StreamsView streamsView = getDefaultRuntime().getStreamsView();
+        final long trimMark = 1;
+        final int numIter = 100;
+        final int parallelNum = 3;
+
+        scheduleConcurrently(numIter, t -> streamsView.get(UUID.randomUUID()));
+        scheduleConcurrently(numIter, t -> streamsView.gc(trimMark));
+        executeScheduled(parallelNum, PARAMETERS.TIMEOUT_NORMAL);
+    }
+}


### PR DESCRIPTION
## Overview

Since streams can be opened during a runtime gc cycle, the collection
holding the opened StreamView references should be thread-safe, otherwise
adding to the collection during iteration would cause exceptions.



## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
