### PR TITLE
Add support for Stream Tagging.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/TableOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TableOptions.java
@@ -4,6 +4,7 @@ import lombok.Builder;
 
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Created by zlokhandwala on 2019-08-09.
@@ -12,6 +13,7 @@ import java.util.Optional;
 public class TableOptions<K, V> {
 
     private final Index.Registry<K, V> indexRegistry;
+    private UUID [] streamTags;
 
     /**
      * If this path is set, {@link CorfuStore} will utilize disk-backed {@link CorfuTable}.
@@ -20,5 +22,13 @@ public class TableOptions<K, V> {
 
     public Optional<Path> getPersistentDataPath() {
         return Optional.ofNullable(persistentDataPath);
+    }
+
+    public void setStreamTags(UUID... tags) {
+        streamTags = tags;
+    }
+
+    public UUID[] getStreamTags() {
+        return streamTags;
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -94,6 +95,9 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
     @Getter
     ISerializer serializer;
 
+    @Getter
+    Set<UUID> streamTags;
+
     /**
      * The arguments this proxy was created with.
      */
@@ -123,17 +127,20 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
      * @param type                Type of underlying object to instantiate a new instance.
      * @param args                Arguments to create this proxy.
      * @param serializer          Serializer used by the SMR entries to serialize the arguments.
+     * @param streamTags          Tags applied to the stream
+     * @param wrapperObject       The wrapped object
      */
     @Deprecated // TODO: Add replacement method that conforms to style
     @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
     public CorfuCompileProxy(CorfuRuntime rt, UUID streamID, Class<T> type, Object[] args,
-                             ISerializer serializer, ICorfuSMR<T> wrapperObject
-    ) {
+                             ISerializer serializer, Set<UUID> streamTags,
+                             ICorfuSMR<T> wrapperObject) {
         this.rt = rt;
         this.streamID = streamID;
         this.type = type;
         this.args = args;
         this.serializer = serializer;
+        this.streamTags = streamTags;
 
         // Since the VLO is thread safe we don't need to use a thread safe stream implementation
         // because the VLO will control access to the stream

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.object;
 
+import java.util.Set;
 import java.util.UUID;
 
 import org.corfudb.runtime.CorfuRuntime;
@@ -31,8 +32,9 @@ public class CorfuCompileWrapperBuilder {
      */
     @SuppressWarnings("checkstyle:abbreviation")
     public static <T extends ICorfuSMR<T>> T getWrapper(Class<T> type, CorfuRuntime rt,
-                                                         UUID streamID, Object[] args,
-                                                         ISerializer serializer)
+                                                        UUID streamID, Object[] args,
+                                                        ISerializer serializer,
+                                                        Set<UUID> streamTags)
             throws Exception {
         // Do we have a compiled wrapper for this type?
         Class<ICorfuSMR<T>> wrapperClass = (Class<ICorfuSMR<T>>)
@@ -45,7 +47,7 @@ public class CorfuCompileWrapperBuilder {
         // Now we create the proxy, which actually manages
         // instances of this object. The wrapper delegates calls to the proxy.
         wrapperObject.setCorfuSMRProxy(new CorfuCompileProxy<T>(rt, streamID,
-                type, args, serializer, wrapperObject));
+                type, args, serializer, streamTags, wrapperObject));
 
         if (wrapperObject instanceof ICorfuSMRProxyWrapper) {
             ((ICorfuSMRProxyWrapper) wrapperObject)
@@ -60,6 +62,7 @@ public class CorfuCompileWrapperBuilder {
                 smrObject.getRuntime(),
                 smrObject.getStreamID(),
                 smrObject.getArguments(),
-                smrObject.getSerializer());
+                smrObject.getSerializer(),
+                smrObject.getStreamTags());
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
@@ -1,5 +1,8 @@
 package org.corfudb.runtime.object;
 
+import java.util.Set;
+import java.util.UUID;
+
 import org.corfudb.util.serializer.ISerializer;
 
 /**
@@ -26,4 +29,6 @@ public interface ICorfuSMRProxyInternal<T extends ICorfuSMR<T>> extends ICorfuSM
      * @return  The serializer to use.
      */
     ISerializer getSerializer();
+
+    Set<UUID> getStreamTags();
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/SMRObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SMRObject.java
@@ -14,6 +14,9 @@ import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -51,6 +54,9 @@ public class SMRObject<T extends ICorfuSMR<T>> {
     @NonNull
     private final Object[] arguments;
 
+    @NonNull
+    private final Set<UUID> streamTags;
+
 
     public static class Builder<T extends ICorfuSMR<T>> {
 
@@ -63,6 +69,8 @@ public class SMRObject<T extends ICorfuSMR<T>> {
         private CorfuRuntime runtime;
         @Getter
         public UUID streamID;
+
+        private Set<UUID> streamTags = new HashSet<>();
 
         private void verify() {
             if (streamName != null && !UUID.nameUUIDFromBytes(streamName.getBytes()).equals(streamID)) {
@@ -107,13 +115,19 @@ public class SMRObject<T extends ICorfuSMR<T>> {
             return this;
         }
 
+        public SMRObject.Builder<T> setStreamTags(UUID ... uuids) {
+            this.streamTags.addAll(Arrays.asList(uuids));
+            return this;
+        }
+
 
         public SMRObject<T> build() {
             if (streamID == null && streamName != null) {
                 streamID = UUID.nameUUIDFromBytes(streamName.getBytes());
             }
             verify();
-            return new SMRObject<>(runtime, type, streamID, streamName, serializer, option, arguments);
+            return new SMRObject<>(runtime, type, streamID, streamName,
+                serializer, option, arguments, streamTags);
         }
 
         public T open() {

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -336,7 +336,8 @@ public class TableRegistry {
                 defaultMetadataMessage,
                 this.runtime,
                 this.protobufSerializer,
-                mapSupplier, versionPolicy);
+                mapSupplier, versionPolicy, tableOptions.getStreamTags()
+                );
         tableMap.put(fullyQualifiedTableName, (Table<Message, Message, Message>) table);
 
         registerTable(namespace, tableName, kClass, vClass, mClass, tableOptions);

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -12,6 +12,7 @@ import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.exceptions.UnreachableClusterException;
+import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.RuntimeLayout;
 import org.junit.After;
@@ -29,6 +30,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -374,6 +376,14 @@ public class AbstractIT extends AbstractCorfuTest {
                 .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {})
                 .open();
         return map;
+    }
+
+    public static TableOptions createTableOptions(UUID ... streamTags) {
+        TableOptions options = TableOptions.builder().build();
+        if (streamTags.length != 0) {
+            options.setStreamTags(streamTags);
+        }
+        return options;
     }
 
     public static class StreamGobbler implements Runnable {

--- a/test/src/test/java/org/corfudb/integration/StreamingIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingIT.java
@@ -12,6 +12,7 @@ import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableSchema;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxBuilder;
+import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.test.SampleSchema.Uuid;
 import org.junit.Before;
 import org.junit.Test;
@@ -128,7 +129,7 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, Uuid, Uuid> n1t1 = store.openTable(
                 "n1", "t1", Uuid.class,
                 Uuid.class, Uuid.class,
-                TableOptions.builder().build()
+                createTableOptions(ObjectsView.TRANSACTION_STREAM_ID)
         );
 
         // Make some updates to the table.
@@ -250,14 +251,12 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, Uuid, Uuid> n1t1 = store.openTable(
                 "n1", "t1", Uuid.class,
                 Uuid.class, Uuid.class,
-                TableOptions.builder().build()
-        );
+                createTableOptions(ObjectsView.TRANSACTION_STREAM_ID));
 
         Table<Uuid, Uuid, Uuid> n2t1 = store.openTable(
                 "n2", "t1", Uuid.class,
                 Uuid.class, Uuid.class,
-                TableOptions.builder().build()
-        );
+                createTableOptions(ObjectsView.TRANSACTION_STREAM_ID));
 
         // Make some updates to the table.
         final int numUpdates = 3;

--- a/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
@@ -54,6 +54,7 @@ public class TransactionStreamIT extends AbstractIT {
 
     @Test
     public void txnStreamTest() throws Exception {
+        UUID txnStreamTag = CorfuRuntime.getStreamID("txn_stream_tag");
 
         Process server_1 = new CorfuServerRunner()
                 .setHost(DEFAULT_HOST)
@@ -85,7 +86,7 @@ public class TransactionStreamIT extends AbstractIT {
 
             consumerRts.add(consumerRt);
 
-            IStreamView txStream = consumerRt.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID);
+            IStreamView txStream = consumerRt.getStreamsView().get(txnStreamTag);
 
             Map<UUID, Integer> counters = new HashMap<>(numWriters);
             int consumed = 0;
@@ -128,6 +129,7 @@ public class TransactionStreamIT extends AbstractIT {
                 CorfuTable<Integer, Integer> map = producersRt.getObjectsView()
                         .build()
                         .setStreamName(String.valueOf(idx))
+                        .setStreamTags(txnStreamTag)
                         .setTypeToken(new TypeToken<CorfuTable<Integer, Integer>>() {})
                         .open();
                 for (int i = 1; i <= numWritesPerThread; i++) {

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
@@ -1,12 +1,16 @@
 package org.corfudb.runtime.object.transactions;
 
+import com.google.common.reflect.TypeToken;
+
 import org.corfudb.protocols.logprotocol.LogEntry;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
 import org.corfudb.protocols.logprotocol.MultiSMREntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.ICorfuTable;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.junit.Test;
 
@@ -18,6 +22,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Created by mwei on 11/22/16.
  */
 public class WriteAfterWriteTransactionContextTest extends AbstractTransactionContextTest {
+    private final String streamName = "test stream";
+    private final String txnStreamName = "txn" + streamName;
+
+    private ICorfuTable<String, String> testMap;
+
 
     /** In a write after write transaction, concurrent modifications
      * with the same read timestamp should abort.
@@ -50,7 +59,7 @@ public class WriteAfterWriteTransactionContextTest extends AbstractTransactionCo
                 .doesNotContainEntry("k", "v3");
 
         IStreamView txStream = getRuntime().getStreamsView()
-                .get(ObjectsView.TRANSACTION_STREAM_ID);
+                .get(CorfuRuntime.getStreamID(txnStreamName));
 
         List<ILogData> txns = txStream.remainingUpTo(Long.MAX_VALUE);
         assertThat(txns).hasSize(1);
@@ -69,5 +78,18 @@ public class WriteAfterWriteTransactionContextTest extends AbstractTransactionCo
         assertThat(smrEntry.getSMRMethod()).isEqualTo("put");
         assertThat((String) args[0]).isEqualTo("k");
         assertThat((String) args[1]).isEqualTo("v2");
+    }
+
+    @Override
+    public ICorfuTable<String, String> getMap() {
+        if (testMap == null) {
+            Object obj = getRuntime().getObjectsView().build()
+                .setStreamName(streamName)
+                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setStreamTags(getRuntime().getStreamID(txnStreamName))
+                .open();
+            testMap = (ICorfuTable<String, String>) obj;
+        }
+       return testMap;
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/ObjectsViewTest.java
@@ -6,6 +6,7 @@ import com.google.common.reflect.TypeToken;
 
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.Semaphore;
 
 import org.corfudb.protocols.logprotocol.LogEntry;
@@ -24,6 +25,8 @@ import org.junit.Test;
  * Created by mwei on 2/18/16.
  */
 public class ObjectsViewTest extends AbstractViewTest {
+    private static final UUID TEST_STREAM_ID =
+        CorfuRuntime.getStreamID("Test_Stream_Id");
 
     @Test
     @SuppressWarnings("unchecked")
@@ -47,6 +50,7 @@ public class ObjectsViewTest extends AbstractViewTest {
                 .build()
                 .setStreamName(mapA)
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setStreamTags(TEST_STREAM_ID)
                 .open();
 
         // TODO: fix so this does not require mapCopy.
@@ -54,6 +58,7 @@ public class ObjectsViewTest extends AbstractViewTest {
                 .build()
                 .setStreamName(mapA)
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setStreamTags(TEST_STREAM_ID)
                 .option(ObjectOpenOption.NO_CACHE)
                 .open();
 
@@ -93,8 +98,7 @@ public class ObjectsViewTest extends AbstractViewTest {
         assertThat(map)
                 .containsEntry("k", "v2");
 
-        IStreamView txStream = r.getStreamsView().get(ObjectsView
-                .TRANSACTION_STREAM_ID);
+        IStreamView txStream = r.getStreamsView().get(TEST_STREAM_ID);
         List<ILogData> txns = txStream.remainingUpTo(Long.MAX_VALUE);
         assertThat(txns).hasSize(1);
         assertThat(txns.get(0).getLogEntry(getRuntime()).getType())

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -488,6 +488,7 @@ public class StreamViewTest extends AbstractViewTest {
                 instance1 = localRuntime.getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
                 .setStreamName("txTestMap")
+                .setStreamTags(ObjectsView.TRANSACTION_STREAM_ID)
                 .open();
 
         // Populate the Transaction Stream up to NUM_ITERATIONS_LOW entries.


### PR DESCRIPTION
## Overview

Description:  Add support for stream tagging.

Why should this be merged: 
Tags will be user-defined and used to log writes for a table in the appropriate
stream.  This can be leveraged to have more control over what gets added to the
transaction stream and other streams.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
