### PR TITLE
Check Null in close of CorfuServerNode

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
@@ -130,7 +130,9 @@ public class CorfuServerNode implements AutoCloseable {
 
         log.info("close: Shutting down Corfu server and cleaning resources");
         serverContext.close();
-        bindFuture.channel().close().syncUninterruptibly();
+        if (bindFuture != null) {
+            bindFuture.channel().close().syncUninterruptibly();
+        }
 
         // A executor service to create the shutdown threads
         // plus name the threads correctly.

--- a/test/src/test/java/org/corfudb/infrastructure/CorfuServerNodeTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CorfuServerNodeTest.java
@@ -1,0 +1,17 @@
+package org.corfudb.infrastructure;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+
+public class CorfuServerNodeTest {
+
+    @Test
+    public void nodeCloseTest() {
+        final int port = 9000;
+        ServerContext context = ServerContextBuilder.defaultContext(port);
+        CorfuServerNode node = new CorfuServerNode(context);
+        assertThatCode(node::close).doesNotThrowAnyException();
+    }
+}


### PR DESCRIPTION
## Overview

Description:

Global variable **bindFuture** might not be initialized if bindServer throws a UnrecoverableCorfuInterruptedError. Since shutdown hooker will call close method, it will throw NullPointerException and get caught by Tanuki.

Why should this be merged: 

Added check for null and a simple unit test.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
