### PR TITLE
Redundant stamped lock validation.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -244,12 +244,8 @@ public class VersionLockedObject<T extends ICorfuSMR<T>> {
             if (directAccessCheckFunction.apply(this)) {
                 log.trace("Access [{}] Direct (writelock) access at {}", this, getVersionUnsafe());
                 R ret = accessFunction.apply(object.getContext(ICorfuExecutionContext.DEFAULT));
-
-                long versionForCorrectness = getVersionUnsafe();
-                if (lock.validate(ts)) {
-                    correctnessLogger.trace("Version, {}", versionForCorrectness);
-                    return ret;
-                }
+                correctnessLogger.trace("Version, {}", getVersionUnsafe());
+                return ret;
             }
             // If not, perform the update operations
             updateFunction.accept(this);


### PR DESCRIPTION
## Overview

Remove redundant lock validation as the exclusive write lock is already held.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
