### PR TITLE
Fix FSM Unit Test and Snapshot Plugin Condition

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -132,7 +132,7 @@ public class InSnapshotSyncState implements LogReplicationState {
                 /*
                   Cancel snapshot sync if still in progress.
                  */
-                 cancelSnapshotSync("request to stop replication.");
+                 cancelSnapshotSync("of a request to stop replication.");
                  return fsm.getStates().get(LogReplicationStateType.INITIALIZED);
             case REPLICATION_SHUTDOWN:
                 /*

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -285,7 +285,7 @@ public class LogReplicationFSM {
             }
 
             // TODO (Anny): consider strategy for continuously failing snapshot sync (never ending cancellation)
-            //   Block until an event shows up in the queue.
+            // Block until an event shows up in the queue.
             LogReplicationEvent event = eventQueue.take();
 
             if (event.getType() == LogReplicationEventType.REPLICATION_START) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
@@ -44,7 +44,6 @@ public abstract class SenderBufferManager {
      */
     private int maxRetry;
 
-
     /*
      * Max time to wait an ACK for a message.
      */
@@ -53,8 +52,7 @@ public abstract class SenderBufferManager {
     /*
      * If there is a timeout for a message, should generate an error or not
      */
-    private boolean errorOnMsgTimeout = true;
-
+    private boolean errorOnMsgTimeout;
 
     /*
      * the max ACK timestamp received. Used by log entry sync.
@@ -67,7 +65,6 @@ public abstract class SenderBufferManager {
     private long maxAckForSnapshotSync = Address.NON_ADDRESS;
 
     private DataSender dataSender;
-
 
     /*
      * The messages sent to the receiver but hasn't been ACKed yet.
@@ -121,7 +118,7 @@ public abstract class SenderBufferManager {
             reader.close();
 
         } catch (Exception e) {
-            log.warn("The config file is not available {} , will use the default vaules for config.", e.getCause());
+            log.warn("The config file is not available {} , will use the default values for config.", config_file, e.getCause());
 
         } finally {
             log.info("Sender Buffer config max_retry {} reader_queue_size {} entry_resend_timer {} waitAck {}",

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -54,7 +54,6 @@ public class SnapshotSender {
     // This flag will indicate the start of a snapshot sync, so start snapshot marker is sent once.
     private boolean startSnapshotSync = true;
 
-
     @Getter
     @VisibleForTesting
     // For testing purposes, used to count the number of messages sent in order to interrupt snapshot sync
@@ -156,8 +155,6 @@ public class SnapshotSender {
         } else {
             log.info("Snapshot sync completed for {} as there is no data in the log.", snapshotSyncEventId);
 
-            // Generate a special LogReplicationEntry with only metadata (used as start marker on receiver side
-            // to complete snapshot sync and send the right ACK)
             try {
                 dataSenderBufferManager.sendWithBuffering(getSnapshotSyncStartMarker(snapshotSyncEventId));
                 snapshotSyncAck = dataSenderBufferManager.sendWithBuffering(getSnapshotSyncEndMarker(snapshotSyncEventId));
@@ -172,8 +169,6 @@ public class SnapshotSender {
 
     private int processReads(List<LogReplicationEntry> logReplicationEntries, UUID snapshotSyncEventId, boolean completed) {
         int numMessages = 0;
-
-        //dataSenderBufferManager.resend();
 
         // If we are starting a snapshot sync, send a start marker.
         if (startSnapshotSync) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
@@ -191,7 +191,7 @@ public class StreamsSnapshotReader implements SnapshotReader {
         List<LogReplicationEntry> messages = new ArrayList<>();
 
         boolean endSnapshotSync = false;
-        LogReplicationEntry msg = null;
+        LogReplicationEntry msg;
 
         // If the currentStreamInfo still has entry to process, it will reuse the currentStreamInfo
         // and process the remaining entries.

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationEntryMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/logreplication/LogReplicationEntryMetadata.java
@@ -74,9 +74,8 @@ public class LogReplicationEntryMetadata {
     }
 
     // Constructor used for snapshot sync
-    public LogReplicationEntryMetadata(MessageType type, long epoch,  UUID syncRequestId, long entryTimeStamp, long snapshotTimestamp, UUID snapshotRequestId) {
-        this(type, epoch, syncRequestId,  entryTimeStamp, Address.NON_ADDRESS, snapshotTimestamp, Address.NON_ADDRESS);
-        this.syncRequestId = snapshotRequestId;
+    public LogReplicationEntryMetadata(MessageType type, long topologyConfigId, long entryTimeStamp, long snapshotTimestamp, UUID snapshotRequestId) {
+        this(type, topologyConfigId, snapshotRequestId, entryTimeStamp, Address.NON_ADDRESS, snapshotTimestamp, Address.NON_ADDRESS);
     }
 
     public static LogReplicationEntryMetadata fromProto(Messages.LogReplicationEntryMetadata proto) {

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -54,7 +54,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
     public final String streamA = "Table001";
 
-    public final int numWrites = 800;
+    public final int numWrites = 5000;
     public final int lockLeaseDuration = 8;
 
     public final int activeSiteCorfuPort = 9000;


### PR DESCRIPTION
## Overview

Description:

- Fix Intermittent Failure on FSM Unit Test
- Fix onSnapshotEnd condition to check for an ack SNAPSHOT_END instead of SNAPSHOT_REPLICATED (intermediate acks)


Why should this be merged: stabilize log replication master branch