### PR TITLE
Use Writer Thread For Eviction

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -1,7 +1,25 @@
 package org.corfudb.infrastructure;
 
+import static org.corfudb.infrastructure.BatchWriterOperation.Type.LOG_ADDRESS_SPACE_QUERY;
+import static org.corfudb.infrastructure.BatchWriterOperation.Type.PREFIX_TRIM;
+import static org.corfudb.infrastructure.BatchWriterOperation.Type.RANGE_WRITE;
+import static org.corfudb.infrastructure.BatchWriterOperation.Type.RESET;
+import static org.corfudb.infrastructure.BatchWriterOperation.Type.SEAL;
+import static org.corfudb.infrastructure.BatchWriterOperation.Type.TAILS_QUERY;
+import static org.corfudb.infrastructure.BatchWriterOperation.Type.WRITE;
+
+
 import com.google.common.annotations.VisibleForTesting;
 import io.netty.channel.ChannelHandlerContext;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -39,24 +57,6 @@ import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.Utils;
-
-import java.lang.invoke.MethodHandles;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-
-import static org.corfudb.infrastructure.BatchWriterOperation.Type.LOG_ADDRESS_SPACE_QUERY;
-import static org.corfudb.infrastructure.BatchWriterOperation.Type.PREFIX_TRIM;
-import static org.corfudb.infrastructure.BatchWriterOperation.Type.RANGE_WRITE;
-import static org.corfudb.infrastructure.BatchWriterOperation.Type.RESET;
-import static org.corfudb.infrastructure.BatchWriterOperation.Type.SEAL;
-import static org.corfudb.infrastructure.BatchWriterOperation.Type.TAILS_QUERY;
-import static org.corfudb.infrastructure.BatchWriterOperation.Type.WRITE;
 
 
 /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServerCache.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServerCache.java
@@ -1,5 +1,7 @@
 package org.corfudb.infrastructure;
 
+import static org.corfudb.util.MetricsUtils.sizeOf;
+
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.github.benmanes.caffeine.cache.RemovalCause;
@@ -19,154 +21,160 @@ import org.corfudb.protocols.wireprotocol.LogData;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-import static org.corfudb.util.MetricsUtils.sizeOf;
-
 /**
  * LogUnit server cache.
- * <p>
- * All reads and writes go through this cache. But in some cases, messages can
- * specify non-cacheable read/write, then they will not go through this cache.
- * <p>
- * Created by WenbinZhu on 5/30/19.
+ *
+ * <p>All reads and writes go through this cache. But in some cases, messages can specify
+ * non-cacheable read/write, then they will not go through this cache.
+ *
+ * <p>Created by WenbinZhu on 5/30/19.
  */
 @Slf4j
 public class LogUnitServerCache {
 
-    private final LoadingCache<Long, ILogData> dataCache;
-    private final StreamLog streamLog;
+  private final LoadingCache<Long, ILogData> dataCache;
+  private final StreamLog streamLog;
 
-    //Size of key in the cache.  8 bytes as its a long
-    private final int KEY_SIZE = 8;
+  // Size of key in the cache.  8 bytes as its a long
+  private final int KEY_SIZE = 8;
 
-    //Empirical threshold of number of streams in a logdata beyond which server performance may be slow
-    private final int MAX_STREAM_THRESHOLD = 20;
+  // Empirical threshold of number of streams in a logdata beyond which server performance may be
+  // slow
+  private final int MAX_STREAM_THRESHOLD = 20;
 
-    private final Optional<Timer> readTimer;
-    private final Optional<Gauge> loadTime;
-    String loadTimeName = "logunit.cache.load_time";
-    private final Optional<Gauge> hitRatio;
-    String hitRatioName = "logunit.cache.hit_ratio";
-    private final Optional<Gauge> weight;
-    String weightName = "logunit.cache.weight";
+  private final Optional<Timer> readTimer;
+  private final Optional<Gauge> loadTime;
+  String loadTimeName = "logunit.cache.load_time";
+  private final Optional<Gauge> hitRatio;
+  String hitRatioName = "logunit.cache.hit_ratio";
+  private final Optional<Gauge> weight;
+  String weightName = "logunit.cache.weight";
 
-    public LogUnitServerCache(LogUnitServerConfig config, StreamLog streamLog) {
-        this.streamLog = streamLog;
-        this.dataCache = Caffeine.newBuilder()
-                .<Long, ILogData>weigher((addr, logData) -> getLogDataTotalSize(logData))
-                .maximumWeight(config.getMaxCacheSize())
-                .recordStats()
-                .removalListener(this::handleEviction)
-                .build(this::handleRetrieval);
+  public LogUnitServerCache(LogUnitServerConfig config, StreamLog streamLog) {
+    this.streamLog = streamLog;
+    this.dataCache =
+        Caffeine.newBuilder()
+            .<Long, ILogData>weigher((addr, logData) -> getLogDataTotalSize(logData))
+            .maximumWeight(config.getMaxCacheSize())
+            .recordStats()
+            .executor(Runnable::run)
+            .removalListener(this::handleEviction)
+            .build(this::handleRetrieval);
 
-        MeterRegistryProvider.getInstance().ifPresent(registry ->
-                CaffeineCacheMetrics.monitor(registry, dataCache, "logunit.read_cache"));
-        hitRatio = MeterRegistryProvider.getInstance().map(registry ->
-                Gauge.builder(hitRatioName,
-                dataCache, cache -> cache.stats().hitRate()).register(registry));
-        loadTime = MeterRegistryProvider.getInstance().map(registry ->
-                Gauge.builder(loadTimeName,
-                        dataCache, cache -> cache.stats().totalLoadTime())
+    MeterRegistryProvider.getInstance()
+        .ifPresent(
+            registry -> CaffeineCacheMetrics.monitor(registry, dataCache, "logunit.read_cache"));
+    hitRatio =
+        MeterRegistryProvider.getInstance()
+            .map(
+                registry ->
+                    Gauge.builder(hitRatioName, dataCache, cache -> cache.stats().hitRate())
                         .register(registry));
-        weight = MeterRegistryProvider.getInstance().map(registry ->
-                Gauge.builder(weightName,
-                        dataCache, cache -> cache.stats().evictionWeight())
+    loadTime =
+        MeterRegistryProvider.getInstance()
+            .map(
+                registry ->
+                    Gauge.builder(loadTimeName, dataCache, cache -> cache.stats().totalLoadTime())
+                        .register(registry));
+    weight =
+        MeterRegistryProvider.getInstance()
+            .map(
+                registry ->
+                    Gauge.builder(weightName, dataCache, cache -> cache.stats().evictionWeight())
                         .register(registry));
 
-        readTimer = MeterRegistryProvider.getInstance().map(registry ->
-                Timer.builder("logunit.read.timer").register(registry));
+    readTimer =
+        MeterRegistryProvider.getInstance()
+            .map(registry -> Timer.builder("logunit.read.timer").register(registry));
+  }
+
+  private int getLogDataTotalSize(ILogData logData) {
+    if (logData.getStreams().size() > MAX_STREAM_THRESHOLD) {
+      log.warn(
+          "Number of streams in this data is higher that threshold {}."
+              + "This may impact the server performance",
+          MAX_STREAM_THRESHOLD);
+    }
+    return logData.getSizeEstimate()
+        + (int) (sizeOf.deepSizeOf(logData.getMetadataMap()))
+        + KEY_SIZE;
+  }
+
+  /**
+   * Retrieves the LogUnitEntry from disk, given an address.
+   *
+   * @param address the address to retrieve the entry from
+   * @return the log unit entry to retrieve into the cache
+   *     <p>This function should not care about trimmed addresses, as that is handled in the
+   *     streamLog. Any address that cannot be retrieved should be returned as un-written (null).
+   */
+  private ILogData handleRetrieval(long address) {
+    Supplier<LogData> readSupplier = () -> streamLog.read(address);
+    LogData entry =
+        readTimer.map(timer -> timer.record(readSupplier)).orElseGet(() -> readSupplier.get());
+    log.trace("handleRetrieval: Retrieved[{} : {}]", address, entry);
+    return entry;
+  }
+
+  private void handleEviction(long address, ILogData entry, RemovalCause cause) {
+    log.trace("handleEviction: Eviction[{}]: {}", address, cause);
+  }
+
+  /**
+   * Returns the log entry form the cache or retrieves it from the underlying storage.
+   *
+   * <p>If the log entry is not cacheable and it does not exist in cache, it will not be cached when
+   * retrieved from the underlying storage.
+   *
+   * @param address the address of the log entry to retrieve
+   * @param cacheable if the log entry should be cached when retrieved from underlying storage
+   * @return the log entry read from cache or retrieved the underlying storage
+   */
+  public ILogData get(long address, boolean cacheable) {
+    if (!cacheable) {
+      ILogData ld = dataCache.getIfPresent(address);
+      return ld != null ? ld : handleRetrieval(address);
     }
 
-    private int getLogDataTotalSize(ILogData logData) {
-        if (logData.getStreams().size() > MAX_STREAM_THRESHOLD) {
-            log.warn("Number of streams in this data is higher that threshold {}." +
-                "This may impact the server performance", MAX_STREAM_THRESHOLD);
-        }
-        return logData.getSizeEstimate() +
-            (int)(sizeOf.deepSizeOf(logData.getMetadataMap())) +
-            KEY_SIZE;
-    }
+    return dataCache.get(address);
+  }
 
-    /**
-     * Retrieves the LogUnitEntry from disk, given an address.
-     *
-     * @param address the address to retrieve the entry from
-     * @return the log unit entry to retrieve into the cache
-     * <p>
-     * This function should not care about trimmed addresses, as that is handled
-     * in the streamLog. Any address that cannot be retrieved should be returned
-     * as un-written (null).
-     */
-    private ILogData handleRetrieval(long address) {
-        Supplier<LogData> readSupplier = () -> streamLog.read(address);
-        LogData entry = readTimer.map(timer -> timer.record(readSupplier))
-                .orElseGet(() -> readSupplier.get());
-        log.trace("handleRetrieval: Retrieved[{} : {}]", address, entry);
-        return entry;
-    }
+  /**
+   * Returns the log entry form the cache or retrieves it from the underlying storage.
+   *
+   * @param address the address of the log entry to retrieve
+   * @return the log entry read from cache or retrieved the underlying storage
+   */
+  public ILogData get(long address) {
+    return get(address, true);
+  }
 
-    private void handleEviction(long address, ILogData entry, RemovalCause cause) {
-        log.trace("handleEviction: Eviction[{}]: {}", address, cause);
-    }
+  /**
+   * Puts the log entry into the cache. {@link LoadingCache#put(Object, Object)}
+   *
+   * @param address the address to write entry to
+   * @param entry the log entry to write
+   */
+  public void put(long address, ILogData entry) {
+    log.trace("LogUnitServerCache.put: Cache write[{} : {}]", address, entry);
+    dataCache.put(address, entry);
+  }
 
-    /**
-     * Returns the log entry form the cache or retrieves it from the underlying storage.
-     * <p>
-     * If the log entry is not cacheable and it does not exist in cache, it will not be
-     * cached when retrieved from the underlying storage.
-     *
-     * @param address   the address of the log entry to retrieve
-     * @param cacheable if the log entry should be cached when retrieved from underlying storage
-     * @return the log entry read from cache or retrieved the underlying storage
-     */
-    public ILogData get(long address, boolean cacheable) {
-        if (!cacheable) {
-            ILogData ld = dataCache.getIfPresent(address);
-            return ld != null ? ld : handleRetrieval(address);
-        }
+  /** Discards all the entries in the cache. {@link LoadingCache#invalidateAll()} */
+  public void invalidateAll() {
+    dataCache.invalidateAll();
+    cleanUpGauges();
+  }
 
-        return dataCache.get(address);
-    }
+  @VisibleForTesting
+  public int getSize() {
+    return dataCache.asMap().size();
+  }
 
-    /**
-     * Returns the log entry form the cache or retrieves it from the underlying storage.
-     *
-     * @param address the address of the log entry to retrieve
-     * @return the log entry read from cache or retrieved the underlying storage
-     */
-    public ILogData get(long address) {
-        return get(address, true);
+  private void cleanUpGauges() {
+    String[] names = new String[] {loadTimeName, hitRatioName, weightName};
+    for (String gaugeName : names) {
+      MeterRegistryProvider.deregisterServerMeter(gaugeName, Tags.empty(), Meter.Type.GAUGE);
     }
-
-    /**
-     * Puts the log entry into the cache.
-     * {@link LoadingCache#put(Object, Object)}
-     *
-     * @param address the address to write entry to
-     * @param entry   the log entry to write
-     */
-    public void put(long address, ILogData entry) {
-        log.trace("LogUnitServerCache.put: Cache write[{} : {}]", address, entry);
-        dataCache.put(address, entry);
-    }
-
-    /**
-     * Discards all the entries in the cache.
-     * {@link LoadingCache#invalidateAll()}
-     */
-    public void invalidateAll() {
-        dataCache.invalidateAll();
-        cleanUpGauges();
-    }
-
-    @VisibleForTesting
-    public int getSize() {
-        return dataCache.asMap().size();
-    }
-
-    private void cleanUpGauges() {
-        String  [] names = new String[] {loadTimeName, hitRatioName, weightName};
-        for (String gaugeName: names) {
-            MeterRegistryProvider.deregisterServerMeter(gaugeName, Tags.empty(), Meter.Type.GAUGE);
-        }
-    }
+  }
 }


### PR DESCRIPTION
## Overview
Allow the caffeine cache to use the logunit thread pool 

Why should this be merged: Reduces the number of threads

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
