### PR TITLE
Lower logging level for log writes

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -209,7 +209,7 @@ public class LogUnitServer extends AbstractServer {
     @ServerHandler(type = CorfuMsgType.WRITE)
     public void write(CorfuPayloadMsg<WriteRequest> msg, ChannelHandlerContext ctx, IServerRouter r) {
         LogData logData = (LogData) msg.getPayload().getData();
-        log.debug("log write: type: {}, address: {}, streams: {}", logData.getType(),
+        log.trace("log write: type: {}, address: {}, streams: {}", logData.getType(),
                 logData.getToken(), logData.getBackpointerMap());
 
         // Its not clear that making all holes high priority is the right thing to do, but since


### PR DESCRIPTION
## Overview
We can not afford so massive amount of logs. 
"Log write" messages often consume up to 80% of all logs in the system overall.
Here are some numbers from a system (3 node cluster), Corfu by itself consumes 80-90% of all logs:

![image](https://user-images.githubusercontent.com/314292/81464278-f6bc7080-9174-11ea-9d53-92aee0d0d229.png)

![image](https://user-images.githubusercontent.com/314292/81464284-1358a880-9175-11ea-851a-eedeb36f7ec5.png)

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
