### PR TITLE
Add option to load data into corfu table

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowser.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowser.java
@@ -3,7 +3,6 @@ package org.corfudb.browser;
 import com.google.common.collect.Iterables;
 import com.google.common.reflect.TypeToken;
 
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -13,15 +12,15 @@ import java.util.stream.Stream;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.CorfuStoreMetadata.TableName;
-import org.corfudb.runtime.collections.CorfuRecord;
-import org.corfudb.runtime.collections.CorfuStoreEntry;
+import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.CorfuDynamicKey;
 import org.corfudb.runtime.collections.CorfuDynamicRecord;
 import org.corfudb.runtime.collections.PersistedStreamingMap;
 import org.corfudb.runtime.collections.StreamingMap;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxBuilder;
 import org.corfudb.runtime.object.ICorfuVersionPolicy;
 import org.corfudb.runtime.view.SMRObject;
 import org.corfudb.runtime.view.TableRegistry;
@@ -134,9 +133,9 @@ public class CorfuStoreBrowser {
                 Iterables.partition(entryStream::iterator, batchSize);
         for (List<Map.Entry<CorfuDynamicKey, CorfuDynamicRecord>> partition : partitions) {
             for (Map.Entry<CorfuDynamicKey, CorfuDynamicRecord> entry : partition) {
-                builder = new StringBuilder("\nKey:\n" + entry.getKey())
-                        .append("\nPayload:\n" + entry.getValue().getPayload())
-                        .append("\nMetadata:\n" + entry.getValue().getMetadata())
+                builder = new StringBuilder("\nKey:\n" + entry.getKey().getKey())
+                        .append("\nPayload:\n").append(entry.getValue().getPayload())
+                        .append("\nMetadata:\n").append(entry.getValue().getMetadata())
                         .append("\n====================\n");
                 log.info(builder.toString());
             }
@@ -202,5 +201,48 @@ public class CorfuStoreBrowser {
         log.info("Table cleared successfully");
         log.info("\n======================\n");
         return tableSize;
+    }
+
+    /**
+     * Loads the table with random data
+     * @param namespace - the namespace where the table belongs
+     * @param tablename - table name without the namespace
+     * @param numItems - total number of items to load
+     * @param batchSize - number of items in each transaction
+     * @return - number of entries in the table
+     */
+    public int loadTable(String namespace, String tablename, int numItems, int batchSize) {
+        verifyNamespaceAndTablename(namespace, tablename);
+        CorfuStore store = new CorfuStore(runtime);
+        try {
+            TableOptions.TableOptionsBuilder<Object, Object> optionsBuilder = TableOptions.builder();
+            if (diskPath != null) {
+                optionsBuilder.persistentDataPath(Paths.get(diskPath));
+            }
+            store.openTable(namespace, tablename,
+                    TableName.getDefaultInstance().getClass(),
+                    TableName.getDefaultInstance().getClass(),
+                    TableName.getDefaultInstance().getClass(),
+                    optionsBuilder.build());
+
+            TableName dummyVal = TableName.newBuilder().setNamespace(namespace).setTableName(tablename).build();
+            log.info("Loading {} items in {} batchSized transactions into {}${}",
+                    numItems, batchSize, namespace, tablename);
+            int itemsRemaining = numItems;
+            while (itemsRemaining > 0) {
+                log.info("loadTable: Items left {}", itemsRemaining);
+                TxBuilder tx = store.tx(namespace);
+                for (int j = batchSize; j > 0 && itemsRemaining > 0; j--, itemsRemaining--) {
+                    TableName dummyKey = TableName.newBuilder()
+                            .setNamespace(Integer.toString(itemsRemaining))
+                            .setTableName(Integer.toString(j)).build();
+                    tx.update(tablename, dummyKey, dummyVal, dummyVal);
+                }
+                tx.commit();
+            }
+        } catch (Exception e) {
+            log.error("loadTable: {} {} {} {} failed.", namespace, tablename, numItems, batchSize, e);
+        }
+        return (int)(Math.ceil((double)numItems/batchSize));
     }
 }

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserMain.java
@@ -23,6 +23,7 @@ import org.docopt.Docopt;
 public class CorfuStoreBrowserMain {
     private enum OperationType {
         listTables,
+        loadTable,
         infoTable,
         showTable,
         dropTable
@@ -34,18 +35,22 @@ public class CorfuStoreBrowserMain {
         "[--keystore=<keystore_file>] [--ks_password=<keystore_password>] " +
         "[--truststore=<truststore_file>] [--truststore_password=<truststore_password>] " +
         "[--diskPath=<pathToTempDirForLargeTables>] "+
+        "[--numItems=<numItems>] "+
+        "[--batchSize=<itemsPerTransaction>] "+
         "[--tlsEnabled=<tls_enabled>]\n"
         + "Options:\n"
         + "--host=<host>   Hostname\n"
         + "--port=<port>   Port\n"
-        + "--operation=<listTables|infoTable|showTable|dropTable> Operation\n"
+        + "--operation=<listTables|infoTable|showTable|dropTable|loadTable> Operation\n"
         + "--namespace=<namespace>   Namespace\n"
         + "--tablename=<tablename>   Table Name\n"
         + "--keystore=<keystore_file> KeyStore File\n"
         + "--ks_password=<keystore_password> KeyStore Password\n"
         + "--truststore=<truststore_file> TrustStore File\n"
         + "--truststore_password=<truststore_password> Truststore Password\n"
-        + "--diskPath=<path to temp folder for large tables> Path to Temp Dir\n"
+        + "--diskPath=<pathToTempDirForLargeTables> Path to Temp Dir\n"
+        + "--numItems=<numItems> Total Number of items for loadTable\n"
+        + "--batchSize=<batchSize> Number of records per transaction for loadTable\n"
         + "--tlsEnabled=<tls_enabled>";
 
     public static void main(String[] args) {
@@ -115,6 +120,17 @@ public class CorfuStoreBrowserMain {
                     break;
                 case showTable:
                     browser.printTable(namespace, tableName);
+                    break;
+                case loadTable:
+                    int numItems = 1000;
+                    if (opts.get("--numItems") != null) {
+                        numItems = Integer.parseInt(opts.get("--numItems").toString());
+                    }
+                    int batchSize = 1000;
+                    if (opts.get("--batchSize") != null) {
+                        batchSize = Integer.parseInt(opts.get("--batchSize").toString());
+                    }
+                    browser.loadTable(namespace, tableName, numItems, batchSize);
                     break;
             }
         } catch (Throwable t) {

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserIT.java
@@ -133,6 +133,26 @@ public class CorfuStoreBrowserIT extends AbstractIT {
     }
 
     /**
+     * Create a table and add data to it using the loadTable command.
+     * @throws IOException
+     */
+    @Test
+    public void loaderTest() throws IOException {
+        final String namespace = "namespace";
+        final String tableName = "table";
+        runSinglePersistentServer(corfuSingleNodeHost,
+                corfuStringNodePort);
+
+        // Start a Corfu runtime
+        runtime = createRuntime(singleNodeEndpoint);
+        final int numItems = 100;
+        final int batchSize = 10;
+
+        CorfuStoreBrowser browser = new CorfuStoreBrowser(runtime);
+        Assert.assertEquals(browser.loadTable(namespace, tableName, numItems, batchSize), batchSize);
+    }
+
+    /**
      * Create a table and add nested protobufs as data to it.  Verify that the
      * browser tool is able to read the contents accurately.
      * @throws IOException


### PR DESCRIPTION
Using corfu browser we can now load data into a dummy table.
This is useful for testing checkpoint issues as well as live testing log-replication feature

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
