### PR TITLE
CorfuStoreBrowser: fix RegistryTable printTable bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import lombok.Getter;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata.TableDescriptors;
 import org.corfudb.runtime.CorfuStoreMetadata.TableName;
@@ -82,6 +83,7 @@ public class TableRegistry {
     /**
      * This {@link CorfuTable} holds the schemas of the key, payload and metadata for every table created.
      */
+    @Getter
     private final CorfuTable<TableName, CorfuRecord<TableDescriptors, Message>> registryTable;
 
     public TableRegistry(CorfuRuntime runtime) {

--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -102,7 +102,15 @@ public class DynamicProtobufSerializer implements ISerializer {
 
             TableDescriptors tableDescriptors = value.getPayload();
             tableDescriptors.getFileDescriptorsMap().forEach((fdName, fileDescriptorProto) -> {
-                fdProtoMap.putIfAbsent(fileDescriptorProto.getName(), fileDescriptorProto);
+                String protoFileName = fileDescriptorProto.getName();
+                // Looks like protobuf file descriptors are randomly truncating the path.
+                // This causes dynamicProtobufSerializer to fail since the full path is needed.
+                if (protoFileName.equals("corfu_options.proto")) {
+                    fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto);
+                    // Until the truncating issue can be addressed, manually add both paths.
+                    protoFileName = "corfudb/runtime/corfu_options.proto";
+                }
+                fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto);
                 identifyMessageTypesinFileDescriptorProto(fileDescriptorProto);
             });
         });

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -298,7 +298,11 @@ public class AbstractIT extends AbstractCorfuTest {
     }
 
     public static CorfuRuntime createRuntimeWithCache() {
-        CorfuRuntime rt = new CorfuRuntime(DEFAULT_ENDPOINT)
+        return createRuntimeWithCache(DEFAULT_ENDPOINT);
+    }
+
+    public static CorfuRuntime createRuntimeWithCache(String endpoint) {
+        CorfuRuntime rt = new CorfuRuntime(endpoint)
                 .setCacheDisabled(false)
                 .connect();
         return rt;

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserIT.java
@@ -5,6 +5,7 @@ import com.google.protobuf.UnknownFieldSet;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
+import org.corfudb.runtime.view.TableRegistry;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -195,5 +196,66 @@ public class CorfuStoreBrowserIT extends AbstractIT {
                 UnknownFieldSet.newBuilder().build(),
                 record.getPayload().getUnknownFields());
         }
+    }
+
+    /**
+     * Create a table and add data to it.  Verify that the browser tool is able
+     * to read the system TableRegistry contents accurately.
+     * @throws IOException
+     * @throws NoSuchMethodException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    @Test
+    public void browserRegistryTableTest() throws
+            IOException,
+            NoSuchMethodException,
+            IllegalAccessException,
+            InvocationTargetException {
+        final String namespace = "namespace";
+        final String tableName = "table";
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost,
+                corfuStringNodePort);
+
+        // Start a Corfu runtime
+        runtime = createRuntime(singleNodeEndpoint);
+
+        CorfuStore store = new CorfuStore(runtime);
+
+        store.openTable(
+                namespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.Uuid.class,
+                SampleSchema.Uuid.class,
+                TableOptions.builder().build());
+
+        final long keyUuid = 1L;
+        final long valueUuid = 3L;
+        final long metadataUuid = 5L;
+
+        SampleSchema.Uuid uuidKey = SampleSchema.Uuid.newBuilder()
+                .setMsb(keyUuid)
+                .setLsb(keyUuid)
+                .build();
+        SampleSchema.Uuid uuidVal = SampleSchema.Uuid.newBuilder()
+                .setMsb(valueUuid)
+                .setLsb(valueUuid)
+                .build();
+        SampleSchema.Uuid metadata = SampleSchema.Uuid.newBuilder()
+                .setMsb(metadataUuid)
+                .setLsb(metadataUuid)
+                .build();
+        TxBuilder tx = store.tx(namespace);
+        tx.create(tableName, uuidKey, uuidVal, metadata)
+                .update(tableName, uuidKey, uuidVal, metadata)
+                .commit();
+        runtime.shutdown();
+
+        runtime = createRuntime(singleNodeEndpoint);
+        CorfuStoreBrowser browser = new CorfuStoreBrowser(runtime);
+        // Invoke listTables and verify table count
+        Assert.assertEquals(2, browser.printTableInfo(TableRegistry.CORFU_SYSTEM_NAMESPACE,
+        TableRegistry.REGISTRY_TABLE_NAME));
     }
 }


### PR DESCRIPTION
RegistryTable is a system table that does not need the
DynamicProtobufSerializer, so the printTable must handle
this differently otherwiser it will hit this exception
java.lang.ClassCastException:
org.corfudb.runtime.CorfuStoreMetadata$TableName cannot be cast to
org.corfudb.runtime.collections.CorfuDynamicKey

Related issue(s) (if applicable): #2378 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
