### PR TITLE
Reset SinkBufferManager on negotiation

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -117,6 +117,7 @@ public class LogReplicationServer extends AbstractServer {
                     metadataMgr.getLastAppliedBaseSnapshotTimestamp(),
                     metadataMgr.getLastProcessedLogTimestamp());
             log.info("Send Negotiation response");
+            sinkManager.reset();
             r.sendResponse(msg, CorfuMsgType.LOG_REPLICATION_NEGOTIATION_RESPONSE.payloadMsg(response));
         } else {
             log.warn("Dropping negotiation request as this node is not the leader.");

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -328,16 +328,22 @@ public class LogReplicationMetadataManager {
         TxBuilder txBuilder = corfuStore.tx(NAMESPACE);
         txBuilder.update(REPLICATION_STATUS_TABLE, key, val, null);
         txBuilder.commit();
+
+        log.trace("setReplicationRemainingEntries: clusterId: {}, remainingEntries: {}, type: {}",
+                clusterId, remainingEntries, type);
     }
 
     public Map<String, ReplicationStatusVal> getReplicationRemainingEntries() {
         Map<String, ReplicationStatusVal> replicationStatusMap = new HashMap<>();
         QueryResult<CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, ReplicationStatusVal>> entries =
-                corfuStore.query(NAMESPACE).executeQuery(REPLICATION_STATUS_TABLE, (x) -> {return true;});
+                corfuStore.query(NAMESPACE).executeQuery(REPLICATION_STATUS_TABLE, record -> true);
 
         for(CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, ReplicationStatusVal>entry : entries.getResult()) {
             replicationStatusMap.put(entry.getKey().getClusterId(), entry.getPayload());
         }
+
+        log.debug("getReplicationRemainingEntries: replicationStatusMap size: {}", replicationStatusMap.size());
+
         return replicationStatusMap;
     }
 
@@ -356,6 +362,8 @@ public class LogReplicationMetadataManager {
         TxBuilder txBuilder = corfuStore.tx(NAMESPACE);
         txBuilder.update(REPLICATION_STATUS_TABLE, key, val, null);
         txBuilder.commit();
+
+        log.trace("setDataConsistentOnStandby: localClusterId: {}, isConsistent: {}", localClusterId, isConsistent);
     }
 
     public Map<String, ReplicationStatusVal> getDataConsistentOnStandby() {
@@ -372,6 +380,9 @@ public class LogReplicationMetadataManager {
         }
         Map<String, ReplicationStatusVal> dataConsistentMap = new HashMap<>();
         dataConsistentMap.put(localClusterId, statusVal);
+
+        log.debug("getDataConsistentOnStandby: localClusterId: {}, statusVal: {}", localClusterId, statusVal);
+
         return dataConsistentMap;
     }
 

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -279,7 +279,7 @@ public class Utils {
             .max()
             .orElseThrow(NoSuchElementException::new);
 
-    log.debug("getLogTail: nodes selected {} global tail {}", segmentsHeadNodes, globalLogTail);
+    log.trace("getLogTail: nodes selected {} global tail {}", segmentsHeadNodes, globalLogTail);
     return globalLogTail;
   }
 


### PR DESCRIPTION
## Overview

Description:

SinkBufferManager has a field `lastProcessedSeq` to apply entry and send ACK. It is initialized when the discovery service starts.

When a non-leader node acquires the lock, `lastProcessedSeq` is very likely outdated, and won't process new entries.

Why should this be merged: 

Fix bug.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
