### PR TITLE
CorfuQueue: Sort entries before returning in entryList()

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
@@ -261,10 +261,9 @@ public class CorfuQueue<E> {
         );
 
         int index = 0;
-        for (Long entryId : corfuTable.keySet().stream().sorted().collect(Collectors.toList())) {
-            if (entryId <= entriesAfter) {
-                continue;
-            }
+        for (Long entryId : corfuTable.keySet().stream()
+                .filter(e -> e > entriesAfter)
+                .sorted().collect(Collectors.toList())) {
             if (++index >= maxEntries) {
                 break;
             }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Persisted Queue supported by CorfuDB using distributed State Machine Replication.
@@ -226,11 +227,12 @@ public class CorfuQueue<E> {
      * <p>This function currently does not return a view like the java.util implementation,
      * and changes to the entryList will *not* be reflected in the map. </p>
      *
+     * @param entriesAfter - Return only entries greater than this entry in the Queue.
      * @param maxEntries - Limit the number of entries returned from start of the queue
      * @throws IllegalArgumentException if maxEntries is negative.
      * @return List of Entries sorted by their enqueue order
      */
-    public List<CorfuQueueRecord<E>> entryList(int maxEntries) {
+    public List<CorfuQueueRecord<E>> entryList(Long entriesAfter, int maxEntries) {
         if (maxEntries <= 0) {
             throw new IllegalArgumentException("entryList given negative maxEntries");
         }
@@ -257,16 +259,19 @@ public class CorfuQueue<E> {
         List<CorfuQueueRecord<E>> copy = new ArrayList<>(
                 Math.min(corfuTable.size(), maxEntries)
         );
+
         int index = 0;
-        for (Map.Entry<Long, E> entry : corfuTable.entrySet()) {
+        for (Long entryId : corfuTable.keySet().stream().sorted().collect(Collectors.toList())) {
+            if (entryId <= entriesAfter) {
+                continue;
+            }
             if (++index >= maxEntries) {
                 break;
             }
             // Note that index is already limited to fit within MAX_BITS_FOR_INDEX
             long ordering = (snapshotVersion << MAX_BITS_FOR_INDEX) | index;
-            long entryId = entry.getKey();
             CorfuQueueRecord<E> record = new CorfuQueueRecord<>(
-                    ordering, entryId, entry.getValue()
+                    ordering, entryId, corfuTable.get(entryId)
             );
             copy.add(record);
         }
@@ -281,7 +286,15 @@ public class CorfuQueue<E> {
      * @return all the entries in the Queue
      */
     public List<CorfuQueueRecord<E>> entryList() {
-        return this.entryList(MAX_INDEX_ENTRIES);
+        return this.entryList(0L, MAX_INDEX_ENTRIES);
+    }
+
+    /**
+     * @param maxEntries limit number of entries returned to this.
+     * @return all the entries in the Queue
+     */
+    public List<CorfuQueueRecord<E>> entryList(int maxEntries) {
+        return this.entryList(0L, maxEntries);
     }
 
     public boolean isEmpty() {

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
@@ -80,6 +80,11 @@ public class CorfuQueueTest extends AbstractViewTest {
         final int expected = 3;
         List<CorfuQueueRecord<String>> records = corfuQueue.entryList();
         assertThat(records.size()).isEqualTo(expected);
+
+        List<CorfuQueueRecord<String>> recAfter = corfuQueue.entryList(
+                records.get(0).getRecordId().getEntryId(),
+                records.size());
+        assertThat(recAfter.size()).isEqualTo(records.size() - 1);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
@@ -81,6 +81,7 @@ public class CorfuQueueTest extends AbstractViewTest {
         List<CorfuQueueRecord<String>> records = corfuQueue.entryList();
         assertThat(records.size()).isEqualTo(expected);
 
+        // Only retrieve entries greater than the first entry.
         List<CorfuQueueRecord<String>> recAfter = corfuQueue.entryList(
                 records.get(0).getRecordId().getEntryId(),
                 records.size());

--- a/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
@@ -88,8 +88,8 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
                     TXBegin(txnType);
                     Long coinToss = new Random().nextLong() % numConflictKeys;
                     conflictMap.put(coinToss, coinToss);
-                    CorfuRecordId id = corfuQueue.enqueue(queueData);
                     lock.lock();
+                    CorfuRecordId id = corfuQueue.enqueue(queueData);
                     final long streamOffset = TXEnd();
                     validator.add(new Record(id, queueData));
                     log.debug("ENQ:" + id + "=>" + queueData + " at " + streamOffset);


### PR DESCRIPTION
This is to preserve order if checkpointer runs first.
Checkpointer uses a normal HashMap and not a LinkedHashMap
causing a loss of ordering if it runs first.
Fix is to sort the entries first.
This also enables the api to allow entries to be returned
only after a user specified previous entry.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #2454 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
