### PR TITLE
Remove Java Generics From CorfuQueue's API

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -1,12 +1,13 @@
 package org.corfudb.protocols.logprotocol;
 
-import io.netty.buffer.ByteBuf;
+import static com.google.common.base.Preconditions.checkState;
 
+
+import io.netty.buffer.ByteBuf;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,8 +17,6 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.CorfuSerializer;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
-
-import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Created by mwei on 1/8/16.
@@ -143,28 +142,6 @@ public class SMREntry extends LogEntry implements ISMRConsumable {
         }
         SMRArguments = arguments;
         serializedSize = b.readerIndex() - readIndex + 1;
-    }
-
-
-    /**
-     * Calculate an Opaque SMR entry's serialized size.
-     * @throws IllegalAccessException
-     */
-    private int calculateOpaqueSMREntrySerializedSize() {
-        if (!opaque) {
-            return 0;
-        }
-
-        int size = 0;
-
-        for (Object smrArg : SMRArguments) {
-            size += ((byte[])smrArg).length;
-        }
-
-        size += (SMRMethod.length() * Character.BYTES);
-        size += Integer.BYTES;
-
-        return size;
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/util/serializer/CorfuQueueSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/CorfuQueueSerializer.java
@@ -1,0 +1,73 @@
+package org.corfudb.util.serializer;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+
+import com.google.protobuf.ByteString;
+import io.netty.buffer.ByteBuf;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuQueue;
+
+public class CorfuQueueSerializer implements ISerializer {
+
+    // Serialization tag for a queue's metadata entry
+    private final byte entryRecordIdMarker = 1;
+
+    // Serialization tag for the queue's payload
+    private final byte entryPayloadMarker = 2;
+
+    private final byte type;
+
+    public CorfuQueueSerializer(byte type) {
+        this.type = type;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte getType() {
+        return type;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+        byte type = b.readByte();
+        switch (type) {
+            case entryRecordIdMarker:
+                return CorfuQueue.CorfuRecordId.deserialize(b);
+            case entryPayloadMarker:
+                int len = b.readInt();
+                byte[] payload = new byte[len];
+                b.readBytes(payload);
+                return ByteString.copyFrom(payload);
+            default:
+                throw new IllegalArgumentException("Unknown type! " + type);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void serialize(Object o, ByteBuf b) {
+        checkNotNull(o);
+        if (o instanceof CorfuQueue.CorfuRecordId) {
+            CorfuQueue.CorfuRecordId recordId = (CorfuQueue.CorfuRecordId) o;
+            b.writeByte(entryRecordIdMarker);
+            recordId.serialize(b);
+            return;
+        } else if (o instanceof ByteString) {
+            b.writeByte(entryPayloadMarker);
+            ByteString payload = (ByteString) o;
+            b.writeInt(payload.size());
+            b.writeBytes(payload.asReadOnlyByteBuffer());
+            return;
+        } else {
+            throw new IllegalArgumentException("Unknown type! " + o.getClass().getSimpleName());
+        }
+    }
+}

--- a/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
@@ -20,6 +20,8 @@ public class Serializers {
     public static final ISerializer JAVA = new JavaSerializer((byte) 1);
     public static final ISerializer JSON = new JsonSerializer((byte) 2);
     public static final ISerializer PRIMITIVE = new PrimitiveSerializer((byte) 3);
+    public static final ISerializer QUEUE_SERIALIZER = new CorfuQueueSerializer((byte) 4);
+
 
     /**
      * @return the recommended default serializer used for converting objects into write format.
@@ -36,6 +38,7 @@ public class Serializers {
         serializersMap.put(JAVA.getType(), JAVA);
         serializersMap.put(JSON.getType(), JSON);
         serializersMap.put(PRIMITIVE.getType(), PRIMITIVE);
+        serializersMap.put(QUEUE_SERIALIZER.getType(), QUEUE_SERIALIZER);
     }
 
     private static final Map<Byte, ISerializer> customSerializers = new HashMap<>();

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -2,22 +2,16 @@ package org.corfudb.runtime.checkpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.collect.Iterables;
+
 import com.google.common.collect.Iterators;
 import com.google.common.reflect.TypeToken;
-
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuQueueTest.java
@@ -12,6 +12,13 @@ import java.util.TreeMap;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
+import com.google.common.reflect.TypeToken;
+import com.google.protobuf.ByteString;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuQueue.CorfuQueueRecord;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.util.serializer.Serializers;
@@ -28,11 +35,14 @@ import org.junit.Test;
 @Slf4j
 public class CorfuQueueTest extends AbstractViewTest {
 
+    private ByteString getByteString(String string) {
+        return ByteString.copyFromUtf8(string);
+    }
+
     @Test
     public void failNonTxnEnqueue() {
-        CorfuQueue<String>
-                corfuQueue = new CorfuQueue<>(getDefaultRuntime(), "test");
-        assertThatThrownBy(() -> corfuQueue.enqueue("c"))
+        CorfuQueue corfuQueue = new CorfuQueue(getDefaultRuntime(), "test");
+        assertThatThrownBy(() -> corfuQueue.enqueue(getByteString("c")))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessage("must be called within a transaction!");
     }
@@ -46,18 +56,17 @@ public class CorfuQueueTest extends AbstractViewTest {
     @Test
     @SuppressWarnings("unchecked")
     public void basicQueueOrder() {
-        CorfuQueue<String>
-                corfuQueue = new CorfuQueue<>(getDefaultRuntime(), "test");
+        CorfuQueue corfuQueue = new CorfuQueue(getDefaultRuntime(), "test");
 
-        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue("c"));
-        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue("b"));
-        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue("a"));
+        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue(getByteString("c")));
+        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue(getByteString("b")));
+        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue(getByteString("a")));
 
-        List<CorfuQueueRecord<String>> records = corfuQueue.entryList();
+        List<CorfuQueueRecord> records = corfuQueue.entryList();
 
-        assertThat(records.get(0).getEntry()).isEqualTo("c");
-        assertThat(records.get(1).getEntry()).isEqualTo("b");
-        assertThat(records.get(2).getEntry()).isEqualTo("a");
+        assertThat(records.get(0).getEntry()).isEqualTo(getByteString("c"));
+        assertThat(records.get(1).getEntry()).isEqualTo(getByteString("b"));
+        assertThat(records.get(2).getEntry()).isEqualTo(getByteString("a"));
 
         assertThatThrownBy(() -> corfuQueue.entryList(Integer.MIN_VALUE)).
                 isExactlyInstanceOf(IllegalArgumentException.class);
@@ -66,10 +75,10 @@ public class CorfuQueueTest extends AbstractViewTest {
         // Remove the middle entry
         corfuQueue.removeEntry(corfuQueue.entryList().get(middleEntryIndex).getRecordId());
 
-        List<CorfuQueueRecord<String>> records2 =
+        List<CorfuQueueRecord> records2 =
                     corfuQueue.entryList(Short.MAX_VALUE);
-        assertThat(records2.get(0).getEntry()).isEqualTo("c");
-        assertThat(records2.get(1).getEntry()).isEqualTo("a");
+        assertThat(records2.get(0).getEntry()).isEqualTo(getByteString("c"));
+        assertThat(records2.get(1).getEntry()).isEqualTo(getByteString("a"));
 
         // Also ensure that the records are comparable across snapshots
         assertThat(records.get(0).getRecordId()).
@@ -81,20 +90,18 @@ public class CorfuQueueTest extends AbstractViewTest {
 
     @Test
     public void queueWithSecondaryIndexCheck() {
-        CorfuQueue<String>
-                corfuQueue = new CorfuQueue<>(getDefaultRuntime(), "test", Serializers.JAVA,
-                Index.Registry.empty());
+        CorfuQueue corfuQueue = new CorfuQueue(getDefaultRuntime(), "test");
 
-        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue("c"));
-        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue("b"));
-        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue("a"));
+        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue(getByteString("c")));
+        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue(getByteString("b")));
+        executeTxn(getDefaultRuntime(), () -> corfuQueue.enqueue(getByteString("a")));
 
         final int expected = 3;
-        List<CorfuQueueRecord<String>> records = corfuQueue.entryList();
+        List<CorfuQueueRecord> records = corfuQueue.entryList();
         assertThat(records.size()).isEqualTo(expected);
 
         // Only retrieve entries greater than the first entry.
-        List<CorfuQueueRecord<String>> recAfter = corfuQueue.entryList(
+        List<CorfuQueueRecord> recAfter = corfuQueue.entryList(
                 records.get(0).getRecordId(),
                 records.size());
         assertThat(recAfter.size()).isEqualTo(records.size() - 1);
@@ -124,7 +131,138 @@ public class CorfuQueueTest extends AbstractViewTest {
         bmap.put(new ByteArray("fg".getBytes()), "fg");
         bmap.put(new ByteArray("abcd".getBytes()), "abcd");
         for (Map.Entry<ByteArray, String> b : bmap.entrySet()) {
-            log.debug("{}", b);
+            log.debug("Entry {}", b);
         }
+    }
+
+    @Test
+    public void queueBackwardsCompatibility() {
+        CorfuQueue oldQueueInstance1 = new CorfuQueue(getDefaultRuntime(), "test",
+                Serializers.JSON);
+
+        CorfuRuntime rt2 = getNewRuntime(getDefaultNode()).connect();
+        CorfuQueue oldQueueInstance2 = new CorfuQueue(rt2, "test",
+                Serializers.QUEUE_SERIALIZER);
+
+        // produce items to the queue with two different serializers from two different clients
+        final int numItemsToProduce = 10;
+        IntStream.range(0, numItemsToProduce).forEach(itemIdx -> {
+            if (itemIdx % 2 == 0) {
+                executeTxn(getDefaultRuntime(),
+                        () -> oldQueueInstance1.enqueue(getByteString(String.valueOf(itemIdx))));
+            } else {
+                executeTxn(rt2,
+                        () -> oldQueueInstance2.enqueue(getByteString(String.valueOf(itemIdx))));
+            }
+        });
+
+        // Verify that a new client is able to see all items produced from the different
+        // clients
+        CorfuRuntime rt3 = getNewRuntime(getDefaultNode()).connect();
+        CorfuQueue newQueueInstance= new CorfuQueue(rt3, "test");
+
+        assertThat(newQueueInstance.size()).isEqualTo(numItemsToProduce);
+
+        IntStream.range(0, numItemsToProduce).forEach(itemIdx -> {
+            assertThat(newQueueInstance.entryList().get(itemIdx).getEntry().toStringUtf8())
+                    .isEqualTo(String.valueOf(itemIdx));
+        });
+    }
+
+    @Test
+    public void queueMapCompatibility() {
+
+        // Produce some items to the corfu queue
+        CorfuQueue queue = new CorfuQueue(getDefaultRuntime(), "test");
+        final int numItemsToProduce = 10;
+        IntStream.range(0, numItemsToProduce).forEach(itemIdx -> {
+            executeTxn(getDefaultRuntime(),
+                    () -> queue.enqueue(getByteString(String.valueOf(itemIdx))));
+        });
+
+        // Verify that the queue can be opened as a map object
+        CorfuRuntime rt2 = getNewRuntime(getDefaultNode()).connect();
+        CorfuTable<CorfuQueue.CorfuRecordId, ByteString> map = rt2.getObjectsView()
+                .build()
+                .setStreamName("test")
+                .setTypeToken(new TypeToken<CorfuTable<CorfuQueue.CorfuRecordId, ByteString>>() {})
+                .setSerializer(Serializers.QUEUE_SERIALIZER)
+                .open();
+
+        assertThat(map.size()).isEqualTo(numItemsToProduce);
+
+        Set<String> entryPayloads = map.entryStream()
+                .map(Map.Entry::getValue)
+                .map(ByteString::toStringUtf8)
+                .collect(Collectors.toSet());
+
+        assertThat(entryPayloads.size()).isEqualTo(numItemsToProduce);
+        IntStream.range(0, numItemsToProduce).forEach(itemIdx -> {
+            assertThat(entryPayloads).contains(String.valueOf(itemIdx));
+        });
+    }
+
+    @Test
+    public void queueCheckpointTest() {
+
+        // Produce to two different queues using the old and new serializer
+        CorfuQueue queueInstance1 = new CorfuQueue(getDefaultRuntime(), "stream1",
+                Serializers.JSON);
+
+        CorfuQueue queueInstance2 = new CorfuQueue(getDefaultRuntime(), "stream2");
+
+        final int numItemsToProduce = 10;
+        IntStream.range(0, numItemsToProduce).forEach(itemIdx -> {
+            executeTxn(getDefaultRuntime(),
+                    () -> queueInstance1.enqueue(getByteString(String.valueOf(itemIdx))));
+            executeTxn(getDefaultRuntime(),
+                    () -> queueInstance2.enqueue(getByteString(String.valueOf(itemIdx))));
+        });
+
+        // Checkpoint the queues
+
+        CorfuRuntime checkpointerRuntime = getNewRuntime(getDefaultNode())
+                .setCacheDisabled(true)
+                .connect();
+
+        CorfuTable<CorfuQueue.CorfuRecordId, ByteString> map1 = checkpointerRuntime
+                .getObjectsView()
+                .build()
+                .setStreamName("stream1")
+                .setTypeToken(new TypeToken<CorfuTable<CorfuQueue.CorfuRecordId, ByteString>>() {})
+                .setSerializer(Serializers.QUEUE_SERIALIZER)
+                .open();
+
+        CorfuTable<CorfuQueue.CorfuRecordId, ByteString> map2 = checkpointerRuntime
+                .getObjectsView()
+                .build()
+                .setStreamName("stream2")
+                .setTypeToken(new TypeToken<CorfuTable<CorfuQueue.CorfuRecordId, ByteString>>() {})
+                .setSerializer(Serializers.QUEUE_SERIALIZER)
+                .open();
+
+        MultiCheckpointWriter mcw = new MultiCheckpointWriter();
+        mcw.addMap(map1);
+        mcw.addMap(map2);
+        Token checkpointAddress = mcw.appendCheckpoints(getRuntime(), "author");
+        checkpointerRuntime.getAddressSpaceView().prefixTrim(checkpointAddress);
+        checkpointerRuntime.getAddressSpaceView().gc();
+
+        // Verify that after checkpointing and trimming that the queues' data
+        // can still be consumed
+
+        CorfuRuntime consumerRuntime = getNewRuntime(getDefaultNode())
+                .setCacheDisabled(true)
+                .connect();
+
+        CorfuQueue instance1Reader = new CorfuQueue(consumerRuntime, "stream1");
+        CorfuQueue instance2Reader = new CorfuQueue(consumerRuntime, "stream2");
+
+        IntStream.range(0, numItemsToProduce).forEach(itemIdx -> {
+            assertThat(instance1Reader.entryList().get(itemIdx).getEntry().toStringUtf8())
+                    .isEqualTo(String.valueOf(itemIdx));
+            assertThat(instance2Reader.entryList().get(itemIdx).getEntry().toStringUtf8())
+                    .isEqualTo(String.valueOf(itemIdx));
+        });
     }
 }


### PR DESCRIPTION
Since this queue is designed to be used with protobufs, this patch
removes Java generics from the API and uses ProtoBuf's ByteString
instead. Fixing the queue type will allow us to serialize the queues
SMREntries much more efficiently.

The benchmarks below show how different serializers perform
with different payload sizes.

4MB Payload
Benchmark                           Mode  Cnt    Score    Error  Units
JsonBenchmark.GoogleGson           thrpt    5    0.818 ±  0.157  ops/s
JsonBenchmark.ObjectOutputStream   thrpt    5  336.744 ± 54.049  ops/s
JsonBenchmark.QueueSerializer      thrpt    5  358.410 ±  9.058  ops/s

8MB Payload
Benchmark                           Mode  Cnt    Score    Error  Units
JsonBenchmark.kryoSerializer       thrpt    5  116.545 ± 72.152  ops/s
JsonBenchmark.ObjectOutputStream   thrpt    5  135.228 ± 78.692  ops/s
JsonBenchmark.QueueSerializer      thrpt    5  163.246 ± 27.071  ops/s

16MB Payload
Benchmark                           Mode  Cnt    Score    Error  Units
JsonBenchmark.googleGson           thrpt    5   0.211 ±  0.013  ops/s
JsonBenchmark.kryoSerializer       thrpt    5   38.168 ±  8.253  ops/s
JsonBenchmark.ObjectOutputStream   thrpt    5   51.139 ± 60.820  ops/s
JsonBenchmark.QueueSerializer      thrpt    5  108.701 ± 11.039  ops/s

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
