### PR TITLE
Use A PRNG for ID Generation

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationEvent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationEvent.java
@@ -4,6 +4,7 @@ import lombok.Data;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationEventMetadata;
 
 import java.util.UUID;
+import org.corfudb.util.Utils;
 
 /**
  * This class represents a Log Replication Event.
@@ -83,7 +84,7 @@ public class LogReplicationEvent {
 \     */
     public LogReplicationEvent(LogReplicationEventType type, LogReplicationEventMetadata metadata) {
         this.type = type;
-        this.eventId = UUID.randomUUID();
+        this.eventId = Utils.genPseudorandomUUID();
         this.metadata = metadata;
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -2,6 +2,13 @@ package org.corfudb.runtime.object.transactions;
 
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -25,14 +32,6 @@ import org.corfudb.runtime.view.Address;
 import org.corfudb.util.CorfuComponent;
 import org.corfudb.util.MetricsUtils;
 import org.corfudb.util.Utils;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 
 /**
  * Represents a transactional context. Transactional contexts
@@ -170,7 +169,7 @@ public abstract class AbstractTransactionalContext implements
     private final Timer.Context txOpDurationContext;
 
     AbstractTransactionalContext(Transaction transaction) {
-        transactionID = UUID.randomUUID();
+        transactionID = Utils.genPseudorandomUUID();
         this.transaction = transaction;
 
         startTime = System.currentTimeMillis();

--- a/runtime/src/main/java/org/corfudb/util/Utils.java
+++ b/runtime/src/main/java/org/corfudb/util/Utils.java
@@ -14,6 +14,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import jdk.internal.org.objectweb.asm.util.Printer;
@@ -44,6 +45,19 @@ public class Utils {
     private static final TraceMethodVisitor mp = new TraceMethodVisitor(printer);
 
     private static final char[] hexArray = "0123456789ABCDEF".toCharArray();
+
+
+    /**
+     * When true randomness is not required using UUID.randomUUID() can be really slow.
+     * Blocking for 50+ ms for entropy to build up is not unusual. This method generates
+     * random UUIDs PRNG.
+     * @return A pseudo-random UUID
+     */
+    public static UUID genPseudorandomUUID() {
+        long msb = ThreadLocalRandom.current().nextLong();
+        long lsb = ThreadLocalRandom.current().nextLong();
+        return new UUID(msb, lsb);
+    }
 
     /** Convert a byte array to a hex string.
      * Source:


### PR DESCRIPTION
## Overview

In CorfuDB UUIDs are mostly used for logging purposes, thus true
randomness is not required. Using UUID.randomUUID for transaction
IDs can be really slow because it uses secureRandom. This patch
uses a PRNG to generate those ids much faster.

Why should this be merged: Reduces the `Transaction::begin` time by up to 50+ milliseconds 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
