### PR TITLE
Universe framework: collect server logs

### DIFF
--- a/it/src/main/java/org/corfudb/universe/UniverseManager.java
+++ b/it/src/main/java/org/corfudb/universe/UniverseManager.java
@@ -203,11 +203,11 @@ public class UniverseManager {
             return this;
         }
 
-        private void initVmUniverse() {
+        private UniverseWorkflow<T> initVmUniverse() {
             checkMode(UniverseMode.VM);
 
             if (initialized) {
-                throw new IllegalStateException("Can't initialize the universe twice");
+                return this;
             }
 
             VmUniverseParams universeParams = ClassUtils.cast(fixture.data());
@@ -216,11 +216,20 @@ public class UniverseManager {
                     .universeParams(universeParams)
                     .build();
 
+            UniverseFixture vmFixture = ClassUtils.cast(fixture);
+            LoggingParams loggingParams = vmFixture
+                    .getLogging()
+                    .testName(testName)
+                    .build();
+
             //Assign universe variable before deploy prevents resources leaks
             universe = VmUniverse.builder()
                     .universeParams(universeParams)
+                    .loggingParams(loggingParams)
                     .applianceManager(manager)
                     .build();
+
+            return this;
         }
 
         private UniverseWorkflow<T> deployDocker() {
@@ -236,7 +245,7 @@ public class UniverseManager {
             checkMode(UniverseMode.DOCKER);
 
             if (initialized) {
-                throw new IllegalStateException("Can't initialize the universe twice");
+                return this;
             }
 
             DefaultDockerClient docker;
@@ -273,12 +282,19 @@ public class UniverseManager {
             checkMode(UniverseMode.PROCESS);
 
             if (initialized) {
-                throw new IllegalStateException("Can't initialize the universe twice");
+                return this;
             }
+
+            UniverseFixture processFixture = ClassUtils.cast(fixture);
+            LoggingParams loggingParams = processFixture
+                    .getLogging()
+                    .testName(testName)
+                    .build();
 
             //Assign universe variable before deploy prevents resources leaks
             universe = ProcessUniverse.builder()
                     .universeParams(fixture.data())
+                    .loggingParams(loggingParams)
                     .build();
 
             return this;

--- a/it/src/main/java/org/corfudb/universe/logging/LoggingParams.java
+++ b/it/src/main/java/org/corfudb/universe/logging/LoggingParams.java
@@ -7,31 +7,21 @@ import lombok.NonNull;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 /**
- * Specifies policies to collect logs from docker containers
+ * Specifies policies to collect logs from docker/vm/processes corfu servers
  */
 @Builder
 public class LoggingParams {
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
-    private static final String CORFU_DB_PATH = "corfudb";
-    private static final String BASE_DIR = "/tmp/";
 
-    @Default
-    private final String timestamp = LocalDateTime.now().format(DATE_FORMATTER);
     @NonNull
     private final String testName;
+
     @Default
     @Getter
     private final boolean enabled = false;
 
-    @Getter
-    @Default
-    private final String baseDir = BASE_DIR;
-
-    public Path getServerLogDir() {
-        return Paths.get(baseDir, CORFU_DB_PATH, timestamp, testName);
+    public Path getRelativeServerLogDir() {
+        return Paths.get(testName);
     }
 }

--- a/it/src/main/java/org/corfudb/universe/node/server/AbstractCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/AbstractCorfuServer.java
@@ -5,10 +5,9 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.universe.logging.LoggingParams;
 import org.corfudb.universe.node.client.LocalCorfuClient;
 import org.corfudb.universe.universe.UniverseParams;
-
-import java.util.Optional;
 
 @Slf4j
 @Getter
@@ -21,9 +20,13 @@ public abstract class AbstractCorfuServer<T extends CorfuServerParams, U extends
     @NonNull
     protected final U universeParams;
 
-    protected AbstractCorfuServer(@NonNull T params, @NonNull U universeParams) {
+    @NonNull
+    protected final LoggingParams loggingParams;
+
+    protected AbstractCorfuServer(@NonNull T params, @NonNull U universeParams, LoggingParams loggingParams) {
         this.params = params;
         this.universeParams = universeParams;
+        this.loggingParams = loggingParams;
     }
 
 

--- a/it/src/main/java/org/corfudb/universe/node/server/CorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/CorfuServer.java
@@ -95,6 +95,11 @@ public interface CorfuServer extends Node, Comparable<CorfuServer> {
 
     LocalCorfuClient getLocalCorfuClient();
 
+    /**
+     * Save server logs in the server logs directory
+     */
+    void collectLogs();
+
     enum Mode {
         SINGLE, CLUSTER
     }

--- a/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
@@ -70,9 +70,14 @@ public class CorfuServerParams implements NodeParams {
     @NonNull
     private final String serverVersion;
 
+    /**
+     * The directory where the universe framework keeps files needed for the framework functionality.
+     * By default the directory is equal to the build directory of a build tool
+     * ('target' directory in case of maven, 'build' directory in case of gradle)
+     */
     @NonNull
     @Default
-    private final Path serverJarDirectory = Paths.get("target");
+    private final Path universeDirectory = Paths.get("target");
 
     @NonNull
     @Default
@@ -86,8 +91,8 @@ public class CorfuServerParams implements NodeParams {
         return clusterName + "-corfu-node" + getPort();
     }
 
-    public String getStreamLogDir() {
-        return getName() + "/" + streamLogDir;
+    public Path getStreamLogDir() {
+        return Paths.get(getName(), streamLogDir);
     }
 
     @Override
@@ -100,7 +105,7 @@ public class CorfuServerParams implements NodeParams {
     }
 
     public Path getInfrastructureJar() {
-        return serverJarDirectory.resolve(
+        return universeDirectory.resolve(
                 String.format("infrastructure-%s-shaded.jar", serverVersion)
         );
     }

--- a/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
@@ -1,7 +1,5 @@
 package org.corfudb.universe.node.server.docker;
 
-import static com.spotify.docker.client.DockerClient.LogsParam;
-
 import com.spotify.docker.client.DockerClient;
 import com.spotify.docker.client.DockerClient.ListImagesParam;
 import com.spotify.docker.client.LogStream;
@@ -29,7 +27,6 @@ import org.corfudb.universe.util.IpAddress;
 import org.corfudb.universe.util.IpTablesUtil;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -42,6 +39,8 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+
+import static com.spotify.docker.client.DockerClient.LogsParam;
 
 /**
  * Implements a docker instance representing a {@link CorfuServer}.
@@ -57,8 +56,6 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
     private final DockerManager dockerManager;
 
     @NonNull
-    private final LoggingParams loggingParams;
-    @NonNull
     private final CorfuClusterParams<CorfuServerParams> clusterParams;
     private final AtomicReference<IpAddress> ipAddress = new AtomicReference<>();
     private final AtomicBoolean destroyed = new AtomicBoolean();
@@ -68,9 +65,8 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
             DockerClient docker, CorfuServerParams params, UniverseParams universeParams,
             CorfuClusterParams<CorfuServerParams> clusterParams, LoggingParams loggingParams,
             DockerManager dockerManager) {
-        super(params, universeParams);
+        super(params, universeParams, loggingParams);
         this.docker = docker;
-        this.loggingParams = loggingParams;
         this.clusterParams = clusterParams;
         this.dockerManager = dockerManager;
     }
@@ -358,14 +354,12 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
                 .build();
 
         // Compose command line for starting Corfu
-        String cmdLine = new StringBuilder()
-                .append("mkdir -p " + params.getStreamLogDir())
-                .append(" && ")
-                .append("java -cp *.jar ")
-                .append(org.corfudb.infrastructure.CorfuServer.class.getCanonicalName())
-                .append(" ")
-                .append(getCommandLineParams())
-                .toString();
+        String cmdLine = String.format("mkdir -p %s", params.getStreamLogDir()) +
+                " && " +
+                "java -cp *.jar " +
+                org.corfudb.infrastructure.CorfuServer.class.getCanonicalName() +
+                " " +
+                getCommandLineParams();
 
         return ContainerConfig.builder()
                 .hostConfig(hostConfig)
@@ -379,15 +373,20 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
     /**
      * Collect logs from container and write to the log directory
      */
-    private void collectLogs() {
+    public void collectLogs() {
         if (!loggingParams.isEnabled()) {
             log.debug("Logging is disabled");
             return;
         }
 
-        File serverLogDir = loggingParams.getServerLogDir().toFile();
-        if (!serverLogDir.exists() && serverLogDir.mkdirs()) {
-            log.info("Created new corfu log directory at {}.", serverLogDir);
+        Path corfuLogDir = params
+                .getUniverseDirectory()
+                .resolve("logs")
+                .resolve(loggingParams.getRelativeServerLogDir());
+
+        File logDirFile = corfuLogDir.toFile();
+        if (!logDirFile.exists() && logDirFile.mkdirs()) {
+            log.info("Created new corfu log directory at {}.", corfuLogDir);
         }
 
         log.debug("Collect logs for: {}", params.getName());
@@ -399,9 +398,9 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
                 log.warn("Empty logs from container: {}", params.getName());
             }
 
-            Path filePathObj = loggingParams.getServerLogDir().resolve(params.getName() + ".log");
-            Files.write(filePathObj, logs.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-        } catch (InterruptedException | DockerException | IOException e) {
+            Path logFile = corfuLogDir.resolve(params.getName() + ".log");
+            Files.write(logFile, logs.getBytes(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+        } catch (Exception e) {
             log.error("Can't collect logs from container: {}", params.getName(), e);
         }
     }

--- a/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
@@ -373,6 +373,7 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
     /**
      * Collect logs from container and write to the log directory
      */
+    @Override
     public void collectLogs() {
         if (!loggingParams.isEnabled()) {
             log.debug("Logging is disabled");
@@ -398,8 +399,11 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
                 log.warn("Empty logs from container: {}", params.getName());
             }
 
-            Path logFile = corfuLogDir.resolve(params.getName() + ".log");
-            Files.write(logFile, logs.getBytes(), StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+            Files.write(
+                    corfuLogDir.resolve(params.getName() + ".log"),
+                    logs.getBytes(),
+                    StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE, StandardOpenOption.SYNC
+            );
         } catch (Exception e) {
             log.error("Can't collect logs from container: {}", params.getName(), e);
         }

--- a/it/src/main/java/org/corfudb/universe/node/server/process/CorfuProcessManager.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/process/CorfuProcessManager.java
@@ -1,12 +1,8 @@
 package org.corfudb.universe.node.server.process;
 
-import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.universe.node.server.CorfuServerParams;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 /**
  * Provides executable commands for the CorfuServer-s to create a directory structure,
@@ -19,33 +15,20 @@ public class CorfuProcessManager {
     @NonNull
     private final CorfuServerParams params;
 
-    @Getter
     @NonNull
-    private final Path corfuDir;
-    private final Path serverDir;
-    private final Path dbDir;
-    @Getter
-    private final Path serverJar;
-    private final Path serverJarRelativePath;
+    private final CorfuServerPath serverPath;
 
-    public CorfuProcessManager(Path corfuDir, @NonNull CorfuServerParams params) {
-
-        this.corfuDir = corfuDir;
+    public CorfuProcessManager(CorfuServerPath serverPath, @NonNull CorfuServerParams params) {
         this.params = params;
-
-        serverDir = corfuDir.resolve(params.getName());
-        dbDir = corfuDir.resolve(params.getStreamLogDir());
-
-        serverJarRelativePath = Paths.get(params.getName(), "corfu-server.jar");
-        serverJar = corfuDir.resolve(serverJarRelativePath);
+        this.serverPath = serverPath;
     }
 
     public String createServerDirCommand() {
-        return "mkdir -p " + serverDir;
+        return "mkdir -p " + serverPath.getServerDir();
     }
 
     public String createStreamLogDirCommand() {
-        return "mkdir -p " + dbDir;
+        return "mkdir -p " + serverPath.getDbDir();
     }
 
     public String pauseCommand() {
@@ -61,17 +44,16 @@ public class CorfuProcessManager {
     }
 
     public String startCommand(String commandLineParams) {
-        Path corfuLog = serverDir.resolve("corfu.log");
 
         // Compose command line for starting Corfu
         return "java -cp " +
-                serverJarRelativePath +
+                serverPath.getServerJarRelativePath() +
                 " " +
                 org.corfudb.infrastructure.CorfuServer.class.getName() +
                 " " +
                 commandLineParams +
                 " > " +
-                corfuLog +
+                serverPath.getCorfuLogFile() +
                 " 2>&1 &";
     }
 
@@ -105,6 +87,7 @@ public class CorfuProcessManager {
 
     public String killCommand() {
         log.info("Kill the corfu server. Params: {}", params);
+
         return "ps -ef" +
                 " | " +
                 "grep -v grep" +
@@ -117,6 +100,6 @@ public class CorfuProcessManager {
     }
 
     public String removeServerDirCommand() {
-        return String.format("rm -rf %s", serverDir);
+        return String.format("rm -rf %s", serverPath.getServerDir());
     }
 }

--- a/it/src/main/java/org/corfudb/universe/node/server/process/CorfuServerPath.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/process/CorfuServerPath.java
@@ -1,0 +1,73 @@
+package org.corfudb.universe.node.server.process;
+
+import lombok.Getter;
+import lombok.NonNull;
+import org.corfudb.universe.node.server.CorfuServerParams;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Information regarding corfu server directory structure.
+ * The default structure is:
+ * <pre>
+ *  ${corfuDir} [~]
+ *  | - ${serverDir}
+ *      | - corfu.log
+ *      | - corfu-server.jar
+ *      | - db
+ *          | - stream log files
+ *          | - corfu - data store directory, contains paxos files and layouts
+ *  </pre>
+ */
+@Getter
+public class CorfuServerPath {
+
+    private static final String SERVER_JAR_NAME = "corfu-server.jar";
+    private static final String DEFAULT_LOG_FILE = "corfu.log";
+
+    /**
+     * Corfu server directory. By default base directory for any corfu server is a home directory: `~/`
+     */
+    @NonNull
+    private final Path corfuDir;
+
+    /**
+     * The directory of a particular instance of a corfu server: ${corfuDir}/${serverParams.getName()}
+     */
+    private final Path serverDir;
+    /**
+     * Corfu stream log (database) directory
+     */
+    private final Path dbDir;
+    /**
+     * Path to corfu server jar file: ${serverDir}/SERVER_JAR_NAME
+     */
+    private final Path serverJar;
+    /**
+     * Corfu server relative path name: ${serverParams.getName()}/SERVER_JAR_NAME
+     */
+    private final Path serverJarRelativePath;
+    /**
+     * Corfu log file: ${serverDir}/corfu.log
+     */
+    private final Path corfuLogFile;
+
+    private final CorfuServerParams params;
+
+    public CorfuServerPath(CorfuServerParams params) {
+        this(Paths.get("~"), params);
+    }
+
+    public CorfuServerPath(Path corfuDir, CorfuServerParams params) {
+        this.corfuDir = corfuDir;
+        this.params = params;
+        serverDir = corfuDir.resolve(params.getName());
+        dbDir = corfuDir.resolve(params.getStreamLogDir());
+
+        corfuLogFile = serverDir.resolve(DEFAULT_LOG_FILE);
+
+        serverJarRelativePath = Paths.get(params.getName(), SERVER_JAR_NAME);
+        serverJar = corfuDir.resolve(serverJarRelativePath);
+    }
+}

--- a/it/src/main/java/org/corfudb/universe/node/server/process/ProcessCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/process/ProcessCorfuServer.java
@@ -249,7 +249,7 @@ public class ProcessCorfuServer extends AbstractCorfuServer<CorfuServerParams, U
             Files.write(
                     corfuLogDir.resolve(params.getName() + ".log"),
                     serverLog.getBytes(StandardCharsets.UTF_8),
-                    StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE
+                    StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE, StandardOpenOption.SYNC
             );
         } catch (Exception e) {
             log.error("Can't download logs for corfu server: " + params.getName());

--- a/it/src/main/java/org/corfudb/universe/node/server/vm/VmCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/vm/VmCorfuServer.java
@@ -5,18 +5,23 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.universe.group.cluster.vm.RemoteOperationHelper;
+import org.corfudb.universe.logging.LoggingParams;
 import org.corfudb.universe.node.NodeException;
 import org.corfudb.universe.node.server.AbstractCorfuServer;
 import org.corfudb.universe.node.server.CorfuServer;
 import org.corfudb.universe.node.server.process.CorfuProcessManager;
+import org.corfudb.universe.node.server.process.CorfuServerPath;
 import org.corfudb.universe.node.stress.vm.VmStress;
 import org.corfudb.universe.universe.vm.VmManager;
 import org.corfudb.universe.universe.vm.VmUniverseParams;
 import org.corfudb.universe.util.IpAddress;
 import org.corfudb.universe.util.IpTablesUtil;
 
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.List;
 
@@ -43,18 +48,20 @@ public class VmCorfuServer extends AbstractCorfuServer<VmCorfuServerParams, VmUn
     @NonNull
     private final CorfuProcessManager processManager;
 
+    @NonNull
+    private final CorfuServerPath serverPath;
+
     @Builder
     public VmCorfuServer(
             VmCorfuServerParams params, VmManager vmManager, VmUniverseParams universeParams,
-            VmStress stress, RemoteOperationHelper remoteOperationHelper) {
-        super(params, universeParams);
+            VmStress stress, RemoteOperationHelper remoteOperationHelper, LoggingParams loggingParams) {
+        super(params, universeParams, loggingParams);
         this.vmManager = vmManager;
         this.ipAddress = getIpAddress();
         this.stress = stress;
         this.remoteOperationHelper = remoteOperationHelper;
-
-        Path corfuDir = Paths.get("~");
-        this.processManager = new CorfuProcessManager(corfuDir, params);
+        this.serverPath = new CorfuServerPath(params);
+        this.processManager = new CorfuProcessManager(serverPath, params);
     }
 
     /**
@@ -71,7 +78,7 @@ public class VmCorfuServer extends AbstractCorfuServer<VmCorfuServerParams, VmUn
 
         remoteOperationHelper.copyFile(
                 params.getInfrastructureJar(),
-                processManager.getServerJar()
+                serverPath.getServerJar()
         );
 
         start();
@@ -253,6 +260,7 @@ public class VmCorfuServer extends AbstractCorfuServer<VmCorfuServerParams, VmUn
         kill();
         try {
             executeSudoCommand(IpTablesUtil.cleanAll());
+            collectLogs();
             removeAppDir();
         } catch (Exception e) {
             throw new NodeException("Can't clean corfu directories", e);
@@ -271,5 +279,37 @@ public class VmCorfuServer extends AbstractCorfuServer<VmCorfuServerParams, VmUn
     @Override
     public IpAddress getNetworkInterface() {
         return ipAddress;
+    }
+
+    @Override
+    public void collectLogs() {
+        if (!loggingParams.isEnabled()) {
+            log.debug("Logging is disabled");
+            return;
+        }
+
+        log.info("Download corfu server logs: {}", params.getName());
+
+        Path corfuLogDir = params
+                .getUniverseDirectory()
+                .resolve("logs")
+                .resolve(loggingParams.getRelativeServerLogDir());
+
+        File logDirFile = corfuLogDir.toFile();
+        if (!logDirFile.exists() && logDirFile.mkdirs()) {
+            log.info("Created new corfu log directory at {}.", corfuLogDir);
+        }
+
+        try {
+            String serverLog = remoteOperationHelper.executeCommand("cat " + serverPath.getCorfuLogFile());
+
+            Files.write(
+                    corfuLogDir.resolve(params.getName() + ".log"),
+                    serverLog.getBytes(StandardCharsets.UTF_8),
+                    StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE
+            );
+        } catch (Exception e) {
+            log.error("Can't download logs for corfu server: " + params.getName());
+        }
     }
 }

--- a/it/src/main/java/org/corfudb/universe/node/server/vm/VmCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/vm/VmCorfuServer.java
@@ -306,7 +306,7 @@ public class VmCorfuServer extends AbstractCorfuServer<VmCorfuServerParams, VmUn
             Files.write(
                     corfuLogDir.resolve(params.getName() + ".log"),
                     serverLog.getBytes(StandardCharsets.UTF_8),
-                    StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE
+                    StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE, StandardOpenOption.SYNC
             );
         } catch (Exception e) {
             log.error("Can't download logs for corfu server: " + params.getName());

--- a/it/src/main/java/org/corfudb/universe/scenario/fixture/Fixtures.java
+++ b/it/src/main/java/org/corfudb/universe/scenario/fixture/Fixtures.java
@@ -8,6 +8,7 @@ import org.corfudb.universe.group.cluster.CorfuClusterParams.CorfuClusterParamsB
 import org.corfudb.universe.group.cluster.SupportClusterParams;
 import org.corfudb.universe.group.cluster.SupportClusterParams.SupportClusterParamsBuilder;
 import org.corfudb.universe.logging.LoggingParams;
+import org.corfudb.universe.logging.LoggingParams.LoggingParamsBuilder;
 import org.corfudb.universe.node.Node.NodeType;
 import org.corfudb.universe.node.client.ClientParams;
 import org.corfudb.universe.node.client.ClientParams.ClientParamsBuilder;
@@ -88,7 +89,7 @@ public interface Fixtures {
 
         private final FixtureUtilBuilder fixtureUtilBuilder = FixtureUtil.builder();
 
-        private final LoggingParams.LoggingParamsBuilder logging = LoggingParams.builder()
+        private final LoggingParamsBuilder logging = LoggingParams.builder()
                 .enabled(false);
 
         private Optional<UniverseParams> data = Optional.empty();
@@ -149,6 +150,9 @@ public interface Fixtures {
         private final Properties vmProperties = VmConfigPropertiesLoader
                 .loadVmProperties()
                 .get();
+
+        private final LoggingParamsBuilder logging = LoggingParams.builder()
+                .enabled(false);
 
         public VmUniverseFixture() {
             Properties credentials = VmConfigPropertiesLoader

--- a/it/src/main/java/org/corfudb/universe/universe/AbstractUniverse.java
+++ b/it/src/main/java/org/corfudb/universe/universe/AbstractUniverse.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ClassUtils;
 import org.corfudb.universe.group.Group;
 import org.corfudb.universe.group.Group.GroupParams;
+import org.corfudb.universe.logging.LoggingParams;
 import org.corfudb.universe.node.Node.NodeParams;
 
 import java.util.UUID;
@@ -21,12 +22,17 @@ public abstract class AbstractUniverse<N extends NodeParams, P extends UniverseP
     @NonNull
     protected final P universeParams;
     @Getter
+    @NonNull
     protected final UUID universeId;
+
+    @NonNull
+    protected final LoggingParams loggingParams;
 
     protected final ConcurrentMap<String, Group> groups = new ConcurrentHashMap<>();
 
-    protected AbstractUniverse(P universeParams) {
+    protected AbstractUniverse(P universeParams, LoggingParams loggingParams) {
         this.universeParams = universeParams;
+        this.loggingParams = loggingParams;
         this.universeId = UUID.randomUUID();
 
         if (universeParams.isCleanUpEnabled()) {

--- a/it/src/main/java/org/corfudb/universe/universe/docker/DockerUniverse.java
+++ b/it/src/main/java/org/corfudb/universe/universe/docker/DockerUniverse.java
@@ -35,15 +35,12 @@ public class DockerUniverse extends AbstractUniverse<NodeParams, UniverseParams>
     private final DockerClient docker;
     private final DockerNetwork network = new DockerNetwork();
     private final AtomicBoolean initialized = new AtomicBoolean();
-    private final LoggingParams loggingParams;
     private final AtomicBoolean destroyed = new AtomicBoolean();
 
     @Builder
     public DockerUniverse(UniverseParams universeParams, DockerClient docker, LoggingParams loggingParams) {
-        super(universeParams);
+        super(universeParams, loggingParams);
         this.docker = docker;
-        this.loggingParams = loggingParams;
-
         init();
     }
 

--- a/it/src/main/java/org/corfudb/universe/universe/process/ProcessUniverse.java
+++ b/it/src/main/java/org/corfudb/universe/universe/process/ProcessUniverse.java
@@ -7,6 +7,7 @@ import org.corfudb.universe.group.Group;
 import org.corfudb.universe.group.Group.GroupParams;
 import org.corfudb.universe.group.cluster.Cluster.ClusterType;
 import org.corfudb.universe.group.cluster.process.ProcessCorfuCluster;
+import org.corfudb.universe.logging.LoggingParams;
 import org.corfudb.universe.node.Node.NodeParams;
 import org.corfudb.universe.universe.AbstractUniverse;
 import org.corfudb.universe.universe.Universe;
@@ -31,8 +32,8 @@ public class ProcessUniverse extends AbstractUniverse<NodeParams, UniverseParams
     private final AtomicBoolean destroyed = new AtomicBoolean(false);
 
     @Builder
-    public ProcessUniverse(UniverseParams universeParams) {
-        super(universeParams);
+    public ProcessUniverse(UniverseParams universeParams, LoggingParams loggingParams) {
+        super(universeParams, loggingParams);
         init();
     }
 

--- a/it/src/main/java/org/corfudb/universe/universe/vm/VmUniverse.java
+++ b/it/src/main/java/org/corfudb/universe/universe/vm/VmUniverse.java
@@ -9,6 +9,7 @@ import org.corfudb.universe.group.Group;
 import org.corfudb.universe.group.Group.GroupParams;
 import org.corfudb.universe.group.cluster.Cluster.ClusterType;
 import org.corfudb.universe.group.cluster.vm.VmCorfuCluster;
+import org.corfudb.universe.logging.LoggingParams;
 import org.corfudb.universe.node.Node.NodeParams;
 import org.corfudb.universe.universe.AbstractUniverse;
 import org.corfudb.universe.universe.Universe;
@@ -35,8 +36,8 @@ public class VmUniverse extends AbstractUniverse<NodeParams, VmUniverseParams> {
     private final ApplianceManager applianceManager;
 
     @Builder
-    public VmUniverse(VmUniverseParams universeParams, ApplianceManager applianceManager) {
-        super(universeParams);
+    public VmUniverse(VmUniverseParams universeParams, ApplianceManager applianceManager, LoggingParams loggingParams) {
+        super(universeParams, loggingParams);
         this.applianceManager = applianceManager;
 
         applianceManager.deploy();


### PR DESCRIPTION
## Overview
This change allows collecting Corfu cluster logs into a `target` directory, which improves the convenience of debugging the universe tests.  

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
