### PR TITLE
Transactional Support for Streams

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -240,6 +240,8 @@ public abstract class AbstractTransactionalContext implements
                                                              SMREntry updateEntry,
                                                              Object[] conflictObject);
 
+    public abstract void logUpdate(UUID streamId, SMREntry updateEntry);
+
     /**
      * Add a given transaction to this transactional context, merging
      * the read and write sets.
@@ -334,6 +336,10 @@ public abstract class AbstractTransactionalContext implements
     long addToWriteSet(ICorfuSMRProxyInternal proxy, SMREntry updateEntry, Object[]
             conflictObjects) {
         return getWriteSetInfo().add(proxy, updateEntry, conflictObjects);
+    }
+
+    void addToWriteSet(UUID streamId, SMREntry updateEntry) {
+        getWriteSetInfo().add(streamId, updateEntry);
     }
 
     void mergeWriteSetInto(WriteSetInfo other) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -183,6 +183,11 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         return addToWriteSet(proxy, updateEntry, conflictObjects);
     }
 
+    @Override
+    public void logUpdate(UUID streamId, SMREntry updateEntry) {
+        addToWriteSet(streamId, updateEntry);
+    }
+
     /**
      * Commit a transaction into this transaction by merging the read/write
      * sets.

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.object.transactions;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
+import java.util.UUID;
 
 import lombok.Getter;
 
@@ -79,6 +80,11 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
                                                     Object[] conflictObject) {
         throw new UnsupportedOperationException(
                 "Can't modify object during a read-only transaction!");
+    }
+
+    @Override
+    public void logUpdate(UUID streamId, SMREntry updateEntry) {
+        throw new UnsupportedOperationException("Can't modify object during a read-only transaction!");
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -22,8 +22,7 @@ public class TransactionalContext {
      * for a given thread.
      */
     private static final ThreadLocal<Deque<AbstractTransactionalContext>>
-            threadTransactionStack = ThreadLocal.withInitial(
-            LinkedList<AbstractTransactionalContext>::new);
+            threadTransactionStack = ThreadLocal.withInitial(LinkedList::new);
 
     /** Whether or not the current thread is in a nested transaction.
      *

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetInfo.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetInfo.java
@@ -37,6 +37,13 @@ public class WriteSetInfo extends ConflictSetInfo {
         }
     }
 
+    public void add(UUID streamId, SMREntry updateEntry) {
+        synchronized (getRootContext().getTransactionID()) {
+            // add the SMRentry to the list of updates for this stream
+            writeSet.addTo(streamId, updateEntry);
+        }
+    }
+
     @Override
     public void mergeInto(ConflictSetInfo other) {
         if (!(other instanceof WriteSetInfo)) {


### PR DESCRIPTION
## Overview
Add the ability for a transaction to span and objects and stream
appends.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
