### PR TITLE
Reduce the default batch size.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -105,7 +105,7 @@ public class CorfuServer {
                     + " -k <seqcache>, --sequencer-cache-size=<seqcache>                         "
                     + "               The size of the sequencer's cache. [default: 250000].\n    "
                     + " -B <size> --batch-size=<size>                                            "
-                    + "              The read/write batch size used for data transfer operations [default: 100].\n"
+                    + "              The read/write batch size used for data transfer operations [default: 20].\n"
                     + " -R <retention>, --metadata-retention=<retention>                         "
                     + "              Maximum number of system reconfigurations (i.e. layouts)    "
                     + "retained for debugging purposes [default: 1000].\n"

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
@@ -104,7 +104,7 @@ public class CorfuInterClusterReplicationServer implements Runnable {
                     + " -k <seqcache>, --sequencer-cache-size=<seqcache>                         "
                     + "               The size of the sequencer's cache. [default: 250000].\n    "
                     + " -B <size> --batch-size=<size>                                            "
-                    + "              The read/write batch size used for data transfer operations [default: 100].\n"
+                    + "              The read/write batch size used for data transfer operations [default: 20].\n"
                     + " -R <retention>, --metadata-retention=<retention>                         "
                     + "              Maximum number of system reconfigurations (i.e. layouts)    "
                     + "retained for debugging purposes [default: 1000].\n"

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/RestoreRedundancyMergeSegments.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/RestoreRedundancyMergeSegments.java
@@ -455,8 +455,7 @@ public class RestoreRedundancyMergeSegments extends Action {
 
         // Create a parallel transfer processor for the committed transfer
         ParallelTransferProcessor parallelTransferProcessor =
-                new ParallelTransferProcessor(committedBatchProcessor, runtime.getParameters()
-                        .getBulkReadSize());
+                new ParallelTransferProcessor(committedBatchProcessor);
 
         // Create a state transfer manager
         StateTransferManager transferManager =

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/RestoreRedundancyMergeSegments.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/actions/RestoreRedundancyMergeSegments.java
@@ -455,7 +455,8 @@ public class RestoreRedundancyMergeSegments extends Action {
 
         // Create a parallel transfer processor for the committed transfer
         ParallelTransferProcessor parallelTransferProcessor =
-                new ParallelTransferProcessor(committedBatchProcessor);
+                new ParallelTransferProcessor(committedBatchProcessor, runtime.getParameters()
+                        .getBulkReadSize());
 
         // Create a state transfer manager
         StateTransferManager transferManager =


### PR DESCRIPTION


## Overview

Description:
- Reduce the default read batch size for transfer operations to address the out of direct memory issue for Netty Server Router.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
