### PR TITLE
CorfuTable Thread Pool Sizing Bug

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -67,7 +67,8 @@ public class CorfuTable<K, V> implements
     // can acquire the VLO lock and cause the other 3 threads to wait, but after acquiring the VLO lock, the thread
     // gets block on parallel stream, because the pool is exhausted with threads that are trying to acquire the VLO
     // look, which creates a circular dependency. In other words, a deadlock.
-    private final static ForkJoinPool pool = new ForkJoinPool(Runtime.getRuntime().availableProcessors() - 1,
+
+    private final static ForkJoinPool pool = new ForkJoinPool(Math.max(Runtime.getRuntime().availableProcessors() - 1, 1),
             pool -> {
                 final ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
                 worker.setName("CorfuTable-Forkjoin-pool-" + worker.getPoolIndex());


### PR DESCRIPTION
## Overview
Fixes fork join pool size bug.


Why should this be merged: fixes bug.

## Checklist (Definition of Done):
- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
