### PR TITLE
Bug fix + better errorhandling for writeRecords

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/statetransfer/batchprocessor/StateTransferBatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/statetransfer/batchprocessor/StateTransferBatchProcessor.java
@@ -7,6 +7,10 @@ import org.corfudb.infrastructure.log.statetransfer.batch.TransferBatchRequest;
 import org.corfudb.infrastructure.log.statetransfer.batch.TransferBatchResponse;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.exceptions.NetworkException;
+import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.exceptions.RetryExhaustedException;
+import org.corfudb.util.CFUtils;
 import org.corfudb.util.Sleep;
 
 import java.time.Duration;
@@ -15,6 +19,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 
 import static org.corfudb.infrastructure.log.statetransfer.batch.TransferBatchResponse.TransferStatus.SUCCEEDED;
 
@@ -43,54 +48,58 @@ public interface StateTransferBatchProcessor {
      */
     default TransferBatchResponse writeRecords(ReadBatch readBatch, LogUnitClient logUnitClient,
                                                int writeRetriesAllowed, Duration writeSleepDuration) {
-        List<Long> totalAddressesInRequest = readBatch.getAddresses();
-        Optional<String> destination = readBatch.getDestination();
+        if (readBatch == null || readBatch.getAddresses().isEmpty()) {
+            throw new IllegalArgumentException("The read batch is empty.");
+        }
+        List<Long> totalAddressesInRequest = ImmutableList.copyOf(readBatch.getAddresses());
         Optional<Exception> lastWriteException = Optional.empty();
         Optional<TransferBatchResponse> transferBatchResponse = Optional.empty();
 
         for (int i = 0; i < writeRetriesAllowed; i++) {
             List<LogData> remainingDataToWrite = readBatch.getData();
             try {
-                boolean writeSucceeded = logUnitClient.writeRange(remainingDataToWrite).join();
-                if (!writeSucceeded) {
-                    throw new IllegalStateException("Failed to write to a log unit server.");
-                } else {
-                    lastWriteException = Optional.empty();
-                    transferBatchResponse = Optional.of(TransferBatchResponse
-                            .builder()
-                            .transferBatchRequest(new TransferBatchRequest(totalAddressesInRequest, destination))
-                            .status(SUCCEEDED)
-                            .build());
-                    break;
-                }
-            } catch (Exception e) {
+                CFUtils.getUninterruptibly(logUnitClient.writeRange(remainingDataToWrite),
+                        OverwriteException.class,
+                        TimeoutException.class,
+                        NetworkException.class);
+                transferBatchResponse = Optional.of(TransferBatchResponse
+                        .builder()
+                        .transferBatchRequest(new TransferBatchRequest(totalAddressesInRequest,
+                                readBatch.getDestination()))
+                        .status(SUCCEEDED)
+                        .build());
+                break;
+            } catch (OverwriteException | TimeoutException | NetworkException e) {
                 lastWriteException = Optional.of(e);
                 Sleep.sleepUninterruptibly(writeSleepDuration);
-                List<Long> remainingAddressesToWrite = readBatch.getAddresses();
                 // Get all the addresses that were supposed to be written to a stream log.
-                long start = remainingAddressesToWrite.get(0);
-                long end = remainingAddressesToWrite.get(remainingAddressesToWrite.size() - 1);
-                Set<Long> knownAddresses =
-                        logUnitClient.requestKnownAddresses(start, end).join().getKnownAddresses();
+                long start = totalAddressesInRequest.get(0);
+                long end = totalAddressesInRequest.get(totalAddressesInRequest.size() - 1);
+                Set<Long> knownAddresses = CFUtils
+                        .getUninterruptibly(logUnitClient.requestKnownAddresses(start, end))
+                        .getKnownAddresses();
                 // Get all the addresses that were not written.
                 Set<Long> nonWrittenAddresses =
-                        Sets.difference(new HashSet<>(remainingAddressesToWrite), knownAddresses);
+                        Sets.difference(new HashSet<>(totalAddressesInRequest), knownAddresses);
                 // Create a new read batch with the missing data and retry.
                 ImmutableList<LogData> nonWrittenData = readBatch.getData()
                         .stream()
                         .filter(data -> nonWrittenAddresses.contains(data.getGlobalAddress()))
                         .collect(ImmutableList.toImmutableList());
                 readBatch = readBatch.toBuilder().data(nonWrittenData).build();
+            } catch (RuntimeException re) {
+                // If it's some other exception, e.g. IllegalArgumentException,
+                // WrongEpochException -> Propagate it to the caller.
+                throw new IllegalStateException(re);
             }
         }
 
-        if (lastWriteException.isPresent()) {
-            throw new IllegalStateException(lastWriteException.get());
-        } else if (transferBatchResponse.isPresent()) {
-            return transferBatchResponse.get();
-        } else {
-            throw new IllegalStateException("Exhausted retries writing to the log unit server.");
-        }
+        final Optional<Exception> finalWriteException = lastWriteException;
+        String msg = "writeRecords: Retries are exhausted.";
+        return transferBatchResponse.orElseThrow(
+                () -> finalWriteException
+                        .map(ex -> new RetryExhaustedException(msg, ex))
+                        .orElse(new RetryExhaustedException(msg)));
     }
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/statetransfer/batchprocessor/StateTransferBatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/statetransfer/batchprocessor/StateTransferBatchProcessor.java
@@ -81,6 +81,16 @@ public interface StateTransferBatchProcessor {
                 // Get all the addresses that were not written.
                 Set<Long> nonWrittenAddresses =
                         Sets.difference(new HashSet<>(totalAddressesInRequest), knownAddresses);
+                // If the delta is empty -> return with success.
+                if (nonWrittenAddresses.isEmpty()) {
+                    transferBatchResponse = Optional.of(TransferBatchResponse
+                            .builder()
+                            .transferBatchRequest(new TransferBatchRequest(totalAddressesInRequest,
+                                    readBatch.getDestination()))
+                            .status(SUCCEEDED)
+                            .build());
+                    break;
+                }
                 // Create a new read batch with the missing data and retry.
                 ImmutableList<LogData> nonWrittenData = readBatch.getData()
                         .stream()

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/log/statetransfer/batchprocessor/StateTransferBatchProcessorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/log/statetransfer/batchprocessor/StateTransferBatchProcessorTest.java
@@ -9,14 +9,19 @@ import org.corfudb.infrastructure.log.statetransfer.batchprocessor.protocolbatch
 import org.corfudb.protocols.wireprotocol.KnownAddressResponse;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.exceptions.RetryExhaustedException;
+import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.AddressSpaceView;
+import org.corfudb.util.NodeLocator;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -31,8 +36,25 @@ import static org.mockito.Mockito.mock;
 class StateTransferBatchProcessorTest extends DataTest {
 
     @Test
+    public void writeRecordsEmptyInput() {
+        List<Long> addresses = ImmutableList.of();
+        List<LogData> stubList = createStubList(addresses);
+        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+        LogUnitClient logUnitClient = mock(LogUnitClient.class);
+        ProtocolBatchProcessor batchProcessor = ProtocolBatchProcessor
+                .builder()
+                .logUnitClient(logUnitClient)
+                .addressSpaceView(addressSpaceView)
+                .build();
+
+        assertThatThrownBy(() -> batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
+                logUnitClient, 1, Duration.ofMillis(50)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     public void writeRecordsSuccess() {
-        // Write successfully, a response should be sent to the caller.
+        // Write successfully immediately, a response should be sent to the caller.
         List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
         List<LogData> stubList = createStubList(addresses);
         LogUnitClient logUnitClient = mock(LogUnitClient.class);
@@ -45,19 +67,19 @@ class StateTransferBatchProcessorTest extends DataTest {
                 .addressSpaceView(addressSpaceView)
                 .build();
         TransferBatchResponse res = batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
-                logUnitClient, 1, Duration.ofMillis(500));
+                logUnitClient, 1, Duration.ofMillis(50));
         assertThat(res.getStatus() == SUCCEEDED).isTrue();
         assertThat(res.getTransferBatchRequest().getAddresses()).isEqualTo(addresses);
     }
 
     @Test
-    public void writeRecordsFailure() {
-        // Write and fail immediately, exception should be propagated to the caller.
+    public void writeRecordsIllegalArgumentException() {
+        // Write and fail immediately with illegal argument exception.
         List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
         List<LogData> stubList = createStubList(addresses);
         LogUnitClient logUnitClient = mock(LogUnitClient.class);
         AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
-        doThrow(new OverwriteException(SAME_DATA)).when(logUnitClient).writeRange(stubList);
+        doThrow(new IllegalArgumentException("Illegal argument")).when(logUnitClient).writeRange(stubList);
         doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>())))
                 .when(logUnitClient)
                 .requestKnownAddresses(0L, 9L);
@@ -67,18 +89,37 @@ class StateTransferBatchProcessorTest extends DataTest {
                 .addressSpaceView(addressSpaceView)
                 .build();
         assertThatThrownBy(() -> batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
-                logUnitClient, 1, Duration.ofMillis(100)))
+                logUnitClient, 1, Duration.ofMillis(50)))
                 .isInstanceOf(IllegalStateException.class)
-                .hasRootCauseInstanceOf(OverwriteException.class);
-
+                .hasRootCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void writeRecordsRetry() {
-        // Try writing 10 records, write only 5 of them, catch the exception.
+    public void writeRecordsWrongEpochException() {
+        // Write and fail immediately with wrong epoch exception.
+        List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
+        List<LogData> stubList = createStubList(addresses);
+        LogUnitClient logUnitClient = mock(LogUnitClient.class);
+        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+        doThrow(new WrongEpochException(0L)).when(logUnitClient).writeRange(stubList);
+        doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>())))
+                .when(logUnitClient)
+                .requestKnownAddresses(0L, 9L);
+        ProtocolBatchProcessor batchProcessor = ProtocolBatchProcessor
+                .builder()
+                .logUnitClient(logUnitClient)
+                .addressSpaceView(addressSpaceView)
+                .build();
+        assertThatThrownBy(() -> batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
+                logUnitClient, 1, Duration.ofMillis(50)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasRootCauseInstanceOf(WrongEpochException.class);
+    }
+
+    @Test
+    public void writeRecordsOverwriteRetry() {
+        // Try writing 10 records, write only 5 of them, catch the overwrite exception.
         // Then retry writing the rest and succeed.
-        // At the end return a transfer batch response with status SUCCEEDED and the correct
-        // initial addresses.
         List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
         List<LogData> stubList = createStubList(addresses);
         List<LogData> knownStubList = stubList.stream()
@@ -106,25 +147,29 @@ class StateTransferBatchProcessorTest extends DataTest {
 
         TransferBatchResponse resp =
                 batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
-                        logUnitClient, 2, Duration.ofMillis(100));
+                        logUnitClient, 2, Duration.ofMillis(50));
         // Should succeed and carry the initial addresses after the retry
         assertThat(resp.getStatus()).isEqualTo(SUCCEEDED);
         assertThat(resp.getTransferBatchRequest().getAddresses()).isEqualTo(addresses);
     }
 
     @Test
-    public void writeRecordsRetryEmpty() {
-        // Try writing 10 records, write all of them, but catch the exception.
+    public void writeRecordsTimeoutRetry() {
+        // Try writing 10 records, but fail with a timeout exception.
         // Retry and succeed.
         List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
-        List<LogData> stubList = createStubList(addresses);
+        List<LogData> allAddressesStub = createStubList(addresses);
+
+        List<Long> written = addresses.stream().filter(x -> x < 5).collect(Collectors.toList());
+        List<LogData> secondBatchStub = allAddressesStub.stream().filter(x -> x.getGlobalAddress() >= 5).collect(Collectors.toList());
         LogUnitClient logUnitClient = mock(LogUnitClient.class);
         CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
-        failedFuture.completeExceptionally(new IllegalStateException("Illegal state"));
+        failedFuture.completeExceptionally(new TimeoutException());
 
-        doReturn(failedFuture).when(logUnitClient).writeRange(stubList);
-        doReturn(CompletableFuture.completedFuture(true)).when(logUnitClient).writeRange(ImmutableList.of());
-        doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>(addresses))))
+        doReturn(failedFuture).when(logUnitClient).writeRange(allAddressesStub);
+        doReturn(CompletableFuture.completedFuture(true)).when(logUnitClient).writeRange(secondBatchStub);
+
+        doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>(written))))
                 .when(logUnitClient)
                 .requestKnownAddresses(0L, 9L);
 
@@ -135,10 +180,75 @@ class StateTransferBatchProcessorTest extends DataTest {
                 .addressSpaceView(addressSpaceView)
                 .build();
         TransferBatchResponse resp =
-                batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
-                        logUnitClient, 2, Duration.ofMillis(100));
+                batchProcessor.writeRecords(ReadBatch.builder().data(allAddressesStub).build(),
+                        logUnitClient, 2, Duration.ofMillis(50));
         assertThat(resp.getStatus()).isEqualTo(SUCCEEDED);
         assertThat(resp.getTransferBatchRequest().getAddresses()).isEqualTo(addresses);
+
+    }
+
+    @Test
+    public void writeRecordsNetworkExceptionRetry() {
+        // Try writing 10 records, but fail with a network exception.
+        // Retry and succeed.
+        List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
+        List<LogData> allAddressesStub = createStubList(addresses);
+
+        List<Long> written = addresses.stream().filter(x -> x < 5).collect(Collectors.toList());
+        List<LogData> secondBatchStub = allAddressesStub.stream().filter(x -> x.getGlobalAddress() >= 5).collect(Collectors.toList());
+        LogUnitClient logUnitClient = mock(LogUnitClient.class);
+        CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new NetworkException("Error", NodeLocator.parseString("127.0.0.1:9000")));
+
+        doReturn(failedFuture).when(logUnitClient).writeRange(allAddressesStub);
+        doReturn(CompletableFuture.completedFuture(true)).when(logUnitClient).writeRange(secondBatchStub);
+
+        doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>(written))))
+                .when(logUnitClient)
+                .requestKnownAddresses(0L, 9L);
+
+        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+        ProtocolBatchProcessor batchProcessor = ProtocolBatchProcessor
+                .builder()
+                .logUnitClient(logUnitClient)
+                .addressSpaceView(addressSpaceView)
+                .build();
+        TransferBatchResponse resp =
+                batchProcessor.writeRecords(ReadBatch.builder().data(allAddressesStub).build(),
+                        logUnitClient, 2, Duration.ofMillis(50));
+        assertThat(resp.getStatus()).isEqualTo(SUCCEEDED);
+        assertThat(resp.getTransferBatchRequest().getAddresses()).isEqualTo(addresses);
+
+    }
+
+    @Test
+    public void writeRecordsRetriesExhausted() {
+        // Try writing 10 records, but fail every retry with a network exception.
+        // At the end an exception is thrown, wrapped in the retry exhausted exception.
+
+        List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
+        List<LogData> allAddressesStub = createStubList(addresses);
+
+        LogUnitClient logUnitClient = mock(LogUnitClient.class);
+        CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new TimeoutException("Timeout"));
+
+        doReturn(failedFuture).when(logUnitClient).writeRange(allAddressesStub);
+
+        doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>())))
+                .when(logUnitClient)
+                .requestKnownAddresses(0L, 9L);
+
+        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+        ProtocolBatchProcessor batchProcessor = ProtocolBatchProcessor
+                .builder()
+                .logUnitClient(logUnitClient)
+                .addressSpaceView(addressSpaceView)
+                .build();
+        assertThatThrownBy(() -> batchProcessor.writeRecords(ReadBatch.builder().data(allAddressesStub).build(),
+                logUnitClient, 3, Duration.ofMillis(50)))
+                .isInstanceOf(RetryExhaustedException.class)
+                .hasRootCauseInstanceOf(TimeoutException.class);
 
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/StateTransferTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StateTransferTest.java
@@ -599,9 +599,6 @@ public class StateTransferTest extends AbstractViewTest {
                 .setPort(SERVERS.PORT_1).build();
         addServer(SERVERS.PORT_1, sc2);
 
-        getManagementServer(SERVERS.PORT_0).shutdown();
-        getManagementServer(SERVERS.PORT_1).shutdown();
-
         final long writtenAddressesBatch1 = 100;
         final long writtenAddressesBatch2 = 5;
 
@@ -628,6 +625,9 @@ public class StateTransferTest extends AbstractViewTest {
                 .addToLayout()
                 .build();
         bootstrapAllServers(layout);
+
+        getManagementServer(SERVERS.PORT_0).shutdown();
+        getManagementServer(SERVERS.PORT_1).shutdown();
 
         CorfuRuntime rt = getNewRuntime(getDefaultNode()).connect();
 


### PR DESCRIPTION
## Overview

Description:

- When we calculate a difference between the known addresses and the remaining addresses, there is a possibility of IndexOutOfBoundsException. This is now fixed by copying all the required range to the immutable list at the beginning and then calculating delta between this list and the known addresses in range.
- For the writeRecords method, during a state transfer we need to retry only for the specific exceptions. If there are other exceptions, for example, WrongEpochException or IllegalArgumentException, we need to fail faster. 


Why should this be merged: 
- Bug fix, error handling improvements.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
