### PR TITLE
End-to-end compression: remove compressed flag and related checks.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -434,12 +434,6 @@ public class StreamLogFiles implements StreamLog, StreamLogWithRankedAddressSpac
                 .DataType.typeMap.get((byte) entry.getDataType().getNumber()),
                 Unpooled.wrappedBuffer(entryData.array()), ldCodecType);
 
-        if (logData.hasPayloadCodec()) {
-            // The server assumes that if a codec has been specified then
-            // the payload it received was already compressed
-            logData.setCompressedFlag();
-        }
-
         logData.setBackpointerMap(getUUIDLongMap(entry.getBackpointersMap()));
         logData.setGlobalAddress(entry.getGlobalAddress());
         logData.setRank(createDataRank(entry));

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -234,20 +234,6 @@ public interface IMetadata {
         return getPayloadCodecType() != Codec.Type.NONE;
     }
 
-    // This field is required ad the server uses the same serialization/deserialization path as the runtime,
-    // we need a flag to let the server not re-encode an already encoded payload.
-    default boolean isCompressed() {
-        return (boolean) getMetadataMap().getOrDefault(LogUnitMetadataType.COMPRESSED, false);
-    }
-
-    /**
-     * Sets the compressed flag to true. This flag is used in order to avoid sthe server re-encoding an already
-     * encoded payload as the code path is shared by server and runtime.
-     */
-    default void setCompressedFlag() {
-        getMetadataMap().put(LogUnitMetadataType.COMPRESSED, true);
-    }
-
     @RequiredArgsConstructor
     enum LogUnitMetadataType implements ITypedEnum {
         RANK(1, TypeToken.of(DataRank.class)),
@@ -260,9 +246,7 @@ public interface IMetadata {
         CLIENT_ID(10, TypeToken.of(UUID.class)),
         THREAD_ID(11, TypeToken.of(Long.class)),
         EPOCH(12, TypeToken.of(Long.class)),
-        PAYLOAD_CODEC(13, TypeToken.of(Codec.Type.class)),
-        COMPRESSED(14, TypeToken.of(Boolean.class))
-        ;
+        PAYLOAD_CODEC(13, TypeToken.of(Codec.Type.class));
         final int type;
         @Getter
         final TypeToken<?> componentType;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -283,13 +283,7 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
                 buf.writeInt(size);
                 buf.writerIndex(lengthIndex + size + 4);
             } else {
-                // Since the server uses the same serialization/deserialization path
-                // we need a flag (isCompressed) to let the server not re-encode an already encoded payload
-                if (hasPayloadCodec() && !isCompressed()) {
-                    doCompressInternal(Unpooled.wrappedBuffer(data), buf);
-                } else {
-                    ICorfuPayload.serialize(buf, data);
-                }
+                ICorfuPayload.serialize(buf, data);
             }
         }
 
@@ -302,7 +296,6 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         ByteBuffer wrappedByteBuf = ByteBuffer.wrap(bufData.array(), 0, bufData.readableBytes());
         ByteBuffer compressedBuf = getPayloadCodecType().getInstance().compress(wrappedByteBuf);
         ICorfuPayload.serialize(buf, Unpooled.wrappedBuffer(compressedBuf));
-        setCompressedFlag();
     }
 
     /**


### PR DESCRIPTION
## Overview

After digging into the code, looks like the compressed flag could be removed to reduce complexity.
When server serializes LogData for a client read request, it should already be in compressed state, even for the unit test framework.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
