### PR TITLE
Add Support for Selected Stream Replication.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -15,6 +15,10 @@ import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 
 import javax.annotation.Nonnull;
 import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -46,13 +50,18 @@ public class LogReplicationServer extends AbstractServer {
         this.serverContext = context;
         this.executor = Executors.newFixedThreadPool(1,
                 new ServerThreadFactory("LogReplicationServer-", new ServerThreadFactory.ExceptionHandler()));
-        LogReplicationConfig config = LogReplicationConfig.fromFile(configFilePath);
+        LogReplicationConfig config = getDefaultLogReplicationConfig();
 
         // TODO (hack): where can we obtain the local corfu endpoint? site manager? or can we always assume port is 9000?
         String corfuPort = serverContext.getLocalEndpoint().equals("localhost:9020") ? ":9001" : ":9000";
         String corfuEndpoint = serverContext.getNodeLocator().getHost() + corfuPort;
         log.info("Initialize Sink Manager with CorfuRuntime to {}", corfuEndpoint);
         this.sinkManager = new SinkManager(corfuEndpoint, config);
+    }
+
+    private LogReplicationConfig getDefaultLogReplicationConfig() {
+        Set<String> streamsToReplicate = new HashSet<>(Arrays.asList("Table001", "Table002", "Table003"));
+        return new LogReplicationConfig(streamsToReplicate, UUID.randomUUID(), UUID.randomUUID());
     }
 
     /* ************ Override Methods ************ */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -31,7 +31,6 @@ public class LogReplicationConfig {
      */
     private UUID remoteSiteID;
 
-    private static final String STREAMS_TO_REPLICATE_KEY = "StreamsToReplicate";
     private static final String REMOTE_SITE_UUID_KEY = "RemoteSiteId";
 
     /**
@@ -46,35 +45,10 @@ public class LogReplicationConfig {
         this.remoteSiteID = remoteSiteID;
     }
 
-    public static LogReplicationConfig fromFile(String filePath) {
-
-        try (InputStream input = new FileInputStream(filePath)) {
-
-            Properties prop = new Properties();
-
-            if (input == null) {
-                log.info("Log Replication Config {} not found, DEFAULT values will be used.", filePath);
-                return getDefaultConfig();
-
-            }
-
-            // Load the properties file
-            prop.load(input);
-
-            // Get Values by Keys from Properties File
-            Set<String> streamsToReplicate = new HashSet<>(Arrays.asList(prop.getProperty(STREAMS_TO_REPLICATE_KEY).split(",")));
-            UUID remoteSiteId = UUID.fromString(prop.getProperty(REMOTE_SITE_UUID_KEY));
-
-            log.info("Loaded log replication config: streams to replicate [{}], remote site id {}", streamsToReplicate, remoteSiteId);
-            return new LogReplicationConfig(streamsToReplicate, UUID.randomUUID(), remoteSiteId);
-
-        } catch (Exception e) {
-            log.error("Caught exception while reading log replication config file {}", filePath, e);
-        }
-
-        return getDefaultConfig();
-    }
-
+    /**
+     * TODO: Perhaps we want to keep this for testing?
+     * @return
+     */
     private static LogReplicationConfig getDefaultConfig() {
         Set<String> streamsToReplicate = new HashSet<>(Arrays.asList("Table001", "Table002", "Table003"));
         return new LogReplicationConfig(streamsToReplicate, UUID.randomUUID(), UUID.randomUUID());

--- a/log-replication/pom.xml
+++ b/log-replication/pom.xml
@@ -61,5 +61,10 @@
       <artifactId>infrastructure</artifactId>
       <version>${revision}</version>
     </dependency>
+    <dependency>
+      <groupId>org.corfudb</groupId>
+      <artifactId>utils</artifactId>
+      <version>${revision}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationManager.java
@@ -111,7 +111,7 @@ public class CorfuReplicationManager {
         try {
             log.info("Start Negotiation");
             LogReplicationNegotiationResponse negotiationResponse = logReplicationRuntime.startNegotiation();
-            log.info("Negotiation Response received: " + negotiationResponse);
+            log.info("Negotiation Response received: {}" + negotiationResponse);
             // Determine if we should proceed with Snapshot Sync or Log Entry Sync
             return processNegotiationResponse(negotiationResponse);
         } catch (Exception e) {

--- a/log-replication/src/main/java/org/corfudb/logreplication/runtime/LogReplicationRuntimeParameters.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/runtime/LogReplicationRuntimeParameters.java
@@ -13,4 +13,6 @@ public class LogReplicationRuntimeParameters extends RuntimeParameters {
 
     private String remoteLogReplicationServerEndpoint;
 
+    private String StreamToReplicateFilePath;
+
 }

--- a/log-replication/src/main/java/org/corfudb/logreplication/runtime/LogReplicationStreamNameFetcher.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/runtime/LogReplicationStreamNameFetcher.java
@@ -1,0 +1,8 @@
+package org.corfudb.logreplication.runtime;
+
+import java.util.Map;
+
+public interface LogReplicationStreamNameFetcher {
+
+    Map<String, String> fetchStreamsToReplicate();
+}

--- a/log-replication/src/test/java/org/corfudb/LogReplicationRuntimeTest.java
+++ b/log-replication/src/test/java/org/corfudb/LogReplicationRuntimeTest.java
@@ -1,0 +1,22 @@
+package org.corfudb;
+
+import org.corfudb.logreplication.runtime.LogReplicationRuntime;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.times;
+
+public class LogReplicationRuntimeTest {
+
+    @Test
+    public void testReplicatedStreamTableCreation() {
+    }
+
+    @Test
+    public void testReplicatedStreamTableVersionMismatch() {
+    }
+}

--- a/utils/proto/log_replication_streams.proto
+++ b/utils/proto/log_replication_streams.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package org.corfudb.utils;
+option java_package = "org.corfudb.utils";
+
+message TableInfo {
+    string name = 1;
+}
+
+message Namespace {
+    string name = 1;
+}


### PR DESCRIPTION
Add Support for Selected Stream Replication.

Clients of the LogReplication server can specify a selected set of streams to be replicated.


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
