### PR TITLE
Calculate Remaining Replicated Entries based on TxStream

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -30,6 +30,7 @@ import org.corfudb.utils.lock.states.LockState;
 
 import javax.annotation.Nonnull;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -524,6 +525,9 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
      * @param newTopology new discovered topology
      */
     public void onClusterRoleChange(TopologyDescriptor newTopology) {
+
+        log.debug("OnClusterRoleChange, topology={}", newTopology);
+
         // Stop ongoing replication, stopLogReplication() checks leadership and active
         // We do not update topology until we successfully stop log replication
         if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {
@@ -574,6 +578,8 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                     topologyDescriptor.getTopologyConfigId(), event.getTopologyConfig());
             return;
         }
+
+        log.debug("Received topology change, topology={}", event.getTopologyConfig());
 
         TopologyDescriptor discoveredTopology = new TopologyDescriptor(event.getTopologyConfig());
         boolean isValid = processDiscoveredTopology(discoveredTopology, localClusterDescriptor == null);
@@ -700,7 +706,15 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     @Override
     public Map<String, LogReplicationMetadata.ReplicationStatusVal> queryReplicationStatus() {
         if (ClusterRole.ACTIVE == localClusterDescriptor.getRole()) {
-            return logReplicationMetadataManager.getReplicationRemainingEntries();
+            Map<String, LogReplicationMetadata.ReplicationStatusVal> mapReplicationStatus = logReplicationMetadataManager.getReplicationRemainingEntries();
+            Map<String, LogReplicationMetadata.ReplicationStatusVal> mapToSend = new HashMap<>(mapReplicationStatus);
+            // If map contains local cluster, remove (as it might have been added by the SinkManager) but this node
+            // has an active role.
+            if (mapToSend.containsKey(localClusterDescriptor.getClusterId())) {
+                log.warn("Remove localClusterDescriptor {} from replicationStatusMap", localClusterDescriptor.getClusterId());
+                mapToSend.remove(localClusterDescriptor.getClusterId());
+            }
+            return mapToSend;
         } else if (ClusterRole.STANDBY == localClusterDescriptor.getRole()) {
             return logReplicationMetadataManager.getDataConsistentOnStandby();
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/TopologyDescriptor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/TopologyDescriptor.java
@@ -168,13 +168,13 @@ public class TopologyDescriptor {
             }
         }
 
-        log.trace("Endpoint {} does not belong to any cluster defined in {}", endpoint, clusters);
+        log.warn("Endpoint {} does not belong to any cluster defined in {}", endpoint, clusters);
         return null;
     }
 
     @Override
     public String toString() {
-        return String.format("Topology[%s] :: Active Cluster=%s :: Standby Clusters=%s :: Invalid Clusters=%s",
+        return String.format("Topology[id=%s] :: Active Cluster=%s :: Standby Clusters=%s :: Invalid Clusters=%s",
                 topologyConfigId, activeClusters, standbyClusters, invalidClusters);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -1,9 +1,14 @@
 package org.corfudb.infrastructure.logreplication.replication;
 
+import static org.corfudb.runtime.view.ObjectsView.TRANSACTION_STREAM_ID;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.infrastructure.logreplication.replication.send.logreader.LogEntryReader;
+import org.corfudb.infrastructure.logreplication.replication.send.logreader.StreamsLogEntryReader.StreamIteratorMetadata;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
@@ -17,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+@Slf4j
 public class LogReplicationAckReader {
     private LogReplicationMetadataManager metadataManager;
     private LogReplicationConfig config;
@@ -50,9 +56,11 @@ public class LogReplicationAckReader {
     private LogReplicationMetadata.ReplicationStatusVal.SyncType lastSyncType =
             LogReplicationMetadata.ReplicationStatusVal.SyncType.LOG_ENTRY;
 
-    Lock lock = new ReentrantLock();
+    private LogEntryReader logEntryReader;
 
-     public LogReplicationAckReader(LogReplicationMetadataManager metadataManager, LogReplicationConfig config,
+    private Lock lock = new ReentrantLock();
+
+    public LogReplicationAckReader(LogReplicationMetadataManager metadataManager, LogReplicationConfig config,
                                     CorfuRuntime runtime, String remoteClusterId) {
         this.metadataManager = metadataManager;
         this.config = config;
@@ -60,8 +68,6 @@ public class LogReplicationAckReader {
         this.remoteClusterId = remoteClusterId;
         lastAckedTsPoller = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat("ack-timestamp-reader").build());
-        lastAckedTsPoller.scheduleWithFixedDelay(new TsPollingTask(), 0,
-                ACKED_TS_READ_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
     public void setAckedTsAndSyncType(long ackedTs, LogReplicationMetadata.ReplicationStatusVal.SyncType syncType) {
@@ -74,13 +80,93 @@ public class LogReplicationAckReader {
         }
     }
 
+    public void setSyncType(LogReplicationMetadata.ReplicationStatusVal.SyncType syncType) {
+        lock.lock();
+        try {
+            lastSyncType = syncType;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    public void startAckReader(LogEntryReader logEntryReader) {
+        this.logEntryReader = logEntryReader;
+        lastAckedTsPoller.scheduleWithFixedDelay(new TsPollingTask(), 0,
+                ACKED_TS_READ_INTERVAL_SECONDS, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Given a timestamp acked by the receiver, calculate how many entries remain to be sent for all replicated streams.
+     *
+     * @param ackedTimestamp Timestamp ack'd by the receiver
+     *
+     * For Log Entry Sync, this function returns the total number of entries remaining to be sent across all replicated
+     * streams based on the transaction stream.
+     *
+     * For Snapshot Sync, a snapshot of each stream at a given point in time is sent. The stream could have been
+     * checkpointed and trimmed so we cannot find the remaining number of entries accurately. In this case, we simply
+     * subtract the acked timestamp from the global log tail when the snapshot sync started.
+     * Note that this method is not accurate because the global tail can reflect the interleaving of replicated and
+     * non-replicated streams, and hence, does not accurately represent the remaining entries to send for replicated streams.
+     *
+     * If there is no data on the active, it returns 0, which means no replication remaining.
+     * If the ack'd timestamp is uninitialized(no ack received), it returns the log tail, which means no replication has
+     * been done.
+     */
+    private long calculateRemainingEntriesToSend(long ackedTimestamp) {
+        // Get all streams tails, which will be used in the computation of remaining entries
+        Map<UUID, Long> tailMap = runtime.getAddressSpaceView().getAllTails().getStreamTails();
+
+        long txStreamTail = getTxStreamTail(tailMap);
+        long maxReplicatedStreamTail = getMaxReplicatedStreamsTail(tailMap);
+        StreamIteratorMetadata currentTxStreamProcessedTs = logEntryReader.getCurrentProcessedEntryMetadata();
+
+        log.trace("calculateRemainingEntriesToSend:: maxTailReplicateStreams={}, txStreamTail={}, lastTxStreamProcessedTs={}, " +
+                        "lastTxStreamProcessedStreamsPresent={}, sync={}",
+                maxReplicatedStreamTail, txStreamTail, currentTxStreamProcessedTs.getTimestamp(),
+                currentTxStreamProcessedTs.isStreamsToReplicatePresent(), lastSyncType);
+
+        // No data to send on the active, so no replication remaining
+        if (maxReplicatedStreamTail == Address.NON_ADDRESS) {
+            log.debug("No data to replicate, replication complete.");
+            return NO_REPLICATION_REMAINING_ENTRIES;
+        }
+
+        if (lastSyncType.equals(LogReplicationMetadata.ReplicationStatusVal.SyncType.SNAPSHOT)) {
+
+            // If during snapshot sync nothing has been ack'ed, all replication is remaining
+            if (ackedTimestamp == Address.NON_ADDRESS) {
+                ackedTimestamp = 0;
+            }
+
+            // In Snapshot Sync
+            // Simply subtract the ack'ed timestamp from the global log tail from the time the snapshot sync started.
+            // Note that this is not accurate because the global log tail does not accurately represent the remaining entries
+            // for replicated streams.
+            // When snapshot sync is ongoing, there may be delta updates also. Add those new entries by querying the address maps
+            return ((baseSnapshotTimestamp - ackedTimestamp) +
+                    getTxStreamTotalEntries(baseSnapshotTimestamp, txStreamTail));
+        }
+
+        // In Log Entry Sync
+        return calculateRemainingEntriesIncrementalUpdates(ackedTimestamp, txStreamTail, currentTxStreamProcessedTs);
+    }
+
+    private long getTxStreamTail(Map<UUID, Long> tailMap) {
+        if (tailMap.containsKey(TRANSACTION_STREAM_ID)) {
+            return tailMap.get(TRANSACTION_STREAM_ID);
+        }
+
+        log.warn("Tx Stream tail not present in sequencer, id={}", TRANSACTION_STREAM_ID);
+        return Address.NON_ADDRESS;
+    }
+
     /**
      * For the given replication runtime, query max stream tail for all streams to be replicated.
      *
      * @return max tail of all streams to be replicated for the given runtime
      */
-    private long getMaxReplicatedStreamsTail() {
-        Map<UUID, Long> tailMap = runtime.getAddressSpaceView().getAllTails().getStreamTails();
+    private long getMaxReplicatedStreamsTail(Map<UUID, Long> tailMap) {
         long maxTail = Address.NON_ADDRESS;
         for (String streamName : config.getStreamsToReplicate()) {
             UUID streamUuid = CorfuRuntime.getStreamID(streamName);
@@ -93,61 +179,134 @@ public class LogReplicationAckReader {
     }
 
     /**
-     * Given a timestamp acked by the receiver, calculate how many entries remain to be sent for all replicated streams.
+     * The calculation of remaining entries during log entry sync takes into account:
+     * - lastAckedTimestamp: last timestamp of entry for which we've received an ACK
+     * - txStreamTail: transaction stream tail
+     * - currentTxStreamProcessedTs: metadata of current entry being processed by the StreamsLogEntryReader,
+     *           it contains the timestamp and a boolean indicating if that entry has data to replicate or not,
+     *           this will give an indication whether if an ACK is expected or not.
      *
-     * @param ackedTimestamp Timestamp ack'd by the receiver
+     * Consider the following representation of the data log, where entries 20, 50, 60, 70 belong to the
+     * tx stream.
      *
-     * For Log Entry Sync, this function returns the total number of entries remaining to be sent across all replicated
-     * streams.
+
+     +---+---+---+---+---+---+---+---+---+---+---+---+
+     |   |   |   |   |   |   |   |   |   |   |   |   |
+     +---+---+---+---+---+---+---+---+---+---+---+---+
+     20          50          60       70         100
+     tx          tx          tx       tx        (log tail / not part of tx stream)
+
+
+     * Case 1.0: Log Entry Sync lagging behind (in processing) current processing not acked with entries to replicate
+     *          - lastAckedTimestamp = 50
+     *          - txStreamTail = 70
+     *          - currentTxStreamProcessedTs = 60, true (contains replicated streams)
      *
-     * For Snapshot Sync, a snapshot of each stream at a given point in time is sent.  The stream could have been
-     * checkpointed and trimmed so we cannot find the remaining number of entries accurately.  In this case, we simply
-     * subtract the acked timestamp from the global log tail when the snapshot sync started.
-     * Note that this method is not accurate because the global tail can reflect the interleaving of replicated and
-     * non-replicated streams, and hence, does not accurately represent the remaining entries to send for replicated streams.
+     *          remainingEntries = entriesBetween(50, 70] = 2
+
+     * Case 1.1: Log Entry Sync lagging behind (in processing) current processing no entries to replicate
+     *          - lastAckedTimestamp = 50
+     *          - txStreamTail = 70
+     *          - currentTxStreamProcessedTs = 60, false (does not contain streams to replicate)
      *
-     * If there is no data on the active, it returns 0, which means no replication remaining.
-     * If the ack'd timestamp is uninitialized(no ack received), it returns the log tail, which means no replication has
-     * been done.
+     * (despite the current processed not requiring ACk, there might be entries between lastAcked and currentProcessed
+     * which still have not been acknowledged so it is better to overestimate as it will eventually converge to an accurate value)
+     *          remainingEntries = entriesBetween(50, 70] = 1
+
+     * Case 2.0: Log Entry Sync Up to Date
+     *          - lastAckedTimestamp = 70
+     *          - txStreamTail = 70
+     *          - currentTxStreamProcessedTs = 70, true (contains replicated streams)
+     *
+     *          remainingEntries = 0
+
+     * Case 2.1: Log Entry Sync Up to Date
+     *          - lastAckedTimestamp = 60
+     *          - txStreamTail = 70
+     *          - currentTxStreamProcessedTs = 70, false (does not contain replicated streams,
+     *          so there is no expectation that lastAckedTimestamp reaches 70)
+     *
+     *          remainingEntries = 0
+
+
+     * Case 2.2: Log Entry Sync Lagging Behind (in ack)
+     *          - lastAckedTimestamp = 60
+     *          - txStreamTail = 70
+     *          - currentTxStreamProcessedTs = 70, true (does contain replicated streams,
+     *           wait until lastAckedTimestamp reflects this)
+     *
+     *          remainingEntries = entriesBetween(60, 70] = 1
+     *
      */
-    private long calculateRemainingEntriesToSend(long ackedTimestamp) {
-        long maxReplicatedStreamTail = getMaxReplicatedStreamsTail();
+    private long calculateRemainingEntriesIncrementalUpdates(long lastAckedTs, long txStreamTail,
+                                                             StreamIteratorMetadata currentTxStreamProcessedTs) {
+        long noRemainingEntriesToSend = 0;
 
-        // No data to send on the Active, so no replication remaining
-        if (maxReplicatedStreamTail == Address.NON_ADDRESS) {
-            return NO_REPLICATION_REMAINING_ENTRIES;
+        // If we have processed up to or beyond the latest known tx stream tail
+        // we can assume we are up to date.
+        // Note: in the case of a switchover the tail won't be moving so we can assume
+        // the tx stream last processed timestamp will never be above the stream's tail,
+        // but in the case of ongoing replication or holes, it might be above.
+        // We can't do much other than report that we're up to date (as it might continue moving)
+        if (txStreamTail <= currentTxStreamProcessedTs.getTimestamp()) {
+            // (Case 2 from description)
+            // If the current processed tx stream entry has data to replicate,
+            // we need to ensure we have received an ACK it, otherwise,
+            // we might be signalling completion when there is still an entry for which
+            // we haven't received confirmation of the recipient.
+            if (currentTxStreamProcessedTs.isStreamsToReplicatePresent()) {
+                if (lastAckedTs == currentTxStreamProcessedTs.getTimestamp()) {
+                    log.trace("Log Entry Sync up to date, lastAckedTs={}, txStreamTail={}, currentTxProcessedTs={}, containsEntries={}", lastAckedTs,
+                            txStreamTail, currentTxStreamProcessedTs.getTimestamp(), currentTxStreamProcessedTs.isStreamsToReplicatePresent());
+                    // (Case 2.0)
+                    return noRemainingEntriesToSend;
+                }
+
+                // (Case 2.2)
+                // Last ack'ed timestamp should match the last processed tx stream timestamp.
+                // Calculate how many entries are missing, based on the tx stream's address map
+                log.trace("Log Entry Sync pending ACKs, lastAckedTs={}, txStreamTail={}, currentTxProcessedTs={}, containsEntries={}", lastAckedTs,
+                        txStreamTail, currentTxStreamProcessedTs.getTimestamp(), currentTxStreamProcessedTs.isStreamsToReplicatePresent());
+                return getTxStreamTotalEntries(lastAckedTs, currentTxStreamProcessedTs.getTimestamp());
+            }
+
+            // (Case 2.1)
+            // Since last tx stream processed timestamp is not intended to be replicated
+            // and we're at or beyond the last known tail, no entries remaining to be sent
+            // at this point.
+            log.trace("Log Entry Sync up to date, no pending ACKs, lastAckedTs={}, txStreamTail={}, currentTxProcessedTs={}, containsEntries={}", lastAckedTs,
+                    txStreamTail, currentTxStreamProcessedTs.getTimestamp(), currentTxStreamProcessedTs.isStreamsToReplicatePresent());
+            return noRemainingEntriesToSend;
         }
 
-        // If doing a snapshot sync and nothing has been acked, all replication is remaining.  So set ack=0
-        if (ackedTimestamp == Address.NON_ADDRESS &&
-                lastSyncType == LogReplicationMetadata.ReplicationStatusVal.SyncType.SNAPSHOT) {
-            ackedTimestamp = 0;
+        // (Cases 1.0 and 1.1)
+        long remainingEntries = getTxStreamTotalEntries(lastAckedTs, txStreamTail);
+        log.trace("Log Entry Sync pending entries for processing, lastAckedTs={}, txStreamTail={}, currentTxProcessedTs={}, containsEntries={}, remaining={}", lastAckedTs,
+                txStreamTail, currentTxStreamProcessedTs.getTimestamp(), currentTxStreamProcessedTs.isStreamsToReplicatePresent(), remainingEntries);
+
+        if (!currentTxStreamProcessedTs.isStreamsToReplicatePresent()) {
+            // Case 1.1
+            // Remove one entry, which accounts for the current processed which does not have streams to replicate
+            return remainingEntries - 1;
         }
 
-        // When in LogEntry Sync, no CP and trim has taken place so the remaining entries can be queried using the
-        // global tail and address maps of the replicated streams
-        if (lastSyncType == LogReplicationMetadata.ReplicationStatusVal.SyncType.LOG_ENTRY) {
-            return calculateRemainingEntriesForLogEntrySync(maxReplicatedStreamTail, ackedTimestamp);
-        }
-
-        // In Snapshot Sync
-        // Simply subtract the ackedTimestamp from the global log tail from the time the snapshot sync started.
-        // Note that this is not accurate because the global log tail does not accurately represent the remaining entries
-        // for replicated streams.
-        // When snapshot sync is ongoing, there may be delta updates also.  Add those new entries by querying the address maps
-        return ((baseSnapshotTimestamp - ackedTimestamp) +
-            calculateRemainingEntriesForLogEntrySync(maxReplicatedStreamTail, baseSnapshotTimestamp));
+        return remainingEntries;
     }
 
-    private long calculateRemainingEntriesForLogEntrySync(long start, long end) {
-        long remainingEntriesToSend = 0;
-        for (String stream : config.getStreamsToReplicate()) {
-            UUID streamId = CorfuRuntime.getStreamID(stream);
-            StreamAddressRange range = new StreamAddressRange(streamId, start, end);
-            StreamAddressSpace addressSpace = runtime.getSequencerView().getStreamAddressSpace(range);
-            remainingEntriesToSend += addressSpace.getAddressMap().getLongCardinality();
+    private long getTxStreamTotalEntries(long lowerBoundary, long upperBoundary) {
+        long totalEntries = 0;
+
+        if (upperBoundary > lowerBoundary) {
+            StreamAddressRange range = new StreamAddressRange(TRANSACTION_STREAM_ID, upperBoundary, lowerBoundary);
+            StreamAddressSpace txStreamAddressSpace = runtime.getSequencerView().getStreamAddressSpace(range);
+            // Count how many entries are present in the Tx Stream (this can include holes,
+            // valid entries and invalid entries), but we count them all (equal weight).
+            // An invalid entry, is a transactional entry with no streams to replicate (which will be ignored)
+            totalEntries = txStreamAddressSpace.getAddressMap().getLongCardinality();
         }
-        return remainingEntriesToSend;
+
+        log.trace("getTxStreamTotalEntries:: entries={} in range ({}, {}]", totalEntries, lowerBoundary, upperBoundary);
+        return totalEntries;
     }
 
     public void shutdown() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -120,6 +120,7 @@ public class LogReplicationSourceManager {
                 dataSender, readProcessor, logReplicationFSMWorkers, ackReader);
 
         this.logReplicationFSM.setTopologyConfigId(params.getTopologyConfigId());
+        this.ackReader.startAckReader(logReplicationFSM.getLogEntryReader());
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication.replication.fsm;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.replication.send.LogEntrySender;
 
 import java.util.UUID;
@@ -134,6 +135,9 @@ public class InLogEntrySyncState implements LogReplicationState {
             // address and send incremental updates from this point onwards.
             if (from.getType() == LogReplicationStateType.WAIT_SNAPSHOT_APPLY
                     || from.getType() == LogReplicationStateType.INITIALIZED) {
+                // Set LogEntryAckReader to Log Entry Sync state, to compute remaining entries based
+                // on the tx stream, regardless of ACKs or updates being processed for the tx stream
+                fsm.getAckReader().setSyncType(LogReplicationMetadata.ReplicationStatusVal.SyncType.LOG_ENTRY);
                 logEntrySender.reset(fsm.getBaseSnapshot(), fsm.getAckedTimestamp());
             }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -99,11 +99,13 @@ public class InSnapshotSyncState implements LogReplicationState {
                 return waitSnapshotApplyState;
             case SYNC_CANCEL:
                 // If cancel was intended for current snapshot sync task, cancel and transition to new state
-                if (transitionEventId == event.getMetadata().getRequestId()) {
+                if (transitionEventId.equals(event.getMetadata().getRequestId())) {
                     cancelSnapshotSync("cancellation request.");
                     // Re-trigger SnapshotSync due to error, generate a new event Id for the new snapshot sync
                     LogReplicationState inSnapshotSyncState = fsm.getStates().get(LogReplicationStateType.IN_SNAPSHOT_SYNC);
-                    inSnapshotSyncState.setTransitionEventId(UUID.randomUUID());
+                    UUID newSnapshotSyncId = UUID.randomUUID();
+                    log.debug("Starting new snapshot sync after cancellation id={}", newSnapshotSyncId);
+                    inSnapshotSyncState.setTransitionEventId(newSnapshotSyncId);
                     snapshotSender.reset();
                     return inSnapshotSyncState;
                 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -162,6 +162,7 @@ public class LogReplicationFSM {
     /**
      * Log Entry Reader (read incremental updated from Corfu Datatore)
      */
+    @Getter
     private LogEntryReader logEntryReader;
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/TestLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/TestLogEntryReader.java
@@ -1,7 +1,9 @@
 package org.corfudb.infrastructure.logreplication.replication.fsm;
 
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.LogEntryReader;
+import org.corfudb.infrastructure.logreplication.replication.send.logreader.StreamsLogEntryReader;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
+import org.corfudb.runtime.view.Address;
 
 import java.util.UUID;
 
@@ -28,5 +30,10 @@ public class TestLogEntryReader implements LogEntryReader {
     @Override
     public boolean hasMessageExceededSize() {
         return false;
+    }
+
+    @Override
+    public StreamsLogEntryReader.StreamIteratorMetadata getCurrentProcessedEntryMetadata() {
+        return new StreamsLogEntryReader.StreamIteratorMetadata(Address.NON_ADDRESS, false);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -55,7 +55,7 @@ public class LogReplicationMetadataManager {
                             LogReplicationMetadataVal.class,
                             null,
                             TableOptions.builder().build());
-            replicationStatusTable = this.corfuStore.openTable(NAMESPACE,
+            this.replicationStatusTable = this.corfuStore.openTable(NAMESPACE,
                             REPLICATION_STATUS_TABLE,
                             ReplicationStatusKey.class,
                             ReplicationStatusVal.class,
@@ -326,7 +326,7 @@ public class LogReplicationMetadataManager {
         txBuilder.update(REPLICATION_STATUS_TABLE, key, val, null);
         txBuilder.commit();
 
-        log.trace("setReplicationRemainingEntries: clusterId: {}, remainingEntries: {}, type: {}",
+        log.debug("setReplicationRemainingEntries: clusterId: {}, remainingEntries: {}, type: {}",
                 clusterId, remainingEntries, type);
     }
 
@@ -336,7 +336,12 @@ public class LogReplicationMetadataManager {
                 corfuStore.query(NAMESPACE).executeQuery(REPLICATION_STATUS_TABLE, record -> true);
 
         for(CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, ReplicationStatusVal>entry : entries.getResult()) {
-            replicationStatusMap.put(entry.getKey().getClusterId(), entry.getPayload());
+            String clusterId = entry.getKey().getClusterId();
+            ReplicationStatusVal value = entry.getPayload();
+            replicationStatusMap.put(clusterId, value);
+            log.debug("getReplicationRemainingEntries: clusterId={}, remainingEntriesToSend={}, " +
+                    "syncType={}, is_consistent={}", clusterId, value.getRemainingEntriesToSend(),
+                    value.getType(), value.getDataConsistent());
         }
 
         log.debug("getReplicationRemainingEntries: replicationStatusMap size: {}", replicationStatusMap.size());
@@ -384,6 +389,7 @@ public class LogReplicationMetadataManager {
     }
 
     public void resetReplicationStatus() {
+        log.info("Reset replication status");
         replicationStatusTable.clear();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
@@ -131,9 +131,6 @@ public class LogEntrySender {
             }
         }
 
-        /*
-         * Generate a LOG_ENTRY_SYNC_CONTINUE event and put it into the state machine.
-         */
         logReplicationFSM.input(new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.LOG_ENTRY_SYNC_CONTINUE,
                 new LogReplicationEventMetadata(logEntrySyncEventId)));
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationError.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationError.java
@@ -4,12 +4,12 @@ package org.corfudb.infrastructure.logreplication.replication.send;
  * Log Replication Error
  */
 public enum LogReplicationError {
-    TRIM_SNAPSHOT_SYNC(0, "A trim exception has occurred during snapshot sync."),
-    TRIM_LOG_ENTRY_SYNC(1, "A trim exception has occurred during log entry sync."),
-    LOG_ENTRY_ACK_TIMEOUT(2, "Log Entry Sync ack has timed out."),
-    LOG_ENTRY_MESSAGE_SIZE_EXCEEDED(3, "Log Replication Entry Message exceeds max allowed size." +
+    TRIM_SNAPSHOT_SYNC(0, "a trim exception during snapshot sync."),
+    TRIM_LOG_ENTRY_SYNC(1, "a trim exception during log entry sync."),
+    LOG_ENTRY_ACK_TIMEOUT(2, "log Entry Sync ack has timed out."),
+    LOG_ENTRY_MESSAGE_SIZE_EXCEEDED(3, "log Replication Entry Message exceeds max allowed size." +
             "Log Replication is TERMINATED."),
-    UNKNOWN (4, "Unknown exception caused sync cancel.");
+    UNKNOWN (4, "unknown exception caused sync cancel.");
 
     private final int code;
     private final String description;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
@@ -197,7 +197,7 @@ public abstract class SenderBufferManager {
         }
 
         for (int i = 0; i < pendingMessages.getSize(); i++) {
-            LogReplicationPendingEntry entry  = pendingMessages.getList().get(i);
+            LogReplicationPendingEntry entry  = pendingMessages.getPendingEntries().get(i);
             if (entry.timeout(msgTimer) || force) {
                 entry.retry();
                 // Update metadata as topologyConfigId could have changed in between resend cycles
@@ -205,8 +205,8 @@ public abstract class SenderBufferManager {
                 dataEntry.getMetadata().setTopologyConfigId(topologyConfigId);
                 CompletableFuture<LogReplicationEntry> cf = dataSender.send(entry.getData());
                 addCFToAcked(entry.getData(), cf);
-                log.debug("Resend message {}[ts={}]", entry.getData().getMetadata().getMessageMetadataType(),
-                        entry.getData().getMetadata().getTimestamp());
+                log.debug("Resend message {}[ts={}, snapshotSyncNum={}]", entry.getData().getMetadata().getMessageMetadataType(),
+                        entry.getData().getMetadata().getTimestamp(), entry.getData().getMetadata().getSnapshotSyncSeqNum());
             }
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderPendingMessageQueue.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderPendingMessageQueue.java
@@ -24,12 +24,12 @@ public class SenderPendingMessageQueue {
      * The list of pending entries.
      */
     @Getter
-    private List<LogReplicationPendingEntry> list;
+    private List<LogReplicationPendingEntry> pendingEntries;
 
 
     public SenderPendingMessageQueue(int maxSize) {
         this.maxSize = maxSize;
-        list = new ArrayList<>();
+        this.pendingEntries = new ArrayList<>();
     }
 
     /**
@@ -37,19 +37,19 @@ public class SenderPendingMessageQueue {
      * @return
      */
     public int getSize() {
-        return list.size();
+        return pendingEntries.size();
     }
 
     public boolean isEmpty() {
-        return list.isEmpty();
+        return pendingEntries.isEmpty();
     }
 
     public boolean isFull() {
-        return (list.size() >= maxSize);
+        return pendingEntries.size() >= maxSize;
     }
 
     public void clear() {
-        list = new ArrayList<>();
+        pendingEntries = new ArrayList<>();
     }
 
     /**
@@ -57,12 +57,12 @@ public class SenderPendingMessageQueue {
      * @param ts
      */
     void evictAccordingToTimestamp(long ts) {
-        log.trace("Evict all messages whose timestamp is smaller or equal to " + ts);
+        log.trace("Evict all messages whose timestamp is smaller or equal to {}", ts);
 
         //As the entries are in the order of timestamp value, we can just remove the first each time
         //until the condition is not met anymore.
-        while(!list.isEmpty() && list.get(0).getData().getMetadata().getTimestamp() <= ts) {
-            list.remove(0);
+        while(!pendingEntries.isEmpty() && pendingEntries.get(0).getData().getMetadata().getTimestamp() <= ts) {
+            pendingEntries.remove(0);
         }
     }
 
@@ -71,12 +71,12 @@ public class SenderPendingMessageQueue {
      * @param seqNum
      */
     void evictAccordingToSeqNum(long seqNum) {
-        log.trace("Evict all messages whose snapshotSeqNum is smaller or equal to " + seqNum);
+        log.trace("Evict all messages whose snapshotSeqNum is smaller or equal to {}", seqNum);
 
         //As the entries are in the order of timestamp value, we can just remove the first each time
         //until the condition is not met anymore.
-        while(!list.isEmpty() && list.get(0).getData().getMetadata().getSnapshotSyncSeqNum() <= seqNum) {
-            list.remove(0);
+        while(!pendingEntries.isEmpty() && pendingEntries.get(0).getData().getMetadata().getSnapshotSyncSeqNum() <= seqNum) {
+            pendingEntries.remove(0);
         }
     }
 
@@ -87,6 +87,6 @@ public class SenderPendingMessageQueue {
      */
     void append(LogReplicationEntry data) {
         LogReplicationPendingEntry entry = new LogReplicationPendingEntry(data);
-        list.add(entry);
+        pendingEntries.add(entry);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -237,8 +237,7 @@ public class SnapshotSender {
 
         log.error("SNAPSHOT SYNC is being CANCELED, due to {}", error.getDescription());
 
-        // Enqueue cancel event, this will cause a transition to the require snapshot sync request, which
-        // will notify application through the data control about this request.
+        // Enqueue cancel event, this will cause re-entrance to snapshot sync to start a new cycle
         fsm.input(new LogReplicationEvent(LogReplicationEventType.SYNC_CANCEL,
                 new LogReplicationEventMetadata(snapshotSyncEventId)));
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogEntryReader.java
@@ -25,4 +25,6 @@ public interface LogEntryReader {
     void setTopologyConfigId(long topologyConfigId);
 
     boolean hasMessageExceededSize();
+
+    StreamsLogEntryReader.StreamIteratorMetadata getCurrentProcessedEntryMetadata();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
@@ -11,6 +11,7 @@ import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.runtime.view.stream.OpaqueStream;
 
@@ -61,12 +62,17 @@ public class StreamsLogEntryReader implements LogEntryReader {
     @VisibleForTesting
     private OpaqueEntry lastOpaqueEntry = null;
 
+    private boolean lastOpaqueEntryValid = true;
+
     private boolean messageExceededSize = false;
+
+    private StreamIteratorMetadata currentProcessedEntryMetadata;
 
     public StreamsLogEntryReader(CorfuRuntime runtime, LogReplicationConfig config) {
         this.rt = runtime;
         this.rt.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
         this.maxDataSizePerMsg = config.getMaxDataSizePerMsg();
+        this.currentProcessedEntryMetadata = new StreamIteratorMetadata(Address.NON_ADDRESS, false);
 
         Set<String> streams = config.getStreamsToReplicate();
 
@@ -165,7 +171,8 @@ public class StreamsLogEntryReader implements LogEntryReader {
         try {
             while (currentMsgSize < maxDataSizePerMsg) {
                 if (lastOpaqueEntry != null) {
-                    if (isValidTransactionEntry(lastOpaqueEntry)) {
+
+                    if (lastOpaqueEntryValid) {
 
                         lastOpaqueEntry = filterTransactionEntry(lastOpaqueEntry);
 
@@ -190,6 +197,8 @@ public class StreamsLogEntryReader implements LogEntryReader {
                 }
 
                 lastOpaqueEntry = txOpaqueStream.next();
+                lastOpaqueEntryValid = isValidTransactionEntry(lastOpaqueEntry);
+                currentProcessedEntryMetadata = new StreamIteratorMetadata(txOpaqueStream.txStream.pos(), lastOpaqueEntryValid);
             }
 
             log.trace("Generate LogEntryDataMessage size {} with {} entries for maxDataSizePerMsg {}. lastEntry size {}",
@@ -226,6 +235,11 @@ public class StreamsLogEntryReader implements LogEntryReader {
     public void reset(long lastSentBaseSnapshotTimestamp, long lastAckedTimestamp) {
         messageExceededSize = false;
         setGlobalBaseSnapshot(lastSentBaseSnapshotTimestamp, lastAckedTimestamp);
+    }
+
+    @Override
+    public StreamIteratorMetadata getCurrentProcessedEntryMetadata() {
+        return currentProcessedEntryMetadata;
     }
 
     /**
@@ -291,6 +305,20 @@ public class StreamsLogEntryReader implements LogEntryReader {
             txStream.seek(firstAddress);
             streamUpTo();
         }
+    }
+
+    public static class StreamIteratorMetadata {
+        private long timestamp;
+        private boolean streamsToReplicatePresent;
+
+        public StreamIteratorMetadata(long timestamp, boolean streamsToReplicatePresent) {
+            this.timestamp = timestamp;
+            this.streamsToReplicatePresent = streamsToReplicatePresent;
+        }
+
+        public long getTimestamp() { return timestamp; }
+
+        public boolean isStreamsToReplicatePresent() { return streamsToReplicatePresent; }
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
@@ -157,7 +157,7 @@ public class StreamsSnapshotReader implements SnapshotReader {
                 }
             }
         } catch (TrimmedException e) {
-            log.error("Catch an TrimmedException exception ", e);
+            log.error("Caught a TrimmedException", e);
             throw e;
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
@@ -56,8 +56,6 @@ public class ReplicatingState implements LogReplicationRuntimeState {
                 // Some node got connected, update connected endpoints
                 fsm.updateConnectedEndpoints(event.getEndpoint());
                 return null;
-            case NEGOTIATION_COMPLETE:
-                return fsm.getStates().get(LogReplicationRuntimeStateType.REPLICATING);
             case LOCAL_LEADER_LOSS:
                 return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
             default: {


### PR DESCRIPTION
## Overview

Description:

- Calculate replicated remaining entries based on the txStream
  to avoid the issue of holes enforced on regular streams by the checkpointer.
- Minor bug fix, restarted Snapshot Sync same baseSnapshot (not reject)
- Add some valuable logging for debugging

Why should this be merged: bug found in setups running checkpointing

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
