### PR TITLE
Don't write a warning to the log when LogData size is unknown

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -140,11 +140,12 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         byte[] tempData = data;
         if (tempData != null) {
             return tempData.length;
-        } else if (lastKnownSize != NOT_KNOWN) {
+        }
+
+        if (lastKnownSize != NOT_KNOWN) {
             return lastKnownSize;
         }
-        log.warn("getSizeEstimate: LogData size estimate is defaulting to 1,"
-                + " this might cause leaks in the cache!");
+
         return 1;
     }
 


### PR DESCRIPTION
## Overview

Description:
LogData class generates a huge amount of messages in the log.  
The warnings are useless, should be disabled.

FYI:
in a test that writes 3m records, the warning appeared 100k times.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
