### PR TITLE
Support queryReplicationStatus() on non-leader Active Node.

### DIFF
--- a/infrastructure/proto/log_replication_metadata.proto
+++ b/infrastructure/proto/log_replication_metadata.proto
@@ -25,3 +25,24 @@ message LogReplicationMetadataKey {
 message LogReplicationMetadataVal {
   string val = 1;
 }
+
+/*
+ * Replication Status Key
+ */
+ message ReplicationStatusKey {
+   string clusterId = 1;
+ }
+
+/*
+ * Replication Status Value
+ * Active Site sets the completionPercent, Standby sets the dataConsistent boolean
+ */
+message ReplicationStatusVal {
+  uint64 replicationCompletion = 1;
+  bool dataConsistent = 2;
+  enum SyncType {
+    SNAPSHOT = 0;
+    LOG_ENTRY = 1;
+  }
+  SyncType type = 3;
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -103,17 +103,17 @@ public class LogReplicationServer extends AbstractServer {
         log.info("Log Replication Negotiation Request received by Server.");
 
         if (isLeader(msg, r)) {
-            LogReplicationMetadataManager metadata = sinkManager.getLogReplicationMetadataManager();
+            LogReplicationMetadataManager metadataMgr = sinkManager.getLogReplicationMetadataManager();
 
             // TODO (Xiaoqin Ma): That's 6 independent DB calls per one LOG_REPLICATION_NEGOTIATION_REQUEST.
             //  Can we do just one? Also, It does not look like we handle failures if one of them fails, for example.
             LogReplicationNegotiationResponse response = new LogReplicationNegotiationResponse(
-                    metadata.getTopologyConfigId(),
-                    metadata.getVersion(),
-                    metadata.getLastSnapStartTimestamp(),
-                    metadata.getLastSnapTransferDoneTimestamp(),
-                    metadata.getLastAppliedBaseSnapshotTimestamp(),
-                    metadata.getLastProcessedLogTimestamp());
+                    metadataMgr.getTopologyConfigId(),
+                    metadataMgr.getVersion(),
+                    metadataMgr.getLastSnapStartTimestamp(),
+                    metadataMgr.getLastSnapTransferDoneTimestamp(),
+                    metadataMgr.getLastAppliedBaseSnapshotTimestamp(),
+                    metadataMgr.getLastProcessedLogTimestamp());
             log.info("Send Negotiation response");
             r.sendResponse(msg, CorfuMsgType.LOG_REPLICATION_NEGOTIATION_RESPONSE.payloadMsg(response));
         } else {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryServiceAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryServiceAdapter.java
@@ -1,6 +1,9 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+
+import java.util.Map;
 
 public interface CorfuReplicationDiscoveryServiceAdapter {
 
@@ -19,5 +22,5 @@ public interface CorfuReplicationDiscoveryServiceAdapter {
      *
      * @return
      */
-    int queryReplicationStatus();
+    Map<String, LogReplicationMetadata.ReplicationStatusVal> queryReplicationStatus();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
@@ -2,6 +2,9 @@ package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
 import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationDiscoveryServiceAdapter;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.TopologyConfigurationMsg;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+
+import java.util.Map;
 
 /**
  * This is the interface for CorfuReplicationClusterManager.
@@ -54,5 +57,5 @@ public interface CorfuReplicationClusterManagerAdapter {
      *
      * @return
      */
-    int queryReplicationStatus();
+    Map<String, LogReplicationMetadata.ReplicationStatusVal> queryReplicationStatus();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerBaseAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerBaseAdapter.java
@@ -5,10 +5,13 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationDiscoveryServiceAdapter;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.TopologyConfigurationMsg;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+
+import java.util.Map;
 
 /***
- * This is the base class for CorfuReplicationSiteManager and implements the basic functionality.
- * Any SiteMangerImplementation should extend this class or implements the interface.
+ * This is the base class for CorfuReplicationClusterManagerAdapter and implements the basic functionality.
+ * Any ClusterManger Adapter implementation should extend this class or implement the interface.
  *
  */
 @Slf4j
@@ -45,7 +48,7 @@ public abstract class CorfuReplicationClusterManagerBaseAdapter implements Corfu
         corfuReplicationDiscoveryService.prepareToBecomeStandby();
     }
 
-    public int queryReplicationStatus() {
+    public Map<String, LogReplicationMetadata.ReplicationStatusVal> queryReplicationStatus() {
         return corfuReplicationDiscoveryService.queryReplicationStatus();
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -1,0 +1,155 @@
+package org.corfudb.infrastructure.logreplication.replication;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.protocols.wireprotocol.StreamAddressRange;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+public class LogReplicationAckReader {
+    private LogReplicationMetadataManager metadataManager;
+    private LogReplicationConfig config;
+    private CorfuRuntime runtime;
+    private String remoteClusterId;
+
+    /*
+     * Periodic Thread which reads the last Acked Timestamp and writes it to the metadata table
+     */
+    private ScheduledExecutorService lastAckedTsPoller;
+
+    /*
+     * Interval at which the thread reads the last Acked Timestamp
+     */
+    private static int ACKED_TS_READ_INTERVAL_SECONDS = 15;
+
+    private static int FULL_REPLICATION_REMAINING_PERCENT = 100;
+    private static int NO_REPLICATION_REMAINING_PERCENT = 0;
+
+    /*
+     * Last ack'd timestamp from Receiver
+     */
+    private long lastAckedTimestamp = Address.NON_ADDRESS;
+
+    /*
+     * Sync Type for which last Ack was Received.  Set to Log Entry Type as the initial FSM state is
+     * Log Entry Sync
+     */
+    private LogReplicationMetadata.ReplicationStatusVal.SyncType lastSyncType =
+            LogReplicationMetadata.ReplicationStatusVal.SyncType.LOG_ENTRY;
+
+    Lock lock = new ReentrantLock();
+
+     public LogReplicationAckReader(LogReplicationMetadataManager metadataManager, LogReplicationConfig config,
+                                    CorfuRuntime runtime, String remoteClusterId) {
+        this.metadataManager = metadataManager;
+        this.config = config;
+        this.runtime = runtime;
+        this.remoteClusterId = remoteClusterId;
+        lastAckedTsPoller = Executors.newSingleThreadScheduledExecutor(
+                new ThreadFactoryBuilder().setNameFormat("ack-timestamp-reader").build());
+        lastAckedTsPoller.scheduleWithFixedDelay(new TsPollingTask(), 0,
+                ACKED_TS_READ_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    public void setAckedTsAndSyncType(long ackedTs, LogReplicationMetadata.ReplicationStatusVal.SyncType syncType) {
+        lock.lock();
+        try {
+            lastAckedTimestamp = ackedTs;
+            lastSyncType = syncType;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    /**
+     * For the given replication runtime, query max stream tail for all streams to be replicated.
+     *
+     * @return max tail of all streams to be replicated for the given runtime
+     */
+    private long getMaxReplicatedStreamsTail() {
+        Map<UUID, Long> tailMap = runtime.getAddressSpaceView().getAllTails().getStreamTails();
+        long maxTail = Address.NON_ADDRESS;
+        for (String streamName : config.getStreamsToReplicate()) {
+            UUID streamUuid = CorfuRuntime.getStreamID(streamName);
+            if (tailMap.containsKey(streamUuid)) {
+                long streamTail = tailMap.get(streamUuid);
+                maxTail = Math.max(maxTail, streamTail);
+            }
+        }
+        return maxTail;
+    }
+
+    /**
+     * Given a timestamp acked by the receiver, calculate how many entries remain to be sent for all replicated streams.
+     *
+     * @param ackedTimestamp Timestamp ack'd by the receiver
+     *
+     * For Log Entry Sync, this function returns the total number of entries remaining to be sent across all replicated
+     * streams.
+     * For Snapshot Sync, each entry sent is a snapshot.  So this function returns the total number of snapshots
+     * remaining to be sent.
+     * If the ack'd timestamp is uninitialized, it returns 100%, which means no replication has been done.
+     */
+    private long calculateRemainingEntriesToSend(long ackedTimestamp) {
+        long maxReplicatedStreamTail = getMaxReplicatedStreamsTail();
+
+        if (maxReplicatedStreamTail == Address.NON_ADDRESS) {
+            // No data to send.  No Replication remaining
+            return NO_REPLICATION_REMAINING_PERCENT;
+        }
+        if (ackedTimestamp == Address.NON_ADDRESS) {
+            return FULL_REPLICATION_REMAINING_PERCENT;
+        }
+        long remainingEntriesToSend = 0;
+        for (String stream : config.getStreamsToReplicate()) {
+            UUID streamId = CorfuRuntime.getStreamID(stream);
+            StreamAddressRange range = new StreamAddressRange(streamId, maxReplicatedStreamTail, ackedTimestamp);
+            StreamAddressSpace addressSpace = runtime.getSequencerView().getStreamAddressSpace(range);
+            remainingEntriesToSend += addressSpace.getAddressMap().getLongCardinality();
+        }
+        return remainingEntriesToSend;
+    }
+
+    public void shutdown() {
+        // Stop accepting any new updates
+        lastAckedTsPoller.shutdown();
+        try {
+            // Wait 100ms for currently running tasks to finish.  If they do not finish, shutdown immediately
+            if (!lastAckedTsPoller.awaitTermination(100, TimeUnit.MILLISECONDS)) {
+                lastAckedTsPoller.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            // If any task is interrupted by shutdownNow, catch that exception and shutdown immediately
+            lastAckedTsPoller.shutdownNow();
+        }
+    }
+
+    /**
+     * Task which periodically updates the metadata table with replication completion percentage
+     */
+    private class TsPollingTask implements Runnable {
+        @Override
+        public void run() {
+            lock.lock();
+            try {
+                long remainingReplicationStatus = calculateRemainingEntriesToSend(lastAckedTimestamp);
+                metadataManager.setReplicationRemainingPercent(remoteClusterId, remainingReplicationStatus,
+                        lastSyncType);
+            } finally {
+                lock.unlock();
+            }
+        }
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -7,24 +7,35 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.replication.fsm.ObservableAckMsg;
-import org.corfudb.infrastructure.logreplication.replication.receive.DataReceiver;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationFSM;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClient;
 import org.corfudb.infrastructure.logreplication.replication.send.CorfuDataSender;
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.DefaultReadProcessor;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationEventMetadata;
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.ReadProcessor;
+import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent.LogReplicationEventType;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * This class represents the Log Replication Manager at the source cluster.
@@ -37,7 +48,7 @@ import java.util.concurrent.Executors;
  **/
 @Data
 @Slf4j
-public class LogReplicationSourceManager implements DataReceiver {
+public class LogReplicationSourceManager {
 
     private CorfuRuntime runtime;
     /*
@@ -61,6 +72,13 @@ public class LogReplicationSourceManager implements DataReceiver {
      */
     private final LogReplicationConfig config;
 
+    /*
+     * Log Replication MetadataManager.
+     */
+    private final LogReplicationMetadataManager metadataManager;
+
+    private final LogReplicationAckReader ackReader;
+
     @VisibleForTesting
     private int countACKs = 0;
 
@@ -68,111 +86,48 @@ public class LogReplicationSourceManager implements DataReceiver {
     private ObservableAckMsg ackMessages = new ObservableAckMsg();
 
     /**
-     * Constructor Source (default)
-     *
-     * @param runtime Corfu Runtime
-     * @param dataSender implementation of a data sender, both snapshot and log entry, this represents
-     *                   the application callback for data transmission
-     * @param params Log Replication Parameters
+     * @param params Log Replication parameters
+     * @param client LogReplication client, which is a data sender, both snapshot and log entry, this represents
+     *              the application callback for data transmission
+     * @param metadataManager Replication Metadata Manager
      */
-    public LogReplicationSourceManager(CorfuRuntime runtime,
-                                       DataSender dataSender,
-                                       LogReplicationRuntimeParameters params) {
-
-        this(runtime, dataSender, params, Executors.newFixedThreadPool(DEFAULT_FSM_WORKER_THREADS, new
-                ThreadFactoryBuilder().setNameFormat("state-machine-worker").build()));
+    public LogReplicationSourceManager(LogReplicationRuntimeParameters params, LogReplicationClient client,
+                                       LogReplicationMetadataManager metadataManager) {
+        this(params, metadataManager, new CorfuDataSender(client));
     }
 
-    public LogReplicationSourceManager(LogReplicationRuntimeParameters params, LogReplicationClient client) {
-        this(CorfuRuntime.fromParameters(CorfuRuntimeParameters.builder()
+    @VisibleForTesting
+    public LogReplicationSourceManager(LogReplicationRuntimeParameters params,
+                                       LogReplicationMetadataManager metadataManager,
+                                       DataSender dataSender) {
+
+        this.runtime = CorfuRuntime.fromParameters(CorfuRuntimeParameters.builder()
                 .trustStore(params.getTrustStore())
                 .tsPasswordFile(params.getTsPasswordFile())
                 .keyStore(params.getKeyStore())
                 .ksPasswordFile(params.getKsPasswordFile())
-                .tlsEnabled(params.isTlsEnabled()).build())
-        .parseConfigurationString(params.getLocalCorfuEndpoint()).connect(), client, params);
-    }
-
-    /**
-     * Constructor LogReplicationSourceManager
-     *
-     * @param runtime Corfu Runtime
-     * @param client Log replication client
-     * @param params Log Replication parameters
-     */
-    public LogReplicationSourceManager(CorfuRuntime runtime, LogReplicationClient client, LogReplicationRuntimeParameters params) {
-        this(runtime, new CorfuDataSender(client), params);
-    }
-
-    /**
-     * Constructor Source (default)
-     *
-     * @param runtime Corfu Runtime
-     * @param dataSender implementation of a data sender, both snapshot and log entry, this represents
-     *                   the application callback for data transmission
-     * @param readProcessor implementation for reads processor (data transformation)
-     * @param params Log Replication Parameters
-     */
-    public LogReplicationSourceManager(CorfuRuntime runtime,
-                                       DataSender dataSender,
-                                       ReadProcessor readProcessor,
-                                       LogReplicationRuntimeParameters params) {
-        // Default to single dedicated thread for state machine workers (perform state tasks)
-        this(runtime, dataSender, readProcessor, params, Executors.newFixedThreadPool(DEFAULT_FSM_WORKER_THREADS, new
-                ThreadFactoryBuilder().setNameFormat("state-machine-worker").build()));
-    }
-
-    /**
-     * Constructor Source to provide ExecutorServices for FSM
-     *
-     * For multi-cluster log replication multiple managers can share a common thread pool.
-     *
-     * @param runtime corfu runtime
-     * @param dataSender implementation of a data sender, both snapshot and log entry, this represents
-     *                   the application callback for data transmission
-     * @param params Log Replication Parameters
-     * @param logReplicationFSMWorkers worker thread pool (state tasks)
-     */
-    public LogReplicationSourceManager(CorfuRuntime runtime,
-                                       DataSender dataSender,
-                                       LogReplicationRuntimeParameters params,
-                                       ExecutorService logReplicationFSMWorkers) {
-        this(runtime, dataSender, new DefaultReadProcessor(runtime), params, logReplicationFSMWorkers);
-    }
-
-    /**
-     * Constructor Source to provide ExecutorServices for FSM
-     *
-     * For multi-cluster log replication multiple managers can share a common thread pool.
-     *
-     * @param runtime corfu runtime
-     * @param dataSender implementation of a data sender, both snapshot and log entry, this represents
-     *                   the application callback for data transmission
-     * @param readProcessor implementation for reads processor (transformation)
-     * @param params Log Replication Parameters
-     * @param logReplicationFSMWorkers worker thread pool (state tasks)
-     */
-    public LogReplicationSourceManager(CorfuRuntime runtime,
-                                       DataSender dataSender,
-                                       ReadProcessor readProcessor,
-                                       LogReplicationRuntimeParameters params,
-                                       ExecutorService logReplicationFSMWorkers) {
+                .tlsEnabled(params.isTlsEnabled()).build());
+        runtime.parseConfigurationString(params.getLocalCorfuEndpoint()).connect();
 
         this.parameters = params;
+
         this.config = parameters.getReplicationConfig();
         if (config.getStreamsToReplicate() == null || config.getStreamsToReplicate().isEmpty()) {
             // Avoid FSM being initialized if there are no streams to replicate
             throw new IllegalArgumentException("Invalid Log Replication: Streams to replicate is EMPTY");
         }
 
-        // If this runtime has opened other streams, it appends non opaque entries and because
-        // the cache is shared we end up doing deserialization. We need guarantees that this runtime is dedicated
-        // for log replication exclusively.
-        this.runtime = CorfuRuntime.fromParameters(runtime.getParameters());
-        this.runtime.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
+        ExecutorService logReplicationFSMWorkers = Executors.newFixedThreadPool(DEFAULT_FSM_WORKER_THREADS, new
+                ThreadFactoryBuilder().setNameFormat("state-machine-worker").build());
+        ReadProcessor readProcessor = new DefaultReadProcessor(runtime);
+        this.metadataManager = metadataManager;
+        // Ack Reader for Snapshot and LogEntry Sync
+        ackReader = new LogReplicationAckReader(this.metadataManager, config, runtime,
+                params.getRemoteClusterDescriptor().getClusterId());
 
         this.logReplicationFSM = new LogReplicationFSM(this.runtime, config, params.getRemoteClusterDescriptor(),
-                dataSender, readProcessor, logReplicationFSMWorkers);
+                dataSender, readProcessor, logReplicationFSMWorkers, ackReader);
+
         this.logReplicationFSM.setTopologyConfigId(params.getTopologyConfigId());
     }
 
@@ -234,30 +189,7 @@ public class LogReplicationSourceManager implements DataReceiver {
         }
 
         log.info("Shutdown Log Replication.");
+        ackReader.shutdown();
         this.runtime.shutdown();
-    }
-
-    @Override
-    public LogReplicationEntry receive(LogReplicationEntry message) {
-        log.trace("Data Message received on source");
-
-        countACKs++;
-        ackMessages.setValue(message);
-
-        // Process ACKs from Application, for both, log entry and snapshot sync.
-        if(message.getMetadata().getMessageMetadataType() == MessageType.LOG_ENTRY_REPLICATED) {
-            log.debug("Log entry sync ACK received on timestamp {}", message.getMetadata().getTimestamp());
-            logReplicationFSM.input(new LogReplicationEvent(LogReplicationEventType.LOG_ENTRY_SYNC_REPLICATED,
-                new LogReplicationEventMetadata(message.getMetadata().getSyncRequestId(), message.getMetadata().getTimestamp())));
-        } else if (message.getMetadata().getMessageMetadataType() == MessageType.SNAPSHOT_REPLICATED) {
-            log.debug("Snapshot sync ACK received on base timestamp {}", message.getMetadata().getSnapshotTimestamp());
-            logReplicationFSM.input(new LogReplicationEvent(LogReplicationEventType.SNAPSHOT_SYNC_COMPLETE,
-                    new LogReplicationEventMetadata(message.getMetadata().getSyncRequestId(), message.getMetadata().getTimestamp(),
-                            message.getMetadata().getTimestamp())));
-        } else {
-            log.debug("Received data message of type {} not an ACK", message.getMetadata().getMessageMetadataType());
-        }
-
-        return null;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/TestSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/TestSnapshotReader.java
@@ -25,13 +25,24 @@ public class TestSnapshotReader implements SnapshotReader {
 
     private int globalIndex = 0;
 
+    /*
+     * Apart from the Test Data, 5 metadata transactions also take place, namely -
+     * 1. 2 TXs for creating the metadata and replication status tables + 1 registry table TX
+     * 2. 1 TX for initializing the metadata in metadata table
+     * 3. 1 TX for initializing the replication status on Source in the replication status table
+     * So the log tail will be num data writes + 5
+     */
+    private int offset = 5;
+
     private CorfuRuntime runtime;
 
     private final long baseSnapshot;
 
+    private List<Long> seqNumsToRead;
+
     public TestSnapshotReader(TestReaderConfiguration config) {
         this.config = config;
-        this.baseSnapshot = config.getNumEntries();
+        this.baseSnapshot = config.getNumEntries() + offset;
         this.runtime = new CorfuRuntime(config.getEndpoint()).connect();
     }
 
@@ -40,19 +51,14 @@ public class TestSnapshotReader implements SnapshotReader {
         // Connect to endpoint
         List<LogReplicationEntry> messages = new ArrayList<>();
 
-        int index = globalIndex;
-
-        // Limit to read as max as BatchSize and until the maximum baseSnapshot
-        for (int i=index; (i<(index+config.getBatchSize()) && index<baseSnapshot) ; i++) {
-        // Read numEntries in consecutive address space and add to messages to return
-            Object data = runtime.getAddressSpaceView().read((long)i).getPayload(runtime);
+        for (long i : seqNumsToRead) {
+            Object data = runtime.getAddressSpaceView().read(i).getPayload(runtime);
             LogReplicationEntryMetadata metadata = new LogReplicationEntryMetadata(MessageType.SNAPSHOT_MESSAGE,
-                    topologyConfigId, i, baseSnapshot, snapshotRequestId);
-            messages.add(new LogReplicationEntry(metadata, (byte[])data));
+                topologyConfigId, i, baseSnapshot, snapshotRequestId);
+            messages.add(new LogReplicationEntry(metadata, (byte[]) data));
             globalIndex++;
         }
-
-        return new SnapshotReadMessage(messages, globalIndex == baseSnapshot);
+        return new SnapshotReadMessage(messages, (globalIndex + offset) == baseSnapshot);
     }
 
     @Override
@@ -67,5 +73,9 @@ public class TestSnapshotReader implements SnapshotReader {
 
     public void setBatchSize(int batchSize) {
         config.setBatchSize(batchSize);
+    }
+
+    public void setSeqNumsToRead(List<Long>seqNums) {
+        this.seqNumsToRead = seqNums;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -81,7 +81,7 @@ public class LogEntryWriter {
         long persistedTopologyConfigId = logReplicationMetadataManager.query(timestamp, LogReplicationMetadataManager.LogReplicationMetadataType.TOPOLOGY_CONFIG_ID);
         long persistedSnapshotStart = logReplicationMetadataManager.query(timestamp, LogReplicationMetadataManager.LogReplicationMetadataType.LAST_SNAPSHOT_STARTED);
         long persistedSnapshotDone= logReplicationMetadataManager.query(timestamp, LogReplicationMetadataManager.LogReplicationMetadataType.LAST_SNAPSHOT_APPLIED);
-        long persistedLogTs = logReplicationMetadataManager.query(timestamp, LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_PROCESSED);
+        long persistedLogTs = logReplicationMetadataManager.query(timestamp, LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_PROCESSED);
 
         long topologyConfigId = txMessage.getMetadata().getTopologyConfigId();
         long baseSnapshotTs = txMessage.getMetadata().getSnapshotTimestamp();
@@ -112,7 +112,7 @@ public class LogEntryWriter {
         TxBuilder txBuilder = logReplicationMetadataManager.getTxBuilder();
 
         logReplicationMetadataManager.appendUpdate(txBuilder, LogReplicationMetadataManager.LogReplicationMetadataType.TOPOLOGY_CONFIG_ID, topologyConfigId);
-        logReplicationMetadataManager.appendUpdate(txBuilder, LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_PROCESSED, entryTs);
+        logReplicationMetadataManager.appendUpdate(txBuilder, LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_PROCESSED, entryTs);
 
         for (OpaqueEntry opaqueEntry : newOpaqueEntryList) {
             for (UUID uuid : opaqueEntry.getEntries().keySet()) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SnapshotSinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SnapshotSinkBufferManager.java
@@ -107,7 +107,6 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
         if (lastProcessedSeq == snapshotEndSeq) {
             return true;
         }
-
         return super.shouldAck();
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -67,7 +67,7 @@ public class SnapshotSender {
         this.snapshotReader = snapshotReader;
         this.fsm = fsm;
         this.maxNumSnapshotMsgPerBatch = snapshotSyncBatchSize <= 0 ? DEFAULT_MAX_NUM_MSG_PER_BATCH : snapshotSyncBatchSize;
-        this.dataSenderBufferManager = new SnapshotSenderBufferManager(dataSender);
+        this.dataSenderBufferManager = new SnapshotSenderBufferManager(dataSender, fsm.getAckReader());
     }
 
     private CompletableFuture<LogReplicationEntry> snapshotSyncAck;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/SnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/SnapshotReader.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 /**
  * An Interface for snapshot logreader.
  *
- * A snapshot logreader provides the functionality for reading data from Corfu.
+ * A snapshot reader provides the functionality for reading data from Corfu.
  */
 public interface SnapshotReader {
 
@@ -22,7 +22,7 @@ public interface SnapshotReader {
     SnapshotReadMessage read(UUID snapshotRequestId);
 
     /**
-     * Reset logreader in between snapshot syncs.
+     * Reset reader in between snapshot syncs.
      *
      * @param snapshotTimestamp new snapshot timestamp.
      */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -156,7 +156,8 @@ public class CorfuLogReplicationRuntime {
         this.metadataManager = metadataManager;
         this.router = new LogReplicationClientRouter(parameters, this);
         this.router.addClient(new LogReplicationHandler());
-        this.sourceManager = new LogReplicationSourceManager(parameters, new LogReplicationClient(router, remoteClusterId));
+        this.sourceManager = new LogReplicationSourceManager(parameters, new LogReplicationClient(router, remoteClusterId),
+            metadataManager);
         this.communicationFSMWorkers = Executors.newSingleThreadExecutor(new
                 ThreadFactoryBuilder().setNameFormat("runtime-fsm-worker").build());
         this.communicationFSMConsumer = Executors.newSingleThreadExecutor(new

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationEntryMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationEntryMetadata.java
@@ -44,7 +44,10 @@ public class LogReplicationEntryMetadata {
      */
     private long snapshotTimestamp;
 
-    private long snapshotSyncSeqNum; //used by snapshot full sync stream only, zero means the start of the stream.
+    /*
+     * Used by snapshot full sync stream only, zero means the start of the stream.
+     */
+    private long snapshotSyncSeqNum;
 
     public LogReplicationEntryMetadata(LogReplicationEntryMetadata inputMetadata) {
         this.messageMetadataType = inputMetadata.messageMetadataType;

--- a/test/src/test/java/org/corfudb/integration/AckDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/AckDataSender.java
@@ -6,7 +6,6 @@ import org.corfudb.infrastructure.logreplication.replication.LogReplicationSourc
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationError;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.List;
@@ -31,12 +30,7 @@ public class AckDataSender implements DataSender {
     public CompletableFuture<LogReplicationEntry> send(LogReplicationEntry message) {
         // Emulate it was sent over the wire and arrived on the source side
         // channel.execute(() -> sourceManager.receive(message));
-        final CompletableFuture<LogReplicationEntry> cf = new CompletableFuture<>();
-        LogReplicationEntry entry = sourceManager.receive(message);
-        if (entry != null) {
-            cf.complete(entry);
-        }
-        return cf;
+        return new CompletableFuture<>();
     }
 
     @Override

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -25,14 +25,7 @@ import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Observable;
-import java.util.Observer;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -43,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import static org.corfudb.integration.ReplicationReaderWriterIT.ckStreamsAndTrim;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test the core components of log replication, namely, Snapshot Sync and Log Entry Sync,
@@ -1224,10 +1218,13 @@ public class LogReplicationIT extends AbstractIT implements Observer {
                 nettyConfig);
 
         // Source Manager
-        LogReplicationSourceManager logReplicationSourceManager = new LogReplicationSourceManager(readerRuntime, sourceDataSender,
+        LogReplicationSourceManager logReplicationSourceManager = new LogReplicationSourceManager(
                 LogReplicationRuntimeParameters.builder()
-                        .remoteClusterDescriptor(new ClusterDescriptor(REMOTE_CLUSTER_ID, LogReplicationClusterInfo.ClusterRole.ACTIVE, CORFU_PORT))
-                        .replicationConfig(config).build());
+                        .remoteClusterDescriptor(new ClusterDescriptor(REMOTE_CLUSTER_ID,
+                                LogReplicationClusterInfo.ClusterRole.ACTIVE, CORFU_PORT))
+                                .replicationConfig(config).localCorfuEndpoint(SOURCE_ENDPOINT).build(),
+                logReplicationMetadataManager,
+                sourceDataSender);
 
         // Set Log Replication Source Manager so we can emulate the channel for data & control messages (required
         // for testing)


### PR DESCRIPTION
## Overview
Add support on non-leader active node to respond to queries for Replication Status.
 
Description:
The leader on the active site keeps an up-to-date in-memory copy of the last ACK received.  A thread periodically reads this ACK value and updates the replication completion status in the metadata table, which is shared among cluster members.  On receiving a query for the replication status, any node(leader or not) can read the metadata table and get the completion  status.
#2624 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
