### PR TITLE
CorfuQueue: Don't embed generic types [backport to 3.0.1]

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.TreeMap;
-import java.util.UUID;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;


### PR DESCRIPTION
Putting a generic type inside another class
doesn't work well with the shallow Gson Json serializer.
Avoid the deserialization mishap by embedding
the ordering into the key which is an internal
type.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
