### PR TITLE
Disable waiting for holes in ProtocolBatchProcessor

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/statetransfer/batchprocessor/protocolbatchprocessor/ProtocolBatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/statetransfer/batchprocessor/protocolbatchprocessor/ProtocolBatchProcessor.java
@@ -51,7 +51,7 @@ public class ProtocolBatchProcessor implements StateTransferBatchProcessor {
      */
     @Getter
     private final ReadOptions readOptions = ReadOptions.builder()
-            .waitForHole(true)
+            .waitForHole(false)
             .clientCacheable(false)
             .serverCacheable(false)
             .build();


### PR DESCRIPTION
## Overview

Description:

If the non-committed part of the log if full of holes, it might take a long time to complete state transfer because we wait for a hole fill before filling and then transferring data. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
