### PR TITLE
Change logSizeQuotaPercentage from int to double

### DIFF
--- a/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
@@ -79,7 +79,7 @@ public class CorfuServerParams implements NodeParams {
     private final String dockerImage = DOCKER_IMAGE_NAME;
 
     @Default
-    private final int logSizeQuotaPercentage = 100;
+    private final double logSizeQuotaPercentage = 100;
 
     @Override
     public String getName() {

--- a/it/src/main/java/org/corfudb/universe/node/server/vm/VmCorfuServerParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/vm/VmCorfuServerParams.java
@@ -30,7 +30,7 @@ public class VmCorfuServerParams extends CorfuServerParams {
     public VmCorfuServerParams(
             VmName vmName, int port, Mode mode, Persistence persistence,
             Level logLevel, String clusterName, Duration stopTimeout, String serverVersion,
-            Path serverJarDirectory, String dockerImage, int logSizeQuotaPercentage) {
+            Path serverJarDirectory, String dockerImage, double logSizeQuotaPercentage) {
 
         super(
                 port, mode, persistence, logLevel, clusterName, stopTimeout,

--- a/it/src/main/java/org/corfudb/universe/universe/vm/VmManager.java
+++ b/it/src/main/java/org/corfudb/universe/universe/vm/VmManager.java
@@ -172,7 +172,7 @@ public class VmManager {
                         ManagedEntityType.VIRTUAL_MACHINE.typeName, name
                 );
                 return Optional.ofNullable(vm);
-            } catch (RemoteException e) {
+            } catch (Exception e) {
                 throw new UniverseException("Can't find a vm: " + vmName, e);
             }
         });


### PR DESCRIPTION
## Overview

Description:
Currently Universe framework didn't allow us to use double in logSizeQuotaPercentage. 
This change fixes that

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
