### PR TITLE
Do not resolve execution context on object reset

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -601,7 +601,7 @@ public class VersionLockedObject<T extends ICorfuSMR<T>> {
                 // This entry actually resets the object. So here
                 // we can safely get a new instance, and add the
                 // previous instance to the undo log.
-                entry.setUndoRecord(object.getContext(context));
+                entry.setUndoRecord(object);
                 object.close();
                 object = newObjectFn.get();
                 log.trace("Apply[{}] Undo->RESET", this);


### PR DESCRIPTION
When calling setUndoRecord(...) during object reset do not try to
resolve the execution context.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
