### PR TITLE
CorfuStore: Adding proto table options for features

### DIFF
--- a/runtime/proto/corfu_options.proto
+++ b/runtime/proto/corfu_options.proto
@@ -11,10 +11,22 @@ message SchemaOptions {
     optional bool secondary_key = 1;
     // Version number in metadata field.
     optional bool version = 2;
+    // Should this table be backed up by Corfu.
+    optional bool needs_backup = 3;
+    // Should this table be log replicated over to remote standby site using corfu log replication.
+    optional bool is_federated = 4;
+    // Tag tables with unique stream listener tags for selectivity in receiving change notifications.
+    repeated string stream_tag = 5;
 }
 
 // Field options to be extended in the user's protobuf fields.
 extend google.protobuf.FieldOptions {
     // 1036 is in the extendable range in the descriptor.proto.
     optional SchemaOptions schema = 1036;
+}
+
+// Message options to be extended in the user's protobuf messages.
+extend google.protobuf.MessageOptions {
+    // 1039 is in the extendable range in the descriptor.proto
+    optional SchemaOptions table_schema = 1039;
 }

--- a/runtime/proto/corfu_store_metadata.proto
+++ b/runtime/proto/corfu_store_metadata.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package org.corfudb.runtime;
 option java_package = "org.corfudb.runtime";
 
+import "corfu_options.proto";
 import "google/protobuf/descriptor.proto";
 import "google/protobuf/any.proto";
 
@@ -34,6 +35,9 @@ message TableMetadata {
 
     // True if these streams are to be cached, False otherwise.
     bool cache = 3;
+
+    // Extract the schema options defined at the table level for easy lookup.
+    SchemaOptions table_options = 4;
 }
 
 // Record to be persisted containing the value and the metadata.

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata.TableDescriptors;
 import org.corfudb.runtime.CorfuStoreMetadata.TableName;
@@ -172,6 +173,9 @@ public class TableRegistry {
 
         TableMetadata.Builder metadataBuilder = TableMetadata.newBuilder();
         metadataBuilder.setDiskBased(tableOptions.getPersistentDataPath().isPresent());
+        metadataBuilder.setTableOptions(defaultValueMessage
+                .getDescriptorForType().getOptions()
+                .getExtension(CorfuOptions.tableSchema));
 
         // Schema validation to ensure that there is either proper modification of the schema across open calls.
         // Or no modification to the protobuf files.

--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -52,7 +52,15 @@ message NestedTypeB {
 
 message ManagedResourceOptionsMsg {
     optional bool skip_snapshot = 1;
+}
 
+message SampleTableAMsg {
+    option (org.corfudb.runtime.table_schema).stream_tag = "searchStreamer";
+    option (org.corfudb.runtime.table_schema).stream_tag = "slowStreamer";
+    option (org.corfudb.runtime.table_schema).needs_backup = true;
+    option (org.corfudb.runtime.table_schema).is_federated = true;
+
+    optional string payload = 1;
 }
 
 extend google.protobuf.MessageOptions {


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

We need a way for verticals to "annotate" their schemas with the features they want from Corfu in protobuf style.
Features like backup-restore, log-replication, stream-tagging can now be specified right at the protobuf declaration time.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
