### PR TITLE
Register System.exit for systemDownHandler for LR CorfuRuntime 

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -78,6 +78,10 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     private static final String LOCK_NAME = "Log_Replication_Lock";
 
     /**
+     * System exit error code called by the Corfu Runtime systemDownHandler
+     */
+    private static final int SYSTEM_EXIT_ERROR_CODE = -3;
+    /**
      * Used by the active cluster to initiate Log Replication
      */
     @Getter
@@ -312,6 +316,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                     .keyStore((String) serverContext.getServerConfig().get("--keystore"))
                     .ksPasswordFile((String) serverContext.getServerConfig().get("--keystore-password-file"))
                     .tlsEnabled((Boolean) serverContext.getServerConfig().get("--enable-tls"))
+                    .systemDownHandler(() -> System.exit(SYSTEM_EXIT_ERROR_CODE))
                     .build())
                     .parseConfigurationString(localCorfuEndpoint).connect();
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -93,6 +93,7 @@ public class LogReplicationSourceManager {
                 .tsPasswordFile(params.getTsPasswordFile())
                 .keyStore(params.getKeyStore())
                 .ksPasswordFile(params.getKsPasswordFile())
+                .systemDownHandler(params.getSystemDownHandler())
                 .tlsEnabled(params.isTlsEnabled()).build());
         runtime.parseConfigurationString(params.getLocalCorfuEndpoint()).connect();
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
@@ -33,7 +33,7 @@ public class LogReplicationStreamNameTableManager {
 
     private ILogReplicationConfigAdapter logReplicationConfigAdapter;
 
-    private CorfuRuntime corfuRuntime;
+    private final CorfuRuntime corfuRuntime;
 
     private String pluginConfigFilePath;
 

--- a/utils/src/main/java/org/corfudb/utils/lock/states/NoLeaseState.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/states/NoLeaseState.java
@@ -90,7 +90,8 @@ public class NoLeaseState extends LockState {
             if (lockStore.acquire(lock.getLockId())) {
                 lock.input(LockEvent.LEASE_ACQUIRED);
             }
-        } catch (Exception e) {
+        }
+        catch (Exception e) {
             log.error("Lock: {} could not acquire lease {}", lock.getLockId(), e);
         }
     }


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Due to the clustering workflow constraints in the production environment, we have to restart the LR once the WCE is hit. This patch registers systemDownHandler on the CorfuRuntime and calls it every time WCE is hit. This should shut down LR JVM that will subsequently get restarted. 



