### PR TITLE
Log Entry Sync allow mixed Transactions

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/TestLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/TestLogEntryReader.java
@@ -28,7 +28,7 @@ public class TestLogEntryReader implements LogEntryReader {
     }
 
     @Override
-    public boolean hasNoiseData() {
+    public boolean hasMessageExceededSize() {
         return false;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/IllegalTransactionStreamsException.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/IllegalTransactionStreamsException.java
@@ -1,9 +1,0 @@
-package org.corfudb.infrastructure.logreplication.replication.send;
-
-public class IllegalTransactionStreamsException extends RuntimeException {
-
-    public IllegalTransactionStreamsException (String message) {
-        super(message);
-    }
-}
-

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationError.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationError.java
@@ -7,7 +7,7 @@ public enum LogReplicationError {
     TRIM_SNAPSHOT_SYNC(0, "A trim exception has occurred during snapshot sync."),
     TRIM_LOG_ENTRY_SYNC(1, "A trim exception has occurred during log entry sync."),
     LOG_ENTRY_ACK_TIMEOUT(2, "Log Entry Sync ack has timed out."),
-    ILLEGAL_TRANSACTION (3, "Illegal Transaction across replicated and non-replicated streams. " +
+    LOG_ENTRY_MESSAGE_SIZE_EXCEEDED(3, "Log Replication Entry Message exceeds max allowed size." +
             "Log Replication is TERMINATED."),
     UNKNOWN (4, "Unknown exception caused sync cancel.");
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -190,7 +190,6 @@ public class SnapshotSender {
         return numMessages + logReplicationEntries.size();
     }
 
-
     /**
      * Prepare a Snapshot Sync Replication start marker.
      *

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogEntryReader.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 /**
  * An Interface for Log Entry Reader
  *
- * A log entry logreader provides the functionality for reading incremental updates from Corfu.
+ * A log entry reader provides the functionality for reading incremental updates from Corfu.
  */
 public interface LogEntryReader {
 
@@ -22,13 +22,7 @@ public interface LogEntryReader {
 
     void reset(long lastSentBaseSnapshotTimestamp, long lastAckedTimestamp);
 
-    // Set current topologyConfigId that will be used to construct messages.
     void setTopologyConfigId(long topologyConfigId);
 
-    // If the transaction log contains both replicated streams and other streams,
-    // we treat it as nosieData.
-    // If the log data size is bigger than the max msg size supported, we set hasNoiseData too.
-    // When haNoiseData, a log replication exception will be thrown and triggers
-    // to stop the log replication state machine.
-    boolean hasNoiseData();
+    boolean hasMessageExceededSize();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/SnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/SnapshotReader.java
@@ -1,6 +1,5 @@
 package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 
-
 import lombok.NonNull;
 
 import java.util.UUID;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/OpaqueEntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/OpaqueEntry.java
@@ -36,6 +36,7 @@ public class OpaqueEntry {
     // TODO(Maithem): Inconsistent behavior when full-sync vs delta (for full sync the versions will change)
     final long version;
 
+
     public OpaqueEntry(long version, Map<UUID, List<SMREntry>> updates) {
         this.entries = updates;
         this.version = version;

--- a/utils/src/main/java/org/corfudb/utils/lock/LockClient.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/LockClient.java
@@ -140,7 +140,7 @@ public class LockClient {
                     try {
                         Collection<LockId> locksWithExpiredLeases = lockStore.filterLocksWithExpiredLeases(locks.keySet());
                         for(LockId lockId : locksWithExpiredLeases) {
-                            log.trace("LockClient: lease revoked for lock {}", lockId.getLockName());
+                            log.debug("LockClient: lease revoked for lock {}", lockId.getLockName());
                             locks.get(lockId).input(LockEvent.LEASE_REVOKED);
                         }
                     } catch (Exception ex) {

--- a/utils/src/main/java/org/corfudb/utils/lock/states/HasLeaseState.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/states/HasLeaseState.java
@@ -25,7 +25,6 @@ public class HasLeaseState extends LockState {
     // duration after which a local task checks if a lease has expired.
     private static int DURATION_BETWEEN_LEASE_CHECKS = 60;
 
-
     // task to renew lease
     private Optional<ScheduledFuture<?>> leaseRenewalFuture = Optional.empty();
 


### PR DESCRIPTION
## Overview

Description:

Allow replication when a transaction is executed across
replicated and non-replicated streams. Filter out the streams
of interest and disregard all other streams.

Why should this be merged: 

Related issue(s) (if applicable): #<number>

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
