### PR TITLE
Shorten the logging of Protobuf Messages

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IServerRouter.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure;
 
+import com.google.protobuf.TextFormat;
 import io.netty.channel.ChannelHandlerContext;
 import java.util.List;
 import java.util.Optional;
@@ -209,8 +210,11 @@ public interface IServerRouter {
         ResponseMsg response = getResponseMsg(responseHeader, getWrongEpochErrorMsg(correctEpoch));
         sendResponse(response, ctx);
 
-        log.trace("sendWrongEpochError[{}]: Incoming request received with wrong epoch, got {}, expected {}, " +
-                "request was {}", requestHeader.getRequestId(), requestHeader.getEpoch(), correctEpoch, requestHeader);
+        if (log.isTraceEnabled()) {
+            log.trace("sendWrongEpochError[{}]: Incoming request received with wrong epoch, got {}, expected {}, " +
+                            "request was {}", requestHeader.getRequestId(), requestHeader.getEpoch(),
+                    correctEpoch, TextFormat.shortDebugString(requestHeader));
+        }
     }
 
     /**
@@ -224,8 +228,10 @@ public interface IServerRouter {
         ResponseMsg response = getResponseMsg(responseHeader, getNotBootstrappedErrorMsg());
         sendResponse(response, ctx);
 
-        log.trace("sendNoBootstrapError[{}]: Received request but not bootstrapped! Request was {}",
-                requestHeader.getRequestId(), requestHeader);
+        if (log.isTraceEnabled()) {
+            log.trace("sendNoBootstrapError[{}]: Received request but not bootstrapped! Request was {}",
+                    requestHeader.getRequestId(), TextFormat.shortDebugString(requestHeader));
+        }
     }
 
     /**
@@ -243,7 +249,9 @@ public interface IServerRouter {
         sendResponse(response, ctx);
 
         log.trace("sendWrongClusterError[{}]: Incoming request with a wrong cluster id, got {}, expected {}, " +
-                "request was: {}", requestHeader.getRequestId(), requestHeader.getClusterId(), clusterId, requestHeader);
+                "request was: {}", requestHeader.getRequestId(),
+                TextFormat.shortDebugString(requestHeader.getClusterId()),
+                TextFormat.shortDebugString(clusterId), TextFormat.shortDebugString(requestHeader));
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/NettyServerRouter.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure;
 
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.TextFormat;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
@@ -133,7 +134,7 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter implements I
         ctx.writeAndFlush(response, ctx.voidPromise());
 
         if(log.isTraceEnabled()) {
-            log.trace("Sent response: {}", response);
+            log.trace("Sent response: {}", TextFormat.shortDebugString(response));
         }
     }
 
@@ -187,7 +188,7 @@ public class NettyServerRouter extends ChannelInboundHandlerAdapter implements I
                 if (validateRequest(request, ctx)) {
                     if (log.isTraceEnabled()) {
                         log.trace("channelRead: Request routed to {}: {}",
-                                handler.getClass().getSimpleName(), request);
+                                handler.getClass().getSimpleName(), TextFormat.shortDebugString(request));
                     }
 
                     try {

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
@@ -1,5 +1,6 @@
 package org.corfudb.protocols.wireprotocol;
 
+import com.google.protobuf.TextFormat;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPromise;
@@ -107,7 +108,7 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
         ResponseMsg response = ((ResponseMsg) m);
 
         if (!response.getPayload().hasHandshakeResponse()) {
-            log.warn("channelRead: Non-Handshake Response received. Message - {}", response);
+            log.warn("channelRead: Non-Handshake Response received. Message - {}", TextFormat.shortDebugString(response));
             if (this.handshakeState.completed()) {
                 // Only send upstream if handshake is complete.
                 super.channelRead(ctx, m);

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/NettyCorfuMessageEncoder.java
@@ -1,5 +1,6 @@
 package org.corfudb.protocols.wireprotocol;
 
+import com.google.protobuf.TextFormat;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufOutputStream;
 import io.netty.channel.ChannelHandlerContext;
@@ -48,7 +49,8 @@ public class NettyCorfuMessageEncoder extends MessageToByteEncoder<Object> {
                         request.writeTo(requestOutputStream);
                     } catch (IOException e) {
                         log.warn("encode[{}]: Exception occurred when encoding request {}, caused by {}",
-                                request.getHeader().getRequestId(), request.getHeader(), e.getCause(), e);
+                                request.getHeader().getRequestId(), TextFormat.shortDebugString(request.getHeader()),
+                                e.getCause(), e);
                     }
                 }
             } else if (object instanceof ResponseMsg) {
@@ -61,7 +63,8 @@ public class NettyCorfuMessageEncoder extends MessageToByteEncoder<Object> {
                         response.writeTo(responseOutputStream);
                     } catch (IOException e) {
                         log.warn("encode[{}]: Exception occurred when encoding response {}, caused by {}",
-                                response.getHeader().getRequestId(), response.getHeader(), e.getCause(), e);
+                                response.getHeader().getRequestId(), TextFormat.shortDebugString(response.getHeader()),
+                                e.getCause(), e);
                     }
                 }
             } else {

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseHandler.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.clients;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.TextFormat;
 import io.netty.channel.ChannelHandlerContext;
 import java.io.ObjectInputStream;
 import java.lang.invoke.MethodHandles;
@@ -151,7 +152,7 @@ public class BaseHandler implements IClient {
      */
     @ResponseHandler(type = PayloadCase.PING_RESPONSE)
     private static Object handlePingResponse(ResponseMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
-        log.debug("Received PING_RESPONSE from the server - {}", msg);
+        log.debug("Received PING_RESPONSE from the server - {}", TextFormat.shortDebugString(msg));
         return true;
     }
 
@@ -178,7 +179,7 @@ public class BaseHandler implements IClient {
      */
     @ResponseHandler(type = PayloadCase.RESET_RESPONSE)
     private static Object handleResetResponse(ResponseMsg msg, ChannelHandlerContext ctx, IClientRouter r) {
-        log.info("Received RESET_RESPONSE from the server - {}", msg);
+        log.info("Received RESET_RESPONSE from the server - {}", TextFormat.shortDebugString(msg));
         return true;
     }
 

--- a/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure;
 
+import com.google.protobuf.TextFormat;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
 import lombok.Setter;
@@ -108,10 +109,10 @@ public class TestServerRouter implements IServerRouter {
                 .allMatch(x -> x.evaluate(newResponse, this))) {
             if (ctx instanceof TestChannelContext) {
                 ctx.writeAndFlush(newResponse);
-                log.info("sendResponse: Sent response - {}", response);
+                log.info("sendResponse: Sent response - {}", TextFormat.shortDebugString(response));
             } else {
                 this.protoResponseMessages.add(newResponse);
-                log.info("sendResponse: Added response - {} to protoResponseMessages List.", response);
+                log.info("sendResponse: Added response - {} to protoResponseMessages List.", TextFormat.shortDebugString(response));
             }
         }
     }

--- a/test/src/test/java/org/corfudb/runtime/clients/TestChannelContext.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestChannelContext.java
@@ -2,6 +2,7 @@ package org.corfudb.runtime.clients;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
+import com.google.protobuf.TextFormat;
 import io.netty.buffer.*;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -270,7 +271,7 @@ public class TestChannelContext implements ChannelHandlerContext {
                 requestMsg.writeTo(requestOutputStream);
             } catch (IOException e) {
                 log.error("simulateSerialization: Exception occurred when encoding request {}, caused by {}",
-                        requestMsg, e.getCause(), e);
+                        TextFormat.shortDebugString(requestMsg), e.getCause(), e);
             }
         } else if (message instanceof ResponseMsg) {
             ResponseMsg responseMsg = (ResponseMsg) message;
@@ -280,7 +281,7 @@ public class TestChannelContext implements ChannelHandlerContext {
                 responseMsg.writeTo(requestOutputStream);
             } catch (IOException e) {
                 log.error("simulateSerialization: Exception occurred when encoding response {}, caused by {}",
-                        responseMsg, e.getCause(), e);
+                        TextFormat.shortDebugString(responseMsg), e.getCause(), e);
             }
         } else {
             throw new UnsupportedOperationException("Test framework does not support serialization of object type "

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.clients;
 
+import com.google.protobuf.TextFormat;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import io.netty.buffer.ByteBufOutputStream;
@@ -313,7 +314,7 @@ public class TestClientRouter implements IClientRouter {
 
         // Evaluate rules.
         if (rules.stream().allMatch(x -> x.evaluate(request, this))) {
-            log.trace(Thread.currentThread().getId() + ":Sent request: {}", request);
+            log.trace(Thread.currentThread().getId() + ":Sent request: {}", TextFormat.shortDebugString(request));
             // Write the message out to the channel
             try {
                 RequestMsg requestMsg = simulateSerialization(request);
@@ -378,7 +379,7 @@ public class TestClientRouter implements IClientRouter {
 
         // Evaluate rules.
         if (rules.stream().allMatch(x -> x.evaluate(request, this))) {
-            log.trace(Thread.currentThread().getId() + ":Sent request: {}", request);
+            log.trace(Thread.currentThread().getId() + ":Sent request: {}", TextFormat.shortDebugString(request));
             // Write the message out to the channel
             try {
                 RequestMsg requestMsg = simulateSerialization(request);
@@ -417,7 +418,7 @@ public class TestClientRouter implements IClientRouter {
         // Check if the message is intended for us. If not, drop the message.
         if (!protoClientId.equals(CorfuProtocolCommon.getUuidMsg(clientID))) {
             log.warn("Incoming message intended for client {}, our id is {}, dropping!",
-                    protoClientId, clientID);
+                    TextFormat.shortDebugString(protoClientId), clientID);
             return false;
         }
         return true;


### PR DESCRIPTION
It produces lots of new lines when logging the Protobuf
Messages. This modification helps to make things logged in a
cleaner way without new lines.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
