### PR TITLE
Reuse Serialization Handle

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -270,6 +270,24 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         }
     }
 
+    public void updateSerializedCacheMetadata() {
+        if (serializedCache == null) {
+            return;
+        }
+        serializedCache.resetReaderIndex();
+        ICorfuPayload.fromBuffer(serializedCache, DataType.class);
+        if (type == DataType.DATA) {
+            int len = serializedCache.readInt();
+            serializedCache.skipBytes(len);
+        }
+        serializedCache.writerIndex(serializedCache.readerIndex());
+        if (type.isMetadataAware()) {
+            ICorfuPayload.serialize(serializedCache, metadataMap);
+        }
+
+        serializedCache.readerIndex();
+    }
+
     void doSerializeInternal(ByteBuf buf) {
         ICorfuPayload.serialize(buf, type);
         if (type == DataType.DATA) {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -62,6 +62,12 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         return logData;
     }
 
+    public static ILogData getLogData(IToken token, Object obj) {
+        LogData logData = new LogData(DataType.DATA, obj);
+        logData.useToken(token);
+        return logData;
+    }
+
     /**
      * Return the payload.
      */

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -185,7 +185,8 @@ public class CheckpointWriter<T extends StreamingMap> {
     private Token forceNoOpEntry() {
         TokenResponse writeToken = rt.getSequencerView().next(streamId);
         LogData logData = new LogData(DataType.HOLE);
-        rt.getAddressSpaceView().write(writeToken, logData, CacheOption.WRITE_AROUND);
+        logData.useToken(writeToken);
+        rt.getAddressSpaceView().write(logData, CacheOption.WRITE_AROUND);
         return writeToken.getToken();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -167,9 +167,12 @@ public class StreamsView extends AbstractView {
                         TransactionalContext.getCurrentContext());
             }
 
+            ld.useToken(tokenResponse);
+            ld.setId(runtime.getParameters().getClientId());
+
             try {
                 // Attempt to write to the log.
-                runtime.getAddressSpaceView().write(tokenResponse, ld, cacheOption);
+                runtime.getAddressSpaceView().write(ld, cacheOption);
                 // If we're here, we succeeded, return the acquired token.
                 return tokenResponse.getSequence();
             } catch (OverwriteException oe) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractQueuedStreamView.java
@@ -200,8 +200,11 @@ public abstract class AbstractQueuedStreamView extends
             // Now, we do the actual write. We could get an overwrite
             // exception here - any other exception we should pass up
             // to the client.
+
+            ld.useToken(tokenResponse);
+            ld.setId(runtime.getParameters().getClientId());
             try {
-                runtime.getAddressSpaceView().write(tokenResponse, ld);
+                runtime.getAddressSpaceView().write(ld);
                 // The write completed successfully, so we return this
                 // address to the client.
                 return tokenResponse.getToken().getSequence();

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CheckpointWriter;
@@ -495,7 +496,7 @@ public class ServerRestartIT extends AbstractIT {
 
         // Should succeed. internally, it will refresh the token.
         CompletableFuture cf = CFUtils.within(CompletableFuture.supplyAsync(() -> {
-            runtime.getAddressSpaceView().write(mockTr, testPayload);
+            runtime.getAddressSpaceView().write(LogData.getLogData(mockTr, testPayload));
             return true;
         }), Duration.ofSeconds(timeToWaitInSeconds));
 

--- a/test/src/test/java/org/corfudb/runtime/CompressionTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CompressionTest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.corfudb.common.compression.Codec;
+import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.junit.Before;
@@ -55,7 +56,7 @@ public class CompressionTest extends AbstractViewTest {
     private long writeDefaultPayload(CorfuRuntime rt) {
         // Write / append data to Log
         TokenResponse tokenResponse = rt.getSequencerView().next();
-        rt.getAddressSpaceView().write(tokenResponse, DEFAULT_PAYLOAD);
+        rt.getAddressSpaceView().write(LogData.getLogData(tokenResponse, DEFAULT_PAYLOAD));
 
         return tokenResponse.getSequence();
     }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicIntegerArray;
 
 import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.collections.ICorfuTable;
@@ -105,7 +106,7 @@ public abstract class AbstractTransactionContextTest extends AbstractTransaction
     @Test
     public void ensureUserTsIsInherited() {
         TokenResponse resp = getRuntime().getSequencerView().next();
-        getRuntime().getAddressSpaceView().write(resp, "data".getBytes());
+        getRuntime().getAddressSpaceView().write(LogData.getLogData(resp, "data".getBytes()));
 
         final Token parentTs = resp.getToken();
 

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionsTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionsTest.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.object.transactions;
 
+import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.object.AbstractObjectTest;
@@ -55,7 +56,7 @@ public abstract class AbstractTransactionsTest extends AbstractObjectTest {
 
         if (getRuntime().getAddressSpaceView().peek(t2.getSequence()) == null) {
             byte[] data = "data".getBytes();
-            getRuntime().getAddressSpaceView().write(s2, data);
+            getRuntime().getAddressSpaceView().write(LogData.getLogData(s2, data));
         }
         
         getRuntime().getObjectsView().TXBuild()

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/OptimisticTransactionContextTest.java
@@ -4,6 +4,7 @@ import com.google.common.reflect.TypeToken;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
@@ -195,7 +196,8 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
         TestRule testRule = new TestRule()
                 .matches(m -> {
                     if (m.getMsgType().equals(CorfuMsgType.WRITE) && retry[0] < rtSlowWriter.getParameters().getWriteRetry()) {
-                        rtIntersect.getAddressSpaceView().write(new Token(0, retry[0]), "hello world".getBytes());
+                        rtIntersect.getAddressSpaceView().write(LogData.getLogData(new Token(0, retry[0]),
+                                "hello world".getBytes()));
                         retry[0]++;
                         return true;
                     } else {
@@ -234,7 +236,8 @@ public class OptimisticTransactionContextTest extends AbstractTransactionContext
         TestRule testRule = new TestRule()
                 .matches(m -> {
                     if (m.getMsgType().equals(CorfuMsgType.WRITE)) {
-                        rtPropagateWrite.getAddressSpaceView().write(new Token(0, 0), "hello world".getBytes());
+                        rtPropagateWrite.getAddressSpaceView().write(LogData.getLogData(new Token(0, 0),
+                                "hello world".getBytes()));
                         retry[0]++;
                         return true;
                     } else {

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -106,9 +106,9 @@ public class AddressSpaceViewTest extends AbstractViewTest {
 
         final long epoch = rt.getLayoutView().getLayout().getEpoch();
 
-        rt.getAddressSpaceView().write(new TokenResponse(new Token(epoch, 0),
+        rt.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(epoch, 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
-                "hello world".getBytes());
+                "hello world".getBytes()));
 
         assertThat(rt.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -124,9 +124,9 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_2))
                 .isEmptyAtAddress(0);
 
-        rt.getAddressSpaceView().write(new TokenResponse(new Token(epoch, 1),
+        rt.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(epoch, 1),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
-                "1".getBytes());
+                "1".getBytes()));
         LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_0))
                 .matchesDataAtAddress(0, testPayload);
         LogUnitServerAssertions.assertThat(getLogUnit(SERVERS.PORT_1))
@@ -143,18 +143,18 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         final long epoch = rt.getLayoutView().getLayout().getEpoch();
 
         // Write two entries, with different cache options
-        rt.getAddressSpaceView().write(new TokenResponse(new Token(epoch, 0),
+        rt.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(epoch, 0),
                 Collections.singletonMap(CorfuRuntime.getStreamID("stream1"), Address.NO_BACKPOINTER)),
-                "payload".getBytes(), CacheOption.WRITE_THROUGH);
+                "payload".getBytes()), CacheOption.WRITE_THROUGH);
 
-        rt.getAddressSpaceView().write(new TokenResponse(new Token(epoch, 1),
+        rt.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(epoch, 1),
                         Collections.singletonMap(CorfuRuntime.getStreamID("stream1"), Address.NO_BACKPOINTER)),
-                "payload".getBytes(), CacheOption.WRITE_AROUND);
+                "payload".getBytes()), CacheOption.WRITE_AROUND);
 
         // write with the default write method
-        rt.getAddressSpaceView().write(new TokenResponse(new Token(epoch, 2),
+        rt.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(epoch, 2),
                         Collections.singletonMap(CorfuRuntime.getStreamID("stream1"), Address.NO_BACKPOINTER)),
-                "payload".getBytes());
+                "payload".getBytes()));
 
         // Verify that write to address 0 is cached and that the write to address 1 isn't cached
         Cache<Long, ILogData> clientCache = rt.getAddressSpaceView().getReadCache();
@@ -189,17 +189,17 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         final long ADDRESS_1 = 1;
         final long ADDRESS_2 = 3;
         Token token = new Token(rt.getLayoutView().getLayout().getEpoch(), ADDRESS_0);
-        rt.getAddressSpaceView().write(token, testPayload);
+        rt.getAddressSpaceView().write(LogData.getLogData(token, testPayload));
 
         assertThat(rt.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
 
 
-        rt.getAddressSpaceView().write(new Token(rt.getLayoutView().getLayout().getEpoch(), ADDRESS_1),
-                "1".getBytes());
+        rt.getAddressSpaceView().write(LogData.getLogData(new Token(rt.getLayoutView().getLayout().getEpoch(), ADDRESS_1),
+                "1".getBytes()));
 
-        rt.getAddressSpaceView().write(new Token(rt.getLayoutView().getLayout().getEpoch(), ADDRESS_2),
-                "3".getBytes());
+        rt.getAddressSpaceView().write(LogData.getLogData(new Token(rt.getLayoutView().getLayout().getEpoch(), ADDRESS_2),
+                "3".getBytes()));
 
         List<Long> rs = new ArrayList<>();
         rs.add(ADDRESS_0);
@@ -228,7 +228,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         final long ADDRESS_1 = 1;
         final long ADDRESS_2 = 3;
         Token token = new Token(rt.getLayoutView().getLayout().getEpoch(), ADDRESS_0);
-        rt.getAddressSpaceView().write(token, testPayload);
+        rt.getAddressSpaceView().write(LogData.getLogData(token, testPayload));
 
         assertThat(rt.getAddressSpaceView().read(ADDRESS_0).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -295,7 +295,7 @@ public class AddressSpaceViewTest extends AbstractViewTest {
         final long numAddresses = 10L;
         for (long i = 0L; i < numAddresses; i++) {
             TokenResponse token = rt.getSequencerView().next();
-            rt.getAddressSpaceView().write(token, (testString + i).getBytes());
+            rt.getAddressSpaceView().write(LogData.getLogData(token, (testString + i).getBytes()));
         }
 
         Map<Long, ILogData> readResult = rt.getAddressSpaceView().read(

--- a/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ChainReplicationViewTest.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.view;
 
 import org.corfudb.common.compression.Codec;
 import org.corfudb.infrastructure.TestLayoutBuilder;
+import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
@@ -27,10 +28,10 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(new TokenResponse(new Token(runtime.getLayoutView()
+        r.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(runtime.getLayoutView()
                         .getLayout().getEpoch(), 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
-                testPayload);
+                testPayload));
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -51,10 +52,10 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
             for (int i = base; i < base + numberRecords; i++) {
-                r.getAddressSpaceView().write(new TokenResponse(new Token(
+                r.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(
                                 runtime.getLayoutView().getLayout().getEpoch(), i),
                                 Collections.singletonMap(CorfuRuntime.getStreamID("a"), Address.NO_BACKPOINTER)),
-                        Integer.toString(i).getBytes());
+                        Integer.toString(i).getBytes()));
             }
         });
         executeScheduled(numberThreads, PARAMETERS.TIMEOUT_LONG);
@@ -99,10 +100,10 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(new TokenResponse(new Token(
+        r.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(
                         runtime.getLayoutView().getLayout().getEpoch(), 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
-                testPayload);
+                testPayload));
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -140,9 +141,9 @@ public class ChainReplicationViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(new TokenResponse(new Token(0, 0),
+        r.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(0, 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
-                testPayload);
+                testPayload));
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());

--- a/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ManagementViewTest.java
@@ -12,6 +12,7 @@ import org.corfudb.infrastructure.TestServerRouter;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.LayoutCommittedRequest;
+import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.NodeState;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics.SequencerStatus;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
@@ -771,8 +772,7 @@ public class ManagementViewTest extends AbstractViewTest {
         } else {
             assertThat(tokenResponse.getBackpointerMap()).containsEntry(streamID, expectedBackpointerValue);
         }
-        corfuRuntime.getAddressSpaceView().write(tokenResponse,
-                "test".getBytes());
+        corfuRuntime.getAddressSpaceView().write(LogData.getLogData(tokenResponse, "test".getBytes()));
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/QuorumReplicationProtocolAdditionalTests.java
@@ -184,9 +184,9 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         CorfuRuntime r = getDefaultRuntime();
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
-        r.getAddressSpaceView().write(new TokenResponse(new Token(r.getLayoutView().getLayout().getEpoch(), 0),
+        r.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(r.getLayoutView().getLayout().getEpoch(), 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
-                testPayload);
+                testPayload));
         ILogData x = r.getAddressSpaceView().read(0);
         assertNotNull(x.getRank());
         assertThat(r.getAddressSpaceView().read(0L).getPayload(r))
@@ -212,9 +212,9 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         scheduleConcurrently(numberThreads, threadNumber -> {
             int base = threadNumber * numberRecords;
             for (int i = base; i < base + numberRecords; i++) {
-                r.getAddressSpaceView().write(new TokenResponse(new Token(r.getLayoutView().getLayout().getEpoch(), i),
+                r.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(r.getLayoutView().getLayout().getEpoch(), i),
                                 Collections.singletonMap(CorfuRuntime.getStreamID("a"), Address.NO_BACKPOINTER)),
-                        Integer.toString(i).getBytes());
+                        Integer.toString(i).getBytes()));
             }
         });
         executeScheduled(numberThreads, PARAMETERS.TIMEOUT_LONG);
@@ -245,9 +245,9 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(new TokenResponse(new Token(r.getLayoutView().getLayout().getEpoch(), 0),
+        r.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(r.getLayoutView().getLayout().getEpoch(), 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
-                testPayload);
+                testPayload));
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());
@@ -271,9 +271,9 @@ public class QuorumReplicationProtocolAdditionalTests extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         byte[] testPayload = "hello world".getBytes();
 
-        r.getAddressSpaceView().write(new TokenResponse(new Token(1, 0),
+        r.getAddressSpaceView().write(LogData.getLogData(new TokenResponse(new Token(1, 0),
                         Collections.singletonMap(streamA, Address.NO_BACKPOINTER)),
-                testPayload);
+                testPayload));
 
         assertThat(r.getAddressSpaceView().read(0L).getPayload(getRuntime()))
                 .isEqualTo("hello world".getBytes());


### PR DESCRIPTION
## Overview
Reuse the same serialzation handle used to check the payload size
to replicate. This will remove the redundant serialization call
that's made after getting a sequencer token.

Why should this be merged: Improves the write-path performance 

Related issue(s) (if applicable): #1949


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
