### PR TITLE
Use A Faster JSON Implementation

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -1,9 +1,20 @@
 package org.corfudb.infrastructure.logreplication.replication.receive;
 
+import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_END;
+import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_MESSAGE;
+
+
 import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
@@ -15,19 +26,6 @@ import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.view.Address;
-import org.immutables.value.internal.$guava$.annotations.$VisibleForTesting;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_END;
-import static org.corfudb.protocols.wireprotocol.logreplication.MessageType.SNAPSHOT_MESSAGE;
 
 /**
  * This class represents the Log Replication Manager at the destination.
@@ -77,7 +75,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      */
     private long topologyConfigId = 0;
 
-    @$VisibleForTesting
+    @VisibleForTesting
     private int rxMessageCounter = 0;
 
     // Count number of received messages, used for testing purposes

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,11 @@
             <version>4.5.5</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>1.2.73</version>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -91,19 +91,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>kryo</artifactId>
-            <version>4.0.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
             <version>3.0.24</version>
-        </dependency>
-        <dependency>
-            <groupId>de.javakaffee</groupId>
-            <artifactId>kryo-serializers</artifactId>
-            <version>0.41</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/IMetadata.java
@@ -1,8 +1,12 @@
 package org.corfudb.protocols.wireprotocol;
 
-import com.esotericsoftware.kryo.NotNull;
-import com.google.common.reflect.TypeToken;
+import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_ID;
+import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_START_LOG_ADDRESS;
+import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_ID;
+import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_TYPE;
 
+
+import com.google.common.reflect.TypeToken;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
@@ -12,23 +16,12 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import javax.annotation.Nullable;
-
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Value;
-
 import org.corfudb.common.compression.Codec;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.Layout;
-
-import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_ID;
-import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINTED_STREAM_START_LOG_ADDRESS;
-import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_ID;
-import static org.corfudb.protocols.wireprotocol.IMetadata.LogUnitMetadataType.CHECKPOINT_TYPE;
 
 /**
  * Created by mwei on 9/18/15.
@@ -234,7 +227,6 @@ public interface IMetadata {
         return getPayloadCodecType() != Codec.Type.NONE;
     }
 
-    @RequiredArgsConstructor
     enum LogUnitMetadataType implements ITypedEnum {
         RANK(1, TypeToken.of(DataRank.class)),
         BACKPOINTER_MAP(3, new TypeToken<Map<UUID, Long>>() {}),
@@ -251,6 +243,11 @@ public interface IMetadata {
         @Getter
         final TypeToken<?> componentType;
 
+        private LogUnitMetadataType(int type, TypeToken<?> componentType) {
+            this.type = type;
+            this.componentType = componentType;
+        }
+
         public byte asByte() {
             return (byte) type;
         }
@@ -261,19 +258,30 @@ public interface IMetadata {
                                 Function.identity()));
     }
 
-    @Value
-    @AllArgsConstructor
     class DataRank implements Comparable<DataRank> {
-        public long rank;
-        @NotNull
-        public UUID uuid;
 
+        private long rank;
+
+        private UUID uuid;
+
+        public DataRank(long rank, UUID uuid) {
+            this.rank = rank;
+            this.uuid = uuid;
+        }
         public DataRank(long rank) {
             this(rank, UUID.randomUUID());
         }
 
         public DataRank buildHigherRank() {
             return new DataRank(rank + 1, uuid);
+        }
+
+        public long getRank() {
+            return rank;
+        }
+
+        public UUID getUuid() {
+            return uuid;
         }
 
         @Override

--- a/runtime/src/main/java/org/corfudb/util/serializer/ISerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/ISerializer.java
@@ -1,51 +1,22 @@
 package org.corfudb.util.serializer;
 
-import com.esotericsoftware.kryo.Kryo;
 import com.google.common.collect.ImmutableMap;
-
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-
 import java.util.function.Function;
-
-import de.javakaffee.kryoserializers.guava.ImmutableListSerializer;
-import de.javakaffee.kryoserializers.guava.ImmutableMapSerializer;
-import de.javakaffee.kryoserializers.guava.ImmutableMultimapSerializer;
-import de.javakaffee.kryoserializers.guava.ImmutableSetSerializer;
-import io.netty.buffer.ByteBuf;
-import io.netty.buffer.Unpooled;
-
 import net.openhft.hashing.LongHashFunction;
-
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.Utils;
-import org.objenesis.strategy.StdInstantiatorStrategy;
 
 /**
  * This class represents a serializer, which takes an object and reads/writes it to a bytebuf.
  * Created by mwei on 9/17/15.
  */
 public interface ISerializer {
-
-    // Used for default cloning.
-    ThreadLocal<Kryo> kryos = new ThreadLocal<Kryo>() {
-        protected Kryo initialValue() {
-            Kryo kryo = new Kryo();
-            // Use an instantiator that does not require no-args
-            kryo.setInstantiatorStrategy(new Kryo.DefaultInstantiatorStrategy(
-                    new StdInstantiatorStrategy()));
-            ImmutableListSerializer.registerSerializers(kryo);
-            ImmutableSetSerializer.registerSerializers(kryo);
-            ImmutableMapSerializer.registerSerializers(kryo);
-            ImmutableMultimapSerializer.registerSerializers(kryo);
-            // configure kryo instance, customize settings
-            return kryo;
-        }
-
-        ;
-    };
 
     byte getType();
 
@@ -143,15 +114,5 @@ public interface ISerializer {
             b.release();
             return Utils.longToBigEndianByteArray(hash);
         }
-    }
-
-    /**
-     * Clone an object through serialization.
-     *
-     * @param o The object to clone.
-     * @return The cloned object.
-     */
-    default Object clone(Object o, CorfuRuntime rt) {
-        return kryos.get().copy(o);
     }
 }

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -27,16 +27,6 @@
 
         <!-- external dependencies -->
         <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>gson</artifactId>
-            <version>${immutables.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <version>${immutables.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>3.1.0</version>


### PR DESCRIPTION
## Overview

Changed the json implementation from GSON to fastjson because of
performance issues. For example, serializing and deserializing
a 4mb byte array takes on ~914.95 ms with GSON, but only ~58.85ms
with fastjson (i.e. 15x faster).

Why should this be merged: Needed to address stream syncing performance problems that is dominated by serialization/deserialization costs. 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
