### PR TITLE
API Changes in CorfuStore::openTable and TxBuilder::update

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
@@ -96,7 +96,7 @@ public class LogReplicationStreamNameTableManager {
     private boolean verifyTableExists(String tableName) {
         CorfuStore corfuStore = new CorfuStore(corfuRuntime);
         try {
-            corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, tableName);
+            corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, tableName);
         } catch (NoSuchElementException e) {
             // Table does not exist
             return false;
@@ -121,7 +121,7 @@ public class LogReplicationStreamNameTableManager {
 
     private boolean tableVersionMatchesPlugin() {
         CorfuStore corfuStore = new CorfuStore(corfuRuntime);
-        corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_PLUGIN_VERSION_TABLE);
+        corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_PLUGIN_VERSION_TABLE);
         LogReplicationStreams.VersionString versionString = LogReplicationStreams.VersionString.newBuilder().setName("VERSION").build();
         Query q = corfuStore.query(CORFU_SYSTEM_NAMESPACE);
 
@@ -175,7 +175,7 @@ public class LogReplicationStreamNameTableManager {
 
     private Set<String> readStreamsToReplicateFromTable() {
         CorfuStore corfuStore = new CorfuStore(corfuRuntime);
-        corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_STREAMS_NAME_TABLE);
+        corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_STREAMS_NAME_TABLE);
         Query q = corfuStore.query(CORFU_SYSTEM_NAMESPACE);
         Set<LogReplicationStreams.TableInfo> tables = q.keySet(LOG_REPLICATION_STREAMS_NAME_TABLE, null);
         Set<String> tableNames = new HashSet<>();

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -103,7 +103,7 @@ public class CorfuStore {
      */
     @Nonnull
     public <K extends Message, V extends Message, M extends Message>
-    Table<K, V, M> openTable(@Nonnull final String namespace,
+    Table<K, V, M> getTable(@Nonnull final String namespace,
                              @Nonnull final String tableName) {
         return runtime.getTableRegistry().getTable(namespace, tableName);
     }

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -231,11 +231,11 @@ public class CorfuStoreIT extends AbstractIT {
         final CorfuStore store3 = new CorfuStore(runtime);
 
         // Attempting to open an unopened table with the short form should throw the IllegalArgumentException
-        assertThatThrownBy(() -> store3.openTable(namespace, tableName)).
+        assertThatThrownBy(() -> store3.getTable(namespace, tableName)).
         isExactlyInstanceOf(IllegalArgumentException.class);
 
         // Attempting to open a non-existent table should throw NoSuchElementException
-        assertThatThrownBy(() -> store3.openTable(namespace, "NonExistingTableName")).
+        assertThatThrownBy(() -> store3.getTable(namespace, "NonExistingTableName")).
                 isExactlyInstanceOf(NoSuchElementException.class);
 
         store3.openTable(namespace, tableName, Uuid.class, Uuid.class, ManagedResources.class,

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
@@ -205,7 +205,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                         EventInfo.newBuilder().setName("abc").build(),
                         user_1)
                 .commit();
-        assertThat(corfuStore.openTable(nsxManager, tableName).get(key1).getMetadata())
+        assertThat(corfuStore.getTable(nsxManager, tableName).get(key1).getMetadata())
                 .isEqualTo(ManagedResources.newBuilder()
                         .setCreateUser("user_1")
                         .setCreateTimestamp(0L)
@@ -219,7 +219,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                         EventInfo.newBuilder().setName("bcd").build(),
                         ManagedResources.newBuilder().setCreateUser("user_2").setVersion(0L).build())
                 .commit();
-        assertThat(corfuStore.openTable(nsxManager, tableName).get(key1).getMetadata())
+        assertThat(corfuStore.getTable(nsxManager, tableName).get(key1).getMetadata())
                 .isEqualTo(ManagedResources.newBuilder()
                         .setCreateUser("user_2")
                         .setCreateTimestamp(0L)
@@ -233,7 +233,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                         EventInfo.newBuilder().setName("cde").build(),
                         user_2)
                 .commit();
-        assertThat(corfuStore.openTable(nsxManager, tableName).get(key1).getMetadata())
+        assertThat(corfuStore.getTable(nsxManager, tableName).get(key1).getMetadata())
                 .isEqualTo(ManagedResources.newBuilder()
                         .setCreateUser("user_2")
                         .setCreateTimestamp(0L)
@@ -241,7 +241,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                         .setVersion(expectedVersion).build());
 
         corfuStore.tx(nsxManager).delete(tableName, key1).commit();
-        assertThat(corfuStore.openTable(nsxManager, tableName).get(key1)).isNull();
+        assertThat(corfuStore.getTable(nsxManager, tableName).get(key1)).isNull();
         expectedVersion = 0L;
 
         corfuStore.tx(nsxManager)
@@ -250,7 +250,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                         EventInfo.newBuilder().setName("def").build(),
                         user_2)
                 .commit();
-        assertThat(corfuStore.openTable(nsxManager, tableName).get(key1).getMetadata())
+        assertThat(corfuStore.getTable(nsxManager, tableName).get(key1).getMetadata())
                 .isEqualTo(ManagedResources.newBuilder(user_2)
                         .setCreateTimestamp(0L)
                         .setNestedType(SampleSchema.NestedTypeA.newBuilder().build())
@@ -345,7 +345,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                         EventInfo.newBuilder().setName("abc").build(),
                         null)
                 .commit();
-        assertThat(corfuStore.openTable(nsxManager, tableName).get(key1).getMetadata())
+        assertThat(corfuStore.getTable(nsxManager, tableName).get(key1).getMetadata())
                 .isNull();
 
         corfuStore.tx(nsxManager)
@@ -354,7 +354,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                         EventInfo.newBuilder().setName("bcd").build(),
                         ManagedResources.newBuilder().setCreateUser("testUser").setVersion(1L).build())
                 .commit();
-        assertThat(corfuStore.openTable(nsxManager, tableName).get(key1).getMetadata())
+        assertThat(corfuStore.getTable(nsxManager, tableName).get(key1).getMetadata())
                 .isNull();
 
         corfuStore.tx(nsxManager)
@@ -363,7 +363,7 @@ public class CorfuStoreTest extends AbstractViewTest {
                         EventInfo.newBuilder().setName("cde").build(),
                         null)
                 .commit();
-        assertThat(corfuStore.openTable(nsxManager, tableName).get(key1).getMetadata())
+        assertThat(corfuStore.getTable(nsxManager, tableName).get(key1).getMetadata())
                 .isNull();
     }
 


### PR DESCRIPTION
openTable() currently has two versions, depending on whether a table has been seen by the runtime.  This change consolidates the apis.
