### PR TITLE
Mask TrimmedException in CorfuCompileProxy

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -193,8 +193,8 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
                         o -> o.syncObjectUnsafe(timestamp),
                         o -> accessMethod.access(o));
             } catch (TrimmedException te) {
-                log.warn("accessInner: Encountered a trim exception while accessing version {} on attempt {}",
-                        timestamp, x);
+                log.info("accessInner: Encountered trimmed address space " +
+                                "while accessing version {} on attempt {}", timestamp, x);
                 // We encountered a TRIM during sync, reset the object
                 underlyingObject.update(o -> {
                     o.resetUnsafe();
@@ -296,8 +296,8 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
                             + " and we don't have a copy");
                 });
             } catch (TrimmedException ex) {
-                log.warn("getUpcallResultInner: Encountered a trim exception while accessing version {} on attempt {}",
-                        timestamp, x);
+                log.info("getUpcallResultInner: Encountered trimmed address space " +
+                        "while accessing version {} on attempt {}", timestamp, x);
                 // We encountered a TRIM during sync, reset the object
                 underlyingObject.update(o -> {
                     o.resetUnsafe();


### PR DESCRIPTION
Encountering a TrimmedException in CorfuCompileProxy is part of a normal
workflow. The current message causes a lot of confusion during
root-cause analysis, since developers incorrectly assume that Corfu
ended up in an exceptional state.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
