### PR TITLE
Fix LogData lastKnownSize which is inaccurate and inconsistent.

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -129,7 +129,6 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
         if (serializedCache == null) {
             serializedCache = Unpooled.buffer();
             doSerializeInternal(serializedCache);
-            lastKnownSize = serializedCache.array().length;
         } else {
             serializedCache.retain();
         }
@@ -282,8 +281,10 @@ public class LogData implements ICorfuPayload<LogData>, IMetadata, ILogData {
                 buf.writerIndex(lengthIndex);
                 buf.writeInt(size);
                 buf.writerIndex(lengthIndex + size + 4);
+                lastKnownSize = size;
             } else {
                 ICorfuPayload.serialize(buf, data);
+                lastKnownSize = data.length;
             }
         }
 

--- a/test/src/test/java/org/corfudb/integration/LargeWriteIT.java
+++ b/test/src/test/java/org/corfudb/integration/LargeWriteIT.java
@@ -1,11 +1,13 @@
 package org.corfudb.integration;
 
 import com.google.common.reflect.TypeToken;
+import org.corfudb.common.compression.Codec;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.WriteSizeException;
+import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
 import java.util.Map;
@@ -32,12 +34,13 @@ public class LargeWriteIT extends AbstractIT {
                 .setSingle(true)
                 .runServer();
 
-        final int maxWriteSize = 100;
+        final int maxWriteSize = 500;
 
         // Configure a client with a max write limit
         CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
                 .builder()
                 .maxWriteSize(maxWriteSize)
+                .codecType(Codec.Type.NONE)
                 .build();
 
         runtime = CorfuRuntime.fromParameters(params);
@@ -65,26 +68,27 @@ public class LargeWriteIT extends AbstractIT {
                 .setSingle(true)
                 .runServer();
 
-        final int maxWriteSize = 100;
+        final int maxWriteSize = 500;
 
         // Configure a client with a max write limit
         CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
                 .builder()
                 .maxWriteSize(maxWriteSize)
+                .codecType(Codec.Type.NONE)
                 .build();
 
         runtime = CorfuRuntime.fromParameters(params);
         runtime.parseConfigurationString(DEFAULT_ENDPOINT);
         runtime.connect();
 
-        String largePayload = new String(new byte[maxWriteSize * 2]);
+        byte[] largePayload = new byte[maxWriteSize * 2];
 
-        Map<String, String> map = runtime.getObjectsView()
+        Map<String, byte[]> map = runtime.getObjectsView()
                 .build()
-                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setTypeToken(new TypeToken<CorfuTable<String, byte[]>>() {})
                 .setStreamName(tableName)
+                .serializer(Serializers.JAVA)
                 .open();
-
 
         runtime.getObjectsView().TXBegin();
         map.put("key1", largePayload);


### PR DESCRIPTION
## Overview

- When set during serialization and deserialization, the LogData
lastKnownSize is set to different values. It is also inaccurate
as it is set to ByteBuf's internal array length during serialization,
which is usually larger the actually (it is dynamically resized and
usually 2x of previous size). It needs to be set to the payload's
serialized size. This incorrect behavior affects transaction size
limit calculation, which results in unnecessary WriteSizeException.

- Also fixed a test where compression should be ruled out.

Related issue(s) (if applicable): #2235 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
