### PR TITLE
LayoutView don't print status messages

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutView.java
@@ -245,10 +245,6 @@ public class LayoutView extends AbstractView {
                     .filter(x -> x)
                     .count();
 
-            log.debug("propose: Successful responses={}, needed={}, timeouts={}, "
-                            + "wrongEpochRejected={}",
-                    count, getQuorumNumber(), timeouts, wrongEpochRejected);
-
             if (count >= getQuorumNumber()) {
                 break;
             }


### PR DESCRIPTION
## Overview

Description:
LayotView class is the biggest contributor to heavy logging. 
It prints status messages hundreds of thousand times.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
