### PR TITLE
CorfuQueue: Capture commit token & fix up Queue for ordering

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -18,12 +18,15 @@ import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.ICorfuSMRAccess;
 import org.corfudb.runtime.object.ICorfuSMRProxyInternal;
 import org.corfudb.runtime.object.VersionLockedObject;
+import org.corfudb.runtime.object.transactions.TransactionalContext.PreCommitListener;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Utils;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -247,6 +250,17 @@ public abstract class AbstractTransactionalContext implements
      * @param tc The transactional context to merge.
      */
     public abstract void addTransaction(AbstractTransactionalContext tc);
+
+    /**
+     * Add an object that needs extra processing right before commit happens
+     *
+     * @param preCommitListener The context of the object that needs extra processing
+     *                         along with its lambda.
+     */
+    public abstract void addPreCommitListener(PreCommitListener preCommitListener);
+
+    @Getter
+    private List<PreCommitListener> preCommitListeners = new ArrayList<>();
 
     /**
      * Commit the transaction to the log.

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -286,4 +286,9 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         log.trace("Commit[{}] Written to {}", this, address);
         return address;
     }
+
+    @Override
+    public void addPreCommitListener(TransactionalContext.PreCommitListener preCommitListener) {
+        this.getPreCommitListeners().add(preCommitListener);
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -85,4 +85,9 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
     public void addTransaction(AbstractTransactionalContext tc) {
         throw new UnsupportedOperationException("Can't merge into a readonly txn (yet)");
     }
+
+    @Override
+    public void addPreCommitListener(TransactionalContext.PreCommitListener preCommitListener) {
+        throw new UnsupportedOperationException("Can't register precommit hooks in readonly txn");
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
 
 /** A class which allows access to transactional contexts, which manage
  * transactions. The static methods of this class provide access to the
@@ -103,5 +104,14 @@ public class TransactionalContext {
                 getTransactionStack().stream().collect(Collectors.toList());
         Collections.reverse(listReverse);
         return listReverse;
+    }
+
+    /**
+     * Callback context for objects that need special processing with TokenResponse
+     * That is returned after conflict resolution is successful but before write happens.
+     * This can be used to capture the commit address of the object into the object itself.
+     */
+    public interface PreCommitListener {
+        void preCommitCallback(TokenResponse tokenResponse);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.collections.CorfuQueue;
 import org.corfudb.runtime.collections.CorfuQueue.CorfuRecordId;
+import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.transactions.AbstractTransactionsTest;
@@ -11,26 +12,32 @@ import org.corfudb.runtime.object.transactions.TransactionType;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Created by hisundar on 5/30/19.
  */
 @Slf4j
 public class CorfuQueueTxTest extends AbstractTransactionsTest {
+    static int myTable = 0;
     @Override
     public void TXBegin() {
         TXBegin(TransactionType.OPTIMISTIC);
     }
 
     public void TXBegin(TransactionType type) {
-        switch (type){
+        switch (type) {
             case WRITE_AFTER_WRITE:
                 WWTXBegin();
                 return;
@@ -38,11 +45,11 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
                 OptimisticTXBegin();
                 return;
             default:
-                throw new IllegalArgumentException("Unsupported TXN type:"+type.toString());
+                throw new IllegalArgumentException("Unsupported TXN type:" + type.toString());
         }
     }
 
-    protected final int numIterations = PARAMETERS.NUM_ITERATIONS_LOW;
+    protected final int numIterations = PARAMETERS.NUM_ITERATIONS_MODERATE;
     protected final Long numConflictKeys = 2L;
 
     /**
@@ -88,14 +95,16 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
                     TXBegin(txnType);
                     Long coinToss = new Random().nextLong() % numConflictKeys;
                     conflictMap.put(coinToss, coinToss);
+                    corfuQueue.enqueue(queueData);
+                    // Each transaction may or may not sleep to simulate out of order between enQ & commit
+                    TimeUnit.MILLISECONDS.sleep(coinToss);
                     lock.lock();
-                    CorfuRecordId id = corfuQueue.enqueue(queueData);
                     final long streamOffset = TXEnd();
-                    validator.add(new Record(id, queueData));
-                    log.debug("ENQ:" + id + "=>" + queueData + " at " + streamOffset);
+                    validator.add(new Record(new CorfuRecordId(0,0,i), queueData));
+                    log.debug("ENQ: {} => {} at {}", i, queueData, streamOffset);
                     lock.unlock();
                 } catch (TransactionAbortedException txException) {
-                    log.debug(queueData + " ---> Abort!!! ");
+                    log.debug("{} ---> Abort!!! ", queueData);
                     // Half the transactions are expected to abort
                     lock.unlock();
                 }
@@ -103,21 +112,172 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
         });
         executeScheduled(numThreads, PARAMETERS.TIMEOUT_LONG);
 
+        // Re-open the queue to ensure that the ordering is retrieved from a persisted source.
+        CorfuQueue<String>
+                corfuQueue2 = new CorfuQueue<>(getRuntime(), "testQueue");
+
+        // After all concurrent transactions are complete, validate that number of Queue entries
+        // are the same as the number of successful transactions.
+        List<CorfuQueue.CorfuQueueRecord<String>> records = corfuQueue2.entryList();
+        assertThat(validator.size()).isEqualTo(records.size());
+
+        // Also validate that the order of the queue matches that of the commit order.
+        CorfuRecordId testOrder = new CorfuRecordId(0,0,0);
+        for (int i = 0; i < validator.size(); i++) {
+            log.debug("Entry:" + records.get(i).getRecordId());
+            CorfuRecordId order = records.get(i).getRecordId();
+            assertThat(testOrder.compareTo(order)).isLessThanOrEqualTo(0);
+            log.debug("queue entry"+i+":"+order+"UUID:"+order.asUUID());
+            testOrder = order;
+            assertThat(validator.get(i).getData()).isEqualTo(records.get(i).getEntry());
+        }
+        int idx = validator.size() - 1;
+        UUID fromRecId = records.get(idx).getRecordId().asUUID();
+        assertThat(fromRecId.getLeastSignificantBits()).isEqualTo(records.get(idx).getRecordId().getEntryId());
+
+        CorfuRecordId backToRecId = new CorfuRecordId(fromRecId);
+        assertThat(backToRecId.getEntryId()).isEqualTo(records.get(idx).getRecordId().getEntryId());
+        assertThat(backToRecId.getEpoch()).isEqualTo(records.get(idx).getRecordId().getEpoch());
+        log.debug("UUID from Record {} = {}", idx, fromRecId);
+        assertThat(backToRecId.getSequence()).isEqualTo(records.get(idx).getRecordId().getSequence());
+        log.debug("RecordId back from UUID = {}", backToRecId);
+    }
+
+    //Assist the test that the log address values are not in the same order of enqueue.
+    public void queueOutOfOrderedByTransaction(TransactionType txnType, boolean inOrder) throws Exception {
+        Semaphore semId = new Semaphore(1);
+        Semaphore semTx= new Semaphore(1);
+        myTable = 0;
+        semId.acquire();
+        semTx.acquire();
+
+        int semIdOwner;
+        int semTxOwner;
+
+        if (inOrder) {
+            semIdOwner = 0;
+            semTxOwner = 0;
+        } else {
+            semIdOwner = 0;
+            semTxOwner = 1;
+        }
+
+        final int numThreads = PARAMETERS.CONCURRENCY_TWO;
+        Map<Integer, Map<Long, Long>> tables = new HashMap<>();
+
+        for (int i = 0; i < numThreads; i++) {
+            tables.put(i, instantiateCorfuObject(CorfuTable.class, "testTable" +i));
+        }
+
+        CorfuQueue<String>
+                corfuQueue = new CorfuQueue<>(getRuntime(), "testQueue");
+        class Record {
+            @Getter
+            public CorfuRecordId id;
+            @Getter
+            public String data;
+
+            public Record(CorfuRecordId id, String data) {
+                this.id = id;
+                this.data = data;
+            }
+        }
+
+        Map<Long, String> validator = new Hashtable<>();
+        ReentrantLock lock = new ReentrantLock();
+        scheduleConcurrently(numThreads, t ->
+        {
+            int tableID;
+            lock.lock();
+            tableID = myTable++;
+            lock.unlock();
+
+            log.info("\nmy tableID :" + tableID + " numIterations: " + numIterations);
+
+            Map<Long, Long> testTable = tables.get(tableID);
+
+            for (Long i = 0L; i < numIterations; i++) {
+                String queueData = t.toString() + ":" + i.toString();
+                try {
+                    TXBegin(txnType);
+                    Long coinToss = new Random().nextLong() % numConflictKeys;
+                    testTable.put(coinToss, coinToss);
+
+                    //enforce the second thread enqueue later
+                    if (tableID != semIdOwner) {
+                        semId.acquire();
+                    }
+
+                    corfuQueue.enqueue(queueData);
+
+                    if (tableID == semIdOwner) {
+                        semId.release();
+                    }
+
+                    //enforce the first thread get enQueue first, but
+                    if (tableID != semTxOwner) {
+                        semTx.acquire();
+                    }
+
+                    final long streamOffset = TXEnd();
+                    if (tableID == semTxOwner) {
+                        semTx.release();
+                    }
+
+                    //hashtable update is synchronized
+                    validator.put(streamOffset, queueData);
+                    log.debug("ENQ:" + "=>" + queueData + " at " + streamOffset);
+                } catch (TransactionAbortedException txException) {
+                    log.warn(queueData + " ---> Abort!!! ");
+                    assertThat(0);
+                }
+            }
+        });
+
+        executeScheduled(numThreads, PARAMETERS.TIMEOUT_LONG);
+
         // After all concurrent transactions are complete, validate that number of Queue entries
         // are the same as the number of successful transactions.
         List<CorfuQueue.CorfuQueueRecord<String>> records = corfuQueue.entryList();
         assertThat(validator.size()).isEqualTo(records.size());
 
-        // Also validate that the order of the queue matches that of the commit order.
-        for (int i = 0; i < validator.size(); i++) {
-            log.debug("Entry:" + records.get(i).getRecordId());
-            assertThat(validator.get(i).getId().equals(records.get(i).getRecordId()));
-            assertThat(validator.get(i).getData()).isEqualTo(records.get(i).getEntry());
+        Map<Long, String> sortedMap = new TreeMap<>(validator);
+
+        int i = 0;
+        int cnt = 0;
+        for (Map.Entry<Long, String> entry : sortedMap.entrySet()) {
+            CorfuRecordId id = records.get(i).getRecordId();
+            String val0 = entry.getValue();
+            String val1 = records.get(i).getEntry();
+
+            if (entry.getKey() != id.getSequence() || !val0.equals(val1)) {
+                log.warn("\nentry: " + entry + " queue item: " + records.get(i));
+                cnt++;
+            }
+            i++;
         }
 
-        // Validate that one cannot compare ID from enqueue with ID from entryList()
-        assertThatThrownBy(() -> validator.get(0).getId().compareTo(records.get(0).getRecordId())).
-                isExactlyInstanceOf(IllegalArgumentException.class);
+        assertThat(cnt).isZero();
+    }
+
+    @Test
+    public void queueInOrderedByWWTxn() throws Exception {
+        queueOutOfOrderedByTransaction(TransactionType.WRITE_AFTER_WRITE, true);
+    }
+
+    @Test
+    public void queueInOrderedByOptimTxn() throws Exception {
+        queueOutOfOrderedByTransaction(TransactionType.OPTIMISTIC, true);
+    }
+
+    @Test
+    public void queueOutOfOrderedByWWTxn() throws Exception {
+        queueOutOfOrderedByTransaction(TransactionType.WRITE_AFTER_WRITE, false);
+    }
+
+    @Test
+    public void queueOutOfOrderedByOptimTxn() throws Exception {
+        queueOutOfOrderedByTransaction(TransactionType.OPTIMISTIC, false);
     }
 }
 


### PR DESCRIPTION
## Overview

The Queue needs to capture the exact address its entries were
written to, so it can then order its entries, of its orderless
hashmap (corfuTable), in the same order that its transactions
materialized.
    
To do this register a preCommitCallback that intercepts the
Sequencer's blessed tokenResponse and fills it up into
the payload of the fields of the Queue.
    
+ Randomize sleep in test case to catch out of order reliably.

Add test case for both inorder and out of order between enqueue op and txEnd.
Co-authored-by: Xiaoqin Ma <maxiaoqin2005@gmail.com>

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
