### PR TITLE
Stop Log Replication if Plugin fails to read the configuration.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -22,6 +22,7 @@ import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicat
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationStreamNameTableManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.RetryExhaustedException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.retry.ExponentialBackoffRetry;
@@ -319,23 +320,24 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
      * - Start Log Replication Server (receiver component)
      */
     private void bootstrapLogReplicationService() {
-        // Through LogReplicationConfigAdapter retrieve system-specific configurations (including streams to replicate)
+        // Through LogReplicationConfigAdapter retrieve system-specific configurations
+        // such as streams to replicate and version
         LogReplicationConfig logReplicationConfig = getLogReplicationConfiguration(getCorfuRuntime());
 
         logReplicationMetadataManager = new LogReplicationMetadataManager(getCorfuRuntime(),
-                topologyDescriptor.getTopologyConfigId(), localClusterDescriptor.getClusterId());
+            topologyDescriptor.getTopologyConfigId(), localClusterDescriptor.getClusterId());
 
         logReplicationServerHandler = new LogReplicationServer(serverContext, logReplicationConfig,
-                logReplicationMetadataManager, localCorfuEndpoint, topologyDescriptor.getTopologyConfigId());
+            logReplicationMetadataManager, localCorfuEndpoint, topologyDescriptor.getTopologyConfigId());
         logReplicationServerHandler.setActive(localClusterDescriptor.getRole().equals(ClusterRole.ACTIVE));
 
         interClusterReplicationService = new CorfuInterClusterReplicationServerNode(serverContext,
-                logReplicationServerHandler, logReplicationConfig);
+            logReplicationServerHandler, logReplicationConfig);
 
         // Pass server's channel context through the Log Replication Context, for shared objects between the server
         // and the client channel (specific requirements of the transport implementation)
         replicationContext = new LogReplicationContext(logReplicationConfig, topologyDescriptor,
-                localCorfuEndpoint, interClusterReplicationService.getRouter().getServerAdapter().getChannelContext());
+            localCorfuEndpoint, interClusterReplicationService.getRouter().getServerAdapter().getChannelContext());
 
         // Unblock server initialization & register to Log Replication Lock, to attempt lock / leadership acquisition
         serverCallback.complete(interClusterReplicationService);
@@ -404,21 +406,26 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
      */
     private LogReplicationConfig getLogReplicationConfiguration(CorfuRuntime runtime) {
 
-        LogReplicationStreamNameTableManager replicationStreamNameTableManager =
+        try {
+            LogReplicationStreamNameTableManager replicationStreamNameTableManager =
                 new LogReplicationStreamNameTableManager(runtime, serverContext.getPluginConfigFilePath());
 
-        Set<String> streamsToReplicate = replicationStreamNameTableManager.getStreamsToReplicate();
+            Set<String> streamsToReplicate = replicationStreamNameTableManager.getStreamsToReplicate();
 
-        // TODO pankti: Check if version does not match. If it does not, create an event for site discovery to
-        //  do a snapshot sync.
-        boolean upgraded = replicationStreamNameTableManager
+            // TODO pankti: Check if version does not match. If it does not, create an event for site discovery to
+            //  do a snapshot sync.
+            boolean upgraded = replicationStreamNameTableManager
                 .isUpgraded();
 
-        if (upgraded) {
-            input(new DiscoveryServiceEvent(DiscoveryServiceEvent.DiscoveryServiceEventType.UPGRADE));
-        }
+            if (upgraded) {
+                input(new DiscoveryServiceEvent(DiscoveryServiceEvent.DiscoveryServiceEventType.UPGRADE));
+            }
 
-        return new LogReplicationConfig(streamsToReplicate, serverContext.getLogReplicationMaxNumMsgPerBatch(), serverContext.getLogReplicationMaxDataMessageSize());
+            return new LogReplicationConfig(streamsToReplicate, serverContext.getLogReplicationMaxNumMsgPerBatch(), serverContext.getLogReplicationMaxDataMessageSize());
+        } catch (Throwable t) {
+            log.error("Exception when fetching the Replication Config", t);
+            throw t;
+        }
     }
 
     /**
@@ -631,7 +638,15 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         log.debug("Received topology change, topology={}", event.getTopologyConfig());
 
         TopologyDescriptor discoveredTopology = new TopologyDescriptor(event.getTopologyConfig());
-        boolean isValid = processDiscoveredTopology(discoveredTopology, localClusterDescriptor == null);
+
+        boolean isValid;
+        try {
+            isValid = processDiscoveredTopology(discoveredTopology, localClusterDescriptor == null);
+        } catch (Throwable t) {
+            log.error("Exception when processing the discovered topology", t);
+            stopLogReplication();
+            return;
+        }
 
         if (isValid) {
             if (clusterRoleChanged(discoveredTopology)) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -1,7 +1,7 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Default testing implementation of a Log Replication Config Provider
@@ -10,27 +10,28 @@ import java.util.Map;
  */
 public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfigAdapter {
 
-    private Map<String, String> streamsNamespaceMap;
+    private Set<String> streamsToReplicate;
 
     private final int totalMapCount = 10;
     private static final String TABLE_PREFIX = "Table00";
     private static final String NAMESPACE = "LR-Test";
 
     public DefaultLogReplicationConfigAdapter() {
-        streamsNamespaceMap = new HashMap<>();
-        streamsNamespaceMap.put("Table001", NAMESPACE);
-        streamsNamespaceMap.put("Table002", NAMESPACE);
-        streamsNamespaceMap.put("Table003", NAMESPACE);
+        streamsToReplicate = new HashSet<>();
+        streamsToReplicate.add("Table001");
+        streamsToReplicate.add("Table002");
+        streamsToReplicate.add("Table003");
 
         // Support for UFO
         for(int i=1; i<=totalMapCount; i++) {
-            streamsNamespaceMap.put(NAMESPACE + "$" + TABLE_PREFIX + i, NAMESPACE);
+            streamsToReplicate.add(NAMESPACE + "$" + TABLE_PREFIX + i);
         }
     }
 
+    // Provides the fully qualified names of streams to replicate
     @Override
-    public Map<String, String> fetchStreamsToReplicate() {
-        return streamsNamespaceMap;
+    public Set<String> fetchStreamsToReplicate() {
+        return streamsToReplicate;
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationConfigAdapter.java
@@ -1,6 +1,6 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
-import java.util.Map;
+import java.util.Set;
 
 /**
  * This Interface must be implemented by any external
@@ -12,7 +12,10 @@ import java.util.Map;
  */
 public interface ILogReplicationConfigAdapter {
 
-    Map<String, String> fetchStreamsToReplicate();
+    /*
+     * Returns a set of fully qualified stream names to replicate
+     */
+    Set<String> fetchStreamsToReplicate();
 
     String getVersion();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationStreamNameTableManager.java
@@ -39,6 +39,11 @@ public class LogReplicationStreamNameTableManager {
 
     private CorfuStore corfuStore;
 
+    private static final String EMPTY_STR = "";
+
+    private static final CommonTypes.Uuid defaultMetadata =
+        CommonTypes.Uuid.newBuilder().setLsb(0).setMsb(0).build();
+
     public LogReplicationStreamNameTableManager(CorfuRuntime runtime, String pluginConfigFilePath) {
         this.pluginConfigFilePath = pluginConfigFilePath;
         this.corfuRuntime = runtime;
@@ -144,26 +149,50 @@ public class LogReplicationStreamNameTableManager {
         }
     }
 
-    private void createStreamNameAndVersionTables(Map<String, String> streams) {
+    private void createStreamNameAndVersionTables(Set<String> streams) {
         try {
-            corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_STREAMS_NAME_TABLE, LogReplicationStreams.TableInfo.class,
-                    LogReplicationStreams.Namespace.class, CommonTypes.Uuid.class, TableOptions.builder().build());
-            corfuStore.openTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_PLUGIN_VERSION_TABLE, LogReplicationStreams.VersionString.class,
-                    LogReplicationStreams.Version.class, CommonTypes.Uuid.class, TableOptions.builder().build());
+            corfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
+                LOG_REPLICATION_STREAMS_NAME_TABLE,
+                LogReplicationStreams.TableInfo.class,
+                LogReplicationStreams.Namespace.class, CommonTypes.Uuid.class,
+                TableOptions.builder().build());
+
+            corfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
+                LOG_REPLICATION_PLUGIN_VERSION_TABLE,
+                LogReplicationStreams.VersionString.class,
+                LogReplicationStreams.Version.class, CommonTypes.Uuid.class,
+                TableOptions.builder().build());
+
             TxBuilder tx = corfuStore.tx(CORFU_SYSTEM_NAMESPACE);
 
             // Populate the plugin version in the version table
-            LogReplicationStreams.VersionString versionString = LogReplicationStreams.VersionString.newBuilder().setName("VERSION").build();
-            LogReplicationStreams.Version version = LogReplicationStreams.Version.newBuilder().setVersion(logReplicationConfigAdapter.getVersion()).build();
-            CommonTypes.Uuid uuid = CommonTypes.Uuid.newBuilder().setLsb(0L).setMsb(0L).build();
-            tx.create(LOG_REPLICATION_PLUGIN_VERSION_TABLE, versionString, version, uuid);
+            LogReplicationStreams.VersionString versionString =
+                LogReplicationStreams.VersionString.newBuilder()
+                    .setName("VERSION").build();
+            LogReplicationStreams.Version version =
+                LogReplicationStreams.Version.newBuilder()
+                    .setVersion(logReplicationConfigAdapter.getVersion()).build();
+            tx.create(LOG_REPLICATION_PLUGIN_VERSION_TABLE, versionString,
+                version, defaultMetadata);
 
-            // Copy all stream names to the stream names table
-            for (Map.Entry<String, String> entry : streams.entrySet()) {
-                LogReplicationStreams.TableInfo tableInfo = LogReplicationStreams.TableInfo.newBuilder().setName(entry.getKey()).build();
-                LogReplicationStreams.Namespace namespace = LogReplicationStreams.Namespace.newBuilder().setName(entry.getValue()).build();
-                uuid = CommonTypes.Uuid.newBuilder().setLsb(0L).setMsb(0L).build();
-                tx.create(LOG_REPLICATION_STREAMS_NAME_TABLE, tableInfo, namespace, uuid);
+            // Copy all stream names to the stream names table.  Each name is
+            // a fully qualified stream name
+            for (String entry : streams) {
+                LogReplicationStreams.TableInfo tableInfo =
+                    LogReplicationStreams.TableInfo.newBuilder().setName(entry)
+                        .build();
+
+                // As each name is fully qualified, no need to insert the
+                // namespace.  Simply insert an empty string there.
+                // TODO: Ideally the Namespace protobuf can be removed but it
+                //  will involve data migration on upgrade as it is a schema
+                //  change
+                LogReplicationStreams.Namespace namespace =
+                    LogReplicationStreams.Namespace.newBuilder().setName(
+                        EMPTY_STR)
+                        .build();
+                tx.create(LOG_REPLICATION_STREAMS_NAME_TABLE, tableInfo,
+                    namespace, defaultMetadata);
             }
             tx.commit();
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
@@ -174,7 +203,8 @@ public class LogReplicationStreamNameTableManager {
     private Set<String> readStreamsToReplicateFromTable() {
         corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, LOG_REPLICATION_STREAMS_NAME_TABLE);
         Query q = corfuStore.query(CORFU_SYSTEM_NAMESPACE);
-        Set<LogReplicationStreams.TableInfo> tables = q.keySet(LOG_REPLICATION_STREAMS_NAME_TABLE, null);
+        Set<LogReplicationStreams.TableInfo> tables =
+            q.keySet(LOG_REPLICATION_STREAMS_NAME_TABLE, null);
         Set<String> tableNames = new HashSet<>();
         tables.forEach(table -> {
             tableNames.add(table.getName());


### PR DESCRIPTION
Description:
Log Replication should stop if the plugin fails to fetch important info
such as streams to replicate and version.

Why should this be merged: Better Error Handling
