### PR TITLE
Add Log Replication Cluster Role ITs

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -489,11 +489,12 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
      *   - Higher config id
      *   - Potential cluster role change
      *
+     * Cluster change from active to standby is a two step process, we first confirm that
+     * we are ready to do the cluster role change, so by the time we receive cluster change
+     * notification, nothing needs to be done, other than stop.
      * @param newTopology new discovered topology
      */
     public void onClusterRoleChange(TopologyDescriptor newTopology) {
-        // TODO: confirm prepare to become standby is a two-step process, otherwise,
-        //  we can't just stop on an intention to switch
         // Stop ongoing replication, stopLogReplication() checks leadership and active
         // We do not update topology until we successfully stop log replication
         if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {
@@ -507,7 +508,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
 
         // Update topology config id in metadata manager
         logReplicationMetadataManager.setupTopologyConfigId(topologyDescriptor.getTopologyConfigId());
-        log.debug("Persist new topologyConfigId {}, cluster id={}, status={}", topologyDescriptor.getTopologyConfigId(),
+        log.debug("Persist new topologyConfigId {}, cluster id={}, role={}", topologyDescriptor.getTopologyConfigId(),
                 localClusterDescriptor.getClusterId(), localClusterDescriptor.getRole());
 
         // Update replication manager
@@ -591,7 +592,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         updateReplicationManagerTopology(discoveredTopology);
         // Update topology config id in metadata manager
         logReplicationMetadataManager.setupTopologyConfigId(topologyDescriptor.getTopologyConfigId());
-        log.debug("Persist new topologyConfigId {}, cluster id={}, status={}", topologyDescriptor.getTopologyConfigId(),
+        log.debug("Persist new topologyConfigId {}, cluster id={}, role={}", topologyDescriptor.getTopologyConfigId(),
                 localClusterDescriptor.getClusterId(), localClusterDescriptor.getRole());
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
+import com.google.common.collect.Sets;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,7 @@ import org.corfudb.util.retry.IntervalRetry;
 import org.corfudb.util.retry.RetryNeededException;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -178,34 +180,40 @@ public class CorfuReplicationManager {
     }
 
     /**
+     * Update Log Replication Runtime config id.
+     */
+    public void updateRuntimeConfigId(TopologyDescriptor newConfig) {
+        runtimeToRemoteCluster.values().forEach(runtime -> runtime.updateFSMConfigId(newConfig));
+    }
+
+    /**
      * The notification of change of adding/removing standby's without epoch change.
      *
      * @param newConfig has the same topologyConfigId as the current config
      */
     public void processStandbyChange(TopologyDescriptor newConfig) {
         if (newConfig.getTopologyConfigId() != topology.getTopologyConfigId()) {
-            log.error("Detected changes in the topology. The new topology descriptor {} doesn't have the same " +
+            log.warn("Detected changes in the topology. The new topology descriptor {} doesn't have the same " +
                     "topologyConfigId as the current one {}", newConfig, topology);
-            return;
         }
 
-        Map<String, ClusterDescriptor> newStandbys = newConfig.getStandbyClusters();
-        Map<String, ClusterDescriptor> currentStandbys = topology.getStandbyClusters();
-        newStandbys.keySet().retainAll(currentStandbys.keySet());
-        Set<String> standbysToRemove = currentStandbys.keySet();
-        standbysToRemove.removeAll(newStandbys.keySet());
+        Set<String> currentStandbys = new HashSet<>(topology.getStandbyClusters().keySet());
+        Set<String> newStandbys = new HashSet<>(newConfig.getStandbyClusters().keySet());
+        Set<String> intersection = Sets.intersection(currentStandbys, newStandbys);
 
-        /*
-         * Remove standbys that are not in the new config
-         */
+        //standbysToRemove = currentStandbys - intersection
+        Set<String> standbysToRemove = new HashSet<>(currentStandbys);
+        standbysToRemove.removeAll(intersection);
+
+        //Remove standbys that are not in the new config
         for (String clusterId : standbysToRemove) {
             stopLogReplicationRuntime(clusterId);
             topology.removeStandbyCluster(clusterId);
         }
 
         //Start the standbys that are in the new config but not in the current config
-        for (String clusterId : newConfig.getStandbyClusters().keySet()) {
-            if (runtimeToRemoteCluster.get(clusterId) == null) {
+        for (String clusterId : newStandbys) {
+            if (!runtimeToRemoteCluster.containsKey(clusterId)) {
                 ClusterDescriptor clusterInfo = newConfig.getStandbyClusters().get(clusterId);
                 topology.addStandbyCluster(clusterInfo);
                 startLogReplicationRuntime(clusterInfo);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -189,9 +189,10 @@ public class CorfuReplicationManager {
     /**
      * The notification of change of adding/removing standby's without epoch change.
      *
-     * @param newConfig has the same topologyConfigId as the current config
+     * @param newConfig should have the same topologyConfigId as the current config
      */
     public void processStandbyChange(TopologyDescriptor newConfig) {
+        // ConfigId mismatch could happen if customized cluster manager does not follow protocol
         if (newConfig.getTopologyConfigId() != topology.getTopologyConfigId()) {
             log.warn("Detected changes in the topology. The new topology descriptor {} doesn't have the same " +
                     "topologyConfigId as the current one {}", newConfig, topology);
@@ -201,7 +202,6 @@ public class CorfuReplicationManager {
         Set<String> newStandbys = new HashSet<>(newConfig.getStandbyClusters().keySet());
         Set<String> intersection = Sets.intersection(currentStandbys, newStandbys);
 
-        //standbysToRemove = currentStandbys - intersection
         Set<String> standbysToRemove = new HashSet<>(currentStandbys);
         standbysToRemove.removeAll(intersection);
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/TopologyDescriptor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/TopologyDescriptor.java
@@ -104,13 +104,7 @@ public class TopologyDescriptor {
      */
     public TopologyDescriptor(long topologyConfigId, @NonNull List<ClusterDescriptor> activeClusters,
                               @NonNull List<ClusterDescriptor> standbyClusters, @NonNull List<ClusterDescriptor> invalidClusters) {
-        this.topologyConfigId = topologyConfigId;
-        this.activeClusters = new HashMap<>();
-        this.standbyClusters = new HashMap<>();
-        this.invalidClusters = new HashMap<>();
-
-        activeClusters.forEach(activeCluster -> this.activeClusters.put(activeCluster.getClusterId(), activeCluster));
-        standbyClusters.forEach(standbyCluster -> this.standbyClusters.put(standbyCluster.getClusterId(), standbyCluster));
+        this(topologyConfigId, activeClusters, standbyClusters);
         invalidClusters.forEach(invalidCluster -> this.invalidClusters.put(invalidCluster.getClusterId(), invalidCluster));
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/TopologyDescriptor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/TopologyDescriptor.java
@@ -8,7 +8,8 @@ import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.ClusterRole;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.ClusterConfigurationMsg;
 
-import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -29,16 +30,16 @@ public class TopologyDescriptor {
 
     // Represents a state of the topology configuration (a topology epoch)
     @Getter
-    private long topologyConfigId;
+    private final long topologyConfigId;
 
     @Getter
-    private Map<String, ClusterDescriptor> activeClusters;
+    private final Map<String, ClusterDescriptor> activeClusters;
 
     @Getter
-    private Map<String, ClusterDescriptor> standbyClusters;
+    private final Map<String, ClusterDescriptor> standbyClusters;
 
     @Getter
-    private Map<String, ClusterDescriptor> invalidClusters;
+    private final Map<String, ClusterDescriptor> invalidClusters;
 
     /**
      * Constructor
@@ -72,7 +73,7 @@ public class TopologyDescriptor {
      */
     public TopologyDescriptor(long topologyConfigId, @NonNull ClusterDescriptor activeCluster,
                               @NonNull List<ClusterDescriptor> standbyClusters) {
-        this(topologyConfigId, Arrays.asList(activeCluster), standbyClusters);
+        this(topologyConfigId, Collections.singletonList(activeCluster), standbyClusters);
     }
 
     /**
@@ -89,13 +90,28 @@ public class TopologyDescriptor {
         this.standbyClusters = new HashMap<>();
         this.invalidClusters = new HashMap<>();
 
-        if(activeClusters != null) {
-            activeClusters.forEach(activeCluster -> this.activeClusters.put(activeCluster.getClusterId(), activeCluster));
-        }
+        activeClusters.forEach(activeCluster -> this.activeClusters.put(activeCluster.getClusterId(), activeCluster));
+        standbyClusters.forEach(standbyCluster -> this.standbyClusters.put(standbyCluster.getClusterId(), standbyCluster));
+    }
 
-        if(standbyClusters != null) {
-            standbyClusters.forEach(standbyCluster -> this.standbyClusters.put(standbyCluster.getClusterId(), standbyCluster));
-        }
+    /**
+     * Constructor
+     *
+     * @param topologyConfigId topology configuration identifier (epoch)
+     * @param activeClusters active cluster's
+     * @param standbyClusters standby cluster's
+     * @param invalidClusters invalid cluster's
+     */
+    public TopologyDescriptor(long topologyConfigId, @NonNull List<ClusterDescriptor> activeClusters,
+                              @NonNull List<ClusterDescriptor> standbyClusters, @NonNull List<ClusterDescriptor> invalidClusters) {
+        this.topologyConfigId = topologyConfigId;
+        this.activeClusters = new HashMap<>();
+        this.standbyClusters = new HashMap<>();
+        this.invalidClusters = new HashMap<>();
+
+        activeClusters.forEach(activeCluster -> this.activeClusters.put(activeCluster.getClusterId(), activeCluster));
+        standbyClusters.forEach(standbyCluster -> this.standbyClusters.put(standbyCluster.getClusterId(), standbyCluster));
+        invalidClusters.forEach(invalidCluster -> this.invalidClusters.put(invalidCluster.getClusterId(), invalidCluster));
     }
 
     /**
@@ -107,15 +123,13 @@ public class TopologyDescriptor {
 
         List<ClusterConfigurationMsg> clusterConfigurationMsgs = Stream.of(activeClusters.values(),
                 standbyClusters.values(), invalidClusters.values())
-                .flatMap(x -> x.stream())
-                .map(cluster -> cluster.convertToMessage())
+                .flatMap(Collection::stream)
+                .map(ClusterDescriptor::convertToMessage)
                 .collect(Collectors.toList());
 
-        TopologyConfigurationMsg topologyConfig = TopologyConfigurationMsg.newBuilder()
+        return TopologyConfigurationMsg.newBuilder()
                 .setTopologyConfigID(topologyConfigId)
                 .addAllClusters(clusterConfigurationMsgs).build();
-
-        return topologyConfig;
     }
 
     /**
@@ -149,7 +163,7 @@ public class TopologyDescriptor {
     public ClusterDescriptor getClusterDescriptor(String endpoint) {
         List<ClusterDescriptor> clusters = Stream.of(activeClusters.values(), standbyClusters.values(),
                 invalidClusters.values())
-                .flatMap(x -> x.stream())
+                .flatMap(Collection::stream)
                 .collect(Collectors.toList());
 
         for(ClusterDescriptor cluster : clusters) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -1,33 +1,49 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
 import org.corfudb.infrastructure.logreplication.infrastructure.NodeDescriptor;
 import org.corfudb.infrastructure.logreplication.infrastructure.TopologyDescriptor;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.TopologyConfigurationMsg;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.ClusterRole;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.TopologyConfigurationMsg;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata;
+import org.corfudb.runtime.Messages;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TableSchema;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.utils.CommonTypes;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.LinkedBlockingQueue;
 
-import static java.lang.Thread.sleep;
-
+/**
+ * This class extends CorfuReplicationClusterManagerAdapter, provides topology config API
+ * for integration tests. The initial topology config should be valid, which means it has only
+ * one active cluster, and one or more standby clusters.
+ */
 @Slf4j
+@SuppressWarnings("checkstyle:magicnumber")
 public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAdapter {
-    public static long epoch = 0;
-    public static final int changeInterval = 5000;
-    public static final String config_file = "/config/corfu/corfu_replication_config.properties";
+    public static final String CONFIG_FILE_PATH = "/config/corfu/corfu_replication_config.properties";
     private static final String DEFAULT_ACTIVE_CLUSTER_NAME = "primary_site";
     private static final String DEFAULT_STANDBY_CLUSTER_NAME = "standby_site";
     private static final int NUM_NODES_PER_CLUSTER = 3;
@@ -41,28 +57,72 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
 
     private static final String ACTIVE_CLUSTER_NODE = "primary_site_node";
     private static final String STANDBY_CLUSTER_NODE = "standby_site_node";
-    private boolean ifShutdown = false;
+
+
+    public static final String CONFIG_NAMESPACE = "ns_lr_config_it";
+    public static final String CONFIG_TABLE_NAME = "lr_config_it";
+    public static final CommonTypes.Uuid OP_RESUME = CommonTypes.Uuid.newBuilder().setLsb(0L).setMsb(0L).build();
+    public static final CommonTypes.Uuid OP_SWITCH = CommonTypes.Uuid.newBuilder().setLsb(1L).setMsb(1L).build();
+    public static final CommonTypes.Uuid OP_TWO_ACTIVE = CommonTypes.Uuid.newBuilder().setLsb(2L).setMsb(2L).build();
+    public static final CommonTypes.Uuid OP_ALL_STANDBY = CommonTypes.Uuid.newBuilder().setLsb(3L).setMsb(3L).build();
+    public static final CommonTypes.Uuid OP_INVALID = CommonTypes.Uuid.newBuilder().setLsb(4L).setMsb(4L).build();
 
     @Getter
-    public SiteManagerCallback siteManagerCallback;
+    private long epoch;
+
+    @Getter
+    private boolean shutdown;
+
+    @Getter
+    public ClusterManagerCallback clusterManagerCallback;
 
     private Thread thread;
 
+    private CorfuRuntime corfuRuntime;
 
+    private CorfuStore corfuStore;
 
     public void start() {
-        siteManagerCallback = new SiteManagerCallback(this);
-        thread = new Thread(siteManagerCallback);
+        epoch = 0L;
+        shutdown = false;
+        topologyConfig = constructTopologyConfigMsg();
+        clusterManagerCallback = new ClusterManagerCallback(this);
+        corfuRuntime = CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
+                .parseConfigurationString("localhost:9000")
+                .setTransactionLogging(true)
+                .connect();
+        corfuStore = new CorfuStore(corfuRuntime);
+        CorfuStoreMetadata.Timestamp ts = corfuStore.getTimestamp();
+        try {
+            Table<Messages.Uuid, Messages.Uuid, Messages.Uuid> table = corfuStore.openTable(
+                    CONFIG_NAMESPACE, CONFIG_TABLE_NAME,
+                    Messages.Uuid.class, Messages.Uuid.class, Messages.Uuid.class,
+                    TableOptions.builder().build()
+            );
+            table.clear();
+        } catch (Exception e) {
+            // Ignore
+        }
+        corfuStore.subscribe(new ConfigStreamListener(this), CONFIG_NAMESPACE,
+                Collections.singletonList(new TableSchema(CONFIG_TABLE_NAME, CommonTypes.Uuid.class, CommonTypes.Uuid.class, CommonTypes.Uuid.class)), ts);
+        thread = new Thread(clusterManagerCallback);
         thread.start();
     }
 
     @Override
     public void shutdown() {
-        ifShutdown = true;
+        shutdown = true;
+        if (corfuRuntime != null) {
+            corfuRuntime.shutdown();
+        }
+        try {
+            thread.join();
+        } catch (InterruptedException ie) {
+            throw new UnrecoverableCorfuInterruptedError(ie);
+        }
     }
 
-
-    public static TopologyDescriptor readConfig() throws IOException {
+    public static TopologyDescriptor readConfig() {
         ClusterDescriptor activeCluster;
         List<String> activeNodeNames = new ArrayList<>();
         List<String> standbyNodeNames = new ArrayList<>();
@@ -78,9 +138,8 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
         String standbyCorfuPort;
         String standbyLogReplicationPort;
 
-        File configFile = new File(config_file);
-        try {
-            FileReader reader = new FileReader(configFile);
+        File configFile = new File(CONFIG_FILE_PATH);
+        try (FileReader reader = new FileReader(configFile)) {
             Properties props = new Properties();
             props.load(reader);
 
@@ -112,9 +171,8 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
             }
             // TODO: add reading of node id (which is the APH node uuid)
 
-            reader.close();
-        } catch (FileNotFoundException e) {
-            log.warn("Plugin Config File {} does not exist. Using default configs", config_file);
+        } catch (IOException e) {
+            log.warn("Plugin Config File {} does not exist. Using default configs", CONFIG_FILE_PATH);
             activeClusterId = DefaultClusterConfig.getActiveClusterId();
             activeCorfuPort = DefaultClusterConfig.getActiveCorfuPort();
             activeLogReplicationPort = DefaultClusterConfig.getActiveLogReplicationPort();
@@ -154,19 +212,9 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
         return new TopologyDescriptor(0L, Arrays.asList(activeCluster), new ArrayList<>(standbySites.values()));
     }
 
-
     public static TopologyConfigurationMsg constructTopologyConfigMsg() {
-        TopologyDescriptor clusterTopologyDescriptor = null;
-        TopologyConfigurationMsg clusterConfigurationMsg;
-
-        try {
-            clusterTopologyDescriptor = readConfig();
-        } catch (Exception e) {
-            log.warn("Caught an exception while loading Topology descriptor " + e);
-        }
-
-        clusterConfigurationMsg = clusterTopologyDescriptor.convertToMessage();
-        return clusterConfigurationMsg;
+        TopologyDescriptor clusterTopologyDescriptor = readConfig();
+        return clusterTopologyDescriptor.convertToMessage();
     }
 
 
@@ -181,56 +229,150 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
     }
 
     /**
-     * Enforce one of the standby Cluster's to become the new active cluster and current active to become standby
+     * Create a new topology config, which changes one of the standby as the active,
+     * and active as standby. Data should flow in the reverse direction.
      **/
-    public static TopologyDescriptor changeActiveCluster(TopologyConfigurationMsg topologyConfig) {
-        TopologyDescriptor topologyDescriptor = new TopologyDescriptor(topologyConfig);
+    public TopologyDescriptor generateConfigWithRoleSwitch() {
+        TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
 
-        // Convert the current active to standby
-        ClusterDescriptor oldActive = topologyDescriptor.getActiveClusters().values().iterator().next();
-        ClusterDescriptor newStandby = new ClusterDescriptor(oldActive, ClusterRole.STANDBY);
+        List<ClusterDescriptor> newActiveClusters = new ArrayList<>();
+        List<ClusterDescriptor> newStandbyClusters = new ArrayList<>();
+        currentConfig.getActiveClusters().values().forEach(activeCluster ->
+                newStandbyClusters.add(new ClusterDescriptor(activeCluster, ClusterRole.STANDBY)));
+        currentConfig.getStandbyClusters().values().forEach(standbyCluster ->
+                newActiveClusters.add(new ClusterDescriptor(standbyCluster, ClusterRole.ACTIVE)));
 
-        List<ClusterDescriptor> standbyClusters = Arrays.asList(newStandby);
-        ClusterDescriptor newPrimary = null;
+        return new TopologyDescriptor(++epoch, newActiveClusters, newStandbyClusters);
+    }
 
-        for (ClusterDescriptor standbyCluster : topologyDescriptor.getStandbyClusters().values()) {
-            if (newPrimary == null) {
-                newPrimary = new ClusterDescriptor(standbyCluster, ClusterRole.ACTIVE);
-            } else {
-                standbyClusters.add(standbyCluster);
-            }
-        }
+    /**
+     * Create a new topology config, which marks all standby cluster as active on purpose.
+     * System should drop messages between any two active clusters.
+     **/
+    public TopologyDescriptor generateConfigWithAllActive() {
+        TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
+        ClusterDescriptor currentActive = currentConfig.getActiveClusters().values().iterator().next();
 
-        TopologyDescriptor newSiteConf = new TopologyDescriptor(1L, Arrays.asList(newPrimary), standbyClusters);
-        return newSiteConf;
+        List<ClusterDescriptor> newActiveClusters = new ArrayList<>();
+        currentConfig.getStandbyClusters().values().forEach(standbyCluster ->
+                newActiveClusters.add(new ClusterDescriptor(standbyCluster, ClusterRole.ACTIVE)));
+        newActiveClusters.add(currentActive);
+
+        return new TopologyDescriptor(++epoch, newActiveClusters, new ArrayList<>());
+    }
+
+    /**
+     * Create a new topology config, which marks all cluster as standby on purpose.
+     * System should not send messages in this case.
+     **/
+    public TopologyDescriptor generateConfigWithAllStandby() {
+        TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
+        ClusterDescriptor currentActive = currentConfig.getActiveClusters().values().iterator().next();
+
+        List<ClusterDescriptor> newStandbyClusters = new ArrayList<>(currentConfig.getStandbyClusters().values());
+        ClusterDescriptor newStandby = new ClusterDescriptor(currentActive, ClusterRole.STANDBY);
+        newStandbyClusters.add(newStandby);
+
+        return new TopologyDescriptor(++epoch, new ArrayList<>(), newStandbyClusters);
+    }
+
+    /**
+     * Create a new topology config, which marks all standby cluster as invalid on purpose.
+     * System should not send messages in this case.
+     **/
+    public TopologyDescriptor generateConfigWithInvalid() {
+        TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
+
+        List<ClusterDescriptor> newActiveClusters = new ArrayList<>(currentConfig.getActiveClusters().values());
+        List<ClusterDescriptor> newInvalidClusters = new ArrayList<>();
+        currentConfig.getStandbyClusters().values().forEach(standbyCluster ->
+                newInvalidClusters.add(new ClusterDescriptor(standbyCluster, ClusterRole.INVALID)));
+
+        return new TopologyDescriptor(++epoch, newActiveClusters, new ArrayList<>(), newInvalidClusters);
+    }
+
+    /**
+     * Bring topology config back to default valid config.
+     **/
+    public TopologyDescriptor generateDefaultValidConfig() {
+        TopologyDescriptor defaultTopology = new TopologyDescriptor(constructTopologyConfigMsg());
+        List<ClusterDescriptor> activeClusters = new ArrayList<>(defaultTopology.getActiveClusters().values());
+        List<ClusterDescriptor> standbyClusters = new ArrayList<>(defaultTopology.getStandbyClusters().values());
+
+        return new TopologyDescriptor(++epoch, activeClusters, standbyClusters);
     }
 
     /**
      * Testing purpose to generate cluster role change.
      */
-    public static class SiteManagerCallback implements Runnable {
-        public boolean clusterRoleChange = false;
-        DefaultClusterManager clusterManager;
+    public static class ClusterManagerCallback implements Runnable {
+        private final DefaultClusterManager clusterManager;
+        private final LinkedBlockingQueue<TopologyDescriptor> queue;
 
-        SiteManagerCallback(DefaultClusterManager clusterManager) {
+        public ClusterManagerCallback(DefaultClusterManager clusterManager) {
             this.clusterManager = clusterManager;
+            queue = new LinkedBlockingQueue<>();
+        }
+
+        public void applyNewTopologyConfig(@NonNull TopologyDescriptor descriptor) {
+            log.info("Applying a new config {}", descriptor);
+            queue.add(descriptor);
         }
 
         @Override
         public void run() {
-            while (!clusterManager.ifShutdown) {
+            while (!clusterManager.isShutdown()) {
                 try {
-                    sleep(changeInterval);
-                    if (clusterRoleChange) {
-                        TopologyDescriptor newConfig = changeActiveCluster(clusterManager.getTopologyConfig());
-                        clusterManager.updateTopologyConfig(newConfig.convertToMessage());
-                        log.warn("Change the cluster config");
-                        clusterRoleChange = false;
-                    }
-                } catch (Exception e) {
-                    log.error("Caught an exception",e);
+                    TopologyDescriptor newConfig = queue.take();
+                    clusterManager.updateTopologyConfig(newConfig.convertToMessage());
+                    log.warn("change the cluster config");
+                } catch (InterruptedException ie) {
+                    throw new UnrecoverableCorfuInterruptedError(ie);
                 }
             }
+        }
+    }
+
+    public static class ConfigStreamListener implements StreamListener {
+
+        private final DefaultClusterManager clusterManager;
+
+        public ConfigStreamListener(DefaultClusterManager clusterManager) {
+            this.clusterManager = clusterManager;
+        }
+
+        @Override
+        public void onNext(CorfuStreamEntries results) {
+            log.info("ConfigStreamListener onNext {} with entry size {}", results, results.getEntries().size());
+            CorfuStreamEntry entry = results.getEntries().values()
+                    .stream()
+                    .findFirst()
+                    .map(corfuStreamEntries -> corfuStreamEntries.get(0))
+                    .orElse(null);
+            if (entry != null && entry.getOperation().equals(CorfuStreamEntry.OperationType.UPDATE)) {
+                log.info("onNext entry is {}, key{}, p{}, m{}, op{}", entry, entry.getKey(), entry.getPayload(), entry.getMetadata(), entry.getOperation());
+                if (entry.getKey().equals(OP_SWITCH)) {
+                    clusterManager.getClusterManagerCallback()
+                            .applyNewTopologyConfig(clusterManager.generateConfigWithRoleSwitch());
+                } else if (entry.getKey().equals(OP_TWO_ACTIVE)) {
+                    clusterManager.getClusterManagerCallback()
+                            .applyNewTopologyConfig(clusterManager.generateConfigWithAllActive());
+                } else if (entry.getKey().equals(OP_ALL_STANDBY)) {
+                    clusterManager.getClusterManagerCallback()
+                            .applyNewTopologyConfig(clusterManager.generateConfigWithAllStandby());
+                } else if (entry.getKey().equals(OP_INVALID)) {
+                    clusterManager.getClusterManagerCallback()
+                            .applyNewTopologyConfig(clusterManager.generateConfigWithInvalid());
+                } else if (entry.getKey().equals(OP_RESUME)) {
+                    clusterManager.getClusterManagerCallback()
+                            .applyNewTopologyConfig(clusterManager.generateDefaultValidConfig());
+                }
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            // Ignore
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -4,6 +4,7 @@ import io.netty.buffer.Unpooled;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.LogReplicationMetadataVal;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
@@ -241,6 +242,7 @@ public class StreamsSnapshotWriter implements SnapshotWriter {
         for (UUID uuid : streamViewMap.keySet()) {
             seqNum = applyShadowStream(uuid, seqNum, snapshot);
         }
+        phase = Phase.TransferPhase;
     }
 
     /**
@@ -270,5 +272,5 @@ public class StreamsSnapshotWriter implements SnapshotWriter {
     enum Phase {
         TransferPhase,
         ApplyPhase
-    };
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -4,7 +4,6 @@ import io.netty.buffer.Unpooled;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.LogReplicationMetadataVal;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -4,6 +4,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
+import org.corfudb.infrastructure.logreplication.infrastructure.TopologyDescriptor;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationSourceManager;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
@@ -255,6 +256,10 @@ public class CorfuLogReplicationRuntime {
         from.onExit(to);
         to.clear();
         to.onEntry(from);
+    }
+
+    public synchronized void updateFSMConfigId(TopologyDescriptor newConfig) {
+        sourceManager.getLogReplicationFSM().setTopologyConfigId(newConfig.getTopologyConfigId());
     }
 
     public synchronized void updateConnectedEndpoints(String endpoint) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/CorfuMessageConverter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/CorfuMessageConverter.java
@@ -98,8 +98,8 @@ public class CorfuMessageConverter {
                 return protoCorfuMsg
                         .setType(CorfuMessageType.LOG_REPLICATION_LEADERSHIP_LOSS)
                         .setPayload(Any.pack(Messages.LogReplicationLeadershipLoss.newBuilder()
-                        .setEndpoint(leadershipLoss.getEndpoint())
-                        .build()))
+                                .setEndpoint(leadershipLoss.getEndpoint())
+                                .build()))
                         .build();
             default:
                 throw new IllegalArgumentException(String.format("{} type is not supported", msg.getMsgType()));
@@ -140,25 +140,25 @@ public class CorfuMessageConverter {
                     return new CorfuMsg(clientId, null, requestId, epoch, null,
                             CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP, priorityLevel);
                 case LOG_REPLICATION_NEGOTIATION_RESPONSE:
-                        LogReplicationNegotiationResponse negotiationResponse = LogReplicationNegotiationResponse
-                                .fromProto(protoMessage.getPayload().unpack(Messages.LogReplicationNegotiationResponse.class));
+                    LogReplicationNegotiationResponse negotiationResponse = LogReplicationNegotiationResponse
+                            .fromProto(protoMessage.getPayload().unpack(Messages.LogReplicationNegotiationResponse.class));
 
-                        return new CorfuPayloadMsg<>(CorfuMsgType.LOG_REPLICATION_NEGOTIATION_RESPONSE, negotiationResponse)
-                                .setClientID(clientId)
-                                .setRequestID(requestId)
-                                .setPriorityLevel(priorityLevel)
-                                .setBuf(buf)
-                                .setEpoch(epoch);
+                    return new CorfuPayloadMsg<>(CorfuMsgType.LOG_REPLICATION_NEGOTIATION_RESPONSE, negotiationResponse)
+                            .setClientID(clientId)
+                            .setRequestID(requestId)
+                            .setPriorityLevel(priorityLevel)
+                            .setBuf(buf)
+                            .setEpoch(epoch);
                 case LOG_REPLICATION_QUERY_LEADERSHIP_RESPONSE:
-                        LogReplicationQueryLeaderShipResponse leadershipResponse = LogReplicationQueryLeaderShipResponse
-                                .fromProto(protoMessage.getPayload().unpack(Messages.LogReplicationQueryLeadershipResponse.class));
+                    LogReplicationQueryLeaderShipResponse leadershipResponse = LogReplicationQueryLeaderShipResponse
+                            .fromProto(protoMessage.getPayload().unpack(Messages.LogReplicationQueryLeadershipResponse.class));
 
-                        return new CorfuPayloadMsg<>(CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP_RESPONSE, leadershipResponse)
-                                .setClientID(clientId)
-                                .setRequestID(requestId)
-                                .setPriorityLevel(priorityLevel)
-                                .setBuf(buf)
-                                .setEpoch(epoch);
+                    return new CorfuPayloadMsg<>(CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP_RESPONSE, leadershipResponse)
+                            .setClientID(clientId)
+                            .setRequestID(requestId)
+                            .setPriorityLevel(priorityLevel)
+                            .setBuf(buf)
+                            .setEpoch(epoch);
                 case LOG_REPLICATION_LEADERSHIP_LOSS:
                     LogReplicationLeadershipLoss leadershipLoss = LogReplicationLeadershipLoss
                             .fromProto(protoMessage.getPayload().unpack(Messages.LogReplicationLeadershipLoss.class));
@@ -169,7 +169,7 @@ public class CorfuMessageConverter {
                             .setBuf(buf)
                             .setEpoch(epoch);
                 default:
-                    throw new IllegalArgumentException(String.format("{} type is not supported", protoMessage.getType().name()));
+                    throw new IllegalArgumentException(String.format("%s type is not supported", protoMessage.getType().name()));
             }
         } catch (Exception e) {
             throw new CorfuMessageProtoBufException(e);

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -1,0 +1,619 @@
+package org.corfudb.integration;
+
+import com.google.common.reflect.TypeToken;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.utils.CommonTypes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.IntPredicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * This test suit exercises some topology config change scenarios.
+ * Each test will start with two single node corfu servers, and two single node log replicators.
+ */
+@Slf4j
+@SuppressWarnings("checkstyle:magicnumber")
+public class CorfuReplicationClusterConfigIT extends AbstractIT {
+    public final static String nettyPluginPath = "src/test/resources/transport/nettyConfig.properties";
+    private final static String streamName = "Table001";
+
+    private final static long shortInterval = 1L;
+    private final static long mediumInterval = 10L;
+    private final static int firstBatch = 10;
+    private final static int secondBatch = 15;
+    private final static int thirdBatch = 20;
+    private final static int largeBatch = 50;
+
+    private final static int activeClusterCorfuPort = 9000;
+    private final static int standbyClusterCorfuPort = 9001;
+    private final static int activeReplicationServerPort = 9010;
+    private final static int standbyReplicationServerPort = 9020;
+    private final static String activeCorfuEndpoint = DEFAULT_HOST + ":" + activeClusterCorfuPort;
+    private final static String standbyCorfuEndpoint = DEFAULT_HOST + ":" + standbyClusterCorfuPort;
+
+    private Process activeCorfuServer = null;
+    private Process standbyCorfuServer = null;
+    private Process activeReplicationServer = null;
+    private Process standbyReplicationServer = null;
+
+    private CorfuRuntime activeRuntime;
+    private CorfuRuntime standbyRuntime;
+    private CorfuTable<String, Integer> mapActive;
+    private CorfuTable<String, Integer> mapStandby;
+
+    private CorfuStore corfuStore;
+    private Table<CommonTypes.Uuid, CommonTypes.Uuid, CommonTypes.Uuid> configTable;
+
+    @Before
+    public void setUp() throws Exception {
+        activeCorfuServer = runServer(activeClusterCorfuPort, true);
+        standbyCorfuServer = runServer(standbyClusterCorfuPort, true);
+
+        CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
+                .builder()
+                .build();
+
+        activeRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+        activeRuntime.parseConfigurationString(activeCorfuEndpoint).connect();
+
+        standbyRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+        standbyRuntime.parseConfigurationString(standbyCorfuEndpoint).connect();
+
+        mapActive = activeRuntime.getObjectsView()
+                .build()
+                .setStreamName(streamName)
+                .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
+                })
+                .open();
+
+        mapStandby = standbyRuntime.getObjectsView()
+                .build()
+                .setStreamName(streamName)
+                .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
+                })
+                .open();
+
+        assertThat(mapActive.size()).isZero();
+        assertThat(mapStandby.size()).isZero();
+
+        corfuStore = new CorfuStore(activeRuntime);
+
+        configTable = corfuStore.openTable(
+                DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
+                CommonTypes.Uuid.class, CommonTypes.Uuid.class, CommonTypes.Uuid.class,
+                TableOptions.builder().build()
+        );
+    }
+
+    @After
+    public void tearDown() throws IOException, InterruptedException {
+        if (activeRuntime != null) {
+            activeRuntime.shutdown();
+        }
+
+        if (standbyRuntime != null) {
+            standbyRuntime.shutdown();
+        }
+
+        shutdownCorfuServer(activeCorfuServer);
+        shutdownCorfuServer(standbyCorfuServer);
+        shutdownCorfuServer(activeReplicationServer);
+        shutdownCorfuServer(standbyReplicationServer);
+    }
+
+    /**
+     * This test verify config change with a role switch.
+     * <p>
+     * 1. Init with corfu 9000 active and 9001 standby
+     * 2. Write 10 entries to active map
+     * 3. Start log replication: Node 9010 - active, Node 9020 - standby
+     * 4. Wait for Snapshot Sync, both maps have size 10
+     * 5. Write 5 more entries to active map, to verify Log Entry Sync
+     * 6. Perform a role switch with corfu store
+     * 7. Write 5 more entries to standby map, which becomes source right now.
+     * 8. Verify data will be replicated in reverse direction.
+     */
+    @Test
+    public void testNewConfigWithSwitchRole() throws Exception {
+        // Write 10 entry to active map
+        for (int i = 0; i < firstBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(firstBatch);
+        assertThat(mapStandby.size()).isZero();
+
+        log.info("Before log replication, append {} entries to active map. Current active corfu" +
+                        "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        activeReplicationServer = runReplicationServer(activeReplicationServerPort, nettyPluginPath);
+        standbyReplicationServer = runReplicationServer(standbyReplicationServerPort, nettyPluginPath);
+        log.info("Replication servers started, and replication is in progress...");
+
+        // Wait until data is fully replicated
+        waitForReplication(size -> size == firstBatch, mapStandby, firstBatch);
+        log.info("After full sync, both maps have size {}. Current active corfu[{}] log tail " +
+                        "is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Write 5 entries to active map
+        for (int i = firstBatch; i < secondBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(secondBatch);
+
+        // Wait until data is fully replicated again
+        waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
+        log.info("After delta sync, both maps have size {}. Current active corfu[{}] log tail " +
+                        "is {}, standby corfu[{}] log tail is {}", secondBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Verify data
+        for (int i = 0; i < secondBatch; i++) {
+            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+        }
+        log.info("Log replication succeeds without config change!");
+
+        // Perform a role switch
+        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+                .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_SWITCH,
+                        DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH)
+                .commit();
+        assertThat(configTable.count()).isOne();
+
+        // Write 5 more entries to mapStandby
+        for (int i = secondBatch; i < thirdBatch; i++) {
+            standbyRuntime.getObjectsView().TXBegin();
+            mapStandby.put(String.valueOf(i), i);
+            standbyRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapStandby.size()).isEqualTo(thirdBatch);
+
+        // Wait until data is fully replicated again
+        waitForReplication(size -> size == thirdBatch, mapActive, thirdBatch);
+        log.info("Data is fully replicated again after role switch, both maps have size {}. " +
+                        "Current active corfu[{}] log tail is {}, standby corfu[{}] log tail is {}",
+                thirdBatch, activeClusterCorfuPort, activeRuntime.getAddressSpaceView().getLogTail(),
+                standbyClusterCorfuPort, standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Double check after 10 seconds
+        TimeUnit.SECONDS.sleep(mediumInterval);
+        //assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        waitForReplication(size -> size == thirdBatch, mapActive, thirdBatch);
+        assertThat(mapStandby.size()).isEqualTo(thirdBatch);
+    }
+
+    /**
+     * This test verify config change with a role switch during a snapshot sync transfer phase.
+     * <p>
+     * 1. Init with corfu 9000 active and 9001 standby
+     * 2. Write 50 entries to active map
+     * 3. Start log replication: Node 9010 - active, Node 9020 - standby
+     * 4. Perform a role switch with corfu store
+     * 5. Standby will drop messages and keep size 0
+     * 6. Verify active map becomes size 0, since source size is 0
+     */
+    //@Test
+    public void testNewConfigWithSwitchRoleDuringTransferPhase() throws Exception {
+        // Write 50 entry to active map
+        for (int i = 0; i < largeBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(largeBatch);
+        assertThat(mapStandby.size()).isZero();
+
+        log.info("Before log replication, append {} entries to active map. Current active corfu" +
+                        "[{}] log tail is {}, standby corfu[{}] log tail is {}", largeBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        activeReplicationServer = runReplicationServer(activeReplicationServerPort);
+        standbyReplicationServer = runReplicationServer(standbyReplicationServerPort);
+        log.info("Replication servers started, and replication is in progress...");
+        TimeUnit.SECONDS.sleep(shortInterval);
+
+        // Perform a role switch during transfer
+        assertThat(mapStandby.size()).isEqualTo(0);
+        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+                .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_SWITCH,
+                        DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH)
+                .commit();
+        assertThat(configTable.count()).isOne();
+        assertThat(mapStandby.size()).isEqualTo(0);
+
+        // Wait until active map size becomes 0
+        waitForReplication(size -> size == 0, mapActive, 0);
+        log.info("After role switch during transfer phase, both maps have size {}. Current " +
+                        "active corfu[{}] log tail is {}, standby corfu[{}] log tail is {}",
+                mapActive.size(), activeClusterCorfuPort, activeRuntime.getAddressSpaceView().getLogTail(),
+                standbyClusterCorfuPort, standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Double check after 10 seconds
+        TimeUnit.SECONDS.sleep(mediumInterval);
+        assertThat(mapActive.size()).isZero();
+        assertThat(mapStandby.size()).isZero();
+    }
+
+    /**
+     * This test verify config change with a role switch during a snapshot sync apply phase.
+     * <p>
+     * 1. Init with corfu 9000 active and 9001 standby
+     * 2. Write 50 entries to active map
+     * 3. Start log replication: Node 9010 - active, Node 9020 - standby
+     * 4. Wait for Snapshot Sync goes to apply phase
+     * 5. Perform a role switch with corfu store
+     * 6. Standby will continue apply and have size 50
+     * 7. Verify both maps have size 50
+     */
+    //@Test
+    public void testNewConfigWithSwitchRoleDuringApplyPhase() throws Exception {
+        // Write 50 entry to active map
+        for (int i = 0; i < largeBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(largeBatch);
+        assertThat(mapStandby.size()).isZero();
+
+        log.info("Before log replication, append {} entries to active map. Current active corfu" +
+                        "[{}] log tail is {}, standby corfu[{}] log tail is {}", largeBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        activeReplicationServer = runReplicationServer(activeReplicationServerPort);
+        standbyReplicationServer = runReplicationServer(standbyReplicationServerPort);
+        log.info("Replication servers started, and replication is in progress...");
+
+        // Wait until apply phase
+        UUID standbyStream = CorfuRuntime.getStreamID(streamName);
+        while (!standbyRuntime.getAddressSpaceView().getAllTails().getStreamTails().containsKey(standbyStream)) {
+            TimeUnit.MILLISECONDS.sleep(100L);
+        }
+
+        log.info("======standby tail is : " + standbyRuntime.getAddressSpaceView().getAllTails().getStreamTails().get(standbyStream));
+
+        // Perform a role switch
+        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+                .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_SWITCH,
+                        DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH)
+                .commit();
+        assertThat(configTable.count()).isOne();
+
+        // Should finish apply
+        waitForReplication(size -> size == largeBatch, mapStandby, largeBatch);
+        assertThat(mapActive.size()).isEqualTo(largeBatch);
+        log.info("After role switch during apply phase, both maps have size {}. Current " +
+                        "active corfu[{}] log tail is {}, standby corfu[{}] log tail is {}",
+                mapActive.size(), activeClusterCorfuPort, activeRuntime.getAddressSpaceView().getLogTail(),
+                standbyClusterCorfuPort, standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Double check after 10 seconds
+        TimeUnit.SECONDS.sleep(mediumInterval);
+        assertThat(mapActive.size()).isEqualTo(largeBatch);
+        assertThat(mapStandby.size()).isEqualTo(largeBatch);
+    }
+
+    /**
+     * This test verify config change with two active clusters
+     * <p>
+     * 1. Init with corfu 9000 active and 9001 standby
+     * 2. Write 10 entries to active map
+     * 3. Start log replication: Node 9010 - active, Node 9020 - standby
+     * 4. Wait for Snapshot Sync, both maps have size 10
+     * 5. Write 5 more entries to active map, to verify Log Entry Sync
+     * 6. Perform a two-active config update with corfu store
+     * 7. Write 5 more entries to active map
+     * 8. Verify data will not be replicated, since both are active
+     */
+    @Test
+    public void testNewConfigWithTwoActive() throws Exception {
+        // Write 10 entry to active map
+        for (int i = 0; i < firstBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(firstBatch);
+        assertThat(mapStandby.size()).isZero();
+
+        log.info("Before log replication, append {} entries to active map. Current active corfu" +
+                        "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        activeReplicationServer = runReplicationServer(activeReplicationServerPort, nettyPluginPath);
+        standbyReplicationServer = runReplicationServer(standbyReplicationServerPort, nettyPluginPath);
+        log.info("Replication servers started, and replication is in progress...");
+
+        // Wait until data is fully replicated
+        waitForReplication(size -> size == firstBatch, mapStandby, firstBatch);
+        log.info("After full sync, both maps have size {}. Current active corfu[{}] log tail " +
+                        "is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Write 5 entries to active map
+        for (int i = firstBatch; i < secondBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(secondBatch);
+
+        // Wait until data is fully replicated again
+        waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
+        log.info("After delta sync, both maps have size {}. Current active corfu[{}] log tail " +
+                        "is {}, standby corfu[{}] log tail is {}", secondBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Verify data
+        for (int i = 0; i < secondBatch; i++) {
+            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+        }
+        log.info("Log replication succeeds without config change!");
+
+        // Perform a config update with two active
+        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+                .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_TWO_ACTIVE,
+                        DefaultClusterManager.OP_TWO_ACTIVE, DefaultClusterManager.OP_TWO_ACTIVE)
+                .commit();
+        assertThat(configTable.count()).isOne();
+        log.info("New topology config applied!");
+        TimeUnit.SECONDS.sleep(mediumInterval);
+
+        // Append to mapStandby
+        for (int i = secondBatch; i < thirdBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        log.info("Active map have {} entries now!", thirdBatch);
+
+        // Standby map should still have secondBatch size
+        log.info("Standby map should still have {} size", secondBatch);
+        waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
+
+        // Double check after 10 seconds
+        TimeUnit.SECONDS.sleep(mediumInterval);
+        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.size()).isEqualTo(secondBatch);
+    }
+
+    /**
+     * This test verify config change with two standby clusters
+     * <p>
+     * 1. Init with corfu 9000 active and 9001 standby
+     * 2. Write 10 entries to active map
+     * 3. Start log replication: Node 9010 - active, Node 9020 - standby
+     * 4. Wait for Snapshot Sync, both maps have size 10
+     * 5. Write 5 more entries to active map, to verify Log Entry Sync
+     * 6. Perform a two-standby config update with corfu store
+     * 7. Write 5 more entries to active map
+     * 8. Verify data will not be replicated, since both are standby
+     */
+    @Test
+    public void testNewConfigWithAllStandby() throws Exception {
+        // Write 10 entry to active map
+        for (int i = 0; i < firstBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(firstBatch);
+        assertThat(mapStandby.size()).isZero();
+
+        log.info("Before log replication, append {} entries to active map. Current active corfu" +
+                        "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        activeReplicationServer = runReplicationServer(activeReplicationServerPort, nettyPluginPath);
+        standbyReplicationServer = runReplicationServer(standbyReplicationServerPort, nettyPluginPath);
+        log.info("Replication servers started, and replication is in progress...");
+
+        // Wait until data is fully replicated
+        waitForReplication(size -> size == firstBatch, mapStandby, firstBatch);
+        log.info("After full sync, both maps have size {}. Current active corfu[{}] log tail " +
+                        "is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Write 5 entries to active map
+        for (int i = firstBatch; i < secondBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(secondBatch);
+
+        // Wait until data is fully replicated again
+        waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
+        log.info("After delta sync, both maps have size {}. Current active corfu[{}] log tail " +
+                        "is {}, standby corfu[{}] log tail is {}", secondBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Verify data
+        for (int i = 0; i < secondBatch; i++) {
+            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+        }
+        log.info("Log replication succeeds without config change!");
+
+        // Perform a config update with all standby
+        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+                .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_ALL_STANDBY,
+                        DefaultClusterManager.OP_ALL_STANDBY, DefaultClusterManager.OP_ALL_STANDBY)
+                .commit();
+        assertThat(configTable.count()).isOne();
+        log.info("New topology config applied!");
+        TimeUnit.SECONDS.sleep(mediumInterval);
+
+        for (int i = secondBatch; i < thirdBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        log.info("Active map have {} entries now!", thirdBatch);
+
+        // Standby map should still have secondBatch size
+        log.info("Standby map should still have {} size", secondBatch);
+        waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
+
+        // Double check after 10 seconds
+        TimeUnit.SECONDS.sleep(mediumInterval);
+        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.size()).isEqualTo(secondBatch);
+    }
+
+    /**
+     * This test verify config change with one active and one invalid
+     * <p>
+     * 1. Init with corfu 9000 active and 9001 standby
+     * 2. Write 10 entries to active map
+     * 3. Start log replication: Node 9010 - active, Node 9020 - standby
+     * 4. Wait for Snapshot Sync, both maps have size 10
+     * 5. Write 5 more entries to active map, to verify Log Entry Sync
+     * 6. Perform a active-invalid config update with corfu store
+     * 7. Write 5 more entries to active map
+     * 8. Verify data will not be replicated, since standby is invalid
+     * 9. Resume to standby and verify data is fully replicated again.
+     */
+    @Test
+    public void testNewConfigWithInvalidClusters() throws Exception {
+        // Write 10 entry to active map
+        for (int i = 0; i < firstBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(firstBatch);
+        assertThat(mapStandby.size()).isZero();
+
+        log.info("Before log replication, append {} entries to active map. Current active corfu" +
+                        "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        activeReplicationServer = runReplicationServer(activeReplicationServerPort, nettyPluginPath);
+        standbyReplicationServer = runReplicationServer(standbyReplicationServerPort, nettyPluginPath);
+        log.info("Replication servers started, and replication is in progress...");
+
+        // Wait until data is fully replicated
+        waitForReplication(size -> size == firstBatch, mapStandby, firstBatch);
+        log.info("After full sync, both maps have size {}. Current active corfu[{}] log tail " +
+                        "is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Write 5 entries to active map
+        for (int i = firstBatch; i < secondBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(secondBatch);
+
+        // Wait until data is fully replicated again
+        waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
+        log.info("After delta sync, both maps have size {}. Current active corfu[{}] log tail " +
+                        "is {}, standby corfu[{}] log tail is {}", secondBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Verify data
+        for (int i = 0; i < secondBatch; i++) {
+            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+        }
+        log.info("Log replication succeeds without config change!");
+
+        // Perform a config update with invalid state
+        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+                .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_INVALID,
+                        DefaultClusterManager.OP_INVALID, DefaultClusterManager.OP_INVALID)
+                .commit();
+        assertThat(configTable.count()).isOne();
+        log.info("New topology config applied!");
+        TimeUnit.SECONDS.sleep(mediumInterval);
+
+        // Append to mapActive
+        for (int i = secondBatch; i < thirdBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+
+        // Standby map should still have secondBatch size
+        waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
+
+        // Double check after 10 seconds
+        TimeUnit.SECONDS.sleep(mediumInterval);
+        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.size()).isEqualTo(secondBatch);
+        log.info("After {} seconds sleep, double check passed", mediumInterval);
+
+        // Change to default active standby config
+        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+                .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_RESUME,
+                        DefaultClusterManager.OP_RESUME, DefaultClusterManager.OP_RESUME)
+                .commit();
+        assertThat(configTable.count()).isEqualTo(2);
+        log.info("New topology config applied!");
+        TimeUnit.SECONDS.sleep(mediumInterval);
+
+        // Standby map should have thirdBatch size, since topology config is resumed.
+        waitForReplication(size -> size == thirdBatch, mapStandby, thirdBatch);
+
+        // Double check after 10 seconds
+        TimeUnit.SECONDS.sleep(mediumInterval);
+        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.size()).isEqualTo(thirdBatch);
+    }
+
+    private void waitForReplication(IntPredicate verifier, CorfuTable table, int expected) {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
+            log.info("Waiting for replication, table size is {}, expected size is {}", table.size(), expected);
+            if (verifier.test(table.size())) {
+                break;
+            }
+            sleepUninterruptibly(shortInterval);
+        }
+        assertThat(verifier.test(table.size())).isTrue();
+    }
+
+    private void sleepUninterruptibly(long seconds) {
+        try {
+            TimeUnit.SECONDS.sleep(seconds);
+        } catch (InterruptedException ie) {
+            throw new UnrecoverableCorfuInterruptedError(ie);
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 
 /**
- * This test suit exercises some topology config change scenarios.
+ * This test suite exercises some topology config change scenarios.
  * Each test will start with two single node corfu servers, and two single node log replicators.
  */
 @Slf4j
@@ -117,7 +117,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     }
 
     /**
-     * This test verify config change with a role switch.
+     * This test verifies config change with a role switch.
      * <p>
      * 1. Init with corfu 9000 active and 9001 standby
      * 2. Write 10 entries to active map
@@ -130,7 +130,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
      */
     @Test
     public void testNewConfigWithSwitchRole() throws Exception {
-        // Write 10 entry to active map
+        // Write 10 entries to active map
         for (int i = 0; i < firstBatch; i++) {
             activeRuntime.getObjectsView().TXBegin();
             mapActive.put(String.valueOf(i), i);
@@ -200,13 +200,12 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Double check after 10 seconds
         TimeUnit.SECONDS.sleep(mediumInterval);
-        //assertThat(mapActive.size()).isEqualTo(thirdBatch);
-        waitForReplication(size -> size == thirdBatch, mapActive, thirdBatch);
+        assertThat(mapActive.size()).isEqualTo(thirdBatch);
         assertThat(mapStandby.size()).isEqualTo(thirdBatch);
     }
 
     /**
-     * This test verify config change with a role switch during a snapshot sync transfer phase.
+     * This test verifies config change with a role switch during a snapshot sync transfer phase.
      * <p>
      * 1. Init with corfu 9000 active and 9001 standby
      * 2. Write 50 entries to active map
@@ -259,7 +258,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     }
 
     /**
-     * This test verify config change with a role switch during a snapshot sync apply phase.
+     * This test verifies config change with a role switch during a snapshot sync apply phase.
      * <p>
      * 1. Init with corfu 9000 active and 9001 standby
      * 2. Write 50 entries to active map
@@ -319,7 +318,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     }
 
     /**
-     * This test verify config change with two active clusters
+     * This test verifies config change with two active clusters
      * <p>
      * 1. Init with corfu 9000 active and 9001 standby
      * 2. Write 10 entries to active map
@@ -332,7 +331,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
      */
     @Test
     public void testNewConfigWithTwoActive() throws Exception {
-        // Write 10 entry to active map
+        // Write 10 entries to active map
         for (int i = 0; i < firstBatch; i++) {
             activeRuntime.getObjectsView().TXBegin();
             mapActive.put(String.valueOf(i), i);
@@ -387,14 +386,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         log.info("New topology config applied!");
         TimeUnit.SECONDS.sleep(mediumInterval);
 
-        // Append to mapStandby
+        // Append to mapActive
         for (int i = secondBatch; i < thirdBatch; i++) {
             activeRuntime.getObjectsView().TXBegin();
             mapActive.put(String.valueOf(i), i);
             activeRuntime.getObjectsView().TXEnd();
         }
         assertThat(mapActive.size()).isEqualTo(thirdBatch);
-        log.info("Active map have {} entries now!", thirdBatch);
+        log.info("Active map has {} entries now!", thirdBatch);
 
         // Standby map should still have secondBatch size
         log.info("Standby map should still have {} size", secondBatch);
@@ -407,7 +406,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     }
 
     /**
-     * This test verify config change with two standby clusters
+     * This test verifies config change with two standby clusters
      * <p>
      * 1. Init with corfu 9000 active and 9001 standby
      * 2. Write 10 entries to active map
@@ -420,7 +419,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
      */
     @Test
     public void testNewConfigWithAllStandby() throws Exception {
-        // Write 10 entry to active map
+        // Write 10 entries to active map
         for (int i = 0; i < firstBatch; i++) {
             activeRuntime.getObjectsView().TXBegin();
             mapActive.put(String.valueOf(i), i);
@@ -481,7 +480,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
             activeRuntime.getObjectsView().TXEnd();
         }
         assertThat(mapActive.size()).isEqualTo(thirdBatch);
-        log.info("Active map have {} entries now!", thirdBatch);
+        log.info("Active map has {} entries now!", thirdBatch);
 
         // Standby map should still have secondBatch size
         log.info("Standby map should still have {} size", secondBatch);
@@ -494,7 +493,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     }
 
     /**
-     * This test verify config change with one active and one invalid
+     * This test verifies config change with one active and one invalid
      * <p>
      * 1. Init with corfu 9000 active and 9001 standby
      * 2. Write 10 entries to active map
@@ -508,7 +507,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
      */
     @Test
     public void testNewConfigWithInvalidClusters() throws Exception {
-        // Write 10 entry to active map
+        // Write 10 entries to active map
         for (int i = 0; i < firstBatch; i++) {
             activeRuntime.getObjectsView().TXBegin();
             mapActive.put(String.valueOf(i), i);

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -44,8 +44,8 @@
     </logger>
 
     <!--<root level="DEBUG">-->
-        <!--&lt;!&ndash;<appender-ref ref="FILE" />&ndash;&gt;-->
+        <!--<appender-ref ref="FILE" />-->
         <!--<appender-ref ref="STDOUT" />-->
-        <!--&lt;!&ndash;<appender-ref ref="MetricsRollingFile" />&ndash;&gt;-->
+        <!--<appender-ref ref="MetricsRollingFile" />-->
     <!--</root>-->
 </configuration>


### PR DESCRIPTION
## Overview

Description:

Add Log Replication Cluster Role ITs

* Modified Default Cluster Manager to support process-based ITs
* Removed current CorfuReplicationSiteConfigIT, since it won't work on Travis.

Why should this be merged: 

Related issue(s) (if applicable): #2627 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
