### PR TITLE
When sequncer fails over, elect non-tail node as primary if possible.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/ConservativeFailureHandlerPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ConservativeFailureHandlerPolicy.java
@@ -31,8 +31,8 @@ public class ConservativeFailureHandlerPolicy implements IReconfigurationHandler
                                  Set<String> healedNodes) {
         LayoutBuilder layoutBuilder = new LayoutBuilder(originalLayout);
         Layout newLayout = layoutBuilder
-                .assignResponsiveSequencerAsPrimary(failedNodes)
                 .removeLogunitServers(failedNodes)
+                .assignResponsiveSequencerAsPrimary(failedNodes)
                 .removeUnresponsiveServers(healedNodes)
                 .addUnresponsiveServers(failedNodes)
                 .build();

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -611,5 +611,9 @@ public class Layout {
         public LayoutStripe(@NonNull List<String> logServers) {
             this.logServers = logServers;
         }
+
+        public String getTailEndpoint() {
+            return logServers.get(logServers.size() - 1);
+        }
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/LayoutManagementView.java
@@ -269,9 +269,9 @@ public class LayoutManagementView extends AbstractView {
         if (currentLayout.getAllServers().contains(endpoint)) {
             LayoutBuilder builder = new LayoutBuilder(currentLayout);
             newLayout = builder.removeLayoutServer(endpoint)
+                    .removeLogunitServer(endpoint)
                     .removeSequencerServer(endpoint)
                     .assignResponsiveSequencerAsPrimary(Collections.emptySet())
-                    .removeLogunitServer(endpoint)
                     .removeUnresponsiveServer(endpoint)
                     .setEpoch(currentLayout.getEpoch() + 1)
                     .build();


### PR DESCRIPTION
## Overview

Description:

Log tail nodes need to serve queries, so when sequencer fails over, we
try to elect a non-tail node as the primary sequencer if possible to
have better load distribution.

Related issue(s) (if applicable): #2575 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
