### PR TITLE
While remove a router, the client should be removed too.

### DIFF
--- a/it/src/test/java/org/corfudb/universe/scenario/AddNodeDuringInvalidateLayoutIT.java
+++ b/it/src/test/java/org/corfudb/universe/scenario/AddNodeDuringInvalidateLayoutIT.java
@@ -1,0 +1,157 @@
+package org.corfudb.universe.scenario;
+
+import org.corfudb.runtime.clients.BaseClient;
+import org.corfudb.runtime.clients.BaseHandler;
+import org.corfudb.runtime.clients.LayoutHandler;
+import org.corfudb.runtime.clients.ManagementHandler;
+import org.corfudb.runtime.clients.NettyClientRouter;
+import org.corfudb.runtime.exceptions.NetworkException;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.universe.GenericIntegrationTest;
+import org.corfudb.universe.UniverseManager.UniverseWorkflow;
+import org.corfudb.universe.group.cluster.docker.DockerCorfuCluster;
+import org.corfudb.universe.node.client.LocalCorfuClient;
+import org.corfudb.universe.node.server.CorfuServer;
+import org.corfudb.universe.scenario.fixture.Fixture;
+import org.corfudb.universe.universe.UniverseParams;
+import org.corfudb.util.CFUtils;
+import org.corfudb.util.NodeLocator;
+import org.corfudb.util.Sleep;
+import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.mockito.Mockito;
+
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class AddNodeDuringInvalidateLayoutIT extends GenericIntegrationTest {
+
+    /**
+     * Test add node behavior while the layout is being invalidated concurrently.
+     * <p>
+     * 1) Deploy and bootstrap a three nodes cluster.
+     * 2) Remove a node.
+     * 2) Try resetting a node and invalidating layout at the same time. This should throw an exception.
+     * 3) Create a separate router for resets. Try resetting a node and invalidating layout at the same.
+     *    The reset should go through.
+     * 4) Create a separate router for adding a node, and invoke the add node procedure.
+     *    Keep invalidating a layout every time RPC is called. The add node should succeed.
+     * 5) Verify that the node is present in the new layout.
+     */
+    @Test(timeout = 300000)
+    public void AddNodeDuringInvalidateLayoutTest() {
+        workflow(wf -> {
+
+                    wf.setupDocker(fixture -> {
+                        fixture.getCluster().numNodes(3);
+                    });
+
+                    wf.deploy();
+                    try {
+                        addNodeDuringInvalidateLayout(wf);
+                    } catch (Exception e) {
+                        Assertions.fail("Test failed: " + e);
+                    }
+
+                }
+        );
+    }
+
+    private void addNodeDuringInvalidateLayout(UniverseWorkflow<Fixture<UniverseParams>> wf) throws Exception {
+        UniverseParams params = wf.getFixture().data();
+        DockerCorfuCluster corfuCluster = wf.getUniverse()
+                .getGroup(params.getGroupParamByIndex(0).getName());
+        Optional<CorfuServer> first = corfuCluster.nodes().values().asList().stream().findFirst();
+
+        if (first.isPresent()) {
+            String endpoint = first.get().getEndpoint();
+            LocalCorfuClient client = corfuCluster.getLocalCorfuClient();
+            final Duration timeOutDuration = Duration.ofSeconds(5);
+            final Duration pollDuration = Duration.ofSeconds(1);
+            final int numRetries = 3;
+            final int waitForResetDurationSeconds = 8;
+            final int resetWaitPeriod = 2000;
+            // Remove a node so we can add it back later.
+            client.getRuntime().getManagementView()
+                    .removeNode(endpoint, numRetries, timeOutDuration, pollDuration);
+            Layout layout = client.getLayout();
+            assertThat(layout.getAllServers().contains(endpoint)).isFalse();
+            // Create a base client to the node we want to reset and the spy to cause a race condition.
+            BaseClient baseClient = client.getRuntime().getLayoutView()
+                    .getRuntimeLayout().getBaseClient(endpoint);
+            BaseClient baseClientSpy = Mockito.spy(baseClient);
+
+            // When a base client tries to perform a reset, invalidate a layout.
+            // This will prune the router of the base client.
+            Mockito.doAnswer(invoke -> {
+                client.getRuntime().invalidateLayout();
+                return invoke.callRealMethod();
+            }).when(baseClientSpy).reset();
+
+            // When we try to issue a reset, depending on when the router was pruned,
+            // either a TimeoutException will be thrown
+            // (because the connection future times out),
+            // or a NetworkException will be thrown
+            // (because the connection future completed exceptionally).
+            assertThatThrownBy(() -> CFUtils.getUninterruptibly(baseClientSpy.reset(),
+                    TimeoutException.class, NetworkException.class))
+                    .isInstanceOfAny(NetworkException.class, TimeoutException.class);
+
+            // Now lets create a client router that is not part of a router pool,
+            // issue a reset to the node we would want to add.
+            // When a reset is called, the layout will be invalidated.
+            try (NettyClientRouter clientRouter = new NettyClientRouter(NodeLocator.parseString(endpoint),
+                    client.getRuntime().getParameters())) {
+
+                baseClient = new BaseClient(clientRouter, layout.getEpoch(), layout.getClusterId());
+                BaseClient spyBaseClient = Mockito.spy(baseClient);
+
+                Mockito.doAnswer(invoke -> {
+                    client.getRuntime().invalidateLayout();
+                    return invoke.callRealMethod();
+                }).when(spyBaseClient).reset();
+
+                // The reset should go through.
+                boolean resetHappened = spyBaseClient.reset()
+                        .get(waitForResetDurationSeconds, TimeUnit.SECONDS);
+                assertThat(resetHappened).isTrue();
+            }
+
+            // Wait until a node fully restarts.
+            Sleep.sleepUninterruptibly(Duration.ofMillis(resetWaitPeriod));
+
+            // Now lets create a client router that is not part of a router pool,
+            // and run the add node workflow.
+            // Every time a clientRouter sends a request, the layout will be invalidated.
+            try (NettyClientRouter clientRouter = new NettyClientRouter(NodeLocator.parseString(endpoint),
+                    client.getRuntime().getParameters())) {
+
+                NettyClientRouter spyRouter = Mockito.spy(clientRouter);
+
+                spyRouter.addClient(new LayoutHandler())
+                        .addClient(new ManagementHandler())
+                        .addClient(new BaseHandler());
+
+                Mockito.doAnswer(invoke -> {
+                    client.getRuntime().invalidateLayout();
+                    return invoke.callRealMethod();
+                }).when(spyRouter).sendMessageAndGetCompletable(Mockito.any(), Mockito.any());
+
+                // Run add node.
+                client.getManagementView()
+                        .addNode(endpoint, numRetries, timeOutDuration, pollDuration);
+                // Verify that the node was added.
+                assertThat(client.getLayout().getAllServers()).contains(endpoint);
+            }
+
+            return;
+        }
+
+        throw new IllegalStateException("Node is not present.");
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -912,6 +912,7 @@ public class CorfuRuntime {
                         .contains(endpoint.toEndpointUrl()))
                 .forEach(endpoint -> {
                     try {
+                        getLayoutView().getRuntimeLayout().removeClient(BaseClient.class, endpoint.toEndpointUrl());
                         IClientRouter router = nodeRouterPool.getNodeRouters().remove(endpoint);
                         if (router != null) {
                             // Stop the channel from keeping connecting/reconnecting to server.

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -30,8 +30,10 @@ public class BaseClient implements IClient {
     @Setter
     private IClientRouter router;
 
+    @Getter
     private final long epoch;
 
+    @Getter
     private final UUID clusterId;
 
     public BaseClient(IClientRouter router, long epoch, UUID clusterId) {

--- a/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
@@ -2,7 +2,6 @@ package org.corfudb.runtime.clients;
 
 import io.netty.channel.ChannelHandlerContext;
 
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
 
 import org.corfudb.protocols.wireprotocol.CorfuMsg;

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -597,6 +597,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<CorfuMsg>
             log.info("keepAlive: channel not established or not open, skipping sending keep alive.");
             return;
         }
+
         // Send a keep alive message to server which ignores epoch
         sendMessageAndGetCompletable(null, CorfuMsgType.KEEP_ALIVE.msg());
         log.trace("keepAlive: sent keep alive to {}", this.channel.remoteAddress());

--- a/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/RuntimeLayout.java
@@ -86,6 +86,7 @@ public class RuntimeLayout {
      * This ensures that a client for a particular endpoint stamped with the required epoch is
      * created only once.
      */
+    @Getter
     private final Map<Class<? extends IClient>,
             Map<String, IClient>> senderClientMap = new ConcurrentHashMap<>();
 
@@ -122,6 +123,15 @@ public class RuntimeLayout {
             });
             return endpointClientMap;
         }).get(endpoint);
+    }
+
+    public void removeClient(final Class<? extends IClient> clientClass,
+                          final String endpoint) {
+        Map<String, IClient> clientMap = senderClientMap.get(clientClass);
+
+        if (clientMap != null) {
+            clientMap.remove(endpoint);
+        }
     }
 
     public BaseClient getBaseClient(String endpoint) {


### PR DESCRIPTION
Overview
While adding a node to the system, a rounter is created and added to the router pool and a mapping information from endpoint to the router is adding to the layout view. 
While a router is stopped, it is removed from the router pool, but the mapping int he layout hasn't been removed. 

While a router is stopped and removed, the mapping information should be removed too to avoid to reuse the stale router.  

Description:
 * If the client is not removed, the stopped router will be reused.
 * Accessing the stopped router will trigger an exception.

Why should this be merged: 
While removing a router, the client on the clientMap should be removed too.
Otherwise, the client bounding the router will be reused and the stopped router will be reused again. 

Add a test case to simulate the race condition:
1. The cluster is setup with one server localhost:9000.
2. l = get the layout with one server and one router.
3. setup the baseclient and the router for server localhost:9001.
4. call invalidate layout to trigger the prune of router for localhost:9001.
5. The following call with router for localhost:9001 will caught an exception all the time. Even after retry with getBaseclient as the client is already in the map. 
With the fix, the retry will succeed to add a new router.