### PR TITLE
Txn stream leak fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/TransactionPoller.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TransactionPoller.java
@@ -35,16 +35,29 @@ public class TransactionPoller implements Runnable {
     private final List<StreamingSubscriptionContext> streamContexts;
 
     /**
+     * A reference to the transaction stream
+     */
+    private final IStreamView txnStream;
+
+    /**
      * Constructor.
      *
      * @param streams The list of StreamingSubscriptionContexts to process.
      */
     public TransactionPoller(@Nonnull CorfuRuntime runtime,
-            @Nonnull List<StreamingSubscriptionContext> streams) {
+                             @Nonnull List<StreamingSubscriptionContext> streams) {
         this.runtime = runtime;
         this.streamContexts = streams.stream()
                 .sorted(Comparator.comparingLong(sc -> sc.getLastReadAddress()))
                 .collect(Collectors.toList());
+
+        StreamOptions options = StreamOptions.builder()
+                .ignoreTrimmed(true)
+                .cacheEntries(false)
+                .build();
+
+        txnStream = runtime.getStreamsView()
+                .get(ObjectsView.TRANSACTION_STREAM_ID, options);
     }
 
     /**
@@ -69,18 +82,12 @@ public class TransactionPoller implements Runnable {
  
         long lastReadAddress = streamContexts.get(0).getLastReadAddress();
 
-        StreamOptions options = StreamOptions.builder()
-                .ignoreTrimmed(true)
-                .cacheEntries(false)
-                .build();
-        IStreamView txStream = runtime.getStreamsView()
-                .get(ObjectsView.TRANSACTION_STREAM_ID, options);
         log.trace("Seeking txStream to {}", lastReadAddress + 1);
-        txStream.seek(lastReadAddress + 1);
+        txnStream.seek(lastReadAddress + 1);
         log.trace("txStream current global position after seeking {}, hasNext {}",
-                txStream.getCurrentGlobalPosition(), txStream.hasNext());
+                txnStream.getCurrentGlobalPosition(), txnStream.hasNext());
 
-        List<ILogData> updates = txStream.remaining();
+        List<ILogData> updates = txnStream.remaining();
 
         log.trace("{} updates remaining in the txStream", updates.size());
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TransactionPoller.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TransactionPoller.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.collections;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -37,6 +38,7 @@ public class TransactionPoller implements Runnable {
     /**
      * A reference to the transaction stream
      */
+    @Getter
     private final IStreamView txnStream;
 
     /**
@@ -52,12 +54,11 @@ public class TransactionPoller implements Runnable {
                 .collect(Collectors.toList());
 
         StreamOptions options = StreamOptions.builder()
-                .ignoreTrimmed(true)
                 .cacheEntries(false)
                 .build();
 
         txnStream = runtime.getStreamsView()
-                .get(ObjectsView.TRANSACTION_STREAM_ID, options);
+                .getUnsafe(ObjectsView.TRANSACTION_STREAM_ID, options);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnStreamingManager.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnStreamingManager.java
@@ -148,6 +148,7 @@ public class TxnStreamingManager {
         if (!lockedStreamingSubscriptionContexts.isEmpty()) {
             log.trace("Locked {} StreamingSubscriptionContexts for processing",
                     lockedStreamingSubscriptionContexts.size());
+
             pollerExecutor.submit(new TransactionPoller(runtime, lockedStreamingSubscriptionContexts));
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -1,7 +1,6 @@
 package org.corfudb.runtime.view;
 
 import com.google.common.annotations.VisibleForTesting;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;

--- a/test/src/test/java/org/corfudb/integration/StreamingIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingIT.java
@@ -144,8 +144,9 @@ public class StreamingIT extends AbstractIT {
         store.subscribe(s1n1t1, "n1",
                 Collections.singletonList(new TableSchema("t1", Uuid.class, Uuid.class, Uuid.class)), ts1);
 
-        // After a brief wait verify that the listener go all the updates.
+        // After a brief wait verify that the listener gets all the updates.
         TimeUnit.SECONDS.sleep(2);
+
         LinkedList<CorfuStreamEntries> updates = s1n1t1.getUpdates();
         assertThat(updates.size() == numUpdates).isTrue();
         for (int i = 0; i < numUpdates; i++) {


### PR DESCRIPTION
## Overview

Description:
CorfuStore just has 1 Transaction poller. But to ensure that new
subscribers are taken care of, periodically this transaction poller
is refreshed and a new one is created. But this causes a leak in the
underlying runtime's TRANSACTION StreamsView's openedStreams
resulting in the JVM going out of Memory after a while.
Simple fix is to remove the prior StreamView when recreating.

+Test case to both catch the memory leak bug and validate the fix.

Why should this be merged: 
Results in OOM otherwise 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
