### PR TITLE
[Corfu-0.3.0.2] Fix NullPointerException in StreamView.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TrimmedException.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime.exceptions;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -23,19 +24,24 @@ public class TrimmedException extends LogUnitException {
      * List of trimmed addresses.
      */
     @Getter
-    @Setter
-    private List<Long> trimmedAddresses;
+    private final List<Long> trimmedAddresses;
 
     public TrimmedException() {
+        trimmedAddresses = Collections.emptyList();
+    }
+
+    public TrimmedException(long trimmed) {
+        super(String.format("Trimmed address: %s", trimmed));
+        trimmedAddresses = Collections.singletonList(trimmed);
     }
 
     public TrimmedException(List<Long> trimmed) {
-        super(String.format("Trimmed addresses %s", trimmed));
+        super(String.format("Trimmed addresses: %s", trimmed));
         trimmedAddresses = trimmed;
     }
 
     public TrimmedException(String message) {
         super(message);
-        retriable = true;
+        trimmedAddresses = Collections.emptyList();
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -64,7 +64,6 @@ public class AddressSpaceView extends AbstractView {
 
     private final static long CACHE_KEY_SIZE = MetricsUtils.sizeOf.deepSizeOf(0L);
     private final static long DEFAULT_MAX_CACHE_ENTRIES = 5000;
-    private final static boolean NO_THROW = false;
 
     /**
      * A cache for read results.
@@ -668,7 +667,7 @@ public class AddressSpaceView extends AbstractView {
      */
     private List<Long> filterTrimmedAddresses(Map<Long, ILogData> allData) {
         return allData.entrySet().stream()
-                .filter(entry -> !isLogDataValid(entry.getKey(), entry.getValue(), NO_THROW))
+                .filter(entry -> !isLogDataValid(entry.getKey(), entry.getValue(), false))
                 .map(Entry::getKey).collect(Collectors.toList());
     }
 
@@ -689,7 +688,7 @@ public class AddressSpaceView extends AbstractView {
 
         if (logData.isTrimmed()) {
             if (throwException) {
-                throw new TrimmedException(String.format("Trimmed address %s", address));
+                throw new TrimmedException(address);
             }
             return false;
         }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -110,8 +110,8 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
                 }
 
                 log.debug("removeFromQueue[{}]: ignoring trimmed addresses {}", this, te.getTrimmedAddresses());
-                // Ignore trimmed address, remove trimmed addresses and get next from queue
-                te.getTrimmedAddresses().forEach(address -> queue.remove(address));
+                // Ignore trimmed address, remove trimmed addresses and get next from queue.
+                te.getTrimmedAddresses().forEach(queue::remove);
 
                 // If a TrimmedException was caught, the requested address (nextRead) is trimmed (lower of all),
                 // we need to continue reading to retrieve the next valid entry for this stream.


### PR DESCRIPTION
## Overview

Description:

Backporting for 0.3.0.2

When read option is set to ignoreTrim and non cacheable, removeFromQueue
will throw NPE when encountering TrimmedException and trying to get the
trimmed addresses list from TrimmedException.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
