### PR TITLE
Runtime: exit systemDownHandler on WrongClusterException

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -982,6 +982,10 @@ public class CorfuRuntime {
                     } catch (InterruptedException ie) {
                         throw new UnrecoverableCorfuInterruptedError(
                                 "Interrupted during layout fetch", ie);
+                    } catch (WrongClusterException we) {
+                        // It is futile trying to re-connect to the wrong cluster
+                        log.warn("Giving up since cluster is incorrect or reconfigured!");
+                        throw we;
                     } catch (ExecutionException ee){
                         if (ee.getCause() instanceof TimeoutException) {
                             log.warn("Tried to get layout from {} but failed by timeout", s);

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.ServerNotReadyException;
+import org.corfudb.runtime.exceptions.WrongClusterException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.util.Sleep;
@@ -148,7 +149,10 @@ public abstract class AbstractView {
                             + "invalidate view", we.getCorrectEpoch());
                 } else if (re instanceof NetworkException) {
                     log.warn("layoutHelper: System seems unavailable", re);
-                } else {
+                } else if (re instanceof WrongClusterException) {
+                    log.warn("layoutHelper: Cluster reconfiguration or incorrect cluster", re);
+                    throw re;
+                }else {
                     throw re;
                 }
                 if (rethrowAllExceptions) {

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -431,7 +431,8 @@ public class AddressSpaceView extends AbstractView {
                 throw new TrimmedException(trimmedAddresses);
             }
 
-            log.warn("read: ignoring trimmed addresses {}", trimmedAddresses);
+            // During streaming this message can flood logs, so modify log level with care.
+            log.debug("read: ignoring trimmed addresses {}", trimmedAddresses);
         }
 
 


### PR DESCRIPTION
## Overview

Description:
Unblock systemDownHandler if WrongClusterException 

Why should this be merged: 
If a node has been added to a cluster the existing
clients should exit early so they can be restarted.
Currently they just spin in systemDownHandler.

Related issue(s) (if applicable): #2409 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
