### PR TITLE
CorfuStore: Add epoch, CLEAR to streaming API

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamListener.java
@@ -5,7 +5,7 @@ package org.corfudb.runtime.collections;
  *
  * Created by hisundar on 2019-10-18
  */
-public interface StreamListener {
+public interface StreamListener{
     /**
      * A corfu update can/may have multiple updates belonging to different streams.
      * This callback will return those updates as a list grouped by their Stream UUIDs.
@@ -21,22 +21,4 @@ public interface StreamListener {
      * @param throwable
      */
     void onError(Throwable throwable);
-
-    /**
-     * Return if two streamer objects are equal.
-     * This is to allow CorfuStore may have to put these callback objects into a Set or Map.
-     */
-    boolean equals(StreamListener o);
-
-    /**
-     * Return a unique integer representing this StreamListener
-     * This is to allow CorfuStore may have to put these callback objects into a Set or Map.
-     */
-    int hashCode();
-
-    /**
-     * Return a human readable string representing this StreamListener.
-     * Log messages within CorfuStore will use this to identify different StreamListeners.
-     */
-    String toString();
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamListener.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamListener.java
@@ -32,7 +32,7 @@ public interface StreamListener {
      * Return a unique integer representing this StreamListener
      * This is to allow CorfuStore may have to put these callback objects into a Set or Map.
      */
-    int hashcode();
+    int hashCode();
 
     /**
      * Return a human readable string representing this StreamListener.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingSubscriptionContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingSubscriptionContext.java
@@ -183,6 +183,7 @@ public class StreamingSubscriptionContext {
             }
 
             MultiObjectSMREntry multiObjSMREntry = (MultiObjectSMREntry) logData.getPayload(runtime);
+            long epoch = logData.getEpoch();
             //Build the CorfuStreamEntries from the MultiObjectSMREntry.
             CorfuStreamEntries update = new CorfuStreamEntries(multiObjSMREntry.getEntryMap()
                     .entrySet()
@@ -193,6 +194,7 @@ public class StreamingSubscriptionContext {
                         e -> e.getValue().getUpdates()
                                 .stream()
                                 .map(smrEntry -> CorfuStreamEntry.fromSMREntry(smrEntry,
+                                            epoch,
                                             tablesOfInterest.get(e.getKey()).getKeyClass(),
                                             tablesOfInterest.get(e.getKey()).getPayloadClass(),
                                             tablesOfInterest.get(e.getKey()).getMetadataClass()))

--- a/test/src/test/java/org/corfudb/integration/StreamingIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingIT.java
@@ -89,7 +89,7 @@ public class StreamingIT extends AbstractIT {
         }
 
         @Override
-        public int hashcode() {
+        public int hashCode() {
             return name.hashCode();
         }
 

--- a/test/src/test/java/org/corfudb/integration/StreamingIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingIT.java
@@ -84,7 +84,7 @@ public class StreamingIT extends AbstractIT {
         }
 
         @Override
-        public boolean equals(StreamListener o) {
+        public boolean equals(Object o) {
             return this.hashCode() == o.hashCode();
         }
 
@@ -177,6 +177,8 @@ public class StreamingIT extends AbstractIT {
         CorfuStreamEntries update = updates.getLast();
         assertThat(update.getEntries().size() == 1).isTrue();
         List<CorfuStreamEntry> entry = update.getEntries().values().stream().findFirst().get();
+        assertThat(entry.get(0).getAddress()).isGreaterThan(0L);
+        assertThat(entry.get(0).getEpoch()).isEqualTo(0L);
         assertThat(entry.size() == 1).isTrue();
         assertThat(entry.get(0).getOperation().equals(CorfuStreamEntry.OperationType.DELETE)).isTrue();
         assertThat(entry.get(0).getKey().equals(uuid0)).isTrue();
@@ -306,7 +308,19 @@ public class StreamingIT extends AbstractIT {
             assertThat(entry.get(0).getMetadata()).isEqualTo(uuid);
         }
 
+        // Now clear a table and make sure that the clear gets propogated
+        n1t1.clear();
+
+        // After a brief pause validate that the listener obtains the clear() table SRM update.
+        TimeUnit.SECONDS.sleep(1);
+        updates = s1n1t1.getUpdates();
+        assertThat(updates.size()).isGreaterThan(0);
+        {
+            CorfuStreamEntries update = updates.get(updates.size() - 1);
+            List<CorfuStreamEntry> entry = update.getEntries().values().stream().findFirst().get();
+            assertThat(entry.get(0).getOperation()).isEqualTo(CorfuStreamEntry.OperationType.CLEAR);
+        }
+
         assertThat(shutdownCorfuServer(corfuServer)).isTrue();
     }
-
 }


### PR DESCRIPTION
Consumers of the streaming api need the epoch to
reconstruct the token that represents a Corfu snapshot. 
So modify streaming api to support epoch info too.

Table.clear() is a supported UFO operation.
This must be sent to streaming api too so that it can be handled appropriately.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
