### PR TITLE
Change how StreamView interacts with its trim mark

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -155,51 +155,72 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
             if (checkpoint) {
                 processCheckpoint(streamAddressSpace, filter, queue);
             } else {
-                // Transfer discovered addresses to queue. We must limit to maxGlobal,
-                // as startAddress could be ahead of maxGlobal---in case it reflects
-                // the tail of the stream.
-                queue.addAll(streamAddressSpace.copyAddressesToSet(maxGlobal));
-
-                long trimMark = streamAddressSpace.getTrimMark();
-
-                // In case we are dealing with a stream that does not have the checkpoint
-                // capability, check to see if we are trying to access an address that has been
-                // previously trimmed.
-                if (!isCheckpointCapable()
-                        && Address.isAddress(trimMark)
-                        && trimMark > stopAddress) {
-                    String message = String.format("getStreamAddressMap[{%s}] stream has been " +
-                                    "trimmed at address %s and we are trying to access the " +
-                                    "stream starting at address %s. This stream does not have " +
-                                    "the checkpoint capability.", this, trimMark, stopAddress);
-                    log.info(message);
-                    throw new TrimmedException(message);
-                }
-                // Address maps might have been trimmed, hence not reflecting all updates to the stream
-                // For this reason, in the case of a valid trim mark, we must be sure this space is
-                // already resolved or loaded by a checkpoint.
-                if (isCheckpointCapable()
-                        && Address.isAddress(trimMark)
-                        && !isTrimCoveredByCheckpointOrLocalView(trimMark)) {
-                    if (getReadOptions().isIgnoreTrim()) {
-                        log.debug("getStreamAddressMap[{}]: Ignoring trimmed exception for address[{}].",
-                                this, streamAddressSpace.getTrimMark());
-                    } else {
-                        String message = String.format("getStreamAddressMap[{%s}] [%d, %d] " +
-                                        "stream has been trimmed at address %s and this space is " +
-                                        "not covered by the loaded checkpoint with start " +
-                                        "address %s, while accessing the stream at version " +
-                                        "%s. Looking for a new checkpoint.",
-                                this, stopAddress, startAddress, trimMark,
-                                getCurrentContext().getCheckpoint().startAddress, maxGlobal);
-                        throw new TrimmedException(message);
-                    }
-                }
+                moveToReadQueue(streamAddressSpace, queue, startAddress, stopAddress, maxGlobal);
             }
         }
 
         addressCount += queue.size();
         return !queue.isEmpty();
+    }
+
+    private void moveToReadQueue(final StreamAddressSpace streamAddressSpace,
+                                  final NavigableSet<Long> queue,
+                                  final long startAddress,
+                                  final long stopAddress,
+                                  final long maxGlobal) {
+
+        // Transfer discovered addresses to queue. We must limit to maxGlobal,
+        // as startAddress could be ahead of maxGlobal---in case it reflects
+        // the tail of the stream.
+        queue.addAll(streamAddressSpace.copyAddressesToSet(maxGlobal));
+
+        final long trimMark = streamAddressSpace.getTrimMark();
+
+        // No valid trim-mark has been defined,
+        // thus we cannot run into trimmed address space.
+        if (!Address.isAddress(trimMark)) {
+            return;
+        }
+
+        // Trim-mark is below or equal to the lowest address,
+        // thus we cannot run into trimmed address space.
+        if (trimMark <= stopAddress) {
+            return;
+        }
+
+        // In case we are dealing with a stream that does not have the checkpoint
+        // capability (transactional stream for example), raise the exception.
+        if (!isCheckpointCapable()) {
+            String message = String.format("getStreamAddressMap[{%s}] stream has been " +
+                    "trimmed at address %s and we are trying to access the " +
+                    "stream starting at address %s. This stream does not have " +
+                    "the checkpoint capability.", this, trimMark, stopAddress);
+            log.info(message);
+            throw new TrimmedException(message);
+        }
+
+        // Address maps might have been trimmed, hence not reflecting all updates to the stream
+        // For this reason, in the case of a valid trim mark, we must be sure this space is
+        // already resolved or loaded by a checkpoint.
+        //
+        // In case of a raw stream (a stream that is not consumed as part of an SMR object),
+        // checkpoint start address and the trim mark will never match, causing the
+        // TrimmedException to be thrown whenever trimMark > stopAddress.
+        if (isCheckpointCapable() && !isTrimCoveredByCheckpointOrLocalView(trimMark)) {
+            if (getReadOptions().isIgnoreTrim()) {
+                log.debug("getStreamAddressMap[{}]: Ignoring trimmed exception for address[{}].",
+                        this, streamAddressSpace.getTrimMark());
+            } else {
+                String message = String.format("getStreamAddressMap[{%s}] [%d, %d] " +
+                                "stream has been trimmed at address %s and this space is " +
+                                "not covered by the loaded checkpoint with start " +
+                                "address %s, while accessing the stream at version " +
+                                "%s. Looking for a new checkpoint.",
+                        this, stopAddress, startAddress, trimMark,
+                        getCurrentContext().getCheckpoint().startAddress, maxGlobal);
+                throw new TrimmedException(message);
+            }
+        }
     }
 
     private void processCheckpoint(StreamAddressSpace streamAddressSpace, Function<ILogData, Boolean> filter,
@@ -252,7 +273,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
      *         False, otherwise.
      */
     private void processCheckpointBatchByEntry(List<Long> batch,
-                                                  Function<ILogData, Boolean> filter) {
+                                               Function<ILogData, Boolean> filter) {
         log.debug("processCheckpointBatchByEntry[{}]: single step across {}", this, batch);
         try {
             boolean checkpointResolved;
@@ -285,7 +306,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
             }
 
             log.trace("getStreamAddressMap[{}]: request stream address space between {} and {}.",
-                        streamId, startAddress, stopAddress);
+                    streamId, startAddress, stopAddress);
             return runtime.getSequencerView()
                     .getStreamAddressSpace(new StreamAddressRange(streamId, startAddress, stopAddress));
         }
@@ -369,4 +390,3 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
         return addressCount;
     }
 }
-


### PR DESCRIPTION
When StreamView is being consumed directly, its trim mark will change
due to externally triggered calls to gc(...). Even when the read range
is above the trim mark, TrimmedException will be thrown because
getCheckpoint().startAddress < trimMark.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
