### PR TITLE
Don't print LogUnitServer messages for getter methods

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -159,7 +159,7 @@ public class LogUnitServer extends AbstractServer {
     public void handleLogAddressSpaceRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
         CorfuPayloadMsg<Void> payloadMsg = new CorfuPayloadMsg<>();
         payloadMsg.copyBaseFields(msg);
-        log.debug("handleLogAddressSpaceRequest: received a log address space request {}", msg);
+        log.trace("handleLogAddressSpaceRequest: received a log address space request {}", msg);
         batchWriter.<StreamsAddressResponse>addTask(LOG_ADDRESS_SPACE_QUERY, payloadMsg)
                 .thenAccept(tailsResp -> r.sendResponse(ctx, msg,
                         CorfuMsgType.LOG_ADDRESS_SPACE_RESPONSE.payloadMsg(tailsResp)))
@@ -174,7 +174,7 @@ public class LogUnitServer extends AbstractServer {
      */
     @ServerHandler(type = CorfuMsgType.TRIM_MARK_REQUEST)
     public void handleTrimMarkRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
-        log.debug("handleTrimMarkRequest: received a trim mark request {}", msg);
+        log.trace("handleTrimMarkRequest: received a trim mark request {}", msg);
         r.sendResponse(ctx, msg, CorfuMsgType.TRIM_MARK_RESPONSE.payloadMsg(streamLog.getTrimMark()));
     }
 
@@ -410,6 +410,7 @@ public class LogUnitServer extends AbstractServer {
      */
     @Override
     public void shutdown() {
+        log.info("Shutdown LogUnit server. Current epoch: {}, ", serverContext.getServerEpoch());
         super.shutdown();
         executor.shutdown();
         logCleaner.shutdown();


### PR DESCRIPTION
## Overview

Description:
Don't print LogUnitServer messages for getter methods which don't change the state

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
