### PR TITLE
Fix CorfuTable values() API that incorrectly deduplicates on return.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.collections;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.reflect.TypeToken;
@@ -462,18 +463,14 @@ public class CorfuTable<K, V> implements
     @Override
     @Accessor
     public @Nonnull Set<K> keySet() {
-        return mainMap.keySet()
-                .stream()
-                .collect(ImmutableSet.toImmutableSet());
+        return ImmutableSet.copyOf(mainMap.keySet());
     }
 
     /** {@inheritDoc} */
     @Override
     @Accessor
     public @Nonnull Collection<V> values() {
-        return mainMap.values()
-                .stream()
-                .collect(ImmutableSet.toImmutableSet());
+        return ImmutableList.copyOf(mainMap.values());
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -297,6 +297,29 @@ public class CorfuTableTest extends AbstractViewTest {
 
         assertThat(((CorfuCompileProxy) ((ICorfuSMR) corfuTable).
                 getCorfuSMRProxy()).getUnderlyingObject().getSmrStream().pos()).isEqualTo(3);
+    }
 
+    /**
+     * Ensure that if the values of the table contains any duplicates,
+     * APIs that tries to retrieve all values can correctly return all
+     * values including duplicates.
+     */
+    @Test
+    public void duplicateValues() {
+        CorfuTable<String, String>
+                corfuTable = getDefaultRuntime().getObjectsView().build()
+                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setStreamName("test")
+                .open();
+
+        corfuTable.put("k1", "aa");
+        corfuTable.put("k2", "cc");
+        corfuTable.put("k3", "aa");
+        corfuTable.put("k4", "bb");
+
+        assertThat(corfuTable.values()).containsExactlyInAnyOrder("aa", "aa", "bb", "cc");
+        assertThat(corfuTable.entrySet()).containsExactlyInAnyOrder(
+                MapEntry.entry("k1", "aa"), MapEntry.entry("k3", "aa"),
+                MapEntry.entry("k4", "bb"), MapEntry.entry("k2", "cc"));
     }
 }


### PR DESCRIPTION
## Overview

CorfuTable values() API is inherited from Java Map interface, which
is not supposed to perform deduplication on return. If CorfuTable
contains duplicates in values, the current values() API would return
less values than expected. This patch fixes the API to return an
immutable list instead of a set.

Related issue(s) (if applicable): #2489 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
