### PR TITLE
CompleteGraphAdvisor: don't write status messages to the log

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/management/CompleteGraphAdvisor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/management/CompleteGraphAdvisor.java
@@ -69,7 +69,7 @@ public class CompleteGraphAdvisor implements ClusterAdvisor {
         NodeRank decisionMaker = maybeDecisionMaker.get();
         if (!decisionMaker.is(localEndpoint)) {
             String message = "The node can't be a decision maker, skip operation. Decision maker node is: {}";
-            log.debug(message, decisionMaker);
+            log.trace(message, decisionMaker);
             return Optional.empty();
         }
 


### PR DESCRIPTION
## Overview

Description:
CompleteGraphAdvisor generates status messages that are not needed

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
