### PR TITLE
Sequencer Reconfiguration Corruption Fixes

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -1,8 +1,6 @@
 package org.corfudb.infrastructure;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -11,17 +9,15 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nonnull;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.corfudb.infrastructure.BatchWriterOperation.Type;
 import org.corfudb.infrastructure.log.StreamLog;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.PriorityLevel;
 import org.corfudb.protocols.wireprotocol.RangeWriteMsg;
+import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsRequest;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.protocols.wireprotocol.TrimRequest;
@@ -185,11 +181,14 @@ public class BatchProcessor implements AutoCloseable {
                                         break;
                                 }
 
+                                tails.setEpoch(sealEpoch);
                                 currOp.setResultValue(tails);
                                 break;
                             case LOG_ADDRESS_SPACE_QUERY:
                                 // Retrieve the address space for every stream in the log.
-                                currOp.setResultValue(streamLog.getStreamsAddressSpace());
+                                StreamsAddressResponse resp = streamLog.getStreamsAddressSpace();
+                                resp.setEpoch(sealEpoch);
+                                currOp.setResultValue(resp);
                                 break;
                             default:
                                 log.warn("Unknown BatchWriterOperation {}", currOp);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/StreamsAddressResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/StreamsAddressResponse.java
@@ -1,11 +1,12 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.Value;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
-
 import java.util.Map;
 import java.util.UUID;
+import lombok.Data;
+import lombok.Setter;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 
 /**
  * Represents the response sent by the sequencer when streams address maps are requested
@@ -14,10 +15,13 @@ import java.util.UUID;
  * It contains a per stream map with its corresponding address space
  * (composed of the addresses of this stream and trim mark)
  */
-@Value
+@Data
 public class StreamsAddressResponse implements ICorfuPayload<StreamsAddressResponse>{
 
     private long logTail;
+
+    @Setter
+    private long epoch = Layout.INVALID_EPOCH;
 
     private final Map<UUID, StreamAddressSpace> addressMap;
 
@@ -33,12 +37,14 @@ public class StreamsAddressResponse implements ICorfuPayload<StreamsAddressRespo
      */
     public StreamsAddressResponse(ByteBuf buf) {
         this.logTail = ICorfuPayload.fromBuffer(buf, Long.class);
+        this.epoch = ICorfuPayload.fromBuffer(buf, Long.class);
         this.addressMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, StreamAddressSpace.class);
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, this.logTail);
+        ICorfuPayload.serialize(buf, this.epoch);
         ICorfuPayload.serialize(buf, this.addressMap);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -13,13 +13,26 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.netty.handler.timeout.TimeoutException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IToken;
 import org.corfudb.protocols.wireprotocol.LogData;
-import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
@@ -38,21 +51,6 @@ import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Sleep;
 import org.corfudb.util.Utils;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.NavigableSet;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 
 /**
@@ -500,17 +498,6 @@ public class AddressSpaceView extends AbstractView {
      */
     public TailsResponse getAllTails() {
         return layoutHelper(Utils::getAllTails);
-    }
-
-    /**
-     * Get log address space, which includes:
-     * 1. Addresses belonging to each stream.
-     * 2. Log Tail.
-     *
-     * @return log address space
-     */
-    public StreamsAddressResponse getLogAddressSpace() {
-        return layoutHelper(Utils::getLogAddressSpace);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -1,9 +1,24 @@
 package org.corfudb.runtime.view;
 
+import static java.util.Objects.requireNonNull;
+
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -22,21 +37,6 @@ import org.corfudb.runtime.view.stream.AddressMapStreamView;
 import org.corfudb.runtime.view.stream.BackpointerStreamView;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.runtime.view.stream.ThreadSafeStreamView;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * This class represents the layout of a Corfu instance.
@@ -285,21 +285,8 @@ public class Layout {
      * Return latest segment.
      * @return the latest segment.
      */
-    public LayoutSegment getLatestSegment() {
+    public LayoutSegment getLastSegment() {
         return this.getSegments().get(this.getSegments().size() - 1);
-    }
-
-    /**
-     * Get the last node in the last segment.
-     *
-     * @return Returns the last node in the last segment.
-     */
-    public String getLastAddedNodeInLastSegment() {
-
-        // Fetching the latest segment. Note: This is the unbounded segment with ongoing writes.
-        // Returning the last node in the first stripe for determinism.
-        List<String> firstStripeLogServers = getLatestSegment().getFirstStripe().getLogServers();
-        return firstStripeLogServers.get(firstStripeLogServers.size() - 1);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -1,17 +1,9 @@
 package org.corfudb.runtime.view;
 
-import com.google.common.collect.Sets;
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.exceptions.LayoutModificationException;
-import org.corfudb.runtime.exceptions.OutrankedException;
-import org.corfudb.runtime.exceptions.QuorumUnreachableException;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
-import org.corfudb.util.CFUtils;
+import static org.corfudb.util.Utils.getLogTail;
 
-import javax.annotation.Nonnull;
+
+import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -21,8 +13,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
-
-import static org.corfudb.util.Utils.getLogTail;
+import javax.annotation.Nonnull;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.LayoutModificationException;
+import org.corfudb.runtime.exceptions.OutrankedException;
+import org.corfudb.runtime.exceptions.QuorumUnreachableException;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.util.CFUtils;
+import org.corfudb.util.Utils;
 
 /**
  * A view of the Layout Manager to manage reconfigurations of the Corfu Cluster.
@@ -415,8 +416,14 @@ public class LayoutManagementView extends AbstractView {
                         || !originalLayout.getPrimarySequencer()
                         .equals(newLayout.getPrimarySequencer())) {
 
-                    StreamsAddressResponse streamsAddressesResponse = runtime.getAddressSpaceView()
-                            .getLogAddressSpace();
+                    // The sequencer state needs to be computed/aggregated across all the
+                    // head nodes of all segments in the newLayout. Note that
+                    // AddressSpaceView::getLogAddressSpace shouldn't be used because
+                    // there is no guarantee that the same head nodes are the same on both
+                    // layouts. AbstractView can operate on a newer layout than
+                    // newLayout.
+                    StreamsAddressResponse streamsAddressesResponse = Utils
+                            .getLogAddressSpace(new RuntimeLayout(newLayout, runtime));
 
                     maxTokenRequested = streamsAddressesResponse.getLogTail();
                     streamsAddressSpace = streamsAddressesResponse.getAddressMap();

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -80,7 +80,7 @@ public class StreamsView extends AbstractView {
      * @return A view
      */
     public IStreamView get(UUID streamId, StreamOptions options) {
-        IStreamView stream = runtime.getLayoutView().getLayout().getLatestSegment()
+        IStreamView stream = runtime.getLayoutView().getLayout().getLastSegment()
                 .getReplicationMode()
                 .getStreamView(runtime, streamId, options);
         openedStreams.add(stream);
@@ -93,7 +93,7 @@ public class StreamsView extends AbstractView {
      * @param options open options
      */
     public IStreamView getUnsafe(UUID stream, StreamOptions options) {
-        return runtime.getLayoutView().getLayout().getLatestSegment()
+        return runtime.getLayoutView().getLayout().getLastSegment()
                 .getReplicationMode().getUnsafeStreamView(runtime, stream, options);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
@@ -41,8 +41,34 @@ public class StreamAddressSpace {
         this.addressMap = addressMap;
     }
 
+    public StreamAddressSpace() {
+        this.addressMap = Roaring64NavigableMap.bitmapOf();
+        this.trimMark = Address.NON_ADDRESS;
+    }
+
     public Roaring64NavigableMap getAddressMap() {
         return addressMap;
+    }
+
+    /**
+     * Merges b into a and returns a as the final result.
+     * @param a StreamAddressSpace to merge into
+     * @param b StreamAddressSpace to merge
+     * @return returns a as the merged StreamAddressSpace
+     */
+    public static StreamAddressSpace merge(StreamAddressSpace a, StreamAddressSpace b) {
+        a.mergeFrom(b);
+        return a;
+    }
+
+    // Merge another StreamAddressSpace into this instance
+    private void mergeFrom(StreamAddressSpace other) {
+        this.trimMark = Long.max(trimMark, other.getTrimMark());
+        this.addressMap.or(other.getAddressMap());
+
+        // Because the trim mark can increase after the merge another
+        // trim needs to be issued
+        this.trim(this.trimMark);
     }
 
     /**
@@ -68,7 +94,7 @@ public class StreamAddressSpace {
      */
     public Long getTail() {
         // If no address is present for this stream, the tail is given by the trim mark (last trimmed address)
-        if (addressMap.getLongCardinality() == NO_ADDRESSES) {
+        if (addressMap.isEmpty()) {
             return trimMark;
         }
 
@@ -89,7 +115,7 @@ public class StreamAddressSpace {
      * Remove addresses from the stream's address map
      * and set the new trim mark (to the greatest of all addresses to remove).
      */
-    public void removeAddresses(List<Long> addresses) {
+    private void removeAddresses(List<Long> addresses) {
         addresses.stream().forEach(addressMap::removeLong);
 
         // Recover allocated but unused memory

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogUpdateAPITest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogUpdateAPITest.java
@@ -1,5 +1,14 @@
 package org.corfudb.infrastructure.logreplication;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
@@ -18,14 +27,7 @@ import org.corfudb.runtime.view.stream.OpaqueStream;
 import org.corfudb.test.SampleSchema.Uuid;
 import org.junit.Test;
 
-import java.lang.reflect.InvocationTargetException;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
+@Slf4j
 public class LogUpdateAPITest extends AbstractViewTest {
     static final private int NUM_KEYS = 10;
 
@@ -116,14 +118,16 @@ public class LogUpdateAPITest extends AbstractViewTest {
             ILogData data = iterator1.next();
             data.getStreams().contains(uuidB);
         }
-        System.out.print("\nstreamBTail " + runtime2.getAddressSpaceView().getAllTails().getStreamTails().get(uuidB));
+        log.debug("streamBTail {}", runtime2.getAddressSpaceView()
+                .getAllTails()
+                .getStreamTails().get(uuidB));
 
 
         Query q = corfuStore1.query(namespace);
         Set<Uuid> aSet = q.keySet(tableAName, null);
         Set<Uuid> bSet = q.keySet(tableBName, null);
 
-        System.out.print("\naSet " + aSet + "\n\nbSet " + bSet);
+        log.debug("aSet {} bSet {}", aSet, bSet);
         assertThat(bSet.containsAll(aSet)).isTrue();
         assertThat(aSet.containsAll(bSet)).isTrue();
     }

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -1,10 +1,30 @@
 package org.corfudb.integration;
 
+import static junit.framework.TestCase.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.Range;
-
 import com.google.common.reflect.TypeToken;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
@@ -32,31 +52,10 @@ import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Sleep;
+import org.corfudb.util.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Optional;
-import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-
-import static junit.framework.TestCase.fail;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class ClusterReconfigIT extends AbstractIT {
 
@@ -1148,8 +1147,8 @@ public class ClusterReconfigIT extends AbstractIT {
                 .open();
 
         // Verify sequencer has correct address map for this stream (addresses and trim mark)
-        StreamAddressSpace addressSpace = runtime2.getAddressSpaceView()
-                .getLogAddressSpace()
+        StreamAddressSpace addressSpace = Utils.getLogAddressSpace(runtime2.getLayoutView()
+                .getRuntimeLayout())
                 .getAddressMap().get(streamId);
 
         assertThat(addressSpace.getTrimMark()).isEqualTo(numEntries);
@@ -1162,8 +1161,8 @@ public class ClusterReconfigIT extends AbstractIT {
         }
 
         // Verify START_ADDRESS of checkpoint for stream
-        StreamAddressSpace checkpointAddressSpace = runtime2.getAddressSpaceView()
-                .getLogAddressSpace()
+        StreamAddressSpace checkpointAddressSpace = Utils.getLogAddressSpace(runtime2.getLayoutView()
+                .getRuntimeLayout())
                 .getAddressMap().get(checkpointStreamId);
 
         // Addresses should correspond to: start, continuation and end records. (total 3 records)

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -1,8 +1,9 @@
 package org.corfudb.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import com.google.common.reflect.TypeToken;
 
+
+import com.google.common.reflect.TypeToken;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -25,7 +26,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CheckpointWriter;
@@ -41,6 +41,7 @@ import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.CFUtils;
+import org.corfudb.util.Utils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -796,7 +797,8 @@ public class ServerRestartIT extends AbstractIT {
             runtimeRestart = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
 
             // Fetch Address Space for the given stream
-            StreamAddressSpace addressSpace = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+            StreamAddressSpace addressSpace = Utils.getLogAddressSpace(runtimeRestart
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID("test"));
 

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -30,6 +30,7 @@ import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.NodeLocator;
+import org.corfudb.util.Utils;
 import org.junit.Test;
 
 
@@ -772,7 +773,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(runtimeRestart);
 
             // Fetch Address Space for the given stream S1
-            StreamAddressSpace addressSpaceA = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+            StreamAddressSpace addressSpaceA = Utils.getLogAddressSpace(runtimeRestart
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(stream1));
 
@@ -782,7 +784,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             assertThat(addressSpaceA.getAddressMap().getLongCardinality()).isEqualTo(insertions);
 
             // Fetch Address Space for the given stream S2
-            StreamAddressSpace addressSpaceB = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+            StreamAddressSpace addressSpaceB =  Utils.getLogAddressSpace(runtimeRestart
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(stream2));
 
@@ -895,7 +898,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
                     .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)).isEqualTo("8");
 
             // Fetch Address Space for the given stream
-            StreamAddressSpace addressSpaceA = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+            StreamAddressSpace addressSpaceA = Utils.getLogAddressSpace(runtimeRestart
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(streamNameA));
 
@@ -985,7 +989,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(rt2);
 
             // Fetch Address Space for the given stream
-            StreamAddressSpace addressSpaceB = rt2.getAddressSpaceView().getLogAddressSpace()
+            StreamAddressSpace addressSpaceB = Utils.getLogAddressSpace(rt2
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(streamNameB));
 
@@ -1010,7 +1015,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(runtimeRestart);
 
             // Fetch Address Space for the given stream
-            addressSpaceB = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+            addressSpaceB = Utils.getLogAddressSpace(runtimeRestart
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(streamNameB));
 
@@ -1279,7 +1285,9 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             Token cpTokenA = cpwA.appendCheckpoint();
 
             // Verify Address Maps from Log Unit and Sequencer Tails (first node)
-            StreamsAddressResponse logUnitResponse = runtime.getAddressSpaceView().getLogAddressSpace();
+            StreamsAddressResponse logUnitResponse = Utils.getLogAddressSpace(runtime
+                    .getLayoutView().getRuntimeLayout());
+
             TokenResponse sequencerTails = runtime.getSequencerView().query(streamID, checkpointId);
 
             // +1 because checkpointer contributes to a NO_OP entry
@@ -1300,7 +1308,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             waitForLayoutChange(layout -> layout.getEpoch() > currentEpoch, runtime);
 
             // Verify Address Maps from Log Unit and Sequencer Tails (second node)
-            logUnitResponse = runtime.getAddressSpaceView().getLogAddressSpace();
+            logUnitResponse = Utils.getLogAddressSpace(runtime.getLayoutView().getRuntimeLayout());
             sequencerTails = runtime.getSequencerView().query(streamID, checkpointId);
 
             assertThat(logUnitResponse.getAddressMap().get(checkpointId).getTail()).isEqualTo(totalEntries + extraEntry);

--- a/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
@@ -1,0 +1,350 @@
+package org.corfudb.runtime.utils;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
+import static org.corfudb.runtime.view.Layout.ReplicationMode.CHAIN_REPLICATION;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.LongStream;
+import lombok.Data;
+import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
+import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.RuntimeLayout;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.util.Utils;
+import org.junit.Test;
+
+public class UtilsTest {
+
+  private static String nodeA = "nodeA";
+  private static String nodeB = "nodeB";
+  private static String nodeC = "nodeC";
+
+  @Data
+  class Context {
+    private final Map<String, LogUnitClient> clientMap;
+    private final RuntimeLayout runtimeLayout;
+
+    public LogUnitClient getLogUnitClient(String node) {
+      return clientMap.get(node);
+    }
+  }
+
+  private Layout getLayout() {
+    long epoch = 1;
+    UUID uuid = UUID.randomUUID();
+    Layout.LayoutStripe stripe = new Layout.LayoutStripe(Arrays.asList(nodeA, nodeB, nodeC));
+    Layout.LayoutSegment segment =
+            new Layout.LayoutSegment(CHAIN_REPLICATION, 0L, -1L, Collections.singletonList(stripe));
+    return new Layout(
+            Arrays.asList(nodeA, nodeB, nodeC),
+            Arrays.asList(nodeA, nodeB, nodeC),
+            Collections.singletonList(segment),
+            Collections.EMPTY_LIST,
+            epoch,
+            uuid);
+  }
+
+  @SuppressWarnings("checkstyle:magicnumber")
+  private Layout getSegmentedLayout() {
+    long epoch = 1;
+    UUID uuid = UUID.randomUUID();
+    Layout.LayoutStripe seg1Strip = new Layout.LayoutStripe(Arrays.asList(nodeA));
+    Layout.LayoutStripe seg2Strip = new Layout.LayoutStripe(Arrays.asList(nodeA, nodeB));
+    Layout.LayoutStripe seg3Strip = new Layout.LayoutStripe(Arrays.asList(nodeB, nodeA));
+
+    Layout.LayoutSegment segment1 =
+            new Layout.LayoutSegment(
+                    CHAIN_REPLICATION, 0L, 100L, Collections.singletonList(seg1Strip));
+    Layout.LayoutSegment segment2 =
+            new Layout.LayoutSegment(
+                    CHAIN_REPLICATION, 100L, 200L, Collections.singletonList(seg2Strip));
+    Layout.LayoutSegment segment3 =
+            new Layout.LayoutSegment(
+                    CHAIN_REPLICATION, 200L, -1L, Collections.singletonList(seg3Strip));
+    return new Layout(
+            Arrays.asList(nodeA, nodeB, nodeC),
+            Arrays.asList(nodeA, nodeB, nodeC),
+            Arrays.asList(segment1, segment2, segment3),
+            Collections.singletonList(nodeC),
+            epoch,
+            uuid);
+  }
+
+  @SuppressWarnings("checkstyle:magicnumber")
+  private Context getContext(Layout layout) {
+    RuntimeLayout runtimeLayout = mock(RuntimeLayout.class);
+    when(runtimeLayout.getLayout()).thenReturn(layout);
+    Map<String, LogUnitClient> clientMap = new HashMap<>();
+    layout.getAllLogServers().forEach(lu -> clientMap.put(lu, mock(LogUnitClient.class)));
+
+    when(runtimeLayout.getLogUnitClient(anyString()))
+            .then(
+                    invokation -> {
+                      String node = (String) invokation.getArguments()[0];
+                      if (!clientMap.containsKey(node)) {
+                        throw new IllegalStateException("not expecting a call to " + node);
+                      }
+                      return clientMap.get(node);
+                    });
+
+    return new Context(clientMap, runtimeLayout);
+  }
+
+  private CompletableFuture<TailsResponse> getTailsResponse(
+          long globalTail, Map<UUID, Long> streamTails, long epoch) {
+    CompletableFuture<TailsResponse> cf = new CompletableFuture<>();
+    TailsResponse resp = new TailsResponse(globalTail, streamTails);
+    resp.setEpoch(epoch);
+    cf.complete(resp);
+    return cf;
+  }
+
+  private CompletableFuture<StreamsAddressResponse> getLogAddressSpaceResponse(
+          long globalTail, Map<UUID, StreamAddressSpace> streamTails, long epoch) {
+    CompletableFuture<StreamsAddressResponse> cf = new CompletableFuture<>();
+    StreamsAddressResponse resp = new StreamsAddressResponse(globalTail, streamTails);
+    resp.setEpoch(epoch);
+    // TODO(Maithem) add epoch?
+    cf.complete(resp);
+    return cf;
+  }
+
+  private CompletableFuture<TailsResponse> getTailsResponse(long globalTail, long epoch) {
+    return getTailsResponse(globalTail, Collections.EMPTY_MAP, epoch);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getLogTailSingleSegmentTest() {
+    Layout layout = getLayout();
+    Context ctx = getContext(layout);
+    final long globalTail = 5;
+
+    when(ctx.getLogUnitClient(nodeA).getLogTail())
+            .thenReturn(getTailsResponse(globalTail, layout.getEpoch()));
+
+    long logTail = Utils.getLogTail(ctx.getRuntimeLayout());
+    assertThat(logTail).isEqualTo(globalTail);
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getLogTail();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    final long invalidEpoch = layout.getEpoch() + 1;
+    when(ctx.getLogUnitClient(nodeA).getLogTail())
+            .thenReturn(getTailsResponse(globalTail, invalidEpoch));
+    assertThatThrownBy(() -> Utils.getLogTail(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getLogTailMultiSegmentTest() {
+    Layout layout = getSegmentedLayout();
+    Context ctx = getContext(layout);
+
+    final long nodeAGlobalTail = 5;
+    final long nodeBGlobalTail = 150;
+    when(ctx.getLogUnitClient(nodeA).getLogTail())
+            .thenReturn(getTailsResponse(nodeAGlobalTail, layout.getEpoch()));
+    when(ctx.getLogUnitClient(nodeB).getLogTail())
+            .thenReturn(getTailsResponse(nodeBGlobalTail, layout.getEpoch()));
+
+    final long logTail = Utils.getLogTail(ctx.getRuntimeLayout());
+    assertThat(logTail).isEqualTo(nodeBGlobalTail);
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getLogTail();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    // Since we coalesce the same node on multiple segments and nodeB is the head of segment2
+    // and segment3 we need to verify that it is only queried once
+    verify(ctx.getLogUnitClient(nodeB), times(1)).getLogTail();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    when(ctx.getLogUnitClient(nodeA).getLogTail())
+            .thenReturn(getTailsResponse(nodeAGlobalTail, layout.getEpoch() + 1));
+    assertThatThrownBy(() -> Utils.getLogTail(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getAllTailsSingleSegmentTest() {
+    Layout layout = getLayout();
+    Context ctx = getContext(layout);
+    final long globalTail = 20;
+
+    Map<UUID, Long> streamTails =
+            ImmutableMap.of(UUID.randomUUID(), 5L, UUID.randomUUID(), 10L, UUID.randomUUID(), 15L);
+
+    when(ctx.getLogUnitClient(nodeA).getAllTails())
+            .thenReturn(getTailsResponse(globalTail, streamTails, layout.getEpoch()));
+
+    TailsResponse tails = Utils.getAllTails(ctx.getRuntimeLayout());
+    assertThat(tails.getLogTail()).isEqualTo(globalTail);
+    assertThat(tails.getStreamTails()).isEqualTo(streamTails);
+    assertThat(tails.getEpoch()).isEqualTo(layout.getEpoch());
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getAllTails();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    when(ctx.getLogUnitClient(nodeA).getAllTails())
+            .thenReturn(getTailsResponse(globalTail, streamTails, layout.getEpoch() + 1));
+    assertThatThrownBy(() -> Utils.getAllTails(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getAllTailsMultiSegmentTest() {
+    Layout layout = getSegmentedLayout();
+    Context ctx = getContext(layout);
+    final long nodeAGlobalTail = 15;
+    final long nodeBGlobalTail = 215;
+
+    UUID s1Id = UUID.randomUUID();
+    UUID s2Id = UUID.randomUUID();
+    UUID s3Id = UUID.randomUUID();
+    UUID s4Id = UUID.randomUUID();
+
+    Map<UUID, Long> nodeAStreamTails = ImmutableMap.of(s1Id, 5L, s2Id, 10L, s4Id, 12L);
+    Map<UUID, Long> nodeBStreamTails = ImmutableMap.of(s1Id, 5L, s2Id, 103L, s3Id, 210L);
+
+    when(ctx.getLogUnitClient(nodeA).getAllTails())
+            .thenReturn(getTailsResponse(nodeAGlobalTail, nodeAStreamTails, layout.getEpoch()));
+
+    when(ctx.getLogUnitClient(nodeB).getAllTails())
+            .thenReturn(getTailsResponse(nodeBGlobalTail, nodeBStreamTails, layout.getEpoch()));
+
+    TailsResponse tails = Utils.getAllTails(ctx.getRuntimeLayout());
+    assertThat(tails.getLogTail()).isEqualTo(nodeBGlobalTail);
+    assertThat(tails.getStreamTails())
+            .isEqualTo(ImmutableMap.of(s1Id, 5L, s2Id, 103L, s3Id, 210L, s4Id, 12L));
+    assertThat(tails.getEpoch()).isEqualTo(layout.getEpoch());
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getAllTails();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    verify(ctx.getLogUnitClient(nodeB), times(1)).getAllTails();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    when(ctx.getLogUnitClient(nodeA).getAllTails())
+            .thenReturn(getTailsResponse(nodeAGlobalTail, nodeAStreamTails, layout.getEpoch() + 1));
+    assertThatThrownBy(() -> Utils.getAllTails(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+
+  private StreamAddressSpace getRandomStreamSpace(long max) {
+    StreamAddressSpace streamA = new StreamAddressSpace();
+    LongStream.range(0, max)
+            .forEach(address -> streamA.addAddress(((address & 0x1) == 1) ? 0 : address));
+    return streamA;
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getLogAddressSpaceSingleSegmentTest() {
+    Layout layout = getLayout();
+    Context ctx = getContext(layout);
+
+    final long nodeAGlobalTail = 50;
+    UUID s1Id = UUID.randomUUID();
+    UUID s2Id = UUID.randomUUID();
+    Map<UUID, StreamAddressSpace> nodeALogAddressSpace =
+            ImmutableMap.of(
+                    s1Id, getRandomStreamSpace(nodeAGlobalTail - 1),
+                    s2Id, getRandomStreamSpace(nodeAGlobalTail - 1));
+
+    when(ctx.getLogUnitClient(nodeA).getLogAddressSpace())
+            .thenReturn(
+                    getLogAddressSpaceResponse(nodeAGlobalTail, nodeALogAddressSpace, layout.getEpoch()));
+
+    StreamsAddressResponse resp = Utils.getLogAddressSpace(ctx.getRuntimeLayout());
+    assertThat(resp.getLogTail()).isEqualTo(nodeAGlobalTail);
+    assertThat(resp.getAddressMap()).isEqualTo(nodeALogAddressSpace);
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getLogAddressSpace();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    when(ctx.getLogUnitClient(nodeA).getLogAddressSpace())
+            .thenReturn(
+                    getLogAddressSpaceResponse(
+                            nodeAGlobalTail, nodeALogAddressSpace, layout.getEpoch() + 1));
+    assertThatThrownBy(() -> Utils.getLogAddressSpace(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getLogAddressSpaceMultiSegmentTest() {
+    Layout layout = getSegmentedLayout();
+    Context ctx = getContext(layout);
+
+    final long nodeAGlobalTail = 50;
+    UUID s1Id = UUID.randomUUID();
+    UUID s2Id = UUID.randomUUID();
+    Map<UUID, StreamAddressSpace> nodeALogAddressSpace =
+            ImmutableMap.of(
+                    s1Id, getRandomStreamSpace(nodeAGlobalTail - 1),
+                    s2Id, getRandomStreamSpace(nodeAGlobalTail - 1));
+
+    UUID s3Id = UUID.randomUUID();
+    final long nodeBGlobalTail = 205;
+
+    StreamAddressSpace s2IdPartial =
+            new StreamAddressSpace(30l, nodeALogAddressSpace.get(s2Id).getAddressMap());
+    s2IdPartial.addAddress(201);
+    s2IdPartial.addAddress(202);
+    s2IdPartial.addAddress(203);
+
+    Map<UUID, StreamAddressSpace> nodeBLogAddressSpace =
+            ImmutableMap.of(s2Id, s2IdPartial, s3Id, getRandomStreamSpace(nodeAGlobalTail - 1));
+
+    when(ctx.getLogUnitClient(nodeA).getLogAddressSpace())
+            .thenReturn(
+                    getLogAddressSpaceResponse(nodeAGlobalTail, nodeALogAddressSpace, layout.getEpoch()));
+    when(ctx.getLogUnitClient(nodeB).getLogAddressSpace())
+            .thenReturn(
+                    getLogAddressSpaceResponse(nodeBGlobalTail, nodeBLogAddressSpace, layout.getEpoch()));
+
+    StreamsAddressResponse resp = Utils.getLogAddressSpace(ctx.getRuntimeLayout());
+
+    assertThat(resp.getLogTail()).isEqualTo(nodeBGlobalTail);
+
+    Map<UUID, StreamAddressSpace> expectedMergedTails =
+            ImmutableMap.of(
+                    s1Id, nodeALogAddressSpace.get(s1Id),
+                    s2Id, s2IdPartial,
+                    s3Id, nodeBLogAddressSpace.get(s3Id));
+
+    assertThat(resp.getAddressMap()).isEqualTo(expectedMergedTails);
+
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getLogAddressSpace();
+    verify(ctx.getLogUnitClient(nodeB), times(1)).getLogAddressSpace();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    when(ctx.getLogUnitClient(nodeA).getLogAddressSpace())
+            .thenReturn(
+                    getLogAddressSpaceResponse(
+                            nodeAGlobalTail, nodeALogAddressSpace, layout.getEpoch() + 1));
+    assertThatThrownBy(() -> Utils.getLogAddressSpace(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+}

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -1,21 +1,27 @@
 package org.corfudb.runtime.view;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
 import com.google.common.cache.Cache;
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.Range;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.corfudb.common.compression.Codec;
 import org.corfudb.infrastructure.LogUnitServerAssertions;
 import org.corfudb.infrastructure.TestLayoutBuilder;
-import org.corfudb.protocols.wireprotocol.*;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.MetricsUtils;
 import org.junit.Test;
-
-import java.util.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Created by mwei on 2/1/16.

--- a/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
@@ -1,0 +1,46 @@
+package org.corfudb.runtime.view.stream;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import org.corfudb.runtime.view.Address;
+import org.junit.Test;
+
+public class StreamAddressSpaceTest {
+
+    @Test
+    public void testStreamAddressSpaceMerge() {
+
+        StreamAddressSpace streamA = new StreamAddressSpace();
+
+        final int numStreamAEntries = 100;
+        IntStream.range(0, numStreamAEntries).forEach(streamA::addAddress);
+
+        assertThat(streamA.getTrimMark()).isEqualTo(Address.NON_ADDRESS);
+        assertThat(streamA.getTail()).isEqualTo(numStreamAEntries - 1);
+
+        // need to take higher trim mark?
+
+        StreamAddressSpace streamB = new StreamAddressSpace();
+        final int numStreamBEntries = 130;
+        IntStream.range(0, numStreamBEntries).forEach(streamB::addAddress);
+        final long streamBTrimMark = 40;
+        streamB.trim(streamBTrimMark);
+
+        assertThat(streamB.getTrimMark()).isEqualTo(streamBTrimMark);
+        assertThat(streamB.getTail()).isEqualTo(numStreamBEntries - 1);
+
+        // Merge steamB into streamA and verify that the highest trim mark is
+        // adopted in streamA
+        StreamAddressSpace.merge(streamA, streamB);
+
+        assertThat(streamA.getTrimMark()).isEqualTo(streamBTrimMark);
+        assertThat(streamA.getTail()).isEqualTo(numStreamBEntries - 1);
+
+        LongStream.range(streamBTrimMark + 1, numStreamBEntries).forEach(address ->
+                assertThat(streamA.getAddressMap().contains(address)).isTrue()
+        );
+    }
+}


### PR DESCRIPTION
## Overview

Prior to this patch, the global tail, stream tails and stream bit
sets were retrieved and computed from the first node in the last
segment. This assumption is incorrect because it can be a node
that is being rebuilt (via state transfer), or in some edge cases
it is not possible to compute the sequencer state from a single node.
This leads to the possibility of computing a view of the log that
is incomplete during reconfiguration of the sequencer. In
consequence, leading to inconsistent reads, data loss and
cluster instability.

This patch introduces multiple fixes to compute the sequencer's
state from all the segments (possibly aggregating views from different
nodes) and forcing the view computation and the reconfiguration to
happen on the same epoch.

Why should this be merged: Fixes data loss/inconsistency/stability issues

Related issue(s) (if applicable): #2678


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
