### PR TITLE
Move to Netty Version 4.1.42 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
-            <version>4.1.43.Final</version>
+            <version>4.1.42.Final</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Overview

Description:

Update Netty to version 4.1.42 as per NSX requirements.

Why should this be merged: required per NSX requirements. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
