### PR TITLE
Change Sequencer Cache Logging Level

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServerCache.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServerCache.java
@@ -138,28 +138,34 @@ public class SequencerServerCache {
         return cacheEntries.peek().txVersion;
     }
 
-    /**
-     * Invalidate the records with the minAddress. It could be one or multiple records
-     * @return the number of entries has been invalidated and removed from the cache.
-     */
-    private int invalidateSmallestTxVersion() {
-        ConflictTxStream firstEntry = cacheEntries.peek();
-        if (cacheEntries.size() == 0) {
-            return 0;
-        }
-
-        int numEntries = 0;
-
-        while (firstAddress() == firstEntry.txVersion) {
-            log.debug("evict items " + numEntries + " with address " + firstAddress());
-            ConflictTxStream entry = cacheEntries.poll();
-            conflictKeys.remove(entry);
-            numEntries++;
-        }
-        log.trace("Evict {} entries", numEntries);
-        maxConflictWildcard = Math.max(maxConflictWildcard, firstEntry.txVersion);
-        return numEntries;
+  /**
+   * Invalidate the records with the minAddress. It could be one or multiple records
+   *
+   * @return the number of entries has been invalidated and removed from the cache.
+   */
+  private int invalidateSmallestTxVersion() {
+    ConflictTxStream firstEntry = cacheEntries.peek();
+    if (cacheEntries.size() == 0) {
+      return 0;
     }
+
+    int numEntries = 0;
+
+    while (firstAddress() == firstEntry.txVersion) {
+      if (log.isTraceEnabled()) {
+        log.trace(
+            "invalidateSmallestTxVersion: items evicted {} min address {}",
+            numEntries,
+            firstAddress());
+      }
+      ConflictTxStream entry = cacheEntries.poll();
+      conflictKeys.remove(entry);
+      numEntries++;
+    }
+
+    maxConflictWildcard = Math.max(maxConflictWildcard, firstEntry.txVersion);
+    return numEntries;
+  }
 
     /**
      * Invalidate all records up to a trim mark (not included).


### PR DESCRIPTION
## Overview
Changed evict logs to trace.

Why should this be merged: Polluting server logs when debug is enabled 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
