### PR TITLE
[backport]Handle TAE for LR sync status update

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.runtime.CorfuRuntime;
@@ -225,6 +226,9 @@ public class CorfuReplicationManager {
      */
     public void updateStatusAsNotStarted() {
         runtimeToRemoteCluster.values().forEach(corfuLogReplicationRuntime ->
-                corfuLogReplicationRuntime.getSourceManager().getAckReader().markSyncStatusNotStarted());
+                corfuLogReplicationRuntime
+                        .getSourceManager()
+                        .getAckReader()
+                        .markSyncStatus(LogReplicationMetadata.SyncStatus.NOT_STARTED));
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication.replication.fsm;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 
 /**
  * This class represents the Init state of the Log Replication State Machine.
@@ -72,7 +73,7 @@ public class InitializedState implements LogReplicationState {
     public void onEntry(LogReplicationState from) {
         try {
             fsm.getAckReader().getOngoing().set(false);
-            fsm.getAckReader().markSyncStatusStopped();
+            fsm.getAckReader().markSyncStatus(LogReplicationMetadata.SyncStatus.STOPPED);
         } catch (Exception e) {
             log.error("Error on exit of InitializedState.", e);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/StoppedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/StoppedState.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication.replication.fsm;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 
 /**
  * This class represents the stopped state of the Log Replication State Machine.
@@ -24,7 +25,7 @@ public class StoppedState implements LogReplicationState {
     @Override
     public void onEntry(LogReplicationState from) {
         fsm.getAckReader().getOngoing().set(false);
-        fsm.getAckReader().markSyncStatusError();
+        fsm.getAckReader().markSyncStatus(LogReplicationMetadata.SyncStatus.ERROR);
         log.info("Unrecoverable error or explicit shutdown. " +
                 "Log Replication is terminated from state {}. To resume, restart the JVM.", from.getType());
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -4,7 +4,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
@@ -14,8 +13,13 @@ import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntry;
 import org.corfudb.protocols.wireprotocol.logreplication.LogReplicationEntryMetadata;
 import org.corfudb.protocols.wireprotocol.logreplication.MessageType;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.util.retry.IRetry;
+import org.corfudb.util.retry.IntervalRetry;
+import org.corfudb.util.retry.RetryNeededException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -40,23 +44,20 @@ public class LogReplicationSinkManager implements DataReceiver {
      * Read SinkManager configuration information from a file.
      * If the file is not available, use the default values.
      */
-    private static final String config_file = "/config/corfu/corfu_replication_config.properties";
+    private static final String CONFIG_FILE = "/config/corfu/corfu_replication_config.properties";
 
-    private final int DEFAULT_ACK_CNT = 1;
-    /*
-     * Duration in milliseconds after which an ACK is sent back to the sender
-     * if the message count is not reached before
-     */
+    private static final int DEFAULT_ACK_CNT = 1;
+
+    // Duration in milliseconds after which an ACK is sent back to the sender
+    // if the message count is not reached before
     private int ackCycleTime = DEFAULT_ACK_CNT;
 
-    /*
-     * Number of messages received before sending a summarized ACK
-     */
+    // Number of messages received before sending a summarized ACK
     private int ackCycleCnt;
 
     private int bufferSize;
 
-    private CorfuRuntime runtime;
+    private final CorfuRuntime runtime;
 
     private LogEntrySinkBufferManager logEntrySinkBufferManager;
     private SnapshotSinkBufferManager snapshotSinkBufferManager;
@@ -73,9 +74,7 @@ public class LogReplicationSinkManager implements DataReceiver {
     private long baseSnapshotTimestamp = Address.NON_ADDRESS - 1;
     private UUID lastSnapshotSyncId = null;
 
-    /*
-     * Current topologyConfigId, used to drop out of date messages.
-     */
+    // Current topologyConfigId, used to drop out of date messages.
     private long topologyConfigId = 0;
 
     @VisibleForTesting
@@ -84,21 +83,21 @@ public class LogReplicationSinkManager implements DataReceiver {
     // Count number of received messages, used for testing purposes
     @VisibleForTesting
     @Getter
-    private ObservableValue rxMessageCount = new ObservableValue(rxMessageCounter);
+    private final ObservableValue<Integer> rxMessageCount = new ObservableValue<>(rxMessageCounter);
 
     private ISnapshotSyncPlugin snapshotSyncPlugin;
 
-    private String pluginConfigFilePath;
+    private final String pluginConfigFilePath;
 
     // true indicates data is consistent on the local(standby) cluster, false indicates it is not.
     // In Snapshot Sync, if the StreamsSnapshotWriter is in the apply phase, the data is not yet
     // consistent and cannot be read by applications.  Data is always consistent during Log Entry Sync
-    private AtomicBoolean dataConsistent = new AtomicBoolean(false);
+    private final AtomicBoolean dataConsistent = new AtomicBoolean(false);
 
     private ExecutorService applyExecutor;
 
     @Getter
-    private AtomicBoolean ongoingApply = new AtomicBoolean(false);
+    private final AtomicBoolean ongoingApply = new AtomicBoolean(false);
 
     /**
      * Constructor Sink Manager
@@ -162,8 +161,30 @@ public class LogReplicationSinkManager implements DataReceiver {
                         .build());
 
         // Set the data consistent status.
-        setDataConsistent(dataConsistent.get());
+        // It could have tx conflict with another log replicator instance.
+        setDataConsistentWithRetry();
         initWriterAndBufferMgr();
+    }
+
+    private void setDataConsistentWithRetry() {
+        try {
+            IRetry.build(IntervalRetry.class, () -> {
+                try {
+                    setDataConsistent(dataConsistent.get());
+                } catch (TransactionAbortedException tae) {
+                    log.error("Error while attempting to setDataConsistent in SinkManager's init", tae);
+                    throw new RetryNeededException();
+                }
+
+                if (log.isTraceEnabled()) {
+                    log.trace("setDataConsistentWithRetry succeeds, current value is {}", dataConsistent.get());
+                }
+                return null;
+            }).run();
+        } catch (InterruptedException e) {
+            log.error("Unrecoverable exception when attempting to setDataConsistent in SinkManager's init.", e);
+            throw new UnrecoverableCorfuInterruptedError(e);
+        }
     }
 
     /**
@@ -204,7 +225,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      * If the configFile doesn't exist, use the default values.
      */
     private void readConfig() {
-        File configFile = new File(config_file);
+        File configFile = new File(CONFIG_FILE);
         try {
             FileReader reader = new FileReader(configFile);
             Properties props = new Properties();
@@ -214,7 +235,7 @@ public class LogReplicationSinkManager implements DataReceiver {
             ackCycleTime = Integer.parseInt(props.getProperty("log_writer_ack_cycle_time", Integer.toString(ackCycleTime)));
             reader.close();
         } catch (FileNotFoundException e) {
-            log.warn("Config file {} does not exist.  Using default configs", config_file);
+            log.warn("Config file {} does not exist.  Using default configs", CONFIG_FILE);
         } catch (IOException e) {
             log.error("IO Exception when reading config file", e);
         }


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Handle TAE for LR sync status update

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
