### PR TITLE
Create log replication folder when LR server starts

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
@@ -237,6 +237,7 @@ public class CorfuInterClusterReplicationServer implements Runnable {
 
         log.info("Started with arguments: {}", opts);
 
+        createReplicationDirectory(opts);
         ServerContext serverContext = getServerContext(opts);
 
         // Register shutdown handler
@@ -331,6 +332,22 @@ public class CorfuInterClusterReplicationServer implements Runnable {
         final Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         final Level level = Level.toLevel(((String) opts.get("--log-level")).toUpperCase());
         root.setLevel(level);
+    }
+
+    /**
+     * Create the replication directory if it does not exist.
+     *
+     * @param opts Server options map.
+     */
+    static void createReplicationDirectory(Map<String, Object> opts) {
+        if ((Boolean) opts.get("--memory")) {
+            return;
+        }
+
+        File replicationDir = new File((String) opts.get("--log-path"));
+        if (!replicationDir.exists() && replicationDir.mkdirs()) {
+            log.info("Created new log replication directory at {}.", replicationDir);
+        }
     }
 
     /**

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServerTest.java
@@ -1,0 +1,31 @@
+package org.corfudb.infrastructure.logreplication.infrastructure;
+
+import org.junit.Test;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CorfuInterClusterReplicationServerTest {
+    private final static String REPLICATION_DIR = "/tmp/replication";
+
+    @Test
+    public void testCreateReplicationDirectory() {
+        Map<String, Object> opts = new HashMap<>();
+
+        opts.put("--memory", true);
+        opts.put("--log-path", REPLICATION_DIR);
+        CorfuInterClusterReplicationServer.createReplicationDirectory(opts);
+        File file = new File((String) opts.get("--log-path"));
+        assertThat(file).doesNotExist();
+
+        opts.put("--memory", false);
+        CorfuInterClusterReplicationServer.createReplicationDirectory(opts);
+        file = new File((String) opts.get("--log-path"));
+        assertThat(file).isDirectory();
+
+        assertThat(file.delete()).isTrue();
+    }
+}


### PR DESCRIPTION
## Overview

Description:

Log Replication Server is using a subfolder to store its node id.

Corfu Server will clean up the whole folder when it gets base server reset, so LR needs to create its folder when it starts.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
