### PR TITLE
Optimized Bitmap Range Operations

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -36,7 +36,7 @@ import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.ValueAdoptedException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.corfudb.util.Utils;
 
 import java.lang.invoke.MethodHandles;
@@ -485,7 +485,7 @@ public class LogUnitServer extends AbstractServer {
     }
 
     @VisibleForTesting
-    StreamAddressSpace getStreamAddressSpace(UUID streamID) {
+    StreamBitmap getStreamAddressSpace(UUID streamID) {
         return streamLog.getStreamsAddressSpace().getAddressMap().get(streamID);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
@@ -1,19 +1,17 @@
 package org.corfudb.infrastructure.log;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.wireprotocol.LogData;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.runtime.view.Address;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-
-import javax.annotation.concurrent.NotThreadSafe;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 
 /**
  * A container object that holds log tail offsets and the global
@@ -88,14 +86,12 @@ public class LogMetadata {
         // Update stream address space (used for sequencer recovery), add this entry as a valid address for this stream.
         streamsAddressSpaceMap.compute(streamId, (id, addressSpace) -> {
             if (addressSpace == null) {
-                Roaring64NavigableMap addressMap = new Roaring64NavigableMap();
-                addressMap.addLong(entryAddress);
                 // Note: stream trim mark is initialized to -6
                 // its value will be computed as checkpoints for this stream are found in the log.
                 // The presence of a checkpoint provides a valid trim mark for a stream.
-                return new StreamAddressSpace(Address.NON_EXIST, addressMap);
+                return new StreamAddressSpace(Address.NON_EXIST, entryAddress);
             }
-            addressSpace.addAddress(entryAddress);
+            addressSpace.add(entryAddress);
             return addressSpace;
         });
     }
@@ -136,7 +132,7 @@ public class LogMetadata {
                             // If this entry still does not exist, means no updates have been observed for
                             // this stream yet. We can initialize the trim mark to the last observed update by the
                             // checkpoint. If further entries are observed they will be added to the address space.
-                            return new StreamAddressSpace(lastUpdateToStream, new Roaring64NavigableMap());
+                            return new StreamAddressSpace(lastUpdateToStream);
                         }
                         // We will hold the maximum of these observed updates as the stream trim mark (highest
                         // checkpointed address), as this guarantees data is available in a checkpoint (safe trim mark).

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -7,7 +7,7 @@ import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicat
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 
 import java.util.Map;
 import java.util.UUID;
@@ -144,7 +144,7 @@ public class LogReplicationAckReader {
         for (String stream : config.getStreamsToReplicate()) {
             UUID streamId = CorfuRuntime.getStreamID(stream);
             StreamAddressRange range = new StreamAddressRange(streamId, start, end);
-            StreamAddressSpace addressSpace = runtime.getSequencerView().getStreamAddressSpace(range);
+            StreamBitmap addressSpace = runtime.getSequencerView().getStreamAddressSpace(range);
             remainingEntriesToSend += addressSpace.size();
         }
         return remainingEntriesToSend;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -145,7 +145,7 @@ public class LogReplicationAckReader {
             UUID streamId = CorfuRuntime.getStreamID(stream);
             StreamAddressRange range = new StreamAddressRange(streamId, start, end);
             StreamAddressSpace addressSpace = runtime.getSequencerView().getStreamAddressSpace(range);
-            remainingEntriesToSend += addressSpace.getAddressMap().getLongCardinality();
+            remainingEntriesToSend += addressSpace.size();
         }
         return remainingEntriesToSend;
     }

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>0.8.13</version>
+            <version>0.9.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
         <dependency>

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ICorfuPayload.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ICorfuPayload.java
@@ -29,7 +29,7 @@ import org.corfudb.protocols.wireprotocol.IMetadata.DataRank;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntryMetadata;
 import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.view.Layout;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.corfudb.util.JsonUtils;
 
 /**
@@ -82,7 +82,7 @@ public interface ICorfuPayload<T> {
                     .put(StreamAddressRange.class, buffer ->
                             new StreamAddressRange(new UUID(buffer.readLong(), buffer.readLong()),
                                     buffer.readLong(), buffer.readLong()))
-                    .put(StreamAddressSpace.class, StreamAddressSpace::deserialize)
+                    .put(StreamBitmap.class, StreamBitmap::deserialize)
                     .put(LogReplicationEntryMetadata.class, buffer -> {
                         LogReplicationEntryMetadata metadata = new LogReplicationEntryMetadata();
                         metadata.setTopologyConfigId(buffer.readLong());
@@ -368,9 +368,9 @@ public interface ICorfuPayload<T> {
             buffer.writeInt(((Codec.Type) payload).getId());
         } else if (payload instanceof PriorityLevel) {
             buffer.writeByte(((PriorityLevel) payload).asByte());
-        } else if (payload instanceof StreamAddressSpace) {
-            StreamAddressSpace streamAddressSpace = (StreamAddressSpace) payload;
-            streamAddressSpace.serialize(buffer);
+        } else if (payload instanceof StreamBitmap) {
+            StreamBitmap streamBitmap = (StreamBitmap) payload;
+            streamBitmap.serialize(buffer);
         } else if (payload instanceof StreamAddressRange) {
             StreamAddressRange streamRange = (StreamAddressRange) payload;
             buffer.writeLong(streamRange.getStreamID().getMostSignificantBits());

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/SequencerRecoveryMsg.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/SequencerRecoveryMsg.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 
 /**
  * Created by rmichoud on 6/20/17.
@@ -17,7 +17,7 @@ import org.corfudb.runtime.view.stream.StreamAddressSpace;
 public class SequencerRecoveryMsg implements ICorfuPayload<SequencerRecoveryMsg> {
 
     private final Long globalTail;
-    private final Map<UUID, StreamAddressSpace> streamsAddressMap;
+    private final Map<UUID, StreamBitmap> streamsAddressMap;
     private final Long sequencerEpoch;
 
     /**
@@ -29,7 +29,7 @@ public class SequencerRecoveryMsg implements ICorfuPayload<SequencerRecoveryMsg>
 
     public SequencerRecoveryMsg(ByteBuf buf) {
         globalTail = ICorfuPayload.fromBuffer(buf, Long.class);
-        streamsAddressMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, StreamAddressSpace.class);
+        streamsAddressMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, StreamBitmap.class);
         sequencerEpoch = ICorfuPayload.fromBuffer(buf, Long.class);
         bootstrapWithoutTailsUpdate = ICorfuPayload.fromBuffer(buf, Boolean.class);
     }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/StreamsAddressResponse.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/StreamsAddressResponse.java
@@ -6,7 +6,7 @@ import java.util.UUID;
 import lombok.Data;
 import lombok.Setter;
 import org.corfudb.runtime.view.Layout;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 
 /**
  * Represents the response sent by the sequencer when streams address maps are requested
@@ -23,9 +23,9 @@ public class StreamsAddressResponse implements ICorfuPayload<StreamsAddressRespo
     @Setter
     private long epoch = Layout.INVALID_EPOCH;
 
-    private final Map<UUID, StreamAddressSpace> addressMap;
+    private final Map<UUID, StreamBitmap> addressMap;
 
-    public StreamsAddressResponse(long logTail, Map<UUID, StreamAddressSpace> streamsAddressesMap) {
+    public StreamsAddressResponse(long logTail, Map<UUID, StreamBitmap> streamsAddressesMap) {
         this.logTail = logTail;
         this.addressMap = streamsAddressesMap;
     }
@@ -38,7 +38,7 @@ public class StreamsAddressResponse implements ICorfuPayload<StreamsAddressRespo
     public StreamsAddressResponse(ByteBuf buf) {
         this.logTail = ICorfuPayload.fromBuffer(buf, Long.class);
         this.epoch = ICorfuPayload.fromBuffer(buf, Long.class);
-        this.addressMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, StreamAddressSpace.class);
+        this.addressMap = ICorfuPayload.mapFromBuffer(buf, UUID.class, StreamBitmap.class);
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -9,7 +9,7 @@ import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics;
 import org.corfudb.protocols.wireprotocol.SequencerRecoveryMsg;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.corfudb.protocols.wireprotocol.StreamsAddressRequest;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TokenRequest;
@@ -88,7 +88,7 @@ public class SequencerClient extends AbstractClient {
      *                                    False otherwise.
      * @return A CompletableFuture which completes once the sequencer is reset.
      */
-    public CompletableFuture<Boolean> bootstrap(Long initialToken, Map<UUID, StreamAddressSpace> streamAddressSpaceMap,
+    public CompletableFuture<Boolean> bootstrap(Long initialToken, Map<UUID, StreamBitmap> streamAddressSpaceMap,
                                                 Long readyStateEpoch,
                                                 boolean bootstrapWithoutTailsUpdate) {
         return sendMessageWithFuture(CorfuMsgType.BOOTSTRAP_SEQUENCER.payloadMsg(
@@ -106,7 +106,7 @@ public class SequencerClient extends AbstractClient {
      * @return A CompletableFuture which completes once the sequencer is reset.
      */
     public CompletableFuture<Boolean> bootstrap(Long initialToken,
-                                                Map<UUID, StreamAddressSpace> streamAddressSpaceMap,
+                                                Map<UUID, StreamBitmap> streamAddressSpaceMap,
                                                 Long readyStateEpoch) {
         return bootstrap(initialToken, streamAddressSpaceMap, readyStateEpoch, false);
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -21,7 +21,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.LayoutModificationException;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.QuorumUnreachableException;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.Utils;
 
@@ -408,7 +408,7 @@ public class LayoutManagementView extends AbstractView {
                 }
 
                 long maxTokenRequested = -1L;
-                Map<UUID, StreamAddressSpace> streamsAddressSpace = Collections.emptyMap();
+                Map<UUID, StreamBitmap> streamsAddressSpace = Collections.emptyMap();
                 boolean bootstrapWithoutTailsUpdate = true;
 
                 // Reconfigure Primary Sequencer if required

--- a/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
@@ -4,7 +4,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.Lists;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
@@ -111,7 +111,7 @@ public class SequencerView extends AbstractView {
      * @param streamsAddressesRange range of streams address space to request.
      * @return address space composed of the trim mark and collection of all addresses belonging to this stream.
      */
-    public StreamAddressSpace getStreamAddressSpace(StreamAddressRange streamsAddressesRange) {
+    public StreamBitmap getStreamAddressSpace(StreamAddressRange streamsAddressesRange) {
         return getStreamsAddressSpace(Arrays.asList(streamsAddressesRange)).get(streamsAddressesRange.getStreamID());
     }
 
@@ -121,7 +121,7 @@ public class SequencerView extends AbstractView {
      * @param streamsAddressesRange list of streams and ranges to be requested.
      * @return address space for each stream in the request.
      */
-    public Map<UUID, StreamAddressSpace> getStreamsAddressSpace(List<StreamAddressRange> streamsAddressesRange) {
+    public Map<UUID, StreamBitmap> getStreamsAddressSpace(List<StreamAddressRange> streamsAddressesRange) {
         try (Timer.Context context = MetricsUtils.getConditionalContext(sequencerNextOneStream)) {
             StreamsAddressResponse streamsAddressResponse = layoutHelper(e ->
                     CFUtils.getUninterruptibly(e.getPrimarySequencerClient()

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -28,7 +28,7 @@ import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.RuntimeLayout;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 
 /**
  * Created by crossbach on 5/22/15.
@@ -332,7 +332,7 @@ public class Utils {
     // coalesce the candidates to unique nodes only
     Set<String> segmentsHeadNodes = getChainHeadFromAllSegments(runtimeLayout.getLayout());
     AtomicLong globalTail = new AtomicLong(Address.NON_EXIST);
-    final Map<UUID, StreamAddressSpace> streamsAddressSpace = new HashMap<>();
+    final Map<UUID, StreamBitmap> streamsAddressSpace = new HashMap<>();
     List<CompletableFuture<StreamsAddressResponse>> cfs =
         segmentsHeadNodes.stream()
             .map(node -> runtimeLayout.getLogUnitClient(node).getLogAddressSpace())
@@ -347,7 +347,7 @@ public class Utils {
               // Find the global max global tail and stream tails across all responses
               globalTail.set(Long.max(resp.getLogTail(), globalTail.get()));
               resp.getAddressMap()
-                  .forEach((k, v) -> streamsAddressSpace.merge(k, v, StreamAddressSpace::merge));
+                  .forEach((k, v) -> streamsAddressSpace.merge(k, v, StreamBitmap::merge));
             });
 
     log.debug(

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -36,7 +36,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.LogUnitException;
 import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
@@ -407,7 +407,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         future.join();
 
         // Retrieve address space from current log unit server (write path)
-        StreamAddressSpace addressSpace = s1.getStreamAddressSpace(streamID);
+        StreamBitmap addressSpace = s1.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
         assertThat(addressSpace.size()).isEqualTo(minAddress + 1);
 

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -409,7 +409,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         // Retrieve address space from current log unit server (write path)
         StreamAddressSpace addressSpace = s1.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(minAddress + 1);
+        assertThat(addressSpace.size()).isEqualTo(minAddress + 1);
 
         // Instantiate new log unit server (restarts) so the log is read and address maps are rebuilt.
         LogUnitServer newServer = new LogUnitServer(new ServerContextBuilder()
@@ -420,7 +420,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         // Retrieve address space from new initialized log unit server (bootstrap path)
         addressSpace = newServer.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(minAddress + 1);
+        assertThat(addressSpace.size()).isEqualTo(minAddress + 1);
 
         // Trim the log, and verify that trim mark is updated on log unit
         newServer.prefixTrim(trimMark);
@@ -430,7 +430,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         // Retrieve address space from current log unit server (after a prefix trim)
         addressSpace = newServer.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(trimMark);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(maxAddress - trimMark);
+        assertThat(addressSpace.size()).isEqualTo(maxAddress - trimMark);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -2,25 +2,24 @@ package org.corfudb.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics;
 import org.corfudb.protocols.wireprotocol.SequencerRecoveryMsg;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenRequest;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TokenType;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.junit.Before;
 import org.junit.Test;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 /**
  * Created by mwei on 12/13/15.
@@ -225,9 +224,9 @@ public class SequencerServerTest extends AbstractServerTest {
         // This one should not be updated
         long newTailC = tailC - 1;
 
-        tailMap.put(streamA, new StreamAddressSpace(Address.NON_ADDRESS, Roaring64NavigableMap.bitmapOf(newTailA)));
-        tailMap.put(streamB, new StreamAddressSpace(Address.NON_ADDRESS, Roaring64NavigableMap.bitmapOf(newTailB)));
-        tailMap.put(streamC, new StreamAddressSpace(Address.NON_ADDRESS, Roaring64NavigableMap.bitmapOf(newTailC)));
+        tailMap.put(streamA, new StreamAddressSpace(Address.NON_ADDRESS, newTailA));
+        tailMap.put(streamB, new StreamAddressSpace(Address.NON_ADDRESS, newTailB));
+        tailMap.put(streamC, new StreamAddressSpace(Address.NON_ADDRESS, newTailC));
 
         // Modifying the sequencerEpoch to simulate sequencer reset.
         server.setSequencerEpoch(-1L);
@@ -285,8 +284,7 @@ public class SequencerServerTest extends AbstractServerTest {
                 Address.NON_EXIST, Collections.emptyMap(), newEpoch, true)), newEpoch);
         assertThat(future1.join()).isEqualTo(false);
         future1 = sendRequestWithEpoch(CorfuMsgType.BOOTSTRAP_SEQUENCER.payloadMsg(new SequencerRecoveryMsg(
-                num, Collections.singletonMap(streamA, new StreamAddressSpace(Address.NON_ADDRESS,
-                Roaring64NavigableMap.bitmapOf(num))), newEpoch, false)), newEpoch);
+                num, Collections.singletonMap(streamA, new StreamAddressSpace(Address.NON_ADDRESS, num)), newEpoch, false)), newEpoch);
         assertThat(future1.join()).isEqualTo(true);
 
         future = sendRequestWithEpoch(CorfuMsgType.TOKEN_REQ.payloadMsg(new TokenRequest(0L, Collections.emptyList())), newEpoch);

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -17,7 +17,7 @@ import org.corfudb.protocols.wireprotocol.TokenRequest;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TokenType;
 import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -218,15 +218,15 @@ public class SequencerServerTest extends AbstractServerTest {
         long globalTail = future.join().getToken().getSequence();
 
         // Construct new tails
-        Map<UUID, StreamAddressSpace> tailMap = new HashMap<>();
+        Map<UUID, StreamBitmap> tailMap = new HashMap<>();
         long newTailA = tailA + 2;
         long newTailB = tailB + 1;
         // This one should not be updated
         long newTailC = tailC - 1;
 
-        tailMap.put(streamA, new StreamAddressSpace(Address.NON_ADDRESS, newTailA));
-        tailMap.put(streamB, new StreamAddressSpace(Address.NON_ADDRESS, newTailB));
-        tailMap.put(streamC, new StreamAddressSpace(Address.NON_ADDRESS, newTailC));
+        tailMap.put(streamA, new StreamBitmap(Address.NON_ADDRESS, newTailA));
+        tailMap.put(streamB, new StreamBitmap(Address.NON_ADDRESS, newTailB));
+        tailMap.put(streamC, new StreamBitmap(Address.NON_ADDRESS, newTailC));
 
         // Modifying the sequencerEpoch to simulate sequencer reset.
         server.setSequencerEpoch(-1L);
@@ -284,7 +284,7 @@ public class SequencerServerTest extends AbstractServerTest {
                 Address.NON_EXIST, Collections.emptyMap(), newEpoch, true)), newEpoch);
         assertThat(future1.join()).isEqualTo(false);
         future1 = sendRequestWithEpoch(CorfuMsgType.BOOTSTRAP_SEQUENCER.payloadMsg(new SequencerRecoveryMsg(
-                num, Collections.singletonMap(streamA, new StreamAddressSpace(Address.NON_ADDRESS, num)), newEpoch, false)), newEpoch);
+                num, Collections.singletonMap(streamA, new StreamBitmap(Address.NON_ADDRESS, num)), newEpoch, false)), newEpoch);
         assertThat(future1.join()).isEqualTo(true);
 
         future = sendRequestWithEpoch(CorfuMsgType.TOKEN_REQ.payloadMsg(new TokenRequest(0L, Collections.emptyList())), newEpoch);

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -1154,10 +1154,10 @@ public class ClusterReconfigIT extends AbstractIT {
         assertThat(addressSpace.getTrimMark()).isEqualTo(numEntries);
         if (trim) {
             // Addresses were trimmed, cardinality of addresses should be 0
-            assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(0L);
+            assertThat(addressSpace.size()).isEqualTo(0L);
         } else {
             // Extra entry corresponds to entry added by checkpointer.
-            assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(numEntries+1);
+            assertThat(addressSpace.size()).isEqualTo(numEntries+1);
         }
 
         // Verify START_ADDRESS of checkpoint for stream
@@ -1166,7 +1166,7 @@ public class ClusterReconfigIT extends AbstractIT {
                 .getAddressMap().get(checkpointStreamId);
 
         // Addresses should correspond to: start, continuation and end records. (total 3 records)
-        assertThat(checkpointAddressSpace.getAddressMap().getLongCardinality()).isEqualTo(numCheckpointRecordsDefault);
+        assertThat(checkpointAddressSpace.size()).isEqualTo(numCheckpointRecordsDefault);
         CheckpointEntry cpEntry = (CheckpointEntry) runtime2.getAddressSpaceView()
                 .read(checkpointAddressSpace.getHighestAddress())
                 .getPayload(runtime2);

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -48,7 +48,7 @@ import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.runtime.view.StreamsView;
 import org.corfudb.runtime.view.stream.IStreamView;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Sleep;
@@ -1147,7 +1147,7 @@ public class ClusterReconfigIT extends AbstractIT {
                 .open();
 
         // Verify sequencer has correct address map for this stream (addresses and trim mark)
-        StreamAddressSpace addressSpace = Utils.getLogAddressSpace(runtime2.getLayoutView()
+        StreamBitmap addressSpace = Utils.getLogAddressSpace(runtime2.getLayoutView()
                 .getRuntimeLayout())
                 .getAddressMap().get(streamId);
 
@@ -1161,7 +1161,7 @@ public class ClusterReconfigIT extends AbstractIT {
         }
 
         // Verify START_ADDRESS of checkpoint for stream
-        StreamAddressSpace checkpointAddressSpace = Utils.getLogAddressSpace(runtime2.getLayoutView()
+        StreamBitmap checkpointAddressSpace = Utils.getLogAddressSpace(runtime2.getLayoutView()
                 .getRuntimeLayout())
                 .getAddressMap().get(checkpointStreamId);
 

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -805,8 +805,8 @@ public class ServerRestartIT extends AbstractIT {
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpace.getTrimMark()).isEqualTo(cpAddress.getSequence());
 
-            assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(expectedAddresses.size());
-            expectedAddresses.forEach(address -> assertThat(addressSpace.getAddressMap().contains(address)).isTrue());
+            assertThat(addressSpace.size()).isEqualTo(expectedAddresses.size());
+            expectedAddresses.forEach(address -> assertThat(addressSpace.contains(address)).isTrue());
         } finally {
             if (r != null) r.shutdown();
             if (runtimeRestart != null) runtimeRestart.shutdown();

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -39,7 +39,7 @@ import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.StaleTokenException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.corfudb.util.CFUtils;
 import org.corfudb.util.Utils;
 import org.junit.Before;
@@ -797,7 +797,7 @@ public class ServerRestartIT extends AbstractIT {
             runtimeRestart = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
 
             // Fetch Address Space for the given stream
-            StreamAddressSpace addressSpace = Utils.getLogAddressSpace(runtimeRestart
+            StreamBitmap addressSpace = Utils.getLogAddressSpace(runtimeRestart
                     .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID("test"));

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -781,7 +781,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Verify address space and trim mark is properly set for the given stream (should be 7 which  is the start log address
             // for the existing checkpoint)
             assertThat(addressSpaceA.getTrimMark()).isEqualTo(snapshotAddress);
-            assertThat(addressSpaceA.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceA.size()).isEqualTo(insertions);
 
             // Fetch Address Space for the given stream S2
             StreamAddressSpace addressSpaceB =  Utils.getLogAddressSpace(runtimeRestart
@@ -792,7 +792,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Verify address space and trim mark is properly set for the given stream (should be 7 which  is the start log address
             // for the existing checkpoint)
             assertThat(addressSpaceB.getTrimMark()).isEqualTo(snapshotAddress);
-            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertionsB);
+            assertThat(addressSpaceB.size()).isEqualTo(insertionsB);
 
             // Open mapB after restart (verify it loads from checkpoint)
             Map<String, Integer> mapBRestart = createMap(runtimeRestart, stream2);
@@ -905,7 +905,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpaceA.getTrimMark()).isEqualTo(snapshotAddress);
-            assertThat(addressSpaceA.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceA.size()).isEqualTo(insertions);
 
             // Open mapA after restart (verify it loads from checkpoint)
             Map<String, Integer> mapARestart = createMap(runtimeRestart, streamNameA);
@@ -996,7 +996,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpaceB.getTrimMark()).isEqualTo(Address.NON_EXIST);
-            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceB.size()).isEqualTo(insertions);
 
             // Open mapB new runtime
             Map<String, Integer> mapBNewRuntime = createMap(rt2, streamNameB);
@@ -1022,7 +1022,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpaceB.getTrimMark()).isEqualTo(Address.NON_EXIST);
-            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceB.size()).isEqualTo(insertions);
 
             // Open mapB after restart
             Map<String, Integer> mapBRestart = createMap(runtimeRestart, streamNameB);

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -28,7 +28,7 @@ import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.StreamingMap;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Utils;
 import org.junit.Test;
@@ -773,7 +773,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(runtimeRestart);
 
             // Fetch Address Space for the given stream S1
-            StreamAddressSpace addressSpaceA = Utils.getLogAddressSpace(runtimeRestart
+            StreamBitmap addressSpaceA = Utils.getLogAddressSpace(runtimeRestart
                     .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(stream1));
@@ -784,7 +784,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             assertThat(addressSpaceA.size()).isEqualTo(insertions);
 
             // Fetch Address Space for the given stream S2
-            StreamAddressSpace addressSpaceB =  Utils.getLogAddressSpace(runtimeRestart
+            StreamBitmap addressSpaceB =  Utils.getLogAddressSpace(runtimeRestart
                     .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(stream2));
@@ -898,7 +898,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
                     .get(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS)).isEqualTo("8");
 
             // Fetch Address Space for the given stream
-            StreamAddressSpace addressSpaceA = Utils.getLogAddressSpace(runtimeRestart
+            StreamBitmap addressSpaceA = Utils.getLogAddressSpace(runtimeRestart
                     .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(streamNameA));
@@ -989,7 +989,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             runtimes.add(rt2);
 
             // Fetch Address Space for the given stream
-            StreamAddressSpace addressSpaceB = Utils.getLogAddressSpace(rt2
+            StreamBitmap addressSpaceB = Utils.getLogAddressSpace(rt2
                     .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
                     .get(CorfuRuntime.getStreamID(streamNameB));

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -618,16 +618,16 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         // Get Stream's Address Space
         StreamAddressSpace addressSpace = client.getLogAddressSpace().join().getAddressMap().get(streamId);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(numEntries);
-        assertThat(addressSpace.getAddressMap().contains(addressOne));
+        assertThat(addressSpace.size()).isEqualTo(numEntries);
+        assertThat(addressSpace.contains(addressOne));
 
         // Get Log Address Space (stream's address space + log tail)
         CompletableFuture<StreamsAddressResponse> cfLog = client.getLogAddressSpace();
         StreamsAddressResponse response = cfLog.get();
         addressSpace = response.getAddressMap().get(streamId);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(numEntries);
-        assertThat(addressSpace.getAddressMap().contains(addressOne));
+        assertThat(addressSpace.size()).isEqualTo(numEntries);
+        assertThat(addressSpace.contains(addressOne));
         assertThat(response.getLogTail()).isEqualTo(addressTwo);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -55,7 +55,7 @@ import org.corfudb.runtime.exceptions.QuotaExceededException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.ValueAdoptedException;
 import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.corfudb.util.serializer.Serializers;
 import org.junit.Test;
 
@@ -616,7 +616,7 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         client.write(ldTwo).join();
 
         // Get Stream's Address Space
-        StreamAddressSpace addressSpace = client.getLogAddressSpace().join().getAddressMap().get(streamId);
+        StreamBitmap addressSpace = client.getLogAddressSpace().join().getAddressMap().get(streamId);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
         assertThat(addressSpace.size()).isEqualTo(numEntries);
         assertThat(addressSpace.contains(addressOne));

--- a/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
@@ -251,7 +251,7 @@ public class UtilsTest {
   private StreamAddressSpace getRandomStreamSpace(long max) {
     StreamAddressSpace streamA = new StreamAddressSpace();
     LongStream.range(0, max)
-            .forEach(address -> streamA.addAddress(((address & 0x1) == 1) ? 0 : address));
+            .forEach(address -> streamA.add(((address & 0x1) == 1) ? 0 : address));
     return streamA;
   }
 
@@ -306,11 +306,11 @@ public class UtilsTest {
     UUID s3Id = UUID.randomUUID();
     final long nodeBGlobalTail = 205;
 
-    StreamAddressSpace s2IdPartial =
-            new StreamAddressSpace(30l, nodeALogAddressSpace.get(s2Id).getAddressMap());
-    s2IdPartial.addAddress(201);
-    s2IdPartial.addAddress(202);
-    s2IdPartial.addAddress(203);
+    StreamAddressSpace s2IdPartial = nodeALogAddressSpace.get(s2Id).copy();
+    s2IdPartial.trim(30L);
+    s2IdPartial.add(201L);
+    s2IdPartial.add(202L);
+    s2IdPartial.add(203L);
 
     Map<UUID, StreamAddressSpace> nodeBLogAddressSpace =
             ImmutableMap.of(s2Id, s2IdPartial, s3Id, getRandomStreamSpace(nodeAGlobalTail - 1));

--- a/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
@@ -9,7 +9,7 @@ import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.runtime.view.stream.StreamBitmap;
 import org.junit.Test;
 
 /**
@@ -117,12 +117,12 @@ public class SequencerViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         // Request 3 tokens on the Sequencer.
         final int tokenCount = 3;
-        StreamAddressSpace expected = new StreamAddressSpace();
+        StreamBitmap expected = new StreamBitmap();
         for (long i = 0; i < tokenCount; i++) {
             r.getSequencerView().next(streamA);
             expected.add(i);
         }
-        // Request StreamAddressSpace should succeed.
+        // Request StreamBitmap should succeed.
         assertThat(r.getSequencerView().getStreamAddressSpace(
                 new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)))
                 .isEqualTo(expected);
@@ -133,7 +133,7 @@ public class SequencerViewTest extends AbstractViewTest {
         Layout newLayout = controlRuntime.getLayoutView().getLayout();
         controlRuntime.getLayoutManagementView().reconfigureSequencerServers(originalLayout, newLayout, false);
 
-        // Request StreamAddressSpace should fail with a WrongEpochException initially
+        // Request StreamBitmap should fail with a WrongEpochException initially
         // This is then retried internally and returned with a valid response.
         assertThat(r.getSequencerView().getStreamAddressSpace(
                 new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)))

--- a/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
@@ -1,16 +1,16 @@
 package org.corfudb.runtime.view;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import java.util.UUID;
 import lombok.Getter;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.junit.Test;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by mwei on 12/23/15.
@@ -117,15 +117,15 @@ public class SequencerViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         // Request 3 tokens on the Sequencer.
         final int tokenCount = 3;
-        Roaring64NavigableMap expectedMap = new Roaring64NavigableMap();
-        for (int i = 0; i < tokenCount; i++) {
+        StreamAddressSpace expected = new StreamAddressSpace();
+        for (long i = 0; i < tokenCount; i++) {
             r.getSequencerView().next(streamA);
-            expectedMap.add(i);
+            expected.add(i);
         }
         // Request StreamAddressSpace should succeed.
         assertThat(r.getSequencerView().getStreamAddressSpace(
-                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)).getAddressMap())
-                .isEqualTo(expectedMap);
+                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)))
+                .isEqualTo(expected);
 
         // Increment the epoch.
         incrementClusterEpoch(controlRuntime);
@@ -136,7 +136,7 @@ public class SequencerViewTest extends AbstractViewTest {
         // Request StreamAddressSpace should fail with a WrongEpochException initially
         // This is then retried internally and returned with a valid response.
         assertThat(r.getSequencerView().getStreamAddressSpace(
-                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)).getAddressMap())
-                .isEqualTo(expectedMap);
+                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)))
+                .isEqualTo(expected);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
@@ -3,7 +3,6 @@ package org.corfudb.runtime.view.stream;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 
-import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import org.corfudb.runtime.view.Address;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public class StreamAddressSpaceTest {
         StreamAddressSpace streamA = new StreamAddressSpace();
 
         final int numStreamAEntries = 100;
-        IntStream.range(0, numStreamAEntries).forEach(streamA::addAddress);
+        LongStream.range(0, numStreamAEntries).forEach(streamA::add);
 
         assertThat(streamA.getTrimMark()).isEqualTo(Address.NON_ADDRESS);
         assertThat(streamA.getTail()).isEqualTo(numStreamAEntries - 1);
@@ -25,7 +24,7 @@ public class StreamAddressSpaceTest {
 
         StreamAddressSpace streamB = new StreamAddressSpace();
         final int numStreamBEntries = 130;
-        IntStream.range(0, numStreamBEntries).forEach(streamB::addAddress);
+        LongStream.range(0, numStreamBEntries).forEach(streamB::add);
         final long streamBTrimMark = 40;
         streamB.trim(streamBTrimMark);
 
@@ -40,7 +39,7 @@ public class StreamAddressSpaceTest {
         assertThat(streamA.getTail()).isEqualTo(numStreamBEntries - 1);
 
         LongStream.range(streamBTrimMark + 1, numStreamBEntries).forEach(address ->
-                assertThat(streamA.getAddressMap().contains(address)).isTrue()
+                assertThat(streamA.contains(address)).isTrue()
         );
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/stream/StreamBitmapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/StreamBitmapTest.java
@@ -7,12 +7,12 @@ import java.util.stream.LongStream;
 import org.corfudb.runtime.view.Address;
 import org.junit.Test;
 
-public class StreamAddressSpaceTest {
+public class StreamBitmapTest {
 
     @Test
     public void testStreamAddressSpaceMerge() {
 
-        StreamAddressSpace streamA = new StreamAddressSpace();
+        StreamBitmap streamA = new StreamBitmap();
 
         final int numStreamAEntries = 100;
         LongStream.range(0, numStreamAEntries).forEach(streamA::add);
@@ -22,7 +22,7 @@ public class StreamAddressSpaceTest {
 
         // need to take higher trim mark?
 
-        StreamAddressSpace streamB = new StreamAddressSpace();
+        StreamBitmap streamB = new StreamBitmap();
         final int numStreamBEntries = 130;
         LongStream.range(0, numStreamBEntries).forEach(streamB::add);
         final long streamBTrimMark = 40;
@@ -33,7 +33,7 @@ public class StreamAddressSpaceTest {
 
         // Merge steamB into streamA and verify that the highest trim mark is
         // adopted in streamA
-        StreamAddressSpace.merge(streamA, streamB);
+        StreamBitmap.merge(streamA, streamB);
 
         assertThat(streamA.getTrimMark()).isEqualTo(streamBTrimMark);
         assertThat(streamA.getTail()).isEqualTo(numStreamBEntries - 1);


### PR DESCRIPTION
## Overview
Improved StreamAddressSpace range operations by removing iterative implementations and replaced it with logical "native" bitmap operations. 

Why should this be merged: Improves performance + reduces memory pressure

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
