### PR TITLE
StreamAddressSpace Cleanup

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -3,36 +3,6 @@ package org.corfudb.infrastructure;
 import com.codahale.metrics.Timer;
 import com.google.common.collect.ImmutableMap;
 import io.netty.channel.ChannelHandlerContext;
-import lombok.Builder;
-import lombok.Builder.Default;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
-
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
-import org.corfudb.protocols.wireprotocol.StreamAddressRange;
-import org.corfudb.protocols.wireprotocol.StreamsAddressRequest;
-import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-import org.corfudb.infrastructure.SequencerServerCache.ConflictTxStream;
-import org.corfudb.protocols.wireprotocol.CorfuMsg;
-import org.corfudb.protocols.wireprotocol.CorfuMsgType;
-import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
-import org.corfudb.protocols.wireprotocol.SequencerMetrics;
-import org.corfudb.protocols.wireprotocol.SequencerMetrics.SequencerStatus;
-import org.corfudb.protocols.wireprotocol.SequencerRecoveryMsg;
-import org.corfudb.protocols.wireprotocol.Token;
-import org.corfudb.protocols.wireprotocol.TokenRequest;
-import org.corfudb.protocols.wireprotocol.TokenResponse;
-import org.corfudb.protocols.wireprotocol.TokenType;
-import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
-import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
-import org.corfudb.runtime.view.Address;
-import org.corfudb.runtime.view.Layout;
-import org.corfudb.util.CorfuComponent;
-import org.corfudb.util.MetricsUtils;
-import org.corfudb.util.Utils;
-
 import java.lang.invoke.MethodHandles;
 import java.util.Collections;
 import java.util.HashMap;
@@ -42,6 +12,33 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.SequencerServerCache.ConflictTxStream;
+import org.corfudb.protocols.wireprotocol.CorfuMsg;
+import org.corfudb.protocols.wireprotocol.CorfuMsgType;
+import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
+import org.corfudb.protocols.wireprotocol.SequencerMetrics;
+import org.corfudb.protocols.wireprotocol.SequencerMetrics.SequencerStatus;
+import org.corfudb.protocols.wireprotocol.SequencerRecoveryMsg;
+import org.corfudb.protocols.wireprotocol.StreamAddressRange;
+import org.corfudb.protocols.wireprotocol.StreamsAddressRequest;
+import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
+import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.protocols.wireprotocol.TokenRequest;
+import org.corfudb.protocols.wireprotocol.TokenResponse;
+import org.corfudb.protocols.wireprotocol.TokenType;
+import org.corfudb.protocols.wireprotocol.TxResolutionInfo;
+import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.Layout;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.util.CorfuComponent;
+import org.corfudb.util.MetricsUtils;
+import org.corfudb.util.Utils;
 
 /**
  * This server implements the sequencer functionality of Corfu.
@@ -443,12 +440,13 @@ public class SequencerServer extends AbstractServer {
                                 "on sequencer reset.",
                         Utils.toReadableId(streamAddressSpace.getKey()),
                         streamAddressSpace.getValue().getTrimMark(),
-                        streamAddressSpace.getValue().getAddressMap().getLongCardinality(),
+                        streamAddressSpace.getValue().size(),
                         streamAddressSpace.getValue().getLowestAddress(),
                         streamAddressSpace.getValue().getHighestAddress());
                 if (log.isTraceEnabled()) {
                     log.trace("Stream[{}] address map on sequencer reset: {}",
-                            Utils.toReadableId(streamAddressSpace.getKey()), streamAddressSpace.getValue().getAddressMap());
+                            Utils.toReadableId(streamAddressSpace.getKey()),
+                            streamAddressSpace.getValue());
                 }
             }
         }
@@ -618,11 +616,11 @@ public class SequencerServer extends AbstractServer {
             // step 3. add allocated addresses to each stream's address map (to keep track of all updates to this stream)
             streamsAddressMap.compute(id, (streamId, addressMap) -> {
                 if (addressMap == null) {
-                    addressMap = new StreamAddressSpace(Address.NON_ADDRESS, new Roaring64NavigableMap());
+                    addressMap = new StreamAddressSpace();
                 }
 
                 for (long i = globalLogTail; i < newTail; i++) {
-                    addressMap.addAddress(i);
+                    addressMap.add(i);
                 }
                 return addressMap;
             });
@@ -689,15 +687,14 @@ public class SequencerServer extends AbstractServer {
      */
     private Map<UUID, StreamAddressSpace> getStreamsAddresses(List<StreamAddressRange> addressRanges) {
         Map<UUID, StreamAddressSpace> requestedAddressSpaces = new HashMap<>();
-        Roaring64NavigableMap addressMap;
 
-        for (StreamAddressRange streamAddressRange : addressRanges) {
-            UUID streamId = streamAddressRange.getStreamID();
+        for (StreamAddressRange range : addressRanges) {
+            UUID streamId = range.getStreamID();
             // Get all addresses in the requested range
             if (streamsAddressMap.containsKey(streamId)) {
-                addressMap = streamsAddressMap.get(streamId).getAddressesInRange(streamAddressRange);
-                requestedAddressSpaces.put(streamId,
-                        new StreamAddressSpace(streamsAddressMap.get(streamId).getTrimMark(), addressMap));
+                StreamAddressSpace streamSubRange = streamsAddressMap.get(streamId)
+                        .getRange(range.getStart(), range.getEnd());
+                requestedAddressSpaces.put(streamId, streamSubRange);
             } else {
                 log.warn("handleStreamsAddressRequest: address space map is not present for stream {}. " +
                         "Verify this is a valid stream.", streamId);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
@@ -1,19 +1,17 @@
 package org.corfudb.infrastructure.log;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.wireprotocol.LogData;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.runtime.view.Address;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-
-import javax.annotation.concurrent.NotThreadSafe;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 
 /**
  * A container object that holds log tail offsets and the global
@@ -88,14 +86,12 @@ public class LogMetadata {
         // Update stream address space (used for sequencer recovery), add this entry as a valid address for this stream.
         streamsAddressSpaceMap.compute(streamId, (id, addressSpace) -> {
             if (addressSpace == null) {
-                Roaring64NavigableMap addressMap = new Roaring64NavigableMap();
-                addressMap.addLong(entryAddress);
                 // Note: stream trim mark is initialized to -6
                 // its value will be computed as checkpoints for this stream are found in the log.
                 // The presence of a checkpoint provides a valid trim mark for a stream.
-                return new StreamAddressSpace(Address.NON_EXIST, addressMap);
+                return new StreamAddressSpace(Address.NON_EXIST, entryAddress);
             }
-            addressSpace.addAddress(entryAddress);
+            addressSpace.add(entryAddress);
             return addressSpace;
         });
     }
@@ -136,7 +132,7 @@ public class LogMetadata {
                             // If this entry still does not exist, means no updates have been observed for
                             // this stream yet. We can initialize the trim mark to the last observed update by the
                             // checkpoint. If further entries are observed they will be added to the address space.
-                            return new StreamAddressSpace(lastUpdateToStream, new Roaring64NavigableMap());
+                            return new StreamAddressSpace(lastUpdateToStream);
                         }
                         // We will hold the maximum of these observed updates as the stream trim mark (highest
                         // checkpointed address), as this guarantees data is available in a checkpoint (safe trim mark).

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -1,6 +1,17 @@
 package org.corfudb.infrastructure.logreplication.replication;
 
+import static org.corfudb.runtime.view.ObjectsView.TRANSACTION_STREAM_ID;
+
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
@@ -12,17 +23,6 @@ import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
-
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
-import static org.corfudb.runtime.view.ObjectsView.TRANSACTION_STREAM_ID;
 
 @Slf4j
 public class LogReplicationAckReader {
@@ -311,7 +311,7 @@ public class LogReplicationAckReader {
             // Count how many entries are present in the Tx Stream (this can include holes,
             // valid entries and invalid entries), but we count them all (equal weight).
             // An invalid entry, is a transactional entry with no streams to replicate (which will be ignored)
-            totalEntries = txStreamAddressSpace.getAddressMap().getLongCardinality();
+            totalEntries = txStreamAddressSpace.size();
         }
 
         log.trace("getTxStreamTotalEntries:: entries={} in range ({}, {}]", totalEntries, lowerBoundary, upperBoundary);

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.roaringbitmap</groupId>
             <artifactId>RoaringBitmap</artifactId>
-            <version>0.8.13</version>
+            <version>0.9.0</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java -->
         <dependency>

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -414,7 +414,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         // Retrieve address space from current log unit server (write path)
         StreamAddressSpace addressSpace = s1.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(minAddress + 1);
+        assertThat(addressSpace.size()).isEqualTo(minAddress + 1);
 
         // Instantiate new log unit server (restarts) so the log is read and address maps are rebuilt.
         LogUnitServer newServer = new LogUnitServer(new ServerContextBuilder()
@@ -425,7 +425,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         // Retrieve address space from new initialized log unit server (bootstrap path)
         addressSpace = newServer.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(minAddress + 1);
+        assertThat(addressSpace.size()).isEqualTo(minAddress + 1);
 
         // Trim the log, and verify that trim mark is updated on log unit
         newServer.prefixTrim(trimMark);
@@ -435,7 +435,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         // Retrieve address space from current log unit server (after a prefix trim)
         addressSpace = newServer.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(trimMark);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(maxAddress - trimMark);
+        assertThat(addressSpace.size()).isEqualTo(maxAddress - trimMark);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -2,25 +2,24 @@ package org.corfudb.infrastructure;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics;
 import org.corfudb.protocols.wireprotocol.SequencerRecoveryMsg;
-import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenRequest;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.protocols.wireprotocol.TokenType;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.junit.Before;
 import org.junit.Test;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 /**
  * Created by mwei on 12/13/15.
@@ -225,9 +224,9 @@ public class SequencerServerTest extends AbstractServerTest {
         // This one should not be updated
         long newTailC = tailC - 1;
 
-        tailMap.put(streamA, new StreamAddressSpace(Address.NON_ADDRESS, Roaring64NavigableMap.bitmapOf(newTailA)));
-        tailMap.put(streamB, new StreamAddressSpace(Address.NON_ADDRESS, Roaring64NavigableMap.bitmapOf(newTailB)));
-        tailMap.put(streamC, new StreamAddressSpace(Address.NON_ADDRESS, Roaring64NavigableMap.bitmapOf(newTailC)));
+        tailMap.put(streamA, new StreamAddressSpace(Address.NON_ADDRESS, newTailA));
+        tailMap.put(streamB, new StreamAddressSpace(Address.NON_ADDRESS, newTailB));
+        tailMap.put(streamC, new StreamAddressSpace(Address.NON_ADDRESS, newTailC));
 
         // Modifying the sequencerEpoch to simulate sequencer reset.
         server.setSequencerEpoch(-1L);
@@ -285,8 +284,7 @@ public class SequencerServerTest extends AbstractServerTest {
                 Address.NON_EXIST, Collections.emptyMap(), newEpoch, true)), newEpoch);
         assertThat(future1.join()).isEqualTo(false);
         future1 = sendRequestWithEpoch(CorfuMsgType.BOOTSTRAP_SEQUENCER.payloadMsg(new SequencerRecoveryMsg(
-                num, Collections.singletonMap(streamA, new StreamAddressSpace(Address.NON_ADDRESS,
-                Roaring64NavigableMap.bitmapOf(num))), newEpoch, false)), newEpoch);
+                num, Collections.singletonMap(streamA, new StreamAddressSpace(Address.NON_ADDRESS, num)), newEpoch, false)), newEpoch);
         assertThat(future1.join()).isEqualTo(true);
 
         future = sendRequestWithEpoch(CorfuMsgType.TOKEN_REQ.payloadMsg(new TokenRequest(0L, Collections.emptyList())), newEpoch);

--- a/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/ClusterReconfigIT.java
@@ -1154,10 +1154,10 @@ public class ClusterReconfigIT extends AbstractIT {
         assertThat(addressSpace.getTrimMark()).isEqualTo(numEntries);
         if (trim) {
             // Addresses were trimmed, cardinality of addresses should be 0
-            assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(0L);
+            assertThat(addressSpace.size()).isEqualTo(0L);
         } else {
             // Extra entry corresponds to entry added by checkpointer.
-            assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(numEntries+1);
+            assertThat(addressSpace.size()).isEqualTo(numEntries+1);
         }
 
         // Verify START_ADDRESS of checkpoint for stream
@@ -1166,7 +1166,7 @@ public class ClusterReconfigIT extends AbstractIT {
                 .getAddressMap().get(checkpointStreamId);
 
         // Addresses should correspond to: start, continuation and end records. (total 3 records)
-        assertThat(checkpointAddressSpace.getAddressMap().getLongCardinality()).isEqualTo(numCheckpointRecordsDefault);
+        assertThat(checkpointAddressSpace.size()).isEqualTo(numCheckpointRecordsDefault);
         CheckpointEntry cpEntry = (CheckpointEntry) runtime2.getAddressSpaceView()
                 .read(checkpointAddressSpace.getHighestAddress())
                 .getPayload(runtime2);

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -805,8 +805,8 @@ public class ServerRestartIT extends AbstractIT {
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpace.getTrimMark()).isEqualTo(cpAddress.getSequence());
 
-            assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(expectedAddresses.size());
-            expectedAddresses.forEach(address -> assertThat(addressSpace.getAddressMap().contains(address)).isTrue());
+            assertThat(addressSpace.size()).isEqualTo(expectedAddresses.size());
+            expectedAddresses.forEach(address -> assertThat(addressSpace.contains(address)).isTrue());
         } finally {
             if (r != null) r.shutdown();
             if (runtimeRestart != null) runtimeRestart.shutdown();

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -781,7 +781,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Verify address space and trim mark is properly set for the given stream (should be 7 which  is the start log address
             // for the existing checkpoint)
             assertThat(addressSpaceA.getTrimMark()).isEqualTo(snapshotAddress);
-            assertThat(addressSpaceA.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceA.size()).isEqualTo(insertions);
 
             // Fetch Address Space for the given stream S2
             StreamAddressSpace addressSpaceB =  Utils.getLogAddressSpace(runtimeRestart
@@ -792,7 +792,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Verify address space and trim mark is properly set for the given stream (should be 7 which  is the start log address
             // for the existing checkpoint)
             assertThat(addressSpaceB.getTrimMark()).isEqualTo(snapshotAddress);
-            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertionsB);
+            assertThat(addressSpaceB.size()).isEqualTo(insertionsB);
 
             // Open mapB after restart (verify it loads from checkpoint)
             Map<String, Integer> mapBRestart = createMap(runtimeRestart, stream2);
@@ -905,7 +905,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpaceA.getTrimMark()).isEqualTo(snapshotAddress);
-            assertThat(addressSpaceA.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceA.size()).isEqualTo(insertions);
 
             // Open mapA after restart (verify it loads from checkpoint)
             Map<String, Integer> mapARestart = createMap(runtimeRestart, streamNameA);
@@ -996,7 +996,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpaceB.getTrimMark()).isEqualTo(Address.NON_EXIST);
-            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceB.size()).isEqualTo(insertions);
 
             // Open mapB new runtime
             Map<String, Integer> mapBNewRuntime = createMap(rt2, streamNameB);
@@ -1022,7 +1022,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpaceB.getTrimMark()).isEqualTo(Address.NON_EXIST);
-            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceB.size()).isEqualTo(insertions);
 
             // Open mapB after restart
             Map<String, Integer> mapBRestart = createMap(runtimeRestart, streamNameB);

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -618,16 +618,16 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         // Get Stream's Address Space
         StreamAddressSpace addressSpace = client.getLogAddressSpace().join().getAddressMap().get(streamId);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(numEntries);
-        assertThat(addressSpace.getAddressMap().contains(addressOne));
+        assertThat(addressSpace.size()).isEqualTo(numEntries);
+        assertThat(addressSpace.contains(addressOne));
 
         // Get Log Address Space (stream's address space + log tail)
         CompletableFuture<StreamsAddressResponse> cfLog = client.getLogAddressSpace();
         StreamsAddressResponse response = cfLog.get();
         addressSpace = response.getAddressMap().get(streamId);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(numEntries);
-        assertThat(addressSpace.getAddressMap().contains(addressOne));
+        assertThat(addressSpace.size()).isEqualTo(numEntries);
+        assertThat(addressSpace.contains(addressOne));
         assertThat(response.getLogTail()).isEqualTo(addressTwo);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
@@ -251,7 +251,7 @@ public class UtilsTest {
   private StreamAddressSpace getRandomStreamSpace(long max) {
     StreamAddressSpace streamA = new StreamAddressSpace();
     LongStream.range(0, max)
-            .forEach(address -> streamA.addAddress(((address & 0x1) == 1) ? 0 : address));
+            .forEach(address -> streamA.add(((address & 0x1) == 1) ? 0 : address));
     return streamA;
   }
 
@@ -306,11 +306,11 @@ public class UtilsTest {
     UUID s3Id = UUID.randomUUID();
     final long nodeBGlobalTail = 205;
 
-    StreamAddressSpace s2IdPartial =
-            new StreamAddressSpace(30l, nodeALogAddressSpace.get(s2Id).getAddressMap());
-    s2IdPartial.addAddress(201);
-    s2IdPartial.addAddress(202);
-    s2IdPartial.addAddress(203);
+    StreamAddressSpace s2IdPartial = nodeALogAddressSpace.get(s2Id).copy();
+    s2IdPartial.trim(30L);
+    s2IdPartial.add(201L);
+    s2IdPartial.add(202L);
+    s2IdPartial.add(203L);
 
     Map<UUID, StreamAddressSpace> nodeBLogAddressSpace =
             ImmutableMap.of(s2Id, s2IdPartial, s3Id, getRandomStreamSpace(nodeAGlobalTail - 1));

--- a/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
@@ -1,16 +1,16 @@
 package org.corfudb.runtime.view;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+import java.util.UUID;
 import lombok.Getter;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.junit.Test;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
-
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Created by mwei on 12/23/15.
@@ -117,15 +117,15 @@ public class SequencerViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         // Request 3 tokens on the Sequencer.
         final int tokenCount = 3;
-        Roaring64NavigableMap expectedMap = new Roaring64NavigableMap();
-        for (int i = 0; i < tokenCount; i++) {
+        StreamAddressSpace expected = new StreamAddressSpace();
+        for (long i = 0; i < tokenCount; i++) {
             r.getSequencerView().next(streamA);
-            expectedMap.add(i);
+            expected.add(i);
         }
         // Request StreamAddressSpace should succeed.
         assertThat(r.getSequencerView().getStreamAddressSpace(
-                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)).getAddressMap())
-                .isEqualTo(expectedMap);
+                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)))
+                .isEqualTo(expected);
 
         // Increment the epoch.
         incrementClusterEpoch(controlRuntime);
@@ -136,7 +136,7 @@ public class SequencerViewTest extends AbstractViewTest {
         // Request StreamAddressSpace should fail with a WrongEpochException initially
         // This is then retried internally and returned with a valid response.
         assertThat(r.getSequencerView().getStreamAddressSpace(
-                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)).getAddressMap())
-                .isEqualTo(expectedMap);
+                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)))
+                .isEqualTo(expected);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
@@ -3,7 +3,6 @@ package org.corfudb.runtime.view.stream;
 import static org.assertj.core.api.Java6Assertions.assertThat;
 
 
-import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import org.corfudb.runtime.view.Address;
 import org.junit.Test;
@@ -16,7 +15,7 @@ public class StreamAddressSpaceTest {
         StreamAddressSpace streamA = new StreamAddressSpace();
 
         final int numStreamAEntries = 100;
-        IntStream.range(0, numStreamAEntries).forEach(streamA::addAddress);
+        LongStream.range(0, numStreamAEntries).forEach(streamA::add);
 
         assertThat(streamA.getTrimMark()).isEqualTo(Address.NON_ADDRESS);
         assertThat(streamA.getTail()).isEqualTo(numStreamAEntries - 1);
@@ -25,7 +24,7 @@ public class StreamAddressSpaceTest {
 
         StreamAddressSpace streamB = new StreamAddressSpace();
         final int numStreamBEntries = 130;
-        IntStream.range(0, numStreamBEntries).forEach(streamB::addAddress);
+        LongStream.range(0, numStreamBEntries).forEach(streamB::add);
         final long streamBTrimMark = 40;
         streamB.trim(streamBTrimMark);
 
@@ -40,7 +39,7 @@ public class StreamAddressSpaceTest {
         assertThat(streamA.getTail()).isEqualTo(numStreamBEntries - 1);
 
         LongStream.range(streamBTrimMark + 1, numStreamBEntries).forEach(address ->
-                assertThat(streamA.getAddressMap().contains(address)).isTrue()
+                assertThat(streamA.contains(address)).isTrue()
         );
     }
 }


### PR DESCRIPTION
## Overview
This patch hides the implementation type of the bitmap used by
StreamAddressSpace. This allows for changing the bitmap implementation
easily.

Why should this be merged: This PR paves the way for optimizing the range queries for StreamAddressSpace

## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
