### PR TITLE
Fail Non-Transactional Enqueue

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
@@ -1,8 +1,18 @@
 package org.corfudb.runtime.collections;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.common.reflect.TypeToken;
 import com.google.protobuf.InvalidProtocolBufferException;
-import lombok.EqualsAndHashCode;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -11,20 +21,9 @@ import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.object.transactions.TransactionalContext.PreCommitListener;
-import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.CorfuGuidGenerator;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 /**
  * Persisted Queue supported by CorfuDB using distributed State Machine Replication.
@@ -160,40 +159,36 @@ public class CorfuQueue<E> {
      *         element prevents it from being added to this queue
      */
     public CorfuRecordId enqueue(E e) {
+        checkState(TransactionalContext.isInTransaction(), "must be called within a transaction!");
         final CorfuRecordId id = new CorfuRecordId(0, guidGenerator.nextLong());
 
-        // If we are in a transaction, then we need the commit address of this transaction
-        // to fix up as the txSequence
-        if (TransactionalContext.isInTransaction()) {
-            /**
-             * This is a callback that is placed into the root transaction's context on
-             * the thread local stack which will be invoked right after this transaction
-             * is deemed successful and has obtained a final sequence number to write.
-             */
-            class QueueEntryAddressGetter implements PreCommitListener {
-                private CorfuRecordId recordId;
-                private QueueEntryAddressGetter(CorfuRecordId recordId) {
-                    this.recordId = recordId;
-                }
+        /**
+         * This is a callback that is placed into the root transaction's context on
+         * the thread local stack which will be invoked right after this transaction
+         * is deemed successful and has obtained a final sequence number to write.
+         */
+        @AllArgsConstructor
+         class QueueEntryAddressGetter implements PreCommitListener {
+             private final CorfuRecordId recordId;
 
-                /**
-                 * If we are in a transaction, determine the commit address and fix it up in
-                 * the queue entry.
-                 * @param tokenResponse
-                 */
-                @Override
-                public void preCommitCallback(TokenResponse tokenResponse) {
-                    recordId.setTxSequence(tokenResponse.getSequence());
-                    log.trace("preCommitCallback for Queue: " + recordId.toString());
-                }
-            }
-            QueueEntryAddressGetter addressGetter = new QueueEntryAddressGetter(id);
-            log.trace("enqueue: Adding preCommitListener for Queue: " + id.toString());
-            TransactionalContext.getRootContext().addPreCommitListener(addressGetter);
-        }
+             /**
+              * If we are in a transaction, determine the commit address and fix it up in
+              * the queue entry.
+              * @param tokenResponse
+              */
+             @Override
+             public void preCommitCallback(TokenResponse tokenResponse) {
+                 recordId.setTxSequence(tokenResponse.getSequence());
+                 log.trace("preCommitCallback for Queue: " + recordId.toString());
+             }
+         }
 
-        corfuTable.put(id, e);
-        return id;
+         QueueEntryAddressGetter addressGetter = new QueueEntryAddressGetter(id);
+         log.trace("enqueue: Adding preCommitListener for Queue: " + id.toString());
+         TransactionalContext.getRootContext().addPreCommitListener(addressGetter);
+
+         corfuTable.put(id, e);
+         return id;
     }
 
     /**


### PR DESCRIPTION
## Overview
Since CorfuQueue::enqueue depends on a transactional context to
work correctly, a validation step is required to fail enqueue
calls that are not within a transaction.

Why should this be merged: Porting #2712