### PR TITLE
Resume Snapshot Sync Apply on Restart

### DIFF
--- a/infrastructure/proto/sample.proto
+++ b/infrastructure/proto/sample.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package org.corfudb.infrastructure.logreplication.proto;
+
+message StringKey {
+    string key = 1;
+}
+
+message IntValue {
+    int32 value = 2;
+}
+
+message Metadata {
+    string metadata = 3;
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -614,7 +614,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         // Skip stale topology notification
         if (event.getTopologyConfig().getTopologyConfigID() < topologyDescriptor.getTopologyConfigId()) {
             log.debug("Stale Topology Change Notification, current={}, received={}",
-                    topologyDescriptor.getTopologyConfigId(), event.getTopologyConfig());
+                    topologyDescriptor.getTopologyConfigId(), event.getTopologyConfig().getTopologyConfigID());
             return;
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -12,11 +12,20 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
 
     private Map<String, String> streamsNamespaceMap;
 
+    private final int totalMapCount = 10;
+    private static final String TABLE_PREFIX = "Table00";
+    private static final String NAMESPACE = "LR-Test";
+
     public DefaultLogReplicationConfigAdapter() {
         streamsNamespaceMap = new HashMap<>();
-        streamsNamespaceMap.put("Table001", "testNamespace");
-        streamsNamespaceMap.put("Table002", "testNamespace");
-        streamsNamespaceMap.put("Table003", "testNamespace");
+        streamsNamespaceMap.put("Table001", NAMESPACE);
+        streamsNamespaceMap.put("Table002", NAMESPACE);
+        streamsNamespaceMap.put("Table003", NAMESPACE);
+
+        // Support for UFO
+        for(int i=1; i<=totalMapCount; i++) {
+            streamsNamespaceMap.put(NAMESPACE + "$" + TABLE_PREFIX + i, NAMESPACE);
+        }
     }
 
     @Override

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
@@ -1,5 +1,6 @@
 package org.corfudb.integration;
 
+import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -10,6 +11,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+@Slf4j
 @RunWith(Parameterized.class)
 public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
 
@@ -55,6 +57,13 @@ public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
     @Test
     public void testLogReplicationEndToEnd() throws Exception {
         System.out.println("\n Using plugin :: " + pluginConfigFilePath);
-        testEndToEndSnapshotAndLogEntrySync();
+        testEndToEndSnapshotAndLogEntrySyncUFO();
+    }
+
+    @Test
+    public void testSnapshotSyncMultipleTables() throws Exception {
+        System.out.println("\n Using plugin :: " + pluginConfigFilePath);
+        final int totalNumMaps = 3;
+        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -1,14 +1,25 @@
 package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.proto.Sample;
+import org.corfudb.runtime.CorfuStoreMetadata;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TableSchema;
 import org.corfudb.util.Sleep;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * This suite of tests validates the behavior of Log Replication
@@ -45,7 +56,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     public void testStandbyClusterReset() throws Exception {
         // (1) Snapshot and Log Entry Sync
         log.debug(">>> (1) Start Snapshot and Log Entry Sync");
-        testEndToEndSnapshotAndLogEntrySync();
+        testEndToEndSnapshotAndLogEntrySyncUFO();
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
@@ -80,7 +91,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     public void testActiveClusterReset() throws Exception {
         // (1) Snapshot and Log Entry Sync
         log.debug(">>> (1) Start Snapshot and Log Entry Sync");
-        testEndToEndSnapshotAndLogEntrySync();
+        testEndToEndSnapshotAndLogEntrySyncUFO();
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
@@ -89,7 +100,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
         // Since step (1) wrote numWrites for snapshotSync and numWrites/2 in logEntrySync, continue from this starting point
         writerService.submit(() -> writeToActive((numWrites + numWrites/2), numWrites));
 
-        // (3) Stop Standby Log Replicator Server
+        // (3) Stop Active Log Replicator Server
         log.debug(">>> (3) Stop Active Node");
         stopActiveLogReplicator();
 
@@ -104,5 +115,123 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
         // (6) Verify Data on Standby after Restart
         log.debug(">>> (6) Verify Data on Standby");
         verifyDataOnStandby((numWrites*2 + numWrites/2));
+    }
+
+    @Test
+    public void testSnapshotSyncApplyInterrupted() throws Exception {
+        final int totalNumMaps = 5;
+        final int standbyIndex = 2;
+        final int numWritesSmaller = 1000;
+
+        try {
+            log.debug("Setup active and standby Corfu's");
+            setupActiveAndStandbyCorfu();
+
+            log.debug("Open map on active and standby");
+            openMaps(totalNumMaps);
+
+            // Subscribe to standby map 'Table002' (standbyIndex) to stop Standby LR as soon as updates are received,
+            // forcing snapshot sync apply to be interrupted and resumed after LR standby is restarted
+            subscribe(TABLE_PREFIX + standbyIndex);
+
+            log.debug("Write data to active CorfuDB before LR is started ...");
+            // Add Data for Snapshot Sync
+            writeToActive(0, numWritesSmaller);
+
+            // Confirm data does exist on Active Cluster
+            for(Table<Sample.StringKey, Sample.IntValue, Sample.Metadata> map : mapNameToMapActive.values()) {
+                assertThat(map.count()).isEqualTo(numWritesSmaller);
+            }
+
+            // Confirm data does not exist on Standby Cluster
+            for(Table<Sample.StringKey, Sample.IntValue, Sample.Metadata> map : mapNameToMapStandby.values()) {
+                assertThat(map.count()).isEqualTo(0);
+            }
+
+            startLogReplicatorServers();
+
+            log.debug("Wait ... Snapshot log replication in progress ...");
+            verifyDataOnStandby(numWritesSmaller);
+
+            // Add Delta's for Log Entry Sync
+            writeToActive(numWritesSmaller, numWritesSmaller / 2);
+
+            log.debug("Wait ... Delta log replication in progress ...");
+            verifyDataOnStandby((numWritesSmaller + (numWritesSmaller / 2)));
+        } finally {
+            executorService.shutdownNow();
+
+            if (activeCorfu != null) {
+                activeCorfu.destroy();
+            }
+
+            if (standbyCorfu != null) {
+                standbyCorfu.destroy();
+            }
+
+            if (activeReplicationServer != null) {
+                activeReplicationServer.destroy();
+            }
+
+            if (standbyReplicationServer != null) {
+                standbyReplicationServer.destroy();
+            }
+        }
+    }
+
+    private void subscribe(String mapName) {
+        // Subscribe to mapName and upon changes stop standby LR
+        CorfuStore corfuStore = new CorfuStore(standbyRuntime);
+        CorfuStoreMetadata.Timestamp ts = corfuStore.getTimestamp();
+        try {
+            corfuStore.openTable(
+                    NAMESPACE, mapName,
+                    Sample.StringKey.class, Sample.IntValue.class, Sample.Metadata.class,
+                    TableOptions.builder().build()
+            );
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        StandbyMapListener configStreamListener = new StandbyMapListener(this);
+        corfuStore.subscribe(configStreamListener, NAMESPACE,
+                Collections.singletonList(new TableSchema(mapName, Sample.StringKey.class, Sample.IntValue.class, Sample.Metadata.class)), ts);
+    }
+
+    /**
+     * Stream Listener on topology config table, which is for test only.
+     * It enables ITs run as processes and communicate with the cluster manager
+     * to update topology config.
+     **/
+    public static class StandbyMapListener implements StreamListener {
+
+        private final LogReplicationAbstractIT abstractIT;
+
+        private boolean interruptedSnapshotSyncApply = false;
+
+        public StandbyMapListener(LogReplicationAbstractIT abstractIT) {
+            this.abstractIT = abstractIT;
+        }
+
+        @Override
+        public synchronized void onNext(CorfuStreamEntries results) {
+            log.info("StandbyMapListener:: onNext {} with entry size {}", results, results.getEntries().size());
+
+            if (!interruptedSnapshotSyncApply) {
+
+                interruptedSnapshotSyncApply = true;
+
+                // Stop Log Replication Server so Snapshot Sync Apply is interrupted in the middle and restart
+                log.debug("StandbyMapListener:: Stop Standby LR while in snapshot sync apply phase...");
+                this.abstractIT.stopStandbyLogReplicator();
+
+                log.debug("StandbyMapListener:: Restart Standby LR...");
+                this.abstractIT.startStandbyLogReplicator();
+            }
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            // Ignore
+        }
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
@@ -2,7 +2,6 @@ package org.corfudb.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,7 +64,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
 
             // Write Entry's to Active Cluster (while replicator is down)
             log.debug("Write additional entries to active CorfuDB ...");
-            writeToActive((numWrites + (numWrites/2)), numWrites/2);
+            writeToActiveNonUFO((numWrites + (numWrites/2)), numWrites/2);
 
             // Confirm data does exist on Active Cluster
             assertThat(mapA.size()).isEqualTo(numWrites*2);
@@ -80,7 +79,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
             startActiveLogReplicator();
 
             log.debug("Verify Data on Standby ...");
-            verifyDataOnStandby((numWrites*2));
+            verifyDataOnStandbyNonUFO((numWrites*2));
 
             log.debug("Entries :: " + mapAStandby.keySet());
 
@@ -146,7 +145,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
 
             // Write Entry's to Active Cluster (while replicator is down)
             log.debug("Write additional entries to active CorfuDB ...");
-            writeToActive((numWrites + (numWrites/2)), numWrites/2);
+            writeToActiveNonUFO((numWrites + (numWrites/2)), numWrites/2);
 
             // Confirm data does exist on Active Cluster
             assertThat(mapA.size()).isEqualTo(numWrites*2);
@@ -161,7 +160,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
 
             // Since we did not checkpoint data should be transferred in delta's
             log.debug("Verify Data on Standby ...");
-            verifyDataOnStandby((numWrites*2));
+            verifyDataOnStandbyNonUFO((numWrites*2));
 
             log.debug("Entries :: " + mapAStandby.keySet());
         } finally {
@@ -197,7 +196,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
 
             log.debug("Write data to active CorfuDB before LR is started ...");
             // Add Data for Snapshot Sync
-            writeToActive(0, numWrites);
+            writeToActiveNonUFO(0, numWrites);
 
             // Confirm data does exist on Active Cluster
             assertThat(mapA.size()).isEqualTo(numWrites);
@@ -211,7 +210,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
             startLogReplicatorServers();
 
             log.debug("Wait ... Snapshot log replication in progress ...");
-            verifyDataOnStandby(numWrites);
+            verifyDataOnStandbyNonUFO(numWrites);
         } finally {
             executorService.shutdownNow();
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -7,12 +7,16 @@ import com.google.common.reflect.TypeToken;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.StringJoiner;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.CorfuInterClusterReplicationServer;
+import org.corfudb.infrastructure.logreplication.proto.Sample;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
@@ -20,7 +24,10 @@ import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuDynamicKey;
 import org.corfudb.runtime.collections.CorfuDynamicRecord;
 import org.corfudb.runtime.collections.CorfuRecord;
+import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.view.SMRObject;
 import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.util.serializer.DynamicProtobufSerializer;
@@ -32,6 +39,10 @@ import org.corfudb.util.serializer.Serializers;
 public class LogReplicationAbstractIT extends AbstractIT {
 
     private static final int MSG_SIZE = 65536;
+
+    public static final String TABLE_PREFIX = "Table00";
+
+    public static final String NAMESPACE = "LR-Test";
 
     public final static String nettyConfig = "src/test/resources/transport/nettyConfig.properties";
 
@@ -70,6 +81,12 @@ public class LogReplicationAbstractIT extends AbstractIT {
     public CorfuTable<String, Integer> mapA;
     public CorfuTable<String, Integer> mapAStandby;
 
+    public Map<String, Table<Sample.StringKey, Sample.IntValue, Sample.Metadata>> mapNameToMapActive;
+    public Map<String, Table<Sample.StringKey, Sample.IntValue, Sample.Metadata>> mapNameToMapStandby;
+
+    public CorfuStore corfuStoreActive;
+    public CorfuStore corfuStoreStandby;
+
     public void testEndToEndSnapshotAndLogEntrySync() throws Exception {
         try {
             log.debug("Setup active and standby Corfu's");
@@ -80,7 +97,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
             log.debug("Write data to active CorfuDB before LR is started ...");
             // Add Data for Snapshot Sync
-            writeToActive(0, numWrites);
+            writeToActiveNonUFO(0, numWrites);
 
             // Confirm data does exist on Active Cluster
             assertThat(mapA.size()).isEqualTo(numWrites);
@@ -91,13 +108,13 @@ public class LogReplicationAbstractIT extends AbstractIT {
             startLogReplicatorServers();
 
             log.debug("Wait ... Snapshot log replication in progress ...");
-            verifyDataOnStandby(numWrites);
+            verifyDataOnStandbyNonUFO(numWrites);
 
             // Add Delta's for Log Entry Sync
-            writeToActive(numWrites, numWrites/2);
+            writeToActiveNonUFO(numWrites, numWrites/2);
 
             log.debug("Wait ... Delta log replication in progress ...");
-            verifyDataOnStandby((numWrites + (numWrites / 2)));
+            verifyDataOnStandbyNonUFO((numWrites + (numWrites / 2)));
         } finally {
             executorService.shutdownNow();
 
@@ -120,6 +137,63 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
     }
 
+    public void testEndToEndSnapshotAndLogEntrySyncUFO() throws Exception {
+        testEndToEndSnapshotAndLogEntrySyncUFO(1);
+    }
+
+    public void testEndToEndSnapshotAndLogEntrySyncUFO(int totalNumMaps) throws Exception {
+        try {
+            log.debug("Setup active and standby Corfu's");
+            setupActiveAndStandbyCorfu();
+
+            log.debug("Open map(s) on active and standby");
+            openMaps(totalNumMaps);
+
+            log.debug("Write data to active CorfuDB before LR is started ...");
+            // Add Data for Snapshot Sync
+            writeToActive(0, numWrites);
+
+            // Confirm data does exist on Active Cluster
+            for(Table<Sample.StringKey, Sample.IntValue, Sample.Metadata> map : mapNameToMapActive.values()) {
+                assertThat(map.count()).isEqualTo(numWrites);
+            }
+
+            // Confirm data does not exist on Standby Cluster
+            for(Table<Sample.StringKey, Sample.IntValue, Sample.Metadata> map : mapNameToMapStandby.values()) {
+                assertThat(map.count()).isEqualTo(0);
+            }
+
+            startLogReplicatorServers();
+
+            log.debug("Wait ... Snapshot log replication in progress ...");
+            verifyDataOnStandby(numWrites);
+
+            // Add Delta's for Log Entry Sync
+            writeToActive(numWrites, numWrites / 2);
+
+            log.debug("Wait ... Delta log replication in progress ...");
+            verifyDataOnStandby((numWrites + (numWrites / 2)));
+        } finally {
+            executorService.shutdownNow();
+
+            if (activeCorfu != null) {
+                activeCorfu.destroy();
+            }
+
+            if (standbyCorfu != null) {
+                standbyCorfu.destroy();
+            }
+
+            if (activeReplicationServer != null) {
+                activeReplicationServer.destroy();
+            }
+
+            if (standbyReplicationServer != null) {
+                standbyReplicationServer.destroy();
+            }
+        }
+    }
+
     public void setupActiveAndStandbyCorfu() throws Exception {
         try {
             // Start Single Corfu Node Cluster on Active Site
@@ -138,9 +212,35 @@ public class LogReplicationAbstractIT extends AbstractIT {
             activeRuntime.connect();
 
             standbyRuntime = new CorfuRuntime(standbyEndpoint).connect();
+
+            corfuStoreActive = new CorfuStore(activeRuntime);
+            corfuStoreStandby = new CorfuStore(standbyRuntime);
         } catch (Exception e) {
             log.debug("Error while starting Corfu");
             throw  e;
+        }
+    }
+
+    public void openMaps(int mapCount) throws Exception {
+        mapNameToMapActive = new HashMap<>();
+        mapNameToMapStandby = new HashMap<>();
+
+        for(int i=1; i<=mapCount; i++) {
+            String mapName = TABLE_PREFIX + i;
+
+            Table<Sample.StringKey, Sample.IntValue, Sample.Metadata> mapActive = corfuStoreActive.openTable(
+                    NAMESPACE, mapName, Sample.StringKey.class, Sample.IntValue.class, Sample.Metadata.class,
+                    TableOptions.builder().build());
+
+            Table<Sample.StringKey, Sample.IntValue, Sample.Metadata> mapStandby = corfuStoreStandby.openTable(
+                    NAMESPACE, mapName, Sample.StringKey.class, Sample.IntValue.class, Sample.Metadata.class,
+                    TableOptions.builder().build());
+
+            mapNameToMapActive.put(mapName, mapActive);
+            mapNameToMapStandby.put(mapName, mapStandby);
+
+            assertThat(mapActive.count()).isEqualTo(0);
+            assertThat(mapStandby.count()).isEqualTo(0);
         }
     }
 
@@ -164,12 +264,30 @@ public class LogReplicationAbstractIT extends AbstractIT {
         assertThat(mapAStandby.size()).isEqualTo(0);
     }
 
-    public void writeToActive(int startIndex, int totalEntries) {
+    public void writeToActiveNonUFO(int startIndex, int totalEntries) {
         int maxIndex = totalEntries + startIndex;
         for (int i = startIndex; i < maxIndex; i++) {
             activeRuntime.getObjectsView().TXBegin();
             mapA.put(String.valueOf(i), i);
             activeRuntime.getObjectsView().TXEnd();
+        }
+    }
+
+    public void writeToActive(int startIndex, int totalEntries) {
+        int maxIndex = totalEntries + startIndex;
+        for(Map.Entry<String, Table<Sample.StringKey, Sample.IntValue, Sample.Metadata>> entry : mapNameToMapActive.entrySet()) {
+
+            log.debug(">>> Write to active cluster, map={}", entry.getKey());
+
+            String mapName = entry.getKey();
+            for (int i = startIndex; i < maxIndex; i++) {
+                Sample.StringKey stringKey = Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build();
+                Sample.IntValue intValue = Sample.IntValue.newBuilder().setValue(i).build();
+                Sample.Metadata metadata = Sample.Metadata.newBuilder().setMetadata("Metadata_" + i).build();
+                corfuStoreActive.tx(NAMESPACE)
+                        .update(mapName, stringKey, intValue, metadata)
+                        .commit();
+            }
         }
     }
 
@@ -296,7 +414,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
         }
     }
 
-    public void verifyDataOnStandby(int expectedConsecutiveWrites) {
+    public void verifyDataOnStandbyNonUFO(int expectedConsecutiveWrites) {
         // Wait until data is fully replicated
         while (mapAStandby.size() != expectedConsecutiveWrites) {
             // Block until expected number of entries is reached
@@ -337,6 +455,99 @@ public class LogReplicationAbstractIT extends AbstractIT {
         }
 
         checkpointAndTrimCorfuStore(cpRuntime, trimMark);
+    }
+
+    public void verifyDataOnStandby(int expectedConsecutiveWrites) {
+        for(Map.Entry<String, Table<Sample.StringKey, Sample.IntValue, Sample.Metadata>> entry : mapNameToMapStandby.entrySet()) {
+
+            log.debug("Verify Data on Standby's Table {}", entry.getKey());
+
+            // Wait until data is fully replicated
+            while (entry.getValue().count() != expectedConsecutiveWrites) {
+                // Block until expected number of entries is reached
+            }
+
+            log.debug("Number updates on Standby Map {} :: {} ", entry.getKey(), expectedConsecutiveWrites);
+
+            // Verify data is present in Standby Site
+            assertThat(entry.getValue().count()).isEqualTo(expectedConsecutiveWrites);
+
+            for (int i = 0; i < (expectedConsecutiveWrites); i++) {
+                assertThat(entry.getValue().get(Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build()).getPayload()).isNotNull();
+            }
+        }
+    }
+
+    /**
+     * Checkpoint and Trim Data Logs
+     *
+     * @param active true, checkpoint/trim on active cluster
+     *               false, checkpoint/trim on standby cluster
+     */
+    public void checkpointAndTrim(boolean active) {
+        CorfuRuntime cpRuntime;
+
+        if (active) {
+            cpRuntime = new CorfuRuntime(activeEndpoint).connect();
+        } else {
+            cpRuntime = new CorfuRuntime(standbyEndpoint).connect();
+        }
+
+        checkpointAndTrimCorfuStore(cpRuntime);
+    }
+
+    public void checkpointAndTrimCorfuStore(CorfuRuntime cpRuntime) {
+        // Open Table Registry
+        TableRegistry tableRegistry = cpRuntime.getTableRegistry();
+        CorfuTable<CorfuStoreMetadata.TableName, CorfuRecord<CorfuStoreMetadata.TableDescriptors,
+                CorfuStoreMetadata.TableMetadata>> tableRegistryCT = tableRegistry.getRegistryTable();
+
+        // Save the regular serializer first..
+        ISerializer protoBufSerializer = Serializers.getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
+
+        // Must register dynamicProtoBufSerializer *AFTER* the getTableRegistry() call to ensure that
+        // the serializer does not go back to the regular ProtoBufSerializer
+        ISerializer dynamicProtoBufSerializer = new DynamicProtobufSerializer(cpRuntime);
+        Serializers.registerSerializer(dynamicProtoBufSerializer);
+
+        // First checkpoint the TableRegistry system table
+        MultiCheckpointWriter<CorfuTable> mcw = new MultiCheckpointWriter<>();
+
+        Token trimMark = null;
+
+        for (CorfuStoreMetadata.TableName tableName : tableRegistry.listTables(null)) {
+            String fullTableName = TableRegistry.getFullyQualifiedTableName(
+                    tableName.getNamespace(), tableName.getTableName()
+            );
+            SMRObject.Builder<CorfuTable<CorfuDynamicKey, CorfuDynamicRecord>> corfuTableBuilder = cpRuntime.getObjectsView().build()
+                    .setTypeToken(new TypeToken<CorfuTable<CorfuDynamicKey, CorfuDynamicRecord>>() {})
+                    .setStreamName(fullTableName)
+                    .setSerializer(dynamicProtoBufSerializer);
+
+            mcw = new MultiCheckpointWriter<>();
+            mcw.addMap(corfuTableBuilder.open());
+            Token token = mcw.appendCheckpoints(cpRuntime, "checkpointer");
+            trimMark = token;
+        }
+
+        // Finally checkpoint the TableRegistry system table itself..
+        mcw.addMap(tableRegistryCT);
+        Token token = mcw.appendCheckpoints(cpRuntime, "checkpointer");
+        trimMark = trimMark != null ? Token.min(trimMark, token) : token;
+
+        cpRuntime.getAddressSpaceView().prefixTrim(trimMark);
+        cpRuntime.getAddressSpaceView().gc();
+
+        // Lastly restore the regular protoBuf serializer and undo the dynamic protoBuf serializer
+        // otherwise the test cannot continue beyond this point.
+        Serializers.registerSerializer(protoBufSerializer);
+
+        // Trim
+        log.debug("**** Trim Log @address=" + trimMark);
+        cpRuntime.getAddressSpaceView().prefixTrim(trimMark);
+        cpRuntime.getAddressSpaceView().invalidateClientCache();
+        cpRuntime.getAddressSpaceView().invalidateServerCaches();
+        cpRuntime.getAddressSpaceView().gc();
     }
 
     public void checkpointAndTrimCorfuStore(CorfuRuntime cpRuntime, Token trimMark) {
@@ -389,5 +600,31 @@ public class LogReplicationAbstractIT extends AbstractIT {
         cpRuntime.getAddressSpaceView().invalidateClientCache();
         cpRuntime.getAddressSpaceView().invalidateServerCaches();
         cpRuntime.getAddressSpaceView().gc();
+    }
+
+    /**
+     * Return the first map on active cluster (typical for cases where the number of map is set to 1)
+     * @return first map on active cluster
+     */
+    public Table<Sample.StringKey, Sample.IntValue, Sample.Metadata> getActiveMap() {
+        Iterator<Map.Entry<String, Table<Sample.StringKey, Sample.IntValue, Sample.Metadata>>> it = mapNameToMapActive.entrySet().iterator();
+        if (it.hasNext()) {
+            return it.next().getValue();
+        }
+
+        return null;
+    }
+
+    /**
+     * Return the first map on standby cluster (typical for cases where the number of map is set to 1)
+     * @return first map on standby cluster
+     */
+    public Table<Sample.StringKey, Sample.IntValue, Sample.Metadata> getStandbyMap() {
+        Iterator<Map.Entry<String, Table<Sample.StringKey, Sample.IntValue, Sample.Metadata>>> it = mapNameToMapStandby.entrySet().iterator();
+        if (it.hasNext()) {
+            return it.next().getValue();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
## Overview

Description:

Resume Snapshot Sync Apply on node restart or leadership change. 

If the lead standby node is restarted after a snapshot transfer is completed but while apply is still not completed, there is no current way to resume snapshot apply on leadership change or restart. 

Why should this be merged: potential bug  

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
