### PR TITLE
CorfuStore: Build-to-Build upgrade support

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -114,7 +114,7 @@ public class CorfuStore {
      * @param namespace Namespace of the table.
      * @param tableName Table name.
      */
-    private void deleteTable(String namespace, String tableName) {
+    public void deleteTable(String namespace, String tableName) {
         runtime.getTableRegistry().deleteTable(namespace, tableName);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -8,6 +8,7 @@ import java.util.Map.Entry;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -277,6 +278,21 @@ public class Table<K extends Message, V extends Message, M extends Message> {
                         entry.getValue().getPayload(),
                         entry.getValue().getMetadata()))
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Stream the whole table out in chunks, useful for very large tables
+     * that won't fit completely in memory.
+     *
+     * @return Collection of filtered entries.
+     */
+    public @Nonnull
+    Stream<CorfuStoreEntry<K, V, M>> entryStream() {
+         return corfuTable.entryStream().map(entry ->
+                 new CorfuStoreEntry<>(
+                         entry.getKey(),
+                         entry.getValue().getPayload(),
+                         entry.getValue().getMetadata()));
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/util/serializer/ProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/ProtobufSerializer.java
@@ -86,6 +86,14 @@ public class ProtobufSerializer implements ISerializer {
             bbis.readFully(data);
             Record record = Record.parseFrom(data);
             Any payload = record.getPayload();
+            if (!classMap.containsKey(payload.getTypeUrl())) {
+                log.error("Deserialization error: Encountered a log update for this class "+payload.getTypeUrl()
+                        +" but its corresponding class type cannot be found in in-memory type map. Dumping map..\n");
+                for (String entry: classMap.keySet()) {
+                    log.error(entry + "=>" + classMap.get(entry));
+                }
+                throw new SerializerException(payload.getTypeUrl()+" not in map!");
+            }
             Message value = payload.unpack(classMap.get(payload.getTypeUrl()));
 
             if (type.equals(MessageType.KEY)) {

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -22,6 +22,7 @@ import org.corfudb.runtime.object.ICorfuVersionPolicy;
 import org.corfudb.runtime.view.ObjectOpenOption;
 import org.corfudb.runtime.view.SMRObject;
 import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.test.SampleSchema;
 import org.corfudb.test.SampleSchema.Uuid;
 import org.corfudb.test.SampleSchema.ManagedResources;
 import org.corfudb.util.serializer.DynamicProtobufSerializer;
@@ -365,6 +366,94 @@ public class CorfuStoreIT extends AbstractIT {
                 TableOptions.builder().persistentDataPath(Paths.get(
                         com.google.common.io.Files.createTempDir().getAbsolutePath())).build());
         assertThat(table.count()).isEqualTo(numRecords);
+
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
+    }
+
+    /**
+     * Proper way to handle a schema upgrade. Example of EventInfo table changing its key protobuf
+     * 1. delete the table in the old version (On real upgrade this would entail a migration step)
+     * 2. checkpoint and trim to wipe out old entries
+     * 3. re-open the table with the new schema
+     * 4. write data in the new shcema
+     *
+     * @throws Exception
+     */
+    @Test
+    public void alterTableUsingDropTest() throws Exception {
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
+
+        // PHASE 1 - Start a Corfu runtime & a CorfuStore instance
+        runtime = createRuntime(singleNodeEndpoint);
+
+        // Creating Corfu Store using a connected corfu client.
+        CorfuStore corfuStore = new CorfuStore(runtime);
+
+        // Define a namespace for the table.
+        final String nsxManager = "nsx-manager";
+        // Define table name.
+        final String tableName = "EventInfo";
+
+        // Create & Register the table.
+        // This is required to initialize the table for the current corfu client.
+        Table<Uuid, SampleSchema.EventInfo, ManagedResources> table = corfuStore.openTable(
+                nsxManager,
+                tableName,
+                Uuid.class,
+                SampleSchema.EventInfo.class,
+                ManagedResources.class,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        Uuid key = Uuid.newBuilder().setLsb(0L).setMsb(0L).build();
+        SampleSchema.EventInfo value = SampleSchema.EventInfo.newBuilder().setName("simpleValue").build();
+
+        long timestamp = System.currentTimeMillis();
+        corfuStore.tx(nsxManager)
+                .create(tableName, key, value,
+                        ManagedResources.newBuilder()
+                                .setCreateTimestamp(timestamp).build())
+                .commit();
+
+        corfuStore.tx(nsxManager)
+                .update(tableName, key, value,
+                        ManagedResources.newBuilder().setCreateUser("CreateUser").build())
+                .commit();
+
+        corfuStore.deleteTable(nsxManager, tableName);
+
+        MultiCheckpointWriter<CorfuTable> mcw = new MultiCheckpointWriter<>();
+        CorfuTable<Uuid, CorfuRecord<SampleSchema.EventInfo, ManagedResources>> corfuTable = runtime.getObjectsView().build()
+                .setTypeToken(new TypeToken<CorfuTable<Uuid, CorfuRecord<SampleSchema.EventInfo, ManagedResources>>>() {
+                })
+                .setStreamName(table.getFullyQualifiedTableName())
+                .open();
+        mcw.addMap(corfuTable);
+        mcw.addMap(runtime.getTableRegistry().getRegistryTable());
+        Token trimPoint = mcw.appendCheckpoints(runtime, "checkpointer");
+        runtime.getAddressSpaceView().prefixTrim(trimPoint);
+        runtime.getAddressSpaceView().gc();
+        runtime.getObjectsView().getObjectCache().clear();
+        runtime.shutdown();
+        runtime = createRuntime(singleNodeEndpoint);
+
+        corfuStore = new CorfuStore(runtime);
+
+        // Re-Create & Register the table.
+        // This is required to initialize the table for the current corfu client.
+        Table<SampleSchema.EventInfo, SampleSchema.EventInfo, ManagedResources> tableV2 = corfuStore.openTable(
+                nsxManager,
+                tableName,
+                SampleSchema.EventInfo.class, // Instead of using UUid using EventInfo as the key itself!
+                SampleSchema.EventInfo.class,
+                ManagedResources.class,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        corfuStore.tx(nsxManager)
+                .update(tableName, value, value,
+                        ManagedResources.newBuilder().setCreateUser("CreateUser").build())
+                .commit();
 
         assertThat(shutdownCorfuServer(corfuServer)).isTrue();
     }

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -204,6 +204,7 @@ public class CorfuStoreIT extends AbstractIT {
                     value.getMetadataTypeUrl(),
                     newMetaBuilder.build()));
         }
+
         assertThat(corfuTable.size()).isEqualTo(1);
         MultiCheckpointWriter<CorfuTable> mcw = new MultiCheckpointWriter<>();
 


### PR DESCRIPTION
## Overview

Description:
This is to help QE with their build to build upgrades.
Updating the schema on openTable allows them to migrate to
a new protobuf version without having to redeploy their setups.

Disk based tables are too huge to be iterated by conventional methods like `entrySet()`
This is the only way a large table that won't fit in memory can be reasonably iterated.
Switched browser to use this existing api speeds it up several fold.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
