### PR TITLE
Explicit close

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -492,6 +492,8 @@ public class CorfuTable<K ,V> implements
 
     /**
      * Present the content of a {@link CorfuTable} via the {@link Stream} interface.
+     * Because the stream can point to other resources managed off-heap, its necessary
+     * to explicitly close it after consumption.
      *
      * @return stream of entries
      */


### PR DESCRIPTION
## Overview
Although RocksDB iterators get closed automatically by finalize,
they should be closed right after they are no longer needed and
not relay on the Java's GC to release those resources.

Why should this be merged: Avoids GC-Finalize lag to release
native memory.  

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
