### PR TITLE
Startup TopologyConfigId Fix Receiver

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -51,10 +51,11 @@ public class LogReplicationServer extends AbstractServer {
     private final HandlerMethods handler = HandlerMethods.generateHandler(MethodHandles.lookup(), this);
 
     public LogReplicationServer(@Nonnull ServerContext context, @Nonnull  LogReplicationConfig logReplicationConfig,
-                                @Nonnull LogReplicationMetadataManager metadataManager, String corfuEndpoint) {
+                                @Nonnull LogReplicationMetadataManager metadataManager, String corfuEndpoint,
+                                long topologyConfigId) {
         this.serverContext = context;
         this.metadataManager = metadataManager;
-        this.sinkManager = new LogReplicationSinkManager(corfuEndpoint, logReplicationConfig, metadataManager, serverContext);
+        this.sinkManager = new LogReplicationSinkManager(corfuEndpoint, logReplicationConfig, metadataManager, serverContext, topologyConfigId);
 
         this.executor = Executors.newFixedThreadPool(1,
                 new ServerThreadFactory("LogReplicationServer-", new ServerThreadFactory.ExceptionHandler()));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -19,7 +19,6 @@ import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Properties;
-import java.util.UUID;
 
 import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_END;
 import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_MESSAGE;
@@ -63,11 +62,6 @@ public class LogReplicationSinkManager implements DataReceiver {
     private LogReplicationConfig config;
 
     /*
-     * The last or current snapshot request id.
-     */
-    private UUID snapshotRequestId = new UUID(0L, 0L);
-
-    /*
      * the current baseSnapshot
      */
     private long baseSnapshotTimestamp = Address.NON_ADDRESS - 1;
@@ -95,7 +89,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      */
     public LogReplicationSinkManager(String localCorfuEndpoint, LogReplicationConfig config,
                                      LogReplicationMetadataManager metadataManager,
-                                     ServerContext context) {
+                                     ServerContext context, long topologyConfigId) {
         this.logReplicationMetadataManager = metadataManager;
         this.runtime =  CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder()
                 .trustStore((String) context.getServerConfig().get("--truststore"))
@@ -113,6 +107,7 @@ public class LogReplicationSinkManager implements DataReceiver {
          */
         this.rxState = RxState.LOG_ENTRY_SYNC;
         this.config = config;
+        this.topologyConfigId = topologyConfigId;
         init();
     }
 
@@ -138,6 +133,8 @@ public class LogReplicationSinkManager implements DataReceiver {
         this.config = config;
         init();
     }
+
+
 
     /**
      * Init variables.
@@ -224,7 +221,7 @@ public class LogReplicationSinkManager implements DataReceiver {
 
             // Invalid message and drop it.
             log.warn("Sink Manager in state {} and received message {}. Dropping Message.", rxState,
-                        message.getMetadata());
+                    message.getMetadata());
 
             return null;
         }
@@ -244,7 +241,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      * @param entry
      */
     private void processSnapshotStart(LogReplicationEntry entry) {
-        long siteConfigID = entry.getMetadata().getTopologyConfigId();
+        long topologyConfigId = entry.getMetadata().getTopologyConfigId();
         long timestamp = entry.getMetadata().getSnapshotTimestamp();
 
         log.debug("Received snapshot sync start marker for {} on base snapshot timestamp {}",
@@ -265,7 +262,7 @@ public class LogReplicationSinkManager implements DataReceiver {
          * Fails to set the baseSnapshot at the metadata store, it could be a out of date message,
          * or the current node is out of sync, ignore it.
          */
-        if (logReplicationMetadataManager.setSrcBaseSnapshotStart(siteConfigID, timestamp) == false) {
+        if (logReplicationMetadataManager.setSrcBaseSnapshotStart(topologyConfigId, timestamp) == false) {
             log.warn("Sink Manager in state {} and received message {}. " +
                             "Dropping Message due to failure update of the metadata store {}",
                     rxState, entry.getMetadata(), logReplicationMetadataManager);
@@ -275,10 +272,7 @@ public class LogReplicationSinkManager implements DataReceiver {
         /*
          * Signal start of snapshot sync to the writer, so data can be cleared (on old snapshot syncs)
          */
-        snapshotWriter.reset(siteConfigID, timestamp);
-
-        // Retrieve snapshot request ID to be used for ACK of snapshot sync complete.
-        snapshotRequestId = entry.getMetadata().getSyncRequestId();
+        snapshotWriter.reset(topologyConfigId, timestamp);
 
         // Update lastTransferDone with the new snapshot transfer timestamp.
         baseSnapshotTimestamp = entry.getMetadata().getSnapshotTimestamp();
@@ -329,7 +323,7 @@ public class LogReplicationSinkManager implements DataReceiver {
     }
 
     /**
-     * While processing an inorder message, the buffer will callback and process the message
+     * While processing an in order message, the buffer will callback and process the message
      * @param message
      */
     public void processMessage(LogReplicationEntry message) {
@@ -361,14 +355,22 @@ public class LogReplicationSinkManager implements DataReceiver {
     }
 
     /**
-     * When there is a site role type flip, the Sink Manager needs do the followings:
-     * 1. reset snapshotWriter and logEntryWriter state
-     * 2. reset buffer logEntryBuffer state.
+     * Update the topology config id
+     *
      * @param topologyConfigId
      */
     public void updateTopologyConfigId(long topologyConfigId) {
         this.topologyConfigId = topologyConfigId;
+    }
 
+    /**
+     * When there is a cluster role change, the Sink Manager needs do the following:
+     *
+     * 1. Reset snapshotWriter and logEntryWriter state
+     * 2. Reset buffer logEntryBuffer state.
+     *
+     * */
+    public void reset() {
         snapshotWriter.reset(topologyConfigId, logReplicationMetadataManager.getLastSrcBaseSnapshotTimestamp());
         logEntryWriter.reset(logReplicationMetadataManager.getLastSrcBaseSnapshotTimestamp(),
                 logReplicationMetadataManager.getLastProcessedLogTimestamp());

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationEntryMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationEntryMetadata.java
@@ -56,8 +56,8 @@ public class LogReplicationEntryMetadata {
         this.timestamp = inputMetadata.timestamp;
     }
 
-    public LogReplicationEntryMetadata(MessageType type, long epoch, UUID syncRequestId, long entryTimeStamp, long previousEntryTimestamp, long snapshotTimestamp, long sequence) {
-        this(type, epoch, syncRequestId, entryTimeStamp, snapshotTimestamp);
+    public LogReplicationEntryMetadata(MessageType type, long topologyConfigId, UUID syncRequestId, long entryTimeStamp, long previousEntryTimestamp, long snapshotTimestamp, long sequence) {
+        this(type, topologyConfigId, syncRequestId, entryTimeStamp, snapshotTimestamp);
         this.previousTimestamp = previousEntryTimestamp;
         this.snapshotSyncSeqNum = sequence;
     }


### PR DESCRIPTION
## Overview

Description:

On receiver startup the topologyConfigId needs to be initialized
or received messages will be filtered out due to different topology
config id when compared to the one in the message.

Why should this be merged: Bug Fix, when starting on a topologyConfigId != 0 all messages are dropped by the receiver.
