### PR TITLE
Enforce java and mvn versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <logback.classic.version>1.2.3</logback.classic.version>
-
+        <maven.enforcer.java>1.8</maven.enforcer.java>
+        <maven.enforcer.mvn>3.5.1</maven.enforcer.mvn>
         <!-- Dependency versions -->
         <junit.jupiter.version>5.4.2</junit.jupiter.version>
     </properties>
@@ -282,6 +283,29 @@
         </pluginManagement>
 
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <executions>
+                    <execution>
+                        <id>config-enforcer</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[${maven.enforcer.mvn},)</version>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>[${maven.enforcer.java},)</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>


### PR DESCRIPTION
## Overview
This patch will fail the build during the validation step when
the required java version and maven are not met. This prevents
obscure failures during the build.

Why should this be merged: improves debugging

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
