### PR TITLE
Use Logger Instead Of Printing to stdout

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationTest.java
@@ -1,14 +1,16 @@
 package org.corfudb.infrastructure.logreplication;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+
 import com.google.common.reflect.TypeToken;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.util.serializer.Serializers;
 
-import java.io.IOException;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
+@Slf4j
 public class LogReplicationTest {
 
     private String endpoint;
@@ -47,10 +49,10 @@ public class LogReplicationTest {
         runtime.parseConfigurationString(endpoint);
         runtime.registerSystemDownHandler(() -> {throw new RuntimeException("Disconnected from database. Terminating thread.");});
 
-        System.out.println("Connecting to Corfu " + endpoint);
+        log.debug("Connecting to Corfu " + endpoint);
         runtime.connect();
 
-        System.out.println("Connected to Corfu " + endpoint);
+        log.debug("Connected to Corfu " + endpoint);
 
         //Create tables
         table1 = runtime.getObjectsView()
@@ -103,11 +105,11 @@ public class LogReplicationTest {
 
     private void verifyData() {
         if (table1.isEmpty() && table2.isEmpty() && table3.isEmpty()) {
-            System.out.println("All tables are EMPTY");
+            log.debug("All tables are EMPTY");
         } else {
-            System.out.println("Table1: " + table1.keySet());
-            System.out.println("Table2: " + table2.keySet());
-            System.out.println("Table3: " + table3.keySet());
+            log.debug("Table1: " + table1.keySet());
+            log.debug("Table2: " + table2.keySet());
+            log.debug("Table3: " + table3.keySet());
 
             for (int i = 0; i < ITERATIONS; i++) {
 
@@ -124,14 +126,14 @@ public class LogReplicationTest {
         LogReplicationTest lrTest = new LogReplicationTest(endpoint);
         lrTest.setupEnv();
         if(args[1].equalsIgnoreCase("sender")) {
-            System.out.println("Generating data for the tables");
+            log.debug("Generating data for the tables");
             lrTest.generateData();
-            System.out.println("Generated data for the tables");
+            log.debug("Generated data for the tables");
         }
         else {
-            System.out.println("Verifying data for the tables");
+            log.debug("Verifying data for the tables");
             lrTest.verifyData();
-            System.out.println("Verified data for the tables");
+            log.debug("Verified data for the tables");
         }
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -1,5 +1,6 @@
 package org.corfudb.integration;
 
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.util.Sleep;
 import org.junit.Before;
 import org.junit.Test;
@@ -15,6 +16,7 @@ import java.util.concurrent.Executors;
  *
  * @author amartinezman
  */
+@Slf4j
 public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT {
 
     private static final int SLEEP_DURATION = 5;
@@ -42,30 +44,30 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     @Test
     public void testStandbyClusterReset() throws Exception {
         // (1) Snapshot and Log Entry Sync
-        System.out.println(">>> (1) Start Snapshot and Log Entry Sync");
+        log.debug(">>> (1) Start Snapshot and Log Entry Sync");
         testEndToEndSnapshotAndLogEntrySync();
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
         // (2) Stop Standby Log Replicator Server
-        System.out.println(">>> (2) Stop Standby Node");
+        log.debug(">>> (2) Stop Standby Node");
         stopStandbyLogReplicator();
 
         // (3) Start daemon thread writing data to active
-        System.out.println(">>> (3) Start daemon writer service");
+        log.debug(">>> (3) Start daemon writer service");
         // Since step (1) wrote numWrites for snapshotSync and numWrites/2 in logEntrySync, continue from this starting point
         writerService.submit(() -> writeToActive((numWrites + numWrites/2), numWrites));
 
         // (4) Sleep Interval so writes keep going through, while standby is down
-        System.out.println(">>> (4) Wait for some time");
+        log.debug(">>> (4) Wait for some time");
         Sleep.sleepUninterruptibly(Duration.ofSeconds(SLEEP_DURATION));
 
         // (5) Restart Standby Log Replicator
-        System.out.println(">>> (5) Restart Standby Node");
+        log.debug(">>> (5) Restart Standby Node");
         startStandbyLogReplicator();
 
         // (6) Verify Data on Standby after Restart
-        System.out.println(">>> (6) Verify Data on Standby");
+        log.debug(">>> (6) Verify Data on Standby");
         verifyDataOnStandby((numWrites*2 + numWrites/2));
     }
 
@@ -77,30 +79,30 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     @Test
     public void testActiveClusterReset() throws Exception {
         // (1) Snapshot and Log Entry Sync
-        System.out.println(">>> (1) Start Snapshot and Log Entry Sync");
+        log.debug(">>> (1) Start Snapshot and Log Entry Sync");
         testEndToEndSnapshotAndLogEntrySync();
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
         // (2) Start daemon thread writing data to active
-        System.out.println(">>> (2) Start daemon writer service");
+        log.debug(">>> (2) Start daemon writer service");
         // Since step (1) wrote numWrites for snapshotSync and numWrites/2 in logEntrySync, continue from this starting point
         writerService.submit(() -> writeToActive((numWrites + numWrites/2), numWrites));
 
         // (3) Stop Standby Log Replicator Server
-        System.out.println(">>> (3) Stop Active Node");
+        log.debug(">>> (3) Stop Active Node");
         stopActiveLogReplicator();
 
         // (4) Sleep Interval so writes keep going through, while standby is down
-        System.out.println(">>> (4) Wait for some time");
+        log.debug(">>> (4) Wait for some time");
         Sleep.sleepUninterruptibly(Duration.ofSeconds(SLEEP_DURATION));
 
         // (5) Restart Active Log Replicator
-        System.out.println(">>> (5) Restart Active Node");
+        log.debug(">>> (5) Restart Active Node");
         startActiveLogReplicator();
 
         // (6) Verify Data on Standby after Restart
-        System.out.println(">>> (6) Verify Data on Standby");
+        log.debug(">>> (6) Verify Data on Standby");
         verifyDataOnStandby((numWrites*2 + numWrites/2));
     }
 }

--- a/test/src/test/java/org/corfudb/integration/DefaultDataControl.java
+++ b/test/src/test/java/org/corfudb/integration/DefaultDataControl.java
@@ -1,16 +1,19 @@
 package org.corfudb.integration;
 
+import static org.assertj.core.api.Assertions.fail;
+
+
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.logreplication.DataControl;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationSourceManager;
 
-import static org.assertj.core.api.Assertions.fail;
-
 /**
  * Test Default Data Control Implementation, used for source and sink (destination) nodes.
  */
+@Slf4j
 public class DefaultDataControl implements DataControl {
 
     @Setter
@@ -39,7 +42,7 @@ public class DefaultDataControl implements DataControl {
             // System.out.println("----- Drop snapshot sync request: " + controlCallsCount);
         } else if (sourceManager != null) {
             // Request/Start Snapshot Sync on Source
-            System.out.println("----- Start Snapshot Sync on Source: " + controlCallsCount);
+            log.debug("----- Start Snapshot Sync on Source: " + controlCallsCount);
             sourceManager.startSnapshotSync();
         } else {
             fail("Source Manager has not been set for DataControl implementation.");

--- a/test/src/test/java/org/corfudb/integration/LockIT.java
+++ b/test/src/test/java/org/corfudb/integration/LockIT.java
@@ -2,6 +2,8 @@ package org.corfudb.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.Sleep;
@@ -30,6 +32,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.Semaphore;
 import java.util.stream.Collectors;
 
+@Slf4j
 public class LockIT extends AbstractIT implements Observer {
 
     private static final int LOCK_TIME_CONSTANT = 6;
@@ -79,7 +82,7 @@ public class LockIT extends AbstractIT implements Observer {
                     .build();
 
            // Since this is the only client, lock should've been acquired, verify, block until condition is met
-           System.out.println("***** Wait until lock is acquired");
+           log.debug("***** Wait until lock is acquired");
            waitCondition = WaitConditionType.LOCK_ACQUIRED;
            blockUntilWaitCondition.acquire();
 
@@ -92,7 +95,7 @@ public class LockIT extends AbstractIT implements Observer {
 
            // Verify for 5 cycles that the lock is renewed
            for (int i=0; i < RENEW_CYCLES; i++) {
-               System.out.println("***** Wait until lock is renewed");
+               log.debug("***** Wait until lock is renewed");
                // TODO: inspect the     // how many times the lease has been acquired by a different client
                //    int32 lease_acquisition_number = 3;
                //    // how many times the lease has been renewed since the last acquisition
@@ -104,7 +107,7 @@ public class LockIT extends AbstractIT implements Observer {
                assertThat(lockRevokedObservables.get(clientId).getValue()).isEqualTo(0);
            }
        } catch (Exception e) {
-           System.out.println("Unexpected exception: " + e);
+           log.debug("Unexpected exception: " + e);
            throw e;
        } finally {
            shutdown();
@@ -147,7 +150,7 @@ public class LockIT extends AbstractIT implements Observer {
             // Since this is the only client, ALL locks should've been acquired, verify, block until condition is met
             waitCondition = WaitConditionType.LOCK_ACQUIRED;
             for (int i=0; i<numLocks; i++) {
-                System.out.println("***** Wait until lock " + i + " is acquired");
+                log.debug("***** Wait until lock " + i + " is acquired");
                 blockUntilWaitCondition.acquire();
             }
 
@@ -155,7 +158,7 @@ public class LockIT extends AbstractIT implements Observer {
             lockIds.forEach(lockId ->
                 assertThat(client.getLocks().get(lockId).getState().getType()).isEqualTo(LockStateType.HAS_LEASE));
         } catch (Exception e) {
-            System.out.println("Unexpected exception: " + e);
+            log.debug("Unexpected exception: " + e);
             throw e;
         } finally {
             shutdown();
@@ -231,7 +234,7 @@ public class LockIT extends AbstractIT implements Observer {
 
             // Verify for 5 cycles that the lock is renewed
             for (int i=0; i < RENEW_CYCLES; i++) {
-                System.out.println("***** Wait until lock is renewed");
+                log.debug("***** Wait until lock is renewed");
                 // Wait for the renewal cycle + 1, and verify that the lock is still acquired by the same client
                 Sleep.sleepUninterruptibly(Duration.ofSeconds(LOCK_TIME_CONSTANT + 1));
                 clientsWithLock = getClientsThatAcquiredLock(lockId, clientIdToLockClient);
@@ -240,7 +243,7 @@ public class LockIT extends AbstractIT implements Observer {
             }
 
         } catch (Exception e) {
-            System.out.println("Caught Exception: " + e);
+            log.debug("Caught Exception: " + e);
             throw e;
         } finally {
             shutdown();
@@ -315,7 +318,7 @@ public class LockIT extends AbstractIT implements Observer {
             // Verify that if clientWithLock is shutdown, a new client acquires the lock
             clientIdToRuntimeMap.get(clientWithLock.getClientId()).shutdown();
 
-            System.out.println("***** Re-acquire lock");
+            log.debug("***** Re-acquire lock");
 
             // Block until any client acquires the lock
             if (lockHasNotBeenAcquired(lockAcquiredObservables)) {
@@ -331,7 +334,7 @@ public class LockIT extends AbstractIT implements Observer {
             assertThat(newClientWithLock).isNotEqualTo(clientsWithLock);
 
         } catch (Exception e) {
-            System.out.println("Caught Exception: " + e);
+            log.debug("Caught Exception: " + e);
             throw e;
         } finally {
             shutdown();

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -1,6 +1,17 @@
 package org.corfudb.integration;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+
 import com.google.common.reflect.TypeToken;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.CorfuInterClusterReplicationServer;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
@@ -17,16 +28,7 @@ import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.ProtobufSerializer;
 import org.corfudb.util.serializer.Serializers;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.util.Arrays;
-import java.util.List;
-import java.util.StringJoiner;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
+@Slf4j
 public class LogReplicationAbstractIT extends AbstractIT {
 
     private static final int MSG_SIZE = 65536;
@@ -70,13 +72,13 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
     public void testEndToEndSnapshotAndLogEntrySync() throws Exception {
         try {
-            System.out.println("\nSetup active and standby Corfu's");
+            log.debug("\nSetup active and standby Corfu's");
             setupActiveAndStandbyCorfu();
 
-            System.out.println("Open map on active and standby");
+            log.debug("Open map on active and standby");
             openMap();
 
-            System.out.println("Write data to active CorfuDB before LR is started ...");
+            log.debug("Write data to active CorfuDB before LR is started ...");
             // Add Data for Snapshot Sync
             writeToActive(0, numWrites);
 
@@ -88,13 +90,13 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
             startLogReplicatorServers();
 
-            System.out.println("Wait ... Snapshot log replication in progress ...");
+            log.debug("Wait ... Snapshot log replication in progress ...");
             verifyDataOnStandby(numWrites);
 
             // Add Delta's for Log Entry Sync
             writeToActive(numWrites, numWrites/2);
 
-            System.out.println("Wait ... Delta log replication in progress ...");
+            log.debug("Wait ... Delta log replication in progress ...");
             verifyDataOnStandby((numWrites + (numWrites / 2)));
         } finally {
             executorService.shutdownNow();
@@ -137,7 +139,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
             standbyRuntime = new CorfuRuntime(standbyEndpoint).connect();
         } catch (Exception e) {
-            System.out.println("Error while starting Corfu");
+            log.debug("Error while starting Corfu");
             throw  e;
         }
     }
@@ -191,7 +193,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
                 });
             }
         } catch (Exception e) {
-            System.out.println("Error caught while running Log Replication Server");
+            log.debug("Error caught while running Log Replication Server");
         }
     }
 
@@ -226,7 +228,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
             }
         }
 
-        System.out.println("*** Active PID :: " + pid);
+        log.debug("*** Active PID :: " + pid);
 
         List<String> paramsKill = Arrays.asList("/bin/sh", "-c", "kill -9 " + pid);
         runCommandForOutput(paramsKill);
@@ -272,7 +274,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
                 });
             }
         } catch (Exception e) {
-            System.out.println("Error caught while running Log Replication Server");
+            log.debug("Error caught while running Log Replication Server");
         }
     }
 
@@ -288,7 +290,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
                 });
             }
         } catch (Exception e) {
-            System.out.println("Error caught while running Log Replication Server");
+            log.debug("Error caught while running Log Replication Server");
         }
     }
 
@@ -298,7 +300,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
             // Block until expected number of entries is reached
         }
 
-        System.out.println("Number updates on Standby :: " + expectedConsecutiveWrites);
+        log.debug("Number updates on Standby :: " + expectedConsecutiveWrites);
 
         // Verify data is present in Standby Site
         assertThat(mapAStandby.size()).isEqualTo(expectedConsecutiveWrites);
@@ -380,7 +382,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
         Serializers.registerSerializer(protoBufSerializer);
 
         // Trim
-        System.out.println("**** Trim Log @address=" + trimMark);
+        log.debug("**** Trim Log @address=" + trimMark);
         cpRuntime.getAddressSpaceView().prefixTrim(trimMark);
         cpRuntime.getAddressSpaceView().invalidateClientCache();
         cpRuntime.getAddressSpaceView().invalidateServerCaches();

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -122,7 +122,7 @@ public class SourceForwardingDataSender implements DataSender {
     public void onError(LogReplicationError error) {
         errorCount++;
         errors.setValue(errorCount);
-        System.out.print("\nSourceFowardingDataSender got an error " + error);
+        log.trace("\nSourceFowardingDataSender got an error " + error);
     }
 
     /*

--- a/test/src/test/java/org/corfudb/runtime/view/stream/OpaqueStreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/OpaqueStreamTest.java
@@ -1,8 +1,13 @@
 package org.corfudb.runtime.view.stream;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
 import com.google.common.reflect.TypeToken;
+import java.util.UUID;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.CustomSerializer;
-import org.corfudb.protocols.logprotocol.MultiSMREntry;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
@@ -12,13 +17,9 @@ import org.corfudb.runtime.exceptions.SerializerException;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.Test;
 
-import java.util.UUID;
-import java.util.stream.Stream;
-
+@Slf4j
 public class OpaqueStreamTest extends AbstractViewTest {
 
     @Test
@@ -58,7 +59,7 @@ public class OpaqueStreamTest extends AbstractViewTest {
         Stream<OpaqueEntry> stream = opaqueStream.streamUpTo(snapshot);
 
         stream.forEach(entry -> {
-            System.out.println(entry.getVersion() + " " + entry.getEntries());
+            log.debug(entry.getVersion() + " " + entry.getEntries());
         });
 
     }
@@ -103,7 +104,7 @@ public class OpaqueStreamTest extends AbstractViewTest {
         Stream<OpaqueEntry> stream = opaqueStream.streamUpTo(snapshot);
 
         stream.forEach(entry -> {
-            System.out.println(entry.getVersion() + " " + entry.getEntries());
+            log.debug(entry.getVersion() + " " + entry.getEntries());
         });
 
         CorfuRuntime rt3 = getNewRuntime(getDefaultNode()).connect();

--- a/test/src/test/java/org/corfudb/utils/TestLockListener.java
+++ b/test/src/test/java/org/corfudb/utils/TestLockListener.java
@@ -1,10 +1,12 @@
 package org.corfudb.utils;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.utils.lock.LockDataTypes;
 import org.corfudb.utils.lock.LockListener;
 
+@Slf4j
 public class TestLockListener implements LockListener {
 
     private int lockAcquiredCount = 0;
@@ -19,14 +21,14 @@ public class TestLockListener implements LockListener {
     @Override
     public void lockAcquired(LockDataTypes.LockId lockId) {
         lockAcquiredCount++;
-        System.out.println("***** Lock has been acquired : " + lockAcquiredCount + " for: " + lockId.getLockName());
+        log.debug("***** Lock has been acquired : " + lockAcquiredCount + " for: " + lockId.getLockName());
         // Update observable value, indicating lock has been acquired
         lockAcquired.setValue(lockAcquiredCount);
     }
 
     @Override
     public void lockRevoked(LockDataTypes.LockId lockId) {
-        System.out.println("***** Lock has been revoked for: " + lockId.getLockName());
+        log.debug("***** Lock has been revoked for: " + lockId.getLockName());
         // Update observable value, indicating lock has been revoked
         lockRevokedCount++;
         lockAcquired.setValue(lockRevokedCount);


### PR DESCRIPTION
## Overview
Move log statements to a logger (instead of printing to stdout).

Why should this be merged: Reduces log pollution during testing.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
