### PR TITLE
CorfuStore: Version should start with 0

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
@@ -193,7 +193,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                 .build();
         ManagedResources user_1 = ManagedResources.newBuilder().setCreateUser("user_1").build();
         ManagedResources user_2 = ManagedResources.newBuilder().setCreateUser("user_2").build();
-        long expectedVersion = 1L;
+        long expectedVersion = 0L;
 
         corfuStore.tx(nsxManager)
                 .create(tableName,
@@ -213,7 +213,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                 .update(tableName,
                         key1,
                         EventInfo.newBuilder().setName("bcd").build(),
-                        ManagedResources.newBuilder().setCreateUser("user_2").setVersion(1L).build())
+                        ManagedResources.newBuilder().setCreateUser("user_2").setVersion(0L).build())
                 .commit();
         assertThat(corfuStore.openTable(nsxManager, tableName).get(key1).getMetadata())
                 .isEqualTo(ManagedResources.newBuilder()
@@ -238,7 +238,7 @@ public class CorfuStoreTest extends AbstractViewTest {
 
         corfuStore.tx(nsxManager).delete(tableName, key1).commit();
         assertThat(corfuStore.openTable(nsxManager, tableName).get(key1)).isNull();
-        expectedVersion = 1L;
+        expectedVersion = 0L;
 
         corfuStore.tx(nsxManager)
                 .update(tableName,


### PR DESCRIPTION
Newly created CorfuStore objects need to have a version field of 0
to be compatible with some older usecases.
(Right now they start with 1)
+TestCase to validate this.

## Overview

Description:

Why should this be merged: 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
