### PR TITLE
A workaround to hole in tail issue.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
@@ -96,6 +96,7 @@ public class StreamViewSMRAdapter implements ISMRStream {
      */
     public List<SMREntry> current() {
         ILogData data = streamView.current();
+
         if (data == null
                 || data.getType() != DataType.DATA
                 || !(data.getPayload(runtime) instanceof ISMRConsumable)) {
@@ -113,6 +114,7 @@ public class StreamViewSMRAdapter implements ISMRStream {
      */
     public List<SMREntry> previous() {
         ILogData data = streamView.previous();
+
         while (Address.isAddress(streamView.getCurrentGlobalPosition())
                 && data != null) {
             if (data.getType() == DataType.DATA

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
@@ -290,9 +290,7 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
      */
     private void updatePointer(final ILogData data) {
         // Update the global pointer, if it is non-checkpoint data.
-        if ((data.isData() && !data.hasCheckpointMetadata()) ||
-                (data.isHole() && (data.getBackpointerMap().isEmpty() || data.containsStream(getCurrentContext().id)))
-        ) {
+        if ((data.isData() || data.isHole()) && !data.hasCheckpointMetadata()) {
             // Note: here we only set the global pointer and do not validate its position with respect to the trim mark,
             // as the pointer is expected to be moving step by step (for instance when syncing a stream up to maxGlobal)
             // The validation is deferred to these methods which call it in advance based on the expected final position

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -84,11 +84,13 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                 // to be serviced immediately, rather than reading one entry at a time.
                 ld = read(currentRead, queue);
 
-                if (queue == getCurrentContext().readQueue && ld != null) {
+                if (queue == getCurrentContext().readQueue) {
                     // Validate that the data entry belongs to this stream, otherwise, skip.
                     // This verification protects from sequencer regression (tokens assigned in an older epoch
                     // that were never written to, and reassigned on a newer epoch)
-                    if (ld.containsStream(this.id) && ld.getType() == DataType.DATA) {
+                    if ((ld.containsStream(this.id) && ld.isData()) ||
+                            (ld.isHole() && (ld.getBackpointerMap().isEmpty() || ld.containsStream(this.id)))
+                    ) {
                         addToResolvedQueue(getCurrentContext(), currentRead);
                         readNext = false;
                     } else {

--- a/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
@@ -71,4 +71,11 @@ public class Serializers {
             throw new RuntimeException(msg);
         }
     }
+
+    /**
+     * Clear custom serializers.
+     */
+    public static synchronized void clearCustomSerializers() {
+        customSerializers.clear();
+    }
 }

--- a/test/src/test/java/org/corfudb/protocols/logprotocol/LogEntryTest.java
+++ b/test/src/test/java/org/corfudb/protocols/logprotocol/LogEntryTest.java
@@ -6,6 +6,7 @@ import org.corfudb.CustomSerializer;
 import org.corfudb.runtime.exceptions.SerializerException;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
+import org.junit.After;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -17,6 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class LogEntryTest {
+
+    @After
+    public void tearDown() {
+        Serializers.clearCustomSerializers();
+    }
 
     @Test
     public void seekToEndSMREntry () {

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -8,17 +8,26 @@ import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
 import org.assertj.core.data.MapEntry;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.object.CorfuCompileProxy;
+import org.corfudb.runtime.object.ICorfuSMR;
+import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.junit.Test;
 
 public class CorfuTableTest extends AbstractViewTest {
+
+    private static final int ITERATIONS = 20;
 
     Collection<String> project(Collection<Map.Entry<String, String>> entries) {
         return entries.stream().map(entry -> entry.getValue()).collect(Collectors.toCollection(ArrayList::new));
@@ -244,5 +253,50 @@ public class CorfuTableTest extends AbstractViewTest {
 
         final Stream<Map.Entry<Integer, Integer>> result = map.entryStream();
         result.forEach(e -> map.put(new Random().nextInt(), 0));
+    }
+
+    @Test
+    @SuppressWarnings({"unchecked", "checkstyle:magicnumber"})
+    public void canHandleHoleInTail() {
+        UUID streamID = UUID.randomUUID();
+
+        CorfuTable<String, String> corfuTable = getDefaultRuntime()
+                .getObjectsView()
+                .build()
+                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setStreamID(streamID)
+                .open();
+
+        corfuTable.put("k1", "dog fox cat");
+        corfuTable.put("k2", "dog bat");
+        corfuTable.put("k3", "fox");
+
+        // create a hole
+        TokenResponse tokenResponse =  getDefaultRuntime()
+                .getSequencerView()
+                .next(streamID);
+
+        Token token = tokenResponse.getToken();
+
+        getDefaultRuntime().getAddressSpaceView()
+                .write(tokenResponse, LogData.getHole(token));
+
+        assertThat(getDefaultRuntime().getAddressSpaceView()
+                .read(token.getSequence()).isHole()).isTrue();
+
+        for (int i = 0; i < ITERATIONS; i++) {
+            getDefaultRuntime().getObjectsView().TXBuild()
+                    .type(TransactionType.SNAPSHOT)
+                    .snapshot(token)
+                    .build()
+                    .begin();
+
+            corfuTable.scanAndFilter(item -> true);
+            getDefaultRuntime().getObjectsView().TXEnd();
+        }
+
+        assertThat(((CorfuCompileProxy) ((ICorfuSMR) corfuTable).
+                getCorfuSMRProxy()).getUnderlyingObject().getSmrStream().pos()).isEqualTo(3);
+
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/concurrent/StreamSeekAtomicityTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/StreamSeekAtomicityTest.java
@@ -19,8 +19,6 @@ public class StreamSeekAtomicityTest extends AbstractTransactionsTest {
     @Override
     public void TXBegin() { OptimisticTXBegin(); }
 
-
-
     protected int numIterations = PARAMETERS.NUM_ITERATIONS_LOW;
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -16,7 +16,6 @@ import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -533,5 +532,59 @@ public class StreamViewTest extends AbstractViewTest {
         // Ensure that we can recover.
         txStream.seek(localRuntime.getSequencerView().query().getSequence());
         txStream.remaining();
+    }
+
+    @Test
+    public void testNextUpTo() {
+        final int numWrites = 10;
+
+        byte[] testPayload = "hello world".getBytes();
+
+        String stream = "stream1";
+        UUID id1 = CorfuRuntime.getStreamID(stream);
+
+        StreamingMap<String, String> map = r.getObjectsView()
+                .build()
+                .setStreamName(stream)
+                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .open();
+
+        CorfuRuntime producer = getNewRuntime(getDefaultNode())
+                .connect();
+
+        CorfuRuntime consumer = getNewRuntime(getDefaultNode())
+                .connect();
+
+        IStreamView svProducer = producer.getStreamsView().get(id1);
+        IStreamView svConsumer = consumer.getStreamsView().get(id1);
+
+
+        for (int x = 0; x < numWrites; x++) {
+            svProducer.append(testPayload);
+        }
+
+        // Emulate the extra Token the Checkpointer requests before appending a checkpoint
+        // producer.getSequencerView().next(id1);
+        // producer.getAddressSpaceView().write(new Token(0, numWrites), LogData.getHole(numWrites));
+
+        // Get two entries before checkpointing (so we don't load from checkpoint on next access)
+        assertThat(svConsumer.nextUpTo(numWrites).getPayload(consumer)).isEqualTo(testPayload);
+        assertThat(svConsumer.nextUpTo(numWrites).getPayload(consumer)).isEqualTo(testPayload);
+
+        MultiCheckpointWriter checkpointWriter = new MultiCheckpointWriter();
+        checkpointWriter.addMap(map);
+        checkpointWriter.appendCheckpoints(r, "Author");
+
+        // Consume Until Tail
+        long tail = consumer.getSequencerView().query(id1);
+
+        ILogData data;
+        while (svConsumer.hasNext()) {
+            data = svConsumer.nextUpTo(tail);
+            if (data != null) {
+                assertThat(data.getPayload(consumer)).isEqualTo(testPayload);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
## Overview

Description:

When a stream's tail is a hole, VLO will try to sync up to tail but never add hole to its resolved queue, which means each sync will query sequencer again.

@lixinchengdu and I bring a workaround that adds hole to resolved queue to avoid re-sync.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
