### PR TITLE
Bug fix + better error handling for writeRecords

### DIFF
--- a/infrastructure/src/test/java/org/corfudb/infrastructure/log/statetransfer/batchprocessor/StateTransferBatchProcessorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/log/statetransfer/batchprocessor/StateTransferBatchProcessorTest.java
@@ -9,14 +9,19 @@ import org.corfudb.infrastructure.log.statetransfer.batchprocessor.protocolbatch
 import org.corfudb.protocols.wireprotocol.KnownAddressResponse;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.exceptions.RetryExhaustedException;
+import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.AddressSpaceView;
+import org.corfudb.util.NodeLocator;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 
@@ -31,8 +36,25 @@ import static org.mockito.Mockito.mock;
 class StateTransferBatchProcessorTest extends DataTest {
 
     @Test
+    public void writeRecordsEmptyInput() {
+        List<Long> addresses = ImmutableList.of();
+        List<LogData> stubList = createStubList(addresses);
+        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+        LogUnitClient logUnitClient = mock(LogUnitClient.class);
+        ProtocolBatchProcessor batchProcessor = ProtocolBatchProcessor
+                .builder()
+                .logUnitClient(logUnitClient)
+                .addressSpaceView(addressSpaceView)
+                .build();
+
+        assertThatThrownBy(() -> batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
+                logUnitClient, 1, Duration.ofMillis(50)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     public void writeRecordsSuccess() {
-        // Write successfully, a response should be sent to the caller.
+        // Write successfully immediately, a response should be sent to the caller.
         List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
         List<LogData> stubList = createStubList(addresses);
         LogUnitClient logUnitClient = mock(LogUnitClient.class);
@@ -45,19 +67,19 @@ class StateTransferBatchProcessorTest extends DataTest {
                 .addressSpaceView(addressSpaceView)
                 .build();
         TransferBatchResponse res = batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
-                logUnitClient, 1, Duration.ofMillis(500));
+                logUnitClient, 1, Duration.ofMillis(50));
         assertThat(res.getStatus() == SUCCEEDED).isTrue();
         assertThat(res.getTransferBatchRequest().getAddresses()).isEqualTo(addresses);
     }
 
     @Test
-    public void writeRecordsFailure() {
-        // Write and fail immediately, exception should be propagated to the caller.
+    public void writeRecordsIllegalArgumentException() {
+        // Write and fail immediately with illegal argument exception.
         List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
         List<LogData> stubList = createStubList(addresses);
         LogUnitClient logUnitClient = mock(LogUnitClient.class);
         AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
-        doThrow(new OverwriteException(SAME_DATA)).when(logUnitClient).writeRange(stubList);
+        doThrow(new IllegalArgumentException("Illegal argument")).when(logUnitClient).writeRange(stubList);
         doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>())))
                 .when(logUnitClient)
                 .requestKnownAddresses(0L, 9L);
@@ -67,18 +89,37 @@ class StateTransferBatchProcessorTest extends DataTest {
                 .addressSpaceView(addressSpaceView)
                 .build();
         assertThatThrownBy(() -> batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
-                logUnitClient, 1, Duration.ofMillis(100)))
+                logUnitClient, 1, Duration.ofMillis(50)))
                 .isInstanceOf(IllegalStateException.class)
-                .hasRootCauseInstanceOf(OverwriteException.class);
-
+                .hasRootCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void writeRecordsRetry() {
-        // Try writing 10 records, write only 5 of them, catch the exception.
+    public void writeRecordsWrongEpochException() {
+        // Write and fail immediately with wrong epoch exception.
+        List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
+        List<LogData> stubList = createStubList(addresses);
+        LogUnitClient logUnitClient = mock(LogUnitClient.class);
+        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+        doThrow(new WrongEpochException(0L)).when(logUnitClient).writeRange(stubList);
+        doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>())))
+                .when(logUnitClient)
+                .requestKnownAddresses(0L, 9L);
+        ProtocolBatchProcessor batchProcessor = ProtocolBatchProcessor
+                .builder()
+                .logUnitClient(logUnitClient)
+                .addressSpaceView(addressSpaceView)
+                .build();
+        assertThatThrownBy(() -> batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
+                logUnitClient, 1, Duration.ofMillis(50)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasRootCauseInstanceOf(WrongEpochException.class);
+    }
+
+    @Test
+    public void writeRecordsOverwriteRetry() {
+        // Try writing 10 records, write only 5 of them, catch the overwrite exception.
         // Then retry writing the rest and succeed.
-        // At the end return a transfer batch response with status SUCCEEDED and the correct
-        // initial addresses.
         List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
         List<LogData> stubList = createStubList(addresses);
         List<LogData> knownStubList = stubList.stream()
@@ -106,25 +147,29 @@ class StateTransferBatchProcessorTest extends DataTest {
 
         TransferBatchResponse resp =
                 batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
-                        logUnitClient, 2, Duration.ofMillis(100));
+                        logUnitClient, 2, Duration.ofMillis(50));
         // Should succeed and carry the initial addresses after the retry
         assertThat(resp.getStatus()).isEqualTo(SUCCEEDED);
         assertThat(resp.getTransferBatchRequest().getAddresses()).isEqualTo(addresses);
     }
 
     @Test
-    public void writeRecordsRetryEmpty() {
-        // Try writing 10 records, write all of them, but catch the exception.
+    public void writeRecordsTimeoutRetry() {
+        // Try writing 10 records, but fail with a timeout exception.
         // Retry and succeed.
         List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
-        List<LogData> stubList = createStubList(addresses);
+        List<LogData> allAddressesStub = createStubList(addresses);
+
+        List<Long> written = addresses.stream().filter(x -> x < 5).collect(Collectors.toList());
+        List<LogData> secondBatchStub = allAddressesStub.stream().filter(x -> x.getGlobalAddress() >= 5).collect(Collectors.toList());
         LogUnitClient logUnitClient = mock(LogUnitClient.class);
         CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
-        failedFuture.completeExceptionally(new IllegalStateException("Illegal state"));
+        failedFuture.completeExceptionally(new TimeoutException());
 
-        doReturn(failedFuture).when(logUnitClient).writeRange(stubList);
-        doReturn(CompletableFuture.completedFuture(true)).when(logUnitClient).writeRange(ImmutableList.of());
-        doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>(addresses))))
+        doReturn(failedFuture).when(logUnitClient).writeRange(allAddressesStub);
+        doReturn(CompletableFuture.completedFuture(true)).when(logUnitClient).writeRange(secondBatchStub);
+
+        doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>(written))))
                 .when(logUnitClient)
                 .requestKnownAddresses(0L, 9L);
 
@@ -135,10 +180,75 @@ class StateTransferBatchProcessorTest extends DataTest {
                 .addressSpaceView(addressSpaceView)
                 .build();
         TransferBatchResponse resp =
-                batchProcessor.writeRecords(ReadBatch.builder().data(stubList).build(),
-                        logUnitClient, 2, Duration.ofMillis(100));
+                batchProcessor.writeRecords(ReadBatch.builder().data(allAddressesStub).build(),
+                        logUnitClient, 2, Duration.ofMillis(50));
         assertThat(resp.getStatus()).isEqualTo(SUCCEEDED);
         assertThat(resp.getTransferBatchRequest().getAddresses()).isEqualTo(addresses);
+
+    }
+
+    @Test
+    public void writeRecordsNetworkExceptionRetry() {
+        // Try writing 10 records, but fail with a network exception.
+        // Retry and succeed.
+        List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
+        List<LogData> allAddressesStub = createStubList(addresses);
+
+        List<Long> written = addresses.stream().filter(x -> x < 5).collect(Collectors.toList());
+        List<LogData> secondBatchStub = allAddressesStub.stream().filter(x -> x.getGlobalAddress() >= 5).collect(Collectors.toList());
+        LogUnitClient logUnitClient = mock(LogUnitClient.class);
+        CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new NetworkException("Error", NodeLocator.parseString("127.0.0.1:9000")));
+
+        doReturn(failedFuture).when(logUnitClient).writeRange(allAddressesStub);
+        doReturn(CompletableFuture.completedFuture(true)).when(logUnitClient).writeRange(secondBatchStub);
+
+        doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>(written))))
+                .when(logUnitClient)
+                .requestKnownAddresses(0L, 9L);
+
+        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+        ProtocolBatchProcessor batchProcessor = ProtocolBatchProcessor
+                .builder()
+                .logUnitClient(logUnitClient)
+                .addressSpaceView(addressSpaceView)
+                .build();
+        TransferBatchResponse resp =
+                batchProcessor.writeRecords(ReadBatch.builder().data(allAddressesStub).build(),
+                        logUnitClient, 2, Duration.ofMillis(50));
+        assertThat(resp.getStatus()).isEqualTo(SUCCEEDED);
+        assertThat(resp.getTransferBatchRequest().getAddresses()).isEqualTo(addresses);
+
+    }
+
+    @Test
+    public void writeRecordsRetriesExhausted() {
+        // Try writing 10 records, but fail every retry with a network exception.
+        // At the end an exception is thrown, wrapped in the retry exhausted exception.
+
+        List<Long> addresses = LongStream.range(0L, 10L).boxed().collect(Collectors.toList());
+        List<LogData> allAddressesStub = createStubList(addresses);
+
+        LogUnitClient logUnitClient = mock(LogUnitClient.class);
+        CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(new TimeoutException("Timeout"));
+
+        doReturn(failedFuture).when(logUnitClient).writeRange(allAddressesStub);
+
+        doReturn(CompletableFuture.completedFuture(new KnownAddressResponse(new HashSet<>())))
+                .when(logUnitClient)
+                .requestKnownAddresses(0L, 9L);
+
+        AddressSpaceView addressSpaceView = mock(AddressSpaceView.class);
+        ProtocolBatchProcessor batchProcessor = ProtocolBatchProcessor
+                .builder()
+                .logUnitClient(logUnitClient)
+                .addressSpaceView(addressSpaceView)
+                .build();
+        assertThatThrownBy(() -> batchProcessor.writeRecords(ReadBatch.builder().data(allAddressesStub).build(),
+                logUnitClient, 3, Duration.ofMillis(50)))
+                .isInstanceOf(RetryExhaustedException.class)
+                .hasRootCauseInstanceOf(TimeoutException.class);
 
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/StateTransferTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StateTransferTest.java
@@ -599,9 +599,6 @@ public class StateTransferTest extends AbstractViewTest {
                 .setPort(SERVERS.PORT_1).build();
         addServer(SERVERS.PORT_1, sc2);
 
-        getManagementServer(SERVERS.PORT_0).shutdown();
-        getManagementServer(SERVERS.PORT_1).shutdown();
-
         final long writtenAddressesBatch1 = 100;
         final long writtenAddressesBatch2 = 5;
 
@@ -628,6 +625,9 @@ public class StateTransferTest extends AbstractViewTest {
                 .addToLayout()
                 .build();
         bootstrapAllServers(layout);
+
+        getManagementServer(SERVERS.PORT_0).shutdown();
+        getManagementServer(SERVERS.PORT_1).shutdown();
 
         CorfuRuntime rt = getNewRuntime(getDefaultNode()).connect();
 


### PR DESCRIPTION
## Overview

Description:
 - When we calculate a difference between the known addresses and the remaining addresses, there is a possibility of IndexOutOfBoundsException. This is now fixed by copying all the required range to the immutable list at the beginning and then calculating delta between this list and the known addresses in range.
 - For the writeRecords method, during a state transfer we need to retry only for the specific exceptions. If there are other exceptions, for example, WrongEpochException or IllegalArgumentException, we need to fail faster.

Why should this be merged: 
- Bug fix, error handling improvements.
Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
