### PR TITLE
Flush Async Logger on Exit

### DIFF
--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration scan="true" scanPeriod="30 seconds">
 
-    <!-- https://logback.qos.ch/manual/configuration.html#stopContext -->
-    <shutdownHook/>
-
     <property name="LOG_DIRECTORY" value="/var/log/corfu" />
 
     <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -27,6 +24,7 @@
     <appender name="async_file" class="ch.qos.logback.classic.AsyncAppender">
         <appender-ref ref="file" />
         <queueSize>1024</queueSize>
+        <maxFlushTime>5000</maxFlushTime>
     </appender>
 
     <root level="info">


### PR DESCRIPTION
## Overview
If not flushed, some crucial logs can be lost.

Why should this be merged: Improves debuggability 

Related issue(s) (if applicable): #2611


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
