### PR TITLE
CorfuQueue: Don't use epoch for ordering

### DIFF
--- a/docs/corfu-queue/corfu-queue-design.md
+++ b/docs/corfu-queue/corfu-queue-design.md
@@ -1,12 +1,11 @@
 The class `CorfuQueue` implements a persisted queue over the abstraction of a CorfuTable. CorfuTable that only uses a HashMap<> to represent the materialized view of a distributed map does not carry a notion of ordering natively. However when implemented over the abstraction of a distributed shared log, the elements added to the map do, in fact, have an ordering imposed by their append or transaction commit operations into the global log. The class `CorfuQueue` attempts to expose this inherent ordering as a persisted Queue with three simple apis:
 
 ###  1. `CorfuRecordId enqueue(E)`
-Since a map has a key and value, where key is a conflict parameter, enqueue generates a non-conflicting Long as the key and inserts the Entry as a value into a CorfuTable. The generated Long is packed into the LSB of a UUID and returned to the caller as a CorfuRecordId. Note that this Id does not carry ordering since the operation could be part of a transaction that has not committed yet.
+Since a map has a key and value, where key is a conflict parameter, enqueue generates a non-conflicting Long as the key and inserts the Entry as a value into a CorfuTable. If enqueue() is wrapped in a Corfu transaction this CorfuRecordId returned will capture the transaction's commit order and together with the entryId define the global cluster-wide order of the entry in the Queue.
 
 ### 2. `List<CorfuQueueRecord<Object>> entryList()`
-Returns a list of all the entries along with their ids. These ids are packed into CorfuRecordId (UUIDs) with the MSB bits composed out of their (stream snapshot address, index in queue) tuples and their LSB bits with the enqueued Long. Thus these Ids have a global comparable ordering maintained by their underlying CorfuTable's [LinkedHashMap](https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html). Note that the CorfuRecordId returned from the enqueue() operation should not be directly compared with that returned from the entryList() api because one does not have ordering while the other does.
+Returns a list of all the entries along with their comparable ids. These ids are packed into CorfuRecordId (convertible into a custom comparable UUID).
 
 ### 3. `E remove(CorfuRecordId id)`
-Instead of a `dequeue()`, the returned id from `enqueue()` or the `entryList()` api can be used to remove entries in any order from the persisted queue.
+Instead of a `dequeue()`, the returned id from `enqueue()` or the `entryList()` api can be used to remove entries in any order from the persisted queue. Note that remove will not change the commit order.
 
-Assuming checkpointing and garbage collection also work in the same insertion order, the abstraction of a logical queue can be done using nothing more than a CorfuTable over a [LinkedHashMap](https://docs.oracle.com/javase/8/docs/api/java/util/LinkedHashMap.html) instead of a simple HashMap<>.

--- a/format/proto/types.proto
+++ b/format/proto/types.proto
@@ -53,6 +53,11 @@ message LogHeader {
     optional bool verify_checksum = 2;
 }
 
+message CorfuQueueIdMsg {
+    optional int64 txSequence = 1;
+    optional int64 entryId = 2;
+}
+
 message Metadata {
     required sfixed32 payload_checksum = 1;
     required sfixed32 length_checksum = 2;

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
@@ -46,8 +46,6 @@ public class CorfuQueueTest extends AbstractViewTest {
         final int middleEntryIndex = 1;
         // Remove the middle entry
         corfuQueue.removeEntry(corfuQueue.entryList().get(middleEntryIndex).getRecordId());
-        assertThat(records.get(0).getRecordId().asUUID().getLeastSignificantBits())
-                .isEqualTo(records.get(0).getRecordId().getEntryId());
 
         List<CorfuQueueRecord<String>> records2 =
                     corfuQueue.entryList(Short.MAX_VALUE);


### PR DESCRIPTION
Ordering is whatever corfu transaction layer considers as ordering.
Since epoch doesn't feature there, remove epoch from Queue.
Also remove UUID and expose a toByteArray() for serialization of CorfuQueueId instead for cleaner abstraction.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
