### PR TITLE
Remove Non-streaming APIs from Streams

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/TransactionPoller.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TransactionPoller.java
@@ -88,7 +88,7 @@ public class TransactionPoller implements Runnable {
         log.trace("txStream current global position after seeking {}, hasNext {}",
                 txnStream.getCurrentGlobalPosition(), txnStream.hasNext());
 
-        List<ILogData> updates = txnStream.remaining();
+        List<ILogData> updates = txnStream.remaining().collect(Collectors.toList());
 
         log.trace("{} updates remaining in the txStream", updates.size());
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ISMRStream.java
@@ -23,9 +23,6 @@ import org.corfudb.protocols.wireprotocol.TokenResponse;
 @SuppressWarnings("checkstyle:abbreviation")
 public interface ISMRStream {
 
-
-    List<SMREntry> remainingUpTo(long maxGlobal);
-
     List<SMREntry> current();
 
     List<SMREntry> previous();
@@ -34,11 +31,7 @@ public interface ISMRStream {
 
     void reset();
 
-    void seek(long globalAddress);
-
     void gc(long trimMark);
-
-    Stream<SMREntry> stream();
 
     Stream<SMREntry> streamUpTo(long maxGlobal);
 
@@ -71,7 +64,5 @@ public interface ISMRStream {
      * @return The UUID for this stream.
      */
     @SuppressWarnings("checkstyle:abbreviation")
-    default UUID getID() {
-        return new UUID(0L, 0L);
-    }
+    UUID getID();
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/StreamViewSMRAdapter.java
@@ -73,22 +73,6 @@ public class StreamViewSMRAdapter implements ISMRStream {
     }
 
     /**
-     * Returns all entries remaining upto the specified the global address specified.
-     *
-     * @param maxGlobal Max Global up to which SMR Entries are required.
-     * @return Returns a list of SMR Entries upto the maxGlobal.
-     */
-    public List<SMREntry> remainingUpTo(long maxGlobal) {
-        return streamView.remainingUpTo(maxGlobal).stream()
-                .filter(m -> m.getType() == DataType.DATA)
-                .filter(m -> m.getPayload(runtime) instanceof ISMRConsumable
-                        || m.hasCheckpointMetadata())
-                .map(this::dataAndCheckpointMapper)
-                .flatMap(List::stream)
-                .collect(Collectors.toList());
-    }
-
-    /**
      * Returns the list of SMREntries positioned at the current global log.
      * It returns null of no data is null.
      *
@@ -132,15 +116,6 @@ public class StreamViewSMRAdapter implements ISMRStream {
 
     public void reset() {
         streamView.reset();
-    }
-
-    public void seek(long globalAddress) {
-        streamView.seek(globalAddress);
-    }
-
-    @Override
-    public Stream<SMREntry> stream() {
-        return streamUpTo(Address.MAX);
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -308,17 +308,6 @@ public class VersionLockedObject<T extends ICorfuSMR<T>> {
     }
 
     /**
-     * Move the pointer for this object (effectively, forcefuly
-     * change the version of this object without playing
-     * any updates).
-     *
-     * @param globalAddress The global address to set the pointer to
-     */
-    public void seek(long globalAddress) {
-        smrStream.seek(globalAddress);
-    }
-
-    /**
      * @see VersionLockedObject#syncObjectUnsafeInner
      */
     public void syncObjectUnsafe(long timestamp) {
@@ -709,16 +698,6 @@ public class VersionLockedObject<T extends ICorfuSMR<T>> {
             log.warn("OptimisticRollback[{}] failed", this);
             resetUnsafe();
         }
-    }
-
-    /** Apply an SMREntry to the version object, while
-     * doing bookkeeping for the underlying stream.
-     *
-     * @param entry smr entry
-     */
-    public void applyUpdateToStreamUnsafe(SMREntry entry, long globalAddress) {
-        applyUpdateUnsafe(entry, globalAddress);
-        seek(globalAddress + 1);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/IStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/IStreamView.java
@@ -128,8 +128,8 @@ public interface IStreamView extends
      *                  if no entries are available.
      */
     @Nonnull
-    default List<ILogData> remaining() {
-        return remainingUpTo(Address.MAX);
+    default Stream<ILogData> remaining() {
+        return streamUpTo(Address.MAX);
     }
 
     /** Retrieve all of the entries from this stream, up to the address given or
@@ -141,7 +141,10 @@ public interface IStreamView extends
      * @return          The next entries in the stream, or an empty list,
      *                  if no entries are available.
      */
-    List<ILogData> remainingUpTo(long maxGlobal);
+    @Nonnull
+    default Stream<ILogData> remainingUpTo(long maxGlobal) {
+        return streamUpTo(maxGlobal);
+    }
 
     /** Returns whether or not there are potentially more entries in this
      * stream - this function may return true even if there are no entries
@@ -174,12 +177,6 @@ public interface IStreamView extends
         return new StreamSpliterator(this, maxGlobal);
     }
 
-    /** Get a Java stream from this stream view.
-     * @return  A Java stream for this stream view.
-     */
-    default Stream<ILogData> stream() {
-        return StreamSupport.stream(spliterator(), false);
-    }
 
     /** Get a Java stream from this stream view, limiting
      * reads to a specified global address.

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/ThreadSafeStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/ThreadSafeStreamView.java
@@ -10,6 +10,7 @@ import javax.annotation.Nonnull;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * A thread-safe implementation of IStreamView.
@@ -88,7 +89,7 @@ public class ThreadSafeStreamView implements IStreamView {
     }
 
     @Override
-    public synchronized List<ILogData> remainingUpTo(long maxGlobal) {
+    public synchronized Stream<ILogData> remainingUpTo(long maxGlobal) {
         return stream.remainingUpTo(maxGlobal);
     }
 

--- a/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -93,7 +94,7 @@ public class TransactionStreamIT extends AbstractIT {
             // Stop polling only when all updates (from all writers) have
             // been consumed.
             while (consumed < numWriters * numWritesPerThread) {
-                List<ILogData> entries = txStream.remaining();
+                List<ILogData> entries = txStream.remaining().collect(Collectors.toList());
 
                 if (!entries.isEmpty()) {
                     ConsumeDelta(counters, entries);

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTrimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTrimTest.java
@@ -6,6 +6,7 @@ import com.google.common.reflect.TypeToken;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -215,7 +216,8 @@ public class CheckpointTrimTest extends AbstractViewTest {
         // Seek beyond the last trimmed address.
         // The first call to remainingUpTo() will load the checkpoint, and the
         // second one will fetch the actual data.
-        Assertions.assertThat(Stream.of(s.remainingUpTo(Long.MAX_VALUE), s.remainingUpTo(Long.MAX_VALUE))
+        Assertions.assertThat(Stream.of(s.remainingUpTo(Long.MAX_VALUE).collect(Collectors.toList()),
+                s.remainingUpTo(Long.MAX_VALUE).collect(Collectors.toList()))
                 .map(List::size).mapToInt(Integer::intValue).sum())
                 .isEqualTo(BATCH_SIZE);
 

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
@@ -11,6 +11,7 @@ import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,7 +53,7 @@ public class WriteAfterWriteTransactionContextTest extends AbstractTransactionCo
         IStreamView txStream = getRuntime().getStreamsView()
                 .get(ObjectsView.TRANSACTION_STREAM_ID);
 
-        List<ILogData> txns = txStream.remainingUpTo(Long.MAX_VALUE);
+        List<ILogData> txns = txStream.remainingUpTo(Long.MAX_VALUE).collect(Collectors.toList());
         assertThat(txns).hasSize(1);
         assertThat(txns.get(0).getLogEntry(getRuntime()).getType()).isEqualTo
             (LogEntry.LogEntryType.MULTIOBJSMR);

--- a/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -7,6 +7,7 @@ import com.google.common.reflect.TypeToken;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
+import java.util.stream.Collectors;
 
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
@@ -95,7 +96,7 @@ public class ObjectsViewTest extends AbstractViewTest {
 
         IStreamView txStream = r.getStreamsView().get(ObjectsView
                 .TRANSACTION_STREAM_ID);
-        List<ILogData> txns = txStream.remainingUpTo(Long.MAX_VALUE);
+        List<ILogData> txns = txStream.remainingUpTo(Long.MAX_VALUE).collect(Collectors.toList());
         assertThat(txns).hasSize(1);
         assertThat(txns.get(0).getLogEntry(getRuntime()).getType())
                 .isEqualTo(LogEntry.LogEntryType.MULTIOBJSMR);

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -137,7 +138,7 @@ public class StreamViewTest extends AbstractViewTest {
             txStream.append(data);
         }
 
-        List<ILogData> entries = txStream.remainingUpTo((firstIter - 1) / 2);
+        List<ILogData> entries = txStream.remainingUpTo((firstIter - 1) / 2).collect(Collectors.toList());
         assertThat(entries.size()).isEqualTo(firstIter / 2);
 
         Token token = new Token(runtime.getLayoutView().getLayout().getEpoch(), (firstIter - 1) / 2);
@@ -145,10 +146,10 @@ public class StreamViewTest extends AbstractViewTest {
         runtime.getAddressSpaceView().invalidateServerCaches();
         runtime.getAddressSpaceView().invalidateClientCache();
 
-        entries = txStream.remainingUpTo((firstIter - 1) / 2);
+        entries = txStream.remainingUpTo((firstIter - 1) / 2).collect(Collectors.toList());
         assertThat(entries.size()).isEqualTo(0);
 
-        entries = txStream.remainingUpTo(firstIter);
+        entries = txStream.remainingUpTo(firstIter).collect(Collectors.toList());
         assertThat(entries.size()).isEqualTo((firstIter / 2));
 
         // Open the stream with a new client
@@ -160,7 +161,7 @@ public class StreamViewTest extends AbstractViewTest {
                 .isInstanceOf(TrimmedException.class);
 
         txStream2.seek(firstIter / 2);
-        entries = txStream2.remainingUpTo(Long.MAX_VALUE);
+        entries = txStream2.remainingUpTo(Long.MAX_VALUE).collect(Collectors.toList());
         assertThat(entries.size()).isEqualTo((firstIter / 2));
     }
 

--- a/test/src/test/java/org/corfudb/runtime/view/stream/AbstractStreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/AbstractStreamViewTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 /**
  * Tests the BackpointerStreamView
@@ -237,7 +238,7 @@ public abstract class AbstractStreamViewTest extends AbstractViewTest {
 
         // Traverse remaining of the stream, because trimmed exceptions are ignored
         // we should get the remaining entries in the stream (trimMark - end of stream).
-        List<ILogData> stream = sv.remaining();
+        List<ILogData> stream = sv.remaining().collect(Collectors.toList());
         assertThat(sv.getCurrentGlobalPosition()).isEqualTo(PARAMETERS.NUM_ITERATIONS_LOW - 1);
         assertThat(stream.size()).isEqualTo(trimMark - 1);
 


### PR DESCRIPTION
#Overview.
Remove non-streaming APIs from the IStreamView.

Why should this be merged: Non-streaming APIs can cause OOM exceptions for JVMs with relatively small heaps. 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
