### PR TITLE
Do not log empty secondary indexes when creating CorfuTable.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -100,8 +100,12 @@ public class CorfuTable<K ,V> implements
             indexSpec.add(index);
         });
 
-        log.info("CorfuTable: creating CorfuTable with the following indexes: {}",
-                secondaryIndexes.keySet());
+        if (!secondaryIndexes.isEmpty()) {
+            log.info(
+                "CorfuTable: creating CorfuTable with the following indexes: {}",
+                secondaryIndexes.keySet()
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## Overview

Description: When there are no secondary indexes, this log message is unnecessary.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
