### PR TITLE
Handle Trim Exceptions on Shadow Streams

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -112,7 +112,7 @@ public class LogReplicationServer extends AbstractServer {
                     metadata.getVersion(),
                     metadata.getLastSnapStartTimestamp(),
                     metadata.getLastSnapTransferDoneTimestamp(),
-                    metadata.getLastSrcBaseSnapshotTimestamp(),
+                    metadata.getLastAppliedBaseSnapshotTimestamp(),
                     metadata.getLastProcessedLogTimestamp());
             log.info("Send Negotiation response");
             r.sendResponse(msg, CorfuMsgType.LOG_REPLICATION_NEGOTIATION_RESPONSE.payloadMsg(response));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -229,7 +229,13 @@ public class ServerContext implements AutoCloseable {
     }
 
     public int getLockLeaseDuration() {
-        Integer lockLeaseDuration = getServerConfig(Integer.class, "--lock-lease");
+        Integer lockLeaseDuration;
+        try {
+            lockLeaseDuration = getServerConfig(Integer.class, "--lock-lease");
+        } catch (ClassCastException e) {
+            // In the testing framework we only support Strings
+            lockLeaseDuration = Integer.valueOf(getServerConfig(String.class, "--lock-lease"));
+        }
         return lockLeaseDuration == null ? Lock.leaseDuration : lockLeaseDuration;
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -45,6 +45,7 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
     public static final String CONFIG_FILE_PATH = "src/test/resources/corfu_replication_config.properties";
     private static final String DEFAULT_ACTIVE_CLUSTER_NAME = "primary_site";
     private static final String DEFAULT_STANDBY_CLUSTER_NAME = "standby_site";
+
     private static final int NUM_NODES_PER_CLUSTER = 3;
 
     private static final String ACTIVE_CLUSTER_NAME = "primary_site";

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultSnapshotSyncPlugin.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultSnapshotSyncPlugin.java
@@ -1,0 +1,23 @@
+package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuRuntime;
+
+/**
+ * Default Snapshot Sync Plugin
+ *
+ * This implementation returns immediately for start and end of a snapshot sync.
+ */
+@Slf4j
+public class DefaultSnapshotSyncPlugin implements ISnapshotSyncPlugin {
+
+    @Override
+    public void onSnapshotSyncStart(CorfuRuntime runtime) {
+        log.debug("onSnapshotSyncStart :: OK");
+    }
+
+    @Override
+    public void onSnapshotSyncEnd(CorfuRuntime runtime) {
+        log.debug("onSnapshotSyncEnd :: OK");
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ISnapshotSyncPlugin.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ISnapshotSyncPlugin.java
@@ -1,0 +1,26 @@
+package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
+
+import org.corfudb.runtime.CorfuRuntime;
+
+/**
+ * This interface must be implemented to plug any system-specific logic upon start and end of a snapshot sync.
+ *
+ * The expectation is that any external checkpoint/trim process is stopped upon snapshot sync start
+ * and resumed on snapshot sync end, aiming to prevent data loss by trimming non-checkpointed shadow streams.
+ *
+ * @author annym
+ */
+public interface ISnapshotSyncPlugin {
+
+    /**
+     * On Snapshot Sync Start, stop any checkpoint / trim processes and return once it has been stopped.
+     *
+     */
+    void onSnapshotSyncStart(CorfuRuntime runtime);
+
+    /**
+     * On Snapshot Sync End, resume any checkpoint / trim processes and return once it has been restarted.
+     *
+     */
+    void onSnapshotSyncEnd(CorfuRuntime runtime);
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/LogReplicationPluginConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/LogReplicationPluginConfig.java
@@ -1,6 +1,6 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
-import lombok.Data;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 
@@ -13,36 +13,57 @@ import java.util.Properties;
 /**
  * This class is an abstraction for all Log Replication plugin's configurations.
  *
- * Currently, three plugins are supported:
+ * Currently, four plugins are supported:
  * - Transport Plugin - defines the adapter to use for inter-cluster communication
  * - Site Information Plugin - defines the adapter to use for cluster information query
  * - Table Replication Specification Plugin - defines the adapter to use to pull the specified tables to be replicates
+ * - Snapshot Sync Plugin - implements callbacks on snapshot sync boundaries (start/end) to implement any external logic
+ *                          required for the duration of a snapshot sync.
  */
-@Data
 @Slf4j
 public class LogReplicationPluginConfig {
 
-    // Transport Configurations
+    // Transport Plugin
     public static final String DEFAULT_JAR_PATH = "/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar";
     public static final String DEFAULT_SERVER_CLASSNAME = "org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationServerChannelAdapter";
     public static final String DEFAULT_CLIENT_CLASSNAME = "org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationClientChannelAdapter";
 
-    // Stream Fetcher
+    // Stream Fetcher Plugin
     public static final String DEFAULT_STREAM_FETCHER_JAR_PATH = "/target/infrastructure-0.3.0-SNAPSHOT.jar";
     public static final String DEFAULT_STREAM_FETCHER_CLASSNAME = "org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter";
 
-    // Topology Manager
+    // Topology Manager Plugin
     public static final String DEFAULT_CLUSTER_MANAGER_CLASSNAME = "org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager";
 
+    // Snapshot Sync Plugin
+    public static final String DEFAULT_SNAPSHOT_SYNC_CLASSNAME = "org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin";
+
+    @Getter
     private String transportAdapterJARPath;
+
+    @Getter
     private String transportServerClassCanonicalName;
+
+    @Getter
     private String transportClientClassCanonicalName;
 
+    @Getter
     private String streamFetcherPluginJARPath;
+
+    @Getter
     private String streamFetcherClassCanonicalName;
 
+    @Getter
     private String topologyManagerAdapterJARPath;
+
+    @Getter
     private String topologyManagerAdapterName;
+
+    @Getter
+    private String snapshotSyncPluginJARPath;
+
+    @Getter
+    private String snapshotSyncPluginCanonicalName;
 
     public LogReplicationPluginConfig(String filepath) {
         try (InputStream input = new FileInputStream(filepath)) {
@@ -55,17 +76,24 @@ public class LogReplicationPluginConfig {
             this.streamFetcherPluginJARPath = prop.getProperty("stream_fetcher_plugin_JAR_path");
             this.streamFetcherClassCanonicalName = prop.getProperty("stream_fetcher_plugin_class_name");
 
+            this.snapshotSyncPluginJARPath = prop.getProperty("snapshot_sync_plugin_JAR_path");
+            this.snapshotSyncPluginCanonicalName = prop.getProperty("snapshot_sync_plugin_class_name");
+
             this.topologyManagerAdapterJARPath = prop.getProperty("topology_manager_adapter_JAR_path");
             this.topologyManagerAdapterName = prop.getProperty("topology_manager_adapter_class_name");
         } catch (IOException e) {
-            log.warn("Exception caught while trying to load adapter configuration from {}. Default configuration " +
-                    "will be used.", filepath);
-            // Default Configuration
+            log.warn("Plugin configuration not found {}. Default configuration will be used.", filepath);
+
+            // Default Configurations
             this.transportAdapterJARPath = getParentDir() + DEFAULT_JAR_PATH;
             this.transportClientClassCanonicalName = DEFAULT_CLIENT_CLASSNAME;
             this.transportServerClassCanonicalName = DEFAULT_SERVER_CLASSNAME;
-            this.streamFetcherPluginJARPath = getStreamFetcherParentDir() + DEFAULT_STREAM_FETCHER_JAR_PATH;
+
+            this.streamFetcherPluginJARPath = getParentDir() + DEFAULT_STREAM_FETCHER_JAR_PATH;
             this.streamFetcherClassCanonicalName = DEFAULT_STREAM_FETCHER_CLASSNAME;
+
+            this.snapshotSyncPluginJARPath = getParentDir() + DEFAULT_JAR_PATH;
+            this.snapshotSyncPluginCanonicalName = DEFAULT_SNAPSHOT_SYNC_CLASSNAME;
 
             this.topologyManagerAdapterJARPath = getParentDir() + DEFAULT_JAR_PATH;
             this.topologyManagerAdapterName = DEFAULT_CLUSTER_MANAGER_CLASSNAME;
@@ -76,21 +104,10 @@ public class LogReplicationPluginConfig {
 
     private static String getParentDir() {
         try {
-            File directory = new File("../infrastructure");
+            File directory = new File("../../../infrastructure");
             return directory.getCanonicalFile().getParent();
         } catch (Exception e) {
             String message = "Failed to load default JAR for channel adapter";
-            log.error(message, e);
-            throw new UnrecoverableCorfuError(message);
-        }
-    }
-
-    private static String getStreamFetcherParentDir() {
-        try {
-            File directory = new File("../log-replication");
-            return directory.getCanonicalFile().getParent();
-        } catch (Exception e) {
-            String message = "Failed to load default JAR for stream fetcher plugin";
             log.error(message, e);
             throw new UnrecoverableCorfuError(message);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -252,7 +252,8 @@ public class LogReplicationSourceManager implements DataReceiver {
         } else if (message.getMetadata().getMessageMetadataType() == MessageType.SNAPSHOT_REPLICATED) {
             log.debug("Snapshot sync ACK received on base timestamp {}", message.getMetadata().getSnapshotTimestamp());
             logReplicationFSM.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_COMPLETE,
-                    new LogReplicationEventMetadata(message.getMetadata().getSyncRequestId(), message.getMetadata().getTimestamp())));
+                    new LogReplicationEventMetadata(message.getMetadata().getSyncRequestId(), message.getMetadata().getTimestamp(),
+                            message.getMetadata().getTimestamp())));
         } else {
             log.debug("Received data message of type {} not an ACK", message.getMetadata().getMessageMetadataType());
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -289,16 +289,16 @@ public class LogReplicationFSM {
             LogReplicationEvent event = eventQueue.take();
 
             if (event.getType() == LogReplicationEventType.REPLICATION_START) {
-                baseSnapshot = event.getMetadata().getSyncTimestamp();
-                ackedTimestamp = baseSnapshot;
+                baseSnapshot = event.getMetadata().getLastBaseSnapshot();
+                ackedTimestamp = event.getMetadata().getLastLogEntrySyncedTimestamp();
                 log.info("Log Replication FSM consume event {}", event);
             }
 
             if (event.getType() == LogReplicationEventType.LOG_ENTRY_SYNC_REPLICATED) {
                 if (state.getType() == LogReplicationStateType.IN_LOG_ENTRY_SYNC &&
                         state.getTransitionEventId().equals(event.getMetadata().getRequestId())) {
-                    log.debug("Log Entry Sync ACK, update last ack timestamp to {}", event.getMetadata().getSyncTimestamp());
-                    ackedTimestamp = event.getMetadata().getSyncTimestamp();
+                    log.debug("Log Entry Sync ACK, update last ack timestamp to {}", event.getMetadata().getLastLogEntrySyncedTimestamp());
+                    ackedTimestamp = event.getMetadata().getLastLogEntrySyncedTimestamp();
                     log.debug("Replicated Event ackTs {} ", ackedTimestamp);
                 }
             } else {
@@ -306,9 +306,9 @@ public class LogReplicationFSM {
                     // Verify it's for the same request, as that request could've been canceled and was received later
                     if (state.getType() == LogReplicationStateType.IN_SNAPSHOT_SYNC &&
                             state.getTransitionEventId().equals(event.getMetadata().getRequestId())) {
-                        log.info("Snapshot Sync ACK, update last ack timestamp to {}", event.getMetadata().getSyncTimestamp());
-                        baseSnapshot = event.getMetadata().getSyncTimestamp();
-                        ackedTimestamp = baseSnapshot;
+                        log.info("Snapshot Sync ACK, update last ack timestamp to {}", event.getMetadata().getLastLogEntrySyncedTimestamp());
+                        baseSnapshot = event.getMetadata().getLastBaseSnapshot();
+                        ackedTimestamp = event.getMetadata().getLastLogEntrySyncedTimestamp();
                     }
                 }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -7,10 +7,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.ISnapshotSyncPlugin;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntryMetadata;
 import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.view.Address;
 import org.immutables.value.internal.$guava$.annotations.$VisibleForTesting;
 
@@ -18,6 +21,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.util.Properties;
 
 import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_END;
@@ -38,14 +43,16 @@ public class LogReplicationSinkManager implements DataReceiver {
 
     private final int DEFAULT_ACK_CNT = 1;
     /*
-     * how long in milliseconds a ACK sent back to sender
+     * Duration in milliseconds after which an ACK is sent back to the sender
+     * if the message count is not reached before
      */
     private int ackCycleTime = DEFAULT_ACK_CNT;
 
     /*
-     * how frequent a ACK sent back to sender
+     * Number of messages received before sending a summarized ACK
      */
     private int ackCycleCnt;
+
     private int bufferSize;
 
     private CorfuRuntime runtime;
@@ -62,13 +69,10 @@ public class LogReplicationSinkManager implements DataReceiver {
 
     private LogReplicationConfig config;
 
-    /*
-     * the current baseSnapshot
-     */
     private long baseSnapshotTimestamp = Address.NON_ADDRESS - 1;
 
     /*
-     * current topologyConfigId, used to drop out of date messages.
+     * Current topologyConfigId, used to drop out of date messages.
      */
     private long topologyConfigId = 0;
 
@@ -79,6 +83,10 @@ public class LogReplicationSinkManager implements DataReceiver {
     @VisibleForTesting
     @Getter
     private ObservableValue rxMessageCount = new ObservableValue(rxMessageCounter);
+
+    private ISnapshotSyncPlugin snapshotSyncPlugin;
+
+    private String pluginConfigFilePath;
 
     /**
      * Constructor Sink Manager
@@ -109,6 +117,7 @@ public class LogReplicationSinkManager implements DataReceiver {
         this.rxState = RxState.LOG_ENTRY_SYNC;
         this.config = config;
         this.topologyConfigId = topologyConfigId;
+        this.pluginConfigFilePath = context.getPluginConfigFilePath();
         init();
     }
 
@@ -120,10 +129,11 @@ public class LogReplicationSinkManager implements DataReceiver {
      */
     @VisibleForTesting
     public LogReplicationSinkManager(String localCorfuEndpoint, LogReplicationConfig config,
-                                     LogReplicationMetadataManager metadataManager) {
+                                     LogReplicationMetadataManager metadataManager, String pluginConfigFilePath) {
         this.logReplicationMetadataManager = metadataManager;
         this.runtime =  CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
                 .parseConfigurationString(localCorfuEndpoint).connect();
+        this.pluginConfigFilePath = pluginConfigFilePath;
 
         /*
          * When the server is up, it will be at LOG_ENTRY_SYNC state by default.
@@ -139,17 +149,31 @@ public class LogReplicationSinkManager implements DataReceiver {
      * Init variables.
      */
     private void init() {
-
         // Read config first before init other components.
         readConfig();
 
+        // Instantiate Snapshot Sync Plugin, this is an external service which will be triggered on start and end
+        // of a snapshot sync.
+        snapshotSyncPlugin = getSnapshotPlugin();
         snapshotWriter = new StreamsSnapshotWriter(runtime, config, logReplicationMetadataManager);
         logEntryWriter = new LogEntryWriter(runtime, config, logReplicationMetadataManager);
-        logEntryWriter.reset(logReplicationMetadataManager.getLastSrcBaseSnapshotTimestamp(),
+        logEntryWriter.reset(logReplicationMetadataManager.getLastAppliedBaseSnapshotTimestamp(),
                 logReplicationMetadataManager.getLastProcessedLogTimestamp());
 
         logEntrySinkBufferManager = new LogEntrySinkBufferManager(ackCycleTime, ackCycleCnt, bufferSize,
                 logReplicationMetadataManager.getLastProcessedLogTimestamp(), this);
+    }
+
+    private ISnapshotSyncPlugin getSnapshotPlugin() {
+        LogReplicationPluginConfig config = new LogReplicationPluginConfig(pluginConfigFilePath);
+        File jar = new File(config.getSnapshotSyncPluginJARPath());
+        try (URLClassLoader child = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader())) {
+            Class plugin = Class.forName(config.getSnapshotSyncPluginCanonicalName(), true, child);
+            return (ISnapshotSyncPlugin) plugin.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            log.error("Fatal error: Failed to get Snapshot Sync Plugin", e);
+            throw new UnrecoverableCorfuError(e);
+        }
     }
 
     /**
@@ -201,14 +225,21 @@ public class LogReplicationSinkManager implements DataReceiver {
 
         // If it receives a SNAPSHOT_START message, prepare a transition
         if (message.getMetadata().getMessageMetadataType().equals(MessageType.SNAPSHOT_START)) {
-            processSnapshotStart(message);
+            if (isValidSnapshotStart(message)) {
+                processSnapshotStart(message);
+                // The SnapshotPlugin will be called when LR is ready to start a snapshot sync,
+                // so the system can prepare for the full sync. Typically, to stop checkpoint/trim
+                // during the period of the snapshot sync to prevent data loss from shadow tables
+                // (temporal non-checkpointed streams). This is a blocking call.
+                log.info("onSnapshotSyncStart :: {}", snapshotSyncPlugin.getClass().getSimpleName());
+                snapshotSyncPlugin.onSnapshotSyncStart(runtime);
+            }
             return null;
         }
 
         if (!receivedValidMessage(message)) {
-
             // It is possible that the sender doesn't receive the SNAPSHOT_END ACK message and
-            // send the SNAPSHOT_END message again, but the receiver has already transited to
+            // sends the SNAPSHOT_END message again, but the receiver has already transited to
             // the LOG_ENTRY_SYNC state.
             // Reply the SNAPSHOT_ACK again and let sender do the proper transition.
             if (message.getMetadata().getMessageMetadataType() == SNAPSHOT_END) {
@@ -227,23 +258,52 @@ public class LogReplicationSinkManager implements DataReceiver {
             return null;
         }
 
-        if (rxState.equals(RxState.LOG_ENTRY_SYNC)) {
-            return logEntrySinkBufferManager.processMsgAndBuffer(message);
-        } else {
-            return snapshotSinkBufferManager.processMsgAndBuffer(message);
-        }
+        return processReceivedMessage(message);
     }
 
     /**
-     * Process a SNAPSHOT_START message. This message will not be pushed to the buffer,
-     * as it trigger a transition and reset the state.
-     * If it is requesting a new snapshot with higher timestamp, transition to SNAPSHOT_SYNC state,
-     * otherwise ignore the message.
-     * @param entry
+     * Process received (valid) message depending on the current rx state (LOG_ENTRY_SYNC or SNAPSHOT_SYNC)
+     *
+     * @param message received message
+     * @return ack
      */
-    private void processSnapshotStart(LogReplicationEntry entry) {
+    private LogReplicationEntry processReceivedMessage(LogReplicationEntry message) {
+        if (rxState.equals(RxState.LOG_ENTRY_SYNC)) {
+            return logEntrySinkBufferManager.processMsgAndBuffer(message);
+        } else {
+            LogReplicationEntry ack = snapshotSinkBufferManager.processMsgAndBuffer(message);
+            // Check to the one persisted...
+            if (ack.getMetadata().getMessageMetadataType() == MessageType.SNAPSHOT_REPLICATED) {
+                long lastAppliedBaseSnapshotTimestamp = logReplicationMetadataManager.getLastAppliedBaseSnapshotTimestamp();
+                long latestSnapshotSyncCycleId = logReplicationMetadataManager.getCurrentSnapshotSyncCycleId();
+                long ackSnapshotSyncCycleId = ack.getMetadata().getSyncRequestId().getMostSignificantBits() & Long.MAX_VALUE;
+                // Verify this snapshot ACK corresponds to the last initialized/valid snapshot sync
+                // as a previous one could have been canceled but still processed due to messages being out of order
+                if ((ackSnapshotSyncCycleId == latestSnapshotSyncCycleId) &&
+                        (ack.getMetadata().getSnapshotTimestamp() == lastAppliedBaseSnapshotTimestamp)) {
+                    // Notify end of snapshot sync. This is a blocking call.
+                    snapshotSyncPlugin.onSnapshotSyncEnd(runtime);
+                } else {
+                    log.warn("SNAPSHOT_SYNC has completed for {}, but new ongoing SNAPSHOT_SYNC is {}",
+                            ack.getMetadata().getSnapshotTimestamp(), lastAppliedBaseSnapshotTimestamp);
+                }
+            }
+            return ack;
+        }
+    }
+
+
+    /**
+     * Verify if current Snapshot Start message determines the start
+     * of a valid Snapshot Sync cycle.
+     *
+     * @param entry received entry
+     * @return true, if it is a valid snapshot start marker
+     *         false, otherwise
+     */
+    private boolean isValidSnapshotStart(LogReplicationEntry entry) {
         long topologyConfigId = entry.getMetadata().getTopologyConfigId();
-        long timestamp = entry.getMetadata().getSnapshotTimestamp();
+        long messageBaseSnapshot = entry.getMetadata().getSnapshotTimestamp();
 
         log.debug("Received snapshot sync start marker for {} on base snapshot timestamp {}",
                 entry.getMetadata().getSyncRequestId(), entry.getMetadata().getSnapshotTimestamp());
@@ -251,24 +311,39 @@ public class LogReplicationSinkManager implements DataReceiver {
         /*
          * It is out of date message due to resend, drop it.
          */
-        if (entry.getMetadata().getSnapshotTimestamp() <= baseSnapshotTimestamp) {
+        if (messageBaseSnapshot <= baseSnapshotTimestamp) {
             // Invalid message and drop it.
-            log.warn("Sink Manager in state {} and received message {}. " +
-                            "Dropping Message due to snapshotTimestamp is smaller than the current one {}",
+            log.warn("Sink Manager, state={} while received message={}. " +
+                            "Dropping message with smaller snapshot timestamp than current {}",
                     rxState, entry.getMetadata(), baseSnapshotTimestamp);
-            return;
+            return false;
         }
 
         /*
          * Fails to set the baseSnapshot at the metadata store, it could be a out of date message,
          * or the current node is out of sync, ignore it.
          */
-        if (logReplicationMetadataManager.setSrcBaseSnapshotStart(topologyConfigId, timestamp) == false) {
+        if (!logReplicationMetadataManager.setSrcBaseSnapshotStart(topologyConfigId, messageBaseSnapshot)) {
             log.warn("Sink Manager in state {} and received message {}. " +
                             "Dropping Message due to failure update of the metadata store {}",
                     rxState, entry.getMetadata(), logReplicationMetadataManager);
-            return;
+            return false;
         }
+
+        return true;
+    }
+
+    /**
+     * Process a SNAPSHOT_START message. This message will not be pushed to the buffer,
+     * as it triggers a transition and resets the state.
+     * If it is requesting a new snapshot with higher timestamp, transition to SNAPSHOT_SYNC state,
+     * otherwise ignore the message.
+     *
+     * @param entry
+     */
+    private boolean processSnapshotStart(LogReplicationEntry entry) {
+        long topologyConfigId = entry.getMetadata().getTopologyConfigId();
+        long timestamp = entry.getMetadata().getSnapshotTimestamp();
 
         /*
          * Signal start of snapshot sync to the writer, so data can be cleared (on old snapshot syncs)
@@ -285,6 +360,7 @@ public class LogReplicationSinkManager implements DataReceiver {
         // Set state in SNAPSHOT_SYNC state.
         rxState = RxState.SNAPSHOT_SYNC;
         log.info("Sink manager entry {} state, snapshot start with {}", rxState, entry.getMetadata());
+        return true;
     }
 
     /**
@@ -305,10 +381,11 @@ public class LogReplicationSinkManager implements DataReceiver {
     }
 
     /**
-     * Process SNAPSHOT transfer messages
-     * @param message
+     * Process transferred SNAPSHOT messages
+     *
+     * @param message received entry message
      */
-    private void applySnapshotSync(LogReplicationEntry message) {
+    private void processSnapshotMessage(LogReplicationEntry message) {
         switch (message.getMetadata().getMessageMetadataType()) {
             case SNAPSHOT_MESSAGE:
                 snapshotWriter.apply(message);
@@ -336,7 +413,7 @@ public class LogReplicationSinkManager implements DataReceiver {
                 break;
 
             case SNAPSHOT_SYNC:
-                applySnapshotSync(message);
+                processSnapshotMessage(message);
                 break;
 
             default:
@@ -372,8 +449,8 @@ public class LogReplicationSinkManager implements DataReceiver {
      *
      * */
     public void reset() {
-        snapshotWriter.reset(topologyConfigId, logReplicationMetadataManager.getLastSrcBaseSnapshotTimestamp());
-        logEntryWriter.reset(logReplicationMetadataManager.getLastSrcBaseSnapshotTimestamp(),
+        snapshotWriter.reset(topologyConfigId, logReplicationMetadataManager.getLastAppliedBaseSnapshotTimestamp());
+        logEntryWriter.reset(logReplicationMetadataManager.getLastAppliedBaseSnapshotTimestamp(),
                 logReplicationMetadataManager.getLastProcessedLogTimestamp());
         logEntrySinkBufferManager = new LogEntrySinkBufferManager(ackCycleTime, ackCycleCnt, bufferSize,
                 logReplicationMetadataManager.getLastProcessedLogTimestamp(), this);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SnapshotSinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SnapshotSinkBufferManager.java
@@ -25,14 +25,13 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
      */
     public SnapshotSinkBufferManager(int ackCycleTime, int ackCycleCnt, int size,
                                      long lastProcessedSeq, LogReplicationSinkManager sinkManager) {
-
         super(SNAPSHOT_MESSAGE, ackCycleTime, ackCycleCnt, size, lastProcessedSeq, sinkManager);
     }
 
     /**
      *
      * @param entry
-     * @return Previous inorder message's snapshotSeqNumber.
+     * @return Previous in order message's snapshotSeqNumber.
      */
     @Override
     long getPreSeq(LogReplicationEntry entry) {
@@ -84,14 +83,8 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
      */
     @Override
     public boolean verifyMessageType(LogReplicationEntry entry) {
-        switch (entry.getMetadata().getMessageMetadataType()) {
-            case SNAPSHOT_MESSAGE:
-            case SNAPSHOT_END:
-                return true;
-            default:
-                log.error("wrong message type ", entry.getMetadata());
-                return false;
-        }
+        return entry.getMetadata().getMessageMetadataType() == SNAPSHOT_MESSAGE ||
+                entry.getMetadata().getMessageMetadataType() == SNAPSHOT_END;
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationEventMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationEventMetadata.java
@@ -20,12 +20,15 @@ public class LogReplicationEventMetadata {
      */
     private UUID requestId;
 
-    /* Represents the last synced timestamp.
-     *
-     * For snapshot sync, it represents the base snapshot.
-     * For log entry sync, it represents the last log entry synced.
-    */
-    private long syncTimestamp;
+    /*
+     * Represents the last log entry synced timestamp.
+     */
+    private long lastLogEntrySyncedTimestamp;
+
+    /*
+     * Represents the last base snapshot timestamp.
+     */
+    private long lastBaseSnapshot;
 
     /**
      * Empty Metadata
@@ -53,16 +56,31 @@ public class LogReplicationEventMetadata {
      */
     public LogReplicationEventMetadata(UUID requestId, long syncTimestamp) {
         this.requestId = requestId;
-        this.syncTimestamp = syncTimestamp;
+        this.lastLogEntrySyncedTimestamp = syncTimestamp;
+    }
+
+    /**
+     * Constructor
+     *
+     * @param requestId identifier of the request that preceded this event.
+     * @param syncTimestamp last synced timestamp.
+     * @param baseSnapshot last base snapshot
+     */
+    public LogReplicationEventMetadata(UUID requestId, long syncTimestamp, long baseSnapshot) {
+        this(requestId, syncTimestamp);
+        this.lastBaseSnapshot = baseSnapshot;
     }
 
     public UUID getRequestId() {
         return this.requestId;
     }
 
-    public long getSyncTimestamp() {
-        return this.syncTimestamp;
+    public long getLastLogEntrySyncedTimestamp() {
+        return this.lastLogEntrySyncedTimestamp;
     }
 
+    public long getLastBaseSnapshot() {
+        return this.lastBaseSnapshot;
+    }
 }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
@@ -130,8 +130,9 @@ public abstract class SenderBufferManager {
     }
 
     /**
-     * process all Acks that have recieved.
-     * @return the max Ack
+     * Process all ack's that have been received.
+     *
+     * @return the max ack
      * @throws InterruptedException
      * @throws ExecutionException
      * @throws TimeoutException

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -225,7 +225,7 @@ public class SnapshotSender {
         // We need to bind the internal event (COMPLETE) to the snapshotSyncEventId that originated it, this way
         // the state machine can correlate to the corresponding state (in case of delayed events)
         fsm.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_COMPLETE,
-                new LogReplicationEventMetadata(snapshotSyncEventId, baseSnapshotTimestamp)));
+                new LogReplicationEventMetadata(snapshotSyncEventId, baseSnapshotTimestamp, baseSnapshotTimestamp)));
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
@@ -33,7 +33,7 @@ import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX
 @Slf4j
 @NotThreadSafe
 /**
- *  Default snapshot logreader implementation
+ *  Default snapshot reader implementation
  *
  *  This implementation provides reads at the stream level (no coalesced state).
  *  It generates TxMessages which will be transmitted by the DataSender (provided by the application).
@@ -205,7 +205,7 @@ public class StreamsSnapshotReader implements SnapshotReader {
                     break;
                 } else {
                     // Skip process this stream as it has no entries to process, will poll the next one.
-                    log.info("Snapshot stream log reader will skip reading stream {} as there are no entries to send",
+                    log.info("Snapshot reader will skip reading stream {} as there are no entries to send",
                             currentStreamInfo.uuid);
                 }
             }
@@ -236,11 +236,11 @@ public class StreamsSnapshotReader implements SnapshotReader {
     }
 
     @Override
-    public void reset(long snapshotTimestamp) {
+    public void reset(long ts) {
         streamsToSend = new PriorityQueue<>(streams);
         preMsgTs = Address.NON_ADDRESS;
         currentMsgTs = Address.NON_ADDRESS;
-        this.snapshotTimestamp = snapshotTimestamp; //rt.getAddressSpaceView().getLogTail();
+        snapshotTimestamp = ts;
         currentStreamInfo = null;
         sequence = 0;
         lastEntry = null;
@@ -250,10 +250,10 @@ public class StreamsSnapshotReader implements SnapshotReader {
      * Used to bookkeeping the stream information for the current processing stream
      */
     public static class OpaqueStreamIterator {
-        String name;
-        UUID uuid;
-        Iterator iterator;
-        long maxVersion; //the max address of the log entries processed for this stream.
+        private String name;
+        private UUID uuid;
+        private Iterator iterator;
+        private long maxVersion; // the max address of the log entries processed for this stream.
 
         OpaqueStreamIterator(String name, CorfuRuntime rt, long snapshot) {
             this.name = name;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -268,8 +268,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                         "logHead={}, lastLogProcessed={}", logHead, negotiationResponse.getLastLogProcessed());
                 fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
                         new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.REPLICATION_START,
-                                new LogReplicationEventMetadata(LogReplicationEventMetadata.getNIL_UUID(), negotiationResponse.getLastLogProcessed())
-                        )));
+                                new LogReplicationEventMetadata(LogReplicationEventMetadata.getNIL_UUID(), negotiationResponse.getLastLogProcessed(),
+                                        negotiationResponse.getSnapshotApplied()))));
             } else {
                 // TODO: it is OK for a first phase, but this might not be efficient/accurate, as the next (+1)
                 //  might not really be the next entry (as that is a globalAddress and the +1 might not even belong to

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationClientChannelAdapter.java
@@ -44,7 +44,7 @@ public class NettyLogReplicationClientChannelAdapter extends IClientChannelAdapt
         executorService.submit(() -> {
             ClusterDescriptor remoteCluster = getRemoteClusterDescriptor();
             for (NodeDescriptor node : remoteCluster.getNodesDescriptors()) {
-                log.info("Create Corfu Channel to remote {}", node.getEndpoint());
+                log.info("Create Netty Channel to remote {}", node.getEndpoint());
                 CorfuNettyClientChannel channel = new CorfuNettyClientChannel(node, getRouter().getParameters().getNettyEventLoop(), this);
                 this.channels.put(node.getEndpoint(), channel);
             }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
@@ -28,8 +28,8 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 @Slf4j
 public class LogReplicationStreamNameTableManager {
 
-    private static final String LOG_REPLICATION_STREAMS_NAME_TABLE = "LogReplicationStreams";
-    private static final String LOG_REPLICATION_PLUGIN_VERSION_TABLE = "LogReplicationPluginVersion";
+    public static final String LOG_REPLICATION_STREAMS_NAME_TABLE = "LogReplicationStreams";
+    public static final String LOG_REPLICATION_PLUGIN_VERSION_TABLE = "LogReplicationPluginVersion";
 
     private ILogReplicationConfigAdapter logReplicationConfigAdapter;
 

--- a/infrastructure/src/main/resources/corfu_plugin_config.properties
+++ b/infrastructure/src/main/resources/corfu_plugin_config.properties
@@ -1,13 +1,16 @@
 # Transport Plugin Configuration (Plugin)
 transport_adapter_JAR_path=/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
-transport_adapter_server_class_name=org.corfudb.transport.channel.GRPCLogReplicationServerChannelAdapter
-transport_adapter_client_class_name=org.corfudb.transport.channel.GRPCLogReplicationClientChannelAdapter
+transport_adapter_server_class_name=org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationServerChannelAdapter
+transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationClientChannelAdapter
 
-#Stream Fetcher Configuration (Plugin)
+# Stream Fetcher Configuration (Plugin)
 stream_fetcher_plugin_JAR_path=/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
-stream_fetcher_plugin_class_name=org.corfudb.logreplication.runtime.DefaultStreamFetcherPlugin
+stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultStreamFetcherPlugin
 
 # Topology Manager Configuration (Plugin)
 topology_manager_adapter_JAR_path=/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
-topology_manager_adapter_class_name=org.corfudb.logreplication.infrastructure.DefaultClusterManager
+topology_manager_adapter_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager
 
+# Snapshot Sync Configuration (Plugin)
+snapshot_sync_plugin_JAR_path=/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+snapshot_sync_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogUpdateAPITest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogUpdateAPITest.java
@@ -21,10 +21,7 @@ import org.corfudb.test.SampleSchema.Uuid;
 import org.junit.Test;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -33,7 +30,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 public class LogUpdateAPITest extends AbstractViewTest {
     static final private int NUM_KEYS = 10;
-
 
     /**
      * Test the TxBuilder logUpdate API work properly.

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -47,7 +47,6 @@ public class AbstractIT extends AbstractCorfuTest {
     static final int DEFAULT_PORT = 9000;
 
     static final int DEFAULT_LOG_REPLICATION_PORT = 9020;
-    static final String DEFAULT_LOG_REPLICATION_FILE = "log_replication";
 
     static final String DEFAULT_ENDPOINT = DEFAULT_HOST + ":" + DEFAULT_PORT;
 
@@ -322,6 +321,16 @@ public class AbstractIT extends AbstractCorfuTest {
                 .runServer();
     }
 
+    public static Process runReplicationServer(int port, String pluginConfigFilePath, int lockLeaseDuration) throws IOException {
+        return new CorfuReplicationServerRunner()
+                .setHost(DEFAULT_HOST)
+                .setPort(port)
+                .setLockLeaseDuration(Integer.valueOf(lockLeaseDuration))
+                .setPluginConfigFilePath(pluginConfigFilePath)
+                .setMsg_size(MSG_SIZE)
+                .runServer();
+    }
+
     public static Process runDefaultServer() throws IOException {
         return new CorfuServerRunner()
                 .setHost(DEFAULT_HOST)
@@ -514,6 +523,7 @@ public class AbstractIT extends AbstractCorfuTest {
         private String pluginConfigFilePath = null;
         private String logPath = null;
         private int msg_size = 0;
+        private Integer lockLeaseDuration;
 
         /**
          * Create a command line string according to the properties set for a Corfu Server
@@ -552,6 +562,10 @@ public class AbstractIT extends AbstractCorfuTest {
 
             if(pluginConfigFilePath != null) {
                 command.append(" --plugin=").append(pluginConfigFilePath);
+            }
+
+            if (lockLeaseDuration != null) {
+                command.append(" --lock-lease=").append(lockLeaseDuration);
             }
 
             command.append(" -d ").append(logLevel).append(" ")

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
@@ -1,9 +1,5 @@
 package org.corfudb.integration;
 
-import com.google.common.reflect.TypeToken;
-import org.corfudb.infrastructure.logreplication.infrastructure.CorfuInterClusterReplicationServer;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.collections.CorfuTable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -13,23 +9,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(Parameterized.class)
-public class CorfuReplicationE2EIT extends AbstractIT {
-
-    private static final int MSG_SIZE = 65536;
-
-    private String pluginConfigFilePath;
-
-    // Note: this flag is kept for debugging purposes only.
-    // Log Replication Server should run as a process as the unexpected termination of it
-    // (for instance the completion of a test) causes SYSTEM_EXIT(ERROR_CODE).
-    // If flipped to debug (easily access logs within the IDE, flip back before pushing upstream).
-    private static boolean runProcess = true;
+public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
 
     public CorfuReplicationE2EIT(String plugin) {
         this.pluginConfigFilePath = plugin;
@@ -39,7 +21,8 @@ public class CorfuReplicationE2EIT extends AbstractIT {
     @Parameterized.Parameters
     public static Collection input() {
 
-        List<String> transportPlugins = Arrays.asList("src/test/resources/transport/grpcConfig.properties",
+        List<String> transportPlugins = Arrays.asList(
+                "src/test/resources/transport/grpcConfig.properties",
                 "src/test/resources/transport/nettyConfig.properties");
 
         if(runProcess) {
@@ -71,144 +54,7 @@ public class CorfuReplicationE2EIT extends AbstractIT {
      */
     @Test
     public void testLogReplicationEndToEnd() throws Exception {
-
-        ExecutorService executorService = Executors.newFixedThreadPool(2);
-        Process activeCorfu = null;
-        Process standbyCorfu = null;
-
-        Process activeReplicationServer = null;
-        Process standbyReplicationServer = null;
-
-        try {
-            final String streamA = "Table001";
-
-            final int activeSiteCorfuPort = 9000;
-            final int standbySiteCorfuPort = 9001;
-
-            final int activeReplicationServerPort = 9010;
-            final int standbyReplicationServerPort = 9020;
-
-            final String activeEndpoint = DEFAULT_HOST + ":" + activeSiteCorfuPort;
-            final String standbyEndpoint = DEFAULT_HOST + ":" + standbySiteCorfuPort;
-
-            final int numWrites = 100;
-
-            // Start Single Corfu Node Cluster on Active Site
-            activeCorfu = runServer(activeSiteCorfuPort, true);
-
-            // Start Corfu Cluster on Standby Site
-            standbyCorfu = runServer(standbySiteCorfuPort, true);
-
-            CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
-                    .builder()
-                    .build();
-
-            CorfuRuntime activeRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
-            activeRuntime.parseConfigurationString(activeEndpoint);
-            activeRuntime.connect();
-
-            CorfuRuntime standbyRuntime = new CorfuRuntime(standbyEndpoint).connect();
-
-            // Write to StreamA on Active Site
-            CorfuTable<String, Integer> mapA = activeRuntime.getObjectsView()
-                    .build()
-                    .setStreamName(streamA)
-                    .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
-                    })
-                    .open();
-
-            CorfuTable<String, Integer> mapAStandby = standbyRuntime.getObjectsView()
-                    .build()
-                    .setStreamName(streamA)
-                    .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
-                    })
-                    .open();
-
-            assertThat(mapA.size()).isEqualTo(0);
-
-            for (int i = 0; i < numWrites; i++) {
-                activeRuntime.getObjectsView().TXBegin();
-                mapA.put(String.valueOf(i), i);
-                activeRuntime.getObjectsView().TXEnd();
-            }
-
-            assertThat(mapA.size()).isEqualTo(numWrites);
-
-            // Confirm data does not exist on Standby Site
-            assertThat(mapAStandby.size()).isEqualTo(0);
-
-            if (runProcess) {
-                // Start Log Replication Server on Active Site
-                activeReplicationServer = runReplicationServer(activeReplicationServerPort, pluginConfigFilePath);
-
-                // Start Log Replication Server on Standby Site
-                standbyReplicationServer = runReplicationServer(standbyReplicationServerPort, pluginConfigFilePath);
-            } else {
-                executorService.submit(() -> {
-                    String[] options = new String[]{"-m", "--max-data-message-size=" + MSG_SIZE, "--plugin=" + pluginConfigFilePath, "--address=localhost",
-                            String.valueOf(activeReplicationServerPort)};
-                    CorfuInterClusterReplicationServer.main(options);
-                });
-
-                executorService.submit(() -> {
-                    String[] options = new String[]{"-m", "--max-data-message-size=" + MSG_SIZE, "--plugin=" + pluginConfigFilePath, "--address=localhost",
-                            String.valueOf(standbyReplicationServerPort)};
-                    CorfuInterClusterReplicationServer.main(options);
-                });
-            }
-
-            System.out.println("\nUsing transport defined in :: " + pluginConfigFilePath);
-
-            // Wait until data is fully replicated
-            System.out.println("Wait ... Snapshot log replication in progress ...");
-            while (mapAStandby.size() != numWrites) {
-                //
-            }
-
-            // Verify data is present in Standby Site
-            assertThat(mapAStandby.size()).isEqualTo(numWrites);
-
-            // Add new updates (deltas)
-            for (int i=0; i < numWrites/2; i++) {
-                activeRuntime.getObjectsView().TXBegin();
-                mapA.put(String.valueOf(numWrites + i), numWrites + i);
-                activeRuntime.getObjectsView().TXEnd();
-            }
-
-            // Verify data is present in Standby Site
-            System.out.println("Wait ... Delta log replication in progress ...");
-            while (mapAStandby.size() != (numWrites + numWrites/2)) {
-                //
-            }
-
-            // Verify data is present in Standby Site (delta)
-            assertThat(mapAStandby.size()).isEqualTo(numWrites + numWrites/2);
-
-            for (int i = 0; i < (numWrites + numWrites/2) ; i++) {
-                assertThat(mapAStandby.containsKey(String.valueOf(i)));
-            }
-
-            System.out.print("Test succeeds");
-
-        } finally {
-
-            executorService.shutdownNow();
-
-            if (activeCorfu != null) {
-                activeCorfu.destroy();
-            }
-
-            if (standbyCorfu != null) {
-                standbyCorfu.destroy();
-            }
-
-            if (activeReplicationServer != null) {
-                activeReplicationServer.destroy();
-            }
-
-            if (standbyReplicationServer != null) {
-                standbyReplicationServer.destroy();
-            }
-        }
+        System.out.println("\n Using plugin :: " + pluginConfigFilePath);
+        testEndToEndSnapshotAndLogEntrySync();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
@@ -1,0 +1,233 @@
+package org.corfudb.integration;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This suite of tests verifies the behavior of log replication in the event of
+ * Checkpoint and Trim both in the sender (source/active cluster) and receiver (sink/standby cluster)
+ */
+public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
+
+    /**
+     * Sets the plugin path before starting any test
+     * @throws Exception
+     */
+    @Before
+    public void setupPluginPath() {
+        if(runProcess) {
+            File f = new File(nettyConfig);
+            this.pluginConfigFilePath = f.getAbsolutePath();
+        } else {
+            this.pluginConfigFilePath = nettyConfig;
+        }
+    }
+
+    /**
+     * Test the case where the log is trimmed on the standby in between two snapshot syncs.
+     * We should guarantee that shadow streams do not throw trim exceptions and data is applied successfully.
+     *
+     * This test does the following:
+     *      (1) Do a Snapshot (full) and Log Entry (delta) Sync
+     *      (2) Stop the active cluster LR (we stop so we can write some more data and checkpoint it, such that we enforce
+     *          s subsequent snapshot sync, otherwise this written data would be transferred in log entry--delta--sync)
+     *      (3) Checkpoint and Trim on Standby Cluster (enforce shadow streams to be trimmed)
+     *      (4) Write additional data on Active Cluster (while LR is down)
+     *          (4.1) Verify Data written is present on active
+     *          (4.2) Verify this new Data is not yet present on standby
+     *      (5) Checkpoint and Trim on Active Cluster (to guarantee when we bring up the server, delta's are not available
+     *          so Snapshot Sync is enforced)
+     *      (6) Start Active LR
+     *      (7) Verify Data reaches standby cluster
+     *
+     *
+     */
+    @Test
+    public void testTrimBetweenSnapshotSync() throws Exception {
+        try {
+            testEndToEndSnapshotAndLogEntrySync();
+
+            // Stop Log Replication on Active, so we can write some data into active Corfu
+            // and checkpoint so we enforce a subsequent Snapshot Sync
+            System.out.println("Stop Active Log Replicator ...");
+            stopActiveLogReplicator();
+
+            // Checkpoint & Trim on the Standby (so shadow stream get trimmed)
+            checkpointAndTrim(false, Collections.singletonList(mapAStandby));
+
+            // Write Entry's to Active Cluster (while replicator is down)
+            System.out.println("Write additional entries to active CorfuDB ...");
+            writeToActive((numWrites + (numWrites/2)), numWrites/2);
+
+            // Confirm data does exist on Active Cluster
+            assertThat(mapA.size()).isEqualTo(numWrites*2);
+
+            // Confirm new data does not exist on Standby Cluster
+            assertThat(mapAStandby.size()).isEqualTo((numWrites + (numWrites/2)));
+
+            // Checkpoint & Trim on the Active so we force a snapshot sync on restart
+            checkpointAndTrim(true, Collections.singletonList(mapA));
+
+            System.out.println("Start active Log Replicator again ...");
+            startActiveLogReplicator();
+
+            System.out.println("Verify Data on Standby ...");
+            verifyDataOnStandby((numWrites*2));
+
+            System.out.println("Entries :: " + mapAStandby.keySet());
+
+        } finally {
+
+            executorService.shutdownNow();
+
+            if (activeCorfu != null) {
+                activeCorfu.destroy();
+            }
+
+            if (standbyCorfu != null) {
+                standbyCorfu.destroy();
+            }
+
+            if (activeReplicationServer != null) {
+                activeReplicationServer.destroy();
+            }
+
+            if (standbyReplicationServer != null) {
+                standbyReplicationServer.destroy();
+            }
+        }
+    }
+
+    /**
+     * Test the case where the log is trimmed in between two cycles of log entry sync.
+     * In this test we stop the active log replicator before trimming so we
+     * can enforce re-negotiation after the trim.
+     */
+    @Test
+    public void testTrimmedExceptionsBetweenLogEntrySync() throws Exception {
+        testLogTrimBetweenLogEntrySync(true);
+    }
+
+    /**
+     * Test the case where the log is trimmed in between two cycles of log entry sync.
+     * In this test we don't stop the active log replicator, so log entry sync is resumed.
+     */
+    @Test
+    public void testTrimmedExceptionsBetweenLogEntrySyncContinuous() throws Exception {
+        testLogTrimBetweenLogEntrySync(false);
+    }
+
+    /**
+     * Test trimming the log on the standby site, in the middle of log entry sync.
+     *
+     * @param stop true, stop the active server right before trimming (to enforce re-negotiation)
+     *             false, trim without stopping the server.
+     */
+    private void testLogTrimBetweenLogEntrySync(boolean stop) throws Exception {
+        try {
+            testEndToEndSnapshotAndLogEntrySync();
+
+            if (stop) {
+                // Stop Log Replication on Active, so we can test re-negotiation in the event of trims
+                System.out.println("Stop Active Log Replicator ...");
+                stopActiveLogReplicator();
+            }
+
+            // Checkpoint & Trim on the Standby, so we trim the shadow stream
+            checkpointAndTrim(false, Collections.singletonList(mapAStandby));
+
+            // Write Entry's to Active Cluster (while replicator is down)
+            System.out.println("Write additional entries to active CorfuDB ...");
+            writeToActive((numWrites + (numWrites/2)), numWrites/2);
+
+            // Confirm data does exist on Active Cluster
+            assertThat(mapA.size()).isEqualTo(numWrites*2);
+
+            if (stop) {
+                // Confirm new data does not exist on Standby Cluster
+                assertThat(mapAStandby.size()).isEqualTo((numWrites + (numWrites / 2)));
+
+                System.out.println("Start active Log Replicator again ...");
+                startActiveLogReplicator();
+            }
+
+            // Since we did not checkpoint data should be transferred in delta's
+            System.out.println("Verify Data on Standby ...");
+            verifyDataOnStandby((numWrites*2));
+
+            System.out.println("Entries :: " + mapAStandby.keySet());
+        } finally {
+
+            executorService.shutdownNow();
+
+            if (activeCorfu != null) {
+                activeCorfu.destroy();
+            }
+
+            if (standbyCorfu != null) {
+                standbyCorfu.destroy();
+            }
+
+            if (activeReplicationServer != null) {
+                activeReplicationServer.destroy();
+            }
+
+            if (standbyReplicationServer != null) {
+                standbyReplicationServer.destroy();
+            }
+        }
+    }
+
+    @Test
+    public void testSnapshotSyncEndToEndWithCheckpointedStreams() throws Exception {
+        try {
+            System.out.println("\nSetup active and standby Corfu's");
+            setupActiveAndStandbyCorfu();
+
+            System.out.println("Open map on active and standby");
+            openMap();
+
+            System.out.println("Write data to active CorfuDB before LR is started ...");
+            // Add Data for Snapshot Sync
+            writeToActive(0, numWrites);
+
+            // Confirm data does exist on Active Cluster
+            assertThat(mapA.size()).isEqualTo(numWrites);
+
+            // Confirm data does not exist on Standby Cluster
+            assertThat(mapAStandby.size()).isZero();
+
+            // Checkpoint and Trim Before Starting
+            checkpointAndTrim(true, Arrays.asList(mapA));
+
+            startLogReplicatorServers();
+
+            System.out.println("Wait ... Snapshot log replication in progress ...");
+            verifyDataOnStandby(numWrites);
+        } finally {
+            executorService.shutdownNow();
+
+            if (activeCorfu != null) {
+                activeCorfu.destroy();
+            }
+
+            if (standbyCorfu != null) {
+                standbyCorfu.destroy();
+            }
+
+            if (activeReplicationServer != null) {
+                activeReplicationServer.destroy();
+            }
+
+            if (standbyReplicationServer != null) {
+                standbyReplicationServer.destroy();
+            }
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -1,0 +1,359 @@
+package org.corfudb.integration;
+
+import com.google.common.reflect.TypeToken;
+import org.corfudb.infrastructure.logreplication.infrastructure.CorfuInterClusterReplicationServer;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata;
+import org.corfudb.runtime.MultiCheckpointWriter;
+import org.corfudb.runtime.collections.CorfuDynamicKey;
+import org.corfudb.runtime.collections.CorfuDynamicRecord;
+import org.corfudb.runtime.collections.CorfuRecord;
+import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.view.SMRObject;
+import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.util.serializer.DynamicProtobufSerializer;
+import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.ProtobufSerializer;
+import org.corfudb.util.serializer.Serializers;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LogReplicationAbstractIT extends AbstractIT {
+
+    private static final int MSG_SIZE = 65536;
+
+    public final static String nettyConfig = "src/test/resources/transport/nettyConfig.properties";
+
+    public String pluginConfigFilePath;
+
+    // Note: this flag is kept for debugging purposes only.
+    // Log Replication Server should run as a process as the unexpected termination of it
+    // (for instance the completion of a test) causes SYSTEM_EXIT(ERROR_CODE).
+    // If flipped to debug (easily access logs within the IDE, flip back before pushing upstream).
+    public static boolean runProcess = true;
+
+    public ExecutorService executorService = Executors.newFixedThreadPool(2);
+    public Process activeCorfu = null;
+    public Process standbyCorfu = null;
+
+    public Process activeReplicationServer = null;
+    public Process standbyReplicationServer = null;
+
+    public final String streamA = "Table001";
+
+    public final int numWrites = 10;
+    public final int lockLeaseDuration = 8;
+
+    public final int activeSiteCorfuPort = 9000;
+    public final int standbySiteCorfuPort = 9001;
+
+    public final int activeReplicationServerPort = 9010;
+    public final int standbyReplicationServerPort = 9020;
+
+    public final String activeEndpoint = DEFAULT_HOST + ":" + activeSiteCorfuPort;
+    public final String standbyEndpoint = DEFAULT_HOST + ":" + standbySiteCorfuPort;
+
+    public CorfuRuntime activeRuntime;
+    public CorfuRuntime standbyRuntime;
+
+    public CorfuTable<String, Integer> mapA;
+    public CorfuTable<String, Integer> mapAStandby;
+
+    public void testEndToEndSnapshotAndLogEntrySync() throws Exception {
+        try {
+            System.out.println("\nSetup active and standby Corfu's");
+            setupActiveAndStandbyCorfu();
+
+            System.out.println("Open map on active and standby");
+            openMap();
+
+            System.out.println("Write data to active CorfuDB before LR is started ...");
+            // Add Data for Snapshot Sync
+            writeToActive(0, numWrites);
+
+            // Confirm data does exist on Active Cluster
+            assertThat(mapA.size()).isEqualTo(numWrites);
+
+            // Confirm data does not exist on Standby Cluster
+            assertThat(mapAStandby.size()).isEqualTo(0);
+
+            startLogReplicatorServers();
+
+            System.out.println("Wait ... Snapshot log replication in progress ...");
+            verifyDataOnStandby(numWrites);
+
+            // Add Delta's for Log Entry Sync
+            writeToActive(numWrites, numWrites/2);
+
+            System.out.println("Wait ... Delta log replication in progress ...");
+            verifyDataOnStandby((numWrites + (numWrites / 2)));
+        } finally {
+            executorService.shutdownNow();
+
+            if (activeCorfu != null) {
+                activeCorfu.destroy();
+            }
+
+            if (standbyCorfu != null) {
+                standbyCorfu.destroy();
+            }
+
+            if (activeReplicationServer != null) {
+                activeReplicationServer.destroy();
+            }
+
+            if (standbyReplicationServer != null) {
+                standbyReplicationServer.destroy();
+            }
+        }
+
+    }
+
+    public void setupActiveAndStandbyCorfu() throws Exception {
+        try {
+            // Start Single Corfu Node Cluster on Active Site
+            activeCorfu = runServer(activeSiteCorfuPort, true);
+
+            // Start Corfu Cluster on Standby Site
+            standbyCorfu = runServer(standbySiteCorfuPort, true);
+
+            // Setup runtime's to active and standby Corfu
+            CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
+                    .builder()
+                    .build();
+
+            activeRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+            activeRuntime.parseConfigurationString(activeEndpoint);
+            activeRuntime.connect();
+
+            standbyRuntime = new CorfuRuntime(standbyEndpoint).connect();
+        } catch (Exception e) {
+            System.out.println("Error while starting Corfu");
+            throw  e;
+        }
+    }
+
+    public void openMap() {
+        // Write to StreamA on Active Site
+        mapA = activeRuntime.getObjectsView()
+                .build()
+                .setStreamName(streamA)
+                .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
+                })
+                .open();
+
+        mapAStandby = standbyRuntime.getObjectsView()
+                .build()
+                .setStreamName(streamA)
+                .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
+                })
+                .open();
+
+        assertThat(mapA.size()).isEqualTo(0);
+        assertThat(mapAStandby.size()).isEqualTo(0);
+    }
+
+    public void writeToActive(int startIndex, int totalEntries) {
+        int maxIndex = totalEntries + startIndex;
+        for (int i = startIndex; i < maxIndex; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapA.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+    }
+
+    public void startLogReplicatorServers() {
+        try {
+            if (runProcess) {
+                // Start Log Replication Server on Active Site
+                activeReplicationServer = runReplicationServer(activeReplicationServerPort, pluginConfigFilePath, lockLeaseDuration);
+
+                // Start Log Replication Server on Standby Site
+                standbyReplicationServer = runReplicationServer(standbyReplicationServerPort, pluginConfigFilePath, lockLeaseDuration);
+            } else {
+                executorService.submit(() -> {
+                    CorfuInterClusterReplicationServer.main(new String[]{"-m", "--max-data-message-size=" + MSG_SIZE,  "--plugin=" + pluginConfigFilePath,
+                            "--address=localhost", "--lock-lease=5", String.valueOf(activeReplicationServerPort)});
+                });
+
+                executorService.submit(() -> {
+                    CorfuInterClusterReplicationServer.main(new String[]{"-m", "--max-data-message-size=" + MSG_SIZE, "--plugin=" + pluginConfigFilePath,
+                            "--address=localhost", "--lock-lease=5", String.valueOf(standbyReplicationServerPort)});
+                });
+            }
+        } catch (Exception e) {
+            System.out.println("Error caught while running Log Replication Server");
+        }
+    }
+
+    public void stopActiveLogReplicator() {
+        List<String> paramsPs = Arrays.asList("/bin/sh", "-c", "ps aux | grep CorfuInterClusterReplicationServer | grep 9010");
+        String result = runCommandForOutput(paramsPs);
+
+        // Get PID
+        String[] output = result.split(" ");
+        int i = 0;
+        String pid = "";
+        for (String st : output) {
+            if (!st.equals("")) {
+                i++;
+                if (i == 2) {
+                    pid = st;
+                    break;
+                }
+            }
+        }
+
+        System.out.println("*** Active PID :: " + pid);
+
+        List<String> paramsKill = Arrays.asList("/bin/sh", "-c", "kill -9 " + pid);
+        runCommandForOutput(paramsKill);
+
+        if (activeReplicationServer != null) {
+            activeReplicationServer.destroyForcibly();
+            activeReplicationServer = null;
+        }
+    }
+
+    public static String runCommandForOutput(List<String> params) {
+        ProcessBuilder pb = new ProcessBuilder(params);
+        Process p;
+        String result = "";
+        try {
+            p = pb.start();
+            final BufferedReader reader = new BufferedReader(new InputStreamReader(p.getInputStream()));
+
+            StringJoiner sj = new StringJoiner(System.getProperty("line.separator"));
+            reader.lines().iterator().forEachRemaining(sj::add);
+            result = sj.toString();
+
+            p.waitFor();
+            p.destroy();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return result;
+    }
+
+    public void startActiveLogReplicator() {
+        try {
+            if (runProcess) {
+                // Start Log Replication Server on Active Site
+                activeReplicationServer = runReplicationServer(activeReplicationServerPort, pluginConfigFilePath, lockLeaseDuration);
+            } else {
+                executorService.submit(() -> {
+                    CorfuInterClusterReplicationServer.main(new String[]{"-m", "--plugin=" + pluginConfigFilePath,
+                            "--address=localhost", String.valueOf(activeReplicationServerPort)});
+                });
+            }
+        } catch (Exception e) {
+            System.out.println("Error caught while running Log Replication Server");
+        }
+    }
+
+    public void verifyDataOnStandby(int expectedConsecutiveWrites) {
+        // Wait until data is fully replicated
+        while (mapAStandby.size() != expectedConsecutiveWrites) {
+            // Block until expected number of entries is reached
+        }
+
+        // Verify data is present in Standby Site
+        assertThat(mapAStandby.size()).isEqualTo(expectedConsecutiveWrites);
+
+        for (int i = 0; i < (expectedConsecutiveWrites); i++) {
+            assertThat(mapAStandby.containsKey(String.valueOf(i)));
+        }
+    }
+
+    /**
+     * Checkpoint and Trim Data Logs
+     *
+     * @param active true, checkpoint/trim on active cluster
+     *               false, checkpoint/trim on standby cluster
+     * @param tables additional tables (asides CorfuStore to be checkpointed)
+     */
+    public void checkpointAndTrim(boolean active, List<CorfuTable> tables) {
+        CorfuRuntime cpRuntime;
+
+        if (active) {
+            cpRuntime = new CorfuRuntime(activeEndpoint).connect();
+        } else {
+            cpRuntime = new CorfuRuntime(standbyEndpoint).connect();
+        }
+
+        // Checkpoint specified tables
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        Token trimMark = null;
+        if (tables.size() != 0) {
+            mcw.addAllMaps(tables);
+            trimMark = mcw.appendCheckpoints(cpRuntime, "author");
+        }
+
+        checkpointAndTrimCorfuStore(cpRuntime, trimMark);
+    }
+
+    public void checkpointAndTrimCorfuStore(CorfuRuntime cpRuntime, Token trimMark) {
+        // Open Table Registry
+        TableRegistry tableRegistry = cpRuntime.getTableRegistry();
+        CorfuTable<CorfuStoreMetadata.TableName, CorfuRecord<CorfuStoreMetadata.TableDescriptors,
+                CorfuStoreMetadata.TableMetadata>> tableRegistryCT = tableRegistry.getRegistryTable();
+
+        // Save the regular serializer first..
+        ISerializer protoBufSerializer = Serializers.getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
+
+        // Must register dynamicProtoBufSerializer *AFTER* the getTableRegistry() call to ensure that
+        // the serializer does not go back to the regular ProtoBufSerializer
+        ISerializer dynamicProtoBufSerializer = new DynamicProtobufSerializer(cpRuntime);
+        Serializers.registerSerializer(dynamicProtoBufSerializer);
+
+        // First checkpoint the TableRegistry system table
+        MultiCheckpointWriter<CorfuTable> mcw = new MultiCheckpointWriter<>();
+
+        for (CorfuStoreMetadata.TableName tableName : tableRegistry.listTables(null)) {
+            String fullTableName = TableRegistry.getFullyQualifiedTableName(
+                    tableName.getNamespace(), tableName.getTableName()
+            );
+            SMRObject.Builder<CorfuTable<CorfuDynamicKey, CorfuDynamicRecord>> corfuTableBuilder = cpRuntime.getObjectsView().build()
+                    .setTypeToken(new TypeToken<CorfuTable<CorfuDynamicKey, CorfuDynamicRecord>>() {})
+                    .setStreamName(fullTableName)
+                    .setSerializer(dynamicProtoBufSerializer);
+
+            mcw = new MultiCheckpointWriter<>();
+            mcw.addMap(corfuTableBuilder.open());
+            Token token = mcw.appendCheckpoints(cpRuntime, "checkpointer");
+            trimMark = trimMark == null ? token : Token.min(trimMark, token);
+        }
+
+        // Finally checkpoint the TableRegistry system table itself..
+        mcw.addMap(tableRegistryCT);
+        Token token = mcw.appendCheckpoints(cpRuntime, "checkpointer");
+        trimMark = Token.min(trimMark, token);
+
+        cpRuntime.getAddressSpaceView().prefixTrim(trimMark);
+        cpRuntime.getAddressSpaceView().gc();
+
+        // Lastly restore the regular protoBuf serializer and undo the dynamic protoBuf serializer
+        // otherwise the test cannot continue beyond this point.
+        Serializers.registerSerializer(protoBufSerializer);
+
+        // Trim
+        System.out.println("**** Trim Log @address=" + trimMark);
+        cpRuntime.getAddressSpaceView().prefixTrim(trimMark);
+        cpRuntime.getAddressSpaceView().invalidateClientCache();
+        cpRuntime.getAddressSpaceView().invalidateServerCaches();
+        cpRuntime.getAddressSpaceView().gc();
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -57,13 +57,14 @@ public class SourceForwardingDataSender implements DataSender {
     @Getter
     private ObservableValue errors = new ObservableValue(errorCount);
 
-    public SourceForwardingDataSender(String destinationEndpoint, LogReplicationConfig config, int ifDropMsg, LogReplicationMetadataManager metadataManager) {
+    public SourceForwardingDataSender(String destinationEndpoint, LogReplicationConfig config, int ifDropMsg, LogReplicationMetadataManager metadataManager,
+                                      String pluginConfigFilePath) {
         this.runtime = CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
                 .parseConfigurationString(destinationEndpoint)
                 .connect();
         this.destinationDataSender = new AckDataSender();
         this.destinationDataControl = new DefaultDataControl(new DefaultDataControlConfig(false, 0));
-        this.destinationLogReplicationManager = new LogReplicationSinkManager(runtime.getLayoutServers().get(0), config, metadataManager);
+        this.destinationLogReplicationManager = new LogReplicationSinkManager(runtime.getLayoutServers().get(0), config, metadataManager, pluginConfigFilePath);
         this.ifDropMsg = ifDropMsg;
         log.info("Init SourceForwardingDataSender with ifDropMsg {}", ifDropMsg);
     }

--- a/test/src/test/resources/transport/grpcConfig.properties
+++ b/test/src/test/resources/transport/grpcConfig.properties
@@ -1,12 +1,16 @@
 # Transport Plugin Configuration
-transport_adapter_JAR_path=/Users/amartinezman/annym/workspace/CorfuDB/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
 transport_adapter_server_class_name=org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationServerChannelAdapter
 transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationClientChannelAdapter
 
 # Stream Fetcher Plugin Configuration
-stream_fetcher_plugin_JAR_path=/Users/amartinezman/annym/workspace/CorfuDB/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
 stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter
 
 # Topology Manager Plugin Configuration
-topology_manager_adapter_JAR_path=/Users/amartinezman/annym/workspace/CorfuDB/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
 topology_manager_adapter_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager
+
+# Snapshot Sync Configuration (Plugin)
+snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+snapshot_sync_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin

--- a/test/src/test/resources/transport/nettyConfig.properties
+++ b/test/src/test/resources/transport/nettyConfig.properties
@@ -1,12 +1,16 @@
 # Transport Plugin Configuration
-transport_adapter_JAR_path=/Users/amartinezman/annym/workspace/CorfuDB/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
 transport_adapter_server_class_name=org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationServerChannelAdapter
 transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationClientChannelAdapter
 
 # Stream Fetcher Plugin Configuration
-stream_fetcher_plugin_JAR_path=/Users/amartinezman/annym/workspace/CorfuDB/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
 stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter
 
 # Topology Manager Configuration
-topology_manager_adapter_JAR_path=/Users/amartinezman/annym/workspace/CorfuDB/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
 topology_manager_adapter_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager
+
+# Snapshot Sync Configuration (Plugin)
+snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+snapshot_sync_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin

--- a/utils/src/main/java/org/corfudb/utils/lock/Lock.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/Lock.java
@@ -62,7 +62,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  *          <li>LEASE_RENEWED:lease for the lock has been renewed</li>
  *          <li>LEASE_REVOKED:lease for the lock has been revoked, some other instance got the lock</li>
  *          <li>LEASE_EXPIRED:lease for the lock has expired as it could not be renewed</li>
- *          <li>UNRECOVERABLE_ERROR:unrecoverable error occured</li>
+ *          <li>UNRECOVERABLE_ERROR:unrecoverable error occurred</li>
  *      </ul>
  *
  * </pre>


### PR DESCRIPTION
Overview

Description:

1. Implement a callback mechanism, where snapshot sync start/end is notified
to a plugin, so checkpoint/trim is disabled for the duration of snapshot sync.
2. Bug Fix: properly set base snapshot on renegotiation for two different log entry (delta) sync cycles
3. Tests to verify 1 and 2

Related issue(s) (if applicable): #2623 
