### PR TITLE
Enable Tx Logging Back on Standby

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -93,7 +93,7 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
         corfuRuntime = CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
                 .parseConfigurationString("localhost:9000")
                 .connect();
-        corfuStore = new CorfuStore(corfuRuntime, false);
+        corfuStore = new CorfuStore(corfuRuntime);
         CorfuStoreMetadata.Timestamp ts = corfuStore.getTimestamp();
         try {
             Table<Messages.Uuid, Messages.Uuid, Messages.Uuid> table = corfuStore.openTable(

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
@@ -42,7 +42,7 @@ public class LogReplicationStreamNameTableManager {
     public LogReplicationStreamNameTableManager(CorfuRuntime runtime, String pluginConfigFilePath) {
         this.pluginConfigFilePath = pluginConfigFilePath;
         this.corfuRuntime = runtime;
-        corfuStore = new CorfuStore(corfuRuntime, false);
+        corfuStore = new CorfuStore(corfuRuntime);
 
         initStreamNameFetcherPlugin();
     }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -212,11 +212,11 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
         replicationEnded.set(true);
 
-        Boolean txStreamEmpty = consumerState.get(timeout, TimeUnit.SECONDS);
-        assertThat(txStreamEmpty).isTrue();
+        Boolean txStreamNotEmpty = consumerState.get(timeout, TimeUnit.SECONDS);
+        assertThat(txStreamNotEmpty).isTrue();
     }
 
-    private Future<Boolean>  subscribeTransactionStream() {
+    private Future<Boolean> subscribeTransactionStream() {
 
         ExecutorService consumer = Executors.newSingleThreadExecutor();
         List<CorfuRuntime> consumerRts = new ArrayList<>();
@@ -250,9 +250,8 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             System.out.println("Total Transaction Stream updates, count=" + counter);
             log.info("Total Tx Stream updates = {}", counter);
 
-            // This one update accounts for the REPLICATION_EVENT_TABLE which forces an entry to the
-            // TableRegistry
-            return counter == 1;
+            // We should have Txn Stream Updates
+            return counter != 0;
         });
     }
 

--- a/utils/src/main/java/org/corfudb/utils/lock/persistence/LockStore.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/persistence/LockStore.java
@@ -56,7 +56,7 @@ public class LockStore {
      * @throws InvocationTargetException
      */
     public LockStore(CorfuRuntime runtime, UUID clientUuid) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        this.corfuStore = new CorfuStore(runtime, false);
+        this.corfuStore = new CorfuStore(runtime);
         this.corfuStore.openTable(namespace,
                 tableName,
                 LockId.class,


### PR DESCRIPTION
## Overview

Description: Enable Tx Logging for LR. 

Why should this be merged: UI relies on Tx logging updates to refresh UI content. Currently, UI does not reflect replicated data.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
