### PR TITLE
Dedicated Executor for acquired lock monitoring

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -219,6 +219,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
 
             default:
                 log.error("Invalid event type {}", event.type);
+                break;
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -7,8 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
-import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.replication.fsm.ObservableAckMsg;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationFSM;
@@ -18,24 +16,13 @@ import org.corfudb.infrastructure.logreplication.replication.send.CorfuDataSende
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.DefaultReadProcessor;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationEventMetadata;
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.ReadProcessor;
-import org.corfudb.protocols.wireprotocol.StreamAddressRange;
-import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
-import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent.LogReplicationEventType;
-import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * This class represents the Log Replication Manager at the source cluster.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
@@ -3,7 +3,6 @@ package org.corfudb.infrastructure.logreplication.replication.receive;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntryMetadata;
-import org.corfudb.runtime.Messages;
 
 import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.LOG_ENTRY_MESSAGE;
 import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.LOG_ENTRY_REPLICATED;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -62,7 +62,7 @@ public class LogEntryWriter {
      * @param metadata
      * @throws ReplicationWriterException
      */
-    void verifyMetadata(LogReplicationEntryMetadata metadata) throws ReplicationWriterException {
+    private void verifyMetadata(LogReplicationEntryMetadata metadata) throws ReplicationWriterException {
         if (metadata.getMessageMetadataType() != MessageType.LOG_ENTRY_MESSAGE) {
             log.error("Wrong message metadata {}, expecting  type {} snapshot {}", metadata,
                     MessageType.LOG_ENTRY_MESSAGE, srcGlobalSnapshot);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -25,7 +25,6 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_END;
 import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_MESSAGE;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -1,6 +1,5 @@
 package org.corfudb.infrastructure.logreplication.replication.receive;
 
-import io.netty.buffer.Unpooled;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationHandler.java
@@ -28,7 +28,7 @@ public class LogReplicationHandler implements IClient, IHandler<LogReplicationCl
 
     @Setter
     @Getter
-    IClientRouter router;
+    private IClientRouter router;
 
     @Getter
     public ClientMsgHandler msgHandler = new ClientMsgHandler(this)

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/StoppedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/StoppedState.java
@@ -14,7 +14,7 @@ import org.corfudb.infrastructure.logreplication.replication.LogReplicationSourc
 @Slf4j
 public class StoppedState implements LogReplicationRuntimeState {
 
-    LogReplicationSourceManager replicationSourceManager;
+    private LogReplicationSourceManager replicationSourceManager;
 
     public StoppedState(LogReplicationSourceManager replicationSourceManager) {
         this.replicationSourceManager = replicationSourceManager;

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/OpaqueStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/OpaqueStream.java
@@ -14,12 +14,12 @@ public class OpaqueStream {
     /**
      * The stream view backing this adapter.
      */
-    final IStreamView streamView;
+    private final IStreamView streamView;
 
     /**
      * Necessary until the runtime is no longer necessary for deserialization.
      */
-    final CorfuRuntime runtime;
+    private final CorfuRuntime runtime;
 
     public OpaqueStream(CorfuRuntime runtime, IStreamView streamView) {
         this.runtime = runtime;

--- a/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
@@ -379,7 +379,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
     }
 
 
-    void accessTxStream(Iterator iterator, int num) {
+    private void accessTxStream(Iterator iterator, int num) {
 
         int i = 0;
         while (iterator.hasNext() && i++ < num) {
@@ -498,7 +498,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
                     })
                     .setSerializer(Serializers.PRIMITIVE)
                     .open();
-            long size = testTable.size();
+            testTable.size();
         } catch (Exception e) {
             System.out.println("caught a exception " + e);
             assertThat(e).isInstanceOf(TrimmedException.class);

--- a/utils/src/main/java/org/corfudb/utils/lock/states/HasLeaseState.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/states/HasLeaseState.java
@@ -104,7 +104,7 @@ public class HasLeaseState extends LockState {
     @Override
     public void onEntry(LockState from) {
         notify(() -> lock.getLockListener().lockAcquired(lock.getLockId()), "Lock Acquired");
-        //Record the lease time
+        // Record the lease time
         leaseTime = Optional.of(Instant.now());
         startLeaseRenewal();
         startLeaseMonitor();
@@ -188,12 +188,12 @@ public class HasLeaseState extends LockState {
 
     /**
      * An independent task is run to make sure the lease is renewed on time. This task generates
-     * a LEASE_EXPIRED event if the lease was not be renewed on time.
+     * a LEASE_EXPIRED event if the lease was not renewed on time.
      */
     private void startLeaseMonitor() {
         synchronized (leaseMonitorFuture) {
             if (!leaseMonitorFuture.isPresent() || leaseMonitorFuture.get().isDone())
-                leaseMonitorFuture = Optional.of(taskScheduler.scheduleWithFixedDelay(
+                leaseMonitorFuture = Optional.of(leaseMonitorScheduler.scheduleWithFixedDelay(
                         () -> {
                             if (leaseTime.isPresent() && leaseTime.get().isBefore(Instant.now().minusSeconds(Lock.leaseDuration))) {
                                 log.info("Lock: {} lease expired for lock {}", lock.getLockId());

--- a/utils/src/main/java/org/corfudb/utils/lock/states/LockState.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/states/LockState.java
@@ -30,6 +30,8 @@ public abstract class LockState {
     protected final LockStore lockStore;
     // Task scheduler to be used by lock states
     protected final ScheduledExecutorService taskScheduler;
+    // Dedicated scheduler to be used in HasLeaseState to monitor acquired lock
+    protected final ScheduledExecutorService leaseMonitorScheduler;
     // Listener executor (for lock lost, lockAcquired) notifications.
     protected final ExecutorService lockListenerExecutor;
 
@@ -38,6 +40,7 @@ public abstract class LockState {
         this.lockStore = lock.getClientContext().getLockStore();
         this.taskScheduler =  lock.getClientContext().getTaskScheduler();
         this.lockListenerExecutor =  lock.getClientContext().getLockListenerExecutor();
+        this.leaseMonitorScheduler = lock.getClientContext().getLeaseMonitorScheduler();
     }
 
     /**


### PR DESCRIPTION
## Overview

Description:

Add a dedicated executor for lock acquired monitoring. The reason is that sharing the executor with the lease renewal task can lead to a blocking scenario, where if lease renewal task is stuck, lock client would not expire on the current lock (already lost). 

Why should this be merged: fixes a potential bug when lease renewal is stuck.
