### PR TITLE
Take metadata size into account when calculating the logData size.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServerCache.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServerCache.java
@@ -24,10 +24,13 @@ public class LogUnitServerCache {
     private final LoadingCache<Long, ILogData> dataCache;
     private final StreamLog streamLog;
 
+    // The Key is a long with size of 8 bytes
+    private static final int LONG_KEY_SIZE = 8;
+
     public LogUnitServerCache(LogUnitServerConfig config, StreamLog streamLog) {
         this.streamLog = streamLog;
         this.dataCache = Caffeine.newBuilder()
-                .<Long, ILogData>weigher((addr, logData) -> logData.getSizeEstimate())
+                .<Long, ILogData>weigher((addr, logData) -> logData.getSizeEstimate() + LONG_KEY_SIZE)
                 .maximumWeight(config.getMaxCacheSize())
                 .removalListener(this::handleEviction)
                 .build(this::handleRetrieval);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ILogData.java
@@ -69,6 +69,9 @@ public interface ILogData extends IMetadata, Comparable<ILogData> {
 
     void releaseBuffer();
 
+    /**
+     * Serialize into a ByteBuffer
+     */
     void acquireBuffer();
 
     default SerializationHandle getSerializedForm() {


### PR DESCRIPTION
The current method only considers the data size, which can give
innacurate result if the metadata size is significant.


- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
