### PR TITLE
Add the LogReplicationSenderBuffer mechanism.

### DIFF
--- a/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
@@ -250,7 +250,6 @@ public class CorfuInterClusterReplicationServer implements Runnable {
                 activeServer = new CorfuInterClusterReplicationServerNode(serverContext);
 
                 replicationDiscoveryService = new CorfuReplicationDiscoveryService(serverContext, activeServer, siteManagerAdapter);
-                siteManagerAdapter.setCorfuReplicationDiscoveryService(replicationDiscoveryService);
 
                 Thread replicationDiscoveryThread = new Thread(replicationDiscoveryService);
                 replicationDiscoveryThread.start();

--- a/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -94,7 +94,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         this.localEndpoint = serverContext.getLocalEndpoint();
         this.nodeInfo = crossSiteConfig.getNodeInfo(localEndpoint);
 
-        siteManager.start();
         registerToLogReplicationLock();
     }
 

--- a/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationSiteManagerAdapter.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationSiteManagerAdapter.java
@@ -7,12 +7,15 @@ import org.corfudb.logreplication.proto.LogReplicationSiteInfo.SiteConfiguration
 
 public abstract class CorfuReplicationSiteManagerAdapter {
     @Getter
-    @Setter
     CorfuReplicationDiscoveryServiceAdapter corfuReplicationDiscoveryService;
 
     @Getter
     SiteConfigurationMsg siteConfigMsg;
 
+    public void setCorfuReplicationDiscoveryService(CorfuReplicationDiscoveryServiceAdapter corfuReplicationDiscoveryService) {
+        this.corfuReplicationDiscoveryService = corfuReplicationDiscoveryService;
+        start();
+    }
 
     public synchronized SiteConfigurationMsg fetchSiteConfig() {
         siteConfigMsg = querySiteConfig();
@@ -39,6 +42,7 @@ public abstract class CorfuReplicationSiteManagerAdapter {
         return corfuReplicationDiscoveryService.queryReplicationStatus();
     }
 
+    //TODO: handle the case that querySiteConfig return an exception.
     public abstract SiteConfigurationMsg querySiteConfig();
 
     public abstract void start();

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/LogEntrySender.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/LogEntrySender.java
@@ -1,7 +1,5 @@
 package org.corfudb.logreplication.send;
 
-import lombok.Data;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.infrastructure.logreplication.DataSender;
@@ -16,18 +14,11 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.exceptions.TrimmedException;
 
-import java.io.File;
-import java.io.FileReader;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 /**
  * This class is responsible of managing the transmission of log entries,
@@ -38,38 +29,8 @@ import java.util.stream.Collectors;
  */
 @Slf4j
 public class LogEntrySender {
-    public static final String config_file = "/config/corfu/corfu_replication_config.properties";
-    public static final int DEFAULT_READER_QUEUE_SIZE = 1;
-    public static final int DEFAULT_RESENT_TIMER = 5000;
-    public static final int DEFAULT_MAX_RETRY = 5;
+
     public static final int DEFAULT_TIMEOUT = 5000;
-
-    /*
-     * for internal timer increasing for each message in milliseconds
-     */
-    final static private long TIME_INCREMENT = 10;
-
-    private int readerBatchSize = DEFAULT_READER_QUEUE_SIZE;
-
-    /*
-     * The timer to resend an entry. This is the roundtrip time between sender/receiver.
-     */
-    private int msgTimer = DEFAULT_RESENT_TIMER;
-
-    /*
-     * The max number of retry for sending an entry.
-     */
-    private int maxRetry = DEFAULT_MAX_RETRY;
-
-    /*
-     * wait for ack or not
-     */
-    private boolean errorOnMsgTimeout = true;
-
-    /*
-     * reset while process messages
-     */
-    long currentTime;
 
     /*
      * Corfu Runtime
@@ -81,16 +42,12 @@ public class LogEntrySender {
      */
     private LogEntryReader logEntryReader;
 
-    /*
-     * Log Entry Listener, application callback to send out reads.
-     */
     private DataSender dataSender;
 
-    /*
-     * The log entry has been sent to the receiver but hasn't ACKed yet.
-     */
-    @Getter
-    LogReplicationEntryQueue pendingEntries;
+   /*
+    * Implementation of buffering messages and sending/resending messages
+    */
+    private LogReplicationSenderBuffer dataSenderBuffer;
 
     private long ackTs = Address.NON_ADDRESS;
 
@@ -102,8 +59,9 @@ public class LogEntrySender {
 
     private volatile boolean taskActive = false;
 
+    long currentTime;
 
-    private Map<Long, CompletableFuture<LogReplicationEntry>> pendingLogEntriesAcked = new HashMap<>();
+    //private Map<Long, CompletableFuture<LogReplicationEntry>> pendingLogEntriesAcked = new HashMap<>();
     private List<CompletableFuture<LogReplicationEntry>> pendingForAck = new ArrayList<>();
 
     /**
@@ -124,60 +82,13 @@ public class LogEntrySender {
     public LogEntrySender(CorfuRuntime runtime, LogEntryReader logEntryReader, DataSender dataSender,
                           ReadProcessor readProcessor, LogReplicationFSM logReplicationFSM) {
 
-        readConfig();
         this.runtime = runtime;
         this.logEntryReader = logEntryReader;
         this.dataSender = dataSender;
+        this.dataSenderBuffer = new LogReplicationSenderBuffer(dataSender);
         this.logReplicationFSM = logReplicationFSM;
-        this.pendingEntries = new LogReplicationEntryQueue(readerBatchSize);
+        //this.pendingEntries = new LogReplicationSenderQueue(readerBatchSize);
     }
-
-    private void readConfig() {
-        try {
-            File configFile = new File(config_file);
-            FileReader reader = new FileReader(configFile);
-
-            Properties props = new Properties();
-            props.load(reader);
-
-            maxRetry = Integer.parseInt(props.getProperty("log_reader_max_retry", Integer.toString(DEFAULT_MAX_RETRY)));
-            readerBatchSize = Integer.parseInt(props.getProperty("log_reader_queue_size", Integer.toString(DEFAULT_READER_QUEUE_SIZE)));
-            msgTimer = Integer.parseInt(props.getProperty("log_reader_resend_timer", Integer.toString(DEFAULT_RESENT_TIMER)));
-            errorOnMsgTimeout = Boolean.parseBoolean(props.getProperty("log_reader_error_on_message_timeout", "true"));
-            reader.close();
-
-        } catch (Exception e) {
-            log.warn("The config file is not available {} , will use the default vaules for config.", e.getCause());
-        } finally {
-            log.info("log logreader config max_retry {} reader_queue_size {} entry_resend_timer {} waitAck {}",
-                    maxRetry, readerBatchSize, msgTimer, errorOnMsgTimeout);
-        }
-    }
-
-    /**
-     * resend the messages in the queue if it times out.
-     * @param
-     * @return it returns false if there is an entry has been resent MAX_RETRY and timeout again.
-     * Otherwise it returns true.
-     */
-
-    void resend() {
-        for (int i = 0; i < pendingEntries.list.size() && taskActive; i++) {
-            LogReplicationPendingEntry entry  = pendingEntries.list.get(i);
-            if (entry.timeout(getCurrentTime(), msgTimer)) {
-                if (errorOnMsgTimeout && entry.retry >= maxRetry) {
-                    log.warn("Entry {} of type {} has been resent max times {} for timer {}.", entry.getData().getMetadata().getTimestamp(),
-                            entry.getData().getMetadata().getMessageMetadataType(), maxRetry, msgTimer);
-                    throw new LogEntrySyncTimeoutException("timeout");
-                }
-
-                entry.retry(getCurrentTime());
-                CompletableFuture<LogReplicationEntry> cf = dataSender.send(entry.getData());
-                pendingLogEntriesAcked.put(entry.getData().getMetadata().getTimestamp(), cf);
-                log.info("resend message " + entry.getData().getMetadata().getTimestamp());
-            }
-        }
-   }
 
     /**
      * Read and send incremental updates (log entries)
@@ -188,21 +99,9 @@ public class LogEntrySender {
 
         try {
             // If there are pending entries, resend them.
-            if (!pendingEntries.list.isEmpty()) {
+            if (!dataSenderBuffer.getPendingEntries().isEmpty()) {
                 try {
-                    LogReplicationEntry ack = (LogReplicationEntry)CompletableFuture.anyOf(pendingLogEntriesAcked
-                            .values().toArray(new CompletableFuture<?>[pendingLogEntriesAcked.size()])).get(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
-                    log.trace("Received Log Entry ack {}", ack.getMetadata());
-
-                    updateAckTs(ack.getMetadata().getTimestamp());
-
-                    // Remove all CFs for all entries with lower timestamps than that of the ACKed LogReplicationEntry
-                    // This is because receiver can send aggregated ACKs.
-                    pendingLogEntriesAcked = pendingLogEntriesAcked.entrySet().stream()
-                            .filter(entry -> entry.getKey() > ack.getMetadata().getTimestamp())
-                            .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
-
-                    log.trace("Total pending log entry acks: {}, for timestamps: {}", pendingLogEntriesAcked.size(), pendingLogEntriesAcked.keySet());
+                    LogReplicationEntry ack = dataSenderBuffer.processAcks();
 
                     // Enforce a Log Entry Sync Replicated (ack) event, which will update metadata information
                     // Todo (Consider directly updating Corfu Metadata information here, without going through FSM)
@@ -210,14 +109,14 @@ public class LogEntrySender {
                                 new LogReplicationEventMetadata(ack.getMetadata().getSyncRequestId(), ack.getMetadata().getTimestamp())));
 
                 } catch (TimeoutException te) {
-                    log.info("Log Entry ACK timed out, pending acks for {}", pendingLogEntriesAcked.keySet());
+                    log.info("Log Entry ACK timed out, pending acks for {}", dataSenderBuffer.getPendingLogEntriesAcked().keySet());
                 } catch (Exception e) {
                     log.error("Exception caught while waiting on log entry ACK.", e);
                     cancelLogEntrySync(LogReplicationError.UNKNOWN, LogReplicationEventType.SYNC_CANCEL, logEntrySyncEventId);
                     return;
                 }
 
-                resend();
+                dataSenderBuffer.resend();
             }
         } catch (LogEntrySyncTimeoutException te) {
             log.error("LogEntrySyncTimeoutException after several retries.", te);
@@ -225,18 +124,14 @@ public class LogEntrySender {
             return;
         }
 
-        while (taskActive && pendingEntries.list.size() < readerBatchSize) {
+        while (taskActive && !dataSenderBuffer.getPendingEntries().isFull()) {
             LogReplicationEntry message;
             // Read and Send Log Entries
             try {
                 message = logEntryReader.read(logEntrySyncEventId);
 
                 if (message != null) {
-                    pendingEntries.append(message, getCurrentTime());
-                    CompletableFuture<LogReplicationEntry> cf = dataSender.send(message);
-                    log.debug("sending data %s", message.getMetadata());
-                    pendingLogEntriesAcked.put(message.getMetadata().getTimestamp(), cf);
-                    log.trace("send message " + message.getMetadata());
+                    dataSenderBuffer.sendWithBuffering(message);
                 } else {
                     // If no message is returned we can break out and enqueue a CONTINUE, so other processes can
                     // take over the shared thread pool of the state machine
@@ -275,6 +170,10 @@ public class LogEntrySender {
 
     }
 
+    public void updateAckTs(long ts) {
+        dataSenderBuffer.updateAckTs(ts);
+    }
+
     /**
      * Reset the log entry sender to initial state
      */
@@ -283,88 +182,6 @@ public class LogEntrySender {
         log.info("Reset baseSnapshot %s ackTs %s", ts0, ts1);
         logEntryReader.reset(ts0, ts1);
         ackTs = ts1;
-        pendingEntries.evictAll();
-    }
-
-    /**
-     * Update the last ackTimestamp and evict all entries whose timestamp is less or equal to the ackTimestamp
-     * @param ackTimestamp
-     */
-    public void updateAckTs(Long ackTimestamp) {
-        if (ackTimestamp <= ackTs)
-            return;
-        ackTs = ackTimestamp;
-        log.info("Pending entries before eviction at {} is {}", ackTs, pendingEntries.list.size());
-        pendingEntries.evictAll(ackTs);
-        log.info("Pending entries AFTER eviction at {} is {}", ackTs, pendingEntries.list.size());
-
-        log.trace("ackTS " + ackTs + " queue size " + pendingEntries.list.size());
-    }
-
-    private long getCurrentTime() {
-        currentTime += TIME_INCREMENT;
-        return currentTime;
-    }
-
-    /**
-     * The element kept in the sliding windown to remember the log entries sent over but hasn't been acknowledged by the
-     * receiver and we use the time to decide when a re-send is necessary.
-     */
-    @Data
-    public static class LogReplicationPendingEntry {
-        // The address of the log entry
-        org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry data;
-
-        // The first time the log entry is sent over
-        long time;
-
-        // The number of retries for this entry
-        int retry;
-
-        public LogReplicationPendingEntry(org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry data, long time) {
-            this.data = data;
-            this.time = time;
-            this.retry = 0;
-        }
-
-        boolean timeout(long ctime, long timer) {
-            log.trace("current time {} - original time {} = {} timer {}", ctime, this.time, timer);
-            return  (ctime - this.time) > timer;
-        }
-
-        void retry(long time) {
-            this.time = time;
-            retry++;
-        }
-    }
-
-    /**
-     * The sliding window to record the pending entries that have sent to the receiver but hasn't got an ACK yet.
-     * The alternative is to remember the address only and reset the stream head to rereading the data if the queue size
-     * is quite big.
-     */
-    public static class LogReplicationEntryQueue {
-
-        int size;
-        ArrayList<LogReplicationPendingEntry> list;
-
-        public LogReplicationEntryQueue(int size) {
-            this.size = size;
-            list = new ArrayList<>();
-        }
-
-        public void evictAll() {
-            list = new ArrayList<>();
-        }
-
-        void evictAll(long address) {
-            log.trace("evict address " + address);
-            list.removeIf(a->(a.data.getMetadata().getTimestamp() <= address));
-        }
-
-        void append(org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry data, long timer) {
-            LogReplicationPendingEntry entry = new LogReplicationPendingEntry(data, timer);
-            list.add(entry);
-        }
+        dataSenderBuffer.getPendingEntries().evictAll();
     }
 }

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationPendingEntry.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationPendingEntry.java
@@ -2,9 +2,10 @@ package org.corfudb.logreplication.send;
 
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 
 /**
- * The element kept in the sliding windown to remember the log entries sent over but hasn't been acknowledged by the
+ * The element kept in the sliding window to remember the log entries sent over but hasn't been acknowledged by the
  * receiver and we use the time to decide when a re-send is necessary.
  */
 
@@ -12,8 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class LogReplicationPendingEntry {
 
-        // The address of the log entry
-        org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry data;
+        LogReplicationEntry data;
 
         // The first time the log entry is sent over
         long time;
@@ -32,8 +32,12 @@ public class LogReplicationPendingEntry {
             return  (ctime - this.time) > timer;
         }
 
-        void retry(long time) {
-            this.time = time;
+    /**
+     * update retry number and the time with current time.
+     * @param currentTime the current system time
+     */
+    void retry(long currentTime) {
+            this.time = currentTime;
             retry++;
         }
 }

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationPendingEntry.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationPendingEntry.java
@@ -1,0 +1,39 @@
+package org.corfudb.logreplication.send;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The element kept in the sliding windown to remember the log entries sent over but hasn't been acknowledged by the
+ * receiver and we use the time to decide when a re-send is necessary.
+ */
+
+@Data
+@Slf4j
+public class LogReplicationPendingEntry {
+
+        // The address of the log entry
+        org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry data;
+
+        // The first time the log entry is sent over
+        long time;
+
+        // The number of retries for this entry
+        int retry;
+
+        public LogReplicationPendingEntry(org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry data, long time) {
+            this.data = data;
+            this.time = time;
+            this.retry = 0;
+        }
+
+        boolean timeout(long ctime, long timer) {
+            log.trace("current time {} - original time {} = {} timer {}", ctime, this.time, timer);
+            return  (ctime - this.time) > timer;
+        }
+
+        void retry(long time) {
+            this.time = time;
+            retry++;
+        }
+}

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationSenderBuffer.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationSenderBuffer.java
@@ -1,0 +1,176 @@
+package org.corfudb.logreplication.send;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.DataSender;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
+import org.corfudb.runtime.view.Address;
+
+import java.io.File;
+import java.io.FileReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class LogReplicationSenderBuffer {
+    public static final String config_file = "/config/corfu/corfu_replication_config.properties";
+    public static final int DEFAULT_READER_QUEUE_SIZE = 1;
+    public static final int DEFAULT_RESENT_TIMER = 5000;
+    public static final int DEFAULT_MAX_RETRY = 5;
+    public static final int DEFAULT_TIMEOUT = 5000;
+
+    /*
+     * for internal timer increasing for each message in milliseconds
+     */
+    final static private long TIME_INCREMENT = 10;
+
+    private int readerBatchSize = DEFAULT_READER_QUEUE_SIZE;
+
+    /*
+     * The timer to resend an entry. This is the roundtrip time between sender/receiver.
+     */
+    private int msgTimer = DEFAULT_RESENT_TIMER;
+
+    /*
+     * The max number of retry for sending an entry.
+     */
+    private int maxRetry = DEFAULT_MAX_RETRY;
+
+    /*
+     * wait for ack or not
+     */
+    private boolean errorOnMsgTimeout = true;
+
+    /*
+     * reset while process messages
+     */
+    long currentTime;
+
+    /*
+     * The log entry has been sent to the receiver but hasn't ACKed yet.
+     */
+    @Getter
+    LogReplicationSenderQueue pendingEntries;
+
+    private long ackTs = Address.NON_ADDRESS;
+
+    DataSender dataSender;
+
+    @Getter
+    @Setter
+    private Map<Long, CompletableFuture<LogReplicationEntry>> pendingLogEntriesAcked;
+
+    public LogReplicationSenderBuffer(DataSender dataSender) {
+        readConfig();
+        pendingEntries = new LogReplicationSenderQueue(readerBatchSize);
+        pendingLogEntriesAcked = new HashMap<>();
+        this.dataSender = dataSender;
+    }
+
+    private void readConfig() {
+        try {
+            File configFile = new File(config_file);
+            FileReader reader = new FileReader(configFile);
+
+            Properties props = new Properties();
+            props.load(reader);
+
+            maxRetry = Integer.parseInt(props.getProperty("log_reader_max_retry", Integer.toString(DEFAULT_MAX_RETRY)));
+            readerBatchSize = Integer.parseInt(props.getProperty("log_reader_queue_size", Integer.toString(DEFAULT_READER_QUEUE_SIZE)));
+            msgTimer = Integer.parseInt(props.getProperty("log_reader_resend_timer", Integer.toString(DEFAULT_RESENT_TIMER)));
+            errorOnMsgTimeout = Boolean.parseBoolean(props.getProperty("log_reader_error_on_message_timeout", "true"));
+            reader.close();
+
+        } catch (Exception e) {
+            log.warn("The config file is not available {} , will use the default vaules for config.", e.getCause());
+        } finally {
+            log.info("log logreader config max_retry {} reader_queue_size {} entry_resend_timer {} waitAck {}",
+                    maxRetry, readerBatchSize, msgTimer, errorOnMsgTimeout);
+        }
+    }
+
+    /**
+     * Update the last ackTimestamp and evict all entries whose timestamp is less or equal to the ackTimestamp
+     * @param ackTimestamp
+     */
+    public void updateAckTs(Long ackTimestamp) {
+        if (ackTimestamp <= ackTs)
+            return;
+        ackTs = ackTimestamp;
+
+        log.debug("Pending entries before eviction at {} is {}", ackTs, pendingEntries.getSize());
+        pendingEntries.evictAll(ackTs);
+        log.debug("Pending entries AFTER eviction at {} is {}", ackTs, pendingEntries.getSize());
+    }
+
+
+    public LogReplicationEntry processAcks() throws InterruptedException, ExecutionException, TimeoutException {
+        LogReplicationEntry ack = (LogReplicationEntry) CompletableFuture.anyOf(pendingLogEntriesAcked
+                .values().toArray(new CompletableFuture<?>[pendingLogEntriesAcked.size()])).get(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
+        log.trace("Received Log Entry ack {}", ack.getMetadata());
+
+        updateAckTs(ack.getMetadata().getTimestamp());
+
+        // Remove all CFs for all entries with lower timestamps than that of the ACKed LogReplicationEntry
+        // This is because receiver can send aggregated ACKs.
+        pendingLogEntriesAcked = pendingLogEntriesAcked.entrySet().stream()
+                .filter(entry -> entry.getKey() > ack.getMetadata().getTimestamp())
+                .collect(Collectors.toMap(x -> x.getKey(), x -> x.getValue()));
+
+        log.trace("Total pending log entry acks: {}, for timestamps: {}", pendingLogEntriesAcked.size(), pendingLogEntriesAcked.keySet());
+        return ack;
+    }
+
+    public void sendWithBuffering(LogReplicationEntry message) {
+        pendingEntries.append(message, getCurrentTime());
+        CompletableFuture<LogReplicationEntry> cf = dataSender.send(message);
+        log.debug("sending data %s", message.getMetadata());
+        pendingLogEntriesAcked.put(message.getMetadata().getTimestamp(), cf);
+        log.trace("send message " + message.getMetadata());
+    }
+
+    /**
+     * resend the messages in the queue if they are timeout.
+     * @param
+     * @return it returns false if there is an entry has been resent MAX_RETRY and timeout again.
+     * Otherwise it returns true.
+     */
+    public void resend() {
+        for (int i = 0; i < pendingEntries.getSize(); i++) {
+            LogReplicationPendingEntry entry  = pendingEntries.getList().get(i);
+            if (entry.timeout(getCurrentTime(), msgTimer)) {
+                if (errorOnMsgTimeout && entry.retry >= maxRetry) {
+                    log.warn("Entry {} of type {} has been resent max times {} for timer {}.", entry.getData().getMetadata().getTimestamp(),
+                            entry.getData().getMetadata().getMessageMetadataType(), maxRetry, msgTimer);
+                    throw new LogEntrySyncTimeoutException("timeout");
+                }
+
+                entry.retry(getCurrentTime());
+                CompletableFuture<LogReplicationEntry> cf = dataSender.send(entry.getData());
+                pendingLogEntriesAcked.put(entry.getData().getMetadata().getTimestamp(), cf);
+                log.info("resend message " + entry.getData().getMetadata().getTimestamp());
+            }
+        }
+    }
+
+    /**
+     * put into the buffer and wait for the ack
+     * @param message
+     */
+    public void send(LogReplicationEntry message){
+
+    }
+
+    private long getCurrentTime() {
+        currentTime += TIME_INCREMENT;
+        return currentTime;
+    }
+
+}

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationSenderQueue.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationSenderQueue.java
@@ -1,0 +1,61 @@
+package org.corfudb.logreplication.send;
+
+import lombok.Data;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+
+/**
+ * The sliding window to record the pending entries that have sent to the receiver but hasn't got an ACK yet.
+ * The alternative is to remember the address only and reset the stream head to rereading the data if the queue size
+ * is quite big.
+ */
+@Slf4j
+public class LogReplicationSenderQueue {
+
+    // The max number of the entries that the queue can contain
+    private int maxSize;
+
+    @Getter
+    private ArrayList<LogReplicationPendingEntry> list;
+
+    /*
+     * reset while process messages
+     */
+    long currentTime;
+
+
+    public LogReplicationSenderQueue(int maxSize) {
+        this.maxSize = maxSize;
+        list = new ArrayList<>();
+    }
+
+    public int getSize() {
+        return list.size();
+    }
+
+    public boolean isEmpty() {
+        return list.isEmpty();
+    }
+
+    public boolean isFull() {
+        return (list.size() == maxSize);
+    }
+
+    public void evictAll() {
+        list = new ArrayList<>();
+    }
+
+    void evictAll(long address) {
+        log.trace("evict address " + address);
+        list.removeIf(a -> (a.data.getMetadata().getTimestamp() <= address));
+    }
+
+    void append(org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry data, long timer) {
+        LogReplicationPendingEntry entry = new LogReplicationPendingEntry(data, timer);
+        list.add(entry);
+    }
+
+
+}

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationSenderQueue.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationSenderQueue.java
@@ -1,8 +1,8 @@
 package org.corfudb.logreplication.send;
 
-import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 
 import java.util.ArrayList;
 
@@ -14,16 +14,16 @@ import java.util.ArrayList;
 @Slf4j
 public class LogReplicationSenderQueue {
 
-    // The max number of the entries that the queue can contain
+    /*
+     * The max number of the entries that the queue can contain
+     */
     private int maxSize;
 
+    /*
+     * The list of pending entries.
+     */
     @Getter
     private ArrayList<LogReplicationPendingEntry> list;
-
-    /*
-     * reset while process messages
-     */
-    long currentTime;
 
 
     public LogReplicationSenderQueue(int maxSize) {
@@ -31,6 +31,10 @@ public class LogReplicationSenderQueue {
         list = new ArrayList<>();
     }
 
+    /**
+     * The current number of pending entries
+     * @return
+     */
     public int getSize() {
         return list.size();
     }
@@ -43,19 +47,21 @@ public class LogReplicationSenderQueue {
         return (list.size() == maxSize);
     }
 
-    public void evictAll() {
+    public void clear() {
         list = new ArrayList<>();
     }
 
-    void evictAll(long address) {
+    /**
+     * Remove all the entries whose timestamp is not larger than the address
+     * @param address
+     */
+    void evictAccordingToTimestamp(long address) {
         log.trace("evict address " + address);
         list.removeIf(a -> (a.data.getMetadata().getTimestamp() <= address));
     }
 
-    void append(org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry data, long timer) {
+    void append(LogReplicationEntry data, long timer) {
         LogReplicationPendingEntry entry = new LogReplicationPendingEntry(data, timer);
         list.add(entry);
     }
-
-
 }

--- a/test/src/test/java/org/corfudb/LogReplicationTest.java
+++ b/test/src/test/java/org/corfudb/LogReplicationTest.java
@@ -137,6 +137,4 @@ public class LogReplicationTest {
             System.out.println("Verified data for the tables");
         }
     }
-
-
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationSiteConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationSiteConfigIT.java
@@ -4,7 +4,6 @@ import com.google.common.reflect.TypeToken;
 import org.corfudb.logreplication.infrastructure.CorfuInterClusterReplicationServer;
 import org.corfudb.logreplication.infrastructure.CorfuReplicationDiscoveryService;
 import org.corfudb.logreplication.infrastructure.CorfuReplicationManager;
-import org.corfudb.logreplication.infrastructure.CorfuReplicationSiteManagerAdapter;
 import org.corfudb.logreplication.infrastructure.CrossSiteConfiguration;
 import org.corfudb.logreplication.infrastructure.DefaultSiteManager;
 import org.corfudb.runtime.CorfuRuntime;

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -92,27 +92,27 @@ public class SourceForwardingDataSender implements DataSender {
 
     @Override
     public CompletableFuture<LogReplicationEntry> send(List<LogReplicationEntry> messages) {
-        CompletableFuture<LogReplicationEntry> lastSentMessage = null;
+        CompletableFuture<LogReplicationEntry> lastAckMessage = null;
         CompletableFuture<LogReplicationEntry> tmp;
 
         for (LogReplicationEntry message :  messages) {
             tmp = send(message);
             if (message.getMetadata().getMessageMetadataType().equals(MessageType.SNAPSHOT_END) ||
                     message.getMetadata().getMessageMetadataType().equals(MessageType.LOG_ENTRY_MESSAGE)) {
-                lastSentMessage = tmp;
+                lastAckMessage = tmp;
             }
         }
 
         try {
-            if (lastSentMessage != null) {
-                LogReplicationEntry entry = lastSentMessage.get();
+            if (lastAckMessage != null) {
+                LogReplicationEntry entry = lastAckMessage.get();
                 ackMessages.setValue(entry);
             }
         } catch (Exception e) {
             System.out.print("Caught an exception " + e);
         }
 
-        return lastSentMessage;
+        return lastAckMessage;
     }
 
     @Override


### PR DESCRIPTION
   * Simplfy the LogEntrySender logic.
   * Start siteManager while DiscoveryService is up.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
