### PR TITLE
State Transfer Codec overwrite fix

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/StateTransfer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/StateTransfer.java
@@ -221,7 +221,6 @@ public class StateTransfer {
                 throw new IllegalStateException("Missing address");
             }
             LogData ld = (LogData) dataMap.get(address);
-            ld.setPayloadCodecType(Codec.Type.valueOf(runtime.getParameters().getCodecType()));
             entries.add(ld);
         }
 


### PR DESCRIPTION
## Overview

In the case of data written with a different codec than that used by the State Transfer runtime, we would overwrite the codec of compressed data. Making it imposible for a runtime reader to decompress correctly. 

A test has been added to confirm this.
