### PR TITLE
Remove Parallel Stream

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -446,16 +446,14 @@ public class CorfuTable<K ,V> implements
     @Override
     @Accessor
     public @Nonnull Set<K> keySet() {
-        return mainMap.entryStream().map(Entry::getKey)
-                .collect(ImmutableSet.toImmutableSet());
+        return mainMap.keySet().stream().collect(ImmutableSet.toImmutableSet());
     }
 
     /** {@inheritDoc} */
     @Override
     @Accessor
     public @Nonnull Collection<V> values() {
-        return mainMap.entryStream().map(Entry::getValue)
-                .collect(ImmutableSet.toImmutableSet());
+        return mainMap.values().stream().collect(ImmutableSet.toImmutableSet());
     }
 
     /**


### PR DESCRIPTION
## Overview
Changed CorfuTable to not use entryStream to implement values()
and keySet().

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
