### PR TITLE
VmManager findVm - cache a vm, don't search each time

### DIFF
--- a/it/src/main/java/org/corfudb/universe/universe/vm/VmManager.java
+++ b/it/src/main/java/org/corfudb/universe/universe/vm/VmManager.java
@@ -218,7 +218,9 @@ public class VmManager {
 
         // Find the template machine in the inventory and clone/create the vm from vmTemplate
         return getVm(universeParams.getTemplateVMName()).flatMap(vmTemplate -> {
-            log.info("Cloning the VM {} via vSphere {}", vmName, universeParams.getVSphereUrl());
+            log.info("Cloning the VM: {} via vSphere: {}, template: {}",
+                    vmName, universeParams.getVSphereUrl(), universeParams.getTemplateVMName()
+            );
 
             Properties vmPropsResult = VmConfigPropertiesLoader
                     .loadVmProperties()


### PR DESCRIPTION
## Overview

Description:
Searching a vm via ViJava has a bug, after some time it gets broken.
Caching helps to avoid that error.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
