### PR TITLE
CICD workflow: fix StreamAddressDiscoveryIT flakiness

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -80,7 +80,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <skipITs>true</skipITs>
                     <trimStackTrace>false</trimStackTrace>
@@ -99,7 +99,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.0.0-M1</version>
+                        <version>3.0.0-M5</version>
                         <configuration>
                             <skipITs>false</skipITs>
                             <reuseForks>false</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.0.0-M1</version>
+                        <version>3.0.0-M5</version>
                         <configuration>
                             <forkCount>1</forkCount>
                             <trimStackTrace>false</trimStackTrace>
@@ -436,7 +436,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M1</version>
+                <version>3.0.0-M5</version>
                 <configuration>
                     <argLine>${argLine}</argLine>
                     <forkCount>1C</forkCount>

--- a/test/src/test/java/org/corfudb/AbstractCorfuTest.java
+++ b/test/src/test/java/org/corfudb/AbstractCorfuTest.java
@@ -57,11 +57,9 @@ public class AbstractCorfuTest {
      */
     public ArrayList<IntConsumer> testSM = null;
 
-    public static final CorfuTestParameters PARAMETERS =
-            new CorfuTestParameters();
+    public static final CorfuTestParameters PARAMETERS = new CorfuTestParameters();
 
-    public static final CorfuTestServers SERVERS =
-            new CorfuTestServers();
+    public static final CorfuTestServers SERVERS = new CorfuTestServers();
 
     @AfterClass
     public static void shutdownNettyGroups() {

--- a/test/src/test/java/org/corfudb/CorfuTestParameters.java
+++ b/test/src/test/java/org/corfudb/CorfuTestParameters.java
@@ -89,7 +89,7 @@ public class CorfuTestParameters {
         TIMEOUT_VERY_SHORT = Duration.of(100, MILLIS);
         TIMEOUT_SHORT = Duration.of(1, SECONDS);
         TIMEOUT_NORMAL = Duration.of(10, SECONDS);
-        TIMEOUT_LONG = Duration.of(2, MINUTES);
+        TIMEOUT_LONG = Duration.of(5, MINUTES);
 
         // Iterations
         NUM_ITERATIONS_VERY_LOW = 10;

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -88,7 +88,7 @@ public class AbstractIT extends AbstractCorfuTest {
     /**
      * Cleans up the corfu log directory before running any test.
      *
-     * @throws Exception
+     * @throws Exception exception
      */
     @Before
     public void setUp() throws Exception {
@@ -100,7 +100,7 @@ public class AbstractIT extends AbstractCorfuTest {
     /**
      * Cleans up all Corfu instances after the tests.
      *
-     * @throws Exception
+     * @throws Exception exception
      */
     @After
     public void cleanUp() throws Exception {
@@ -228,7 +228,6 @@ public class AbstractIT extends AbstractCorfuTest {
      * @param pid parent process identifier
      * @return list of children process identifiers
      *
-     * @throws IOException
      */
     private static List<Long> getChildPIDs (long pid) {
         List<Long> childPIDs = new ArrayList<>();


### PR DESCRIPTION
## Overview

Description:
 - fix StreamAddressDiscoveryIT flakiness (by increasing timeouts) - 2 minutes is not enough to finish inserting 20k records
 - update maven failsafe plugin versions

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
