### PR TITLE
PersistedStreamingMap SIGSEGV Fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/RocksDbEntryIterator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/RocksDbEntryIterator.java
@@ -1,0 +1,96 @@
+package org.corfudb.runtime.collections;
+
+import io.netty.buffer.Unpooled;
+import org.corfudb.util.serializer.ISerializer;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDB;
+
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.AbstractMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ *
+ * A wrapper class that provides an iterator over the RocksDb map entries. It is compatible with Java's {@link Iterator}.
+ *
+ * Created by Maithem on 1/21/20.
+ */
+@NotThreadSafe
+public class RocksDbEntryIterator<K, V> implements Iterator<Map.Entry<K, V>>, AutoCloseable {
+
+    /**
+     * A reference to the underlying RocksDb iterator
+     */
+    final private WrappedRocksIterator wrappedRocksIterator;
+
+    /**
+     * Serializer to serialize/deserialize the key/values
+     */
+    final private ISerializer serializer;
+
+    /**
+     * place holder for the current value
+     */
+    private Map.Entry<K, V> next;
+
+    final private ReadOptions readOptions;
+
+    public RocksDbEntryIterator(RocksDB rocksDB, ISerializer serializer) {
+        // Start iterator at the current snapshot
+        readOptions = new ReadOptions();
+        readOptions.setSnapshot(null);
+        this.wrappedRocksIterator = new WrappedRocksIterator(rocksDB.newIterator(readOptions));
+        this.serializer = serializer;
+        wrappedRocksIterator.seekToFirst();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean hasNext() {
+        if (next == null && wrappedRocksIterator.isOpen() && wrappedRocksIterator.isValid()) {
+            // Retrieve entry if it exists and move the iterator
+            next = new AbstractMap.SimpleEntry(
+                    serializer.deserialize(Unpooled.wrappedBuffer(wrappedRocksIterator.key()), null),
+                    serializer.deserialize(Unpooled.wrappedBuffer(wrappedRocksIterator.value()), null));
+            wrappedRocksIterator.next();
+        }
+
+        if (next == null && wrappedRocksIterator.isOpen()) {
+            // close the iterator if it has fully consumed.
+            wrappedRocksIterator.close();
+            readOptions.close();
+        }
+
+        return next != null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map.Entry<K, V> next() {
+        if (hasNext()) {
+            Map.Entry<K, V> res = next;
+            next = null;
+            return res;
+        } else {
+            throw new NoSuchElementException();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() {
+        // Release the underlying RocksDB resources
+        if (wrappedRocksIterator.isOpen()) {
+            wrappedRocksIterator.close();
+            readOptions.close();
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/collections/WrappedRocksIterator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/WrappedRocksIterator.java
@@ -1,0 +1,140 @@
+package org.corfudb.runtime.collections;
+
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.RocksIteratorInterface;
+
+/**
+ *
+ * A wrapper class that makes a access to the RocksIterator safe: the rocks library does some checks but they
+ * are enforced via assert, but assert checking is disabled on many jvms by default, hence the explicit checking.
+ *
+ * Created by Maithem on 1/24/20.
+ */
+public class WrappedRocksIterator implements RocksIteratorInterface {
+
+    private final RocksIterator iterator;
+    public WrappedRocksIterator(RocksIterator iterator) {
+        this.iterator = iterator;
+    }
+
+    /**
+     * A helper method that is called before accessing the iterator.
+     * This is necessary to make sure that the iterator hasn't been closed.
+     */
+    private void checkHandle() {
+        if (!iterator.isOwningHandle()) {
+            throw new IllegalStateException("RocksIterator has been closed");
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isValid() {
+        checkHandle();
+        boolean res =  iterator.isValid();
+        status();
+        return res;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void seekToFirst() {
+        checkHandle();
+        iterator.seekToFirst();
+        status();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void seekToLast() {
+        throw new UnsupportedOperationException("seekToLast");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void seek(byte[] target) {
+        throw new UnsupportedOperationException("seek");
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void seekForPrev(byte[] target){
+        throw new UnsupportedOperationException("seekForPrev");
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void next() {
+       checkHandle();
+       iterator.next();
+       status();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void prev() {
+        throw new UnsupportedOperationException("prev");
+    }
+
+    /**
+     * Returns the key of the current position of the iterator.
+     */
+    public byte[] key() {
+        checkHandle();
+        byte[] res = iterator.key();
+        status();
+        return res;
+    }
+
+    /**
+     * Returns the value of the current position of the iterator.
+     */
+    public byte[] value() {
+        checkHandle();
+        byte[] res = iterator.value();
+        status();
+        return res;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void status() {
+        try {
+            iterator.status();
+        } catch (RocksDBException e) {
+            throw new UnrecoverableCorfuError("Iterator is in an invalid state", e);
+        }
+    }
+
+    public boolean isOpen() {
+        return iterator.isOwningHandle();
+    }
+
+    /**
+     * Closes the iterator. This method is idempotent.
+     */
+    public void close() {
+        iterator.close();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -240,37 +240,6 @@ public class TableRegistry {
     }
 
     /**
-     * A set of options defined for disk-backed {@link CorfuTable}.
-     *
-     * For a set of options that dictate RocksDB memory usage can be found here:
-     * https://github.com/facebook/rocksdb/wiki/Memory-usage-in-RocksDB
-     *
-     * Block Cache:  Which can be set via Options::setTableFormatConfig.
-     *               Out of box, RocksDB will use LRU-based block cache
-     *               implementation with 8MB capacity.
-     * Index/Filter: Is a function of the block cache. Generally it infates
-     *               the block cache by about 50%. The exact number can be
-     *               retrieved via "rocksdb.estimate-table-readers-mem"
-     *               property.
-     * Write Buffer: Also known as memtable is defined by the ColumnFamilyOptions
-     *               option. The default is 64 MB.
-     */
-    private Options getPersistentMapOptions() {
-        final int maxSizeAmplificationPercent = 50;
-        final Options options = new Options();
-
-        options.setCreateIfMissing(true);
-        options.setCompressionType(CompressionType.LZ4_COMPRESSION);
-
-        // Set a threshold at which full compaction will be triggered.
-        // This is important as it purges tombstoned entries.
-        final CompactionOptionsUniversal compactionOptions = new CompactionOptionsUniversal();
-        compactionOptions.setMaxSizeAmplificationPercent(maxSizeAmplificationPercent);
-        options.setCompactionOptionsUniversal(compactionOptions);
-        return options;
-    }
-
-    /**
      * Opens a Corfu table with the specified options.
      *
      * @param namespace    Namespace of the table.
@@ -316,7 +285,7 @@ public class TableRegistry {
             versionPolicy = ICorfuVersionPolicy.MONOTONIC;
             mapSupplier = () -> new PersistedStreamingMap<>(
                     tableOptions.getPersistentDataPath().get(),
-                    getPersistentMapOptions(),
+                    PersistedStreamingMap.getPersistedStreamingMapOptions(),
                     protobufSerializer, this.runtime);
         }
 

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -53,7 +53,6 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
             .build();
     }
     
-
     @Test
     public void testWriteReadWithChecksum() {
         // Enable checksum, then append and read the same entry

--- a/test/src/test/java/org/corfudb/runtime/collections/RocksDbEntryIteratorTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/RocksDbEntryIteratorTest.java
@@ -1,0 +1,78 @@
+package org.corfudb.runtime.collections;
+
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.stream.IntStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.corfudb.AbstractCorfuTest.PARAMETERS;
+
+/**
+ *
+ * Tests that exercise {@link RocksDbEntryIterator} functionality.
+ *
+ * Created by Maithem on 1/30/20.
+ */
+public class RocksDbEntryIteratorTest {
+
+    @Test
+    public void iteratorTest() throws Exception {
+        String path = PARAMETERS.TEST_TEMP_DIR;
+        String rocksDbPath = Paths.get(path, "rocksdb").toAbsolutePath().toString();
+        final Options options = new Options()
+                .setCreateIfMissing(true);
+        RocksDB rocksDb = RocksDB.open(options, rocksDbPath);
+        ISerializer serializer = Serializers.PRIMITIVE;
+
+        final int numEntries = 57;
+
+        // Generate some data
+        IntStream.range(0, numEntries).forEach(num -> {
+            try {
+                ByteBuf keyByteBuf = Unpooled.buffer();
+                ByteBuf valByteBuf = Unpooled.buffer();
+                serializer.serialize(num, keyByteBuf);
+                serializer.serialize(num, valByteBuf);
+                byte[] key = new byte[keyByteBuf.writerIndex()];
+                keyByteBuf.readBytes(key);
+                byte[] val = Arrays.copyOf(key, key.length);
+                rocksDb.put(key, val);
+            } catch (RocksDBException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        RocksDbEntryIterator iterator = new RocksDbEntryIterator(rocksDb, serializer);
+
+        // Verify that all the entries can be retrieved from the iterator
+        IntStream.range(0, numEntries).forEach(num -> {
+            Map.Entry<Integer, Integer> entry = iterator.next();
+            assertThat(entry.getKey()).isEqualTo(num);
+            assertThat(entry.getValue()).isEqualTo(num);
+        });
+
+        assertThat(iterator.hasNext()).isFalse();
+        assertThatThrownBy(() -> iterator.next())
+                .isExactlyInstanceOf(NoSuchElementException.class);
+        assertThat(iterator.hasNext()).isFalse();
+
+        // Verify that the iterator can be closed multiple times
+
+        Assertions.assertDoesNotThrow(() -> iterator.close());
+        Assertions.assertDoesNotThrow(() -> iterator.close());
+    }
+}


### PR DESCRIPTION
This patch fixes a bug where the iterator is accessed after it
has been closed, which ends up causing a segfault.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
