### PR TITLE
Fix NPE & Shutdown Server for UnrecoverableErrors

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -123,9 +123,10 @@ public class LogReplicationServer extends AbstractServer {
 
     @ServerHandler(type = CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP)
     private void handleLogReplicationQueryLeadership(CorfuMsg msg, ChannelHandlerContext ctx, IServerRouter r) {
-        log.info("Log Replication Query Leadership Request received by Server.");
+        log.debug("Log Replication Query Leadership Request received by Server.");
         LogReplicationQueryLeaderShipResponse resp = new LogReplicationQueryLeaderShipResponse(0,
                 isLeader.get(), serverContext.getLocalEndpoint());
+        log.debug("Send Log Replication Leadership Response isLeader={}, endpoint={}", resp.isLeader(), resp.getEndpoint());
         r.sendResponse(msg, CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP_RESPONSE.payloadMsg(resp));
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServerNode.java
@@ -88,17 +88,17 @@ public class CorfuInterClusterReplicationServerNode implements AutoCloseable {
     }
 
     /**
-     * Closes the currently running corfu server.
+     * Closes the currently running corfu log replication server.
      */
     @Override
     public void close() {
 
         if (!close.compareAndSet(false, true)) {
-            log.trace("close: Server already shutdown");
+            log.trace("close: Log Replication Server already shutdown");
             return;
         }
 
-        log.info("close: Shutting down Corfu server and cleaning resources");
+        log.info("close: Shutting down Log Replication server and cleaning resources");
         serverContext.close();
 
         this.router.getServerAdapter().stop();
@@ -107,7 +107,7 @@ public class CorfuInterClusterReplicationServerNode implements AutoCloseable {
         // A executor service to create the shutdown threads
         // plus name the threads correctly.
         final ExecutorService shutdownService = Executors.newFixedThreadPool(serverMap.size(),
-                new ServerThreadFactory("CorfuServer-shutdown-",
+                new ServerThreadFactory("ReplicationCorfuServer-shutdown-",
                         new ServerThreadFactory.ExceptionHandler()));
 
         // Turn into a list of futures on the shutdown, returning
@@ -127,7 +127,7 @@ public class CorfuInterClusterReplicationServerNode implements AutoCloseable {
 
         CompletableFuture.allOf(shutdownFutures).join();
         shutdownService.shutdown();
-        log.info("close: Server shutdown and resources released");
+        log.info("close: Log Replication Server shutdown and resources released");
     }
 
     public LogReplicationServer getLogReplicationServer() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/TopologyDescriptor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/TopologyDescriptor.java
@@ -168,7 +168,7 @@ public class TopologyDescriptor {
             }
         }
 
-        log.warn("Endpoint {} does not belong to any cluster defined in {}", endpoint, clusters);
+        log.trace("Endpoint {} does not belong to any cluster defined in {}", endpoint, clusters);
         return null;
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationHandler.java
@@ -44,7 +44,7 @@ public class LogReplicationHandler implements IClient, IHandler<LogReplicationCl
     @ClientHandler(type = CorfuMsgType.LOG_REPLICATION_ENTRY)
     private static Object handleLogReplicationAck(CorfuPayloadMsg<LogReplicationEntry> msg,
                                                   ChannelHandlerContext ctx, IClientRouter r) {
-        log.info("Handle log replication ACK");
+        log.debug("Handle log replication ACK");
         return msg.getPayload();
     }
 
@@ -58,7 +58,7 @@ public class LogReplicationHandler implements IClient, IHandler<LogReplicationCl
     @ClientHandler(type = CorfuMsgType.LOG_REPLICATION_QUERY_LEADERSHIP_RESPONSE)
     private static Object handleLogReplicationQueryLeadershipResponse(CorfuPayloadMsg<LogReplicationQueryLeaderShipResponse> msg,
                                                                       ChannelHandlerContext ctx, IClientRouter r) {
-        log.debug("Handle log replication query leadership response msg {}", msg);
+        log.trace("Handle log replication query leadership response msg {}", msg);
         return msg.getPayload();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationServerRouter.java
@@ -88,7 +88,7 @@ public class LogReplicationServerRouter implements IServerRouter {
 
     @Override
     public void sendResponse(CorfuMsg inMsg, CorfuMsg outMsg) {
-        log.info("Ready to send response {}", outMsg.getMsgType());
+        log.trace("Ready to send response {}", outMsg.getMsgType());
         outMsg.copyBaseFields(inMsg);
         try {
             serverAdapter.send(CorfuMessageConverterUtils.toProtoBuf(outMsg));
@@ -131,7 +131,7 @@ public class LogReplicationServerRouter implements IServerRouter {
     public void receive(CorfuMessage protoMessage) {
         CorfuMsg corfuMsg;
         try {
-            log.info("Received message {}", protoMessage.getType().name());
+            log.trace("Received message {}", protoMessage.getType().name());
             // Transform protoBuf into CorfuMessage
             corfuMsg = CorfuMessageConverterUtils.fromProtoBuf(protoMessage);
         } catch (CorfuMessageProtoBufException e) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteLeaderState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteLeaderState.java
@@ -108,7 +108,7 @@ public class VerifyingRemoteLeaderState implements LogReplicationRuntimeState {
                                 .toArray(new CompletableFuture<?>[pendingLeadershipQueries.size()])).get(CorfuLogReplicationRuntime.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
 
                         if (leadershipResponse.isLeader()) {
-                            log.info("Leader for remote cluster, node={}", leadershipResponse.getEndpoint());
+                            log.info("Received Leadership Response :: leader for remote cluster, node={}", leadershipResponse.getEndpoint());
                             leader = leadershipResponse.getEndpoint();
                             fsm.setRemoteLeaderEndpoint(leader);
 
@@ -120,8 +120,7 @@ public class VerifyingRemoteLeaderState implements LogReplicationRuntimeState {
                             fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.REMOTE_LEADER_FOUND, leader));
                             return;
                         } else {
-                            log.debug("Node {} is not the leader. Leadership={}", leadershipResponse.getEndpoint(),
-                                    leadershipResponse.isLeader());
+                            log.debug("Received Leadership Response :: node {} is not the leader", leadershipResponse.getEndpoint());
 
                             // Remove CF for completed request
                             pendingLeadershipQueries.remove(leadershipResponse.getEndpoint());

--- a/utils/src/main/java/org/corfudb/utils/lock/LockClient.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/LockClient.java
@@ -161,7 +161,7 @@ public class LockClient {
                             locks.get(lockId).input(LockEvent.LEASE_REVOKED);
                         }
                     } catch (Exception ex) {
-
+                        log.error("Caught exception while monitoring locks.", ex);
                     }
                 },
                 DurationBetweenLockMonitorRuns,

--- a/utils/src/main/java/org/corfudb/utils/lock/states/HasLeaseState.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/states/HasLeaseState.java
@@ -171,11 +171,13 @@ public class HasLeaseState extends LockState {
                                     lock.input(LockEvent.LEASE_RENEWED);
                                     leaseTime = Optional.of(Instant.now());
                                 } else {
-                                    log.info("Lock: {} lease revoked for lock {}", lock.getLockId());
+                                    log.info("Lease revoked for lock {}:{}", lock.getLockId().getLockGroup(),
+                                            lock.getLockId().getLockName());
                                     lock.input(LockEvent.LEASE_REVOKED);
                                 }
                             } catch (Exception e) {
-                                log.error("Lock: {} could not renew lease for lock {}", lock.getLockId(), e);
+                                log.error("Could not renew lease for lock {}:{}", lock.getLockId().getLockGroup(),
+                                        lock.getLockId().getLockName(), e);
                             }
                         },
                         0,


### PR DESCRIPTION
## Overview

Description:

- Fix a NPE that we hit on stopLogReplication when an invalid topology is provided onProcessNotificationUpdate. 
- Shutdown Corfu Log Replication Service whenever Discovery Service is terminated. 
- Fix some logs to improve current readability/debugging

Why should this be merged: fix some ongoing bugs in LR


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
