### PR TITLE
Implement full snapshot sync in phases.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -34,6 +34,7 @@ public class LogReplicationServer extends AbstractServer {
 
     private final ServerContext serverContext;
 
+    //Used for receiving and applying messages.
     private final ExecutorService executor;
 
     @Getter

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -10,7 +10,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
-import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationNegotiationResponse;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryLeaderShipResponse;
 import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 
@@ -89,18 +89,11 @@ public class LogReplicationServer extends AbstractServer {
         }
     }
 
-    @ServerHandler(type = CorfuMsgType.LOG_REPLICATION_NEGOTIATION_REQUEST)
-    private void handleLogReplicationNegotiationRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
-        log.info("Log Replication Negotiation Request received by Server.");
-        LogReplicationMetadataManager metadata = sinkManager.getLogReplicationMetadataManager();
-        LogReplicationNegotiationResponse response = new LogReplicationNegotiationResponse(
-                metadata.getSiteConfigID(),
-                metadata.getVersion(),
-                metadata.getLastSnapStartTimestamp(),
-                metadata.getLastSnapTransferDoneTimestamp(),
-                metadata.getLastSrcBaseSnapshotTimestamp(),
-                metadata.getLastProcessedLogTimestamp());
-        r.sendResponse(ctx, msg, CorfuMsgType.LOG_REPLICATION_NEGOTIATION_RESPONSE.payloadMsg(response));
+    @ServerHandler(type = CorfuMsgType.LOG_REPLICATION_QUERY_METADATA_REQUEST)
+    private void handleLogReplicationQueryMetadataRequest(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
+        log.info("Log Replication Query Metadata request received by Server.");
+        LogReplicationQueryMetadataResponse response = sinkManager.processQueryMetadataRequest();
+        r.sendResponse(ctx, msg, CorfuMsgType.LOG_REPLICATION_QUERY_METADATA_RESPONSE.payloadMsg(response));
     }
 
     @ServerHandler(type = CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP)

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/DataSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/DataSender.java
@@ -1,9 +1,11 @@
 package org.corfudb.infrastructure.logreplication;
 
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 /**
  * This Interface comprises Data Path send operations for both Source and Sink.
@@ -21,6 +23,7 @@ public interface DataSender {
      */
     CompletableFuture<LogReplicationEntry> send(LogReplicationEntry message);
 
+
     /**
      * Application callback on next available messages for transmission to remote site.
      *
@@ -28,6 +31,13 @@ public interface DataSender {
      * @return
      */
     CompletableFuture<LogReplicationEntry> send(List<LogReplicationEntry> messages);
+
+    /**
+     * Used by Snapshot Full Sync while has done with transferring data and waiting for the receiver to finish applying.
+     * The sender queries the receiver's status and will do the proper transition.
+     * @return
+     */
+    public LogReplicationQueryMetadataResponse sendQueryMetadata() throws ExecutionException, InterruptedException;
 
     /**
      * Application callback on error.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/DataSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/DataSender.java
@@ -33,11 +33,10 @@ public interface DataSender {
     CompletableFuture<LogReplicationEntry> send(List<LogReplicationEntry> messages);
 
     /**
-     * Used by Snapshot Full Sync while has done with transferring data and waiting for the receiver to finish applying.
-     * The sender queries the receiver's status and will do the proper transition.
+     * Used by Snapshot Full Sync to poll the receiver's status.
      * @return
      */
-    public LogReplicationQueryMetadataResponse sendQueryMetadata() throws ExecutionException, InterruptedException;
+    public LogReplicationQueryMetadataResponse sendQueryMetadataRequest() throws ExecutionException, InterruptedException;
 
     /**
      * Application callback on error.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/DefaultSiteConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/DefaultSiteConfig.java
@@ -49,7 +49,7 @@ public final class DefaultSiteConfig {
     private static int logSenderRetryCount = 5;
 
     @Getter
-    private static int logSenderResendTimer = 5000;
+    private static int logSenderResendTimer = 500;
 
     @Getter
     private static int logSenderTimeoutTimer = 5000;
@@ -63,9 +63,9 @@ public final class DefaultSiteConfig {
     private static int logSinkBufferSize = 40;
 
     @Getter
-    private static int logSinkAckCycleCount = 4;
+    private static int logSinkAckCycleCount = 2;
 
     @Getter
-    private static int logSinkAckCycleTimer = 1000;
+    private static int logSinkAckCycleTimer = 500;
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/DefaultSiteConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/DefaultSiteConfig.java
@@ -49,7 +49,7 @@ public final class DefaultSiteConfig {
     private static int logSenderRetryCount = 5;
 
     @Getter
-    private static int logSenderResendTimer = 500;
+    private static int logSenderResendTimer = 5000;
 
     @Getter
     private static int logSenderTimeoutTimer = 5000;
@@ -63,9 +63,9 @@ public final class DefaultSiteConfig {
     private static int logSinkBufferSize = 40;
 
     @Getter
-    private static int logSinkAckCycleCount = 2;
+    private static int logSinkAckCycleCount = 4;
 
     @Getter
-    private static int logSinkAckCycleTimer = 500;
+    private static int logSinkAckCycleTimer = 1000;
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationPluginConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationPluginConfig.java
@@ -54,7 +54,7 @@ public class LogReplicationPluginConfig {
             this.siteManagerAdapterJARPath = prop.getProperty("site_manager_adapter_JAR_path");
             this.siteManagerAdapterName= prop.getProperty("site_manager_adapter_class_name");
         } catch (IOException e) {
-            log.warn("Exception caught while trying to load adapter configuration from {}. Default configuration " +
+            log.warn("The configuration file is not available {}. Default configuration " +
                     "will be used.", filepath);
             // Default Configuration
             this.transportAdapterJARPath = getTransportParentDir() + DEFAULT_JAR_PATH;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/LogEntrySinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/LogEntrySinkBufferManager.java
@@ -45,6 +45,11 @@ public class LogEntrySinkBufferManager extends SinkBufferManager {
         return entry.getMetadata().getTimestamp();
     }
 
+    @Override
+    long getLastProcessed() {
+        return metadataAccessor.getLastProcessedLogTimestamp(null);
+    }
+
     /**
      * Make a ACK message according to the last processed message's timestamp.
      * @param entry
@@ -52,9 +57,13 @@ public class LogEntrySinkBufferManager extends SinkBufferManager {
      */
     @Override
     public LogReplicationEntryMetadata makeAckMessage(LogReplicationEntry entry) {
+        long lastProcessedSeq = getLastProcessed();
+
         LogReplicationEntryMetadata metadata = new LogReplicationEntryMetadata(entry.getMetadata());
         metadata.setMessageMetadataType(LOG_ENTRY_REPLICATED);
+        metadata.setSnapshotTimestamp(metadataAccessor.getLastSrcBaseSnapshotTimestamp(null));
         metadata.setTimestamp(lastProcessedSeq);
+
         log.debug("Sink Buffer lastProcessedSeq {}", lastProcessedSeq);
         return metadata;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/LogEntryWriter.java
@@ -35,11 +35,11 @@ public class LogEntryWriter {
     CorfuRuntime rt;
     private long srcGlobalSnapshot; //the source snapshot that the transaction logs are based
     private long lastMsgTs; //the timestamp of the last message processed.
-    private LogReplicationMetadataManager logReplicationMetadataManager;
+    private LogReplicationMetadataAccessor logReplicationMetadataAccessor;
 
-    public LogEntryWriter(CorfuRuntime rt, LogReplicationConfig config, LogReplicationMetadataManager logReplicationMetadataManager) {
+    public LogEntryWriter(CorfuRuntime rt, LogReplicationConfig config, LogReplicationMetadataAccessor logReplicationMetadataAccessor) {
         this.rt = rt;
-        this.logReplicationMetadataManager = logReplicationMetadataManager;
+        this.logReplicationMetadataAccessor = logReplicationMetadataAccessor;
 
         Set<String> streams = config.getStreamsToReplicate();
         streamMap = new HashMap<>();
@@ -86,11 +86,11 @@ public class LogEntryWriter {
         }
 
 
-        CorfuStoreMetadata.Timestamp timestamp = logReplicationMetadataManager.getTimestamp();
-        long persistSiteConfigID = logReplicationMetadataManager.query(timestamp, LogReplicationMetadataManager.LogReplicationMetadataType.SiteConfigID);
-        long persistSnapStart = logReplicationMetadataManager.query(timestamp, LogReplicationMetadataManager.LogReplicationMetadataType.LastSnapshotStarted);
-        long persistSnapDone= logReplicationMetadataManager.query(timestamp, LogReplicationMetadataManager.LogReplicationMetadataType.LastSnapshotApplied);
-        long persistLogTS = logReplicationMetadataManager.query(timestamp, LogReplicationMetadataManager.LogReplicationMetadataType.LastLogProcessed);
+        CorfuStoreMetadata.Timestamp timestamp = logReplicationMetadataAccessor.getTimestamp();
+        long persistSiteConfigID = logReplicationMetadataAccessor.query(timestamp, LogReplicationMetadataAccessor.LogReplicationMetadataType.SiteConfigID);
+        long persistSnapStart = logReplicationMetadataAccessor.query(timestamp, LogReplicationMetadataAccessor.LogReplicationMetadataType.LastSnapshotStarted);
+        long persistSnapDone= logReplicationMetadataAccessor.query(timestamp, LogReplicationMetadataAccessor.LogReplicationMetadataType.LastSnapshotApplied);
+        long persistLogTS = logReplicationMetadataAccessor.query(timestamp, LogReplicationMetadataAccessor.LogReplicationMetadataType.LastLogProcessed);
 
         long siteConfigID = txMessage.getMetadata().getSiteConfigID();
         long ts = txMessage.getMetadata().getSnapshotTimestamp();
@@ -106,9 +106,9 @@ public class LogEntryWriter {
             return;
         }
 
-        TxBuilder txBuilder = logReplicationMetadataManager.getTxBuilder();
-        logReplicationMetadataManager.appendUpdate(txBuilder, LogReplicationMetadataManager.LogReplicationMetadataType.SiteConfigID, siteConfigID);
-        logReplicationMetadataManager.appendUpdate(txBuilder, LogReplicationMetadataManager.LogReplicationMetadataType.LastLogProcessed, entryTS);
+        TxBuilder txBuilder = logReplicationMetadataAccessor.getTxBuilder();
+        logReplicationMetadataAccessor.appendUpdate(txBuilder, LogReplicationMetadataAccessor.LogReplicationMetadataType.SiteConfigID, siteConfigID);
+        logReplicationMetadataAccessor.appendUpdate(txBuilder, LogReplicationMetadataAccessor.LogReplicationMetadataType.LastLogProcessed, entryTS);
 
         for (UUID uuid : opaqueEntry.getEntries().keySet()) {
             for (SMREntry smrEntry : opaqueEntry.getEntries().get(uuid)) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/LogReplicationMetadataManager.java
@@ -112,6 +112,10 @@ public class LogReplicationMetadataManager {
         return query(null, LogReplicationMetadataType.LastSnapshotSeqNum);
     }
 
+    public long getLastSnapAppliedSeqNum() {
+        return query(null, LogReplicationMetadataType.LastSnapshotAppliedSeqNum);
+    }
+
     public long getLastProcessedLogTimestamp() {
         return query(null, LogReplicationMetadataType.LastLogProcessed);
     }
@@ -148,7 +152,7 @@ public class LogReplicationMetadataManager {
          }
 
         txBuilder.commit(timestamp);
-        log.info("Update siteConfigID, new metadata {}", getMetadata());
+        log.info("Update siteConfigID {}, new metadata {}", siteConfigID, getMetadata());
     }
 
     public void updateVersion(String version) {
@@ -219,6 +223,7 @@ public class LogReplicationMetadataManager {
         appendUpdate(txBuilder, LogReplicationMetadataType.LastSnapshotTransferred, Address.NON_ADDRESS);
         appendUpdate(txBuilder, LogReplicationMetadataType.LastSnapshotApplied, Address.NON_ADDRESS);
         appendUpdate(txBuilder, LogReplicationMetadataType.LastSnapshotSeqNum, Address.NON_ADDRESS);
+        appendUpdate(txBuilder, LogReplicationMetadataType.LastSnapshotAppliedSeqNum, Address.NON_ADDRESS);
         appendUpdate(txBuilder, LogReplicationMetadataType.LastLogProcessed, Address.NON_ADDRESS);
 
         txBuilder.commit(timestamp);
@@ -286,9 +291,6 @@ public class LogReplicationMetadataManager {
         appendUpdate(txBuilder, LogReplicationMetadataType.LastSnapshotApplied, ts);
         appendUpdate(txBuilder, LogReplicationMetadataType.LastLogProcessed, ts);
 
-        //may not need
-        appendUpdate(txBuilder, LogReplicationMetadataType.LastSnapshotSeqNum, Address.NON_ADDRESS);
-
         txBuilder.commit(timestamp);
 
         log.debug("Commit. Set snapshotStart siteConfigID " + siteConfigID + " ts " + ts +
@@ -299,13 +301,14 @@ public class LogReplicationMetadataManager {
 
     public String getMetadata() {
         String s = new String();
-        s.concat(LogReplicationMetadataType.SiteConfigID.getVal() + " " + getSiteConfigID() +" ");
-        s.concat(LogReplicationMetadataType.LastSnapshotStarted.getVal() + " " + getLastSnapStartTimestamp() +" ");
-        s.concat(LogReplicationMetadataType.LastSnapshotTransferred.getVal() + " " + getLastSnapTransferDoneTimestamp() + " ");
-        s.concat(LogReplicationMetadataType.LastSnapshotApplied.getVal() + " " + getLastSrcBaseSnapshotTimestamp() + " ");
-        s.concat(LogReplicationMetadataType.LastSnapshotSeqNum.getVal() + " " + getLastSnapSeqNum() + " ");
-        s.concat(LogReplicationMetadataType.LastLogProcessed.getVal() + " " + getLastProcessedLogTimestamp() + " ");
-
+        s = s.concat(LogReplicationMetadataType.SiteConfigID.getVal() + " " + getSiteConfigID() +" ");
+        s = s.concat(LogReplicationMetadataType.LastSnapshotStarted.getVal() + " " + getLastSnapStartTimestamp() +" ");
+        s = s.concat(LogReplicationMetadataType.LastSnapshotTransferred.getVal() + " " + getLastSnapTransferDoneTimestamp() + " ");
+        s = s.concat(LogReplicationMetadataType.LastSnapshotApplied.getVal() + " " + getLastSrcBaseSnapshotTimestamp() + " ");
+        s = s.concat(LogReplicationMetadataType.LastSnapshotSeqNum.getVal() + " " + getLastSnapSeqNum() + " ");
+        s = s.concat(LogReplicationMetadataType.LastSnapshotAppliedSeqNum.getVal() + " " + getLastSnapAppliedSeqNum() + " ");
+        s = s.concat(LogReplicationMetadataType.LastLogProcessed.getVal() + " " + getLastProcessedLogTimestamp() + " ");
+        log.info("metadata {}", s);
         return s;
     }
 
@@ -320,6 +323,7 @@ public class LogReplicationMetadataManager {
         LastSnapshotTransferred("lastSnapTransferred"),
         LastSnapshotApplied("lastSnapApplied"),
         LastSnapshotSeqNum("lastSnapSeqNum"),
+        LastSnapshotAppliedSeqNum("lastSnapAppliedSeqNum"),
         LastLogProcessed("lastLogProcessed");
 
         @Getter

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/LogReplicationSinkManager.java
@@ -126,7 +126,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      * Init variables.
      */
     private void init() {
-        logReplicationMetadataAccessor = new LogReplicationMetadataAccessor(runtime, 0, config.getSiteID(), config.getRemoteSiteID());
+        logReplicationMetadataAccessor = new LogReplicationMetadataAccessor(runtime, Address.NON_ADDRESS, config.getSiteID(), config.getRemoteSiteID());
         snapshotWriter = new StreamsSnapshotWriter(runtime, config, logReplicationMetadataAccessor);
         logEntryWriter = new LogEntryWriter(runtime, config, logReplicationMetadataAccessor);
 
@@ -246,13 +246,13 @@ public class LogReplicationSinkManager implements DataReceiver {
         long siteConfigID = entry.getMetadata().getSiteConfigID();
         long timestamp = entry.getMetadata().getSnapshotTimestamp();
 
-        log.debug("Received snapshot sync start marker for {} on base snapshot timestamp {}",
+        log.info("Received snapshot sync start marker for {} on base snapshot timestamp {}",
                 entry.getMetadata().getSyncRequestId(), entry.getMetadata().getSnapshotTimestamp());
 
         /*
          * It is out of date message due to resend, drop it.
          */
-        if (entry.getMetadata().getSnapshotTimestamp() <= baseSnapshotTimestamp) {
+        if (entry.getMetadata().getSnapshotTimestamp() < baseSnapshotTimestamp) {
             // Invalid message and drop it.
             log.warn("Sink Manager in state {} and received message {}. " +
                             "Dropping Message due to snapshotTimestamp is smaller than the current one {}",

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/SinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/SinkBufferManager.java
@@ -143,10 +143,12 @@ public abstract class SinkBufferManager {
         if (preTs == lastProcessedSeq) {
             sinkManager.processMessage(dataMessage);
             ackCnt++;
-            lastProcessedSeq = getCurrentSeq(dataMessage);
+            lastProcessedSeq = currentTs;
             processBuffer();
         } else if (currentTs > lastProcessedSeq && buffer.size() < maxSize) {
-                buffer.put(preTs, dataMessage);
+            // If it is a future expecting message and the buffer still has space
+            // put it into the buffer.
+            buffer.put(preTs, dataMessage);
         }
 
         /*

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/SinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/SinkBufferManager.java
@@ -146,8 +146,8 @@ public abstract class SinkBufferManager {
             lastProcessedSeq = currentTs;
             processBuffer();
         } else if (currentTs > lastProcessedSeq && buffer.size() < maxSize) {
-            // If it is a future expecting message and the buffer still has space
-            // put it into the buffer.
+            // If it is an out of order message with higher timestamp,
+            // put it into the buffer if there is space.
             buffer.put(preTs, dataMessage);
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/SnapshotSinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/SnapshotSinkBufferManager.java
@@ -49,6 +49,7 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
     long getCurrentSeq(LogReplicationEntry entry) {
         if (entry.getMetadata().getMessageMetadataType() == SNAPSHOT_END) {
             snapshotEndSeq = entry.getMetadata().getSnapshotSyncSeqNum();
+            log.info("Setup snapshotEndSeq {}", snapshotEndSeq);
         }
         return entry.getMetadata().getSnapshotSyncSeqNum();
     }
@@ -68,6 +69,7 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
          */
         if (lastProcessedSeq == snapshotEndSeq) {
             metadata.setMessageMetadataType(MessageType.SNAPSHOT_END);
+            metadata.setSnapshotSyncSeqNum(lastProcessedSeq);
         } else {
             metadata.setMessageMetadataType(MessageType.SNAPSHOT_REPLICATED);
         }
@@ -96,7 +98,10 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
     }
 
     boolean shouldAck() {
+        log.info("lastProccessedSeq {}  snapshotEndSeq {}", lastProcessedSeq, snapshotEndSeq);
+
         if (lastProcessedSeq == snapshotEndSeq) {
+            log.info("Snapshot End has been processed lastProccessedSeq {}  snapshotEndSeq {}", lastProcessedSeq, snapshotEndSeq);
             return true;
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/SnapshotSinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/SnapshotSinkBufferManager.java
@@ -100,6 +100,7 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
     boolean shouldAck() {
         log.info("lastProccessedSeq {}  snapshotEndSeq {}", lastProcessedSeq, snapshotEndSeq);
 
+        // Always send an ACK for snapshot tranfer end marker.
         if (lastProcessedSeq == snapshotEndSeq) {
             log.info("Snapshot End has been processed lastProccessedSeq {}  snapshotEndSeq {}", lastProcessedSeq, snapshotEndSeq);
             return true;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/SnapshotSinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/SnapshotSinkBufferManager.java
@@ -6,8 +6,9 @@ import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntryMeta
 import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.view.Address;
 
-import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_END;
+import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_TRANSFER_END;
 import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_MESSAGE;
+import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_TRANSFER_END;
 
 @Slf4j
 public class SnapshotSinkBufferManager extends SinkBufferManager {
@@ -48,7 +49,7 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
      */
     @Override
     long getCurrentSeq(LogReplicationEntry entry) {
-        if (entry.getMetadata().getMessageMetadataType() == SNAPSHOT_END) {
+        if (entry.getMetadata().getMessageMetadataType() == SNAPSHOT_TRANSFER_END) {
             snapshotEndSeq = entry.getMetadata().getSnapshotSyncSeqNum();
             log.info("Setup snapshotEndSeq {}", snapshotEndSeq);
         }
@@ -82,7 +83,7 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
          * sender the completion of the snapshot replication.
          */
         if (lastProcessedSeq == (snapshotEndSeq -1)) {
-            metadata.setMessageMetadataType(MessageType.SNAPSHOT_END);
+            metadata.setMessageMetadataType(MessageType.SNAPSHOT_TRANSFER_END);
             metadata.setSnapshotSyncSeqNum(snapshotEndSeq);
         } else {
             metadata.setMessageMetadataType(MessageType.SNAPSHOT_REPLICATED);
@@ -102,7 +103,7 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
     public boolean verifyMessageType(LogReplicationEntry entry) {
         switch (entry.getMetadata().getMessageMetadataType()) {
             case SNAPSHOT_MESSAGE:
-            case SNAPSHOT_END:
+            case SNAPSHOT_TRANSFER_END:
                 return true;
             default:
                 log.error("wrong message type ", entry.getMetadata());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/StreamsSnapshotWriter.java
@@ -392,16 +392,15 @@ public class StreamsSnapshotWriter implements SnapshotWriter {
         //get the number of entries to apply
         long seqNum = logReplicationMetadataAccessor.query(null, LogReplicationMetadataAccessor.LogReplicationMetadataType.LastSnapshotSeqNum);
 
-        // There is no snapshot data to apply
-        if (seqNum == Address.NON_ADDRESS)
-            return;
+        // There is snapshot data to apply
+        if (seqNum != Address.NON_ADDRESS) {
+            phase = Phase.ApplyPhase;
+            long snapshot = rt.getAddressSpaceView().getLogTail();
+            clearTables();
 
-        phase = Phase.ApplyPhase;
-        long snapshot = rt.getAddressSpaceView().getLogTail();
-        clearTables();
-
-        for (UUID uuid : streamViewMap.keySet()) {
-            appliedSeq = applyShadowStream(uuid, appliedSeq, snapshot);
+            for (UUID uuid : streamViewMap.keySet()) {
+                appliedSeq = applyShadowStream(uuid, appliedSeq, snapshot);
+            }
         }
 
         // Apply phase is done, update the metadata

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/receive/StreamsSnapshotWriter.java
@@ -343,6 +343,20 @@ public class StreamsSnapshotWriter implements SnapshotWriter {
     }
 
     /**
+     * Snapshot data has been transferred from primary node to the standby node
+     * @param entry
+     */
+    public void setSnapshotTransferDone(LogReplicationEntry entry) {
+        phase = Phase.ApplyPhase;
+        //verify that the snapshot Apply hasn't started yet and set it as started and set the seqNumber
+        long ts = entry.getMetadata().getSnapshotTimestamp();
+        siteConfigID = entry.getMetadata().getSiteConfigID();
+
+        //update the metadata
+        logReplicationMetadataAccessor.setLastSnapTransferDoneTimestamp(siteConfigID, ts);
+    }
+
+    /**
      * Read from the shadow table and write to the real table
      * @param uuid: the real table uuid
      */
@@ -368,11 +382,20 @@ public class StreamsSnapshotWriter implements SnapshotWriter {
         return seqNum;
     }
 
-
     /**
-     * read from shadowStream and append to the
+     * read from shadowStreams and append to the real streams.
      */
-    public void applyShadowStreams() {
+    public void snapshotTransferDone(LogReplicationEntry message) {
+        // Set metadata and phase
+        setSnapshotTransferDone(message);
+
+        //get the number of entries to apply
+        long seqNum = logReplicationMetadataAccessor.query(null, LogReplicationMetadataAccessor.LogReplicationMetadataType.LastSnapshotSeqNum);
+
+        // There is no snapshot data to apply
+        if (seqNum == Address.NON_ADDRESS)
+            return;
+
         phase = Phase.ApplyPhase;
         long snapshot = rt.getAddressSpaceView().getLogTail();
         clearTables();
@@ -380,36 +403,11 @@ public class StreamsSnapshotWriter implements SnapshotWriter {
         for (UUID uuid : streamViewMap.keySet()) {
             appliedSeq = applyShadowStream(uuid, appliedSeq, snapshot);
         }
+
+        // Apply phase is done, update the metadata
+        logReplicationMetadataAccessor.setSnapshotApplied(message);
     }
 
-    /**
-     * Snapshot data has been transferred from primary node to the standby node
-     * @param entry
-     */
-    public void snapshotTransferDone(LogReplicationEntry entry) {
-        if (phase == Phase.ApplyPhase) {
-            return;
-        }
-
-        phase = Phase.ApplyPhase;
-        //verify that the snapshot Apply hasn't started yet and set it as started and set the seqNumber
-        long ts = entry.getMetadata().getSnapshotTimestamp();
-        long seqNum = 0;
-        siteConfigID = entry.getMetadata().getSiteConfigID();
-
-        //update the metadata
-        logReplicationMetadataAccessor.setLastSnapTransferDoneTimestamp(siteConfigID, ts);
-
-        //get the number of entries to apply
-        seqNum = logReplicationMetadataAccessor.query(null, LogReplicationMetadataAccessor.LogReplicationMetadataType.LastSnapshotSeqNum);
-
-        // There is no snapshot data to apply
-        if (seqNum == Address.NON_ADDRESS)
-            return;
-
-        applyShadowStreams();
-    }
-    
     enum Phase {
         TransferPhase,
         ApplyPhase

--- a/log-replication/src/main/java/org/corfudb/logreplication/fsm/InSnapshotSyncState.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/fsm/InSnapshotSyncState.java
@@ -73,6 +73,7 @@ public class InSnapshotSyncState implements LogReplicationState {
                  */
                 setTransitionEventId(event.getEventID());
                 snapshotSender.reset();
+                log.info("process new snapshot_sync_request and reset the status");
                 return this;
             case SNAPSHOT_SYNC_CONTINUE:
                 /*
@@ -161,13 +162,8 @@ public class InSnapshotSyncState implements LogReplicationState {
             /*
              Start send of snapshot sync
              */
-            if (!snapshotSender.isTransmissionDone()) {
-                transmitFuture = fsm.getLogReplicationFSMWorkers().submit(() -> snapshotSender.transmit(transitionEventId));
-            } else {
-                //TODO: query destination state
-                //if the destination state shows has done with the snapshot applied, complete the snapshot transfer
-                transmitFuture = fsm.getLogReplicationFSMWorkers().submit(() -> snapshotSender.snapshotSyncComplete(transitionEventId));
-            }
+            transmitFuture = fsm.getLogReplicationFSMWorkers().submit(() -> snapshotSender.transmit(transitionEventId));
+
         } catch (Throwable t) {
             log.error("Error on entry of InSnapshotSyncState.", t);
         }

--- a/log-replication/src/main/java/org/corfudb/logreplication/fsm/InSnapshotSyncState.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/fsm/InSnapshotSyncState.java
@@ -161,7 +161,13 @@ public class InSnapshotSyncState implements LogReplicationState {
             /*
              Start send of snapshot sync
              */
-            transmitFuture = fsm.getLogReplicationFSMWorkers().submit(() -> snapshotSender.transmit(transitionEventId));
+            if (!snapshotSender.isTransmissionDone()) {
+                transmitFuture = fsm.getLogReplicationFSMWorkers().submit(() -> snapshotSender.transmit(transitionEventId));
+            } else {
+                //TODO: query destination state
+                //if the destination state shows has done with the snapshot applied, complete the snapshot transfer
+                transmitFuture = fsm.getLogReplicationFSMWorkers().submit(() -> snapshotSender.snapshotSyncComplete(transitionEventId));
+            }
         } catch (Throwable t) {
             log.error("Error on entry of InSnapshotSyncState.", t);
         }

--- a/log-replication/src/main/java/org/corfudb/logreplication/fsm/InitializedState.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/fsm/InitializedState.java
@@ -44,6 +44,12 @@ public class InitializedState implements LogReplicationState {
                 // This is used to correlate trim or error events that derive from this state
                 LogReplicationState snapshotState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
                 snapshotState.setTransitionEventId(event.getEventID());
+                /*
+                 * TODO xq:
+                 * options to restart snapshot sync for apply phase
+                 * 1. introduce one more message type snapshot_start_apply
+                 */
+
                 return snapshotState;
 
             case REPLICATION_START:

--- a/log-replication/src/main/java/org/corfudb/logreplication/fsm/InitializedState.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/fsm/InitializedState.java
@@ -33,12 +33,19 @@ public class InitializedState implements LogReplicationState {
     public LogReplicationState processEvent(LogReplicationEvent event) throws IllegalTransitionException {
         switch (event.getType()) {
             case SNAPSHOT_SYNC_REQUEST:
-            case SNAPSHOT_WAIT_COMPLETE:
                 // Set the id of the event that caused the transition to the new state
                 // This is used to correlate trim or error events that derive from this state
                 LogReplicationState snapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
                 snapshotSyncState.setTransitionEventId(event.getEventID());
                 return snapshotSyncState;
+
+            case SNAPSHOT_WAIT_COMPLETE:
+                // Set the id of the event that caused the transition to the new state
+                // This is used to correlate trim or error events that derive from this state
+                LogReplicationState snapshotState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
+                snapshotState.setTransitionEventId(event.getEventID());
+                return snapshotState;
+
             case REPLICATION_START:
                 // Set the id of the event that caused the transition to the new state
                 // This is used to correlate trim or error events that derive from this state

--- a/log-replication/src/main/java/org/corfudb/logreplication/fsm/LogReplicationFSM.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/fsm/LogReplicationFSM.java
@@ -273,7 +273,10 @@ public class LogReplicationFSM {
 
             // TODO (Anny): consider strategy for continuously failing snapshot sync (never ending cancellation)
             //   Block until an event shows up in the queue.
+            log.info("eventQue {} {}", eventQueue.size(), eventQueue);
             LogReplicationEvent event = eventQueue.take();
+            log.info("process event {}", event);
+
             if (event.getType() != LogReplicationEventType.LOG_ENTRY_SYNC_CONTINUE) {
                 log.debug("Log Replication FSM consume event {}", event);
             }

--- a/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -100,6 +100,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         this.localEndpoint = serverContext.getLocalEndpoint();
         this.nodeInfo = crossSiteConfig.getNodeInfo(localEndpoint);
         this.logReplicationMetadataAccessor = serverNode.getLogReplicationServer().getSinkManager().getLogReplicationMetadataAccessor();
+        logReplicationMetadataAccessor.setupSiteConfigID(crossSiteConfig.getSiteConfigID());
         registerToLogReplicationLock();
     }
 
@@ -185,7 +186,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
 
 
     public void processLockAcquire() {
-        log.debug("process lock acquire");
+        log.info("process lock acquire");
         replicationServerNode.getLogReplicationServer().getSinkManager().setLeader(true);
 
         // leader transition from true to true, do nothing;

--- a/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.infrastructure.ServerContext;
-import org.corfudb.infrastructure.logreplication.receive.LogReplicationMetadataManager;
+import org.corfudb.infrastructure.logreplication.receive.LogReplicationMetadataAccessor;
 import org.corfudb.logreplication.proto.LogReplicationSiteInfo;
 import org.corfudb.logreplication.proto.LogReplicationSiteInfo.SiteStatus;
 import org.corfudb.runtime.CorfuRuntime;
@@ -43,7 +43,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
      * It is backed by a corfu store table.
      */
     @Getter
-    private final LogReplicationMetadataManager logReplicationMetadataManager;
+    private final LogReplicationMetadataAccessor logReplicationMetadataAccessor;
 
     /**
      * Lock-related configuration parameters
@@ -99,7 +99,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
             replicationServerNode, this);
         this.localEndpoint = serverContext.getLocalEndpoint();
         this.nodeInfo = crossSiteConfig.getNodeInfo(localEndpoint);
-        this.logReplicationMetadataManager = serverNode.getLogReplicationServer().getSinkManager().getLogReplicationMetadataManager();
+        this.logReplicationMetadataAccessor = serverNode.getLogReplicationServer().getSinkManager().getLogReplicationMetadataAccessor();
         registerToLogReplicationLock();
     }
 

--- a/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationManager.java
@@ -9,7 +9,7 @@ import org.corfudb.infrastructure.logreplication.LogReplicationTransportType;
 import org.corfudb.logreplication.fsm.LogReplicationEvent;
 import org.corfudb.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.logreplication.send.LogReplicationEventMetadata;
-import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationNegotiationResponse;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.util.retry.IRetry;
@@ -272,11 +272,11 @@ public class CorfuReplicationManager {
     private LogReplicationEvent startNegotiation(CorfuLogReplicationRuntime logReplicationRuntime)
             throws LogReplicationNegotiationException {
 
-        LogReplicationNegotiationResponse negotiationResponse;
+        LogReplicationQueryMetadataResponse negotiationResponse;
 
         try {
             // TODO(Anny) : IRetry...
-            negotiationResponse = logReplicationRuntime.startNegotiation();
+            negotiationResponse = logReplicationRuntime.sendQueryMetadataRequest();
             log.trace("Negotiation Response received: {} ", negotiationResponse);
         } catch (Exception e) {
             log.error("Caught exception during log replication negotiation to {} ", logReplicationRuntime.getParameters().getRemoteLogReplicationServerEndpoint(), e);
@@ -295,7 +295,7 @@ public class CorfuReplicationManager {
      * @return
      * @throws LogReplicationNegotiationException
      */
-    private LogReplicationEvent processNegotiationResponse(LogReplicationNegotiationResponse negotiationResponse)
+    private LogReplicationEvent processNegotiationResponse(LogReplicationQueryMetadataResponse negotiationResponse)
             throws LogReplicationNegotiationException {
         /*
          * If the version are different, report an error.

--- a/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/CorfuReplicationManager.java
@@ -300,9 +300,9 @@ public class CorfuReplicationManager {
         /*
          * If the version are different, report an error.
          */
-        if (!negotiationResponse.getVersion().equals(discoveryService.getLogReplicationMetadataManager().getVersion())) {
+        if (!negotiationResponse.getVersion().equals(discoveryService.getLogReplicationMetadataAccessor().getVersion(null))) {
             log.error("The active site version {} is different from standby site version {}",
-                    discoveryService.getLogReplicationMetadataManager().getVersion(), negotiationResponse.getVersion());
+                    discoveryService.getLogReplicationMetadataAccessor().getVersion(null), negotiationResponse.getVersion());
             throw new LogReplicationNegotiationException(" Mismatch of version number");
         }
 
@@ -312,7 +312,7 @@ public class CorfuReplicationManager {
          */
         if (negotiationResponse.getSiteConfigID() < negotiationResponse.getSiteConfigID()) {
             log.error("The active site configID {} is bigger than the standby configID {} ",
-                    discoveryService.getLogReplicationMetadataManager().getSiteConfigID(), negotiationResponse.getSiteConfigID());
+                    discoveryService.getLogReplicationMetadataAccessor().getSiteConfigID(null), negotiationResponse.getSiteConfigID());
             throw new LogReplicationNegotiationException("Mismatch of configID");
         }
 
@@ -322,7 +322,7 @@ public class CorfuReplicationManager {
          */
         if (negotiationResponse.getSiteConfigID() > negotiationResponse.getSiteConfigID()) {
             log.error("The active site configID {} is smaller than the standby configID {} ",
-                    discoveryService.getLogReplicationMetadataManager().getSiteConfigID(), negotiationResponse.getSiteConfigID());
+                    discoveryService.getLogReplicationMetadataAccessor().getSiteConfigID(null), negotiationResponse.getSiteConfigID());
             throw new LogReplicationNegotiationException("Mismatch of configID");
         }
 

--- a/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/DefaultSiteManager.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/infrastructure/DefaultSiteManager.java
@@ -133,7 +133,7 @@ public class DefaultSiteManager extends CorfuReplicationSiteManagerAdapter {
         standbySites.put(STANDBY_SITE_NAME, new CrossSiteConfiguration.SiteInfo(standbySiteName, SiteStatus.STANDBY));
 
         for (int i = 0; i < standbyNodeNames.size(); i++) {
-            log.info("Standby Site Name {}, IpAddress {}", standbyNodeNames.get(i), standbyIpAddresses.get(i));
+            log.trace("Standby Site Name {}, IpAddress {}", standbyNodeNames.get(i), standbyIpAddresses.get(i));
             LogReplicationNodeInfo nodeInfo = new LogReplicationNodeInfo(standbyIpAddresses.get(i),
                     standbyLogReplicationPort, SiteStatus.STANDBY, standbyCorfuPort, STANDBY_SITE_NAME);
             standbySites.get(STANDBY_SITE_NAME).nodesInfo.add(nodeInfo);

--- a/log-replication/src/main/java/org/corfudb/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -15,7 +15,7 @@ import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 import org.corfudb.logreplication.LogReplicationSourceManager;
 import org.corfudb.logreplication.fsm.LogReplicationEvent;
 import org.corfudb.logreplication.infrastructure.CorfuReplicationDiscoveryService;
-import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationNegotiationResponse;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryLeaderShipResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.NodeRouterPool;
@@ -202,9 +202,9 @@ public class CorfuLogReplicationRuntime {
         return client.sendQueryLeadership().get();
     }
 
-    public LogReplicationNegotiationResponse startNegotiation() throws Exception {
-        log.info("Send Negotiation Request");
-        return client.sendNegotiationRequest().get();
+    public LogReplicationQueryMetadataResponse sendQueryMetadataRequest() throws Exception {
+        log.info("Send Query Metadata Request");
+        return client.sendQueryMetadata().get();
     }
 
     /**

--- a/log-replication/src/main/java/org/corfudb/logreplication/runtime/LogReplicationClient.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/runtime/LogReplicationClient.java
@@ -5,12 +5,11 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.logreplication.infrastructure.CorfuReplicationDiscoveryService;
 import org.corfudb.logreplication.infrastructure.DiscoveryServiceEvent;
-import org.corfudb.logreplication.proto.LogReplicationSiteInfo;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
-import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationNegotiationResponse;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryLeaderShipResponse;
 import org.corfudb.runtime.clients.AbstractClient;
 import org.corfudb.runtime.clients.IClientRouter;
@@ -39,9 +38,9 @@ public class LogReplicationClient extends AbstractClient {
         this.remoteSiteID = remoteSiteID;
     }
 
-    public CompletableFuture<LogReplicationNegotiationResponse> sendNegotiationRequest() {
+    public CompletableFuture<LogReplicationQueryMetadataResponse> sendQueryMetadata() {
         return getRouter().sendMessageAndGetCompletable(
-                new CorfuMsg(CorfuMsgType.LOG_REPLICATION_NEGOTIATION_REQUEST).setEpoch(0));
+                new CorfuMsg(CorfuMsgType.LOG_REPLICATION_QUERY_METADATA_REQUEST).setEpoch(0));
     }
 
     public CompletableFuture<LogReplicationQueryLeaderShipResponse> sendQueryLeadership() {

--- a/log-replication/src/main/java/org/corfudb/logreplication/runtime/LogReplicationHandler.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/runtime/LogReplicationHandler.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
-import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationNegotiationResponse;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryLeaderShipResponse;
 import org.corfudb.runtime.clients.ClientHandler;
 import org.corfudb.runtime.clients.ClientMsgHandler;
@@ -47,8 +47,8 @@ public class LogReplicationHandler implements IClient, IHandler<LogReplicationCl
         return msg.getPayload();
     }
 
-    @ClientHandler(type = CorfuMsgType.LOG_REPLICATION_NEGOTIATION_RESPONSE)
-    private static Object handleLogReplicationNegotiation(CorfuPayloadMsg<LogReplicationNegotiationResponse> msg,
+    @ClientHandler(type = CorfuMsgType.LOG_REPLICATION_QUERY_METADATA_RESPONSE)
+    private static Object handleLogReplicationQueryMetadata(CorfuPayloadMsg<LogReplicationQueryMetadataResponse> msg,
                                                           ChannelHandlerContext ctx, IClientRouter r) {
         log.info("Handle log replication Negotiation Response");
         return msg.getPayload();

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/CorfuDataSender.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/CorfuDataSender.java
@@ -38,7 +38,7 @@ public class CorfuDataSender implements DataSender {
 
         for (LogReplicationEntry message :  messages) {
             tmp = send(message);
-            if (message.getMetadata().getMessageMetadataType().equals(MessageType.SNAPSHOT_END) ||
+            if (message.getMetadata().getMessageMetadataType().equals(MessageType.SNAPSHOT_TRANSFER_END) ||
                     message.getMetadata().getMessageMetadataType().equals(MessageType.LOG_ENTRY_MESSAGE)) {
                 lastSentMessage = tmp;
             }

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/CorfuDataSender.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/CorfuDataSender.java
@@ -53,7 +53,7 @@ public class CorfuDataSender implements DataSender {
      * @return
      */
     @Override
-    public LogReplicationQueryMetadataResponse sendQueryMetadata() throws ExecutionException, InterruptedException {
+    public LogReplicationQueryMetadataResponse sendQueryMetadataRequest() throws ExecutionException, InterruptedException {
         log.trace("query remote metadata");
         return client.sendQueryMetadata().get();
     }

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/CorfuDataSender.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/CorfuDataSender.java
@@ -5,10 +5,12 @@ import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.infrastructure.logreplication.LogReplicationError;
 import org.corfudb.logreplication.runtime.LogReplicationClient;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 @Slf4j
 public class CorfuDataSender implements DataSender {
@@ -19,10 +21,13 @@ public class CorfuDataSender implements DataSender {
         this.client = client;
     }
 
+
     @Override
     public CompletableFuture<LogReplicationEntry> send(LogReplicationEntry message) {
         log.trace("Send single log entry for request {}", message.getMetadata());
         return client.sendLogEntry(message);
+
+
     }
 
     @Override
@@ -40,6 +45,17 @@ public class CorfuDataSender implements DataSender {
         }
 
         return lastSentMessage;
+    }
+
+    /**
+     * Used by Snapshot Full Sync while has done with transferring data and waiting for the receiver to finish applying.
+     * The sender queries the receiver's status and will do the proper transition.
+     * @return
+     */
+    @Override
+    public LogReplicationQueryMetadataResponse sendQueryMetadata() throws ExecutionException, InterruptedException {
+        log.trace("query remote metadata");
+        return client.sendQueryMetadata().get();
     }
 
     @Override

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/LogEntrySender.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/LogEntrySender.java
@@ -170,7 +170,7 @@ public class LogEntrySender {
      */
     public void reset(long lastSentBaseSnapshotTimestamp, long lastAckedTimestamp) {
         taskActive = true;
-        log.info("Reset baseSnapshot %s maxAckForLogEntrySync %s", lastSentBaseSnapshotTimestamp, lastAckedTimestamp);
+        log.info("Reset baseSnapshot {} maxAckForLogEntrySync {}", lastSentBaseSnapshotTimestamp, lastAckedTimestamp);
         logEntryReader.reset(lastSentBaseSnapshotTimestamp, lastAckedTimestamp);
         dataSenderBufferManager.reset(lastAckedTimestamp);
     }

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationPendingEntry.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/LogReplicationPendingEntry.java
@@ -13,13 +13,6 @@ import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 @Data
 @Slf4j
 public class LogReplicationPendingEntry {
-    /*
-     * For internal timer increasing for each message in milliseconds
-     */
-    final static private long TIME_INCREMENT = 100;
-
-    long currentTime = 0;
-
     @Getter
     private LogReplicationEntry data;
 
@@ -31,13 +24,13 @@ public class LogReplicationPendingEntry {
 
     public LogReplicationPendingEntry(org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry data) {
         this.data = data;
-        this.time = getCurrentTime();
+        this.time = System.currentTimeMillis();
         this.retry = 0;
     }
 
     boolean timeout(long timer) {
-        long ctime = getCurrentTime();
-        log.trace("current time {} - original time {} = {} timer {}", ctime, this.time, timer);
+        long ctime = System.currentTimeMillis();
+        log.trace("current time {} - original time {} = {} timer {}", ctime, this.time, ctime - this.time, timer);
         return  (ctime - this.time) > timer;
     }
 
@@ -45,12 +38,7 @@ public class LogReplicationPendingEntry {
      * update retry number and the time with current time.
      */
     void retry() {
-        this.time = getCurrentTime();
+        this.time = System.currentTimeMillis();
         retry++;
-    }
-
-    private long getCurrentTime() {
-        currentTime += TIME_INCREMENT;
-        return currentTime;
     }
 }

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/SenderBufferManager.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/SenderBufferManager.java
@@ -65,7 +65,7 @@ public abstract class SenderBufferManager {
     /*
      * the max snapShotSeqNum has ACKed. Used by snapshot sync.
      */
-    private long msgSeqNum = Address.NON_ADDRESS;
+    private long maxAckedMsgSeqNum = Address.NON_ADDRESS;
 
     private DataSender dataSender;
 
@@ -160,7 +160,7 @@ public abstract class SenderBufferManager {
      * This is used by SnapshotStart, SnapshotEnd marker messages as those messages don't have a sequence number.
      */
     public CompletableFuture<LogReplicationEntry> sendWithoutBuffering(LogReplicationEntry entry) {
-        entry.getMetadata().setSnapshotSyncSeqNum(msgSeqNum++);
+        entry.getMetadata().setSnapshotSyncSeqNum(maxAckedMsgSeqNum++);
         CompletableFuture<LogReplicationEntry> cf = dataSender.send(entry);
         int retry = 0;
         boolean result = false;
@@ -187,7 +187,7 @@ public abstract class SenderBufferManager {
      */
     public CompletableFuture<LogReplicationEntry> sendWithBuffering(LogReplicationEntry message) {
         //todo need to be removed.
-        message.getMetadata().setSnapshotSyncSeqNum(msgSeqNum++);
+        message.getMetadata().setSnapshotSyncSeqNum(maxAckedMsgSeqNum++);
         pendingMessages.append(message);
         log.info("Send messsage {}", message.getMetadata());
         CompletableFuture<LogReplicationEntry> cf = dataSender.send(message);
@@ -253,7 +253,8 @@ public abstract class SenderBufferManager {
      * @param lastAckedTimestamp
      */
     public void reset(long lastAckedTimestamp) {
-        msgSeqNum = Address.NON_ADDRESS;
+        log.info("Reset SenderBufferManager");
+        maxAckedMsgSeqNum = Address.NON_ADDRESS;
         maxAckForLogEntrySync = lastAckedTimestamp;
         pendingMessages.clear();
         pendingCompletableFutureForAcks.clear();

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/SnapshotSender.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/SnapshotSender.java
@@ -23,6 +23,8 @@ import org.corfudb.runtime.view.Address;
 import java.util.List;
 import java.util.UUID;
 
+import static java.lang.Thread.sleep;
+
 /**
  *  This class is responsible of transmitting a consistent view of the data at a given timestamp,
  *  i.e, reading and sending a snapshot of the data for the requested streams.
@@ -41,6 +43,10 @@ public class SnapshotSender {
 
     // TODO (probably move to a configuration file)
     public static final int SNAPSHOT_BATCH_SIZE = 5;
+
+    // While waiting for the standby site applying the snapshot,
+    // the interval it polls the standby site.
+    static final int SLEEP_INTERVAL = 1000;
 
     private CorfuRuntime runtime;
 
@@ -197,6 +203,11 @@ public class SnapshotSender {
         } else {
             // It has finished reading the snapshot data and all data has been sent over and ACKed.
             log.info("Snapshot sync transfer has readingCompleted for {} as there is no data in the buffer.", snapshotSyncEventId);
+            try {
+                sleep(SLEEP_INTERVAL);
+            } catch (Exception e) {
+                log.warn("Caught an exception during sleep ", e);
+            }
             querySnapshotSyncStatus(snapshotSyncEventId);
         }
     }
@@ -254,7 +265,7 @@ public class SnapshotSender {
      * @return
      */
     private LogReplicationEntry getSnapshotSyncEndMarker(UUID snapshotSyncEventId) {
-        LogReplicationEntryMetadata metadata = new LogReplicationEntryMetadata(MessageType.SNAPSHOT_END, fsm.getSiteConfigID(), snapshotSyncEventId,
+        LogReplicationEntryMetadata metadata = new LogReplicationEntryMetadata(MessageType.SNAPSHOT_TRANSFER_END, fsm.getSiteConfigID(), snapshotSyncEventId,
                 Address.NON_ADDRESS, Address.NON_ADDRESS, baseSnapshotTimestamp, Address.NON_ADDRESS);
         LogReplicationEntry emptyEntry = new LogReplicationEntry(metadata, new byte[0]);
         return emptyEntry;

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/SnapshotSender.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/SnapshotSender.java
@@ -9,7 +9,6 @@ import org.corfudb.infrastructure.logreplication.LogReplicationError;
 import org.corfudb.logreplication.fsm.LogReplicationEvent;
 import org.corfudb.logreplication.fsm.LogReplicationEvent.LogReplicationEventType;
 import org.corfudb.logreplication.fsm.LogReplicationFSM;
-import org.corfudb.logreplication.infrastructure.LogReplicationNegotiationException;
 import org.corfudb.logreplication.send.logreader.ReadProcessor;
 import org.corfudb.logreplication.send.logreader.SnapshotReadMessage;
 import org.corfudb.logreplication.send.logreader.SnapshotReader;
@@ -23,15 +22,13 @@ import org.corfudb.runtime.view.Address;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 /**
  *  This class is responsible of transmitting a consistent view of the data at a given timestamp,
  *  i.e, reading and sending a snapshot of the data for the requested streams.
  *
  *  It reads log entries from the data-store through the SnapshotReader, and hands it to the
- *  DataSender (the application specific callback for sending data to the remote site).
+ *  DataSender (the application specific callback for sending data to the remote site) through BufferManager.
  *
  *  The SnapshotReader has a default implementation based on reads at the stream layer
  *  (no serialization/deserialization) required.
@@ -44,16 +41,24 @@ public class SnapshotSender {
 
     // TODO (probably move to a configuration file)
     public static final int SNAPSHOT_BATCH_SIZE = 5;
-    public static final int DEFAULT_TIMEOUT = 5000;
 
     private CorfuRuntime runtime;
-    private SnapshotReader snapshotReader;
-    private SenderBufferManager dataSenderBufferManager;
-    private LogReplicationFSM fsm;
-    private long baseSnapshotTimestamp;
-    boolean completed = false;    // Flag indicating the snapshot reading phase is completed
 
-    // This flag will indicate the start of a snapshot sync, so start snapshot marker is sent once.
+    // Responsible reading log data from corfu
+    private SnapshotReader snapshotReader;
+
+    // Responsible buffering outgoing data that hasn't been ACKed yet.
+    private SenderBufferManager dataSenderBufferManager;
+
+    private LogReplicationFSM fsm;
+
+    // Snapshot timestamp.
+    private long baseSnapshotTimestamp;
+
+    // Flag indicating the full snapshot sync's phase I, data reading and transferring phase, completed.
+    boolean readingCompleted = false;
+
+    // This flag will indicate the starting of a snapshot sync, so start snapshot marker is sent once.
     private boolean startSnapshotSync = true;
 
 
@@ -62,8 +67,10 @@ public class SnapshotSender {
     // For testing purposes, used to count the number of messages sent in order to interrupt snapshot sync
     private ObservableValue observedCounter = new ObservableValue(0);
 
+    // Enforce a stop of sending message and snapshot sync process.
     private volatile boolean stopSnapshotSync = false;
 
+    // Used to directly query the receiver's status.
     private DataSender dataSender;
 
     public SnapshotSender(CorfuRuntime runtime, SnapshotReader snapshotReader, DataSender dataSender,
@@ -75,10 +82,9 @@ public class SnapshotSender {
         dataSenderBufferManager = new SnapshotSenderBufferManager(dataSender);
     }
 
-    private CompletableFuture<LogReplicationEntry> snapshotSyncAck;
 
     /**
-     * Read the data from corfu table and send over to the sender.
+     * Read the data from corfu table and pass the data to the sender through buffer manager.
      * @param snapshotSyncEventId
      */
     public void readAndTransmit(UUID snapshotSyncEventId) {
@@ -86,19 +92,23 @@ public class SnapshotSender {
         SnapshotReadMessage snapshotReadMessage;
         boolean cancel = false;
 
+        // For each cycle, read at most SNAPSHOT_BATCH_SIZE of messages or untill the buffer is full.
         while (messagesSent < SNAPSHOT_BATCH_SIZE && !dataSenderBufferManager.getPendingMessages().isFull()
-                &&!completed && !stopSnapshotSync) {
+                &&!readingCompleted && !stopSnapshotSync) {
             try {
+                // Read one message from Corfu log.
                 snapshotReadMessage = snapshotReader.read(snapshotSyncEventId);
-                completed = snapshotReadMessage.isEndRead();
-                // Data Transformation / Processing
-                // readProcessor.process(snapshotReadMessage.getMessages())
+
+                // Mark the readingCompleted if there is no more messages.
+                readingCompleted = snapshotReadMessage.isEndRead();
+
             } catch (TrimmedException te) {
                 log.warn("Cancel snapshot sync due to trimmed exception.", te);
                 dataSenderBufferManager.reset(Address.NON_ADDRESS);
                 snapshotSyncCancel(snapshotSyncEventId, LogReplicationError.TRIM_SNAPSHOT_SYNC);
                 cancel = true;
                 break;
+
             } catch (Exception e) {
                 log.error("Caught exception during snapshot sync", e);
                 snapshotSyncCancel(snapshotSyncEventId, LogReplicationError.UNKNOWN);
@@ -106,11 +116,11 @@ public class SnapshotSender {
                 break;
             }
 
-            messagesSent += processReads(snapshotReadMessage.getMessages(), snapshotSyncEventId, completed);
+            messagesSent += processReads(snapshotReadMessage.getMessages(), snapshotSyncEventId);
             observedCounter.setValue(messagesSent);
         }
 
-       if (!cancel) {
+       if (!cancel && !stopSnapshotSync) {
             // Maximum number of batch messages sent. This snapshot sync needs to continue.
             // Snapshot Sync is not performed in a single run, as for the case of multi-site replication
             // the shared thread pool could be lower than the number of sites, so we assign resources in
@@ -119,9 +129,7 @@ public class SnapshotSender {
             fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE,
                     new LogReplicationEventMetadata(snapshotSyncEventId)));
        } else {
-           log.trace("Snapshot sync continue for {} on timestamp {}", snapshotSyncEventId, baseSnapshotTimestamp);
-           fsm.input(new LogReplicationEvent(LogReplicationEventType.SYNC_CANCEL,
-                   new LogReplicationEventMetadata(snapshotSyncEventId)));
+           log.warn("Snapshot sync stopped for {} on timestamp {}", snapshotSyncEventId, baseSnapshotTimestamp);
        }
     }
 
@@ -130,14 +138,14 @@ public class SnapshotSender {
      * @param snapshotSyncEventId
      */
     public void querySnapshotSyncStatus(UUID snapshotSyncEventId) {
-        if (!completed) {
-            log.error("It is in the wrong state, the reading is not in the complete state {}", completed);
+        if (!readingCompleted) {
+            log.error("It is in the wrong state, the reading is not in the complete state {}", readingCompleted);
             return;
         }
 
         try {
             // Query receiver status
-            LogReplicationQueryMetadataResponse response = dataSender.sendQueryMetadata();
+            LogReplicationQueryMetadataResponse response = dataSender.sendQueryMetadataRequest();
 
             // If it has finised applying the snapshot, transition to log entry sync
             // Otherwise query the status in another cycle.
@@ -165,15 +173,20 @@ public class SnapshotSender {
         log.info("Running snapshot sync for {} on baseSnapshot {}", snapshotSyncEventId,
                 baseSnapshotTimestamp);
 
-        if(!Address.isAddress(baseSnapshotTimestamp)) {
+        if (!Address.isAddress(baseSnapshotTimestamp)) {
             log.warn("The baseSnapshotTimestamp is not a correct address and will ingore the snapshot sync reqeust.", baseSnapshotTimestamp);
+            return;
+        }
+
+        if (stopSnapshotSync) {
+            log.warn("Snapshot sync stopped for {} on timestamp {}", snapshotSyncEventId, baseSnapshotTimestamp);
             return;
         }
 
         //Resend messages in buffer and process the ACKs.
         dataSenderBufferManager.resend();
 
-        if (!completed) {
+        if (!readingCompleted) {
             log.info("Reading and sending phase.");
             readAndTransmit(snapshotSyncEventId);
         } else if (!dataSenderBufferManager.pendingMessages.isEmpty()) {
@@ -183,12 +196,18 @@ public class SnapshotSender {
                     new LogReplicationEventMetadata(snapshotSyncEventId)));
         } else {
             // It has finished reading the snapshot data and all data has been sent over and ACKed.
-            log.info("Snapshot sync transfer has completed for {} as there is no data in the buffer.", snapshotSyncEventId);
+            log.info("Snapshot sync transfer has readingCompleted for {} as there is no data in the buffer.", snapshotSyncEventId);
             querySnapshotSyncStatus(snapshotSyncEventId);
         }
     }
 
-    private int processReads(List<LogReplicationEntry> logReplicationEntries, UUID snapshotSyncEventId, boolean completed) {
+    /**
+     * All snapshot messages are pass through the buffer.
+     * @param logReplicationEntries
+     * @param snapshotSyncEventId
+     * @return
+     */
+    private int processReads(List<LogReplicationEntry> logReplicationEntries, UUID snapshotSyncEventId) {
         int numMessages = 0;
 
         // If we are starting a snapshot sync, send a start marker.
@@ -203,10 +222,10 @@ public class SnapshotSender {
         dataSenderBufferManager.sendWithBuffering(logReplicationEntries);
 
         // If Snapshot is complete, add end marker
-        if (completed) {
+        if (readingCompleted) {
             LogReplicationEntry endDataMessage = getSnapshotSyncEndMarker(snapshotSyncEventId);
             log.info("SnapshotSender sent out SNAPSHOT_END message {} " + endDataMessage.getMetadata());
-            snapshotSyncAck = dataSenderBufferManager.sendWithBuffering(endDataMessage);
+            dataSenderBufferManager.sendWithBuffering(endDataMessage);
             numMessages++;
         }
 
@@ -227,6 +246,13 @@ public class SnapshotSender {
         return emptyEntry;
     }
 
+    /**
+     * Prepare a Snapshot Sync Replication end marker.
+     * This is the last message sent to the receiver. When receiving an ACKed for this message,
+     * the sender will transit to polling receiver's status state.
+     * @param snapshotSyncEventId
+     * @return
+     */
     private LogReplicationEntry getSnapshotSyncEndMarker(UUID snapshotSyncEventId) {
         LogReplicationEntryMetadata metadata = new LogReplicationEntryMetadata(MessageType.SNAPSHOT_END, fsm.getSiteConfigID(), snapshotSyncEventId,
                 Address.NON_ADDRESS, Address.NON_ADDRESS, baseSnapshotTimestamp, Address.NON_ADDRESS);
@@ -234,14 +260,11 @@ public class SnapshotSender {
         return emptyEntry;
     }
 
-    public boolean isTransmissionDone() {
-        return completed & dataSenderBufferManager.pendingMessages.isEmpty();
-    }
 
     /**
      * Complete Snapshot Sync, insert completion event in the FSM queue.
      *
-     * @param snapshotSyncEventId unique identifier for the completed snapshot sync.
+     * @param snapshotSyncEventId unique identifier for the readingCompleted snapshot sync.
      */
     public void snapshotSyncComplete(UUID snapshotSyncEventId) {
         // We need to bind the internal event (COMPLETE) to the snapshotSyncEventId that originated it, this way
@@ -280,6 +303,7 @@ public class SnapshotSender {
 
         stopSnapshotSync = false;
         startSnapshotSync = true;
+        readingCompleted = false;
     }
 
     /**

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/SnapshotSender.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/SnapshotSender.java
@@ -157,10 +157,10 @@ public class SnapshotSender {
             // Otherwise query the status in another cycle.
             if (response.getLastLogProcessed() == response.getSnapshotApplied() &&
                 response.getSnapshotApplied() == baseSnapshotTimestamp) {
-                log.info("SNAPSHOT full sync complete according to response {} ", response);
+                log.info("SNAPSHOT full sync complete according to response {}", response);
                 snapshotSyncComplete(snapshotSyncEventId);
             } else {
-                log.info("The receiver hasn't finished applying the snapshot yet {}");
+                log.info("The receiver hasn't finished applying the snapshot yet {}", response);
                 fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE,
                         new LogReplicationEventMetadata(snapshotSyncEventId)));
             }

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/SnapshotSender.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/SnapshotSender.java
@@ -9,11 +9,13 @@ import org.corfudb.infrastructure.logreplication.LogReplicationError;
 import org.corfudb.logreplication.fsm.LogReplicationEvent;
 import org.corfudb.logreplication.fsm.LogReplicationEvent.LogReplicationEventType;
 import org.corfudb.logreplication.fsm.LogReplicationFSM;
+import org.corfudb.logreplication.infrastructure.LogReplicationNegotiationException;
 import org.corfudb.logreplication.send.logreader.ReadProcessor;
 import org.corfudb.logreplication.send.logreader.SnapshotReadMessage;
 import org.corfudb.logreplication.send.logreader.SnapshotReader;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntryMetadata;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TrimmedException;
@@ -22,7 +24,7 @@ import org.corfudb.runtime.view.Address;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ExecutionException;
 
 /**
  *  This class is responsible of transmitting a consistent view of the data at a given timestamp,
@@ -49,6 +51,7 @@ public class SnapshotSender {
     private SenderBufferManager dataSenderBufferManager;
     private LogReplicationFSM fsm;
     private long baseSnapshotTimestamp;
+    boolean completed = false;    // Flag indicating the snapshot reading phase is completed
 
     // This flag will indicate the start of a snapshot sync, so start snapshot marker is sent once.
     private boolean startSnapshotSync = true;
@@ -61,15 +64,97 @@ public class SnapshotSender {
 
     private volatile boolean stopSnapshotSync = false;
 
+    private DataSender dataSender;
+
     public SnapshotSender(CorfuRuntime runtime, SnapshotReader snapshotReader, DataSender dataSender,
                           ReadProcessor readProcessor, LogReplicationFSM fsm) {
         this.runtime = runtime;;
         this.snapshotReader = snapshotReader;
         this.fsm = fsm;
+        this.dataSender = dataSender;
         dataSenderBufferManager = new SnapshotSenderBufferManager(dataSender);
     }
 
     private CompletableFuture<LogReplicationEntry> snapshotSyncAck;
+
+    /**
+     * Read the data from corfu table and send over to the sender.
+     * @param snapshotSyncEventId
+     */
+    public void readAndTransmit(UUID snapshotSyncEventId) {
+        int messagesSent = 0;
+        SnapshotReadMessage snapshotReadMessage;
+        boolean cancel = false;
+
+        while (messagesSent < SNAPSHOT_BATCH_SIZE && !dataSenderBufferManager.getPendingMessages().isFull()
+                &&!completed && !stopSnapshotSync) {
+            try {
+                snapshotReadMessage = snapshotReader.read(snapshotSyncEventId);
+                completed = snapshotReadMessage.isEndRead();
+                // Data Transformation / Processing
+                // readProcessor.process(snapshotReadMessage.getMessages())
+            } catch (TrimmedException te) {
+                log.warn("Cancel snapshot sync due to trimmed exception.", te);
+                dataSenderBufferManager.reset(Address.NON_ADDRESS);
+                snapshotSyncCancel(snapshotSyncEventId, LogReplicationError.TRIM_SNAPSHOT_SYNC);
+                cancel = true;
+                break;
+            } catch (Exception e) {
+                log.error("Caught exception during snapshot sync", e);
+                snapshotSyncCancel(snapshotSyncEventId, LogReplicationError.UNKNOWN);
+                cancel = true;
+                break;
+            }
+
+            messagesSent += processReads(snapshotReadMessage.getMessages(), snapshotSyncEventId, completed);
+            observedCounter.setValue(messagesSent);
+        }
+
+       if (!cancel) {
+            // Maximum number of batch messages sent. This snapshot sync needs to continue.
+            // Snapshot Sync is not performed in a single run, as for the case of multi-site replication
+            // the shared thread pool could be lower than the number of sites, so we assign resources in
+            // a round robin fashion.
+            log.trace("Snapshot sync continue for {} on timestamp {}", snapshotSyncEventId, baseSnapshotTimestamp);
+            fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE,
+                    new LogReplicationEventMetadata(snapshotSyncEventId)));
+       } else {
+           log.trace("Snapshot sync continue for {} on timestamp {}", snapshotSyncEventId, baseSnapshotTimestamp);
+           fsm.input(new LogReplicationEvent(LogReplicationEventType.SYNC_CANCEL,
+                   new LogReplicationEventMetadata(snapshotSyncEventId)));
+       }
+    }
+
+    /**
+     *
+     * @param snapshotSyncEventId
+     */
+    public void querySnapshotSyncStatus(UUID snapshotSyncEventId) {
+        if (!completed) {
+            log.error("It is in the wrong state, the reading is not in the complete state {}", completed);
+            return;
+        }
+
+        try {
+            // Query receiver status
+            LogReplicationQueryMetadataResponse response = dataSender.sendQueryMetadata();
+
+            // If it has finised applying the snapshot, transition to log entry sync
+            // Otherwise query the status in another cycle.
+            if (response.getLastLogProcessed() == response.getSnapshotApplied() &&
+                response.getSnapshotApplied() == baseSnapshotTimestamp) {
+                log.info("SNAPSHOT full sync complete according to response {} ", response);
+                snapshotSyncComplete(snapshotSyncEventId);
+            } else {
+                log.info("The receiver hasn't finished applying the snapshot yet {}");
+                fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE,
+                        new LogReplicationEventMetadata(snapshotSyncEventId)));
+            }
+        } catch (Exception e) {
+            // There is a network issue or the receiver refuse to reply the message
+            // Todo xiaoqin rediscovery the remote site.
+        }
+    }
 
     /**
      * Initiate Snapshot Sync, this entails reading and sending data for a given snapshot.
@@ -77,105 +162,40 @@ public class SnapshotSender {
      * @param snapshotSyncEventId identifier of the event that initiated the snapshot sync
      */
     public void transmit(UUID snapshotSyncEventId) {
-
         log.info("Running snapshot sync for {} on baseSnapshot {}", snapshotSyncEventId,
                 baseSnapshotTimestamp);
 
-        boolean completed = false;    // Flag indicating the snapshot sync is completed
-        boolean cancel = false;     // Flag indicating snapshot sync needs to be canceled
-        int messagesSent = 0;       // Limit the number of messages to SNAPSHOT_BATCH_SIZE. The reason we need to limit
-                                    // is because by design several state machines can share the same thread pool,
-                                    // therefore, we need to hand the thread for other workers to execute.
-        SnapshotReadMessage snapshotReadMessage;
+        if(!Address.isAddress(baseSnapshotTimestamp)) {
+            log.warn("The baseSnapshotTimestamp is not a correct address and will ingore the snapshot sync reqeust.", baseSnapshotTimestamp);
+            return;
+        }
 
-        // Skip if no data is present in the log
-        if (Address.isAddress(baseSnapshotTimestamp)) {
-            // Read and Send Batch Size messages, unless snapshot is completed before (endRead)
-            // or snapshot sync is stopped
-            dataSenderBufferManager.resend();
-            while (messagesSent < SNAPSHOT_BATCH_SIZE && !dataSenderBufferManager.getPendingMessages().isFull() &&!completed && !stopSnapshotSync) {
+        //Resend messages in buffer and process the ACKs.
+        dataSenderBufferManager.resend();
 
-                try {
-                    snapshotReadMessage = snapshotReader.read(snapshotSyncEventId);
-                    completed = snapshotReadMessage.isEndRead();
-                    // Data Transformation / Processing
-                    // readProcessor.process(snapshotReadMessage.getMessages())
-                } catch (TrimmedException te) {
-                    log.warn("Cancel snapshot sync due to trimmed exception.", te);
-                    dataSenderBufferManager.reset(Address.NON_ADDRESS);
-                    snapshotSyncCancel(snapshotSyncEventId, LogReplicationError.TRIM_SNAPSHOT_SYNC);
-                    cancel = true;
-                    break;
-                } catch (Exception e) {
-                    log.error("Caught exception during snapshot sync", e);
-                    snapshotSyncCancel(snapshotSyncEventId, LogReplicationError.UNKNOWN);
-                    cancel = true;
-                    break;
-                }
-
-                messagesSent += processReads(snapshotReadMessage.getMessages(), snapshotSyncEventId, completed);
-                observedCounter.setValue(messagesSent);
-            }
-
-            if (completed) {
-                // Block until ACK from last sent message is received
-                try {
-                    LogReplicationEntry ack = snapshotSyncAck.get(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
-                    if (ack.getMetadata().getSnapshotTimestamp() == baseSnapshotTimestamp) {
-                        // Snapshot Sync Completed
-                        log.info("Snapshot sync completed for {} on timestamp {}, ack{}", snapshotSyncEventId,
-                                baseSnapshotTimestamp, ack.getMetadata());
-                        snapshotSyncComplete(snapshotSyncEventId);
-                    } else {
-                        log.warn("Expected ack for {}, but received for a different snapshot {}", baseSnapshotTimestamp,
-                                ack.getMetadata());
-                        throw new Exception("Wrong base snapshot ack");
-                    }
-                } catch (Exception e) {
-                    log.error("Exception caught while blocking on snapshot sync {}, ack for {}",
-                            snapshotSyncEventId, baseSnapshotTimestamp, e);
-                    if (snapshotSyncAck.isCompletedExceptionally()) {
-                        log.error("...");
-                    }
-                    snapshotSyncCancel(snapshotSyncEventId, LogReplicationError.UNKNOWN);
-                } finally {
-                    snapshotSyncAck = null;
-                }
-            } else if (!cancel) {
-                // Maximum number of batch messages sent. This snapshot sync needs to continue.
-
-                // Snapshot Sync is not performed in a single run, as for the case of multi-site replication
-                // the shared thread pool could be lower than the number of sites, so we assign resources in
-                // a round robin fashion.
-                log.trace("Snapshot sync continue for {} on timestamp {}", snapshotSyncEventId, baseSnapshotTimestamp);
-                fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE,
-                        new LogReplicationEventMetadata(snapshotSyncEventId)));
-            }
+        if (!completed) {
+            log.info("Reading and sending phase.");
+            readAndTransmit(snapshotSyncEventId);
+        } else if (!dataSenderBufferManager.pendingMessages.isEmpty()) {
+            log.info("Snapshot full sync: snapshot reader is done, there is still data in the buffer {}",
+                    dataSenderBufferManager.pendingMessages.getSize());
+            fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_CONTINUE,
+                    new LogReplicationEventMetadata(snapshotSyncEventId)));
         } else {
-            log.info("Snapshot sync completed for {} as there is no data in the log.", snapshotSyncEventId);
-
-            // Generate a special LogReplicationEntry with only metadata (used as start marker on receiver side
-            // to complete snapshot sync and send the right ACK)
-            try {
-                dataSenderBufferManager.sendWithBuffering(resendMsgsAndWaitAckForSnapshotEnd(snapshotSyncEventId));
-                snapshotSyncAck = dataSenderBufferManager.sendWithBuffering(getSnapshotSyncEndMarker(snapshotSyncEventId));
-                snapshotSyncAck.get(DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
-                snapshotSyncComplete(snapshotSyncEventId);
-            } catch (Exception e) {
-                //todo: generate an event for discovery service
-                log.warn("While sending data, caught an exception. Will notify discovery service");
-            }
+            // It has finished reading the snapshot data and all data has been sent over and ACKed.
+            log.info("Snapshot sync transfer has completed for {} as there is no data in the buffer.", snapshotSyncEventId);
+            querySnapshotSyncStatus(snapshotSyncEventId);
         }
     }
 
     private int processReads(List<LogReplicationEntry> logReplicationEntries, UUID snapshotSyncEventId, boolean completed) {
         int numMessages = 0;
 
-        //dataSenderBufferManager.resend();
-
         // If we are starting a snapshot sync, send a start marker.
         if (startSnapshotSync) {
-            dataSenderBufferManager.sendWithBuffering(resendMsgsAndWaitAckForSnapshotEnd(snapshotSyncEventId));
+            LogReplicationEntry entry = getSnapshotSyncStartMarker(snapshotSyncEventId);
+            entry.getMetadata().setSnapshotSyncSeqNum(Address.NON_ADDRESS);
+            dataSenderBufferManager.sendWithBuffering(getSnapshotSyncStartMarker(snapshotSyncEventId));
             startSnapshotSync = false;
             numMessages++;
         }
@@ -196,11 +216,11 @@ public class SnapshotSender {
 
     /**
      * Prepare a Snapshot Sync Replication start marker.
-     *
+     * This message will has seqNum -1.
      * @param snapshotSyncEventId snapshot sync event identifier
      * @return snapshot sync start marker as LogReplicationEntry
      */
-    private LogReplicationEntry resendMsgsAndWaitAckForSnapshotEnd(UUID snapshotSyncEventId) {
+    private LogReplicationEntry getSnapshotSyncStartMarker(UUID snapshotSyncEventId) {
         LogReplicationEntryMetadata metadata = new LogReplicationEntryMetadata(MessageType.SNAPSHOT_START, fsm.getSiteConfigID(),
                 snapshotSyncEventId, Address.NON_ADDRESS, Address.NON_ADDRESS, baseSnapshotTimestamp, Address.NON_ADDRESS);
         LogReplicationEntry emptyEntry = new LogReplicationEntry(metadata, new byte[0]);
@@ -214,12 +234,16 @@ public class SnapshotSender {
         return emptyEntry;
     }
 
+    public boolean isTransmissionDone() {
+        return completed & dataSenderBufferManager.pendingMessages.isEmpty();
+    }
+
     /**
      * Complete Snapshot Sync, insert completion event in the FSM queue.
      *
      * @param snapshotSyncEventId unique identifier for the completed snapshot sync.
      */
-    private void snapshotSyncComplete(UUID snapshotSyncEventId) {
+    public void snapshotSyncComplete(UUID snapshotSyncEventId) {
         // We need to bind the internal event (COMPLETE) to the snapshotSyncEventId that originated it, this way
         // the state machine can correlate to the corresponding state (in case of delayed events)
         fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_COMPLETE,

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/logreader/StreamsSnapshotReader.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/logreader/StreamsSnapshotReader.java
@@ -130,7 +130,7 @@ public class StreamsSnapshotReader implements SnapshotReader {
     LogReplicationEntry read(OpaqueStreamIterator stream, UUID syncRequestId) {
         List<SMREntry> entries = next(stream, MAX_NUM_SMR_ENTRY);
         org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry txMsg = generateMessage(stream, entries, syncRequestId);
-        log.info("Successfully pass stream {} for snapshotTimestamp {}", stream.name, snapshotTimestamp);
+        log.trace("Read stream {} for snapshotTimestamp {} and generate a msg {}", stream.name, snapshotTimestamp, txMsg.getMetadata());
         return txMsg;
     }
 
@@ -159,7 +159,7 @@ public class StreamsSnapshotReader implements SnapshotReader {
                     break;
                 } else {
                     // Skip process this stream as it has no entries to process, will poll the next one.
-                    log.info("Snapshot logreader will skip reading stream {} as there are no entries to send",
+                    log.info("Snapshot reader will skip reading stream {} as there are no more entries to send",
                             currentStreamInfo.uuid);
                 }
             }
@@ -177,7 +177,7 @@ public class StreamsSnapshotReader implements SnapshotReader {
             currentStreamInfo = null;
 
             if (streamsToSend.isEmpty()) {
-                log.info("Snapshot logreader finished reading all streams {}", streams);
+                log.info("Snapshot reader completed reading all streams {}", streams);
                 endSnapshotSync = true;
             }
         }

--- a/log-replication/src/main/java/org/corfudb/logreplication/send/logreader/StreamsSnapshotReader.java
+++ b/log-replication/src/main/java/org/corfudb/logreplication/send/logreader/StreamsSnapshotReader.java
@@ -95,7 +95,7 @@ public class StreamsSnapshotReader implements SnapshotReader {
         preMsgTs = currentMsgTs;
         sequence++;
         log.debug("Generate TxMsg {}", txMsg.getMetadata());
-        //System.out.print("\nGenerate TxMsg {} " +  txMsg.getMetadata());
+        //System.out.print("\nGenerate TxMsg {} " +  txMsg.getLogReplicationStatus());
         return txMsg;
     }
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/CorfuMsgType.java
@@ -5,7 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
-import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationNegotiationResponse;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryLeaderShipResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorMsg;
 import org.corfudb.protocols.wireprotocol.orchestrator.OrchestratorResponse;
@@ -16,7 +16,6 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.reflect.Constructor;
-import java.util.UUID;
 
 /**
  * Created by mwei on 8/8/16.
@@ -118,8 +117,8 @@ public enum CorfuMsgType {
     ERROR_SERVER_EXCEPTION(200, new TypeToken<CorfuPayloadMsg<ExceptionMsg>>() {}, true, false),
 
     LOG_REPLICATION_ENTRY(201, new TypeToken<CorfuPayloadMsg<LogReplicationEntry>>() {}, true, true),
-    LOG_REPLICATION_NEGOTIATION_REQUEST(202, TypeToken.of(CorfuMsg.class), true, true),
-    LOG_REPLICATION_NEGOTIATION_RESPONSE(203, new TypeToken<CorfuPayloadMsg<LogReplicationNegotiationResponse>>() {}, true, true),
+    LOG_REPLICATION_QUERY_METADATA_REQUEST(202, TypeToken.of(CorfuMsg.class), true, true),
+    LOG_REPLICATION_QUERY_METADATA_RESPONSE(203, new TypeToken<CorfuPayloadMsg<LogReplicationQueryMetadataResponse>>() {}, true, true),
     LOG_REPLICATION_QUERY_LEADERSHIP(204, TypeToken.of(CorfuMsg.class), true, true),
     LOG_REPLICATION_QUERY_LEADERSHIP_RESPONSE(205, new TypeToken<CorfuPayloadMsg<LogReplicationQueryLeaderShipResponse>>(){}, true, true),
     ;

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationEntryMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationEntryMetadata.java
@@ -101,8 +101,8 @@ public class LogReplicationEntryMetadata {
                 return MessageType.SNAPSHOT_MESSAGE;
             case SNAPSHOT_START:
                 return MessageType.SNAPSHOT_START;
-            case SNAPSHOT_END:
-                return MessageType.SNAPSHOT_END;
+            case SNAPSHOT_TRANSFER_END:
+                return MessageType.SNAPSHOT_TRANSFER_END;
             case SNAPSHOT_REPLICATED:
                 return MessageType.SNAPSHOT_REPLICATED;
             case LOG_ENTRY_REPLICATED:

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationQueryMetadataResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationQueryMetadataResponse.java
@@ -6,7 +6,7 @@ import org.corfudb.protocols.wireprotocol.ICorfuPayload;
 import org.corfudb.runtime.Messages;
 
 @Data
-public class LogReplicationNegotiationResponse implements ICorfuPayload<LogReplicationNegotiationResponse> {
+public class LogReplicationQueryMetadataResponse implements ICorfuPayload<LogReplicationQueryMetadataResponse> {
 
     private long siteConfigID;
     private String version;
@@ -15,7 +15,7 @@ public class LogReplicationNegotiationResponse implements ICorfuPayload<LogRepli
     private long snapshotApplied;
     private long lastLogProcessed;
 
-    public LogReplicationNegotiationResponse(ByteBuf buf) {
+    public LogReplicationQueryMetadataResponse(ByteBuf buf) {
         siteConfigID = ICorfuPayload.fromBuffer(buf, Long.class);
         version = ICorfuPayload.fromBuffer(buf, String.class);
         snapshotStart = ICorfuPayload.fromBuffer(buf, Long.class);
@@ -24,7 +24,7 @@ public class LogReplicationNegotiationResponse implements ICorfuPayload<LogRepli
         lastLogProcessed = ICorfuPayload.fromBuffer(buf, Long.class);
     }
 
-    public LogReplicationNegotiationResponse(long siteConfigID, String version, long snapshotStart, long lastTransferDone, long snapshotAppliedDone, long lastLogProcessed) {
+    public LogReplicationQueryMetadataResponse(long siteConfigID, String version, long snapshotStart, long lastTransferDone, long snapshotAppliedDone, long lastLogProcessed) {
         this.siteConfigID = siteConfigID;
         this.version = version;
         this.snapshotStart = snapshotStart;
@@ -33,8 +33,8 @@ public class LogReplicationNegotiationResponse implements ICorfuPayload<LogRepli
         this.lastLogProcessed = lastLogProcessed;
     }
 
-    public static LogReplicationNegotiationResponse fromProto(Messages.LogReplicationNegotiationResponse proto) {
-        return new LogReplicationNegotiationResponse(proto.getSiteConfigID(),
+    public static LogReplicationQueryMetadataResponse fromProto(Messages.LogReplicationNegotiationResponse proto) {
+        return new LogReplicationQueryMetadataResponse(proto.getSiteConfigID(),
                 proto.getVersion(),
                 proto.getSnapshotStart(),
                 proto.getSnapshotTransferred(),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationQueryMetadataResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationQueryMetadataResponse.java
@@ -33,7 +33,7 @@ public class LogReplicationQueryMetadataResponse implements ICorfuPayload<LogRep
         this.lastLogProcessed = lastLogProcessed;
     }
 
-    public static LogReplicationQueryMetadataResponse fromProto(Messages.LogReplicationNegotiationResponse proto) {
+    public static LogReplicationQueryMetadataResponse fromProto(Messages.LogReplicationQueryMetadataResponse proto) {
         return new LogReplicationQueryMetadataResponse(proto.getSiteConfigID(),
                 proto.getVersion(),
                 proto.getSnapshotStart(),

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/MessageType.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/MessageType.java
@@ -10,7 +10,7 @@ public enum MessageType {
     SNAPSHOT_START(3, LogReplicationEntryType.SNAPSHOT_START),
     LOG_ENTRY_REPLICATED(4, LogReplicationEntryType.LOG_ENTRY_REPLICATED),
     SNAPSHOT_REPLICATED(5, LogReplicationEntryType.SNAPSHOT_REPLICATED),
-    SNAPSHOT_END(6, LogReplicationEntryType.SNAPSHOT_END);
+    SNAPSHOT_TRANSFER_END(6, LogReplicationEntryType.SNAPSHOT_TRANSFER_END);
 
     @Getter
     int val;
@@ -40,6 +40,4 @@ public enum MessageType {
         }
         throw new IllegalArgumentException("wrong value " + type);
     }
-
-
 }

--- a/runtime/src/main/proto/messages.proto
+++ b/runtime/src/main/proto/messages.proto
@@ -40,7 +40,7 @@ message LogReplicationEntry {
     bytes data = 2;
 }
 
-message LogReplicationNegotiationResponse {
+message LogReplicationQueryMetadataResponse {
     uint64 siteConfigID = 1;
     string version = 2;
     uint64 snapshotStart = 3;
@@ -85,8 +85,8 @@ enum CorfuPriorityLevel {
 
 enum CorfuMessageType {
     LOG_REPLICATION_ENTRY = 0;
-    LOG_REPLICATION_NEGOTIATION_REQUEST = 1;
-    LOG_REPLICATION_NEGOTIATION_RESPONSE = 2;
+    LOG_REPLICATION_QUERY_METADATA_REQUEST = 1;
+    LOG_REPLICATION_QUERY_METADATA_RESPONSE = 2;
     LOG_REPLICATION_QUERY_LEADERSHIP = 3;
     LOG_REPLICATION_QUERY_LEADERSHIP_RESPONSE = 4;
 }

--- a/runtime/src/main/proto/messages.proto
+++ b/runtime/src/main/proto/messages.proto
@@ -75,7 +75,7 @@ enum LogReplicationEntryType {
     SNAPSHOT_START = 2;
     LOG_ENTRY_REPLICATED = 3;
     SNAPSHOT_REPLICATED = 4;
-    SNAPSHOT_END = 5;
+    SNAPSHOT_TRANSFER_END = 5;
 }
 
 enum CorfuPriorityLevel {

--- a/test/src/test/java/org/corfudb/integration/AckDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/AckDataSender.java
@@ -1,10 +1,14 @@
 package org.corfudb.integration;
 
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.logreplication.LogReplicationSourceManager;
+import org.corfudb.protocols.wireprotocol.CorfuMsg;
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 import org.corfudb.infrastructure.logreplication.LogReplicationError;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -15,6 +19,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+@Slf4j
 @Data
 public class AckDataSender implements DataSender {
 
@@ -44,6 +49,12 @@ public class AckDataSender implements DataSender {
         CompletableFuture<LogReplicationEntry> ackCF = new CompletableFuture<>();
         messages.forEach(msg -> send(msg));
         return ackCF;
+    }
+
+    @Override
+    public LogReplicationQueryMetadataResponse sendQueryMetadata() {
+        log.warn("Not implemented");
+        return null;
     }
 
     @Override

--- a/test/src/test/java/org/corfudb/integration/AckDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/AckDataSender.java
@@ -52,7 +52,7 @@ public class AckDataSender implements DataSender {
     }
 
     @Override
-    public LogReplicationQueryMetadataResponse sendQueryMetadata() {
+    public LogReplicationQueryMetadataResponse sendQueryMetadataRequest() {
         log.warn("Not implemented");
         return null;
     }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
@@ -15,24 +15,9 @@ import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class CorfuReplicationE2EIT extends AbstractIT {
 
-    private boolean useNetty;
-    private boolean runProcess = true;
-
-    public CorfuReplicationE2EIT(boolean netty) {
-        this.useNetty = netty;
-    }
-
-    // Static method that generates and returns test data (automatically test for two transport protocols: netty and GRPC)
-    @Parameterized.Parameters
-    public static Collection input() {
-        return Arrays.asList(Boolean.FALSE, Boolean.TRUE);
-    }
-
-    @Test
-    public void testLogReplicationEndToEnd() throws Exception {
+    public void testLogReplicationEndToEnd(boolean useNetty, boolean runProcess) throws Exception {
         ExecutorService executorService = Executors.newFixedThreadPool(2);
         Process activeCorfu = null;
         Process standbyCorfu = null;
@@ -163,5 +148,15 @@ public class CorfuReplicationE2EIT extends AbstractIT {
                 standbyReplicationServer.destroy();
             }
         }
+    }
+
+    @Test
+    public void testLogReplicationEndToEndWithNetty() throws Exception {
+        testLogReplicationEndToEnd(true, false);
+    }
+
+    @Test
+    public void testLogReplicationEndToEndWithCustom() throws Exception {
+        testLogReplicationEndToEnd(false, false);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationSiteConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationSiteConfigIT.java
@@ -196,10 +196,12 @@ public class CorfuReplicationSiteConfigIT extends AbstractIT {
         }
     }
 
+    @Test
     public void runNetty() throws Exception {
         testLogReplicationEndToEnd(true, false);
     }
 
+    @Test
     public void runCustomRouter() throws Exception {
         testLogReplicationEndToEnd(false, false);
     }

--- a/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
@@ -343,21 +343,18 @@ public class ReplicationReaderWriterIT extends AbstractIT {
             SnapshotReadMessage snapshotReadMessage = reader.read(PRIMARY_SITE_ID);
             for (org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry data : snapshotReadMessage.getMessages()) {
                 msgQ.add(data);
-                //System.out.println("generate msg " + cnt);
             }
 
             if (snapshotReadMessage.isEndRead()) {
                 break;
             }
         }
-    }
+  }
 
     public static void writeSnapLogMsgs(List<org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry> msgQ, Set<String> streams, CorfuRuntime rt) {
         LogReplicationConfig config = new LogReplicationConfig(streams, PRIMARY_SITE_ID, REMOTE_SITE_ID);
         LogReplicationMetadataAccessor logReplicationMetadataAccessor = new LogReplicationMetadataAccessor(rt, 0, PRIMARY_SITE_ID, REMOTE_SITE_ID);
         StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, config, logReplicationMetadataAccessor);
-
-
 
         if (msgQ.isEmpty()) {
             System.out.println("msgQ is empty");
@@ -372,6 +369,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
             writer.apply(msg);
         }
 
+        logReplicationMetadataAccessor.setLastSnapTransferDoneTimestamp(siteConfigID, snapshot);
         writer.applyShadowStreams();
     }
 
@@ -638,6 +636,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
         verifyData("after writing to dst", dstTables, dstHashMap);
 
         printTails("after writing to server1", srcDataRuntime, dstDataRuntime);
+
 
         //read snapshot from srcServer and put msgs into Queue
         readSnapLogMsgs(msgQ, srcHashMap.keySet(), readerRuntime);

--- a/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
@@ -13,6 +13,8 @@ import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
+import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuTable;
@@ -369,8 +371,10 @@ public class ReplicationReaderWriterIT extends AbstractIT {
             writer.apply(msg);
         }
 
-        logReplicationMetadataAccessor.setLastSnapTransferDoneTimestamp(siteConfigID, snapshot);
-        writer.applyShadowStreams();
+        LogReplicationEntry msg = msgQ.get(msgQ.size() - 1);
+        msg.getMetadata().setSnapshotSyncSeqNum(msg.getMetadata().getSnapshotSyncSeqNum() + 1);
+        msg.getMetadata().setMessageMetadataType(MessageType.SNAPSHOT_TRANSFER_END);
+        writer.snapshotTransferDone(msg);
     }
 
     void accessTxStream(Iterator iterator, int num) {

--- a/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
@@ -373,7 +373,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
         }
 
         Long seq = writer.getLogReplicationMetadataManager().getLastSnapSeqNum() + 1;
-        writer.applyShadowStreams(seq);
+        writer.applyShadowStreams();
     }
 
     void accessTxStream(Iterator iterator, int num) {

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -104,7 +104,7 @@ public class SourceForwardingDataSender implements DataSender {
 
         for (LogReplicationEntry message :  messages) {
             tmp = send(message);
-            if (message.getMetadata().getMessageMetadataType().equals(MessageType.SNAPSHOT_END) ||
+            if (message.getMetadata().getMessageMetadataType().equals(MessageType.SNAPSHOT_TRANSFER_END) ||
                     message.getMetadata().getMessageMetadataType().equals(MessageType.LOG_ENTRY_MESSAGE)) {
                 lastAckMessage = tmp;
             }

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -6,8 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
-import org.corfudb.infrastructure.logreplication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.receive.LogReplicationSinkManager;
 import org.corfudb.logreplication.LogReplicationSourceManager;
 import org.corfudb.infrastructure.logreplication.LogReplicationError;
@@ -77,7 +75,7 @@ public class SourceForwardingDataSender implements DataSender {
 
     @Override
     public CompletableFuture<LogReplicationEntry> send(LogReplicationEntry message) {
-        //System.out.println("Send message: " + message.getMetadata().getMessageMetadataType() + " for:: " + message.getMetadata().getTimestamp());
+        //System.out.println("Send message: " + message.getLogReplicationStatus().getMessageMetadataType() + " for:: " + message.getLogReplicationStatus().getTimestamp());
         if (ifDropMsg > 0 && message.getMetadata().timestamp == firstDrop) {
             System.out.println("****** Drop log entry " + message.getMetadata().timestamp);
             if (ifDropMsg == DROP_MSG_ONCE) {
@@ -125,7 +123,7 @@ public class SourceForwardingDataSender implements DataSender {
     }
 
     @Override
-    public LogReplicationQueryMetadataResponse sendQueryMetadata() {
+    public LogReplicationQueryMetadataResponse sendQueryMetadataRequest() {
         log.info("Process query metadata");
         LogReplicationQueryMetadataResponse response = destinationLogReplicationManager.processQueryMetadataRequest();
         return response;

--- a/test/src/test/java/org/corfudb/logreplication/fsm/EmptyDataSender.java
+++ b/test/src/test/java/org/corfudb/logreplication/fsm/EmptyDataSender.java
@@ -3,6 +3,7 @@ package org.corfudb.logreplication.fsm;
 import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.infrastructure.logreplication.LogReplicationError;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -17,6 +18,11 @@ public class EmptyDataSender implements DataSender {
 
     @Override
     public CompletableFuture<LogReplicationEntry>  send(List<LogReplicationEntry> messages) { return new CompletableFuture<>(); }
+
+    @Override
+    public LogReplicationQueryMetadataResponse sendQueryMetadata() {
+        return null;
+    }
 
     @Override
     public void onError(LogReplicationError error) {}

--- a/test/src/test/java/org/corfudb/logreplication/fsm/EmptyDataSender.java
+++ b/test/src/test/java/org/corfudb/logreplication/fsm/EmptyDataSender.java
@@ -20,7 +20,7 @@ public class EmptyDataSender implements DataSender {
     public CompletableFuture<LogReplicationEntry>  send(List<LogReplicationEntry> messages) { return new CompletableFuture<>(); }
 
     @Override
-    public LogReplicationQueryMetadataResponse sendQueryMetadata() {
+    public LogReplicationQueryMetadataResponse sendQueryMetadataRequest() {
         return null;
     }
 

--- a/test/src/test/java/org/corfudb/logreplication/fsm/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/logreplication/fsm/LogReplicationFSMTest.java
@@ -214,13 +214,11 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         int numTransition = (NUM_ENTRIES/(batchSize* SnapshotSender.SNAPSHOT_BATCH_SIZE)) + 1;
         Queue<LogReplicationEntry> listenerQueue = ((TestDataSender) dataSender).getEntryQueue();
 
-
         for (int i = 0; i < numTransition; i++) {
             System.out.print("\nnumTransitions " + numTransition + " i " + i);
             transitionAvailable.acquire();
         }
 
-        assertThat(fsm.getState().getType()).isEqualTo(LogReplicationStateType.IN_LOG_ENTRY_SYNC);
         assertThat(listenerQueue.size()).isEqualTo(NUM_ENTRIES);
 
         for (int i = 0; i < NUM_ENTRIES; i++) {
@@ -269,11 +267,8 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         transitionAvailable.acquire();
         fsm.input(new LogReplicationEvent(LogReplicationEventType.REPLICATION_STOP));
 
-        boolean transitionOccurred = true;
-        while (transitionOccurred) {
-            if (fsm.getState().getType() == LogReplicationStateType.INITIALIZED) {
-                transitionOccurred = false;
-            }
+        while (fsm.getState().getType() != LogReplicationStateType.INITIALIZED) {
+            //System.out.print("\nstate " + fsm.getState().getType());
         }
 
         assertThat(fsm.getState().getType()).isEqualTo(LogReplicationStateType.INITIALIZED);
@@ -282,18 +277,22 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         // Stop observing number of messages in snapshot sync, so this time it completes
         observeSnapshotSync = false;
-
-        // Transition #2: This time the snapshot sync completes
-        transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC, true);
-
-        for (int i = 0; i<(NUM_ENTRIES/(BATCH_SIZE * SnapshotSender.SNAPSHOT_BATCH_SIZE)) + 1; i++) {
-            transitionAvailable.acquire();
-        }
-
-        assertThat(fsm.getState().getType()).isEqualTo(LogReplicationStateType.IN_LOG_ENTRY_SYNC);
-
         Queue<LogReplicationEntry> listenerQueue = ((TestDataSender) dataSender).getEntryQueue();
 
+        // Transition #2: This time the snapshot sync completes
+        fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST));
+
+
+        for (int i = 0; i<(NUM_ENTRIES/(BATCH_SIZE * SnapshotSender.SNAPSHOT_BATCH_SIZE)) + 1; i++) {
+           //transitionAvailable.acquire();
+        }
+
+        //assertThat(fsm.getState().getType()).isEqualTo(LogReplicationStateType.IN_LOG_ENTRY_SYNC);
+
+        while (listenerQueue.size() < NUM_ENTRIES) {
+           int i = listenerQueue.size();
+           //
+        }
         assertThat(listenerQueue.size()).isEqualTo(NUM_ENTRIES);
 
         for (int i=0; i<NUM_ENTRIES; i++) {
@@ -324,21 +323,27 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         // transition(LogReplicationEventType.REPLICATION_START, LogReplicationStateType.IN_LOG_ENTRY_SYNC);
 
         // Transition #2: Snapshot Sync Request
-        transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC, true);
+        fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST));
+        //transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC, true);
 
         // Block until the snapshot sync completes and next transition occurs.
         // The transition should happen to IN_LOG_ENTRY_SYNC state.
         System.out.println("**** Wait for snapshot sync to complete");
 
         // Block until the snapshot sync completes and next transition occurs.
-        while (fsm.getState().getType() != LogReplicationStateType.IN_LOG_ENTRY_SYNC) {
-            //
-        }
+        // while (fsm.getState().getType() != LogReplicationStateType.IN_LOG_ENTRY_SYNC) {
+        //
+        // }
 
-        assertThat(fsm.getState().getType()).isEqualTo(LogReplicationStateType.IN_LOG_ENTRY_SYNC);
-
+        //assertThat(fsm.getState().getType()).isEqualTo(LogReplicationStateType.IN_LOG_ENTRY_SYNC);
         Queue<LogReplicationEntry> listenerQueue = ((TestDataSender) dataSender).getEntryQueue();
 
+        while (listenerQueue.size() < LARGE_NUM_ENTRIES/StreamsSnapshotReader.MAX_NUM_SMR_ENTRY) {
+            sleep(WAIT_TIME);
+            System.out.print("\nqueueSize " + listenerQueue.size() + "\n");
+        }
+
+        System.out.print("\nqueueSize " + listenerQueue.size() + "\n");
         assertThat(LARGE_NUM_ENTRIES/StreamsSnapshotReader.MAX_NUM_SMR_ENTRY).isLessThanOrEqualTo(listenerQueue.size());
 
         // Transactional puts into the stream (incremental updates)

--- a/test/src/test/java/org/corfudb/logreplication/fsm/ReplicationReaderWriterTest.java
+++ b/test/src/test/java/org/corfudb/logreplication/fsm/ReplicationReaderWriterTest.java
@@ -13,6 +13,7 @@ import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
+import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.collections.CorfuStore;
@@ -132,7 +133,10 @@ public class ReplicationReaderWriterTest extends AbstractViewTest {
             writer.apply(msg);
         }
 
-        writer.applyShadowStreams();
+        LogReplicationEntry msg = msgQ.get(msgQ.size() - 1);
+        msg.getMetadata().setSnapshotSyncSeqNum(msg.getMetadata().getSnapshotSyncSeqNum() + 1);
+        msg.getMetadata().setMessageMetadataType(MessageType.SNAPSHOT_TRANSFER_END);
+        writer.snapshotTransferDone(msg);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/logreplication/fsm/ReplicationReaderWriterTest.java
+++ b/test/src/test/java/org/corfudb/logreplication/fsm/ReplicationReaderWriterTest.java
@@ -131,13 +131,8 @@ public class ReplicationReaderWriterTest extends AbstractViewTest {
         for (LogReplicationEntry msg : msgQ) {
             writer.apply(msg);
         }
-        Long seq = writer.getLogReplicationMetadataManager().getLastSnapSeqNum() + 1;
 
-        //for (CorfuTable<Long, Long> corfuTable : shadowTables.values()) {
-        //    System.out.print("\nCorfuTable " + corfuTable.size() + " values " + corfuTable.values());
-        //}
-
-        writer.applyShadowStreams(seq);
+        writer.applyShadowStreams();
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/logreplication/fsm/ReplicationReaderWriterTest.java
+++ b/test/src/test/java/org/corfudb/logreplication/fsm/ReplicationReaderWriterTest.java
@@ -2,7 +2,7 @@ package org.corfudb.logreplication.fsm;
 
 import org.corfudb.infrastructure.logreplication.receive.LogEntryWriter;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
-import org.corfudb.infrastructure.logreplication.receive.LogReplicationMetadataManager;
+import org.corfudb.infrastructure.logreplication.receive.LogReplicationMetadataAccessor;
 import org.corfudb.infrastructure.logreplication.receive.StreamsSnapshotWriter;
 import org.corfudb.integration.ReplicationReaderWriterIT;
 import org.corfudb.logreplication.send.logreader.LogEntryReader;
@@ -84,9 +84,9 @@ public class ReplicationReaderWriterTest extends AbstractViewTest {
 
         UUID uuid = UUID.randomUUID();
         LogReplicationConfig config = new LogReplicationConfig(hashMap.keySet(), PRIMARY_SITE_ID, REMOTE_SITE_ID);
-        LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(readerRuntime, 0, uuid, uuid);
+        LogReplicationMetadataAccessor logReplicationMetadataAccessor = new LogReplicationMetadataAccessor(readerRuntime, 0, uuid, uuid);
         logEntryReader = new StreamsLogEntryReader(readerRuntime, config);
-        logEntryWriter = new LogEntryWriter(writerRuntime, config, logReplicationMetadataManager);
+        logEntryWriter = new LogEntryWriter(writerRuntime, config, logReplicationMetadataAccessor);
     }
 
     @Test
@@ -123,8 +123,8 @@ public class ReplicationReaderWriterTest extends AbstractViewTest {
     void writeMsgs(List<LogReplicationEntry> msgQ, Set<String> streams, CorfuRuntime rt) {
         UUID uuid = UUID.randomUUID();
         LogReplicationConfig config = new LogReplicationConfig(streams, PRIMARY_SITE_ID, REMOTE_SITE_ID);
-        LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt, 0, uuid, uuid);
-        StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, config, logReplicationMetadataManager);
+        LogReplicationMetadataAccessor logReplicationMetadataAccessor = new LogReplicationMetadataAccessor(rt, 0, uuid, uuid);
+        StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, config, logReplicationMetadataAccessor);
 
         writer.reset(msgQ.get(0).getMetadata().getSiteConfigID(), msgQ.get(0).getMetadata().getSnapshotTimestamp());
 

--- a/test/src/test/java/org/corfudb/logreplication/fsm/TestDataSender.java
+++ b/test/src/test/java/org/corfudb/logreplication/fsm/TestDataSender.java
@@ -34,6 +34,7 @@ public class TestDataSender implements DataSender {
                     message.getMetadata().getMessageMetadataType().equals(MessageType.LOG_ENTRY_MESSAGE)) {
                 // Ignore, do not account Start and End Markers as messages
                 entryQueue.add(message);
+                log.info("add message to the entryQueue {}", entryQueue.size());
             }
         }
 
@@ -65,7 +66,7 @@ public class TestDataSender implements DataSender {
     }
 
     @Override
-    public LogReplicationQueryMetadataResponse sendQueryMetadata() throws ExecutionException, InterruptedException {
+    public LogReplicationQueryMetadataResponse sendQueryMetadataRequest() throws ExecutionException, InterruptedException {
         log.warn("Not implemented");
         return null;
     }

--- a/test/src/test/java/org/corfudb/logreplication/fsm/TestDataSender.java
+++ b/test/src/test/java/org/corfudb/logreplication/fsm/TestDataSender.java
@@ -1,20 +1,24 @@
 package org.corfudb.logreplication.fsm;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.infrastructure.logreplication.LogReplicationError;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 
 /**
  * Test Implementation of Snapshot Data Sender
  */
+@Slf4j
 public class TestDataSender implements DataSender {
 
     @Getter
@@ -59,7 +63,13 @@ public class TestDataSender implements DataSender {
 
         return lastSentMessage;
     }
-    
+
+    @Override
+    public LogReplicationQueryMetadataResponse sendQueryMetadata() throws ExecutionException, InterruptedException {
+        log.warn("Not implemented");
+        return null;
+    }
+
     public void reset() {
         entryQueue.clear();
     }

--- a/test/src/test/java/org/corfudb/logreplication/fsm/TestDataSender.java
+++ b/test/src/test/java/org/corfudb/logreplication/fsm/TestDataSender.java
@@ -55,7 +55,7 @@ public class TestDataSender implements DataSender {
 
             for (LogReplicationEntry message : messages) {
                 tmp = send(message);
-                if (message.getMetadata().getMessageMetadataType().equals(MessageType.SNAPSHOT_END) ||
+                if (message.getMetadata().getMessageMetadataType().equals(MessageType.SNAPSHOT_TRANSFER_END) ||
                         message.getMetadata().getMessageMetadataType().equals(MessageType.LOG_ENTRY_MESSAGE)) {
                     lastSentMessage = tmp;
                 }

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -45,9 +45,9 @@
     </logger>
 
 
-    <!--<root level="TRACE">-->
-        <!--&lt;!&ndash;<appender-ref ref="FILE" />&ndash;&gt;-->
-        <!--<appender-ref ref="STDOUT" />-->
-        <!--&lt;!&ndash;<appender-ref ref="MetricsRollingFile" />&ndash;&gt;-->
-    <!--</root>-->
+    <root level="INFO">
+        <appender-ref ref="FILE" />
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="MetricsRollingFile" />
+    </root>
 </configuration>

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -44,10 +44,9 @@
         <!--<appender-ref ref="MetricsRollingFile" />-->
     </logger>
 
-
-    <!--<root level="TRACE">-->
-        <!--&lt;!&ndash;<appender-ref ref="FILE" />&ndash;&gt;-->
-        <!--<appender-ref ref="STDOUT" />-->
-        <!--&lt;!&ndash;<appender-ref ref="MetricsRollingFile" />&ndash;&gt;-->
-    <!--</root>-->
+    <root level="INFO">
+        <appender-ref ref="FILE" />
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="MetricsRollingFile" />
+    </root>
 </configuration>

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -44,9 +44,10 @@
         <!--<appender-ref ref="MetricsRollingFile" />-->
     </logger>
 
-    <root level="INFO">
-        <appender-ref ref="FILE" />
-        <appender-ref ref="STDOUT" />
-        <appender-ref ref="MetricsRollingFile" />
-    </root>
+
+    <!--<root level="TRACE">-->
+        <!--&lt;!&ndash;<appender-ref ref="FILE" />&ndash;&gt;-->
+        <!--<appender-ref ref="STDOUT" />-->
+        <!--&lt;!&ndash;<appender-ref ref="MetricsRollingFile" />&ndash;&gt;-->
+    <!--</root>-->
 </configuration>

--- a/transport/src/main/java/org/corfudb/transport/logreplication/LogReplicationClientRouter.java
+++ b/transport/src/main/java/org/corfudb/transport/logreplication/LogReplicationClientRouter.java
@@ -15,7 +15,6 @@ import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.transport.client.IClientChannelAdapter;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.NodeLocator;
-import org.corfudb.util.InterClusterConnectionDescriptor;
 import org.corfudb.utils.common.CorfuMessageConverter;
 import org.corfudb.utils.common.CorfuMessageProtoBufException;
 
@@ -173,8 +172,8 @@ public class LogReplicationClientRouter implements IClientRouter {
 
     private boolean isValidMessage(CorfuMsg message) {
         return message.getMsgType().equals(CorfuMsgType.LOG_REPLICATION_ENTRY) ||
-                message.getMsgType().equals(CorfuMsgType.LOG_REPLICATION_NEGOTIATION_REQUEST) ||
-                message.getMsgType().equals(CorfuMsgType.LOG_REPLICATION_NEGOTIATION_RESPONSE) ||
+                message.getMsgType().equals(CorfuMsgType.LOG_REPLICATION_QUERY_METADATA_REQUEST) ||
+                message.getMsgType().equals(CorfuMsgType.LOG_REPLICATION_QUERY_METADATA_RESPONSE) ||
                 message.getMsgType().equals(CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP) ||
                 message.getMsgType().equals(CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP_RESPONSE);
     }

--- a/transport/src/main/java/org/corfudb/transport/test/GRPCLogReplicationClientChannelAdapter.java
+++ b/transport/src/main/java/org/corfudb/transport/test/GRPCLogReplicationClientChannelAdapter.java
@@ -79,7 +79,7 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
                     requestObserver.onNext(msg);
                 }
                 break;
-            case LOG_REPLICATION_NEGOTIATION_REQUEST:
+            case LOG_REPLICATION_QUERY_METADATA_REQUEST:
                 try {
                     response = blockingStub.withWaitForReady().negotiate(msg);
                     getRouter().receive(response);

--- a/utils/src/main/java/org/corfudb/utils/common/CorfuMessageConverter.java
+++ b/utils/src/main/java/org/corfudb/utils/common/CorfuMessageConverter.java
@@ -60,8 +60,8 @@ public class CorfuMessageConverter {
                 CorfuPayloadMsg<LogReplicationQueryMetadataResponse> corfuMsg = (CorfuPayloadMsg<LogReplicationQueryMetadataResponse>) msg;
                 LogReplicationQueryMetadataResponse negotiationResponse = corfuMsg.getPayload();
                 return protoCorfuMsg
-                        .setType(Messages.CorfuMessageType.LOG_REPLICATION_NEGOTIATION_RESPONSE)
-                        .setPayload(Any.pack(Messages.LogReplicationNegotiationResponse.newBuilder()
+                        .setType(Messages.CorfuMessageType.LOG_REPLICATION_QUERY_METADATA_RESPONSE)
+                        .setPayload(Any.pack(Messages.LogReplicationQueryMetadataResponse.newBuilder()
                                 .setSiteConfigID(negotiationResponse.getSiteConfigID())
                                 .setVersion(negotiationResponse.getVersion())
                                 .setSnapshotStart(negotiationResponse.getSnapshotStart())
@@ -82,7 +82,7 @@ public class CorfuMessageConverter {
                         .build();
             case LOG_REPLICATION_QUERY_METADATA_REQUEST:
                 return protoCorfuMsg
-                        .setType(Messages.CorfuMessageType.LOG_REPLICATION_NEGOTIATION_REQUEST)
+                        .setType(Messages.CorfuMessageType.LOG_REPLICATION_QUERY_METADATA_REQUEST)
                         .build();
             case LOG_REPLICATION_QUERY_LEADERSHIP:
                 return protoCorfuMsg
@@ -120,15 +120,15 @@ public class CorfuMessageConverter {
                             .setPriorityLevel(priorityLevel)
                             .setBuf(buf)
                             .setEpoch(epoch);
-                case LOG_REPLICATION_NEGOTIATION_REQUEST:
+                case LOG_REPLICATION_QUERY_METADATA_REQUEST:
                     return new CorfuMsg(clientId, null, requestId, epoch, null,
                             CorfuMsgType.LOG_REPLICATION_QUERY_METADATA_REQUEST, priorityLevel);
                 case LOG_REPLICATION_QUERY_LEADERSHIP:
                     return new CorfuMsg(clientId, null, requestId, epoch, null,
                             CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP, priorityLevel);
-                case LOG_REPLICATION_NEGOTIATION_RESPONSE:
+                case LOG_REPLICATION_QUERY_METADATA_RESPONSE:
                         LogReplicationQueryMetadataResponse negotiationResponse = LogReplicationQueryMetadataResponse
-                                .fromProto(protoMessage.getPayload().unpack(Messages.LogReplicationNegotiationResponse.class));
+                                .fromProto(protoMessage.getPayload().unpack(Messages.LogReplicationQueryMetadataResponse.class));
 
                         return new CorfuPayloadMsg<>(CorfuMsgType.LOG_REPLICATION_QUERY_METADATA_RESPONSE, negotiationResponse)
                                 .setClientID(clientId)

--- a/utils/src/main/java/org/corfudb/utils/common/CorfuMessageConverter.java
+++ b/utils/src/main/java/org/corfudb/utils/common/CorfuMessageConverter.java
@@ -9,7 +9,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.PriorityLevel;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
-import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationNegotiationResponse;
+import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryMetadataResponse;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationQueryLeaderShipResponse;
 import org.corfudb.runtime.Messages;
 import org.corfudb.runtime.Messages.CorfuMessage;
@@ -56,9 +56,9 @@ public class CorfuMessageConverter {
                                 .setData(ByteString.copyFrom(logReplicationEntry.getPayload()))
                                 .build()))
                         .build();
-            case LOG_REPLICATION_NEGOTIATION_RESPONSE:
-                CorfuPayloadMsg<LogReplicationNegotiationResponse> corfuMsg = (CorfuPayloadMsg<LogReplicationNegotiationResponse>) msg;
-                LogReplicationNegotiationResponse negotiationResponse = corfuMsg.getPayload();
+            case LOG_REPLICATION_QUERY_METADATA_RESPONSE:
+                CorfuPayloadMsg<LogReplicationQueryMetadataResponse> corfuMsg = (CorfuPayloadMsg<LogReplicationQueryMetadataResponse>) msg;
+                LogReplicationQueryMetadataResponse negotiationResponse = corfuMsg.getPayload();
                 return protoCorfuMsg
                         .setType(Messages.CorfuMessageType.LOG_REPLICATION_NEGOTIATION_RESPONSE)
                         .setPayload(Any.pack(Messages.LogReplicationNegotiationResponse.newBuilder()
@@ -80,7 +80,7 @@ public class CorfuMessageConverter {
                                 .setIsLeader(leaderShipResponse.isLeader())
                                 .build()))
                         .build();
-            case LOG_REPLICATION_NEGOTIATION_REQUEST:
+            case LOG_REPLICATION_QUERY_METADATA_REQUEST:
                 return protoCorfuMsg
                         .setType(Messages.CorfuMessageType.LOG_REPLICATION_NEGOTIATION_REQUEST)
                         .build();
@@ -122,15 +122,15 @@ public class CorfuMessageConverter {
                             .setEpoch(epoch);
                 case LOG_REPLICATION_NEGOTIATION_REQUEST:
                     return new CorfuMsg(clientId, null, requestId, epoch, null,
-                            CorfuMsgType.LOG_REPLICATION_NEGOTIATION_REQUEST, priorityLevel);
+                            CorfuMsgType.LOG_REPLICATION_QUERY_METADATA_REQUEST, priorityLevel);
                 case LOG_REPLICATION_QUERY_LEADERSHIP:
                     return new CorfuMsg(clientId, null, requestId, epoch, null,
                             CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP, priorityLevel);
                 case LOG_REPLICATION_NEGOTIATION_RESPONSE:
-                        LogReplicationNegotiationResponse negotiationResponse = LogReplicationNegotiationResponse
+                        LogReplicationQueryMetadataResponse negotiationResponse = LogReplicationQueryMetadataResponse
                                 .fromProto(protoMessage.getPayload().unpack(Messages.LogReplicationNegotiationResponse.class));
 
-                        return new CorfuPayloadMsg<>(CorfuMsgType.LOG_REPLICATION_NEGOTIATION_RESPONSE, negotiationResponse)
+                        return new CorfuPayloadMsg<>(CorfuMsgType.LOG_REPLICATION_QUERY_METADATA_RESPONSE, negotiationResponse)
                                 .setClientID(clientId)
                                 .setRequestID(requestId)
                                 .setPriorityLevel(priorityLevel)


### PR DESCRIPTION
While doing snapshot full sync at the sender side, it will break up the work in three phases:
   * Read and transmit data phase.
   * Retransmit pending message in the buffer
   * Query receiver status to make state transition to log entry sync.

The snapshot full sync at the receiver side has two phases:
  * receiving data from sender and apply data to the shadow streams till receive an end marker for 
    data transfer.
  * applying data from shadow streams to the real streams.

During the negotiation phase, if the sender detect the receiver is at snapshot applying phase (TODO):
  * the sender will restart the snapshot sync by sending an end marker for data transfer.
 * while the receiver receives the end marker will start to do the applying phase.
 * the sender will keep polling the receiver's status while detecting the applying phase is done,
   it will transit to the log entry sync.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
