### PR TITLE
Sequencer Reconfiguration Corruption Fixes

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -1,7 +1,6 @@
 package org.corfudb.infrastructure;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
@@ -10,17 +9,15 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-
 import javax.annotation.Nonnull;
-
 import lombok.extern.slf4j.Slf4j;
-
 import org.corfudb.infrastructure.BatchWriterOperation.Type;
 import org.corfudb.infrastructure.log.StreamLog;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.PriorityLevel;
 import org.corfudb.protocols.wireprotocol.RangeWriteMsg;
+import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsRequest;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.protocols.wireprotocol.TrimRequest;
@@ -184,11 +181,14 @@ public class BatchProcessor implements AutoCloseable {
                                         break;
                                 }
 
+                                tails.setEpoch(sealEpoch);
                                 currOp.setResultValue(tails);
                                 break;
                             case LOG_ADDRESS_SPACE_QUERY:
                                 // Retrieve the address space for every stream in the log.
-                                currOp.setResultValue(streamLog.getStreamsAddressSpace());
+                                StreamsAddressResponse resp = streamLog.getStreamsAddressSpace();
+                                resp.setEpoch(sealEpoch);
+                                currOp.setResultValue(resp);
                                 break;
                             default:
                                 log.warn("Unknown BatchWriterOperation {}", currOp);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/StreamsAddressResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/StreamsAddressResponse.java
@@ -1,11 +1,12 @@
 package org.corfudb.protocols.wireprotocol;
 
 import io.netty.buffer.ByteBuf;
-import lombok.Value;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
-
 import java.util.Map;
 import java.util.UUID;
+import lombok.Data;
+import lombok.Setter;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 
 /**
  * Represents the response sent by the sequencer when streams address maps are requested
@@ -14,10 +15,13 @@ import java.util.UUID;
  * It contains a per stream map with its corresponding address space
  * (composed of the addresses of this stream and trim mark)
  */
-@Value
+@Data
 public class StreamsAddressResponse implements ICorfuPayload<StreamsAddressResponse>{
 
     private long logTail;
+
+    @Setter
+    private long epoch = Layout.INVALID_EPOCH;
 
     private final Map<UUID, StreamAddressSpace> addressMap;
 
@@ -33,12 +37,14 @@ public class StreamsAddressResponse implements ICorfuPayload<StreamsAddressRespo
      */
     public StreamsAddressResponse(ByteBuf buf) {
         this.logTail = ICorfuPayload.fromBuffer(buf, Long.class);
+        this.epoch = ICorfuPayload.fromBuffer(buf, Long.class);
         this.addressMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, StreamAddressSpace.class);
     }
 
     @Override
     public void doSerialize(ByteBuf buf) {
         ICorfuPayload.serialize(buf, this.logTail);
+        ICorfuPayload.serialize(buf, this.epoch);
         ICorfuPayload.serialize(buf, this.addressMap);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -10,13 +10,28 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.netty.handler.timeout.TimeoutException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.IToken;
 import org.corfudb.protocols.wireprotocol.LogData;
-import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
@@ -35,24 +50,6 @@ import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Sleep;
 import org.corfudb.util.Utils;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.NavigableSet;
-import java.util.Set;
-import java.util.concurrent.CompletionException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
 
 /**
  * A view of the address space implemented by Corfu.
@@ -503,28 +500,14 @@ public class AddressSpaceView extends AbstractView {
      * Get the log's tail, i.e., last address in the address space.
      */
     public Long getLogTail() {
-        return layoutHelper(
-                e -> Utils.getLogTail(e.getLayout(), runtime));
+        return layoutHelper(Utils::getLogTail);
     }
 
     /**
      * Get all tails, includes: log tail and stream tails.
      */
     public TailsResponse getAllTails() {
-        return layoutHelper(
-                e -> Utils.getAllTails(e.getLayout(), runtime));
-    }
-
-    /**
-     * Get log address space, which includes:
-     * 1. Addresses belonging to each stream.
-     * 2. Log Tail.
-     *
-     * @return
-     */
-    public StreamsAddressResponse getLogAddressSpace() {
-        return layoutHelper(
-                e -> Utils.getLogAddressSpace(e.getLayout(), runtime));
+        return layoutHelper(Utils::getAllTails);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -5,6 +5,17 @@ import static java.util.Objects.requireNonNull;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -23,18 +34,6 @@ import org.corfudb.runtime.view.stream.AddressMapStreamView;
 import org.corfudb.runtime.view.stream.BackpointerStreamView;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.runtime.view.stream.ThreadSafeStreamView;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.stream.Collectors;
 
 /**
  * This class represents the layout of a Corfu instance.
@@ -196,6 +195,17 @@ public class Layout {
     }
 
     /**
+     * Get all the unique log unit server endpoints in the layout.
+     *
+     * @return a set of all log unit server endpoints
+     */
+    public Set<String> getAllLogServers() {
+        return segments.stream()
+                .flatMap(seg -> seg.getAllLogServers().stream())
+                .collect(Collectors.toSet());
+    }
+
+    /**
      * Returns the primary sequencer.
      *
      * @return The primary sequencer.
@@ -257,21 +267,8 @@ public class Layout {
      * Return latest segment.
      * @return the latest segment.
      */
-    public LayoutSegment getLatestSegment() {
+    public LayoutSegment getLastSegment() {
         return this.getSegments().get(this.getSegments().size() - 1);
-    }
-
-    /**
-     * Get the last node in the last segment.
-     *
-     * @return Returns the last node in the last segment.
-     */
-    public String getLastAddedNodeInLastSegment() {
-
-        // Fetching the latest segment. Note: This is the unbounded segment with ongoing writes.
-        // Returning the last node in the first stripe for determinism.
-        List<String> firstStripeLogServers = getLatestSegment().getFirstStripe().getLogServers();
-        return firstStripeLogServers.get(firstStripeLogServers.size() - 1);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -1,17 +1,9 @@
 package org.corfudb.runtime.view;
 
-import com.google.common.collect.Sets;
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.exceptions.LayoutModificationException;
-import org.corfudb.runtime.exceptions.OutrankedException;
-import org.corfudb.runtime.exceptions.QuorumUnreachableException;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
-import org.corfudb.util.CFUtils;
+import static org.corfudb.util.Utils.getLogTail;
 
-import javax.annotation.Nonnull;
+
+import com.google.common.collect.Sets;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
@@ -21,8 +13,17 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
-
-import static org.corfudb.util.Utils.getLogTail;
+import javax.annotation.Nonnull;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.LayoutModificationException;
+import org.corfudb.runtime.exceptions.OutrankedException;
+import org.corfudb.runtime.exceptions.QuorumUnreachableException;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.util.CFUtils;
+import org.corfudb.util.Utils;
 
 /**
  * A view of the Layout Manager to manage reconfigurations of the Corfu Cluster.
@@ -146,7 +147,7 @@ public class LayoutManagementView extends AbstractView {
             }
             if (isLogUnitServer) {
                 layoutBuilder.addLogunitServer(logUnitStripeIndex,
-                        getLogTail(currentLayout, runtime),
+                        getLogTail(runtime.getLayoutView().getRuntimeLayout(currentLayout)),
                         endpoint);
             }
             if (isUnresponsiveServer) {
@@ -197,7 +198,7 @@ public class LayoutManagementView extends AbstractView {
 
             LayoutBuilder layoutBuilder = new LayoutBuilder(currentLayout);
             layoutBuilder.addLogunitServer(0,
-                    getLogTail(currentLayout, runtime),
+                    getLogTail(runtime.getLayoutView().getRuntimeLayout(currentLayout)),
                     endpoint);
             layoutBuilder.removeUnresponsiveServers(Collections.singleton(endpoint));
             newLayout = layoutBuilder.build();
@@ -415,8 +416,14 @@ public class LayoutManagementView extends AbstractView {
                         || !originalLayout.getPrimarySequencer()
                         .equals(newLayout.getPrimarySequencer())) {
 
-                    StreamsAddressResponse streamsAddressesResponse = runtime.getAddressSpaceView()
-                            .getLogAddressSpace();
+                    // The sequencer state needs to be computed/aggregated across all the
+                    // head nodes of all segments in the newLayout. Note that
+                    // AddressSpaceView::getLogAddressSpace shouldn't be used because
+                    // there is no guarantee that the same head nodes are the same on both
+                    // layouts. AbstractView can operate on a newer layout than
+                    // newLayout.
+                    StreamsAddressResponse streamsAddressesResponse = Utils
+                            .getLogAddressSpace(new RuntimeLayout(newLayout, runtime));
 
                     maxTokenRequested = streamsAddressesResponse.getLogTail();
                     streamsAddressSpace = streamsAddressesResponse.getAddressMap();

--- a/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/StreamsView.java
@@ -80,7 +80,7 @@ public class StreamsView extends AbstractView {
      * @return A view
      */
     public IStreamView get(UUID streamId, StreamOptions options) {
-        IStreamView stream = runtime.getLayoutView().getLayout().getLatestSegment()
+        IStreamView stream = runtime.getLayoutView().getLayout().getLastSegment()
                 .getReplicationMode()
                 .getStreamView(runtime, streamId, options);
         openedStreams.add(stream);
@@ -93,7 +93,7 @@ public class StreamsView extends AbstractView {
      * @param options open options
      */
     public IStreamView getUnsafe(UUID stream, StreamOptions options) {
-        return runtime.getLayoutView().getLayout().getLatestSegment()
+        return runtime.getLayoutView().getLayout().getLastSegment()
                 .getReplicationMode().getUnsafeStreamView(runtime, stream, options);
     }
 

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -1,30 +1,40 @@
 package org.corfudb.util;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
+
+import java.text.DecimalFormat;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
 import jdk.internal.org.objectweb.asm.util.Printer;
 import jdk.internal.org.objectweb.asm.util.Textifier;
 import jdk.internal.org.objectweb.asm.util.TraceMethodVisitor;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
-import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.RuntimeLayout;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 
-import java.text.DecimalFormat;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
 /**
  * Created by crossbach on 5/22/15.
  */
 @Slf4j
 public class Utils {
-
-    private static final int DEFAULT_LOGUNIT = 0;
 
     private Utils() {
         // prevent instantiation of this class
@@ -110,143 +120,193 @@ public class Utils {
         return Long.toHexString((id.getLeastSignificantBits()) & 0xFFFF);
     }
 
+
     /**
-     * Get global log tail.
-     *
-     * @param layout Latest layout to query log tail from Log Unit
-     * @param runtime Runtime
-     *
-     * @return Log global tail
+     * Verify that the stripes are not empty and that each segment has one stripe.
+     * @param segments segments to validate
      */
-    public static long getLogTail(Layout layout, CorfuRuntime runtime) {
-        long globalLogTail = Address.NON_EXIST;
-
-        Layout.LayoutSegment segment = layout.getLatestSegment();
-
-        // Query the head log unit in every stripe.
-        if (segment.getReplicationMode() == Layout.ReplicationMode.CHAIN_REPLICATION) {
-            for (Layout.LayoutStripe stripe : segment.getStripes()) {
-
-                TailsResponse response = CFUtils.getUninterruptibly(
-                        runtime.getLayoutView().getRuntimeLayout(layout)
-                                .getLogUnitClient(stripe.getLogServers().get(DEFAULT_LOGUNIT))
-                                .getLogTail());
-                globalLogTail = Long.max(globalLogTail, response.getLogTail());
-            }
-        } else if (segment.getReplicationMode() == Layout.ReplicationMode.QUORUM_REPLICATION) {
-            throw new UnsupportedOperationException();
+    private static void validateSegments(List<Layout.LayoutSegment> segments) {
+        checkNotNull(segments);
+        checkArgument(!segments.isEmpty());
+        long previousSegmentEndAddress = 0;
+        for (Layout.LayoutSegment segment : segments) {
+            checkState(segment.getStart() == previousSegmentEndAddress);
+            previousSegmentEndAddress = segment.getEnd();
+            // only supported for chain replication
+            checkArgument(segment.getReplicationMode() == Layout.ReplicationMode.CHAIN_REPLICATION);
+            // Since stripping is not supported, we can assume only one stripe exists
+            checkArgument(segment.getStripes().size() == 1);
+            // A stripe cannot be empty
+            checkArgument(!segment.getStripes().get(0).getLogServers().isEmpty());
         }
-
-        return globalLogTail;
+        // The last segment (i.e open segment) end address is -1 (denoting infinity)
+        checkState(previousSegmentEndAddress == -1);
     }
 
     /**
-     * Fetches the max global log tail and all stream tails from the log unit cluster. This depends on the mode of
-     * replication being used.
-     * CHAIN: Block on fetch of global log tail from the head log unit in every stripe.
-     * QUORUM: Block on fetch of global log tail from a majority in every stripe.
+     * Get maximum trim mark from all log units.
      *
-     * @param layout  Latest layout to get clients to fetch tails.
-     * @return The max global log tail obtained from the log unit servers.
+     * @param runtimeLayout current RuntimeLayout
+     * @return a token representing the trim mark
      */
-    public static TailsResponse getAllTails(Layout layout, CorfuRuntime runtime) {
-        Set<TailsResponse> luResponses = new HashSet<>();
+    public static Token getTrimMark(RuntimeLayout runtimeLayout) {
+        Layout layout = runtimeLayout.getLayout();
 
-        Layout.LayoutSegment segment = layout.getLatestSegment();
+        List<CompletableFuture<Long>> futures = layout
+                .getAllLogServers()
+                .stream()
+                .map(runtimeLayout::getLogUnitClient)
+                .map(LogUnitClient::getTrimMark)
+                .collect(Collectors.toList());
 
-        // Query the tail of the head log unit in every stripe.
-        if (segment.getReplicationMode() == Layout.ReplicationMode.CHAIN_REPLICATION) {
-            for (Layout.LayoutStripe stripe : segment.getStripes()) {
+        long trimMark = futures.stream()
+                .map(CFUtils::getUninterruptibly)
+                .max(Comparator.naturalOrder())
+                .get();
 
-                TailsResponse res = CFUtils.getUninterruptibly(
-                        runtime.getLayoutView().getRuntimeLayout(layout)
-                                .getLogUnitClient(stripe.getLogServers().get(DEFAULT_LOGUNIT))
-                                .getAllTails());
-                luResponses.add(res);
-            }
-        } else if (segment.getReplicationMode() == Layout.ReplicationMode.QUORUM_REPLICATION) {
-            throw new UnsupportedOperationException();
-        }
-
-        return aggregateLogUnitTails(luResponses);
+        return new Token(layout.getEpoch(), trimMark);
     }
 
     /**
-     * Given a set of request tails, we aggregate them and maintain
-     * the greatest address per stream and the greatest tail over
-     * all responses.
-     * @param responses a set of tail responses
-     * @return An max-aggregation of all tails
+     * Perform prefix trim on all log unit servers.
+     *
+     * @param runtimeLayout current RuntimeLayout
+     * @param address a token with address to trim
      */
-    static TailsResponse aggregateLogUnitTails(Set<TailsResponse> responses) {
-        long globalTail = Address.NON_ADDRESS;
-        Map<UUID, Long> globalStreamTails = new HashMap<>();
+    public static void prefixTrim(RuntimeLayout runtimeLayout, Token address) {
+        List<CompletableFuture<Void>> futures = runtimeLayout
+                .getLayout()
+                .getAllLogServers()
+                .stream()
+                .map(runtimeLayout::getLogUnitClient)
+                .map(lu -> lu.prefixTrim(address))
+                .collect(Collectors.toList());
 
-        for (TailsResponse res : responses) {
-            globalTail = Math.max(globalTail, res.getLogTail());
-
-            for (Map.Entry<UUID, Long> stream : res.getStreamTails().entrySet()) {
-                long streamTail = globalStreamTails.getOrDefault(stream.getKey(), Address.NON_ADDRESS);
-                globalStreamTails.put(stream.getKey(), Math.max(streamTail, stream.getValue()));
-            }
-        }
-        // All epochs should be equal as all the tails are queried using a single runtime layout.
-        return new TailsResponse(globalTail, globalStreamTails);
-    }
-
-    static Map<UUID, StreamAddressSpace> aggregateStreamAddressMap(Map<UUID, StreamAddressSpace> streamAddressSpaceMap,
-                                                                   Map<UUID, StreamAddressSpace> aggregated) {
-        for (Map.Entry<UUID, StreamAddressSpace> stream : streamAddressSpaceMap.entrySet()) {
-            if (aggregated.containsKey(stream.getKey())) {
-                long currentTrimMark = aggregated.get(stream.getKey()).getTrimMark();
-                aggregated.get(stream.getKey()).getAddressMap().or(stream.getValue().getAddressMap());
-                aggregated.get(stream.getKey()).setTrimMark(Math.max(currentTrimMark, stream.getValue().getTrimMark()));
-            } else {
-                aggregated.put(stream.getKey(), stream.getValue());
-            }
-        }
-
-        return aggregated;
+        futures.forEach(CFUtils::getUninterruptibly);
     }
 
     /**
-     * Retrieve the space of addresses of the log, i.e., for all streams in the log.
-     * This is typically used for sequencer recovery.
-     *
-     * @param layout latest layout.
-     * @param runtime current runtime.
-     * @return response with all streams addresses and global log tail.
+     * Find the chain's head node of each segment
+     * @param layout layout to search in
+     * @return returns a set of nodes the represent the first node in all segments
      */
-    public static StreamsAddressResponse getLogAddressSpace(Layout layout, CorfuRuntime runtime) {
-        Set<StreamsAddressResponse> luResponses = new HashSet<>();
-
-        Layout.LayoutSegment segment = layout.getLatestSegment();
-
-        // Query the head log unit in every stripe.
-        if (segment.getReplicationMode() == Layout.ReplicationMode.CHAIN_REPLICATION) {
-            for (Layout.LayoutStripe stripe : segment.getStripes()) {
-
-                StreamsAddressResponse res = CFUtils.getUninterruptibly(
-                        runtime.getLayoutView().getRuntimeLayout(layout)
-                                .getLogUnitClient(stripe.getLogServers().get(DEFAULT_LOGUNIT))
-                                .getLogAddressSpace());
-                luResponses.add(res);
-            }
-        } else if (segment.getReplicationMode() == Layout.ReplicationMode.QUORUM_REPLICATION) {
-            throw new UnsupportedOperationException();
-        }
-
-        return aggregateLogAddressSpace(luResponses);
+    private static Set<String> getChainHeadFromAllSegments(Layout layout) {
+        validateSegments(layout.getSegments());
+        List<Layout.LayoutSegment> segments = layout.getSegments();
+        return segments.stream()
+                .map(Layout.LayoutSegment::getFirstStripe)
+                .map(Layout.LayoutStripe::getLogServers)
+                .map(strip -> strip.get(0))
+                .collect(Collectors.toSet());
     }
 
-    static StreamsAddressResponse aggregateLogAddressSpace(Set<StreamsAddressResponse> responses) {
-        Map<UUID, StreamAddressSpace> streamAddressSpace = new HashMap<>();
-        long logTail = Address.NON_ADDRESS;
-
-        for (StreamsAddressResponse res : responses) {
-            logTail = Math.max(logTail, res.getLogTail());
-            streamAddressSpace = aggregateStreamAddressMap(res.getAddressMap(), streamAddressSpace);
-        }
-        return new StreamsAddressResponse(logTail, streamAddressSpace);
+  /** Throws a WrongEpochException if the actual and expected epochs don't match. */
+  private static void epochCheck(long actualValue, long expectedValue) {
+    if (actualValue != expectedValue) {
+      throw new WrongEpochException(expectedValue);
     }
+  }
+
+  /**
+   * Compute the max tail across the first node of each segment in the layout on the same epoch.
+   *
+   * @param runtimeLayout current RuntimeLayout
+   * @return Log global tail
+   */
+  public static long getLogTail(RuntimeLayout runtimeLayout) {
+    // Since a node can exist as a head for multiple segments we need to a set to
+    // coalesce the candidates to unique nodes only
+    Set<String> segmentsHeadNodes = getChainHeadFromAllSegments(runtimeLayout.getLayout());
+    List<CompletableFuture<TailsResponse>> cfs =
+        segmentsHeadNodes.stream()
+            .map(node -> runtimeLayout.getLogUnitClient(node).getLogTail())
+            .collect(Collectors.toList());
+
+    long globalLogTail =
+        cfs.stream()
+            .map(CFUtils::getUninterruptibly)
+            .mapToLong(
+                resp -> {
+                  epochCheck(resp.getEpoch(), runtimeLayout.getLayout().getEpoch());
+                  return resp.getLogTail();
+                })
+            .max()
+            .orElseThrow(NoSuchElementException::new);
+
+    log.debug("getLogTail: nodes selected {} global tail {}", segmentsHeadNodes, globalLogTail);
+    return globalLogTail;
+  }
+
+  /**
+   * Fetches the max global log tail and all stream tails from the log unit cluster. This depends on
+   * the mode of replication being used. CHAIN: Block on fetch of global log tail from the head log
+   * unit in every segment.*
+   *
+   * @param runtimeLayout current RuntimeLayout
+   * @return The max global log tail and max global tails across all segments
+   */
+  public static TailsResponse getAllTails(RuntimeLayout runtimeLayout) {
+    // Since a node can exist as a head for multiple segments we need to a set to
+    // coalesce the candidates to unique nodes only
+    Set<String> segmentsHeadNodes = getChainHeadFromAllSegments(runtimeLayout.getLayout());
+
+    AtomicLong globalTail = new AtomicLong(Address.NON_EXIST);
+    final Map<UUID, Long> streamTails = new HashMap<>();
+
+    List<CompletableFuture<TailsResponse>> cfs =
+        segmentsHeadNodes.stream()
+            .map(node -> runtimeLayout.getLogUnitClient(node).getAllTails())
+            .collect(Collectors.toList());
+
+    cfs.stream()
+        .map(CFUtils::getUninterruptibly)
+        .forEach(
+            resp -> {
+              // All responses should be computed on the same epoch
+              epochCheck(resp.getEpoch(), runtimeLayout.getLayout().getEpoch());
+              // Find the global max global tail and stream tails across all responses
+              globalTail.set(Long.max(resp.getLogTail(), globalTail.get()));
+              resp.getStreamTails().forEach((k, v) -> streamTails.merge(k, v, Long::max));
+            });
+
+    log.debug("getAllTails: nodes selected {} stream tails {}", segmentsHeadNodes, streamTails);
+
+    return new TailsResponse(runtimeLayout.getLayout().getEpoch(), globalTail.get(), streamTails);
+  }
+  /**
+   * Retrieve the space of addresses of the log, i.e., for all streams in the log. This is typically
+   * used for sequencer recovery.
+   *
+   * @param runtimeLayout layout view for the calculation
+   * @return response with all streams addresses and global log tail.
+   */
+  public static StreamsAddressResponse getLogAddressSpace(RuntimeLayout runtimeLayout) {
+    // Since a node can exist as a head for multiple segments we need to a set to
+    // coalesce the candidates to unique nodes only
+    Set<String> segmentsHeadNodes = getChainHeadFromAllSegments(runtimeLayout.getLayout());
+    AtomicLong globalTail = new AtomicLong(Address.NON_EXIST);
+    final Map<UUID, StreamAddressSpace> streamsAddressSpace = new HashMap<>();
+    List<CompletableFuture<StreamsAddressResponse>> cfs =
+        segmentsHeadNodes.stream()
+            .map(node -> runtimeLayout.getLogUnitClient(node).getLogAddressSpace())
+            .collect(Collectors.toList());
+    cfs.stream()
+        .map(CFUtils::getUninterruptibly)
+        .forEach(
+            resp -> {
+              // All responses should be computed on the same epoch
+              epochCheck(resp.getEpoch(), runtimeLayout.getLayout().getEpoch());
+              // Find the global max global tail and stream tails across all responses
+              globalTail.set(Long.max(resp.getLogTail(), globalTail.get()));
+              resp.getAddressMap()
+                  .forEach((k, v) -> streamsAddressSpace.merge(k, v, StreamAddressSpace::merge));
+            });
+
+    log.debug(
+        "getLogAddressSpace: nodes selected {} log tail {} stream addresses {}",
+        segmentsHeadNodes,
+        globalTail.get(),
+        streamsAddressSpace);
+    return new StreamsAddressResponse(globalTail.get(), streamsAddressSpace);
+  }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -4,15 +4,12 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.corfudb.format.Types;
 import org.corfudb.infrastructure.log.StreamLogFiles;
-import org.corfudb.protocols.wireprotocol.*;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.LogUnitException;
-
-import org.corfudb.runtime.exceptions.OverwriteException;
-import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
-import org.corfudb.util.serializer.Serializers;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.corfudb.infrastructure.LogUnitServerAssertions.assertThat;
+import static org.junit.Assert.fail;
 
 import java.io.File;
 import java.io.IOException;
@@ -25,11 +22,22 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.corfudb.infrastructure.LogUnitServerAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.DataType;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.IMetadata;
+import org.corfudb.protocols.wireprotocol.LogData;
+import org.corfudb.protocols.wireprotocol.ReadRequest;
+import org.corfudb.protocols.wireprotocol.TailsRequest;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.TrimRequest;
+import org.corfudb.protocols.wireprotocol.WriteRequest;
+import org.corfudb.runtime.exceptions.OverwriteException;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.util.serializer.Serializers;
+import org.junit.Test;
 
 /**
  * Created by mwei on 2/4/16.
@@ -39,6 +47,41 @@ public class LogUnitServerTest extends AbstractServerTest {
     @Override
     public AbstractServer getDefaultServer() {
         return new LogUnitServer(new ServerContextBuilder().build());
+    }
+
+    @Test
+    public void verifyLogTailQueriesEpoch() {
+        String serviceDir = PARAMETERS.TEST_TEMP_DIR;
+
+        ServerContext sc = new ServerContextBuilder()
+                .setLogPath(serviceDir)
+                .setSingle(true)
+                .setMemory(false)
+                .build();
+
+        sc.installSingleNodeLayoutIfAbsent();
+        sc.setServerRouter(router);
+        sc.setServerEpoch(sc.getCurrentLayout().getEpoch(), router);
+
+        LogUnitServer s1 = new LogUnitServer(sc);
+
+        setServer(s1);
+        setContext(sc);
+        TailsResponse req1 = (TailsResponse) sendRequest(CorfuMsgType.TAIL_REQUEST
+                .payloadMsg(new TailsRequest(TailsRequest.LOG_TAIL)))
+                .join();
+
+        TailsResponse req2 = (TailsResponse) sendRequest(CorfuMsgType.TAIL_REQUEST
+                .payloadMsg(new TailsRequest(TailsRequest.STREAMS_TAILS)))
+                .join();
+
+        TailsResponse req3 = (TailsResponse) sendRequest(CorfuMsgType.TAIL_REQUEST
+                .payloadMsg(new TailsRequest(TailsRequest.ALL_STREAMS_TAIL)))
+                .join();
+
+        assertThat(req1.getEpoch()).isEqualTo(sc.getCurrentLayout().getEpoch());
+        assertThat(req2.getEpoch()).isEqualTo(sc.getCurrentLayout().getEpoch());
+        assertThat(req3.getEpoch()).isEqualTo(sc.getCurrentLayout().getEpoch());
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -53,6 +53,7 @@ import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Sleep;
+import org.corfudb.util.Utils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -1170,8 +1171,8 @@ public class ClusterReconfigIT extends AbstractIT {
                 .open();
 
         // Verify sequencer has correct address map for this stream (addresses and trim mark)
-        StreamAddressSpace addressSpace = runtime2.getAddressSpaceView()
-                .getLogAddressSpace()
+        StreamAddressSpace addressSpace = Utils.getLogAddressSpace(runtime2.getLayoutView()
+                .getRuntimeLayout())
                 .getAddressMap().get(streamId);
 
         assertThat(addressSpace.getTrimMark()).isEqualTo(numEntries);
@@ -1184,8 +1185,8 @@ public class ClusterReconfigIT extends AbstractIT {
         }
 
         // Verify START_ADDRESS of checkpoint for stream
-        StreamAddressSpace checkpointAddressSpace = runtime2.getAddressSpaceView()
-                .getLogAddressSpace()
+        StreamAddressSpace checkpointAddressSpace = Utils.getLogAddressSpace(runtime2.getLayoutView()
+                .getRuntimeLayout())
                 .getAddressMap().get(checkpointStreamId);
 
         // Addresses should correspond to: start, continuation and end records. (total 3 records)

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -1,8 +1,9 @@
 package org.corfudb.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import com.google.common.reflect.TypeToken;
 
+
+import com.google.common.reflect.TypeToken;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -25,7 +26,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CheckpointWriter;
@@ -41,6 +41,7 @@ import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.CFUtils;
+import org.corfudb.util.Utils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -796,7 +797,8 @@ public class ServerRestartIT extends AbstractIT {
             runtimeRestart = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
 
             // Fetch Address Space for the given stream
-            StreamAddressSpace addressSpace = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+            StreamAddressSpace addressSpace = Utils.getLogAddressSpace(runtimeRestart
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID("test"));
 

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -17,6 +17,7 @@ import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.NodeLocator;
+import org.corfudb.util.Utils;
 import org.junit.Test;
 
 import java.time.Duration;
@@ -771,7 +772,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(runtimeRestart);
 
             // Fetch Address Space for the given stream S1
-            StreamAddressSpace addressSpaceA = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+            StreamAddressSpace addressSpaceA = Utils.getLogAddressSpace(runtimeRestart
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(stream1));
 
@@ -781,7 +783,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             assertThat(addressSpaceA.getAddressMap().getLongCardinality()).isEqualTo(insertions);
 
             // Fetch Address Space for the given stream S2
-            StreamAddressSpace addressSpaceB = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+            StreamAddressSpace addressSpaceB =  Utils.getLogAddressSpace(runtimeRestart
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(stream2));
 
@@ -894,7 +897,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
                     .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)).isEqualTo("8");
 
             // Fetch Address Space for the given stream
-            StreamAddressSpace addressSpaceA = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+            StreamAddressSpace addressSpaceA = Utils.getLogAddressSpace(runtimeRestart
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(streamNameA));
 
@@ -984,7 +988,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(rt2);
 
             // Fetch Address Space for the given stream
-            StreamAddressSpace addressSpaceB = rt2.getAddressSpaceView().getLogAddressSpace()
+            StreamAddressSpace addressSpaceB = Utils.getLogAddressSpace(rt2
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(streamNameB));
 
@@ -1009,7 +1014,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(runtimeRestart);
 
             // Fetch Address Space for the given stream
-            addressSpaceB = runtimeRestart.getAddressSpaceView().getLogAddressSpace()
+            addressSpaceB = Utils.getLogAddressSpace(runtimeRestart
+                    .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(streamNameB));
 
@@ -1278,7 +1284,9 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             Token cpTokenA = cpwA.appendCheckpoint();
 
             // Verify Address Maps from Log Unit and Sequencer Tails (first node)
-            StreamsAddressResponse logUnitResponse = runtime.getAddressSpaceView().getLogAddressSpace();
+            StreamsAddressResponse logUnitResponse = Utils.getLogAddressSpace(runtime
+                    .getLayoutView().getRuntimeLayout());
+
             TokenResponse sequencerTails = runtime.getSequencerView().query(streamID, checkpointId);
 
             // +1 because checkpointer contributes to a NO_OP entry
@@ -1299,7 +1307,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             waitForLayoutChange(layout -> layout.getEpoch() > currentEpoch, runtime);
 
             // Verify Address Maps from Log Unit and Sequencer Tails (second node)
-            logUnitResponse = runtime.getAddressSpaceView().getLogAddressSpace();
+            logUnitResponse = Utils.getLogAddressSpace(runtime.getLayoutView().getRuntimeLayout());
             sequencerTails = runtime.getSequencerView().query(streamID, checkpointId);
 
             assertThat(logUnitResponse.getAddressMap().get(checkpointId).getTail()).isEqualTo(totalEntries + extraEntry);

--- a/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
@@ -1,0 +1,349 @@
+package org.corfudb.runtime.utils;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
+import static org.corfudb.runtime.view.Layout.ReplicationMode.CHAIN_REPLICATION;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.LongStream;
+import lombok.Data;
+import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
+import org.corfudb.protocols.wireprotocol.TailsResponse;
+import org.corfudb.runtime.clients.LogUnitClient;
+import org.corfudb.runtime.exceptions.WrongEpochException;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.RuntimeLayout;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.util.Utils;
+import org.junit.Test;
+
+public class UtilsTest {
+
+  private static String nodeA = "nodeA";
+  private static String nodeB = "nodeB";
+  private static String nodeC = "nodeC";
+
+  @Data
+  class Context {
+    private final Map<String, LogUnitClient> clientMap;
+    private final RuntimeLayout runtimeLayout;
+
+    public LogUnitClient getLogUnitClient(String node) {
+      return clientMap.get(node);
+    }
+  }
+
+  private Layout getLayout() {
+    long epoch = 1;
+    UUID uuid = UUID.randomUUID();
+    Layout.LayoutStripe stripe = new Layout.LayoutStripe(Arrays.asList(nodeA, nodeB, nodeC));
+    Layout.LayoutSegment segment =
+            new Layout.LayoutSegment(CHAIN_REPLICATION, 0L, -1L, Collections.singletonList(stripe));
+    return new Layout(
+            Arrays.asList(nodeA, nodeB, nodeC),
+            Arrays.asList(nodeA, nodeB, nodeC),
+            Collections.singletonList(segment),
+            Collections.EMPTY_LIST,
+            epoch,
+            uuid);
+  }
+
+  @SuppressWarnings("checkstyle:magicnumber")
+  private Layout getSegmentedLayout() {
+    long epoch = 1;
+    UUID uuid = UUID.randomUUID();
+    Layout.LayoutStripe seg1Strip = new Layout.LayoutStripe(Arrays.asList(nodeA));
+    Layout.LayoutStripe seg2Strip = new Layout.LayoutStripe(Arrays.asList(nodeA, nodeB));
+    Layout.LayoutStripe seg3Strip = new Layout.LayoutStripe(Arrays.asList(nodeB, nodeA));
+
+    Layout.LayoutSegment segment1 =
+            new Layout.LayoutSegment(
+                    CHAIN_REPLICATION, 0L, 100L, Collections.singletonList(seg1Strip));
+    Layout.LayoutSegment segment2 =
+            new Layout.LayoutSegment(
+                    CHAIN_REPLICATION, 100L, 200L, Collections.singletonList(seg2Strip));
+    Layout.LayoutSegment segment3 =
+            new Layout.LayoutSegment(
+                    CHAIN_REPLICATION, 200L, -1L, Collections.singletonList(seg3Strip));
+    return new Layout(
+            Arrays.asList(nodeA, nodeB, nodeC),
+            Arrays.asList(nodeA, nodeB, nodeC),
+            Arrays.asList(segment1, segment2, segment3),
+            Collections.singletonList(nodeC),
+            epoch,
+            uuid);
+  }
+
+  private Context getContext(Layout layout) {
+    RuntimeLayout runtimeLayout = mock(RuntimeLayout.class);
+    when(runtimeLayout.getLayout()).thenReturn(layout);
+    Map<String, LogUnitClient> clientMap = new HashMap<>();
+    layout.getAllLogServers().forEach(lu -> clientMap.put(lu, mock(LogUnitClient.class)));
+
+    when(runtimeLayout.getLogUnitClient(anyString()))
+            .then(
+                    invokation -> {
+                      String node = (String) invokation.getArguments()[0];
+                      if (!clientMap.containsKey(node)) {
+                        throw new IllegalStateException("not expecting a call to " + node);
+                      }
+                      return clientMap.get(node);
+                    });
+
+    return new Context(clientMap, runtimeLayout);
+  }
+
+  private CompletableFuture<TailsResponse> getTailsResponse(
+          long globalTail, Map<UUID, Long> streamTails, long epoch) {
+    CompletableFuture<TailsResponse> cf = new CompletableFuture<>();
+    TailsResponse resp = new TailsResponse(globalTail, streamTails);
+    resp.setEpoch(epoch);
+    cf.complete(resp);
+    return cf;
+  }
+
+  private CompletableFuture<StreamsAddressResponse> getLogAddressSpaceResponse(
+          long globalTail, Map<UUID, StreamAddressSpace> streamTails, long epoch) {
+    CompletableFuture<StreamsAddressResponse> cf = new CompletableFuture<>();
+    StreamsAddressResponse resp = new StreamsAddressResponse(globalTail, streamTails);
+    resp.setEpoch(epoch);
+    // TODO(Maithem) add epoch?
+    cf.complete(resp);
+    return cf;
+  }
+
+  private CompletableFuture<TailsResponse> getTailsResponse(long globalTail, long epoch) {
+    return getTailsResponse(globalTail, Collections.EMPTY_MAP, epoch);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getLogTailSingleSegmentTest() {
+    Layout layout = getLayout();
+    Context ctx = getContext(layout);
+    final long globalTail = 5;
+
+    when(ctx.getLogUnitClient(nodeA).getLogTail())
+            .thenReturn(getTailsResponse(globalTail, layout.getEpoch()));
+
+    long logTail = Utils.getLogTail(ctx.getRuntimeLayout());
+    assertThat(logTail).isEqualTo(globalTail);
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getLogTail();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    final long invalidEpoch = layout.getEpoch() + 1;
+    when(ctx.getLogUnitClient(nodeA).getLogTail())
+            .thenReturn(getTailsResponse(globalTail, invalidEpoch));
+    assertThatThrownBy(() -> Utils.getLogTail(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getLogTailMultiSegmentTest() {
+    Layout layout = getSegmentedLayout();
+    Context ctx = getContext(layout);
+
+    final long nodeAGlobalTail = 5;
+    final long nodeBGlobalTail = 150;
+    when(ctx.getLogUnitClient(nodeA).getLogTail())
+            .thenReturn(getTailsResponse(nodeAGlobalTail, layout.getEpoch()));
+    when(ctx.getLogUnitClient(nodeB).getLogTail())
+            .thenReturn(getTailsResponse(nodeBGlobalTail, layout.getEpoch()));
+
+    final long logTail = Utils.getLogTail(ctx.getRuntimeLayout());
+    assertThat(logTail).isEqualTo(nodeBGlobalTail);
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getLogTail();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    // Since we coalesce the same node on multiple segments and nodeB is the head of segment2
+    // and segment3 we need to verify that it is only queried once
+    verify(ctx.getLogUnitClient(nodeB), times(1)).getLogTail();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    when(ctx.getLogUnitClient(nodeA).getLogTail())
+            .thenReturn(getTailsResponse(nodeAGlobalTail, layout.getEpoch() + 1));
+    assertThatThrownBy(() -> Utils.getLogTail(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getAllTailsSingleSegmentTest() {
+    Layout layout = getLayout();
+    Context ctx = getContext(layout);
+    final long globalTail = 20;
+
+    Map<UUID, Long> streamTails =
+            ImmutableMap.of(UUID.randomUUID(), 5L, UUID.randomUUID(), 10L, UUID.randomUUID(), 15L);
+
+    when(ctx.getLogUnitClient(nodeA).getAllTails())
+            .thenReturn(getTailsResponse(globalTail, streamTails, layout.getEpoch()));
+
+    TailsResponse tails = Utils.getAllTails(ctx.getRuntimeLayout());
+    assertThat(tails.getLogTail()).isEqualTo(globalTail);
+    assertThat(tails.getStreamTails()).isEqualTo(streamTails);
+    assertThat(tails.getEpoch()).isEqualTo(layout.getEpoch());
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getAllTails();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    when(ctx.getLogUnitClient(nodeA).getAllTails())
+            .thenReturn(getTailsResponse(globalTail, streamTails, layout.getEpoch() + 1));
+    assertThatThrownBy(() -> Utils.getAllTails(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getAllTailsMultiSegmentTest() {
+    Layout layout = getSegmentedLayout();
+    Context ctx = getContext(layout);
+    final long nodeAGlobalTail = 15;
+    final long nodeBGlobalTail = 215;
+
+    UUID s1Id = UUID.randomUUID();
+    UUID s2Id = UUID.randomUUID();
+    UUID s3Id = UUID.randomUUID();
+    UUID s4Id = UUID.randomUUID();
+
+    Map<UUID, Long> nodeAStreamTails = ImmutableMap.of(s1Id, 5L, s2Id, 10L, s4Id, 12L);
+    Map<UUID, Long> nodeBStreamTails = ImmutableMap.of(s1Id, 5L, s2Id, 103L, s3Id, 210L);
+
+    when(ctx.getLogUnitClient(nodeA).getAllTails())
+            .thenReturn(getTailsResponse(nodeAGlobalTail, nodeAStreamTails, layout.getEpoch()));
+
+    when(ctx.getLogUnitClient(nodeB).getAllTails())
+            .thenReturn(getTailsResponse(nodeBGlobalTail, nodeBStreamTails, layout.getEpoch()));
+
+    TailsResponse tails = Utils.getAllTails(ctx.getRuntimeLayout());
+    assertThat(tails.getLogTail()).isEqualTo(nodeBGlobalTail);
+    assertThat(tails.getStreamTails())
+            .isEqualTo(ImmutableMap.of(s1Id, 5L, s2Id, 103L, s3Id, 210L, s4Id, 12L));
+    assertThat(tails.getEpoch()).isEqualTo(layout.getEpoch());
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getAllTails();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    verify(ctx.getLogUnitClient(nodeB), times(1)).getAllTails();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    when(ctx.getLogUnitClient(nodeA).getAllTails())
+            .thenReturn(getTailsResponse(nodeAGlobalTail, nodeAStreamTails, layout.getEpoch() + 1));
+    assertThatThrownBy(() -> Utils.getAllTails(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+
+  private StreamAddressSpace getRandomStreamSpace(long max) {
+    StreamAddressSpace streamA = new StreamAddressSpace();
+    LongStream.range(0, max)
+            .forEach(address -> streamA.addAddress(((address & 0x1) == 1) ? 0 : address));
+    return streamA;
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getLogAddressSpaceSingleSegmentTest() {
+    Layout layout = getLayout();
+    Context ctx = getContext(layout);
+
+    final long nodeAGlobalTail = 50;
+    UUID s1Id = UUID.randomUUID();
+    UUID s2Id = UUID.randomUUID();
+    Map<UUID, StreamAddressSpace> nodeALogAddressSpace =
+            ImmutableMap.of(
+                    s1Id, getRandomStreamSpace(nodeAGlobalTail - 1),
+                    s2Id, getRandomStreamSpace(nodeAGlobalTail - 1));
+
+    when(ctx.getLogUnitClient(nodeA).getLogAddressSpace())
+            .thenReturn(
+                    getLogAddressSpaceResponse(nodeAGlobalTail, nodeALogAddressSpace, layout.getEpoch()));
+
+    StreamsAddressResponse resp = Utils.getLogAddressSpace(ctx.getRuntimeLayout());
+    assertThat(resp.getLogTail()).isEqualTo(nodeAGlobalTail);
+    assertThat(resp.getAddressMap()).isEqualTo(nodeALogAddressSpace);
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getLogAddressSpace();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    when(ctx.getLogUnitClient(nodeA).getLogAddressSpace())
+            .thenReturn(
+                    getLogAddressSpaceResponse(
+                            nodeAGlobalTail, nodeALogAddressSpace, layout.getEpoch() + 1));
+    assertThatThrownBy(() -> Utils.getLogAddressSpace(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:magicnumber")
+  public void getLogAddressSpaceMultiSegmentTest() {
+    Layout layout = getSegmentedLayout();
+    Context ctx = getContext(layout);
+
+    final long nodeAGlobalTail = 50;
+    UUID s1Id = UUID.randomUUID();
+    UUID s2Id = UUID.randomUUID();
+    Map<UUID, StreamAddressSpace> nodeALogAddressSpace =
+            ImmutableMap.of(
+                    s1Id, getRandomStreamSpace(nodeAGlobalTail - 1),
+                    s2Id, getRandomStreamSpace(nodeAGlobalTail - 1));
+
+    UUID s3Id = UUID.randomUUID();
+    final long nodeBGlobalTail = 205;
+
+    StreamAddressSpace s2IdPartial =
+            new StreamAddressSpace(30l, nodeALogAddressSpace.get(s2Id).getAddressMap());
+    s2IdPartial.addAddress(201);
+    s2IdPartial.addAddress(202);
+    s2IdPartial.addAddress(203);
+
+    Map<UUID, StreamAddressSpace> nodeBLogAddressSpace =
+            ImmutableMap.of(s2Id, s2IdPartial, s3Id, getRandomStreamSpace(nodeAGlobalTail - 1));
+
+    when(ctx.getLogUnitClient(nodeA).getLogAddressSpace())
+            .thenReturn(
+                    getLogAddressSpaceResponse(nodeAGlobalTail, nodeALogAddressSpace, layout.getEpoch()));
+    when(ctx.getLogUnitClient(nodeB).getLogAddressSpace())
+            .thenReturn(
+                    getLogAddressSpaceResponse(nodeBGlobalTail, nodeBLogAddressSpace, layout.getEpoch()));
+
+    StreamsAddressResponse resp = Utils.getLogAddressSpace(ctx.getRuntimeLayout());
+
+    assertThat(resp.getLogTail()).isEqualTo(nodeBGlobalTail);
+
+    Map<UUID, StreamAddressSpace> expectedMergedTails =
+            ImmutableMap.of(
+                    s1Id, nodeALogAddressSpace.get(s1Id),
+                    s2Id, s2IdPartial,
+                    s3Id, nodeBLogAddressSpace.get(s3Id));
+
+    assertThat(resp.getAddressMap()).isEqualTo(expectedMergedTails);
+
+    verify(ctx.getLogUnitClient(nodeA), times(1)).getLogAddressSpace();
+    verify(ctx.getLogUnitClient(nodeB), times(1)).getLogAddressSpace();
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeA);
+    verify(ctx.getRuntimeLayout(), times(1)).getLogUnitClient(nodeB);
+    verify(ctx.getRuntimeLayout(), times(0)).getLogUnitClient(nodeC);
+
+    when(ctx.getLogUnitClient(nodeA).getLogAddressSpace())
+            .thenReturn(
+                    getLogAddressSpaceResponse(
+                            nodeAGlobalTail, nodeALogAddressSpace, layout.getEpoch() + 1));
+    assertThatThrownBy(() -> Utils.getLogAddressSpace(ctx.getRuntimeLayout()))
+            .isInstanceOf(WrongEpochException.class);
+  }
+}

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -1,21 +1,27 @@
 package org.corfudb.runtime.view;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
 import com.google.common.cache.Cache;
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.Range;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.corfudb.common.compression.Codec;
 import org.corfudb.infrastructure.LogUnitServerAssertions;
 import org.corfudb.infrastructure.TestLayoutBuilder;
-import org.corfudb.protocols.wireprotocol.*;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.MetricsUtils;
 import org.junit.Test;
-
-import java.util.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Created by mwei on 2/1/16.

--- a/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
@@ -1,0 +1,46 @@
+package org.corfudb.runtime.view.stream;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import org.corfudb.runtime.view.Address;
+import org.junit.Test;
+
+public class StreamAddressSpaceTest {
+
+    @Test
+    public void testStreamAddressSpaceMerge() {
+
+        StreamAddressSpace streamA = new StreamAddressSpace();
+
+        final int numStreamAEntries = 100;
+        IntStream.range(0, numStreamAEntries).forEach(streamA::addAddress);
+
+        assertThat(streamA.getTrimMark()).isEqualTo(Address.NON_ADDRESS);
+        assertThat(streamA.getTail()).isEqualTo(numStreamAEntries - 1);
+
+        // need to take higher trim mark?
+
+        StreamAddressSpace streamB = new StreamAddressSpace();
+        final int numStreamBEntries = 130;
+        IntStream.range(0, numStreamBEntries).forEach(streamB::addAddress);
+        final long streamBTrimMark = 40;
+        streamB.trim(streamBTrimMark);
+
+        assertThat(streamB.getTrimMark()).isEqualTo(streamBTrimMark);
+        assertThat(streamB.getTail()).isEqualTo(numStreamBEntries - 1);
+
+        // Merge steamB into streamA and verify that the highest trim mark is
+        // adopted in streamA
+        StreamAddressSpace.merge(streamA, streamB);
+
+        assertThat(streamA.getTrimMark()).isEqualTo(streamBTrimMark);
+        assertThat(streamA.getTail()).isEqualTo(numStreamBEntries - 1);
+
+        LongStream.range(streamBTrimMark + 1, numStreamBEntries).forEach(address ->
+                assertThat(streamA.getAddressMap().contains(address)).isTrue()
+        );
+    }
+}


### PR DESCRIPTION
## Overview

Prior to this patch, the global tail, stream tails and stream bit
sets were retrieved and computed from the first node in the last
segment. This assumption is incorrect because it can be a node
that is being rebuilt (via state transfer), or in some edge cases
it is not possible to compute the sequencer state from a single node.
This leads to the possibility of computing a view of the log that
is incomplete during reconfiguration of the sequencer. In
consequence, leading to inconsistent reads, data loss and
cluster instability.

This patch introduces multiple fixes to compute the sequencer's
state from all the segments (possibly aggregating views from different
nodes) and forcing the view computation and the reconfiguration to
happen on the same epoch.

Port #2715

