### PR TITLE
NPE in prepareToBecomeStandby

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -95,6 +95,8 @@ public class LogReplicationServer extends AbstractServer {
                 log.info("Sending ACK {} on {} to Client ", ack.getMetadata(), ts);
                 r.sendResponse(msg, CorfuMsgType.LOG_REPLICATION_ENTRY.payloadMsg(ack));
             }
+        } else {
+            log.warn("Dropping log replication entry as this node is not the leader.");
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -507,6 +507,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     public void processLockRelease() {
         log.debug("Lock released");
         isLeader.set(false);
+        stopLogReplication();
         // Signal Log Replication Server/Sink to stop receiving messages, leadership loss
         interClusterReplicationService.getLogReplicationServer().setLeadership(false);
     }
@@ -688,21 +689,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     @Override
     public void updateTopology(LogReplicationClusterInfo.TopologyConfigurationMsg topologyConfig) {
         input(new DiscoveryServiceEvent(DiscoveryServiceEventType.DISCOVERED_TOPOLOGY, topologyConfig));
-    }
-
-    /**
-     * No work needs to be done here.  If in the Active state, writes to all replicated streams have stopped at this time.
-     * Following this, the ClusterManagerAdapter can query the status of ongoing snapshot sync on the
-     * local(active) cluster.
-     */
-    @Override
-    public void prepareToBecomeStandby() {
-        if (ClusterRole.ACTIVE == localClusterDescriptor.getRole()) {
-            log.info("Received a Request to Become Standby");
-        } else {
-            log.warn("Illegal prepareToBecomeStandby when cluster {} with role {}",
-                    localClusterDescriptor.getClusterId(), localClusterDescriptor.getRole());
-        }
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryServiceAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryServiceAdapter.java
@@ -15,11 +15,6 @@ public interface CorfuReplicationDiscoveryServiceAdapter {
 
     /**
      *
-     */
-    void prepareToBecomeStandby();
-
-    /**
-     *
      * @return
      */
     Map<String, LogReplicationMetadata.ReplicationStatusVal> queryReplicationStatus();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
@@ -43,15 +43,6 @@ public interface CorfuReplicationClusterManagerAdapter {
     void shutdown();
 
     /**
-     * While doing a cluster role type flip, it is the API used to notify the current log
-     * replication node to prepare a cluster role type change. It will do some
-     * bookkeeping to calculate the number of log entries to be sent over
-     *
-     */
-    void prepareToBecomeStandby();
-
-
-    /**
      * This API is used to query the log replication status when it is preparing a role type flip and
      * the replicated tables should be in read-only mode.
      *

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerBaseAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerBaseAdapter.java
@@ -44,10 +44,6 @@ public abstract class CorfuReplicationClusterManagerBaseAdapter implements Corfu
         }
     }
 
-    public void prepareToBecomeStandby() {
-        corfuReplicationDiscoveryService.prepareToBecomeStandby();
-    }
-
     public Map<String, LogReplicationMetadata.ReplicationStatusVal> queryReplicationStatus() {
         return corfuReplicationDiscoveryService.queryReplicationStatus();
     }


### PR DESCRIPTION
## Overview

Description:

  We hit a NPE when SiteMgr plugin calls prepareToBecomeStandby and no localDescriptor is defined.
Removing this API as we no longer have any specific actions on this call (it evolved from the initial design).

Why should this be merged: bug found in actual setups

## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
