### PR TITLE
Collect Metrics for JVM Safe Point Stats

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/JVMMetrics.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/JVMMetrics.java
@@ -1,0 +1,44 @@
+package org.corfudb.common.metrics.micrometer;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.Optional;
+import lombok.Data;
+import lombok.Getter;
+import sun.management.HotspotRuntimeMBean;
+import sun.management.ManagementFactoryHelper;
+
+/** Provides JVM level metrics. */
+
+public final class JVMMetrics {
+
+    @Getter(lazy=true)
+    private final static HotspotRuntimeMBean runtimeMBean = ManagementFactoryHelper.getHotspotRuntimeMBean();
+
+    @Data
+    private static class SafePointStats {
+        long safepointTime;
+        long safepointCount;
+    }
+
+    public static void register(Optional<MeterRegistry> metricsRegistry) {
+
+        if (metricsRegistry.isPresent()) {
+            SafePointStats safePointStats = new SafePointStats();
+
+            Gauge.builder("jvm.safe_point_time", safePointStats, data -> {
+                long current = getRuntimeMBean().getTotalSafepointTime();
+                long delta = current - data.safepointTime;
+                data.safepointTime = current;
+                return delta;
+            }).strongReference(true).register(metricsRegistry.get());
+
+            Gauge.builder("jvm.safe_point_count", safePointStats, data -> {
+                long current = getRuntimeMBean().getSafepointCount();
+                long delta = current - data.safepointCount;
+                data.safepointCount = current;
+                return delta;
+            }).strongReference(true).register(metricsRegistry.get());
+        }
+    }
+}

--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
@@ -1,5 +1,8 @@
 package org.corfudb.common.metrics.micrometer;
 
+import static org.corfudb.common.metrics.micrometer.registries.LoggingMeterRegistryWithHistogramSupport.DataProtocol.INFLUX;
+
+
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
@@ -13,8 +16,6 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Supplier;
-
-import static org.corfudb.common.metrics.micrometer.registries.LoggingMeterRegistryWithHistogramSupport.DataProtocol.INFLUX;
 
 /**
  * A configuration class for a meter (metrics) registry.
@@ -64,7 +65,9 @@ public class MeterRegistryProvider {
                         new LoggingMeterRegistryWithHistogramSupport(config, logger::debug, INFLUX);
                 registry.config().commonTags("endpoint", localEndpoint);
                 endpoint = Optional.of(localEndpoint);
-                return Optional.of(registry);
+                Optional<MeterRegistry> ret = Optional.of(registry);
+                JVMMetrics.register(ret);
+                return ret;
             };
 
             init(supplier);

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -7,6 +7,25 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -15,7 +34,7 @@ import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.comm.ChannelImplementation;
 import org.corfudb.common.compression.Codec;
-import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
+import org.corfudb.common.metrics.micrometer.JVMMetrics;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider.MeterRegistryInitializer;
 import org.corfudb.protocols.wireprotocol.PriorityLevel;
 import org.corfudb.protocols.wireprotocol.VersionInfo;
@@ -49,26 +68,6 @@ import org.corfudb.util.UuidUtils;
 import org.corfudb.util.Version;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nonnull;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 /**
  * Created by mwei on 12/9/15.
@@ -852,6 +851,7 @@ public class CorfuRuntime {
             if (logger.isDebugEnabled()) {
                 registry = Optional.of(MeterRegistryInitializer.newInstance(logger,
                         microMeterRuntimeConfig.loggingInterval, parameters.clientId));
+                JVMMetrics.register(registry);
             }
             else {
                 registry = Optional.empty();


### PR DESCRIPTION
## Overview
Excessive JVM pauses can adversely affect the fault detection system
rendering the cluster instable because of unnecessary reconfigurations.
Safepoint metrics are crucial for debugging such problems, so this patch
adds safe point stats to the standard collection process.

Why should this be merged: Improves debugging cluster instability and performance issues. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
