### PR TITLE
Some code cleanup. Remove the not required arg for checkpoint function.

### DIFF
--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -701,12 +701,12 @@ public class ServerRestartIT extends AbstractIT {
             // Checkpoint Writer 2
             CheckpointWriter cpw2 = new CheckpointWriter(r, CorfuRuntime.getStreamID("test"),
                     "checkpointer-2", corfuTable1);
-            Token cp2Token = cpw2.appendCheckpoint(new Token(0, snapshotAddress2 - 1), (long) snapshotAddress2 - 1);
+            Token cp2Token = cpw2.appendCheckpoint(new Token(0, snapshotAddress2 - 1));
 
             // Checkpoint Writer 1
             CheckpointWriter cpw1 = new CheckpointWriter(r, CorfuRuntime.getStreamID("test"),
                     "checkpointer-1", corfuTable1);
-            cpw1.appendCheckpoint(new Token(0, snapshotAddress1 - 1), (long) snapshotAddress1 - 1);
+            cpw1.appendCheckpoint(new Token(0, snapshotAddress1 - 1));
 
             // Trim @snapshotAddress=15 (Checkpoint Writer 2)
             r.getAddressSpaceView().prefixTrim(cp2Token);

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -749,12 +749,12 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Start checkpoint with snapshot time 9 for mapA
             CheckpointWriter cpw = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(stream1),
                     "checkpointer-test", mapA);
-            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress), (long) snapshotAddress);
+            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress));
 
             // Start checkpoint with snapshot time 9 for mapB
             CheckpointWriter cpwB = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(stream2),
                     "checkpointer-test", mapB);
-            cpwB.appendCheckpoint(new Token(0, snapshotAddress), (long) snapshotAddress);
+            cpwB.appendCheckpoint(new Token(0, snapshotAddress));
 
             // Trim the log
             runtime.getAddressSpaceView().prefixTrim(cpAddress);
@@ -871,7 +871,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // we're interested in verifying the behaviour of streamA with end address != trim address.
             CheckpointWriter cpw = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(streamNameA),
                     "checkpoint-test", mapA);
-            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress), (long) snapshotAddress);
+            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress));
 
             // Trim the log
             runtime.getAddressSpaceView().prefixTrim(cpAddress);
@@ -970,7 +970,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Checkpoint A with snapshot @ 9
             CheckpointWriter cpw = new CheckpointWriter(runtime, CorfuRuntime.getStreamID(streamNameA),
                     "checkpointer-test", mapA);
-            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress - 1), (long) snapshotAddress - 1);
+            Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress - 1));
 
             // Trim the log
             runtime.getAddressSpaceView().prefixTrim(cpAddress);

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -272,9 +272,8 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         Token snapshot = TransactionalContext
                 .getCurrentContext()
                 .getSnapshotTimestamp();
-        long streamTail = r.getSequencerView().query(streamId);
         try {
-            cpw.startCheckpoint(snapshot, streamTail);
+            cpw.startCheckpoint(snapshot);
             cpw.appendObjectState(m.entryStream());
             cpw.finishCheckpoint();
 
@@ -658,11 +657,11 @@ public class CheckpointSmokeTest extends AbstractViewTest {
 
         // Checkpoint Writer 2 @15
         CheckpointWriter cpw2 = new CheckpointWriter(r, CorfuRuntime.getStreamID(streamA), "checkpointer-2", mA);
-        Token cp2Token = cpw2.appendCheckpoint(new Token(0, snapshotAddress2 - 1), (long) snapshotAddress2 - 1);
+        Token cp2Token = cpw2.appendCheckpoint(new Token(0, snapshotAddress2 - 1));
 
         // Checkpoint Writer 1 @10
         CheckpointWriter cpw1 = new CheckpointWriter(r, CorfuRuntime.getStreamID(streamA), "checkpointer-1", mA);
-        cpw1.appendCheckpoint(new Token(0, snapshotAddress1 - 1), (long) snapshotAddress1 - 1);
+        cpw1.appendCheckpoint(new Token(0, snapshotAddress1 - 1));
 
         // Trim @snapshotAddress=15
         r.getAddressSpaceView().prefixTrim(cp2Token);


### PR DESCRIPTION
## Overview

Description:
Remove the tail arg from checkpoint function as it can be referenced from the snapshot's sequence. 

Why should this be merged: 
Make code clean and easy to read.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
