### PR TITLE
Fix potential inconsistent read due to index update before fsync().

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -319,7 +319,7 @@ public class LogUnitServer extends AbstractServer {
         KnownAddressRequest request = msg.getPayload();
         try {
             Set<Long> knownAddresses = streamLog
-                    .getKnownAddressesInRange(request.getStartRange(), request.getEndRange());
+                    .getWrittenAddressesInRange(request.getStartRange(), request.getEndRange());
             r.sendResponse(ctx, msg,
                     CorfuMsgType.KNOWN_ADDRESS_RESPONSE.payloadMsg(knownAddresses));
         } catch (Exception e) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -134,8 +134,7 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
      * @return Set of known addresses.
      */
     @Override
-    public Set<Long> getKnownAddressesInRange(long rangeStart, long rangeEnd) {
-
+    public Set<Long> getWrittenAddressesInRange(long rangeStart, long rangeEnd) {
         Set<Long> result = new HashSet<>();
         for (long address = rangeStart; address <= rangeEnd; address++) {
             if (logCache.containsKey(address)) {
@@ -155,8 +154,8 @@ public class InMemoryStreamLog implements StreamLog, StreamLogWithRankedAddressS
     }
 
     @Override
-    public void sync(boolean force){
-        //no-op
+    public void sync(boolean force) {
+        // No-op
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/SegmentHandle.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/SegmentHandle.java
@@ -1,18 +1,20 @@
 package org.corfudb.infrastructure.log;
 
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * The global log is partition into segments, each segment contains a range of consecutive
@@ -21,36 +23,97 @@ import java.util.concurrent.ConcurrentHashMap;
  * @author Maithem
  */
 @Slf4j
-@Data
+@Getter
+@RequiredArgsConstructor
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 class SegmentHandle {
-    final long segment;
 
+    // Segment number.
+    @EqualsAndHashCode.Include
+    private final long segment;
+
+    // Name of the underlying segment file.
     @NonNull
-    final FileChannel writeChannel;
+    @EqualsAndHashCode.Include
+    private final String fileName;
 
+    // File channel for log writes.
     @NonNull
-    final FileChannel readChannel;
+    private final FileChannel writeChannel;
 
+    // File channel for reads.
     @NonNull
-    String fileName;
+    private final FileChannel readChannel;
 
+    // Index of log entries that are guaranteed to be persisted.
     private final Map<Long, AddressMetaData> knownAddresses = new ConcurrentHashMap<>();
-    private final Set<Long> trimmedAddresses = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private final Set<Long> pendingTrims = Collections.newSetFromMap(new ConcurrentHashMap<>());
-    private volatile int refCount = 0;
 
+    // Index of log entries that are written but not guaranteed to be persisted.
+    private final Map<Long, AddressMetaData> pendingAddresses = new ConcurrentHashMap<>();
 
-    public synchronized void retain() {
-        refCount++;
+    // Reference count of this segment.
+    private AtomicInteger refCount = new AtomicInteger(0);
+
+    /**
+     * Increase reference count.
+     */
+    public void retain() {
+        refCount.incrementAndGet();
     }
 
-    public synchronized void release() {
-        if (refCount == 0) {
-            throw new IllegalStateException("refCount cannot be less than 0, segment " + segment);
-        }
-        refCount--;
+    /**
+     * Decrease reference count.
+     */
+    public void release() {
+        refCount.updateAndGet(ref -> {
+            if (ref <= 0) {
+                throw new IllegalStateException("refCount cannot be less than 0, segment: " + segment);
+            }
+            return ref - 1;
+        });
     }
 
+    /**
+     * Get the current reference count.
+     */
+    public int getRefCount() {
+        return refCount.get();
+    }
+
+    /**
+     * Check if the provided address is written to the segment, regardless
+     * of whether persisted on disk.
+     *
+     * @param address the address to check if written
+     * @return true if address is written to this segment, false otherwise
+     */
+    public boolean isAddressWritten(long address) {
+        return knownAddresses.containsKey(address) || pendingAddresses.containsKey(address);
+    }
+
+    /**
+     * Merge the pending addresses into the known addresses, making
+     * pending addresses visible to the readers. This method should
+     * be called after the addresses in the pending addresses are
+     * guaranteed to be in secondary storage.
+     */
+    public void mergePendingAddresses() {
+        knownAddresses.putAll(pendingAddresses);
+        pendingAddresses.clear();
+    }
+
+    /**
+     * Force the log writes in write channel to secondary storage.
+     *
+     * @throws IOException if sync failed
+     */
+    public void sync() throws IOException {
+        writeChannel.force(true);
+    }
+
+    /**
+     * Close the file channels and force updates to secondary storage.
+     */
     public void close() {
         Set<FileChannel> channels = new HashSet<>(
                 Arrays.asList(writeChannel, readChannel)
@@ -65,5 +128,7 @@ class SegmentHandle {
                 IOUtils.closeQuietly(channel);
             }
         }
+
+        refCount.set(0);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -78,14 +78,14 @@ public interface StreamLog {
     long getTrimMark();
 
     /**
-     * Returns the known addresses in this Log Unit in the specified consecutive
-     * range of addresses.
+     * Returns the written addresses in this Log Unit in the specified consecutive
+     * range of addresses, regardless of whether persisted on disk.
      *
      * @param rangeStart Start address of range.
      * @param rangeEnd   End address of range.
      * @return Set of known addresses.
      */
-    Set<Long> getKnownAddressesInRange(long rangeStart, long rangeEnd);
+    Set<Long> getWrittenAddressesInRange(long rangeStart, long rangeEnd);
 
     /**
      * Sync the stream log file to secondary storage.

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpaceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogWithRankedAddressSpaceTest.java
@@ -50,7 +50,7 @@ public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
     }
 
     @Test
-    public void testHigherRank() {
+    public void testHigherRank() throws Exception {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
         long address = 0;
         writeToLog(log, address, DataType.DATA, "v-1", 1);
@@ -63,7 +63,7 @@ public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
     }
 
     @Test
-    public void testLowerRank() {
+    public void testLowerRank() throws Exception {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
         long address = 0;
         writeToLog(log, address, DataType.DATA, "v-1", 2);
@@ -81,7 +81,7 @@ public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
     }
 
     @Test
-    public void testHigherRankAgainstProposal() {
+    public void testHigherRankAgainstProposal() throws Exception {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
         long address = 0;
         writeToLog(log, address, DataType.RANK_ONLY, "v-1", 1);
@@ -94,7 +94,7 @@ public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
     }
 
     @Test
-    public void testLowerRankAgainstProposal() {
+    public void testLowerRankAgainstProposal() throws Exception {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
         long address = 0;
         writeToLog(log, address, DataType.RANK_ONLY, "v-1", 2);
@@ -112,7 +112,7 @@ public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
     }
 
     @Test
-    public void testProposalWithHigherRankAgainstData() {
+    public void testProposalWithHigherRankAgainstData() throws Exception {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
         long address = 0;
         writeToLog(log, address, DataType.DATA, "v-1", 1);
@@ -132,7 +132,7 @@ public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
 
 
     @Test
-    public void testProposalWithLowerRankAgainstData() {
+    public void testProposalWithLowerRankAgainstData() throws Exception {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
         long address = 0;
         writeToLog(log, address, DataType.DATA, "v-1", 2);
@@ -151,7 +151,7 @@ public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
 
 
     @Test
-    public void testProposalsHigherRank() {
+    public void testProposalsHigherRank() throws Exception {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
         long address = 0;
         writeToLog(log, address, DataType.RANK_ONLY, "v-1", 1);
@@ -164,7 +164,7 @@ public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
     }
 
     @Test
-    public void testProposalsLowerRank() {
+    public void testProposalsLowerRank() throws Exception {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
         long address = 0;
         writeToLog(log, address, DataType.RANK_ONLY, "v-1", 2);
@@ -182,7 +182,7 @@ public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
     }
 
     @Test
-    public void checkProposalIsIdempotent() {
+    public void checkProposalIsIdempotent() throws Exception {
         StreamLogFiles log = new StreamLogFiles(getContext(), false);
         long address = 0;
         IMetadata.DataRank sameRank = new IMetadata.DataRank(1);
@@ -194,17 +194,21 @@ public class StreamLogWithRankedAddressSpaceTest extends AbstractCorfuTest {
         assertTrue(new String(value2.getData()).contains("v-1"));
     }
 
-    private void writeToLog(StreamLog log, long address, DataType dataType, String payload, long rank) {
+    private void writeToLog(StreamLog log, long address, DataType dataType,
+                            String payload, long rank) throws Exception {
         this.writeToLog(log, address, dataType, payload, new IMetadata.DataRank(rank));
+        log.sync(true);
     }
 
-    private void writeToLog(StreamLog log, long address, DataType dataType, String payload, IMetadata.DataRank rank) {
+    private void writeToLog(StreamLog log, long address, DataType dataType,
+                            String payload, IMetadata.DataRank rank) throws Exception {
         ByteBuf b = Unpooled.buffer();
         byte[] streamEntry = payload.getBytes();
         Serializers.CORFU.serialize(streamEntry, b);
         LogData data = new LogData(dataType, b);
         data.setRank(rank);
         log.append(address, data);
+        log.sync(true);
     }
 
     private String getDirPath() {


### PR DESCRIPTION
## Overview

Description:

There is a potential inconsistent read issue. The current batchProcessor on log unit server performs a batch of write() and then calls fsync(), however because the segment index (knownAddress) is updated immediately after a successful write(), but before fsync(), any read() before fsync() can still retrieve the update. This could cause inconsistent read. The first read could see the data, while the second read, after process restarts, cannot see the data because data is not guaranteed to be persisted in secondary storage without fsync(). 

Related issue(s) (if applicable): #2470 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
