### PR TITLE
Remove The Boss EventLoopGroup

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
@@ -98,8 +98,7 @@ public class CorfuServerNode implements AutoCloseable {
      * Start the Corfu Server by listening on the specified port.
      */
     public ChannelFuture start() {
-        bindFuture = bindServer(serverContext.getBossGroup(),
-                serverContext.getWorkerGroup(),
+        bindFuture = bindServer(serverContext.getWorkerGroup(),
                 this::configureBootstrapOptions,
                 serverContext,
                 router,
@@ -180,8 +179,6 @@ public class CorfuServerNode implements AutoCloseable {
      * {@link EventLoopGroup}s. For implementations which listen on multiple ports,
      * {@link EventLoopGroup}s may be reused.
      *
-     * @param bossGroup           The "boss" {@link EventLoopGroup} which services incoming
-     *                            connections.
      * @param workerGroup         The "worker" {@link EventLoopGroup} which services incoming
      *                            requests.
      * @param bootstrapConfigurer A {@link BootstrapConfigurer} which will receive the
@@ -193,8 +190,7 @@ public class CorfuServerNode implements AutoCloseable {
      * @param port                The port the {@link ServerChannel} will be created on.
      * @return A {@link ChannelFuture} which can be used to wait for the server to be shutdown.
      */
-    public ChannelFuture bindServer(@Nonnull EventLoopGroup bossGroup,
-                                    @Nonnull EventLoopGroup workerGroup,
+    public ChannelFuture bindServer(@Nonnull EventLoopGroup workerGroup,
                                     @Nonnull BootstrapConfigurer bootstrapConfigurer,
                                     @Nonnull ServerContext context,
                                     @Nonnull NettyServerRouter router,
@@ -202,7 +198,7 @@ public class CorfuServerNode implements AutoCloseable {
                                     int port) {
         try {
             ServerBootstrap bootstrap = new ServerBootstrap();
-            bootstrap.group(bossGroup, workerGroup)
+            bootstrap.group(workerGroup)
                     .channel(context.getChannelImplementation().getServerChannelClass());
             bootstrapConfigurer.configure(bootstrap);
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -1,9 +1,30 @@
 package org.corfudb.infrastructure;
 
+import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_NUM_MSG_PER_BATCH;
+import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_DATA_MSG_SIZE_SUPPORTED;
+import static org.corfudb.util.MetricsUtils.isMetricsReportingSetUp;
+
+
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.Sets;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.channel.EventLoopGroup;
+import java.io.File;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -26,28 +47,9 @@ import org.corfudb.util.NodeLocator;
 import org.corfudb.util.UuidUtils;
 import org.corfudb.utils.lock.Lock;
 
-import javax.annotation.Nonnull;
-import java.io.File;
-import java.nio.file.Files;
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
-import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MAX_DATA_MSG_SIZE_SUPPORTED;
-import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.DEFAULT_MAX_NUM_MSG_PER_BATCH;
-import static org.corfudb.util.MetricsUtils.isMetricsReportingSetUp;
 
 /**
  * Server Context:
@@ -142,9 +144,6 @@ public class ServerContext implements AutoCloseable {
     private final EventLoopGroup clientGroup;
 
     @Getter
-    private final EventLoopGroup bossGroup;
-
-    @Getter
     private final EventLoopGroup workerGroup;
 
     @Getter (AccessLevel.PACKAGE)
@@ -179,11 +178,9 @@ public class ServerContext implements AutoCloseable {
         if (providedEventLoops) {
             clientGroup = getServerConfig(EventLoopGroup.class, "client");
             workerGroup = getServerConfig(EventLoopGroup.class, "worker");
-            bossGroup = getServerConfig(EventLoopGroup.class, "boss");
         } else {
             clientGroup = getNewClientGroup();
             workerGroup = getNewWorkerGroup();
-            bossGroup = getNewBossGroup();
         }
 
         nodeLocator = NodeLocator
@@ -668,21 +665,6 @@ public class ServerContext implements AutoCloseable {
     }
 
     /**
-     * Get a new "boss" group, which services (accepts) incoming connections.
-     *
-     * @return A boss group.
-     */
-    private EventLoopGroup getNewBossGroup() {
-        final ThreadFactory threadFactory = new ThreadFactoryBuilder()
-                .setNameFormat(getThreadPrefix() + "accept-%d")
-                .build();
-        EventLoopGroup group = getChannelImplementation().getGenerator()
-                .generate(1, threadFactory);
-        log.info("getBossGroup: Type {}", group.getClass().getSimpleName());
-        return group;
-    }
-
-    /**
      * Get a new "worker" group, which services incoming requests.
      *
      * @return A worker group.
@@ -754,11 +736,6 @@ public class ServerContext implements AutoCloseable {
         // Shutdown the active event loops unless they were provided to us
         if (!getChannelImplementation().equals(ChannelImplementation.LOCAL)) {
             clientGroup.shutdownGracefully(
-                    params.getNettyShutdownQuitePeriod(),
-                    params.getNettyShutdownTimeout(),
-                    TimeUnit.MILLISECONDS
-            );
-            bossGroup.shutdownGracefully(
                     params.getNettyShutdownQuitePeriod(),
                     params.getNettyShutdownTimeout(),
                     TimeUnit.MILLISECONDS

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationServerChannelAdapter.java
@@ -77,8 +77,6 @@ public class NettyLogReplicationServerChannelAdapter extends IServerChannelAdapt
      * {@link EventLoopGroup}s. For implementations which listen on multiple ports,
      * {@link EventLoopGroup}s may be reused.
      *
-     * @param bossGroup           The "boss" {@link EventLoopGroup} which services incoming
-     *                            connections.
      * @param workerGroup         The "worker" {@link EventLoopGroup} which services incoming
      *                            requests.
      * @param bootstrapConfigurer A {@link BootstrapConfigurer} which will receive the
@@ -86,14 +84,13 @@ public class NettyLogReplicationServerChannelAdapter extends IServerChannelAdapt
      * @param port                The port will be created on.
      * @return A {@link ChannelFuture} which can be used to wait for the server to be shutdown.
      */
-    public ChannelFuture bindServer(@Nonnull EventLoopGroup bossGroup,
-                                    @Nonnull EventLoopGroup workerGroup,
+    public ChannelFuture bindServer(@Nonnull EventLoopGroup workerGroup,
                                     @Nonnull BootstrapConfigurer bootstrapConfigurer,
                                     String address,
                                     int port) {
         try {
             ServerBootstrap bootstrap = new ServerBootstrap();
-            bootstrap.group(bossGroup, workerGroup)
+            bootstrap.group(workerGroup)
                     .channel(getServerContext().getChannelImplementation().getServerChannelClass());
             bootstrapConfigurer.configure(bootstrap);
 
@@ -118,8 +115,7 @@ public class NettyLogReplicationServerChannelAdapter extends IServerChannelAdapt
      * Start the Corfu Replication Server by listening on the specified port.
      */
     private ChannelFuture startServer() {
-        bindFuture = bindServer(getServerContext().getBossGroup(),
-                getServerContext().getWorkerGroup(),
+        bindFuture = bindServer(getServerContext().getWorkerGroup(),
                 this::configureBootstrapOptions,
                 (String) getServerContext().getServerConfig().get("--address"),
                 port);

--- a/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ServerContextBuilder.java
@@ -97,7 +97,6 @@ public class ServerContextBuilder {
         // Provide the server with event loop groups
         if (implementation.equals("local")) {
             builder.put("client", TestThreadGroups.NETTY_CLIENT_GROUP.get());
-            builder.put("boss", TestThreadGroups.NETTY_BOSS_GROUP.get());
             builder.put("worker", TestThreadGroups.NETTY_CLIENT_GROUP.get());
         }
         ServerContext sc = new ServerContext(builder.build());

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -42,7 +42,8 @@ import org.junit.Test;
 /**
  * Created by maithem on 11/2/16.
  */
-public class StreamLogFilesTest extends AbstractCorfuTest {
+public class
+StreamLogFilesTest extends AbstractCorfuTest {
 
     private String getDirPath() {
         return PARAMETERS.TEST_TEMP_DIR;

--- a/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/NettyCommTest.java
@@ -4,6 +4,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelFuture;
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+import javax.annotation.Nonnull;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.AbstractCorfuTest;
@@ -18,505 +25,519 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import javax.annotation.Nonnull;
-import java.io.File;
-import java.io.IOException;
-import java.net.ServerSocket;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-/**
- * Created by mwei on 3/28/16.
- */
+/** Created by mwei on 3/28/16. */
 @Slf4j
 public class NettyCommTest extends AbstractCorfuTest {
 
-    @Rule
-    public TemporaryFolder reloadFolder = new TemporaryFolder();
+  @Rule public TemporaryFolder reloadFolder = new TemporaryFolder();
 
-
-    private Integer findRandomOpenPort() throws IOException {
-        try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
-        }
+  private Integer findRandomOpenPort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
     }
+  }
 
-    private BaseClient getBaseClient(IClientRouter router) {
-        return new BaseClient(router, 0L, UUID.fromString("00000000-0000-0000-0000-000000000000"));
-    }
+  private BaseClient getBaseClient(IClientRouter router) {
+    return new BaseClient(router, 0L, UUID.fromString("00000000-0000-0000-0000-000000000000"));
+  }
 
-    @Test
-    public void nettyServerClientPingable() throws Exception {
-        runWithBaseServer(
-                (port) -> new NettyServerData(ServerContextBuilder.defaultContext(port)),
-                (port) -> new NettyClientRouter("localhost", port),
-                (r, d) -> assertThat(getBaseClient(r).pingSync()).isTrue()
-        );
-    }
+  @Test
+  public void nettyServerClientPingable() throws Exception {
+    runWithBaseServer(
+        (port) -> new NettyServerData(ServerContextBuilder.defaultContext(port)),
+        (port) -> new NettyClientRouter("localhost", port),
+        (r, d) -> assertThat(getBaseClient(r).pingSync()).isTrue());
+  }
 
-    @Test
-    public void nettyServerClientPingableAfterFailure() throws Exception {
-        runWithBaseServer(
-                (port) -> new NettyServerData(ServerContextBuilder.defaultContext(port)),
-                (port) -> new NettyClientRouter("localhost", port),
-                (r, d) -> {
-                    assertThat(getBaseClient(r).pingSync()).isTrue();
-                    d.shutdownServer();
-                    d.bootstrapServer();
+  @Test
+  public void nettyServerClientPingableAfterFailure() throws Exception {
+    runWithBaseServer(
+        (port) -> new NettyServerData(ServerContextBuilder.defaultContext(port)),
+        (port) -> new NettyClientRouter("localhost", port),
+        (r, d) -> {
+          assertThat(getBaseClient(r).pingSync()).isTrue();
+          d.shutdownServer();
+          d.bootstrapServer();
 
-                    getBaseClient(r).pingSync();
-                }
-        );
-    }
+          getBaseClient(r).pingSync();
+        });
+  }
 
-    @Test
-    public void nettyTlsNoMutualAuth() throws Exception {
-        runWithBaseServer(
-                (port) -> new NettyServerData(
-                        new ServerContextBuilder()
-                                .setTlsEnabled(true)
-                                .setImplementation("auto")
-                                .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                                .setTlsProtocols("TLSv1.2")
-                                .setKeystore("src/test/resources/security/s1.jks")
-                                .setKeystorePasswordFile("src/test/resources/security/storepass")
-                                .setTruststore("src/test/resources/security/s1.jks")
-                                .setTruststorePasswordFile("src/test/resources/security/storepass")
-                                .setPort(port)
-                                .build()
-                ),
-                (port) -> new NettyClientRouter(
-                        NodeLocator.builder().host("localhost").port(port).build(),
-                        CorfuRuntimeParameters.builder()
-                                .tlsEnabled(true)
-                                .keyStore("src/test/resources/security/r1.jks")
-                                .ksPasswordFile("src/test/resources/security/storepass")
-                                .trustStore("src/test/resources/security/trust1.jks")
-                                .tsPasswordFile("src/test/resources/security/storepass")
-                                .build()
-                ),
-                checkPing()
-        );
-    }
-
-    @Test
-    public void nettyTlsMutualAuth() throws Exception {
-        runWithBaseServer(
-                (port) -> new NettyServerData(new ServerContextBuilder()
-                        .setImplementation("auto")
-                        .setTlsEnabled(true)
-                        .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                        .setTlsProtocols("TLSv1.2")
-                        .setKeystore("src/test/resources/security/s1.jks")
-                        .setKeystorePasswordFile("src/test/resources/security/storepass")
-                        .setTruststore("src/test/resources/security/trust1.jks")
-                        .setTruststorePasswordFile("src/test/resources/security/storepass")
-                        .setTlsMutualAuthEnabled(true)
-                        .setPort(port)
-                        .build()),
-                (port) -> new NettyClientRouter(
-                        NodeLocator.builder().host("localhost").port(port).build(),
-                        CorfuRuntimeParameters.builder()
-                                .tlsEnabled(true)
-                                .keyStore("src/test/resources/security/r1.jks")
-                                .ksPasswordFile("src/test/resources/security/storepass")
-                                .trustStore("src/test/resources/security/trust1.jks")
-                                .tsPasswordFile("src/test/resources/security/storepass")
-                                .build()
-                ),
-                checkPing()
-        );
-    }
-
-    private NettyCommFunction checkPing() {
-        return (r, d) -> {
-            for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
-                boolean ping = getBaseClient(r).pingSync();
-                if (ping) {
-                    return;
-                }
-                TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
-            }
-            fail("Broken connection");
-        };
-    }
-
-    @Test
-    public void nettyTlsUnknownServer() throws Exception {
-        runWithBaseServer(
-                (port) -> new NettyServerData(new ServerContextBuilder()
-                        .setImplementation("auto")
-                        .setTlsEnabled(true)
-                        .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                        .setTlsProtocols("TLSv1.2")
-                        .setKeystore("src/test/resources/security/s3.jks")
-                        .setKeystorePasswordFile("src/test/resources/security/storepass")
-                        .setTruststore("src/test/resources/security/trust1.jks")
-                        .setTruststorePasswordFile("src/test/resources/security/storepass")
-                        .setSaslPlainTextAuth(false)
-                        .setPort(port)
-                        .build()),
-                (port) -> new NettyClientRouter(
-                        NodeLocator.builder().host("localhost").port(port).build(),
-                        CorfuRuntimeParameters.builder()
-                                .tlsEnabled(true)
-                                .keyStore("src/test/resources/security/r1.jks")
-                                .ksPasswordFile("src/test/resources/security/storepass")
-                                .trustStore("src/test/resources/security/trust2.jks")
-                                .tsPasswordFile("src/test/resources/security/storepass")
-                                .build()),
-                (r, d) -> assertThat(getBaseClient(r).pingSync()).isFalse()
-        );
-    }
-
-    @Test
-    public void nettyTlsUnknownClient() throws Exception {
-        runWithBaseServer(
-                (port) -> new NettyServerData(new ServerContextBuilder()
-                        .setImplementation("auto")
-                        .setTlsEnabled(true)
-                        .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                        .setTlsProtocols("TLSv1.2")
-                        .setKeystore("src/test/resources/security/s1.jks")
-                        .setKeystorePasswordFile("src/test/resources/security/storepass")
-                        .setTruststore("src/test/resources/security/trust2.jks")
-                        .setTruststorePasswordFile("src/test/resources/security/storepass")
-                        .setTlsMutualAuthEnabled(true)
-                        .setPort(port)
-                        .build()),
-                (port) -> new NettyClientRouter(
-                        NodeLocator.builder().host("localhost").port(port).build(),
-                        CorfuRuntimeParameters.builder()
-                                .tlsEnabled(true)
-                                .keyStore("src/test/resources/security/r2.jks")
-                                .ksPasswordFile("src/test/resources/security/storepass")
-                                .trustStore("src/test/resources/security/trust1.jks")
-                                .tsPasswordFile("src/test/resources/security/storepass")
-                                .build()),
-                (r, d) -> assertThat(getBaseClient(r).pingSync()).isFalse()
-        );
-    }
-
-    @Test
-    public void nettyTlsUnknownClientNoMutualAuth() throws Exception {
-        runWithBaseServer(
-                (port) -> new NettyServerData(new ServerContextBuilder()
-                        .setImplementation("auto")
-                        .setTlsEnabled(true)
-                        .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                        .setTlsProtocols("TLSv1.2")
-                        .setKeystore("src/test/resources/security/s1.jks")
-                        .setKeystorePasswordFile("src/test/resources/security/storepass")
-                        .setTruststore("src/test/resources/security/trust2.jks")
-                        .setTruststorePasswordFile("src/test/resources/security/storepass")
-                        .setPort(port)
-                        .build()),
-                (port) -> new NettyClientRouter(
-                        NodeLocator.builder().host("localhost").port(port).build(),
-                        CorfuRuntimeParameters.builder()
-                                .tlsEnabled(true)
-                                .keyStore("src/test/resources/security/r2.jks")
-                                .ksPasswordFile("src/test/resources/security/storepass")
-                                .trustStore("src/test/resources/security/trust1.jks")
-                                .tsPasswordFile("src/test/resources/security/storepass")
-                                .build()),
-                (r, d) -> assertThat(getBaseClient(r).pingSync()).isTrue()
-        );
-    }
-
-    @Test
-    public void nettySasl() throws Exception {
-        runWithBaseServer(
-                (port) -> {
-                    System.setProperty("java.security.auth.login.config",
-                            "src/test/resources/security/corfudb_jaas.config");
-                    NettyServerData d = new NettyServerData(new ServerContextBuilder()
-                            .setImplementation("auto")
-                            .setTlsEnabled(true)
-                            .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                            .setTlsProtocols("TLSv1.2")
-                            .setKeystore("src/test/resources/security/s1.jks")
-                            .setKeystorePasswordFile("src/test/resources/security/storepass")
-                            .setTruststore("src/test/resources/security/trust1.jks")
-                            .setTruststorePasswordFile("src/test/resources/security/storepass")
-                            .setSaslPlainTextAuth(true)
-                            .setPort(port)
-                            .build());
-                    return d;
-                },
-                (port) -> new NettyClientRouter(
-                        NodeLocator.builder().host("localhost").port(port).build(),
-                        CorfuRuntimeParameters.builder()
-                                .tlsEnabled(true)
-                                .keyStore("src/test/resources/security/r1.jks")
-                                .ksPasswordFile("src/test/resources/security/storepass")
-                                .trustStore("src/test/resources/security/trust1.jks")
-                                .tsPasswordFile("src/test/resources/security/storepass")
-                                .saslPlainTextEnabled(true)
-                                .usernameFile("src/test/resources/security/username1")
-                                .passwordFile("src/test/resources/security/userpass1")
-                                .build()),
-                (r, d) -> assertThat(getBaseClient(r).pingSync()).isTrue()
-        );
-    }
-
-    @Test
-    public void nettyServerClientHandshakeDefaultId() throws Exception {
-        runWithBaseServer(
-                (port) -> new NettyServerData(ServerContextBuilder.defaultContext(port)),
-                (port) -> {
-                    NodeLocator nl = NodeLocator.builder()
-                            .host("localhost")
-                            .port(port)
-                            .nodeId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
-                            .build();
-                    return new NettyClientRouter(nl, CorfuRuntimeParameters.builder().build());
-                },
-                (r, d) -> assertThat(getBaseClient(r).pingSync()).isTrue());
-    }
-
-    private UUID nodeId;
-
-    @Test
-    public void nettyServerClientHandshakeMatchIds() throws Exception {
-        runWithBaseServer(
-                (port) -> {
-                    ServerContext sc = ServerContextBuilder
-                            .defaultContext(port);
-                    nodeId = sc.getNodeId();
-                    return new NettyServerData(sc);
-                },
-                (port) -> {
-                    NodeLocator nl = NodeLocator.builder()
-                            .host("localhost")
-                            .port(port)
-                            .nodeId(nodeId)
-                            .build();
-                    return new NettyClientRouter(nl, CorfuRuntimeParameters.builder().build());
-                },
-                (r, d) -> assertThat(getBaseClient(r).pingSync()).isTrue());
-    }
-
-    @Test
-    public void nettyServerClientHandshakeMismatchId() throws Exception {
-        runWithBaseServer(
-                (port) -> new NettyServerData(ServerContextBuilder.defaultContext(port)),
-                (port) -> {
-                    NodeLocator nl = NodeLocator.builder()
-                            .host("localhost")
-                            .port(port)
-                            .nodeId(UUID.nameUUIDFromBytes("test".getBytes()))
-                            .build();
-                    return new NettyClientRouter(nl, CorfuRuntimeParameters.builder().build());
-                },
-                (r, d) -> assertThat(getBaseClient(r).pingSync()).isFalse()
-        );
-    }
-
-    @Test
-    public void nettySaslWrongPassword() throws Exception {
-        runWithBaseServer(
-                (port) -> {
-                    System.setProperty("java.security.auth.login.config",
-                            "src/test/resources/security/corfudb_jaas.config");
-                    NettyServerData d = new NettyServerData(new ServerContextBuilder()
-                            .setImplementation("auto")
-                            .setTlsEnabled(true)
-                            .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                            .setTlsProtocols("TLSv1.2")
-                            .setKeystore("src/test/resources/security/s1.jks")
-                            .setKeystorePasswordFile("src/test/resources/security/storepass")
-                            .setTruststore("src/test/resources/security/trust1.jks")
-                            .setTruststorePasswordFile("src/test/resources/security/storepass")
-                            .setSaslPlainTextAuth(true)
-                            .setPort(port)
-                            .build());
-                    return d;
-                },
-                (port) -> new NettyClientRouter(
-                        NodeLocator.builder().host("localhost").port(port).build(),
-                        CorfuRuntimeParameters.builder()
-                                .tlsEnabled(true)
-                                .keyStore("src/test/resources/security/r1.jks")
-                                .ksPasswordFile("src/test/resources/security/storepass")
-                                .trustStore("src/test/resources/security/trust1.jks")
-                                .tsPasswordFile("src/test/resources/security/storepass")
-                                .saslPlainTextEnabled(true)
-                                .usernameFile("src/test/resources/security/username1")
-                                .passwordFile("src/test/resources/security/userpass2")
-                                .build()),
-                (r, d) -> assertThat(getBaseClient(r).pingSync()).isFalse()
-        );
-    }
-
-    @Test
-    public void testTlsUpdateServerTrust() throws Exception {
-        reloadedTrustManagerTestHelper(false);
-    }
-
-    @Test
-    public void testTlsUpdateClientTrust() throws Exception {
-        reloadedTrustManagerTestHelper(true);
-    }
-
-    /**
-     * Create a trust store that will fail the SSL handshake, check if fails,
-     * then replace it, and check if pass.
-     *
-     * @param replaceClientTrust
-     * @throws Exception
-     */
-    private void reloadedTrustManagerTestHelper(boolean replaceClientTrust) throws Exception {
-        int port = findRandomOpenPort();
-
-        File clientTrustNoServer = new File("src/test/resources/security/reload/client_trust_no_server.jks");
-        File serverTrustNoClient = new File("src/test/resources/security/reload/server_trust_no_client.jks");
-        File clientTrustWithServer = new File("src/test/resources/security/reload/client_trust_with_server.jks");
-        File serverTrustWithClient = new File("src/test/resources/security/reload/server_trust_with_client.jks");
-        File serverTrustFile = reloadFolder.newFile("temp_server.jks");
-        File clientTrustFile = reloadFolder.newFile("temp_client.jks");
-
-        if (replaceClientTrust) {
-            Files.copy(clientTrustNoServer.toPath(), clientTrustFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            Files.copy(serverTrustWithClient.toPath(), serverTrustFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } else {
-            Files.copy(clientTrustWithServer.toPath(), clientTrustFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            Files.copy(serverTrustNoClient.toPath(), serverTrustFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        }
-
-
-        NettyServerData serverData = new NettyServerData(
+  @Test
+  public void nettyTlsNoMutualAuth() throws Exception {
+    runWithBaseServer(
+        (port) ->
+            new NettyServerData(
                 new ServerContextBuilder()
-                        .setImplementation("auto")
-                        .setTlsEnabled(true)
-                        .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
-                        .setTlsProtocols("TLSv1.2")
-                        .setKeystore("src/test/resources/security/reload/server_key.jks")
-                        .setKeystorePasswordFile("src/test/resources/security/reload/password")
-                        .setTruststore(serverTrustFile.getAbsolutePath())
-                        .setTruststorePasswordFile("src/test/resources/security/reload/password")
-                        .setTlsMutualAuthEnabled(true)
-                        .setPort(port)
-                        .build()
-        );
-        serverData.bootstrapServer();
-
-
-        NettyClientRouter clientRouter = new NettyClientRouter(
+                    .setTlsEnabled(true)
+                    .setImplementation("auto")
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s1.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/s1.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setPort(port)
+                    .build()),
+        (port) ->
+            new NettyClientRouter(
                 NodeLocator.builder().host("localhost").port(port).build(),
                 CorfuRuntimeParameters.builder()
-                        .tlsEnabled(true)
-                        .keyStore("src/test/resources/security/reload/client_key.jks")
-                        .ksPasswordFile("src/test/resources/security/reload/password")
-                        .trustStore(clientTrustFile.getAbsolutePath())
-                        .tsPasswordFile("src/test/resources/security/reload/password")
-                        .build());
+                    .tlsEnabled(true)
+                    .keyStore("src/test/resources/security/r1.jks")
+                    .ksPasswordFile("src/test/resources/security/storepass")
+                    .trustStore("src/test/resources/security/trust1.jks")
+                    .tsPasswordFile("src/test/resources/security/storepass")
+                    .build()),
+        checkPing());
+  }
 
-        assertThat(getBaseClient(clientRouter).pingSync()).isFalse();
-        clientRouter.stop();
-
-
-        if (replaceClientTrust) {
-            Files.copy(clientTrustWithServer.toPath(), clientTrustFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } else {
-            Files.copy(serverTrustWithClient.toPath(), serverTrustFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        }
-        clientRouter = new NettyClientRouter(
+  @Test
+  public void nettyTlsMutualAuth() throws Exception {
+    runWithBaseServer(
+        (port) ->
+            new NettyServerData(
+                new ServerContextBuilder()
+                    .setImplementation("auto")
+                    .setTlsEnabled(true)
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s1.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/trust1.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setTlsMutualAuthEnabled(true)
+                    .setPort(port)
+                    .build()),
+        (port) ->
+            new NettyClientRouter(
                 NodeLocator.builder().host("localhost").port(port).build(),
                 CorfuRuntimeParameters.builder()
-                        .tlsEnabled(true)
-                        .keyStore("src/test/resources/security/reload/client_key.jks")
-                        .ksPasswordFile("src/test/resources/security/reload/password")
-                        .trustStore(clientTrustFile.getAbsolutePath())
-                        .tsPasswordFile("src/test/resources/security/reload/password")
-                        .build());
-        clientRouter.getConnectionFuture().join();
-        assertThat(getBaseClient(clientRouter).pingSync()).isTrue();
-        clientRouter.stop();
+                    .tlsEnabled(true)
+                    .keyStore("src/test/resources/security/r1.jks")
+                    .ksPasswordFile("src/test/resources/security/storepass")
+                    .trustStore("src/test/resources/security/trust1.jks")
+                    .tsPasswordFile("src/test/resources/security/storepass")
+                    .build()),
+        checkPing());
+  }
 
-        serverData.shutdownServer();
-    }
-
-    private void runWithBaseServer(NettyServerDataConstructor nsdc,
-                                   NettyClientRouterConstructor ncrc,
-                                   NettyCommFunction actionFn) throws Exception {
-        int port = findRandomOpenPort();
-
-        NettyServerData d = nsdc.createNettyServerData(port);
-        NettyClientRouter ncr = null;
-        try {
-            d.bootstrapServer();
-            ncr = ncrc.createNettyClientRouter(port);
-            ncr.addClient(new BaseHandler());
-            actionFn.runTest(ncr, d);
-        } catch (Exception ex) {
-            log.error("Exception ", ex);
-            throw ex;
-        } finally {
-            try {
-                if (ncr != null) {
-                    ncr.stop();
-                }
-            } catch (Exception ex) {
-                log.warn("Error shutting down client...", ex);
-            }
-            d.shutdownServer();
+  private NettyCommFunction checkPing() {
+    return (r, d) -> {
+      for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+        boolean ping = getBaseClient(r).pingSync();
+        if (ping) {
+          return;
         }
+        TimeUnit.MILLISECONDS.sleep(PARAMETERS.TIMEOUT_VERY_SHORT.toMillis());
+      }
+      fail("Broken connection");
+    };
+  }
 
+  @Test
+  public void nettyTlsUnknownServer() throws Exception {
+    runWithBaseServer(
+        (port) ->
+            new NettyServerData(
+                new ServerContextBuilder()
+                    .setImplementation("auto")
+                    .setTlsEnabled(true)
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s3.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/trust1.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setSaslPlainTextAuth(false)
+                    .setPort(port)
+                    .build()),
+        (port) ->
+            new NettyClientRouter(
+                NodeLocator.builder().host("localhost").port(port).build(),
+                CorfuRuntimeParameters.builder()
+                    .tlsEnabled(true)
+                    .keyStore("src/test/resources/security/r1.jks")
+                    .ksPasswordFile("src/test/resources/security/storepass")
+                    .trustStore("src/test/resources/security/trust2.jks")
+                    .tsPasswordFile("src/test/resources/security/storepass")
+                    .build()),
+        (r, d) -> assertThat(getBaseClient(r).pingSync()).isFalse());
+  }
+
+  @Test
+  public void nettyTlsUnknownClient() throws Exception {
+    runWithBaseServer(
+        (port) ->
+            new NettyServerData(
+                new ServerContextBuilder()
+                    .setImplementation("auto")
+                    .setTlsEnabled(true)
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s1.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/trust2.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setTlsMutualAuthEnabled(true)
+                    .setPort(port)
+                    .build()),
+        (port) ->
+            new NettyClientRouter(
+                NodeLocator.builder().host("localhost").port(port).build(),
+                CorfuRuntimeParameters.builder()
+                    .tlsEnabled(true)
+                    .keyStore("src/test/resources/security/r2.jks")
+                    .ksPasswordFile("src/test/resources/security/storepass")
+                    .trustStore("src/test/resources/security/trust1.jks")
+                    .tsPasswordFile("src/test/resources/security/storepass")
+                    .build()),
+        (r, d) -> assertThat(getBaseClient(r).pingSync()).isFalse());
+  }
+
+  @Test
+  public void nettyTlsUnknownClientNoMutualAuth() throws Exception {
+    runWithBaseServer(
+        (port) ->
+            new NettyServerData(
+                new ServerContextBuilder()
+                    .setImplementation("auto")
+                    .setTlsEnabled(true)
+                    .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                    .setTlsProtocols("TLSv1.2")
+                    .setKeystore("src/test/resources/security/s1.jks")
+                    .setKeystorePasswordFile("src/test/resources/security/storepass")
+                    .setTruststore("src/test/resources/security/trust2.jks")
+                    .setTruststorePasswordFile("src/test/resources/security/storepass")
+                    .setPort(port)
+                    .build()),
+        (port) ->
+            new NettyClientRouter(
+                NodeLocator.builder().host("localhost").port(port).build(),
+                CorfuRuntimeParameters.builder()
+                    .tlsEnabled(true)
+                    .keyStore("src/test/resources/security/r2.jks")
+                    .ksPasswordFile("src/test/resources/security/storepass")
+                    .trustStore("src/test/resources/security/trust1.jks")
+                    .tsPasswordFile("src/test/resources/security/storepass")
+                    .build()),
+        (r, d) -> assertThat(getBaseClient(r).pingSync()).isTrue());
+  }
+
+  @Test
+  public void nettySasl() throws Exception {
+    runWithBaseServer(
+        (port) -> {
+          System.setProperty(
+              "java.security.auth.login.config", "src/test/resources/security/corfudb_jaas.config");
+          NettyServerData d =
+              new NettyServerData(
+                  new ServerContextBuilder()
+                      .setImplementation("auto")
+                      .setTlsEnabled(true)
+                      .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                      .setTlsProtocols("TLSv1.2")
+                      .setKeystore("src/test/resources/security/s1.jks")
+                      .setKeystorePasswordFile("src/test/resources/security/storepass")
+                      .setTruststore("src/test/resources/security/trust1.jks")
+                      .setTruststorePasswordFile("src/test/resources/security/storepass")
+                      .setSaslPlainTextAuth(true)
+                      .setPort(port)
+                      .build());
+          return d;
+        },
+        (port) ->
+            new NettyClientRouter(
+                NodeLocator.builder().host("localhost").port(port).build(),
+                CorfuRuntimeParameters.builder()
+                    .tlsEnabled(true)
+                    .keyStore("src/test/resources/security/r1.jks")
+                    .ksPasswordFile("src/test/resources/security/storepass")
+                    .trustStore("src/test/resources/security/trust1.jks")
+                    .tsPasswordFile("src/test/resources/security/storepass")
+                    .saslPlainTextEnabled(true)
+                    .usernameFile("src/test/resources/security/username1")
+                    .passwordFile("src/test/resources/security/userpass1")
+                    .build()),
+        (r, d) -> assertThat(getBaseClient(r).pingSync()).isTrue());
+  }
+
+  @Test
+  public void nettyServerClientHandshakeDefaultId() throws Exception {
+    runWithBaseServer(
+        (port) -> new NettyServerData(ServerContextBuilder.defaultContext(port)),
+        (port) -> {
+          NodeLocator nl =
+              NodeLocator.builder()
+                  .host("localhost")
+                  .port(port)
+                  .nodeId(UUID.fromString("00000000-0000-0000-0000-000000000000"))
+                  .build();
+          return new NettyClientRouter(nl, CorfuRuntimeParameters.builder().build());
+        },
+        (r, d) -> assertThat(getBaseClient(r).pingSync()).isTrue());
+  }
+
+  private UUID nodeId;
+
+  @Test
+  public void nettyServerClientHandshakeMatchIds() throws Exception {
+    runWithBaseServer(
+        (port) -> {
+          ServerContext sc = ServerContextBuilder.defaultContext(port);
+          nodeId = sc.getNodeId();
+          return new NettyServerData(sc);
+        },
+        (port) -> {
+          NodeLocator nl =
+              NodeLocator.builder().host("localhost").port(port).nodeId(nodeId).build();
+          return new NettyClientRouter(nl, CorfuRuntimeParameters.builder().build());
+        },
+        (r, d) -> assertThat(getBaseClient(r).pingSync()).isTrue());
+  }
+
+  @Test
+  public void nettyServerClientHandshakeMismatchId() throws Exception {
+    runWithBaseServer(
+        (port) -> new NettyServerData(ServerContextBuilder.defaultContext(port)),
+        (port) -> {
+          NodeLocator nl =
+              NodeLocator.builder()
+                  .host("localhost")
+                  .port(port)
+                  .nodeId(UUID.nameUUIDFromBytes("test".getBytes()))
+                  .build();
+          return new NettyClientRouter(nl, CorfuRuntimeParameters.builder().build());
+        },
+        (r, d) -> assertThat(getBaseClient(r).pingSync()).isFalse());
+  }
+
+  @Test
+  public void nettySaslWrongPassword() throws Exception {
+    runWithBaseServer(
+        (port) -> {
+          System.setProperty(
+              "java.security.auth.login.config", "src/test/resources/security/corfudb_jaas.config");
+          NettyServerData d =
+              new NettyServerData(
+                  new ServerContextBuilder()
+                      .setImplementation("auto")
+                      .setTlsEnabled(true)
+                      .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                      .setTlsProtocols("TLSv1.2")
+                      .setKeystore("src/test/resources/security/s1.jks")
+                      .setKeystorePasswordFile("src/test/resources/security/storepass")
+                      .setTruststore("src/test/resources/security/trust1.jks")
+                      .setTruststorePasswordFile("src/test/resources/security/storepass")
+                      .setSaslPlainTextAuth(true)
+                      .setPort(port)
+                      .build());
+          return d;
+        },
+        (port) ->
+            new NettyClientRouter(
+                NodeLocator.builder().host("localhost").port(port).build(),
+                CorfuRuntimeParameters.builder()
+                    .tlsEnabled(true)
+                    .keyStore("src/test/resources/security/r1.jks")
+                    .ksPasswordFile("src/test/resources/security/storepass")
+                    .trustStore("src/test/resources/security/trust1.jks")
+                    .tsPasswordFile("src/test/resources/security/storepass")
+                    .saslPlainTextEnabled(true)
+                    .usernameFile("src/test/resources/security/username1")
+                    .passwordFile("src/test/resources/security/userpass2")
+                    .build()),
+        (r, d) -> assertThat(getBaseClient(r).pingSync()).isFalse());
+  }
+
+  @Test
+  public void testTlsUpdateServerTrust() throws Exception {
+    reloadedTrustManagerTestHelper(false);
+  }
+
+  @Test
+  public void testTlsUpdateClientTrust() throws Exception {
+    reloadedTrustManagerTestHelper(true);
+  }
+
+  /**
+   * Create a trust store that will fail the SSL handshake, check if fails, then replace it, and
+   * check if pass.
+   *
+   * @param replaceClientTrust
+   * @throws Exception
+   */
+  private void reloadedTrustManagerTestHelper(boolean replaceClientTrust) throws Exception {
+    int port = findRandomOpenPort();
+
+    File clientTrustNoServer =
+        new File("src/test/resources/security/reload/client_trust_no_server.jks");
+    File serverTrustNoClient =
+        new File("src/test/resources/security/reload/server_trust_no_client.jks");
+    File clientTrustWithServer =
+        new File("src/test/resources/security/reload/client_trust_with_server.jks");
+    File serverTrustWithClient =
+        new File("src/test/resources/security/reload/server_trust_with_client.jks");
+    File serverTrustFile = reloadFolder.newFile("temp_server.jks");
+    File clientTrustFile = reloadFolder.newFile("temp_client.jks");
+
+    if (replaceClientTrust) {
+      Files.copy(
+          clientTrustNoServer.toPath(),
+          clientTrustFile.toPath(),
+          StandardCopyOption.REPLACE_EXISTING);
+      Files.copy(
+          serverTrustWithClient.toPath(),
+          serverTrustFile.toPath(),
+          StandardCopyOption.REPLACE_EXISTING);
+    } else {
+      Files.copy(
+          clientTrustWithServer.toPath(),
+          clientTrustFile.toPath(),
+          StandardCopyOption.REPLACE_EXISTING);
+      Files.copy(
+          serverTrustNoClient.toPath(),
+          serverTrustFile.toPath(),
+          StandardCopyOption.REPLACE_EXISTING);
     }
 
-    @FunctionalInterface
-    public interface NettyServerDataConstructor {
-        NettyServerData createNettyServerData(int port) throws Exception;
+    NettyServerData serverData =
+        new NettyServerData(
+            new ServerContextBuilder()
+                .setImplementation("auto")
+                .setTlsEnabled(true)
+                .setTlsCiphers("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256")
+                .setTlsProtocols("TLSv1.2")
+                .setKeystore("src/test/resources/security/reload/server_key.jks")
+                .setKeystorePasswordFile("src/test/resources/security/reload/password")
+                .setTruststore(serverTrustFile.getAbsolutePath())
+                .setTruststorePasswordFile("src/test/resources/security/reload/password")
+                .setTlsMutualAuthEnabled(true)
+                .setPort(port)
+                .build());
+    serverData.bootstrapServer();
+
+    NettyClientRouter clientRouter =
+        new NettyClientRouter(
+            NodeLocator.builder().host("localhost").port(port).build(),
+            CorfuRuntimeParameters.builder()
+                .tlsEnabled(true)
+                .keyStore("src/test/resources/security/reload/client_key.jks")
+                .ksPasswordFile("src/test/resources/security/reload/password")
+                .trustStore(clientTrustFile.getAbsolutePath())
+                .tsPasswordFile("src/test/resources/security/reload/password")
+                .build());
+
+    assertThat(getBaseClient(clientRouter).pingSync()).isFalse();
+    clientRouter.stop();
+
+    if (replaceClientTrust) {
+      Files.copy(
+          clientTrustWithServer.toPath(),
+          clientTrustFile.toPath(),
+          StandardCopyOption.REPLACE_EXISTING);
+    } else {
+      Files.copy(
+          serverTrustWithClient.toPath(),
+          serverTrustFile.toPath(),
+          StandardCopyOption.REPLACE_EXISTING);
     }
+    clientRouter =
+        new NettyClientRouter(
+            NodeLocator.builder().host("localhost").port(port).build(),
+            CorfuRuntimeParameters.builder()
+                .tlsEnabled(true)
+                .keyStore("src/test/resources/security/reload/client_key.jks")
+                .ksPasswordFile("src/test/resources/security/reload/password")
+                .trustStore(clientTrustFile.getAbsolutePath())
+                .tsPasswordFile("src/test/resources/security/reload/password")
+                .build());
+    clientRouter.getConnectionFuture().join();
+    assertThat(getBaseClient(clientRouter).pingSync()).isTrue();
+    clientRouter.stop();
 
-    @FunctionalInterface
-    public interface NettyClientRouterConstructor {
-        NettyClientRouter createNettyClientRouter(int port) throws Exception;
-    }
+    serverData.shutdownServer();
+  }
 
-    @FunctionalInterface
-    public interface NettyCommFunction {
-        void runTest(NettyClientRouter r, NettyServerData d) throws Exception;
-    }
+  private void runWithBaseServer(
+      NettyServerDataConstructor nsdc,
+      NettyClientRouterConstructor ncrc,
+      NettyCommFunction actionFn)
+      throws Exception {
+    int port = findRandomOpenPort();
 
-    @Data
-    public class NettyServerData {
-        ServerBootstrap b;
-        volatile ChannelFuture f;
-
-        final ServerContext serverContext;
-
-        private final String address = "localhost";
-
-        NettyServerData(@Nonnull ServerContext context) {
-            this.serverContext = context;
+    NettyServerData d = nsdc.createNettyServerData(port);
+    NettyClientRouter ncr = null;
+    try {
+      d.bootstrapServer();
+      ncr = ncrc.createNettyClientRouter(port);
+      ncr.addClient(new BaseHandler());
+      actionFn.runTest(ncr, d);
+    } catch (Exception ex) {
+      log.error("Exception ", ex);
+      throw ex;
+    } finally {
+      try {
+        if (ncr != null) {
+          ncr.stop();
         }
-
-        void bootstrapServer() {
-            BaseServer baseServer = new BaseServer(serverContext);
-            NettyServerRouter nsr = new NettyServerRouter(ImmutableList.of(baseServer),
-                    serverContext);
-            CorfuServerNode corfuServerNode = new CorfuServerNode(serverContext,
-                    ImmutableMap.of(BaseServer.class, baseServer));
-            f = corfuServerNode.bindServer(serverContext.getBossGroup(),
-                    serverContext.getWorkerGroup(),
-                    corfuServerNode::configureBootstrapOptions,
-                    serverContext,
-                    nsr,
-                    address,
-                    Integer.parseInt((String) serverContext
-                            .getServerConfig().get("<port>")));
-        }
-
-        void shutdownServer() {
-            f.channel().close().awaitUninterruptibly();
-        }
-
+      } catch (Exception ex) {
+        log.warn("Error shutting down client...", ex);
+      }
+      d.shutdownServer();
     }
+  }
+
+  @FunctionalInterface
+  public interface NettyServerDataConstructor {
+    NettyServerData createNettyServerData(int port) throws Exception;
+  }
+
+  @FunctionalInterface
+  public interface NettyClientRouterConstructor {
+    NettyClientRouter createNettyClientRouter(int port) throws Exception;
+  }
+
+  @FunctionalInterface
+  public interface NettyCommFunction {
+    void runTest(NettyClientRouter r, NettyServerData d) throws Exception;
+  }
+
+  @Data
+  public class NettyServerData {
+    ServerBootstrap b;
+    volatile ChannelFuture f;
+
+    final ServerContext serverContext;
+
+    private final String address = "localhost";
+
+    NettyServerData(@Nonnull ServerContext context) {
+      this.serverContext = context;
+    }
+
+    void bootstrapServer() {
+      BaseServer baseServer = new BaseServer(serverContext);
+      NettyServerRouter nsr = new NettyServerRouter(ImmutableList.of(baseServer), serverContext);
+      CorfuServerNode corfuServerNode =
+          new CorfuServerNode(serverContext, ImmutableMap.of(BaseServer.class, baseServer));
+      f =
+          corfuServerNode.bindServer(
+              serverContext.getWorkerGroup(),
+              corfuServerNode::configureBootstrapOptions,
+              serverContext,
+              nsr,
+              address,
+              Integer.parseInt((String) serverContext.getServerConfig().get("<port>")));
+    }
+
+    void shutdownServer() {
+      f.channel().close().awaitUninterruptibly();
+    }
+  }
 }

--- a/test/src/test/java/org/corfudb/test/concurrent/TestThreadGroups.java
+++ b/test/src/test/java/org/corfudb/test/concurrent/TestThreadGroups.java
@@ -12,12 +12,6 @@ public class TestThreadGroups {
 
     private static final int QUIET_PERIOD = 50;
     private static final int TIMEOUT = 100;
-    /**
-     * Netty "boss" thread group which is reused in tests.
-     */
-    public static SingletonResource<EventLoopGroup> NETTY_BOSS_GROUP =
-        SingletonResource.withInitial(() ->
-            getEventLoopGroup(1, "boss-%d"));
 
     /**
      * Netty "worker" thread group which is reused in tests.
@@ -38,7 +32,6 @@ public class TestThreadGroups {
      * Gracefully shutdown the event loop groups.
      */
     public static void shutdownThreadGroups() {
-        NETTY_BOSS_GROUP.cleanup(group -> group.shutdownGracefully(QUIET_PERIOD, TIMEOUT, TimeUnit.MILLISECONDS));
         NETTY_WORKER_GROUP.cleanup(group -> group.shutdownGracefully(QUIET_PERIOD, TIMEOUT, TimeUnit.MILLISECONDS));
         NETTY_CLIENT_GROUP.cleanup(group -> group.shutdownGracefully(QUIET_PERIOD, TIMEOUT, TimeUnit.MILLISECONDS));
     }


### PR DESCRIPTION
## Overview
This patch makes both boss and worker threads use the same
EventLoopGroup. Since CorfuDB clients tend to have long lived
connections and the rate at which new connections are made is
relatively low reusing the same thread pool for both tasks
shouldn't impact performance.

Why should this be merged: Removes unnecessary code.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
