### PR TITLE
CorfuStore option Tx Logging Disabled

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -793,11 +793,11 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         }
 
         UUID forceSyncId = UUID.randomUUID();
-        log.info("Received the forceSnapshotSync command for standby cluster {}, forced sync id {}",
+        log.info("Received forceSnapshotSync command for standby cluster {}, forced sync id {}",
                 clusterId, forceSyncId);
 
-        // Write an force sync event to the logReplicationEventTable
-        ReplicationEventKey key = ReplicationEventKey.newBuilder().setKey(System.currentTimeMillis() + " "+ clusterId).build();
+        // Write a force sync event to the logReplicationEventTable
+        ReplicationEventKey key = ReplicationEventKey.newBuilder().setKey(System.currentTimeMillis() + " " + clusterId).build();
         ReplicationEvent event = ReplicationEvent.newBuilder()
                 .setClusterId(clusterId)
                 .setEventId(forceSyncId.toString())

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -828,6 +828,10 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         if (lockClient != null) {
             lockClient.shutdown();
         }
+
+        if (logReplicationMetadataManager != null) {
+            logReplicationMetadataManager.shutdown();
+        }
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -31,13 +31,12 @@ public final class LogReplicationEventListener implements StreamListener {
         // If the current node is not a leader, ignore the notifications.
         synchronized (discoveryService) {
             if (!discoveryService.getIsLeader().get()) {
-                log.info("The onNext call  with {} will be skipped as the current node as it is not the leader.", results);
+                log.info("The onNext call with {} will be skipped as the current node as it is not the leader.", results);
                 return;
             }
 
             log.info("LogReplicationEventListener onNext {} will be processed at node {} in the cluster {}",
                     results, discoveryService.getLocalNodeDescriptor(), discoveryService.getLocalClusterDescriptor());
-
 
             // If the current node is the leader, it generates a discovery event and put it into the discovery service event queue.
             for (List<CorfuStreamEntry> entryList : results.getEntries().values()) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -93,9 +93,8 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
         clusterManagerCallback = new ClusterManagerCallback(this);
         corfuRuntime = CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
                 .parseConfigurationString("localhost:9000")
-                .setTransactionLogging(true)
                 .connect();
-        corfuStore = new CorfuStore(corfuRuntime);
+        corfuStore = new CorfuStore(corfuRuntime, false);
         CorfuStoreMetadata.Timestamp ts = corfuStore.getTimestamp();
         try {
             Table<Messages.Uuid, Messages.Uuid, Messages.Uuid> table = corfuStore.openTable(

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -20,7 +20,6 @@ import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TableSchema;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
-import org.corfudb.utils.CommonTypes;
 
 import java.io.File;
 import java.io.FileReader;
@@ -62,12 +61,12 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
 
     public static final String CONFIG_NAMESPACE = "ns_lr_config_it";
     public static final String CONFIG_TABLE_NAME = "lr_config_it";
-    public static final CommonTypes.Uuid OP_RESUME = CommonTypes.Uuid.newBuilder().setLsb(0L).setMsb(0L).build();
-    public static final CommonTypes.Uuid OP_SWITCH = CommonTypes.Uuid.newBuilder().setLsb(1L).setMsb(1L).build();
-    public static final CommonTypes.Uuid OP_TWO_ACTIVE = CommonTypes.Uuid.newBuilder().setLsb(2L).setMsb(2L).build();
-    public static final CommonTypes.Uuid OP_ALL_STANDBY = CommonTypes.Uuid.newBuilder().setLsb(3L).setMsb(3L).build();
-    public static final CommonTypes.Uuid OP_INVALID = CommonTypes.Uuid.newBuilder().setLsb(4L).setMsb(4L).build();
-    public static final CommonTypes.Uuid OP_ENFORCE_SNAPSHOT_FULL_SYNC = CommonTypes.Uuid.newBuilder().setLsb(5L).setMsb(5L).build();
+    public static final Messages.Uuid OP_RESUME = Messages.Uuid.newBuilder().setLsb(0L).setMsb(0L).build();
+    public static final Messages.Uuid OP_SWITCH = Messages.Uuid.newBuilder().setLsb(1L).setMsb(1L).build();
+    public static final Messages.Uuid OP_TWO_ACTIVE = Messages.Uuid.newBuilder().setLsb(2L).setMsb(2L).build();
+    public static final Messages.Uuid OP_ALL_STANDBY = Messages.Uuid.newBuilder().setLsb(3L).setMsb(3L).build();
+    public static final Messages.Uuid OP_INVALID = Messages.Uuid.newBuilder().setLsb(4L).setMsb(4L).build();
+    public static final Messages.Uuid OP_ENFORCE_SNAPSHOT_FULL_SYNC = Messages.Uuid.newBuilder().setLsb(5L).setMsb(5L).build();
 
     @Getter
     private long configId;
@@ -103,12 +102,14 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
                     TableOptions.builder().build()
             );
             table.clear();
+
+
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
         configStreamListener = new ConfigStreamListener(this);
         corfuStore.subscribe(configStreamListener, CONFIG_NAMESPACE,
-                Collections.singletonList(new TableSchema(CONFIG_TABLE_NAME, CommonTypes.Uuid.class, CommonTypes.Uuid.class, CommonTypes.Uuid.class)), ts);
+                Collections.singletonList(new TableSchema(CONFIG_TABLE_NAME, Messages.Uuid.class, Messages.Uuid.class, Messages.Uuid.class)), ts);
         thread = new Thread(clusterManagerCallback);
         thread.start();
     }
@@ -358,14 +359,14 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
 
         @Override
         public void onNext(CorfuStreamEntries results) {
-            log.info("ConfigStreamListener onNext {} with entry size {}", results, results.getEntries().size());
+            log.info("onNext :: entry size={}", results.getEntries().size());
             CorfuStreamEntry entry = results.getEntries().values()
                     .stream()
                     .findFirst()
                     .map(corfuStreamEntries -> corfuStreamEntries.get(0))
                     .orElse(null);
             if (entry != null && entry.getOperation().equals(CorfuStreamEntry.OperationType.UPDATE)) {
-                log.info("onNext entry is {}, key{}, p{}, m{}, op{}", entry, entry.getKey(), entry.getPayload(), entry.getMetadata(), entry.getOperation());
+                log.info("onNext :: key={}, payload={}, metadata={}", entry.getKey(), entry.getPayload(), entry.getMetadata());
                 if (entry.getKey().equals(OP_SWITCH)) {
                     clusterManager.getClusterManagerCallback()
                             .applyNewTopologyConfig(clusterManager.generateConfigWithRoleSwitch());
@@ -393,6 +394,9 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
                         }
                     }
                 }
+            } else {
+                log.info("onNext :: operation={}, key={}, payload={}, metadata={}", entry.getOperation().name(),
+                        entry.getKey(), entry.getPayload(), entry.getMetadata());
             }
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -58,17 +58,21 @@ public class LogReplicationMetadataManager {
     private final String localClusterId;
 
     public LogReplicationMetadataManager(CorfuRuntime rt, long topologyConfigId, String localClusterId) {
+
+        // LR does not require transaction logging enabled as we don't want to trigger subscriber's logic
+        // on replicated data which could eventually lead to overwrites
+        this.runtime = rt;
+        this.corfuStore = new CorfuStore(runtime, false);
+
+        // This special runtime with transaction logging enabled is required for the REPLICATION_EVENT_TABLE
+        // which is a table used to communicate events between lead and non-lead nodes in LR (e.g., notify
+        // force snapshot sync from a non-lead to the lead node)
         CorfuRuntime.CorfuRuntimeParameters params = rt.getParameters();
         this.runtimeTxLogging = CorfuRuntime.fromParameters(params)
                 .setTransactionLogging(true)
                 .parseConfigurationString(rt.getLayoutServers().get(0))
                 .connect();
         this.corfuStoreTxLogging = new CorfuStore(runtimeTxLogging);
-
-        this.runtime = rt;
-        // LR does not require transaction logging as we don't want data change notifications on the replicated data
-        // this runtime is reused by the LogEntryWriter and SnapshotWriter
-        this.corfuStore = new CorfuStore(runtime, false);
 
         metadataTableName = getPersistedWriterMetadataTableName(localClusterId);
         try {
@@ -701,6 +705,12 @@ public class LogReplicationMetadataManager {
      */
     public void unsubscribeReplicationEventTable(StreamListener listener) {
         corfuStore.unsubscribe(listener);
+    }
+
+    public void shutdown() {
+        if (runtimeTxLogging != null) {
+            runtimeTxLogging.shutdown();
+        }
     }
 
     public enum LogReplicationMetadataType {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
@@ -37,9 +37,12 @@ public class LogReplicationStreamNameTableManager {
 
     private String pluginConfigFilePath;
 
+    private CorfuStore corfuStore;
+
     public LogReplicationStreamNameTableManager(CorfuRuntime runtime, String pluginConfigFilePath) {
         this.pluginConfigFilePath = pluginConfigFilePath;
         this.corfuRuntime = runtime;
+        corfuStore = new CorfuStore(corfuRuntime, false);
 
         initStreamNameFetcherPlugin();
     }
@@ -94,7 +97,6 @@ public class LogReplicationStreamNameTableManager {
     }
 
     private boolean verifyTableExists(String tableName) {
-        CorfuStore corfuStore = new CorfuStore(corfuRuntime);
         try {
             corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, tableName);
         } catch (NoSuchElementException e) {
@@ -105,7 +107,6 @@ public class LogReplicationStreamNameTableManager {
     }
 
     private void openExistingTable(String tableName) {
-        CorfuStore corfuStore = new CorfuStore(corfuRuntime);
         try {
             if (Objects.equals(tableName, LOG_REPLICATION_STREAMS_NAME_TABLE)) {
                 corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, tableName, LogReplicationStreams.TableInfo.class,
@@ -120,7 +121,6 @@ public class LogReplicationStreamNameTableManager {
     }
 
     private boolean tableVersionMatchesPlugin() {
-        CorfuStore corfuStore = new CorfuStore(corfuRuntime);
         corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_PLUGIN_VERSION_TABLE);
         LogReplicationStreams.VersionString versionString = LogReplicationStreams.VersionString.newBuilder().setName("VERSION").build();
         Query q = corfuStore.query(CORFU_SYSTEM_NAMESPACE);
@@ -135,7 +135,6 @@ public class LogReplicationStreamNameTableManager {
     }
 
     private void deleteExistingStreamNameAndVersionTables() {
-        CorfuStore corfuStore = new CorfuStore(corfuRuntime);
         try {
             corfuStore.deleteTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_STREAMS_NAME_TABLE);
             corfuStore.deleteTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_PLUGIN_VERSION_TABLE);
@@ -146,7 +145,6 @@ public class LogReplicationStreamNameTableManager {
     }
 
     private void createStreamNameAndVersionTables(Map<String, String> streams) {
-        CorfuStore corfuStore = new CorfuStore(corfuRuntime);
         try {
             corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_STREAMS_NAME_TABLE, LogReplicationStreams.TableInfo.class,
                     LogReplicationStreams.Namespace.class, CommonTypes.Uuid.class, TableOptions.builder().build());
@@ -174,7 +172,6 @@ public class LogReplicationStreamNameTableManager {
     }
 
     private Set<String> readStreamsToReplicateFromTable() {
-        CorfuStore corfuStore = new CorfuStore(corfuRuntime);
         corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_STREAMS_NAME_TABLE);
         Query q = corfuStore.query(CORFU_SYSTEM_NAMESPACE);
         Set<LogReplicationStreams.TableInfo> tables = q.keySet(LOG_REPLICATION_STREAMS_NAME_TABLE, null);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -37,9 +37,19 @@ public class CorfuStore {
      */
     @Nonnull
     public CorfuStore(@Nonnull final CorfuRuntime runtime) {
-        runtime.setTransactionLogging(true);
-        this.runtime = runtime;
+        this(runtime, true);
     }
+
+    /**
+     * Creates a new CorfuStore.
+     *
+     * @param runtime Connected instance of the Corfu Runtime.
+     * @param enableTxLogging
+     */
+    @Nonnull
+    public CorfuStore(@Nonnull final CorfuRuntime runtime, boolean enableTxLogging) {
+        runtime.setTransactionLogging(enableTxLogging);
+        this.runtime = runtime;    }
 
     /**
      * Fetches the latest logical timestamp (global tail) in Corfu's distributed log.

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -49,7 +49,6 @@ public class ObjectsView extends AbstractView {
     @Setter
     boolean transactionLogging = false;
 
-
     @Getter
     Map<ObjectID, Object> objectCache = new ConcurrentHashMap<>();
 

--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -125,7 +125,7 @@ public class DynamicProtobufSerializer implements ISerializer {
      * @return Protobuf Serializer.
      */
     private ISerializer createProtobufSerializer() {
-        Map<String, Class<? extends Message>> classMap = new ConcurrentHashMap<>();
+        ConcurrentMap<String, Class<? extends Message>> classMap = new ConcurrentHashMap<>();
 
         // Register the schemas of TableName, TableDescriptors & TableMetadata
         // to be able to understand registry table.

--- a/runtime/src/main/java/org/corfudb/util/serializer/ProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/ProtobufSerializer.java
@@ -10,7 +10,9 @@ import io.netty.buffer.ByteBufOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 
+import lombok.Getter;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata.Record;
 import org.corfudb.runtime.collections.CorfuRecord;
@@ -35,9 +37,10 @@ public class ProtobufSerializer implements ISerializer {
 
     public static final byte PROTOBUF_SERIALIZER_CODE = (byte) 25;
 
-    private final Map<String, Class<? extends Message>> classMap;
+    @Getter
+    private final ConcurrentMap<String, Class<? extends Message>> classMap;
 
-    public ProtobufSerializer(Map<String, Class<? extends Message>> classMap) {
+    public ProtobufSerializer(ConcurrentMap<String, Class<? extends Message>> classMap) {
         this.type = PROTOBUF_SERIALIZER_CODE;
         this.classMap = classMap;
     }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -11,6 +11,7 @@ import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.Lo
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
+import org.corfudb.runtime.Messages;
 import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuTable;
@@ -18,7 +19,6 @@ import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.util.Sleep;
-import org.corfudb.utils.CommonTypes;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,9 +69,9 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     private CorfuTable<String, Integer> mapActive;
     private CorfuTable<String, Integer> mapStandby;
 
-    private CorfuStore corfuStore;
+    private CorfuStore activeCorfuStore;
     private CorfuStore standbyCorfuStore;
-    private Table<CommonTypes.Uuid, CommonTypes.Uuid, CommonTypes.Uuid> configTable;
+    private Table<Messages.Uuid, Messages.Uuid, Messages.Uuid> configTable;
 
     @Before
     public void setUp() throws Exception {
@@ -105,16 +105,16 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         assertThat(mapActive.size()).isZero();
         assertThat(mapStandby.size()).isZero();
 
-        corfuStore = new CorfuStore(activeRuntime);
+        activeCorfuStore = new CorfuStore(activeRuntime);
         standbyCorfuStore = new CorfuStore(standbyRuntime);
 
-        configTable = corfuStore.openTable(
+        configTable = activeCorfuStore.openTable(
                 DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
-                CommonTypes.Uuid.class, CommonTypes.Uuid.class, CommonTypes.Uuid.class,
+                Messages.Uuid.class, Messages.Uuid.class, Messages.Uuid.class,
                 TableOptions.builder().build()
         );
 
-        corfuStore.openTable(LogReplicationMetadataManager.NAMESPACE,
+        activeCorfuStore.openTable(LogReplicationMetadataManager.NAMESPACE,
                 REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -212,7 +212,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                         .setClusterId(DefaultClusterConfig.getStandbyClusterId())
                         .build();
         CorfuRecord<LogReplicationMetadata.ReplicationStatusVal, Message> record =
-                corfuStore.query(LogReplicationMetadataManager.NAMESPACE).getRecord(REPLICATION_STATUS_TABLE, key);
+                activeCorfuStore.query(LogReplicationMetadataManager.NAMESPACE).getRecord(REPLICATION_STATUS_TABLE, key);
         LogReplicationMetadata.ReplicationStatusVal replicationStatusVal = record.getPayload();
 
         log.info("ReplicationStatusVal: RemainingEntriesToSend: {}, SyncType: {}, Status: {}",
@@ -234,7 +234,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                 .isEqualTo(LogReplicationMetadata.SyncStatus.COMPLETED);
 
         // Perform a role switch
-        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+        activeCorfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
                 .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_SWITCH,
                         DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH)
                 .commit();
@@ -295,7 +295,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         assertThat(mapStandby.size()).isEqualTo(thirdBatch);
 
         // Second Role Switch
-        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+        activeCorfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
                 .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_SWITCH,
                         DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH)
                 .commit();
@@ -322,7 +322,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         assertThat(mapStandby.size()).isEqualTo(fourthBatch);
 
         // Verify Sync Status
-        record = corfuStore.query(LogReplicationMetadataManager.NAMESPACE).getRecord(REPLICATION_STATUS_TABLE, key);
+        record = activeCorfuStore.query(LogReplicationMetadataManager.NAMESPACE).getRecord(REPLICATION_STATUS_TABLE, key);
         replicationStatusVal = record.getPayload();
 
         log.info("ReplicationStatusVal: RemainingEntriesToSend: {}, SyncType: {}, Status: {}",
@@ -377,7 +377,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Perform a role switch during transfer
         assertThat(mapStandby.size()).isEqualTo(0);
-        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+        activeCorfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
                 .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_SWITCH,
                         DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH)
                 .commit();
@@ -437,7 +437,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         log.info("======standby tail is : " + standbyRuntime.getAddressSpaceView().getAllTails().getStreamTails().get(standbyStream));
 
         // Perform a role switch
-        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+        activeCorfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
                 .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_SWITCH,
                         DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH)
                 .commit();
@@ -518,7 +518,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         log.info("Log replication succeeds without config change!");
 
         // Perform a config update with two active
-        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+        activeCorfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
                 .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_TWO_ACTIVE,
                         DefaultClusterManager.OP_TWO_ACTIVE, DefaultClusterManager.OP_TWO_ACTIVE)
                 .commit();
@@ -606,7 +606,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         log.info("Log replication succeeds without config change!");
 
         // Perform a config update with all standby
-        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+        activeCorfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
                 .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_ALL_STANDBY,
                         DefaultClusterManager.OP_ALL_STANDBY, DefaultClusterManager.OP_ALL_STANDBY)
                 .commit();
@@ -694,7 +694,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         log.info("Log replication succeeds without config change!");
 
         // Perform a config update with invalid state
-        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+        activeCorfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
                 .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_INVALID,
                         DefaultClusterManager.OP_INVALID, DefaultClusterManager.OP_INVALID)
                 .commit();
@@ -720,7 +720,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         log.info("After {} seconds sleep, double check passed", mediumInterval);
 
         // Change to default active standby config
-        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+        activeCorfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
                 .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_RESUME,
                         DefaultClusterManager.OP_RESUME, DefaultClusterManager.OP_RESUME)
                 .commit();
@@ -808,7 +808,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                         .setClusterId(DefaultClusterConfig.getStandbyClusterId())
                         .build();
         CorfuRecord<LogReplicationMetadata.ReplicationStatusVal, Message> record =
-                corfuStore.query(LogReplicationMetadataManager.NAMESPACE).getRecord(REPLICATION_STATUS_TABLE, key);
+                activeCorfuStore.query(LogReplicationMetadataManager.NAMESPACE).getRecord(REPLICATION_STATUS_TABLE, key);
         LogReplicationMetadata.ReplicationStatusVal replicationStatusVal = record.getPayload();
 
         log.info("ReplicationStatusVal: RemainingEntriesToSend: {}, SyncType: {}, Status: {}",
@@ -859,7 +859,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         assertThat(mapActive.size()).isEqualTo(thirdBatch);
 
         // Perform an enforce full snapshot sync
-        corfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
+        activeCorfuStore.tx(DefaultClusterManager.CONFIG_NAMESPACE)
                 .update(DefaultClusterManager.CONFIG_TABLE_NAME, DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC,
                         DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC, DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC)
                 .commit();
@@ -870,7 +870,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         assertThat(mapStandby.size()).isEqualTo(thirdBatch);
 
         // Verify that a forced snapshot sync is finished.
-        record = corfuStore.query(LogReplicationMetadataManager.NAMESPACE).getRecord(REPLICATION_STATUS_TABLE, key);
+        record = activeCorfuStore.query(LogReplicationMetadataManager.NAMESPACE).getRecord(REPLICATION_STATUS_TABLE, key);
         replicationStatusVal = record.getPayload();
 
         log.info("ReplicationStatusVal: RemainingEntriesToSend: {}, SyncType: {}, Status: {}",

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -792,7 +792,6 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         standbyReplicationServer = runReplicationServer(standbyReplicationServerPort, nettyPluginPath);
         log.info("Replication servers started, and replication is in progress...");
 
-
         // Wait until data is fully replicated
         waitForReplication(size -> size == firstBatch, mapStandby, firstBatch);
 
@@ -886,7 +885,6 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                 .isEqualTo(LogReplicationMetadata.ReplicationStatusVal.SyncType.LOG_ENTRY);
         assertThat(replicationStatusVal.getStatus())
                 .isEqualTo(LogReplicationMetadata.SyncStatus.ONGOING);
-
         assertThat(replicationStatusVal.getSnapshotSyncInfo().getType())
                 .isEqualTo(LogReplicationMetadata.SnapshotSyncInfo.SnapshotSyncType.FORCED);
         assertThat(replicationStatusVal.getSnapshotSyncInfo().getStatus())

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -2,9 +2,6 @@ package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.proto.Sample;
-import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
-import org.corfudb.protocols.logprotocol.MultiSMREntry;
-import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
@@ -25,8 +22,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -254,27 +249,11 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
             System.out.println("Total Transaction Stream updates, count=" + counter);
             log.info("Total Tx Stream updates = {}", counter);
-            return counter == 0;
-        });
-    }
 
-    /**
-     *
-     * Extract the updates from the MultiObjectSMREntry and updates the counters map
-     */
-    private void ConsumeDelta(Map<UUID, Integer> map, List<ILogData> deltas) {
-        for (ILogData ld : deltas) {
-            MultiObjectSMREntry multiObjSmr = (MultiObjectSMREntry) ld.getPayload(null);
-            for (Map.Entry<UUID, MultiSMREntry> multiSMREntry : multiObjSmr.getEntryMap().entrySet()) {
-                for (SMREntry update : multiSMREntry.getValue().getUpdates()) {
-                    int key = (int) update.getSMRArguments()[0];
-                    int val = (int) update.getSMRArguments()[1];
-                    assertThat(key).isEqualTo(val);
-                    int newVal = map.getOrDefault(multiSMREntry.getKey(), 0) + key;
-                    map.put(multiSMREntry.getKey(), newVal);
-                }
-            }
-        }
+            // This one update accounts for the REPLICATION_EVENT_TABLE which forces an entry to the
+            // TableRegistry
+            return counter == 1;
+        });
     }
 
     private void subscribe(String mapName) {

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserIT.java
@@ -8,6 +8,7 @@ import java.nio.file.Paths;
 
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.util.serializer.Serializers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -130,6 +131,8 @@ public class CorfuStoreBrowserIT extends AbstractIT {
         Assert.assertEquals(browser.dropTable(namespace, tableName), 1);
         // Invoke tableInfo and verify size
         Assert.assertEquals(browser.printTableInfo(namespace, tableName), 0);
+        // TODO: Remove this once serializers move into the runtime
+        Serializers.clearCustomSerializers();
     }
 
     /**
@@ -151,6 +154,9 @@ public class CorfuStoreBrowserIT extends AbstractIT {
 
         CorfuStoreBrowser browser = new CorfuStoreBrowser(runtime);
         Assert.assertEquals(browser.loadTable(namespace, tableName, numItems, batchSize, itemSize), batchSize);
+        runtime.shutdown();
+        // TODO: Remove this once serializers move into the runtime
+        Serializers.clearCustomSerializers();
     }
 
     /**
@@ -216,6 +222,9 @@ public class CorfuStoreBrowserIT extends AbstractIT {
                 UnknownFieldSet.newBuilder().build(),
                 record.getPayload().getUnknownFields());
         }
+        runtime.shutdown();
+        // TODO: Remove this once serializers move into the runtime
+        Serializers.clearCustomSerializers();
     }
 
     /**
@@ -276,6 +285,8 @@ public class CorfuStoreBrowserIT extends AbstractIT {
         // Invoke listTables and verify table count
         Assert.assertEquals(2, browser.printTableInfo(TableRegistry.CORFU_SYSTEM_NAMESPACE,
         TableRegistry.REGISTRY_TABLE_NAME));
+        // Todo: Remove this once serializers move into the runtime
+        Serializers.clearCustomSerializers();
     }
 
     /**
@@ -328,6 +339,8 @@ public class CorfuStoreBrowserIT extends AbstractIT {
                 .build();
         TxnContext tx = store.txn(namespace);
         tx.put(table, uuidKey, uuidVal, metadata).commit();
+        // Todo: Remove this once serializers move into the runtime
+        Serializers.clearCustomSerializers();
         runtime.shutdown();
 
         runtime = createRuntime(singleNodeEndpoint);
@@ -337,5 +350,9 @@ public class CorfuStoreBrowserIT extends AbstractIT {
         final CorfuStoreBrowser browser = new CorfuStoreBrowser(runtime, tempDir);
         // Verify table count
         Assert.assertEquals(1, browser.printTable(namespace, tableName));
+
+        // Todo: Remove this once serializers move into the runtime
+        Serializers.clearCustomSerializers();
+        runtime.shutdown();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -221,6 +221,7 @@ public class CorfuStoreIT extends AbstractIT {
 
         runtime.getAddressSpaceView().prefixTrim(trimPoint);
         runtime.getAddressSpaceView().gc();
+        Serializers.clearCustomSerializers();
         runtime.shutdown();
 
         // PHASE 3

--- a/utils/src/main/java/org/corfudb/utils/lock/persistence/LockStore.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/persistence/LockStore.java
@@ -62,7 +62,7 @@ public class LockStore {
      * @throws InvocationTargetException
      */
     public LockStore(CorfuRuntime runtime, UUID clientUuid) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        this.corfuStore = new CorfuStore(runtime);
+        this.corfuStore = new CorfuStore(runtime, false);
         this.table = this.corfuStore.openTable(namespace,
                 tableName,
                 LockId.class,


### PR DESCRIPTION
## Overview

LR does require TX Logging to be disabled on the standby site to avoid
generation of DCNs on replicated data and CorfuStore enforces it to be enabled.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
