### PR TITLE
[Port 0.3.1.1] Fix NullPointerException in queryReplicationStatus 

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -782,7 +782,10 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
      */
     @Override
     public Map<String, LogReplicationMetadata.ReplicationStatusVal> queryReplicationStatus() {
-        if (ClusterRole.ACTIVE == localClusterDescriptor.getRole()) {
+        if (localClusterDescriptor == null) {
+            log.warn("Cluster configuration has not been pushed to current LR node.");
+            return null;
+        } else if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {
             Map<String, LogReplicationMetadata.ReplicationStatusVal> mapReplicationStatus = logReplicationMetadataManager.getReplicationRemainingEntries();
             Map<String, LogReplicationMetadata.ReplicationStatusVal> mapToSend = new HashMap<>(mapReplicationStatus);
             // If map contains local cluster, remove (as it might have been added by the SinkManager) but this node
@@ -792,7 +795,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 mapToSend.remove(localClusterDescriptor.getClusterId());
             }
             return mapToSend;
-        } else if (ClusterRole.STANDBY == localClusterDescriptor.getRole()) {
+        } else if (localClusterDescriptor.getRole() == ClusterRole.STANDBY) {
             return logReplicationMetadataManager.getDataConsistentOnStandby();
         }
         log.error("Received Replication Status Query in Incorrect Role {}.", localClusterDescriptor.getRole());


### PR DESCRIPTION
## Overview

Description:

Fix LR NPE when queryReplicationStatus is called and cluster configuration has still not been set by external configuration provider (Cluster Manager).

Why should this be merged: avoid NPE

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
