### PR TITLE
Retain caller's context when unwrapping exceptions

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -359,7 +359,7 @@ public class LogUnitServer extends AbstractServer {
             if (ce.getCause() instanceof WrongEpochException) {
                 // The BaseServer expects to observe this exception,
                 // when it happens, so it needs to be unwrapped
-                throw (WrongEpochException) ce.getCause();
+                throw (WrongEpochException) Utils.extractCauseWithCompleteStacktrace(ce);
             }
         }
         log.info("LogUnit sealServerWithEpoch: sealed and flushed with epoch {}", epoch);

--- a/it/src/main/java/org/corfudb/universe/universe/docker/FakeDns.java
+++ b/it/src/main/java/org/corfudb/universe/universe/docker/FakeDns.java
@@ -3,6 +3,8 @@ package org.corfudb.universe.universe.docker;
 import com.google.common.base.Throwables;
 import com.google.common.net.InetAddresses;
 
+import org.corfudb.util.Utils;
+
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -137,7 +139,7 @@ public class FakeDns {
                 method.setAccessible(true);
                 return (InetAddress[]) method.invoke(fallbackNameService, host);
             } catch (ReflectiveOperationException | NoSuchElementException | SecurityException e) {
-                Throwables.propagateIfPossible(e.getCause(), UnknownHostException.class);
+                Throwables.propagateIfPossible(Utils.extractCauseWithCompleteStacktrace(e), UnknownHostException.class);
                 throw new AssertionError("unexpected reflection issue", e);
             }
         }
@@ -163,7 +165,7 @@ public class FakeDns {
                 method.setAccessible(true);
                 return (String) method.invoke(fallbackNameService, (Object) addr);
             } catch (ReflectiveOperationException | NoSuchElementException | SecurityException e) {
-                Throwables.propagateIfPossible(e.getCause(), UnknownHostException.class);
+                Throwables.propagateIfPossible(Utils.extractCauseWithCompleteStacktrace(e), UnknownHostException.class);
                 throw new AssertionError("unexpected reflection issue", e);
             }
         }

--- a/runtime/src/main/java/org/corfudb/runtime/ViewsGarbageCollector.java
+++ b/runtime/src/main/java/org/corfudb/runtime/ViewsGarbageCollector.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.util.Utils;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.concurrent.Executors;
@@ -86,7 +87,7 @@ public class ViewsGarbageCollector {
                     endTs - startTs, runtime.getObjectsView().getObjectCache().size(), trimMark);
         } catch (Exception e) {
             if (e.getCause() instanceof InterruptedException) {
-                throw new UnrecoverableCorfuInterruptedError((InterruptedException) e.getCause());
+                throw new UnrecoverableCorfuInterruptedError((InterruptedException) Utils.extractCauseWithCompleteStacktrace(e));
             } else {
                 log.error("Encountered an error while running runtime GC", e);
             }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -60,6 +60,7 @@ import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Sleep;
+import org.corfudb.util.Utils;
 
 
 /**
@@ -413,7 +414,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
             return f;
         } catch (ExecutionException ee) {
             CompletableFuture<T> f = new CompletableFuture<>();
-            f.completeExceptionally(ee.getCause());
+            f.completeExceptionally(Utils.extractCauseWithCompleteStacktrace(ee));
             return f;
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -14,6 +14,7 @@ import org.corfudb.runtime.exceptions.ServerNotReadyException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.util.Sleep;
+import org.corfudb.util.Utils;
 
 /**
  * All views inherit from AbstractView.
@@ -84,15 +85,16 @@ public abstract class AbstractView {
             // If an error or an unchecked exception is thrown by the layout.get() completable
             // future, the exception will materialize as an ExecutionException. In that case,
             // we need to propagate this Error or unchecked exception.
-            if (ex.getCause() instanceof Error) {
+            final Throwable cause = Utils.extractCauseWithCompleteStacktrace(ex);
+            if (cause instanceof Error) {
                 log.error("getLayoutUninterruptibly: Encountered error. Aborting layoutHelper", ex);
-                throw (Error) ex.getCause();
+                throw (Error) cause;
             }
 
-            if (ex.getCause() instanceof RuntimeException) {
+            if (cause instanceof RuntimeException) {
                 log.error("getLayoutUninterruptibly: Encountered unchecked exception. "
                         + "Aborting layoutHelper", ex);
-                throw (RuntimeException) ex.getCause();
+                throw (RuntimeException) cause;
             }
 
             log.error("getLayoutUninterruptibly: Encountered exception while fetching layout");

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -397,7 +397,7 @@ public class AddressSpaceView extends AbstractView {
             // Guava wraps the exceptions thrown from the lower layers, therefore
             // we need to unwrap them before throwing them to the upper layers that
             // don't understand the guava exceptions
-            Throwable cause = e.getCause();
+            final Throwable cause = Utils.extractCauseWithCompleteStacktrace(e);
             if (cause instanceof RuntimeException) {
                 throw (RuntimeException) cause;
             } else {
@@ -486,7 +486,7 @@ public class AddressSpaceView extends AbstractView {
                                 try {
                                     return future.join();
                                 } catch (CompletionException ex) {
-                                    Throwable cause = ex.getCause();
+                                    final Throwable cause = Utils.extractCauseWithCompleteStacktrace(ex);
                                     if (cause instanceof RuntimeException) {
                                         throw (RuntimeException) cause;
                                     } else {

--- a/runtime/src/main/java/org/corfudb/runtime/view/QuorumFuturesFactory.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/QuorumFuturesFactory.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeoutException;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
+import org.corfudb.util.Utils;
 
 /**
  * Factory for custom futures used by the quorum replication.
@@ -153,7 +154,7 @@ public class QuorumFuturesFactory {
                                 try {
                                     futures[i].get(); // this will throw the ExecutionException
                                 } catch (ExecutionException e) {
-                                    Throwable t = e.getCause();
+                                    Throwable t = Utils.extractCauseWithCompleteStacktrace(e);
                                     throwables.add(t);
                                     if (failFastThrowables.contains(t.getClass())) {
                                         done = canceled = true;

--- a/runtime/src/main/java/org/corfudb/runtime/view/SealServersHelper.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SealServersHelper.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.util.CFUtils;
+import org.corfudb.util.Utils;
 
 /**
  * Helper class to seal requested servers.
@@ -135,7 +136,7 @@ public class SealServersHelper {
             throw new UnrecoverableCorfuInterruptedError("Sealing interrupted", ie);
         } catch (ExecutionException e) {
             if (e.getCause() instanceof QuorumUnreachableException) {
-                throw (QuorumUnreachableException) e.getCause();
+                throw (QuorumUnreachableException) Utils.extractCauseWithCompleteStacktrace(e);
             }
         }
 

--- a/runtime/src/main/java/org/corfudb/util/CFUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/CFUtils.java
@@ -1,7 +1,6 @@
 package org.corfudb.util;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 
 import java.time.Duration;

--- a/runtime/src/main/java/org/corfudb/util/CFUtils.java
+++ b/runtime/src/main/java/org/corfudb/util/CFUtils.java
@@ -1,6 +1,7 @@
 package org.corfudb.util;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 
 import java.time.Duration;
@@ -55,19 +56,20 @@ public final class CFUtils {
         } catch (InterruptedException e) {
             throw new UnrecoverableCorfuInterruptedError("Interrupted while completing future", e);
         } catch (ExecutionException ee) {
-            if (throwableA.isInstance(ee.getCause())) {
-                throw (A) ee.getCause();
+            final Throwable cause = Utils.extractCauseWithCompleteStacktrace(ee);
+            if (throwableA.isInstance(cause)) {
+                throw (A) cause;
             }
-            if (throwableB.isInstance(ee.getCause())) {
-                throw (B) ee.getCause();
+            if (throwableB.isInstance(cause)) {
+                throw (B) cause;
             }
-            if (throwableC.isInstance(ee.getCause())) {
-                throw (C) ee.getCause();
+            if (throwableC.isInstance(cause)) {
+                throw (C) cause;
             }
-            if (throwableD.isInstance(ee.getCause())) {
-                throw (D) ee.getCause();
+            if (throwableD.isInstance(cause)) {
+                throw (D) cause;
             }
-            throw new RuntimeException(ee.getCause());
+            throw new RuntimeException(cause);
         }
     }
 
@@ -201,7 +203,7 @@ public final class CFUtils {
 
         Throwable unwrapThrowable = throwable;
         if (throwable instanceof ExecutionException || throwable instanceof CompletionException) {
-            unwrapThrowable = throwable.getCause();
+            unwrapThrowable = Utils.extractCauseWithCompleteStacktrace(throwable);
         }
 
         if (throwableA.isInstance(unwrapThrowable)) {

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -6,6 +6,7 @@ import jdk.internal.org.objectweb.asm.util.Textifier;
 import jdk.internal.org.objectweb.asm.util.TraceMethodVisitor;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.apache.commons.lang3.ArrayUtils;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.CorfuRuntime;
@@ -237,6 +238,20 @@ public class Utils {
         }
 
         return aggregateLogAddressSpace(luResponses);
+    }
+
+    public static Throwable extractCauseWithCompleteStacktrace(Throwable throwable) {
+        final Throwable cause = throwable.getCause();
+        if (cause == null) {
+            return cause;
+        }
+
+        final StackTraceElement[] entireStackTrace = ArrayUtils.addAll(
+            throwable.getStackTrace(),
+            cause.getStackTrace()
+        );
+        cause.setStackTrace(entireStackTrace);
+        return cause;
     }
 
     static StreamsAddressResponse aggregateLogAddressSpace(Set<StreamsAddressResponse> responses) {

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -247,8 +247,8 @@ public class Utils {
      * exception's stack trace. Prevents losing caller context
      *
      * @param throwable the Throwable to extract the causing Throwable from
-     * @return causing Throwable of the input {@code throwable} with the outer throwable's stack trace prepended,
-     *         {@code null} if no causing exception
+     * @return causing Throwable of the input {@code throwable} with the outer throwable's
+     *         stack trace prepended, {@code null} if no causing exception
      */
     public static Throwable extractCauseWithCompleteStacktrace(Throwable throwable) {
         final Throwable cause = throwable.getCause();
@@ -269,7 +269,9 @@ public class Utils {
             // Note: Stacktrace might be immutable
             cause.setStackTrace(entireStackTrace);
         } catch (Exception e) {
-            log.info("Failed to append outer throwable's stacktrace to causing throwable's stack trace", e);
+            log.info("Failed to append outer throwable's stacktrace to "
+                        + "causing throwable's stack trace",
+                     e);
         }
         return cause;
     }

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -1,24 +1,26 @@
 package org.corfudb.util;
 
 
-import jdk.internal.org.objectweb.asm.util.Printer;
-import jdk.internal.org.objectweb.asm.util.Textifier;
-import jdk.internal.org.objectweb.asm.util.TraceMethodVisitor;
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
-import org.apache.commons.lang3.ArrayUtils;
-import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
-import org.corfudb.protocols.wireprotocol.TailsResponse;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.Layout;
-
 import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+
+import jdk.internal.org.objectweb.asm.util.Printer;
+import jdk.internal.org.objectweb.asm.util.Textifier;
+import jdk.internal.org.objectweb.asm.util.TraceMethodVisitor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.ArrayUtils;
+
+import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+
 /**
  * Created by crossbach on 5/22/15.
  */
@@ -240,17 +242,35 @@ public class Utils {
         return aggregateLogAddressSpace(luResponses);
     }
 
+    /**
+     * Get exception.getCause() with its stacktrace modified to include the outer
+     * exception's stack trace. Prevents losing caller context
+     *
+     * @param throwable the Throwable to extract the causing Throwable from
+     * @return causing Throwable of the input {@code throwable} with the outer throwable's stack trace prepended,
+     *         {@code null} if no causing exception
+     */
     public static Throwable extractCauseWithCompleteStacktrace(Throwable throwable) {
         final Throwable cause = throwable.getCause();
         if (cause == null) {
             return cause;
         }
 
-        final StackTraceElement[] entireStackTrace = ArrayUtils.addAll(
-            throwable.getStackTrace(),
-            cause.getStackTrace()
-        );
-        cause.setStackTrace(entireStackTrace);
+        try {
+            final StackTraceElement[] callerStackTrace = ArrayUtils.addAll(
+                throwable.getStackTrace(),
+                new StackTraceElement("Dummy stack frame", "--- End caller context ---", null, -1)
+            );
+            final StackTraceElement[] entireStackTrace = ArrayUtils.addAll(
+                callerStackTrace,
+                cause.getStackTrace()
+            );
+
+            // Note: Stacktrace might be immutable
+            cause.setStackTrace(entireStackTrace);
+        } catch (Exception e) {
+            log.info("Failed to append outer throwable's stacktrace to causing throwable's stack trace", e);
+        }
         return cause;
     }
 

--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -35,6 +35,7 @@ import org.corfudb.test.DisabledOnTravis;
 import org.corfudb.test.concurrent.TestThreadGroups;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.Sleep;
+import org.corfudb.util.Utils;
 import org.fusesource.jansi.Ansi;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -465,10 +466,11 @@ public class AbstractCorfuTest {
                 f.get();
             }
         } catch (ExecutionException ee) {
-            if (ee.getCause() instanceof Error) {
-                throw (Error) ee.getCause();
+            final Throwable cause = Utils.extractCauseWithCompleteStacktrace(ee);
+            if (cause instanceof Error) {
+                throw (Error) cause;
             }
-            throw (Exception) ee.getCause();
+            throw (Exception) cause;
         } catch (InterruptedException ie) {
             throw new RuntimeException(ie);
         }
@@ -522,7 +524,7 @@ public class AbstractCorfuTest {
             try {
                 return result.get();
             } catch (ExecutionException e) {
-                throw (Exception) e.getCause();
+                throw (Exception) Utils.extractCauseWithCompleteStacktrace(e);
             } catch (InterruptedException ie){
                 throw new RuntimeException(ie);
             }

--- a/test/src/test/java/org/corfudb/runtime/utils/ExceptionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/ExceptionContextTest.java
@@ -25,21 +25,9 @@ public class ExceptionContextTest extends AbstractViewTest {
     }
 
     @Test
-    public void validateCallerStackTracePresent() throws InterruptedException, ArithmeticException {
-        final ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor((r) -> {
-            Thread t = Executors.defaultThreadFactory().newThread(r);
-            t.setName("exception_context_test_thread");
-            t.setDaemon(true);
-            return t;
-        });
-
-        final CompletableFuture<Integer> future = new CompletableFuture<>();
-        service.submit(() -> {
-            try {
-                throw new DummyCausingException("Dummy causing exception");
-            } catch (DummyCausingException e) {
-                future.completeExceptionally(e);
-            }
+    public void validateCallerStackTracePresent() throws InterruptedException {
+        final CompletableFuture<Void> future = CompletableFuture.supplyAsync(() -> {
+            throw new DummyCausingException("Dummy causing exception");
         });
 
         ExecutionException originalExecutionException = null;

--- a/test/src/test/java/org/corfudb/runtime/utils/ExceptionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/ExceptionContextTest.java
@@ -1,0 +1,86 @@
+package org.corfudb.runtime.utils;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.util.CFUtils;
+
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ExceptionContextTest extends AbstractViewTest {
+
+    private static class DummyCausingException extends RuntimeException {
+        DummyCausingException(String message) {
+            super(message);
+        }
+    }
+
+    @Test
+    public void validateCallerStackTracePresent() throws InterruptedException, ArithmeticException {
+        final ScheduledExecutorService service = Executors.newSingleThreadScheduledExecutor((r) -> {
+            Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setName("exception_context_test_thread");
+            t.setDaemon(true);
+            return t;
+        });
+
+        final CompletableFuture<Integer> future = new CompletableFuture<>();
+        service.submit(() -> {
+            try{
+                throw new DummyCausingException("Dummy causing exception");
+            } catch(DummyCausingException e) {
+                future.completeExceptionally(e);
+            }
+        });
+
+        ExecutionException originalExecutionException = null;
+        try {
+            future.get();
+        } catch(ExecutionException e) {
+            originalExecutionException = e;
+        }
+        final StackTraceElement[] causeOriginalStackTrace = originalExecutionException.getCause().getStackTrace();
+
+        RuntimeException causeFromGetUninterruptibly = null;
+        try {
+            CFUtils.getUninterruptibly(future, RuntimeException.class);
+        } catch(DummyCausingException e) {
+            causeFromGetUninterruptibly = e;
+        }
+        final List<StackTraceElement> causeFromGetUniterruptiblyStackTrace = Arrays.asList(causeFromGetUninterruptibly.getStackTrace());
+
+        final int callerContextEndIndex = causeFromGetUniterruptiblyStackTrace.indexOf(
+            new StackTraceElement("Dummy stack frame", "--- End caller context ---", null, -1)
+        );
+        assertNotEquals(callerContextEndIndex, -1);
+
+        final List<String> expectedStackTraceContents = Arrays.asList(
+            "CompletableFuture.reportGet",
+            "CompletableFuture.get",
+            "CFUtils.getUninterruptibly",
+            "ExceptionContextTest.validateCallerStackTracePresent"
+        );
+
+        expectedStackTraceContents.forEach(contents -> {
+            final String className = contents.split("\\.")[0];
+            final String methodName = contents.split("\\.")[1];
+            final boolean present = causeFromGetUniterruptiblyStackTrace.subList(0, callerContextEndIndex).stream().anyMatch(stackTraceElement -> {
+                return stackTraceElement.getClassName().endsWith(className) && stackTraceElement.getMethodName().equals(methodName);
+            });
+            assertTrue(present, String.format("Could not find stack trace element for: %s", contents));
+        });
+
+        for(int i = 0; i < causeOriginalStackTrace.length; ++i) {
+            assertEquals(causeOriginalStackTrace[i], causeFromGetUniterruptiblyStackTrace.get(callerContextEndIndex + i + 1));
+        }
+    }
+}


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
