### PR TITLE
Layout Bootstrap and ClusterId Validation for the Server Message Routing 

### DIFF
--- a/cmdlets/src/main/clojure/org/corfudb/shell.clj
+++ b/cmdlets/src/main/clojure/org/corfudb/shell.clj
@@ -150,11 +150,11 @@ The variable *r holds the last runtime obtrained, and *o holds the last router o
 (defn get-stream ([stream] (.. (.. *r (getStreamsView)) (get stream))))
 
 ; Functions that get clients
-(defn get-base-client ([router epoch] (new BaseClient router epoch)))
-(defn get-layout-client ([router epoch] (new LayoutClient router epoch)))
-(defn get-sequencer-client ([router epoch] (new SequencerClient router epoch)))
-(defn get-logunit-client ([router epoch] (new LogUnitClient router epoch)))
-(defn get-management-client ([router epoch] (new ManagementClient router epoch)))
+(defn get-base-client ([router epoch cluster-id] (new BaseClient router epoch cluster-id)))
+(defn get-layout-client ([router epoch cluster-id] (new LayoutClient router epoch cluster-id)))
+(defn get-sequencer-client ([router epoch cluster-id] (new SequencerClient router epoch cluster-id)))
+(defn get-logunit-client ([router epoch cluster-id] (new LogUnitClient router epoch cluster-id)))
+(defn get-management-client ([router epoch cluster-id] (new ManagementClient router epoch cluster-id)))
 
 ; Helper functions
 (defn uuid-from-string "Takes a string and parses it to UUID if it is not a UUID"

--- a/corfu_scripts/corfu_bootstrap_cluster.clj
+++ b/corfu_scripts/corfu_bootstrap_cluster.clj
@@ -31,8 +31,8 @@ Options:
                       (do
                         (doseq [server (.getLayoutServers new-layout)]
                            (do (let [router (get-router server localcmd)]
-                               (.get (.bootstrapLayout (new LayoutClient router (.getEpoch new-layout) (.getClusterId new-layout)) new-layout))
-                               (.get (.bootstrapManagement (new ManagementClient router (.getEpoch new-layout) (.getClusterId new-layout)) new-layout))
+                               (.get (.bootstrapLayout (get-layout-client router (.getEpoch new-layout) (.getClusterId new-layout)) new-layout))
+                               (.get (.bootstrapManagement (get-management-client router (.getEpoch new-layout) (.getClusterId new-layout)) new-layout))
                             )))
                         (println "New layout installed!")
                         ))))

--- a/corfu_scripts/corfu_bootstrap_cluster.clj
+++ b/corfu_scripts/corfu_bootstrap_cluster.clj
@@ -31,12 +31,11 @@ Options:
                       (do
                         (doseq [server (.getLayoutServers new-layout)]
                            (do (let [router (get-router server localcmd)]
-                               (.get (.bootstrapLayout (new LayoutClient router (.getEpoch new-layout)) new-layout))
-                               (.get (.bootstrapManagement (new ManagementClient router (.getEpoch new-layout)) new-layout))
+                               (.get (.bootstrapLayout (new LayoutClient router (.getEpoch new-layout) (.getClusterId new-layout)) new-layout))
+                               (.get (.bootstrapManagement (new ManagementClient router (.getEpoch new-layout) (.getClusterId new-layout)) new-layout))
                             )))
                         (println "New layout installed!")
-                        )
-                  )))
+                        ))))
 
 ; determine whether to read or write
 (cond (.. localcmd (get "--layout")) (bootstrap-cluster (.. localcmd (get "--layout")))

--- a/corfu_scripts/corfu_layout.clj
+++ b/corfu_scripts/corfu_layout.clj
@@ -2,6 +2,7 @@
 (in-ns 'org.corfudb.shell) ; so our IDE knows what NS we are using
 
 (import org.docopt.Docopt) ; parse some cmdline opts
+(import java.util.UUID)
 (require 'clojure.pprint)
 (require 'clojure.java.shell)
 (def usage "corfu_layout.
@@ -24,7 +25,7 @@ Options:
 
 (defn print-query [endpoint] (do
                                (println (format "Query %s:" endpoint))
-                               (let [q (.. (get-layout-client (get-router server localcmd) 0) (getLayout))]
+                               (let [q (.. (get-layout-client (get-router server localcmd) 0 (.UUID (fromString "00000000-0000-0000-0000-000000000000"))) (getLayout))]
                                  (println (.. (.. q (get)) (toString)))
                                )))
 

--- a/corfu_scripts/corfu_layouts.clj
+++ b/corfu_scripts/corfu_layouts.clj
@@ -45,9 +45,8 @@ Options:
            (.. (get-layout-view) (updateLayout layout layout-rank))
            -1)
          (catch org.corfudb.runtime.exceptions.OutrankedException e
-                (inc layout-rank))))
-   )))
-  )
+                (inc layout-rank))))))))
+
 (defn print-layout [] (pprint-json (.. (.. (get-layout-view) (getLayout)) (asJSONString))))
 (defn edit-layout [] (let [layout (.. (get-layout-view) (getLayout))
                            temp-file (java.io.File/createTempFile "corfu" ".tmp")]
@@ -89,15 +88,10 @@ Options:
                                                         (throw e)))
                                                     ))
                                          (install-layout new-layout)
-                                         (println "New layout installed!")
-                                         )
-                                   )
-                                )
-                            )
+                                         (println "New layout installed!")))))
                        ))))
 
 ; determine whether to read or write
 (cond (.. localcmd (get "query")) (print-layout)
   (.. localcmd (get "edit")) (edit-layout)
-  :else (println "Unknown arguments.")
-  )
+  :else (println "Unknown arguments."))

--- a/corfu_scripts/corfu_layouts.clj
+++ b/corfu_scripts/corfu_layouts.clj
@@ -2,6 +2,7 @@
 (in-ns 'org.corfudb.shell) ; so our IDE knows what NS we are using
 
 (import org.docopt.Docopt) ; parse some cmdline opts
+(import java.util.UUID)
 (require 'clojure.pprint)
 (require 'clojure.java.shell)
 (def usage "corfu_layouts, work with the Corfu layout view.
@@ -82,7 +83,7 @@ Options:
                                          (doseq [server (into [] (remove (set (.getLayoutServers layout)) (.getLayoutServers new-layout)))]
                                                 (do
                                                     (try
-                                                      (.get (.bootstrapLayout (get-layout-client (get-router server localcmd) 0) new-layout))
+                                                      (.get (.bootstrapLayout (get-layout-client (get-router server localcmd) 0 (.UUID (fromString "00000000-0000-0000-0000-000000000000"))) new-layout))
                                                       (catch Exception e
                                                         (println server ":" (.getMessage e))
                                                         (throw e)))

--- a/corfu_scripts/corfu_logunit.clj
+++ b/corfu_scripts/corfu_logunit.clj
@@ -4,6 +4,7 @@
 (import org.docopt.Docopt) ; parse some cmdline opts
 (import org.corfudb.protocols.wireprotocol.TokenResponse)
 (import org.corfudb.protocols.wireprotocol.LogData)
+(import java.util.UUID)
 (import org.corfudb.protocols.wireprotocol.DataType)
 (import org.corfudb.protocols.wireprotocol.ILogData)
 
@@ -59,7 +60,7 @@ Options:
 
 ; a function which reads a logunit entry to stdout
 (defn read-logunit [address] (let [obj
-         (.. (.. (get-logunit-client (get-router (.. localcmd (get "<endpoint>")) localcmd) 0) (read address)) (get))]
+         (.. (.. (get-logunit-client (get-router (.. localcmd (get "<endpoint>")) localcmd) 0 "00000000-0000-0000-0000-000000000000")) (read address)) (get))]
 
          (let [read-response (.. (.. obj (getAddresses)) (get address))]
          (if (.equals (.. read-response (getType)) org.corfudb.protocols.wireprotocol.DataType/DATA)
@@ -77,7 +78,7 @@ Options:
           (.. logData (useToken (new TokenResponse address 0 (java.util.Collections/singletonMap stream (long -5)))))
           )
 
-      (.. (.. (get-logunit-client (get-router (.. localcmd (get "<endpoint>")) localcmd) 0)
+      (.. (.. (get-logunit-client (get-router (.. localcmd (get "<endpoint>")) localcmd) 0 (.UUID (fromString "00000000-0000-0000-0000-000000000000")))
               (write logData)) (get))
 ))))
 

--- a/corfu_scripts/corfu_logunit.clj
+++ b/corfu_scripts/corfu_logunit.clj
@@ -60,7 +60,7 @@ Options:
 
 ; a function which reads a logunit entry to stdout
 (defn read-logunit [address] (let [obj
-         (.. (.. (get-logunit-client (get-router (.. localcmd (get "<endpoint>")) localcmd) 0 "00000000-0000-0000-0000-000000000000")) (read address)) (get))]
+         (.. (.. (get-logunit-client (get-router (.. localcmd (get "<endpoint>")) localcmd) 0 (.UUID (fromString "00000000-0000-0000-0000-000000000000")))) (read address)) (get))]
 
          (let [read-response (.. (.. obj (getAddresses)) (get address))]
          (if (.equals (.. read-response (getType)) org.corfudb.protocols.wireprotocol.DataType/DATA)

--- a/corfu_scripts/corfu_management_bootstrap.clj
+++ b/corfu_scripts/corfu_management_bootstrap.clj
@@ -3,7 +3,7 @@
 
 (import org.docopt.Docopt)                                  ; parse some cmdline opts
 (import org.corfudb.runtime.view.Layout)
-
+(import java.util.UUID)
 (def usage "corfu_management_bootstrap, to bootstrap Corfu Management Server.
 Usage:
   corfu_management_bootstrap -c <config> -l <layout> [-e [-u <keystore> -f <keystore_password_file>] [-r <truststore> -w <truststore_password_file>] [-g -o <username_file> -j <password_file>]]
@@ -24,7 +24,7 @@ Options:
 (def localcmd (.. (new Docopt usage) (parse *args)))
 
 (defn build-layout [endpoint layout] (do
-                                       (let [q (.. (get-management-client (get-router server localcmd) 0) (bootstrapManagement (Layout/fromJSONString (str layout))))]
+                                       (let [q (.. (get-management-client (get-router server localcmd) 0 (.UUID (.fromString "00000000-0000-0000-0000-000000000000"))) (bootstrapManagement (Layout/fromJSONString (str layout))))]
                                             (.. q (get))
                                             )
                                        (println endpoint "bootstrapped successfully")

--- a/corfu_scripts/corfu_ping.clj
+++ b/corfu_scripts/corfu_ping.clj
@@ -1,6 +1,6 @@
 ; Pings the endpoint given as the first argument
 (in-ns 'org.corfudb.shell) ; so our IDE knows what NS we are using
-
+(import java.util.UUID)
 (import org.docopt.Docopt) ; parse some cmdline opts
 
 (def usage "corfu_ping, ping Corfu servers.
@@ -30,7 +30,7 @@ Options:
 (doseq [endpoint (.toArray (.. localcmd (get "<endpoint>")))]
   (do
      (println (format "PING %s" endpoint))
-     (let [ping (time-expression (.. (get-base-client (get-router server localcmd) 0) (pingSync)))]
+     (let [ping (time-expression (.. (get-base-client (get-router server localcmd) 0 (.UUID (.fromString "00000000-0000-0000-0000-000000000000"))) (pingSync)))]
        (if (:result ping) (println (format "ACK time=%.3fms" (/ (:time ping) 1000000.0)))
            (println (format "NACK timeout=%.3fms" (/ (:time ping) 1000000.0)))
        )

--- a/corfu_scripts/corfu_query.clj
+++ b/corfu_scripts/corfu_query.clj
@@ -23,7 +23,7 @@ Options:
 
 (defn print-query [endpoint] (do
                                (println (format "Query %s:" endpoint))
-                               (let [q (.. (get-base-client (get-router server localcmd) 0) (getVersionInfo))]
+                               (let [q (.. (get-base-client (get-router server localcmd) 0 (.UUID (.fromString "00000000-0000-0000-0000-000000000000"))) (getVersionInfo))]
                                (println (bean (.. q (get)))))
                                ))
 

--- a/corfu_scripts/corfu_reset.clj
+++ b/corfu_scripts/corfu_reset.clj
@@ -1,6 +1,6 @@
 ; Reset the endpoint given as the first argument
 (in-ns 'org.corfudb.shell) ; so our IDE knows what NS we are using
-
+(import java.util.UUID)
 (import org.docopt.Docopt) ; parse some cmdline opts
 (require 'clojure.pprint)
 (require 'clojure.java.shell)
@@ -23,7 +23,7 @@ Options:
 (def localcmd (.. (new Docopt usage) (parse *args)))
 
 (defn print-reset [endpoint] (do (println (str "Reset " endpoint ":"))
-                                 (if (.. (.. (get-base-client (get-router server localcmd) 0) (reset)) (get))
+                                 (if (.. (.. (get-base-client (get-router server localcmd) 0 (.UUID (.fromString "00000000-0000-0000-0000-000000000000"))) (reset)) (get))
                                      (println "ACK")
                                      (println "NACK")
                                      )

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
@@ -80,11 +80,17 @@ public class CorfuServerNode implements AutoCloseable {
      * @param serverMap     Server Map with all components.
      */
     public CorfuServerNode(@Nonnull ServerContext serverContext,
-                           @Nonnull Map<Class, AbstractServer> serverMap) {
+                           @Nonnull ImmutableMap<Class, AbstractServer> serverMap) {
         this.serverContext = serverContext;
         this.serverMap = serverMap;
-        router = new NettyServerRouter(new ArrayList<>(serverMap.values()));
+        router = new NettyServerRouter(serverMap.values().asList(), serverContext);
         this.serverContext.setServerRouter(router);
+        // If the node is started in the single node setup and was bootstrapped,
+        // set the server epoch as well.
+        if(serverContext.isSingleNodeSetup() && serverContext.getCurrentLayout() != null){
+            serverContext.setServerEpoch(serverContext.getCurrentLayout().getEpoch(),
+                    router);
+        }
         this.close = new AtomicBoolean(false);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IServerRouter.java
@@ -2,13 +2,26 @@ package org.corfudb.infrastructure;
 
 import io.netty.channel.ChannelHandlerContext;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
+import org.corfudb.protocols.wireprotocol.WrongClusterMsg;
+import org.corfudb.runtime.view.Layout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Created by mwei on 12/13/15.
  */
 public interface IServerRouter {
+
+    // Lombok annotations are not allowed for the interfaces.
+    Logger log = LoggerFactory.getLogger(IServerRouter.class);
+
     void sendResponse(ChannelHandlerContext ctx, CorfuMsg inMsg, CorfuMsg outMsg);
 
     /**
@@ -22,8 +35,13 @@ public interface IServerRouter {
     void setServerEpoch(long newEpoch);
 
     /**
+     * Get the currently bootstrapped layout.
+     */
+    Optional<Layout> getCurrentLayout();
+
+    /**
      * Register a server to route messages to.
-     * @param server    The server to route messages to
+     * @param server The server to route messages to
      */
     void addServer(AbstractServer server);
 
@@ -31,4 +49,113 @@ public interface IServerRouter {
      * Get a list of registered servers.
      */
     List<AbstractServer> getServers();
+
+    /**
+     * Set a serverContext for this router.
+     * @param serverContext A current server context.
+     */
+    void setServerContext(ServerContext serverContext);
+
+    /**
+     * Send WRONG_EPOCH message.
+     *
+     * @param msg The incoming message.
+     * @param ctx The context of the channel handler.
+     */
+    default void sendWrongEpochMessage(CorfuMsg msg, ChannelHandlerContext ctx) {
+        sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH,
+                getServerEpoch()));
+        log.trace("Incoming message with wrong epoch, got {}, expected {}, message was: {}",
+                msg.getEpoch(), getServerEpoch(), msg);
+    }
+
+    /**
+     * Send LAYOUT_NOBOOTSTRAP message.
+     *
+     * @param msg The incoming message.
+     * @param ctx The context of the channel handler.
+     */
+    default void sendNoBootstrapMessage(CorfuMsg msg, ChannelHandlerContext ctx) {
+        sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.LAYOUT_NOBOOTSTRAP));
+        log.trace("Received message but not bootstrapped! Message={}", msg);
+    }
+
+    /**
+     * Send WRONG_CLUSTER_ID message.
+     *
+     * @param msg              The incoming message.
+     * @param ctx              The context of the channel handler.
+     * @param currentClusterID The current cluster id.
+     */
+    default void sendWrongClusterIdMessage(CorfuMsg msg, ChannelHandlerContext ctx, UUID currentClusterID) {
+        sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_CLUSTER_ID,
+                new WrongClusterMsg(currentClusterID, msg.getClusterID())));
+        log.trace("Incoming message with a wrong cluster ID, got {}, expected {}, message was {}",
+                msg.getClusterID(), currentClusterID, msg);
+    }
+
+    /**
+     * Validate the epoch of a CorfuMsg, and send a WRONG_EPOCH response if
+     * the server is in the wrong epoch. Ignored if the message type is reset (which
+     * is valid in any epoch).
+     *
+     * @param msg The incoming message to validate.
+     * @param ctx The context of the channel handler.
+     * @return True, if the epoch is correct, but false otherwise.
+     */
+    default boolean epochIsValid(CorfuMsg msg, ChannelHandlerContext ctx) {
+        long serverEpoch = getServerEpoch();
+        if (msg.getEpoch() != serverEpoch) {
+            sendWrongEpochMessage(msg, ctx);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Validate that the message's cluster ID is equal to the cluster ID of a bootstrapped layout.
+     *
+     * @param msg           The incoming message.
+     * @param ctx           The context of the channel handler.
+     * @param currentLayout The layout a server was bootstrapped with.
+     * @return True, if the message's cluster ID is equal to this node's cluster ID, otherwise false.
+     */
+    default boolean clusterIdIsValid(CorfuMsg msg, ChannelHandlerContext ctx, Layout currentLayout) {
+        UUID currentClusterID = currentLayout.getClusterId();
+
+        boolean clusterIdsMatch = msg.getClusterID()
+                .equals(currentClusterID);
+
+        if (!clusterIdsMatch) {
+            sendWrongClusterIdMessage(msg, ctx, currentClusterID);
+        }
+        return clusterIdsMatch;
+    }
+
+    /**
+     * Validate the incoming message. The message is valid if:
+     * 1) The flag ignoreEpoch is set to true or it's set to false, and the epoch is valid for all the messages.
+     * 2) Also if the flag ignoreClusterId is set to false,
+     *      a. The current layout server should be bootstrapped and
+     *      b. the message's cluster ID should be equal to the bootstrapped layout's cluster ID.
+     *
+     * @param msg The incoming message.
+     * @param ctx The context of the channel handler.
+     * @return True, if it's a valid message, and false otherwise.
+     */
+    default boolean messageIsValid(CorfuMsg msg, ChannelHandlerContext ctx) {
+        if (!msg.getMsgType().ignoreEpoch && !epochIsValid(msg, ctx)) {
+            return false;
+        }
+
+        if(!msg.getMsgType().ignoreClusterId){
+            return getCurrentLayout()
+                    .map(layout -> clusterIdIsValid(msg, ctx, layout))
+                    .orElseGet(() -> {
+                        sendNoBootstrapMessage(msg, ctx);
+                        return false;
+                    });
+        }
+        return true;
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -220,14 +220,21 @@ public class ManagementServer extends AbstractServer {
                                                        ChannelHandlerContext ctx, IServerRouter r) {
         if (serverContext.getManagementLayout() != null) {
             // We are already bootstrapped, bootstrap again is not allowed.
-            log.warn("Got a request to bootstrap a server with {} which is already bootstrapped, "
-                    + "rejecting!", msg.getPayload());
+            log.warn("handleManagementBootstrap: Got a request to bootstrap a server " +
+                    "with {} which is already bootstrapped, rejecting!", msg.getPayload());
             r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.MANAGEMENT_ALREADY_BOOTSTRAP_ERROR));
         } else {
-            log.info("Received Bootstrap Layout : {}", msg.getPayload());
-            serverContext.saveManagementLayout(msg.getPayload());
-            r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
-
+            Layout layout = msg.getPayload();
+            log.info("handleManagementBootstrap: received bootstrap layout : {}", layout);
+            if(layout.getClusterId() == null){
+                log.warn("handleManagementBootstrap: clusterId for the layout {} is not present.",
+                        layout.getClusterId());
+                r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.NACK));
+            }
+            else{
+                serverContext.saveManagementLayout(layout);
+                r.sendResponse(ctx, msg, new CorfuMsg(CorfuMsgType.ACK));
+            }
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -86,6 +86,7 @@ public class SequencerServer extends AbstractServer {
     /**
      * Inherit from CorfuServer a server context.
      */
+    @Getter
     private final ServerContext serverContext;
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -335,11 +335,19 @@ public class ServerContext implements AutoCloseable {
      *  @return True, if a new layout was installed, false otherwise.
      */
     public synchronized boolean installSingleNodeLayoutIfAbsent() {
-        if ((Boolean) getServerConfig().get("--single") && getCurrentLayout() == null) {
+        if (isSingleNodeSetup() && getCurrentLayout() == null) {
             setCurrentLayout(getNewSingleNodeLayout());
             return true;
         }
         return false;
+    }
+
+    /**
+     * Check if it's a single node setup.
+     * @return True if it is, false otherwise.
+     */
+    public boolean isSingleNodeSetup(){
+        return (Boolean) getServerConfig().get("--single");
     }
 
     /**
@@ -417,7 +425,7 @@ public class ServerContext implements AutoCloseable {
      */
     public synchronized long getServerEpoch() {
         Long epoch = dataStore.get(SERVER_EPOCH_RECORD);
-        return epoch == null ? 0 : epoch;
+        return epoch == null ? Layout.INVALID_EPOCH : epoch;
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/FailureDetector.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/FailureDetector.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -93,7 +94,7 @@ public class FailureDetector implements IDetector {
 
         // Perform polling of all responsive servers.
         return pollRound(
-                layout.getEpoch(), allServers, routerMap, sequencerMetrics,
+                layout.getEpoch(), layout.getClusterId(), allServers, routerMap, sequencerMetrics,
                 ImmutableList.copyOf(layout.getUnresponsiveServers())
         );
     }
@@ -116,7 +117,7 @@ public class FailureDetector implements IDetector {
      */
     @VisibleForTesting
     PollReport pollRound(
-            long epoch, Set<String> allServers, Map<String, IClientRouter> router,
+            long epoch, UUID clusterID, Set<String> allServers, Map<String, IClientRouter> router,
             SequencerMetrics sequencerMetrics, ImmutableList<String> layoutUnresponsiveNodes) {
 
         if (failureThreshold < 1) {
@@ -126,7 +127,7 @@ public class FailureDetector implements IDetector {
         List<PollReport> reports = new ArrayList<>();
         for (int iteration = 0; iteration < failureThreshold; iteration++) {
             PollReport currReport = pollIteration(
-                    allServers, router, epoch, sequencerMetrics, layoutUnresponsiveNodes
+                    allServers, router, epoch, clusterID, sequencerMetrics, layoutUnresponsiveNodes
             );
             reports.add(currReport);
 
@@ -225,12 +226,13 @@ public class FailureDetector implements IDetector {
      * @param allServers              all servers in the cluster
      * @param clientRouters           client clientRouters
      * @param epoch                   current epoch
+     * @param clusterID               current cluster id
      * @param sequencerMetrics        metrics
      * @param layoutUnresponsiveNodes all unresponsive servers in a cluster
      * @return a poll report
      */
     private PollReport pollIteration(
-            Set<String> allServers, Map<String, IClientRouter> clientRouters, long epoch,
+            Set<String> allServers, Map<String, IClientRouter> clientRouters, long epoch, UUID clusterID,
             SequencerMetrics sequencerMetrics, ImmutableList<String> layoutUnresponsiveNodes) {
 
         log.trace("Poll iteration. Epoch: {}", epoch);
@@ -239,7 +241,7 @@ public class FailureDetector implements IDetector {
 
         ClusterStateCollector clusterCollector = ClusterStateCollector.builder()
                 .localEndpoint(localEndpoint)
-                .clusterState(pollAsync(allServers, clientRouters, epoch))
+                .clusterState(pollAsync(allServers, clientRouters, epoch, clusterID))
                 .build();
 
         //Cluster state internal map.
@@ -265,15 +267,17 @@ public class FailureDetector implements IDetector {
      * @param allServers    All active members in the layout.
      * @param clientRouters Map of routers for all active members.
      * @param epoch         Current epoch for the polling round to stamp the ping messages.
+     * @param clusterId     Current clusterId
      * @return Map of Completable futures for the pings.
      */
     private Map<String, CompletableFuture<NodeState>> pollAsync(
-            Set<String> allServers, Map<String, IClientRouter> clientRouters, long epoch) {
+            Set<String> allServers, Map<String, IClientRouter> clientRouters, long epoch, UUID clusterId) {
         // Poll servers for health.  All ping activity will happen in the background.
         Map<String, CompletableFuture<NodeState>> clusterState = new HashMap<>();
         allServers.forEach(s -> {
             try {
-                clusterState.put(s, new ManagementClient(clientRouters.get(s), epoch).sendNodeStateRequest());
+                clusterState.put(s, new ManagementClient(clientRouters.get(s), epoch, clusterId)
+                        .sendNodeStateRequest());
             } catch (Exception e) {
                 CompletableFuture<NodeState> cf = new CompletableFuture<>();
                 cf.completeExceptionally(e);

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/FailureDetectorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/FailureDetectorTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,6 +28,7 @@ public class FailureDetectorTest {
         failureDetector.setNetworkStretcher(ns);
 
         long epoch = 1;
+        UUID clusterId = UUID.fromString("00000000-0000-0000-0000-000000000000");
         ImmutableSet<String> allServers = ImmutableSet.of("a", "b", "c");
         Map<String, IClientRouter> routerMap = new HashMap<>();
         SequencerMetrics metrics = SequencerMetrics.READY;
@@ -34,7 +36,7 @@ public class FailureDetectorTest {
 
         long start = System.currentTimeMillis();
         PollReport report = failureDetector.pollRound(
-                epoch, allServers, routerMap, metrics, responsiveServers
+                epoch, clusterId, allServers, routerMap, metrics, responsiveServers
         );
         Duration time = Duration.ofMillis(System.currentTimeMillis() - start);
         assertThat(time).isGreaterThan(Duration.ofMillis(450));

--- a/it/src/test/java/org/corfudb/universe/scenario/WriteAfterResetIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/WriteAfterResetIT.java
@@ -1,0 +1,150 @@
+package org.corfudb.universe.scenario;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.ReadResponse;
+import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.exceptions.NoBootstrapException;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.universe.GenericIntegrationTest;
+import org.corfudb.universe.UniverseManager.UniverseWorkflow;
+import org.corfudb.universe.group.cluster.CorfuCluster;
+import org.corfudb.universe.group.cluster.CorfuClusterParams;
+import org.corfudb.universe.node.client.CorfuClient;
+import org.corfudb.universe.node.server.CorfuServer;
+import org.corfudb.universe.scenario.fixture.Fixture;
+import org.corfudb.universe.scenario.fixture.Fixtures;
+import org.corfudb.universe.universe.UniverseParams;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Slf4j
+public class WriteAfterResetIT extends GenericIntegrationTest {
+
+    /**
+     * Test a log unit behavior after the reset.
+     * <p>
+     * 1) Deploy a single node cluster.
+     * 2) Connect a client's runtime to the node.
+     * 3) Write 100 addresses to the log unit.
+     * 4) Perform a reset.
+     * 5) Try writing record to the log unit, the write should not go through the router,
+     *    as the server is not bootstrapped.
+     * 6) Bootstrap a node with a new layout.
+     * 7) Write a record to the log unit.
+     * 8) The write should go through, as the server is now bootstrapped.
+     */
+
+    private LogData getLogData(long address) {
+        ByteBuf b = Unpooled.buffer();
+        byte[] streamEntry = "Payload".getBytes();
+        Serializers.CORFU.serialize(streamEntry, b);
+        LogData ld = new LogData(DataType.DATA, b);
+        ld.setGlobalAddress(address);
+        ld.setEpoch(0L);
+        return ld;
+    }
+
+    @Test(timeout = 300000)
+    public void writeAfterResetTest() {
+        workflow(wf -> {
+
+                    wf.setupDocker(fixture -> {
+                        fixture.getCluster().numNodes(1);
+                    });
+
+                    wf.deploy();
+                    try {
+                        writeAfterReset(wf);
+                    } catch (Exception e) {
+                        Assertions.fail("Test failed: " + e);
+                    }
+
+                }
+        );
+    }
+
+    private void writeAfterReset(UniverseWorkflow<Fixture<UniverseParams>> wf) throws Exception {
+        UniverseParams params = wf.getFixture().data();
+        CorfuCluster<CorfuServer, CorfuClusterParams> corfuCluster = wf.getUniverse()
+                .getGroup(params.getGroupParamByIndex(0).getName());
+        CorfuClient corfuClient = corfuCluster.getLocalCorfuClient();
+        corfuClient.getRuntime().invalidateLayout();
+        Layout layout = corfuClient.getLayout();
+        assertThat(layout.getFirstSegment().getAllLogServers().size()).isEqualTo(1);
+
+        // Start writing to some stream.
+        CorfuTable<String, String> table =
+                corfuClient.createDefaultCorfuTable(Fixtures.TestFixtureConst.DEFAULT_STREAM_NAME);
+        for (int i = 0; i < Fixtures.TestFixtureConst.DEFAULT_TABLE_ITER; i++) {
+            table.put(String.valueOf(i), String.valueOf(i));
+        }
+
+        String endpoint = corfuCluster.getFirstServer().getEndpoint();
+        CorfuClient resetClient = corfuCluster.getLocalCorfuClient();
+        Layout previousLayout = corfuClient.getLayout();
+
+        boolean resetHappened = resetClient.getRuntime()
+                .getLayoutView()
+                .getRuntimeLayout()
+                .getBaseClient(endpoint)
+                .reset()
+                .join();
+
+        if (resetHappened) {
+            Duration resetSleepDuration = Duration.ofMillis(2000);
+            long address = 100L;
+            TimeUnit.MILLISECONDS.sleep(resetSleepDuration.toMillis());
+            // After the reset write some data at address 100.
+            corfuClient.getRuntime().getLayoutView()
+                    .getRuntimeLayout(previousLayout)
+                    .getLogUnitClient(endpoint)
+                    .write(getLogData(address)).whenComplete((value, ex) -> {
+                if (ex != null) {
+                    // NotSealedException should be thrown.
+                    assertThat(ex).hasCauseExactlyInstanceOf(NoBootstrapException.class);
+
+                } else {
+                    Assertions.fail("NotSealedException should have been thrown.");
+                }
+            }).exceptionally(ex -> {
+                // Bootstrap a new 1 node cluster.
+                corfuCluster.bootstrap();
+                CorfuClient corfuClient2 = corfuCluster.getLocalCorfuClient();
+                corfuClient2.invalidateLayout();
+                // Write at address 100.
+                boolean writeWentThrough = corfuClient2.getRuntime().getLayoutView()
+                        .getRuntimeLayout()
+                        .getLogUnitClient(endpoint)
+                        .write(getLogData(address)).join();
+                if(writeWentThrough){
+                    // Read at address 100.
+                    ReadResponse response = corfuClient2.getRuntime().getLayoutView()
+                            .getRuntimeLayout()
+                            .getLogUnitClient(endpoint)
+                            .read(address)
+                            .join();
+                    assertThat(new String(response.getAddresses().get(address).getData())).contains("Payload");
+                }
+                else{
+                    Assertions.fail("Write after bootstrap should succeeded.");
+                }
+                return true;
+            }).join();
+
+
+        } else {
+            Assertions.fail("Reset did not happen.");
+        }
+    }
+
+}

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsg.java
@@ -36,6 +36,11 @@ public class CorfuMsg {
     UUID clientID;
 
     /**
+     * The unique id of the cluster the request is made to.
+     */
+    UUID clusterID;
+
+    /**
      * The request id of this request/response.
      */
     @SuppressWarnings({"checkstyle:abbreviationaswordinname", "checkstyle:membername"})
@@ -89,6 +94,7 @@ public class CorfuMsg {
                     + "Marker = " + marker + " but expected 0xC0FC0FC0");
         }
         UUID clientId = new UUID(buffer.readLong(), buffer.readLong());
+        UUID clusterId = new UUID(buffer.readLong(), buffer.readLong());
         long requestId = buffer.readLong();
         long epoch = buffer.readLong();
         PriorityLevel priority = PriorityLevel.typeMap.get(buffer.readByte());
@@ -96,6 +102,7 @@ public class CorfuMsg {
         CorfuMsg msg = message.getConstructor().construct();
 
         msg.clientID = clientId;
+        msg.clusterID = clusterId;
         msg.requestID = requestId;
         msg.epoch = epoch;
         msg.priorityLevel = priority;
@@ -119,6 +126,15 @@ public class CorfuMsg {
             buffer.writeLong(clientID.getMostSignificantBits());
             buffer.writeLong(clientID.getLeastSignificantBits());
         }
+        if (clusterID == null) {
+            buffer.writeLong(0L);
+            buffer.writeLong(0L);
+        }
+        else {
+            buffer.writeLong(clusterID.getMostSignificantBits());
+            buffer.writeLong(clusterID.getLeastSignificantBits());
+        }
+
         buffer.writeLong(requestID);
         buffer.writeLong(epoch);
         buffer.writeByte(priorityLevel.asByte());
@@ -138,6 +154,7 @@ public class CorfuMsg {
      */
     public void copyBaseFields(CorfuMsg msg) {
         this.clientID = msg.clientID;
+        this.clusterID = msg.clusterID;
         this.epoch = msg.epoch;
         this.requestID = msg.requestID;
         this.priorityLevel = msg.priorityLevel;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -13,6 +13,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
+import java.util.UUID;
 
 /**
  * Created by mwei on 8/8/16.
@@ -21,36 +22,37 @@ import java.lang.reflect.Constructor;
 @AllArgsConstructor
 public enum CorfuMsgType {
     // Base Messages
-    PING(0, TypeToken.of(CorfuMsg.class), true),
-    PONG(1, TypeToken.of(CorfuMsg.class), true),
-    RESET(2, TypeToken.of(CorfuMsg.class), true),
-    SEAL(3, new TypeToken<CorfuPayloadMsg<Long>>() {}, true),
-    ACK(4, TypeToken.of(CorfuMsg.class), true),
-    WRONG_EPOCH(5, new TypeToken<CorfuPayloadMsg<Long>>() {},  true),
+    PING(0, TypeToken.of(CorfuMsg.class), true, true),
+    PONG(1, TypeToken.of(CorfuMsg.class), true, false),
+    RESET(2, TypeToken.of(CorfuMsg.class), true, false),
+    SEAL(3, new TypeToken<CorfuPayloadMsg<Long>>() {}, true, false),
+    ACK(4, TypeToken.of(CorfuMsg.class), true, false),
+    WRONG_EPOCH(5, new TypeToken<CorfuPayloadMsg<Long>>() {},  true, false),
     NACK(6, TypeToken.of(CorfuMsg.class)),
-    VERSION_REQUEST(7, TypeToken.of(CorfuMsg.class), true),
-    VERSION_RESPONSE(8, new TypeToken<JSONPayloadMsg<VersionInfo>>() {}, true),
-    NOT_READY(9, TypeToken.of(CorfuMsg.class), true),
+    VERSION_REQUEST(7, TypeToken.of(CorfuMsg.class), true, true),
+    VERSION_RESPONSE(8, new TypeToken<JSONPayloadMsg<VersionInfo>>() {}, true, false),
+    NOT_READY(9, TypeToken.of(CorfuMsg.class), true, false),
+    WRONG_CLUSTER_ID(28, new TypeToken<CorfuPayloadMsg<WrongClusterMsg>>(){}, true, false),
 
     // Layout Messages
-    LAYOUT_REQUEST(10, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
-    LAYOUT_RESPONSE(11, TypeToken.of(LayoutMsg.class), true),
-    LAYOUT_PREPARE(12, new TypeToken<CorfuPayloadMsg<LayoutPrepareRequest>>(){}, true),
+    LAYOUT_REQUEST(10, new TypeToken<CorfuPayloadMsg<Long>>(){}, true, true),
+    LAYOUT_RESPONSE(11, TypeToken.of(LayoutMsg.class), true, false),
+    LAYOUT_PREPARE(12, new TypeToken<CorfuPayloadMsg<LayoutPrepareRequest>>(){}, true, false),
     LAYOUT_PREPARE_REJECT(13, new TypeToken<CorfuPayloadMsg<LayoutPrepareResponse>>(){}),
-    LAYOUT_PROPOSE(14, new TypeToken<CorfuPayloadMsg<LayoutProposeRequest>>(){}, true),
+    LAYOUT_PROPOSE(14, new TypeToken<CorfuPayloadMsg<LayoutProposeRequest>>(){}, true, false),
     LAYOUT_PROPOSE_REJECT(15, new TypeToken<CorfuPayloadMsg<LayoutProposeResponse>>(){}),
-    LAYOUT_COMMITTED(16, new TypeToken<CorfuPayloadMsg<LayoutCommittedRequest>>(){}, true),
+    LAYOUT_COMMITTED(16, new TypeToken<CorfuPayloadMsg<LayoutCommittedRequest>>(){}, true, false),
     LAYOUT_QUERY(17, new TypeToken<CorfuPayloadMsg<Long>>(){}),
-    LAYOUT_BOOTSTRAP(18, new TypeToken<CorfuPayloadMsg<LayoutBootstrapRequest>>(){}, true),
-    LAYOUT_NOBOOTSTRAP(19, TypeToken.of(CorfuMsg.class), true),
+    LAYOUT_BOOTSTRAP(18, new TypeToken<CorfuPayloadMsg<LayoutBootstrapRequest>>(){}, true, true),
+    LAYOUT_NOBOOTSTRAP(19, TypeToken.of(CorfuMsg.class), true, false),
 
     // Sequencer Messages
     TOKEN_REQ(20, new TypeToken<CorfuPayloadMsg<TokenRequest>>(){}),
     TOKEN_RES(21, new TypeToken<CorfuPayloadMsg<TokenResponse>>(){}),
     BOOTSTRAP_SEQUENCER(22, new TypeToken<CorfuPayloadMsg<SequencerRecoveryMsg>>(){}),
     SEQUENCER_TRIM_REQ(23, new TypeToken<CorfuPayloadMsg<Long>>() {}),
-    SEQUENCER_METRICS_REQUEST(24, TypeToken.of(CorfuMsg.class), true),
-    SEQUENCER_METRICS_RESPONSE(25, new TypeToken<CorfuPayloadMsg<SequencerMetrics>>(){}, true),
+    SEQUENCER_METRICS_REQUEST(24, TypeToken.of(CorfuMsg.class), true, false),
+    SEQUENCER_METRICS_RESPONSE(25, new TypeToken<CorfuPayloadMsg<SequencerMetrics>>(){}, true, false),
     STREAMS_ADDRESS_REQUEST(26, new TypeToken<CorfuPayloadMsg<StreamsAddressRequest>>(){}),
     STREAMS_ADDRESS_RESPONSE(27, new TypeToken<CorfuPayloadMsg<StreamsAddressResponse>>(){}),
 
@@ -62,17 +64,17 @@ public enum CorfuMsgType {
     PREFIX_TRIM(38, new TypeToken<CorfuPayloadMsg<TrimRequest>>() {}),
     TAIL_REQUEST(41, new TypeToken<CorfuPayloadMsg<TailsRequest>>(){}),
     TAIL_RESPONSE(42, new TypeToken<CorfuPayloadMsg<TailsResponse>>(){}),
-    COMPACT_REQUEST(43, TypeToken.of(CorfuMsg.class), true),
-    FLUSH_CACHE(44, TypeToken.of(CorfuMsg.class), true),
+    COMPACT_REQUEST(43, TypeToken.of(CorfuMsg.class), true, false),
+    FLUSH_CACHE(44, TypeToken.of(CorfuMsg.class), true, false),
     TRIM_MARK_REQUEST(45, TypeToken.of(CorfuMsg.class)),
     TRIM_MARK_RESPONSE(46, new TypeToken<CorfuPayloadMsg<Long>>(){}),
-    RESET_LOGUNIT(47, new TypeToken<CorfuPayloadMsg<Long>>(){}, true),
+    RESET_LOGUNIT(47, new TypeToken<CorfuPayloadMsg<Long>>(){}, true, false),
     LOG_ADDRESS_SPACE_REQUEST(48, TypeToken.of(CorfuMsg.class)),
     LOG_ADDRESS_SPACE_RESPONSE(49, new TypeToken<CorfuPayloadMsg<StreamsAddressResponse>>(){}),
 
     WRITE_OK(50, TypeToken.of(CorfuMsg.class)),
     ERROR_TRIMMED(51, TypeToken.of(CorfuMsg.class)),
-    ERROR_OVERWRITE(52, new TypeToken<CorfuPayloadMsg<Integer>>(){}, true),
+    ERROR_OVERWRITE(52, new TypeToken<CorfuPayloadMsg<Integer>>(){}, true, false),
     ERROR_OOS(53, TypeToken.of(CorfuMsg.class)),
     ERROR_RANK(54, TypeToken.of(CorfuMsg.class)),
     ERROR_NOENTRY(55, TypeToken.of(CorfuMsg.class)),
@@ -82,41 +84,42 @@ public enum CorfuMsgType {
     ERROR_VALUE_ADOPTED(59,new TypeToken<CorfuPayloadMsg<ReadResponse>>() {}),
 
     // EXTRA CODES
-    LAYOUT_ALREADY_BOOTSTRAP(60, TypeToken.of(CorfuMsg.class), true),
-    LAYOUT_PREPARE_ACK(61, new TypeToken<CorfuPayloadMsg<LayoutPrepareResponse>>(){}, true),
-    RESTART(62, TypeToken.of(CorfuMsg.class), true),
-    KEEP_ALIVE(63, TypeToken.of(CorfuMsg.class), true),
+    LAYOUT_ALREADY_BOOTSTRAP(60, TypeToken.of(CorfuMsg.class), true, false),
+    LAYOUT_PREPARE_ACK(61, new TypeToken<CorfuPayloadMsg<LayoutPrepareResponse>>(){}, true, false),
+    RESTART(62, TypeToken.of(CorfuMsg.class), true, false),
+    KEEP_ALIVE(63, TypeToken.of(CorfuMsg.class), true, true),
 
     // Management Messages
-    MANAGEMENT_BOOTSTRAP_REQUEST(70, new TypeToken<CorfuPayloadMsg<Layout>>(){}, true),
-    MANAGEMENT_NOBOOTSTRAP_ERROR(71, TypeToken.of(CorfuMsg.class), true),
-    MANAGEMENT_ALREADY_BOOTSTRAP_ERROR(72, TypeToken.of(CorfuMsg.class), true),
-    MANAGEMENT_HEALING_DETECTED(73, new TypeToken<CorfuPayloadMsg<DetectorMsg>>(){}, true),
-    MANAGEMENT_FAILURE_DETECTED(74, new TypeToken<CorfuPayloadMsg<DetectorMsg>>(){}, true),
-    ORCHESTRATOR_REQUEST(77, new TypeToken<CorfuPayloadMsg<OrchestratorMsg>>() {}, true),
-    ORCHESTRATOR_RESPONSE(78, new TypeToken<CorfuPayloadMsg<OrchestratorResponse>>() {}, true),
-    MANAGEMENT_LAYOUT_REQUEST(79, TypeToken.of(CorfuMsg.class), true),
+    MANAGEMENT_BOOTSTRAP_REQUEST(70, new TypeToken<CorfuPayloadMsg<Layout>>(){}, true, true),
+    MANAGEMENT_NOBOOTSTRAP_ERROR(71, TypeToken.of(CorfuMsg.class), true, false),
+    MANAGEMENT_ALREADY_BOOTSTRAP_ERROR(72, TypeToken.of(CorfuMsg.class), true, false),
+    MANAGEMENT_HEALING_DETECTED(73, new TypeToken<CorfuPayloadMsg<DetectorMsg>>(){}, true, false),
+    MANAGEMENT_FAILURE_DETECTED(74, new TypeToken<CorfuPayloadMsg<DetectorMsg>>(){}, true, false),
+    ORCHESTRATOR_REQUEST(77, new TypeToken<CorfuPayloadMsg<OrchestratorMsg>>() {}, true, true),
+    ORCHESTRATOR_RESPONSE(78, new TypeToken<CorfuPayloadMsg<OrchestratorResponse>>() {}, true, false),
+    MANAGEMENT_LAYOUT_REQUEST(79, TypeToken.of(CorfuMsg.class), true, false),
 
     // Handshake Messages
-    HANDSHAKE_INITIATE(80, new TypeToken<CorfuPayloadMsg<HandshakeMsg>>() {}, true),
-    HANDSHAKE_RESPONSE(81, new TypeToken<CorfuPayloadMsg<HandshakeResponse>>() {}, true),
+    HANDSHAKE_INITIATE(80, new TypeToken<CorfuPayloadMsg<HandshakeMsg>>() {}, true, false),
+    HANDSHAKE_RESPONSE(81, new TypeToken<CorfuPayloadMsg<HandshakeResponse>>() {}, true, false),
 
     NODE_STATE_REQUEST(82, TypeToken.of(CorfuMsg.class)),
-    NODE_STATE_RESPONSE(83, new TypeToken<CorfuPayloadMsg<NodeState>>(){}, true),
+    NODE_STATE_RESPONSE(83, new TypeToken<CorfuPayloadMsg<NodeState>>(){}, true, false),
 
     FAILURE_DETECTOR_METRICS_REQUEST(84, TypeToken.of(CorfuMsg.class)),
-    FAILURE_DETECTOR_METRICS_RESPONSE(85, new TypeToken<CorfuPayloadMsg<NodeState>>(){}, true),
+    FAILURE_DETECTOR_METRICS_RESPONSE(85, new TypeToken<CorfuPayloadMsg<NodeState>>(){}, true, false),
 
     KNOWN_ADDRESS_REQUEST(86, new TypeToken<CorfuPayloadMsg<KnownAddressRequest>>() {}),
     KNOWN_ADDRESS_RESPONSE(87, new TypeToken<CorfuPayloadMsg<KnownAddressResponse>>() {}),
 
-    ERROR_SERVER_EXCEPTION(200, new TypeToken<CorfuPayloadMsg<ExceptionMsg>>() {}, true),
+    ERROR_SERVER_EXCEPTION(200, new TypeToken<CorfuPayloadMsg<ExceptionMsg>>() {}, true, false),
     ;
 
 
     public final int type;
     public final TypeToken<? extends CorfuMsg> messageType;
-    public Boolean ignoreEpoch = false;
+    public boolean ignoreEpoch = false;
+    public boolean ignoreClusterId = false;
 
     public <T> CorfuPayloadMsg<T> payloadMsg(T payload) {
         // todo:: maybe some typechecking here (performance impact?)

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WrongClusterMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/WrongClusterMsg.java
@@ -1,0 +1,39 @@
+package org.corfudb.protocols.wireprotocol;
+
+import io.netty.buffer.ByteBuf;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.UUID;
+
+/**
+ * A message sent from the server router to the client in response to
+ * the client sending an original message stamped with a clusterId that is different
+ * from the server's clusterId.
+ */
+@Builder
+@AllArgsConstructor
+@Getter
+public class WrongClusterMsg implements ICorfuPayload<WrongClusterMsg> {
+
+    /**
+     * Server's expected clusterId.
+     */
+    private final UUID serverClusterId;
+    /**
+     * ClusterId that belongs to the original client's message.
+     */
+    private final UUID clientClusterId;
+
+    public WrongClusterMsg(ByteBuf buf){
+        serverClusterId = ICorfuPayload.fromBuffer(buf, UUID.class);
+        clientClusterId = ICorfuPayload.fromBuffer(buf, UUID.class);
+    }
+
+    @Override
+    public void doSerialize(ByteBuf buf) {
+        ICorfuPayload.serialize(buf, serverClusterId);
+        ICorfuPayload.serialize(buf, clientClusterId);
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/BootstrapUtil.java
+++ b/runtime/src/main/java/org/corfudb/runtime/BootstrapUtil.java
@@ -55,7 +55,7 @@ public class BootstrapUtil {
      */
     private static void bootstrapLayoutServer(IClientRouter router, Layout layout)
             throws ExecutionException, InterruptedException, AlreadyBootstrappedException {
-        LayoutClient layoutClient = new LayoutClient(router, layout.getEpoch());
+        LayoutClient layoutClient = new LayoutClient(router, layout.getEpoch(), layout.getClusterId());
 
         try {
             CFUtils.getUninterruptibly(layoutClient.bootstrapLayout(layout),
@@ -78,7 +78,7 @@ public class BootstrapUtil {
     private static void bootstrapManagementServer(IClientRouter router, Layout layout)
             throws ExecutionException, InterruptedException, AlreadyBootstrappedException {
         ManagementClient managementClient
-                = new ManagementClient(router, layout.getEpoch());
+                = new ManagementClient(router, layout.getEpoch(), layout.getClusterId());
 
         try {
             CFUtils.getUninterruptibly(managementClient.bootstrapManagement(layout),

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -951,7 +951,7 @@ public class CorfuRuntime {
                         IClientRouter router = getRouter(s);
                         // Try to get a layout.
                         CompletableFuture<Layout> layoutFuture =
-                                new LayoutClient(router, Layout.INVALID_EPOCH).getLayout();
+                                new LayoutClient(router, Layout.INVALID_EPOCH, Layout.INVALID_CLUSTER_ID).getLayout();
                         // Wait for layout
                         Layout l = layoutFuture.get();
 

--- a/runtime/src/main/java/org/corfudb/runtime/RebootUtil.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RebootUtil.java
@@ -11,6 +11,8 @@ import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Sleep;
 
 import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Utility to Reboot a server which includes reset or restart
@@ -26,6 +28,10 @@ public class RebootUtil {
     }
 
     /**
+     * A default cluster Id for resets if none are provided by a user.
+     */
+    private static final UUID DEFAULT_CLUSTER_ID = Layout.INVALID_CLUSTER_ID;
+    /**
      * Resets the given server.
      * Attempts to reset a server finite number of times.
      * Note: reset will wipe out all existing Corfu data.
@@ -34,11 +40,14 @@ public class RebootUtil {
      * @param endpoint      endpoint of the server to reset
      * @param retries       Number of retries to bootstrap each node before giving up.
      * @param retryDuration Duration between retries.
+     * @param clusterId     Optional cluster Id. If None is provided, then the default one
+     *                      will be used to create a base client.
      */
     public static void reset(@NonNull String endpoint,
                              int retries,
-                             @NonNull Duration retryDuration) {
-        reboot(endpoint, CorfuRuntimeParameters.builder().build(), retries, retryDuration, true);
+                             @NonNull Duration retryDuration,
+                             Optional<UUID> clusterId) {
+        reboot(endpoint, CorfuRuntimeParameters.builder().build(), retries, retryDuration, true, clusterId);
     }
 
     /**
@@ -51,13 +60,16 @@ public class RebootUtil {
      * @param corfuRuntimeParameters CorfuRuntimeParameters can specify security parameters.
      * @param retries                Number of retries to bootstrap each node before giving up.
      * @param retryDuration          Duration between retries.
+     * @param clusterId              Optional cluster Id. If None is provided, then the default one
+     *                               will be used to create a base client.
      */
     public static void reset(@NonNull String endpoint,
                              @NonNull CorfuRuntimeParameters corfuRuntimeParameters,
                              int retries,
-                             @NonNull Duration retryDuration) {
+                             @NonNull Duration retryDuration,
+                             Optional<UUID> clusterId) {
 
-        reboot(endpoint, corfuRuntimeParameters, retries, retryDuration, true);
+        reboot(endpoint, corfuRuntimeParameters, retries, retryDuration, true, clusterId);
     }
 
     /**
@@ -69,12 +81,15 @@ public class RebootUtil {
      * @param endpoint      endpoint of the server to reset
      * @param retries       Number of retries to bootstrap each node before giving up.
      * @param retryDuration Duration between retries.
+     * @param clusterId     Optional cluster Id. If None is provided, then the default one
+     *                      will be used to create a base client.
      */
     public static void restart(@NonNull String endpoint,
                                int retries,
-                               @NonNull Duration retryDuration) {
+                               @NonNull Duration retryDuration,
+                               Optional<UUID> clusterId) {
 
-        reboot(endpoint, CorfuRuntimeParameters.builder().build(), retries, retryDuration, false);
+        reboot(endpoint, CorfuRuntimeParameters.builder().build(), retries, retryDuration, false, clusterId);
     }
 
     /**
@@ -87,25 +102,30 @@ public class RebootUtil {
      * @param corfuRuntimeParameters CorfuRuntimeParameters can specify security parameters.
      * @param retries                Number of retries to bootstrap each node before giving up.
      * @param retryDuration          Duration between retries.
+     * @param clusterId              Optional cluster Id. If None is provided, then the default one
+     *                               will be used to create a base client.
      */
     public static void restart(@NonNull String endpoint,
                                @NonNull CorfuRuntimeParameters corfuRuntimeParameters,
                                int retries,
-                               @NonNull Duration retryDuration) {
+                               @NonNull Duration retryDuration,
+                               Optional<UUID> clusterId) {
 
-        reboot(endpoint, corfuRuntimeParameters, retries, retryDuration, false);
+        reboot(endpoint, corfuRuntimeParameters, retries, retryDuration, false, clusterId);
     }
 
     private static void reboot(@NonNull String endpoint,
                                @NonNull CorfuRuntimeParameters corfuRuntimeParameters,
                                int retries,
                                @NonNull Duration retryDuration,
-                               boolean resetData) {
+                               boolean resetData,
+                               Optional<UUID> clusterId) {
 
         IClientRouter router = new NettyClientRouter(NodeLocator.parseString(endpoint),
                 corfuRuntimeParameters);
         router.addClient(new BaseHandler());
-        BaseClient baseClient = new BaseClient(router, Layout.INVALID_EPOCH);
+        BaseClient baseClient = new BaseClient(router, Layout.INVALID_EPOCH,
+                clusterId.orElse(DEFAULT_CLUSTER_ID));
 
         while (retries-- > 0) {
             try {

--- a/runtime/src/main/java/org/corfudb/runtime/clients/AbstractClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/AbstractClient.java
@@ -1,12 +1,12 @@
 package org.corfudb.runtime.clients;
 
-import java.util.concurrent.CompletableFuture;
-
 import lombok.Getter;
 import lombok.Setter;
-
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.PriorityLevel;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * Abstract clients stamped with an epoch to send messages stamped with the required epoch.
@@ -19,19 +19,23 @@ abstract class AbstractClient implements IClient {
     private final long epoch;
 
     @Getter
+    private final UUID clusterID;
+
+    @Getter
     @Setter
     private IClientRouter router;
 
     @Setter
     private PriorityLevel priorityLevel = PriorityLevel.NORMAL;
 
-    AbstractClient(IClientRouter router, long epoch) {
+    AbstractClient(IClientRouter router, long epoch, UUID clusterID) {
         this.router = router;
         this.epoch = epoch;
+        this.clusterID = clusterID;
     }
 
     <T> CompletableFuture<T> sendMessageWithFuture(CorfuMsg msg) {
-        return router.sendMessageAndGetCompletable(msg.setEpoch(epoch)
-                .setPriorityLevel(priorityLevel));
+        return router.sendMessageAndGetCompletable(
+                msg.setEpoch(epoch).setClusterID(clusterID).setPriorityLevel(priorityLevel));
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.clients;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import lombok.Getter;
@@ -31,9 +32,12 @@ public class BaseClient implements IClient {
 
     private final long epoch;
 
-    public BaseClient(IClientRouter router, long epoch) {
+    private final UUID clusterId;
+
+    public BaseClient(IClientRouter router, long epoch, UUID clusterId) {
         this.router = router;
         this.epoch = epoch;
+        this.clusterId = clusterId;
     }
 
     /**
@@ -58,7 +62,7 @@ public class BaseClient implements IClient {
      * @return Completable future which returns true on successful epoch set.
      */
     public CompletableFuture<Boolean> sealRemoteServer(long newEpoch) {
-        CorfuMsg msg = new CorfuPayloadMsg<>(CorfuMsgType.SEAL, newEpoch).setEpoch(epoch);
+        CorfuMsg msg = new CorfuPayloadMsg<>(CorfuMsgType.SEAL, newEpoch).setEpoch(epoch).setClusterID(clusterId);
         log.info("sealRemoteServer: send SEAL from me(clientId={}) to new epoch {}",
                 msg.getClientID(), epoch);
         return router.sendMessageAndGetCompletable(msg);
@@ -66,7 +70,7 @@ public class BaseClient implements IClient {
 
     public CompletableFuture<VersionInfo> getVersionInfo() {
         return router.sendMessageAndGetCompletable(
-                new CorfuMsg(CorfuMsgType.VERSION_REQUEST).setEpoch(epoch));
+                new CorfuMsg(CorfuMsgType.VERSION_REQUEST).setEpoch(epoch).setClusterID(clusterId));
     }
 
 
@@ -78,7 +82,7 @@ public class BaseClient implements IClient {
      */
     public CompletableFuture<Boolean> ping() {
         return router.sendMessageAndGetCompletable(
-                new CorfuMsg(CorfuMsgType.PING).setEpoch(epoch));
+                new CorfuMsg(CorfuMsgType.PING).setEpoch(epoch).setClusterID(clusterId));
     }
 
     /**
@@ -90,7 +94,7 @@ public class BaseClient implements IClient {
      */
     public CompletableFuture<Boolean> reset() {
         return router.sendMessageAndGetCompletable(new CorfuMsg(CorfuMsgType.RESET)
-                .setEpoch(epoch));
+                .setEpoch(epoch).setClusterID(clusterId));
     }
 
     /**
@@ -101,6 +105,6 @@ public class BaseClient implements IClient {
      */
     public CompletableFuture<Boolean> restart() {
         return router.sendMessageAndGetCompletable(new CorfuMsg(CorfuMsgType.RESTART)
-                .setEpoch(epoch));
+                .setEpoch(epoch).setClusterID(clusterId));
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseHandler.java
@@ -14,7 +14,9 @@ import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.ExceptionMsg;
 import org.corfudb.protocols.wireprotocol.JSONPayloadMsg;
 import org.corfudb.protocols.wireprotocol.VersionInfo;
+import org.corfudb.protocols.wireprotocol.WrongClusterMsg;
 import org.corfudb.runtime.exceptions.ServerNotReadyException;
+import org.corfudb.runtime.exceptions.WrongClusterException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 
 /**
@@ -138,5 +140,20 @@ public class BaseHandler implements IClient {
         log.warn("Server threw exception for request {}", msg.getRequestID(),
                 msg.getPayload().getThrowable());
         throw msg.getPayload().getThrowable();
+    }
+
+    /**
+     * Handle a wrong cluster id exception.
+     * @param msg Wrong cluster id exception message.
+     * @param ctx A context the message was sent under.
+     * @param r A reference to the router.
+     * @return None, throw a wrong cluster id exception.
+     */
+    @ClientHandler(type = CorfuMsgType.WRONG_CLUSTER_ID)
+    private static Object handleWrongClusterId(CorfuPayloadMsg<WrongClusterMsg> msg,
+                                               ChannelHandlerContext ctx, IClientRouter r) {
+        WrongClusterMsg wrongClusterMessage = msg.getPayload();
+        throw new WrongClusterException(wrongClusterMessage.getServerClusterId(),
+                wrongClusterMessage.getClientClusterId());
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/IHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/IHandler.java
@@ -1,5 +1,7 @@
 package org.corfudb.runtime.clients;
 
+import java.util.UUID;
+
 /**
  * Handler Clients to handle the responses form the server.
  *
@@ -12,7 +14,8 @@ public interface IHandler<C extends AbstractClient> {
      * Fetches the sender client.
      *
      * @param epoch Epoch to stamp the sender client with.
+     * @param clusterID Cluster ID the client wants to connect to.
      * @return Client.
      */
-    C getClient(long epoch);
+    C getClient(long epoch, UUID clusterID);
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.clients;
 
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nonnull;
@@ -22,8 +23,8 @@ import org.corfudb.runtime.view.Layout;
  */
 public class LayoutClient extends AbstractClient {
 
-    public LayoutClient(IClientRouter router, long epoch) {
-        super(router, epoch);
+    public LayoutClient(IClientRouter router, long epoch, UUID clusterID) {
+        super(router, epoch, clusterID);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LayoutHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LayoutHandler.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.lang.invoke.MethodHandles;
+import java.util.UUID;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -31,8 +32,8 @@ public class LayoutHandler implements IClient, IHandler<LayoutClient> {
     IClientRouter router;
 
     @Override
-    public LayoutClient getClient(long epoch) {
-        return new LayoutClient(router, epoch);
+    public LayoutClient getClient(long epoch, UUID clusterID) {
+        return new LayoutClient(router, epoch, clusterID);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -43,8 +43,8 @@ import org.corfudb.util.serializer.Serializers;
  */
 public class LogUnitClient extends AbstractClient {
 
-    public LogUnitClient(IClientRouter router, long epoch) {
-        super(router, epoch);
+    public LogUnitClient(IClientRouter router, long epoch, UUID clusterID) {
+        super(router, epoch, clusterID);
     }
 
     public String getHost() {

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitHandler.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.lang.invoke.MethodHandles;
+import java.util.UUID;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -35,8 +36,8 @@ public class LogUnitHandler implements IClient, IHandler<LogUnitClient> {
     IClientRouter router;
 
     @Override
-    public LogUnitClient getClient(long epoch) {
-        return new LogUnitClient(router, epoch);
+    public LogUnitClient getClient(long epoch, UUID clusterID) {
+        return new LogUnitClient(router, epoch, clusterID);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -35,8 +35,8 @@ import org.corfudb.util.CFUtils;
  */
 public class ManagementClient extends AbstractClient {
 
-    public ManagementClient(IClientRouter router, long epoch) {
-        super(router, epoch);
+    public ManagementClient(IClientRouter router, long epoch, UUID clusterID) {
+        super(router, epoch, clusterID);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementHandler.java
@@ -4,6 +4,7 @@ package org.corfudb.runtime.clients;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.lang.invoke.MethodHandles;
+import java.util.UUID;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -26,8 +27,8 @@ public class ManagementHandler implements IClient, IHandler<ManagementClient> {
     IClientRouter router;
 
     @Override
-    public ManagementClient getClient(long epoch) {
-        return new ManagementClient(router, epoch);
+    public ManagementClient getClient(long epoch, UUID clusterID) {
+        return new ManagementClient(router, epoch, clusterID);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -25,8 +25,8 @@ import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
  */
 public class SequencerClient extends AbstractClient {
 
-    public SequencerClient(IClientRouter router, long epoch) {
-        super(router, epoch);
+    public SequencerClient(IClientRouter router, long epoch, UUID clusterID) {
+        super(router, epoch, clusterID);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerHandler.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import io.netty.channel.ChannelHandlerContext;
 
 import java.lang.invoke.MethodHandles;
+import java.util.UUID;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -28,8 +29,8 @@ public class SequencerHandler implements IClient, IHandler<SequencerClient> {
     IClientRouter router;
 
     @Override
-    public SequencerClient getClient(long epoch) {
-        return new SequencerClient(router, epoch);
+    public SequencerClient getClient(long epoch, UUID clusterID) {
+        return new SequencerClient(router, epoch, clusterID);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -88,6 +88,12 @@ public class Layout {
      */
     public static final long INVALID_EPOCH = -1L;
 
+    /**
+     * Invalid cluster id.
+     * It is used to fetch layout by the corfu runtime.
+     */
+    public static final UUID INVALID_CLUSTER_ID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+
     /** The unique Id for the Corfu cluster represented by this layout.
      *  Should remain consistent for the lifetime of the layout. May be
      *  {@code null} in a legacy layout.

--- a/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ManagementView.java
@@ -495,7 +495,8 @@ public class ManagementView extends AbstractView {
         // Get layout futures for layout requests from all layout servers.
         for (String server : layoutServers) {
             IClientRouter router = runtime.getRouter(server);
-            layoutFuturesMap.put(server, new LayoutClient(router, Layout.INVALID_EPOCH).getLayout());
+            layoutFuturesMap.put(server, new LayoutClient(router, Layout.INVALID_EPOCH, Layout.INVALID_CLUSTER_ID)
+                    .getLayout());
         }
 
         return layoutFuturesMap;

--- a/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
@@ -21,6 +21,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -109,8 +110,9 @@ public class RuntimeLayout {
             endpointClientMap.computeIfAbsent(endpoint, s -> {
                 try {
                     Constructor<? extends IClient> ctor =
-                            clientClass.getDeclaredConstructor(IClientRouter.class, long.class);
-                    IClient inst = ctor.newInstance(getRuntime().getRouter(endpoint), layout.getEpoch());
+                            clientClass.getDeclaredConstructor(IClientRouter.class, long.class, UUID.class);
+                    IClient inst = ctor.newInstance(getRuntime()
+                            .getRouter(endpoint), layout.getEpoch(), layout.getClusterId());
                     inst.setPriorityLevel(getRuntime().getParameters().getPriorityLevel());
                     return inst;
                 } catch (NoSuchMethodException | IllegalAccessException | InstantiationException

--- a/test/src/test/java/org/corfudb/infrastructure/AbstractServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/AbstractServerTest.java
@@ -15,6 +15,8 @@ import org.corfudb.runtime.clients.SequencerHandler;
 import org.corfudb.runtime.clients.TestClientRouter;
 import org.junit.Before;
 
+import java.util.AbstractMap;
+import java.util.AbstractMap.SimpleEntry;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -50,6 +52,10 @@ public abstract class AbstractServerTest extends AbstractCorfuTest {
         router.addServer(server);
     }
 
+    public void setContext(ServerContext sc) {
+        router.setServerContext(sc);
+    }
+
     public abstract AbstractServer getDefaultServer();
 
     public <T> CompletableFuture<T> sendRequest(UUID clientId, CorfuMsg msg) {
@@ -67,6 +73,33 @@ public abstract class AbstractServerTest extends AbstractCorfuTest {
         clientRouter.setClientID(testClientId);
         return clientRouter.sendMessageAndGetCompletable(msg);
     }
+
+    public <T> CompletableFuture<T> sendRequestWithEpoch(CorfuMsg msg, long epoch) {
+        msg.setClientID(testClientId)
+                .setRequestID(requestCounter.getAndIncrement())
+                .setEpoch(epoch);
+        clientRouter.setClientID(testClientId);
+        return clientRouter.sendMessageAndGetCompletable(msg);
+    }
+
+    public <T> CompletableFuture<T> sendRequestWithClusterId(CorfuMsg msg, UUID clusterId) {
+        msg.setClientID(testClientId)
+                .setRequestID(requestCounter.getAndIncrement())
+                .setClusterID(clusterId)
+                .setEpoch(0L);
+        clientRouter.setClientID(testClientId);
+        return clientRouter.sendMessageAndGetCompletable(msg);
+    }
+
+    public <T> CompletableFuture<T> sendRequestWithClusterId(UUID clientId, CorfuMsg msg, UUID clusterId) {
+        msg.setClientID(clientId)
+                .setRequestID(requestCounter.getAndIncrement())
+                .setClusterID(clusterId)
+                .setEpoch(0L);
+        clientRouter.setClientID(clientId);
+        return clientRouter.sendMessageAndGetCompletable(msg);
+    }
+
 
     public TestClientRouter getClientRouter() {
         TestClientRouter tcn = new TestClientRouter(router);

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitCacheTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitCacheTest.java
@@ -30,13 +30,30 @@ public class LogUnitCacheTest extends AbstractServerTest {
     private static final double MAX_HEAP_RATIO = 0.9;
 
     @Override
-    public AbstractServer getDefaultServer() {
+    public LogUnitServer getDefaultServer() {
         String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
-        return new LogUnitServer(new ServerContextBuilder()
+        ServerContext sc = new ServerContextBuilder()
                 .setLogPath(serviceDir)
+                .setSingle(true)
                 .setMemory(false)
-                .build());
+                .build();
+
+        sc.installSingleNodeLayoutIfAbsent();
+        sc.setServerRouter(router);
+        sc.setServerEpoch(sc.getCurrentLayout().getEpoch(), router);
+
+        LogUnitServer s1 = new LogUnitServer(sc);
+
+        setServer(s1);
+        setContext(sc);
+        return s1;
+    }
+
+    @Override
+    public void setServer(AbstractServer server) {
+        router.reset();
+        router.addServer(server);
     }
 
     /**
@@ -48,7 +65,7 @@ public class LogUnitCacheTest extends AbstractServerTest {
         final long start = 0L;
         final long end = start + size;
 
-        LogUnitServer logUnitServer = (LogUnitServer) getDefaultServer();
+        LogUnitServer logUnitServer = getDefaultServer();
         setServer(logUnitServer);
 
         List<Long> addresses = LongStream.range(start, end).boxed().collect(Collectors.toList());

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -44,13 +44,20 @@ public class LogUnitServerTest extends AbstractServerTest {
     public void checkOverwritesFail() throws Exception {
         String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
-        LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
+        ServerContext sc = new ServerContextBuilder()
                 .setLogPath(serviceDir)
+                .setSingle(true)
                 .setMemory(false)
-                .build());
+                .build();
 
-        this.router.reset();
-        this.router.addServer(s1);
+        sc.installSingleNodeLayoutIfAbsent();
+        sc.setServerRouter(router);
+        sc.setServerEpoch(sc.getCurrentLayout().getEpoch(), router);
+
+        LogUnitServer s1 = new LogUnitServer(sc);
+
+        setServer(s1);
+        setContext(sc);
 
         final long ADDRESS_0 = 0L;
         final long ADDRESS_1 = 100L;
@@ -89,13 +96,20 @@ public class LogUnitServerTest extends AbstractServerTest {
     public void cantOpenReadOnlyLogFiles() throws Exception {
         String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
-        LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
+        ServerContext sc = new ServerContextBuilder()
                 .setLogPath(serviceDir)
+                .setSingle(true)
                 .setMemory(false)
-                .build());
+                .build();
 
-        this.router.reset();
-        this.router.addServer(s1);
+        sc.installSingleNodeLayoutIfAbsent();
+        sc.setServerRouter(router);
+        sc.setServerEpoch(sc.getCurrentLayout().getEpoch(), router);
+
+        LogUnitServer s1 = new LogUnitServer(sc);
+
+        setServer(s1);
+        setContext(sc);
 
         final long LOW_ADDRESS = 0L; final String low_payload = "0";
         final long MID_ADDRESS = 100L; final String mid_payload = "100";
@@ -134,13 +148,20 @@ public class LogUnitServerTest extends AbstractServerTest {
             throws Exception {
         String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
-        LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
+        ServerContext sc = new ServerContextBuilder()
                 .setLogPath(serviceDir)
+                .setSingle(true)
                 .setMemory(false)
-                .build());
+                .build();
 
-        this.router.reset();
-        this.router.addServer(s1);
+        sc.installSingleNodeLayoutIfAbsent();
+        sc.setServerRouter(router);
+        sc.setServerEpoch(sc.getCurrentLayout().getEpoch(), router);
+
+        LogUnitServer s1 = new LogUnitServer(sc);
+
+        setServer(s1);
+        setContext(sc);
 
         final long LOW_ADDRESS = 0L; final String low_payload = "0";
         final long MID_ADDRESS = 100L; final String mid_payload = "100";
@@ -163,8 +184,8 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .setLogPath(serviceDir)
                 .setMemory(false)
                 .build());
-        this.router.reset();
-        this.router.addServer(s2);
+
+        setServer(s2);
 
         assertThat(s2)
                 .containsDataAtAddress(LOW_ADDRESS)
@@ -193,13 +214,20 @@ public class LogUnitServerTest extends AbstractServerTest {
             throws Exception {
         String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
-        LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
+        ServerContext sc = new ServerContextBuilder()
                 .setLogPath(serviceDir)
+                .setSingle(true)
                 .setMemory(false)
-                .build());
+                .build();
 
-        this.router.reset();
-        this.router.addServer(s1);
+        sc.installSingleNodeLayoutIfAbsent();
+        sc.setServerRouter(router);
+        sc.setServerEpoch(sc.getCurrentLayout().getEpoch(), router);
+
+        LogUnitServer s1 = new LogUnitServer(sc);
+
+        setServer(s1);
+        setContext(sc);
 
         final long START_ADDRESS = 0L; final String low_payload = "0";
         final int num_iterations_very_low = PARAMETERS.NUM_ITERATIONS_VERY_LOW;
@@ -226,8 +254,8 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .setLogPath(serviceDir)
                 .setMemory(false)
                 .build());
-        this.router.reset();
-        this.router.addServer(s2);
+
+        setServer(s2);
 
         for (int i = 0; i < num_iterations_very_low; i++)
             assertThat(s2)
@@ -258,8 +286,8 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .setLogPath(serviceDir)
                 .setMemory(false)
                 .build());
-        this.router.reset();
-        this.router.addServer(s3);
+
+        setServer(s3);
 
         for (int i = 0; i < num_iterations_very_low; i++)
             assertThat(s3)
@@ -298,13 +326,20 @@ public class LogUnitServerTest extends AbstractServerTest {
         final long trimMark = 15000L;
         UUID streamID = UUID.randomUUID();
 
-        LogUnitServer logUnitServer = new LogUnitServer(new ServerContextBuilder()
+        ServerContext sc = new ServerContextBuilder()
                 .setLogPath(serviceDir)
+                .setSingle(true)
                 .setMemory(false)
-                .build());
+                .build();
 
-        this.router.reset();
-        this.router.addServer(logUnitServer);
+        sc.installSingleNodeLayoutIfAbsent();
+        sc.setServerRouter(router);
+        sc.setServerEpoch(sc.getCurrentLayout().getEpoch(), router);
+
+        LogUnitServer s1 = new LogUnitServer(sc);
+
+        setServer(s1);
+        setContext(sc);
 
         // Write 10K entries in descending order for the range 20k-10K
         CompletableFuture<Boolean> future = null;
@@ -327,7 +362,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         future.join();
 
         // Retrieve address space from current log unit server (write path)
-        StreamAddressSpace addressSpace = logUnitServer.getStreamAddressSpace(streamID);
+        StreamAddressSpace addressSpace = s1.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
         assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(minAddress + 1);
 
@@ -357,13 +392,20 @@ public class LogUnitServerTest extends AbstractServerTest {
     public void checkUnCachedWrites() throws Exception {
         String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
-        LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
+        ServerContext sc = new ServerContextBuilder()
                 .setLogPath(serviceDir)
+                .setSingle(true)
                 .setMemory(false)
-                .build());
+                .build();
 
-        this.router.reset();
-        this.router.addServer(s1);
+        sc.installSingleNodeLayoutIfAbsent();
+        sc.setServerRouter(router);
+        sc.setServerEpoch(sc.getCurrentLayout().getEpoch(), router);
+
+        LogUnitServer s1 = new LogUnitServer(sc);
+
+        setServer(s1);
+        setContext(sc);
 
         ByteBuf b = Unpooled.buffer();
         Serializers.CORFU.serialize("0".getBytes(), b);
@@ -384,8 +426,7 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .setMemory(false)
                 .build());
 
-        this.router.reset();
-        this.router.addServer(s1);
+        setServer(s1);
 
         ILogData entry = s1.getDataCache().get(globalAddress);
 
@@ -460,13 +501,20 @@ public class LogUnitServerTest extends AbstractServerTest {
     public void checkOverwriteExceptionIsNotThrownWhenTheRankIsHigher() throws Exception {
         String serviceDir = PARAMETERS.TEST_TEMP_DIR;
 
-        LogUnitServer s1 = new LogUnitServer(new ServerContextBuilder()
+        ServerContext sc = new ServerContextBuilder()
                 .setLogPath(serviceDir)
+                .setSingle(true)
                 .setMemory(false)
-                .build());
+                .build();
 
-        this.router.reset();
-        this.router.addServer(s1);
+        sc.installSingleNodeLayoutIfAbsent();
+        sc.setServerRouter(router);
+        sc.setServerEpoch(sc.getCurrentLayout().getEpoch(), router);
+
+        LogUnitServer s1 = new LogUnitServer(sc);
+
+        setServer(s1);
+        setContext(sc);
 
         final long ADDRESS_0 = 0L;
         final long ADDRESS_1 = 100L;
@@ -519,8 +567,7 @@ public class LogUnitServerTest extends AbstractServerTest {
                 .setLogPath(serviceDir)
                 .setMemory(false)
                 .build());
-        this.router.reset();
-        this.router.addServer(s2);
+        setServer(s2);
 
         assertThat(s2)
                 .containsDataAtAddress(ADDRESS_0);

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -44,7 +44,7 @@ public class ServerContextBuilder {
     String prefix = "";
     String retention = "1000";
 
-    String clusterId = "auto";
+    String clusterId = "00000000-0000-0000-0000-000000000000";
     boolean isTest = true;
 
     public ServerContextBuilder() {

--- a/test/src/test/java/org/corfudb/infrastructure/TestLayoutBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestLayoutBuilder.java
@@ -34,6 +34,7 @@ public class TestLayoutBuilder {
         layoutServers = new ArrayList<>();
         unresponsiveServers = new ArrayList<>();
         segments = new ArrayList<>();
+        clusterId = Layout.INVALID_CLUSTER_ID;
     }
 
     static String getEndpoint(int port) {
@@ -49,7 +50,7 @@ public class TestLayoutBuilder {
                 .addLogUnit(port)
                 .addToSegment()
                 .addToLayout()
-                .setClusterId(UUID.randomUUID())
+                .setClusterId(Layout.INVALID_CLUSTER_ID)
                 .build();
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -1,21 +1,20 @@
 package org.corfudb.infrastructure;
 
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
-import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.runtime.clients.TestChannelContext;
 import org.corfudb.runtime.clients.TestRule;
+import org.corfudb.runtime.view.Layout;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -31,7 +30,7 @@ public class TestServerRouter implements IServerRouter {
     public Map<CorfuMsgType, AbstractServer> handlerMap;
 
     @Getter
-    public List<AbstractServer> servers;
+    public ArrayList<AbstractServer> servers;
 
     public List<TestRule> rules;
 
@@ -39,6 +38,10 @@ public class TestServerRouter implements IServerRouter {
 
     @Getter
     long serverEpoch;
+
+    @Setter
+    @Getter
+    ServerContext serverContext;
 
     @Getter
     int port = 0;
@@ -75,11 +78,6 @@ public class TestServerRouter implements IServerRouter {
         }
     }
 
-    /**
-     * Register a server to route messages to
-     *
-     * @param server The server to route messages to
-     */
     @Override
     public void addServer(AbstractServer server) {
         servers.add(server);
@@ -90,24 +88,9 @@ public class TestServerRouter implements IServerRouter {
         });
     }
 
-    /**
-     * Validate the epoch of a CorfuMsg, and send a WRONG_EPOCH response if
-     * the server is in the wrong epoch. Ignored if the message type is reset (which
-     * is valid in any epoch).
-     *
-     * @param msg The incoming message to validate.
-     * @param ctx The context of the channel handler.
-     * @return True, if the epoch is correct, but false otherwise.
-     */
-    public boolean validateEpoch(CorfuMsg msg, ChannelHandlerContext ctx) {
-        if (!msg.getMsgType().ignoreEpoch && msg.getEpoch() != serverEpoch) {
-            sendResponse(ctx, msg, new CorfuPayloadMsg<>(CorfuMsgType.WRONG_EPOCH,
-                    getServerEpoch()));
-            log.trace("Incoming message with wrong epoch, got {}, expected {}, message was: {}",
-                    msg.getEpoch(), serverEpoch, msg);
-            return false;
-        }
-        return true;
+    @Override
+    public List<AbstractServer> getServers() {
+        return servers;
     }
 
     public void sendServerMessage(CorfuMsg msg) {
@@ -116,7 +99,7 @@ public class TestServerRouter implements IServerRouter {
 
     public void sendServerMessage(CorfuMsg msg, ChannelHandlerContext ctx) {
         AbstractServer as = handlerMap.get(msg.getMsgType());
-        if (validateEpoch(msg, ctx)) {
+        if (messageIsValid(msg, ctx)) {
             if (as != null) {
                 // refactor and move threading to handler
                 as.handleMessage(msg, ctx, this);
@@ -132,5 +115,13 @@ public class TestServerRouter implements IServerRouter {
     public void setServerEpoch(long serverEpoch) {
         this.serverEpoch = serverEpoch;
         getServers().forEach(s -> s.sealServerWithEpoch(serverEpoch));
+    }
+
+    @Override
+    public Optional<Layout> getCurrentLayout() {
+        if(getServerContext() == null) {
+            throw new IllegalStateException("ServerContext should be set.");
+        }
+        return Optional.ofNullable(getServerContext().getCurrentLayout());
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/clients/AbstractClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/AbstractClientTest.java
@@ -38,8 +38,8 @@ public abstract class AbstractClientTest extends AbstractCorfuTest {
     public void resetTest() {
         serverRouter = new TestServerRouter();
         router = new TestClientRouter(serverRouter);
-        getServersForTest().stream().forEach(serverRouter::addServer);
-        getClientsForTest().stream().forEach(router::addClient);
+        getServersForTest().forEach(serverRouter::addServer);
+        getClientsForTest().forEach(router::addClient);
     }
 
     @After

--- a/test/src/test/java/org/corfudb/runtime/clients/BaseHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/BaseHandlerTest.java
@@ -8,6 +8,7 @@ import org.corfudb.util.CFUtils;
 import org.junit.Test;
 
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Created by mwei on 7/27/16.
@@ -26,7 +27,7 @@ public class BaseHandlerTest extends AbstractClientTest {
     @Override
     Set<IClient> getClientsForTest() {
         BaseHandler baseHandler = new BaseHandler();
-        client = new BaseClient(router, 0L);
+        client = new BaseClient(router, 0L, UUID.fromString("00000000-0000-0000-0000-000000000000"));
         return new ImmutableSet.Builder<IClient>()
                 .add(baseHandler)
                 .build();

--- a/test/src/test/java/org/corfudb/runtime/clients/LayoutHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LayoutHandlerTest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.clients;
 import com.google.common.collect.ImmutableSet;
 import org.corfudb.infrastructure.AbstractServer;
 import org.corfudb.infrastructure.LayoutServer;
+import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.TestLayoutBuilder;
 import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.NoBootstrapException;
@@ -11,6 +12,7 @@ import org.corfudb.runtime.view.Layout;
 import org.junit.Test;
 
 import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -24,15 +26,17 @@ public class LayoutHandlerTest extends AbstractClientTest {
 
     @Override
     Set<AbstractServer> getServersForTest() {
+        ServerContext sc = defaultServerContext();
+        serverRouter.setServerContext(sc);
         return new ImmutableSet.Builder<AbstractServer>()
-                .add(new LayoutServer(defaultServerContext()))
+                .add(new LayoutServer(sc))
                 .build();
     }
 
     @Override
     Set<IClient> getClientsForTest() {
         LayoutHandler layoutHandler = new LayoutHandler();
-        client = new LayoutClient(router, 0L);
+        client = new LayoutClient(router, 0L, UUID.fromString("00000000-0000-0000-0000-000000000000"));
         return new ImmutableSet.Builder<IClient>()
                 .add(new BaseHandler())
                 .add(layoutHandler)

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -82,12 +82,16 @@ public class LogUnitHandlerTest extends AbstractClientTest {
     Set<AbstractServer> getServersForTest() {
         String dirPath = PARAMETERS.TEST_TEMP_DIR;
         serverContext = new ServerContextBuilder()
-                .setSingle(false)
+                .setSingle(true)
                 .setNoVerify(false)
                 .setMemory(false)
                 .setLogPath(dirPath)
                 .setServerRouter(serverRouter)
                 .build();
+
+        serverContext.installSingleNodeLayoutIfAbsent();
+        serverRouter.setServerContext(serverContext);
+        serverContext.setServerEpoch(serverContext.getCurrentLayout().getEpoch(), serverRouter);
         LogUnitServer server = new LogUnitServer(serverContext);
         return new ImmutableSet.Builder<AbstractServer>()
                 .add(server)
@@ -97,7 +101,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
     @Override
     Set<IClient> getClientsForTest() {
         LogUnitHandler logUnitHandler = new LogUnitHandler();
-        client = new LogUnitClient(router, 0L);
+        client = new LogUnitClient(router, 0L, UUID.fromString("00000000-0000-0000-0000-000000000000"));
         return new ImmutableSet.Builder<IClient>()
                 .add(new BaseHandler())
                 .add(logUnitHandler)

--- a/test/src/test/java/org/corfudb/runtime/clients/ManagementHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/ManagementHandlerTest.java
@@ -45,6 +45,7 @@ public class ManagementHandlerTest extends AbstractClientTest {
                 .setPort(SERVERS.PORT_0)
                 .build();
         server = new ManagementServer(serverContext);
+        serverRouter.setServerContext(serverContext);
         MetricRegistry metricRegistry = CorfuRuntime.getDefaultMetrics();
         return new ImmutableSet.Builder<AbstractServer>()
                 .add(server)
@@ -60,7 +61,7 @@ public class ManagementHandlerTest extends AbstractClientTest {
     @Override
     Set<IClient> getClientsForTest() {
         ManagementHandler managementHandler = new ManagementHandler();
-        client = new ManagementClient(router, 0L);
+        client = new ManagementClient(router, 0L, UUID.fromString("00000000-0000-0000-0000-000000000000"));
         return new ImmutableSet.Builder<IClient>()
                 .add(new BaseHandler())
                 .add(managementHandler)

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -1,5 +1,9 @@
 package org.corfudb.runtime.clients;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
 import lombok.Data;
@@ -25,8 +29,6 @@ import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.UUID;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * Created by mwei on 3/28/16.
  */
@@ -46,255 +48,255 @@ public class NettyCommTest extends AbstractCorfuTest {
     }
 
     private BaseClient getBaseClient(IClientRouter router) {
-        return new BaseClient(router, 0L);
+        return new BaseClient(router, 0L, UUID.fromString("00000000-0000-0000-0000-000000000000"));
     }
 
     @Test
     public void nettyServerClientPingable() throws Exception {
         runWithBaseServer(
-                (port) -> {
-                    return new NettyServerData(ServerContextBuilder.defaultContext(port));
-                },
-                (port) -> {
-                    return new NettyClientRouter("localhost", port);
-                },
-                (r, d) -> {
-                    assertThat(getBaseClient(r).pingSync())
-                            .isTrue();
-                });
+            (port) -> {
+                return new NettyServerData(ServerContextBuilder.defaultContext(port));
+            },
+            (port) -> {
+                return new NettyClientRouter("localhost", port);
+            },
+            (r, d) -> {
+                assertThat(getBaseClient(r).pingSync())
+                    .isTrue();
+            });
     }
 
     @Test
     public void nettyServerClientPingableAfterFailure() throws Exception {
         runWithBaseServer(
-                (port) -> {
-                    return new NettyServerData(ServerContextBuilder.defaultContext(port));
-                },
-                (port) -> {
-                    return new NettyClientRouter("localhost", port);
-                },
-                (r, d) -> {
-                    assertThat(getBaseClient(r).pingSync())
-                            .isTrue();
-                    d.shutdownServer();
-                    d.bootstrapServer();
+            (port) -> {
+                return new NettyServerData(ServerContextBuilder.defaultContext(port));
+            },
+            (port) -> {
+                return new NettyClientRouter("localhost", port);
+            },
+            (r, d) -> {
+                assertThat(getBaseClient(r).pingSync())
+                        .isTrue();
+                d.shutdownServer();
+                d.bootstrapServer();
 
-                    getBaseClient(r).pingSync();
-                });
+                getBaseClient(r).pingSync();
+            });
     }
 
     @Test
     public void nettyTlsNoMutualAuth() throws Exception {
         runWithBaseServer(
-                (port) -> {
-                    NettyServerData d = new NettyServerData(
-                            new ServerContextBuilder()
-                                    .setTlsEnabled(true)
-                                    .setImplementation("auto")
-                                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                                    .setTlsProtocols("TLSv1.2")
-                                    .setKeystore("src/test/resources/security/s1.jks")
-                                    .setKeystorePasswordFile("src/test/resources/security/storepass")
-                                    .setTruststore("src/test/resources/security/s1.jks")
-                                    .setTruststorePasswordFile("src/test/resources/security/storepass")
-                                    .setPort(port)
-                                    .build()
-                    );
-                    return d;
-                },
-                (port) -> new NettyClientRouter(
-                        NodeLocator.builder().host("localhost").port(port).build(),
-                        CorfuRuntimeParameters.builder()
-                                .tlsEnabled(true)
-                                .keyStore("src/test/resources/security/r1.jks")
-                                .ksPasswordFile("src/test/resources/security/storepass")
-                                .trustStore("src/test/resources/security/trust1.jks")
-                                .tsPasswordFile("src/test/resources/security/storepass")
-                                .build())
-                ,
-                (r, d) -> {
-                    assertThat(getBaseClient(r).pingSync())
-                            .isTrue();
-                });
+            (port) -> {
+                NettyServerData d = new NettyServerData(
+                    new ServerContextBuilder()
+                        .setTlsEnabled(true)
+                        .setImplementation("auto")
+                        .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                        .setTlsProtocols("TLSv1.2")
+                        .setKeystore("src/test/resources/security/s1.jks")
+                        .setKeystorePasswordFile("src/test/resources/security/storepass")
+                        .setTruststore("src/test/resources/security/s1.jks")
+                        .setTruststorePasswordFile("src/test/resources/security/storepass")
+                        .setPort(port)
+                        .build()
+                );
+                return d;
+            },
+            (port) -> new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
+                    CorfuRuntimeParameters.builder()
+                    .tlsEnabled(true)
+                    .keyStore("src/test/resources/security/r1.jks")
+                    .ksPasswordFile("src/test/resources/security/storepass")
+                    .trustStore("src/test/resources/security/trust1.jks")
+                    .tsPasswordFile("src/test/resources/security/storepass")
+                    .build())
+            ,
+            (r, d) -> {
+                assertThat(getBaseClient(r).pingSync())
+                    .isTrue();
+            });
     }
 
     @Test
     public void nettyTlsMutualAuth() throws Exception {
         runWithBaseServer(
-                (port) -> {
-                    NettyServerData d = new NettyServerData(new ServerContextBuilder()
-                            .setImplementation("auto")
-                            .setTlsEnabled(true)
-                            .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                            .setTlsProtocols("TLSv1.2")
-                            .setKeystore("src/test/resources/security/s1.jks")
-                            .setKeystorePasswordFile("src/test/resources/security/storepass")
-                            .setTruststore("src/test/resources/security/trust1.jks")
-                            .setTruststorePasswordFile("src/test/resources/security/storepass")
-                            .setTlsMutualAuthEnabled(true)
-                            .setPort(port)
-                            .build());
-                    return d;
-                },
-                (port) -> {
-                    return new NettyClientRouter(
-                            NodeLocator.builder().host("localhost").port(port).build(),
-                            CorfuRuntimeParameters.builder()
-                                    .tlsEnabled(true)
-                                    .keyStore("src/test/resources/security/r1.jks")
-                                    .ksPasswordFile("src/test/resources/security/storepass")
-                                    .trustStore("src/test/resources/security/trust1.jks")
-                                    .tsPasswordFile("src/test/resources/security/storepass")
-                                    .build());
-                },
-                (r, d) -> {
-                    assertThat(getBaseClient(r).pingSync())
-                            .isTrue();
-                });
+            (port) -> {
+            NettyServerData d = new NettyServerData(new ServerContextBuilder()
+                    .setImplementation("auto")
+                    .setTlsEnabled(true)
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s1.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/trust1.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setTlsMutualAuthEnabled(true)
+                    .setPort(port)
+                    .build());
+                return d;
+            },
+            (port) -> {
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
+                    CorfuRuntimeParameters.builder()
+                        .tlsEnabled(true)
+                        .keyStore("src/test/resources/security/r1.jks")
+                        .ksPasswordFile("src/test/resources/security/storepass")
+                        .trustStore("src/test/resources/security/trust1.jks")
+                        .tsPasswordFile("src/test/resources/security/storepass")
+                        .build());
+            },
+            (r, d) -> {
+                assertThat(getBaseClient(r).pingSync())
+                    .isTrue();
+            });
     }
 
     @Test
     public void nettyTlsUnknownServer() throws Exception {
         runWithBaseServer(
-                (port) -> {
-                    NettyServerData d = new NettyServerData(new ServerContextBuilder()
-                            .setImplementation("auto")
-                            .setTlsEnabled(true)
-                            .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                            .setTlsProtocols("TLSv1.2")
-                            .setKeystore("src/test/resources/security/s3.jks")
-                            .setKeystorePasswordFile("src/test/resources/security/storepass")
-                            .setTruststore("src/test/resources/security/trust1.jks")
-                            .setTruststorePasswordFile("src/test/resources/security/storepass")
-                            .setSaslPlainTextAuth(false)
-                            .setPort(port)
-                            .build());
-                    return d;
-                },
-                (port) -> {
-                    return new NettyClientRouter(
-                            NodeLocator.builder().host("localhost").port(port).build(),
-                            CorfuRuntimeParameters.builder()
-                                    .tlsEnabled(true)
-                                    .keyStore("src/test/resources/security/r1.jks")
-                                    .ksPasswordFile("src/test/resources/security/storepass")
-                                    .trustStore("src/test/resources/security/trust2.jks")
-                                    .tsPasswordFile("src/test/resources/security/storepass")
-                                    .build());
-                },
-                (r, d) -> {
-                    assertThat(getBaseClient(r).pingSync())
-                            .isFalse();
-                });
+            (port) -> {
+                NettyServerData d = new NettyServerData(new ServerContextBuilder()
+                    .setImplementation("auto")
+                    .setTlsEnabled(true)
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s3.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/trust1.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setSaslPlainTextAuth(false)
+                    .setPort(port)
+                    .build());
+                return d;
+            },
+            (port) -> {
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
+                    CorfuRuntimeParameters.builder()
+                        .tlsEnabled(true)
+                        .keyStore("src/test/resources/security/r1.jks")
+                        .ksPasswordFile("src/test/resources/security/storepass")
+                        .trustStore("src/test/resources/security/trust2.jks")
+                        .tsPasswordFile("src/test/resources/security/storepass")
+                        .build());
+            },
+            (r, d) -> {
+                assertThat(getBaseClient(r).pingSync())
+                    .isFalse();
+            });
     }
 
     @Test
     public void nettyTlsUnknownClient() throws Exception {
         runWithBaseServer(
-                (port) -> {
-                    NettyServerData d = new NettyServerData(new ServerContextBuilder()
-                            .setImplementation("auto")
-                            .setTlsEnabled(true)
-                            .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                            .setTlsProtocols("TLSv1.2")
-                            .setKeystore("src/test/resources/security/s1.jks")
-                            .setKeystorePasswordFile("src/test/resources/security/storepass")
-                            .setTruststore("src/test/resources/security/trust2.jks")
-                            .setTruststorePasswordFile("src/test/resources/security/storepass")
-                            .setTlsMutualAuthEnabled(true)
-                            .setPort(port)
-                            .build());
-                    return d;
-                },
-                (port) -> {
-                    return new NettyClientRouter(
-                            NodeLocator.builder().host("localhost").port(port).build(),
-                            CorfuRuntimeParameters.builder()
-                                    .tlsEnabled(true)
-                                    .keyStore("src/test/resources/security/r2.jks")
-                                    .ksPasswordFile("src/test/resources/security/storepass")
-                                    .trustStore("src/test/resources/security/trust1.jks")
-                                    .tsPasswordFile("src/test/resources/security/storepass")
-                                    .build());
-                },
-                (r, d) -> {
-                    assertThat(getBaseClient(r).pingSync())
-                            .isFalse();
-                });
+            (port) -> {
+                NettyServerData d = new NettyServerData(new ServerContextBuilder()
+                    .setImplementation("auto")
+                    .setTlsEnabled(true)
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s1.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/trust2.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setTlsMutualAuthEnabled(true)
+                    .setPort(port)
+                    .build());
+                return d;
+            },
+            (port) -> {
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
+                    CorfuRuntimeParameters.builder()
+                        .tlsEnabled(true)
+                        .keyStore("src/test/resources/security/r2.jks")
+                        .ksPasswordFile("src/test/resources/security/storepass")
+                        .trustStore("src/test/resources/security/trust1.jks")
+                        .tsPasswordFile("src/test/resources/security/storepass")
+                        .build());
+            },
+            (r, d) -> {
+                assertThat(getBaseClient(r).pingSync())
+                    .isFalse();
+            });
     }
 
     @Test
     public void nettyTlsUnknownClientNoMutualAuth() throws Exception {
         runWithBaseServer(
-                (port) -> {
-                    NettyServerData d = new NettyServerData(new ServerContextBuilder()
-                            .setImplementation("auto")
-                            .setTlsEnabled(true)
-                            .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                            .setTlsProtocols("TLSv1.2")
-                            .setKeystore("src/test/resources/security/s1.jks")
-                            .setKeystorePasswordFile("src/test/resources/security/storepass")
-                            .setTruststore("src/test/resources/security/trust2.jks")
-                            .setTruststorePasswordFile("src/test/resources/security/storepass")
-                            .setPort(port)
-                            .build());
-                    return d;
-                },
-                (port) -> {
-                    return new NettyClientRouter(
-                            NodeLocator.builder().host("localhost").port(port).build(),
-                            CorfuRuntimeParameters.builder()
-                                    .tlsEnabled(true)
-                                    .keyStore("src/test/resources/security/r2.jks")
-                                    .ksPasswordFile("src/test/resources/security/storepass")
-                                    .trustStore("src/test/resources/security/trust1.jks")
-                                    .tsPasswordFile("src/test/resources/security/storepass")
-                                    .build());
-                },
-                (r, d) -> {
-                    assertThat(getBaseClient(r).pingSync())
-                            .isTrue();
-                });
+            (port) -> {
+                NettyServerData d = new NettyServerData(new ServerContextBuilder()
+                    .setImplementation("auto")
+                    .setTlsEnabled(true)
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s1.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/trust2.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setPort(port)
+                    .build());
+                return d;
+            },
+            (port) -> {
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
+                    CorfuRuntimeParameters.builder()
+                        .tlsEnabled(true)
+                        .keyStore("src/test/resources/security/r2.jks")
+                        .ksPasswordFile("src/test/resources/security/storepass")
+                        .trustStore("src/test/resources/security/trust1.jks")
+                        .tsPasswordFile("src/test/resources/security/storepass")
+                        .build());
+            },
+            (r, d) -> {
+                assertThat(getBaseClient(r).pingSync())
+                    .isTrue();
+            });
     }
 
     @Test
     public void nettySasl() throws Exception {
         runWithBaseServer(
-                (port) -> {
-                    System.setProperty("java.security.auth.login.config",
-                            "src/test/resources/security/corfudb_jaas.config");
-                    NettyServerData d = new NettyServerData(new ServerContextBuilder()
-                            .setImplementation("auto")
-                            .setTlsEnabled(true)
-                            .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                            .setTlsProtocols("TLSv1.2")
-                            .setKeystore("src/test/resources/security/s1.jks")
-                            .setKeystorePasswordFile("src/test/resources/security/storepass")
-                            .setTruststore("src/test/resources/security/trust1.jks")
-                            .setTruststorePasswordFile("src/test/resources/security/storepass")
-                            .setSaslPlainTextAuth(true)
-                            .setPort(port)
-                            .build());
-                    return d;
-                },
-                (port) -> {
-                    return new NettyClientRouter(
-                            NodeLocator.builder().host("localhost").port(port).build(),
-                            CorfuRuntimeParameters.builder()
-                                    .tlsEnabled(true)
-                                    .keyStore("src/test/resources/security/r1.jks")
-                                    .ksPasswordFile("src/test/resources/security/storepass")
-                                    .trustStore("src/test/resources/security/trust1.jks")
-                                    .tsPasswordFile("src/test/resources/security/storepass")
-                                    .saslPlainTextEnabled(true)
-                                    .usernameFile("src/test/resources/security/username1")
-                                    .passwordFile("src/test/resources/security/userpass1")
-                                    .build());
-                },
-                (r, d) -> {
-                    assertThat(getBaseClient(r).pingSync())
-                            .isTrue();
-                });
+            (port) -> {
+                System.setProperty("java.security.auth.login.config",
+                    "src/test/resources/security/corfudb_jaas.config");
+                NettyServerData d = new NettyServerData(new ServerContextBuilder()
+                    .setImplementation("auto")
+                    .setTlsEnabled(true)
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s1.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/trust1.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setSaslPlainTextAuth(true)
+                    .setPort(port)
+                    .build());
+                return d;
+            },
+            (port) -> {
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
+                    CorfuRuntimeParameters.builder()
+                        .tlsEnabled(true)
+                        .keyStore("src/test/resources/security/r1.jks")
+                        .ksPasswordFile("src/test/resources/security/storepass")
+                        .trustStore("src/test/resources/security/trust1.jks")
+                        .tsPasswordFile("src/test/resources/security/storepass")
+                        .saslPlainTextEnabled(true)
+                        .usernameFile("src/test/resources/security/username1")
+                        .passwordFile("src/test/resources/security/userpass1")
+                        .build());
+            },
+            (r, d) -> {
+                assertThat(getBaseClient(r).pingSync())
+                    .isTrue();
+            });
     }
 
     @Test
@@ -365,41 +367,41 @@ public class NettyCommTest extends AbstractCorfuTest {
     @Test
     public void nettySaslWrongPassword() throws Exception {
         runWithBaseServer(
-                (port) -> {
-                    System.setProperty("java.security.auth.login.config",
-                            "src/test/resources/security/corfudb_jaas.config");
-                    NettyServerData d = new NettyServerData(new ServerContextBuilder()
-                            .setImplementation("auto")
-                            .setTlsEnabled(true)
-                            .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                            .setTlsProtocols("TLSv1.2")
-                            .setKeystore("src/test/resources/security/s1.jks")
-                            .setKeystorePasswordFile("src/test/resources/security/storepass")
-                            .setTruststore("src/test/resources/security/trust1.jks")
-                            .setTruststorePasswordFile("src/test/resources/security/storepass")
-                            .setSaslPlainTextAuth(true)
-                            .setPort(port)
-                            .build());
-                    return d;
-                },
-                (port) -> {
-                    return new NettyClientRouter(
-                            NodeLocator.builder().host("localhost").port(port).build(),
-                            CorfuRuntimeParameters.builder()
-                                    .tlsEnabled(true)
-                                    .keyStore("src/test/resources/security/r1.jks")
-                                    .ksPasswordFile("src/test/resources/security/storepass")
-                                    .trustStore("src/test/resources/security/trust1.jks")
-                                    .tsPasswordFile("src/test/resources/security/storepass")
-                                    .saslPlainTextEnabled(true)
-                                    .usernameFile("src/test/resources/security/username1")
-                                    .passwordFile("src/test/resources/security/userpass2")
-                                    .build());
-                },
-                (r, d) -> {
-                    assertThat(getBaseClient(r).pingSync())
-                            .isFalse();
-                });
+            (port) -> {
+                System.setProperty("java.security.auth.login.config",
+                    "src/test/resources/security/corfudb_jaas.config");
+                NettyServerData d = new NettyServerData(new ServerContextBuilder()
+                    .setImplementation("auto")
+                    .setTlsEnabled(true)
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s1.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/trust1.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setSaslPlainTextAuth(true)
+                    .setPort(port)
+                    .build());
+                return d;
+            },
+            (port) -> {
+                return new NettyClientRouter(
+                    NodeLocator.builder().host("localhost").port(port).build(),
+                    CorfuRuntimeParameters.builder()
+                        .tlsEnabled(true)
+                        .keyStore("src/test/resources/security/r1.jks")
+                        .ksPasswordFile("src/test/resources/security/storepass")
+                        .trustStore("src/test/resources/security/trust1.jks")
+                        .tsPasswordFile("src/test/resources/security/storepass")
+                        .saslPlainTextEnabled(true)
+                        .usernameFile("src/test/resources/security/username1")
+                        .passwordFile("src/test/resources/security/userpass2")
+                        .build());
+            },
+            (r, d) -> {
+                assertThat(getBaseClient(r).pingSync())
+                    .isFalse();
+            });
     }
 
     @Test
@@ -415,7 +417,6 @@ public class NettyCommTest extends AbstractCorfuTest {
     /**
      * Create a trust store that will fail the SSL handshake, check if fails,
      * then replace it, and check if pass.
-     *
      * @param replaceClientTrust
      * @throws Exception
      */
@@ -439,31 +440,31 @@ public class NettyCommTest extends AbstractCorfuTest {
 
 
         NettyServerData serverData = new NettyServerData(
-                new ServerContextBuilder()
-                        .setImplementation("auto")
-                        .setTlsEnabled(true)
-                        .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                        .setTlsProtocols("TLSv1.2")
-                        .setKeystore("src/test/resources/security/reload/server_key.jks")
-                        .setKeystorePasswordFile("src/test/resources/security/reload/password")
-                        .setTruststore(serverTrustFile.getAbsolutePath())
-                        .setTruststorePasswordFile("src/test/resources/security/reload/password")
-                        .setTlsMutualAuthEnabled(true)
-                        .setPort(port)
-                        .build()
+            new ServerContextBuilder()
+                .setImplementation("auto")
+                .setTlsEnabled(true)
+                .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                .setTlsProtocols("TLSv1.2")
+                .setKeystore("src/test/resources/security/reload/server_key.jks")
+                .setKeystorePasswordFile("src/test/resources/security/reload/password")
+                .setTruststore(serverTrustFile.getAbsolutePath())
+                .setTruststorePasswordFile("src/test/resources/security/reload/password")
+                .setTlsMutualAuthEnabled(true)
+                .setPort(port)
+                .build()
         );
         serverData.bootstrapServer();
 
 
         NettyClientRouter clientRouter = new NettyClientRouter(
-                NodeLocator.builder().host("localhost").port(port).build(),
-                CorfuRuntimeParameters.builder()
-                        .tlsEnabled(true)
-                        .keyStore("src/test/resources/security/reload/client_key.jks")
-                        .ksPasswordFile("src/test/resources/security/reload/password")
-                        .trustStore(clientTrustFile.getAbsolutePath())
-                        .tsPasswordFile("src/test/resources/security/reload/password")
-                        .build());
+            NodeLocator.builder().host("localhost").port(port).build(),
+            CorfuRuntimeParameters.builder()
+                .tlsEnabled(true)
+                .keyStore("src/test/resources/security/reload/client_key.jks")
+                .ksPasswordFile("src/test/resources/security/reload/password")
+                .trustStore(clientTrustFile.getAbsolutePath())
+                .tsPasswordFile("src/test/resources/security/reload/password")
+                .build());
 
         assertThat(getBaseClient(clientRouter).pingSync()).isFalse();
         clientRouter.stop();
@@ -507,9 +508,7 @@ public class NettyCommTest extends AbstractCorfuTest {
             throw ex;
         } finally {
             try {
-                if (ncr != null) {
-                    ncr.stop();
-                }
+                if (ncr != null) {ncr.stop();}
             } catch (Exception ex) {
                 log.warn("Error shutting down client...", ex);
             }
@@ -548,17 +547,18 @@ public class NettyCommTest extends AbstractCorfuTest {
 
         void bootstrapServer() {
             BaseServer baseServer = new BaseServer(serverContext);
-            NettyServerRouter nsr = new NettyServerRouter(Collections.singletonList(baseServer));
+            NettyServerRouter nsr = new NettyServerRouter(ImmutableList.of(baseServer),
+                    serverContext);
             CorfuServerNode corfuServerNode = new CorfuServerNode(serverContext,
-                    Collections.singletonMap(BaseServer.class, baseServer));
+                    ImmutableMap.of(BaseServer.class, baseServer));
             f = corfuServerNode.bindServer(serverContext.getBossGroup(),
                     serverContext.getWorkerGroup(),
                     corfuServerNode::configureBootstrapOptions,
                     serverContext,
                     nsr,
                     address,
-                    Integer.parseInt((String) serverContext
-                            .getServerConfig().get("<port>")));
+                    Integer.parseInt((String)serverContext
+                        .getServerConfig().get("<port>")));
         }
 
         void shutdownServer() {

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouterTest.java
@@ -8,6 +8,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +30,7 @@ public class TestClientRouterTest extends AbstractCorfuTest {
         tcr = new TestClientRouter(tsr);
         BaseHandler baseHandler = new BaseHandler();
         tcr.addClient(baseHandler);
-        bc = new BaseClient(tcr, 0L);
+        bc = new BaseClient(tcr, 0L, UUID.fromString("00000000-0000-0000-0000-000000000000"));
 
     }
 

--- a/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
@@ -32,6 +32,7 @@ import org.corfudb.util.serializer.Serializers;
 import org.junit.jupiter.api.Assertions;
 import org.rocksdb.Env;
 import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.SstFileManager;
 
@@ -65,7 +66,7 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
 
     public DiskBackedCorfuClientTest() {
         AbstractViewTest.initEventGroup();
-        super.resetTests();
+        resetTests();
     }
 
     @Override
@@ -145,6 +146,12 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
             getDefaultRuntime().getObjectsView().TXEnd();
         }
 
+    }
+
+    @Override
+    public void resetTests() {
+        RocksDB.loadLibrary();
+        super.resetTests();
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -505,6 +505,12 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
             this.serverRouter.addServer(layoutServer);
             this.serverRouter.addServer(logUnitServer);
             this.serverRouter.addServer(managementServer);
+            serverContext.setServerRouter(this.serverRouter);
+            this.serverRouter.setServerContext(this.serverContext);
+            if(serverContext.isSingleNodeSetup() && serverContext.getCurrentLayout() != null){
+                serverContext.setServerEpoch(serverContext.getCurrentLayout().getEpoch(),
+                        this.serverRouter);
+            }
         }
 
         TestServer(int port) {

--- a/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/LayoutViewTest.java
@@ -85,11 +85,23 @@ public class LayoutViewTest extends AbstractViewTest {
             .addLogUnit(SERVERS.PORT_0)
             .addToSegment()
             .addToLayout()
-            .setClusterId(UUID.nameUUIDFromBytes("wrong cluster".getBytes()))
+            .setClusterId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
             .build();
         r.getLayoutView().getRuntimeLayout(l).sealMinServerSet();
         r.invalidateLayout();
-        assertThatThrownBy(() -> r.getLayoutView().updateLayout(l, 1L))
+        Layout l2 = new TestLayoutBuilder()
+                .setEpoch(1)
+                .addLayoutServer(SERVERS.PORT_0)
+                .addSequencer(SERVERS.PORT_0)
+                .buildSegment()
+                .buildStripe()
+                .addLogUnit(SERVERS.PORT_0)
+                .addToSegment()
+                .addToLayout()
+                .setClusterId(UUID.fromString("00000000-0000-0000-0000-000000000001"))
+                .build();
+
+        assertThatThrownBy(() -> r.getLayoutView().updateLayout(l2, 1L))
             .isInstanceOf(WrongClusterException.class);
     }
 


### PR DESCRIPTION
## Overview

Description:
This is a bug fix to prevent writes from happening to the non bootstrapped corfu server. 

Why should this be merged: 
We had this bug happening a couple of times in production for the following scenario:
1) The node belongs to cluster A.
2) The node is getting reset to join to cluster B.
3) Some client, who used a cluster A in the past, writes a record stamped with epoch 0 to the log unit.
4) The node is getting reset to join a cluster B.
5) Although the routers of this node are reset, the packet comes out of limbo (either because it got stuck in the netty caches or just delayed during routing), gets accepted to the node's log unit *before* the node is bootstrapped with a new layout of cluster B.
6) Since the default sealed epoch is still the same (0), the record goes through the batch processor and gets written finally in the stream log.
7) As you may have guessed, this creates data inconsistency that usually manifests itself in the broken state transfer or corrupted data.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
