### PR TITLE
Disable Codecov Patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,5 @@ coverage:
   ignore:
     - "generator/src/main/java/**/*"
     - "samples/**/*"
+  status:
+    patch: off


### PR DESCRIPTION
## Overview

Description:

Disable codecov/patch status which measures lines adjusted in the pull request and leave only codecov/project status which measures overall project coverage and compares it against the base of the pull request or parent commit.