### PR TITLE
Fix NPE thrown by browser tool when value and/or metadata are null.

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowser.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowser.java
@@ -142,9 +142,11 @@ public class CorfuStoreBrowser {
                     builder = new StringBuilder("\nKey:\n")
                             .append(JsonFormat.printer().print(entry.getKey().getKey()))
                             .append("\nPayload:\n")
-                            .append(JsonFormat.printer().print(entry.getValue().getPayload()))
+                            .append(entry.getValue() != null && entry.getValue().getPayload() != null ?
+                                JsonFormat.printer().print(entry.getValue().getPayload()) : "")
                             .append("\nMetadata:\n")
-                            .append(JsonFormat.printer().print(entry.getValue().getMetadata()))
+                            .append(entry.getValue() != null && entry.getValue().getMetadata() != null ?
+                                JsonFormat.printer().print(entry.getValue().getMetadata()) : "")
                             .append("\n====================\n");
                     log.info(builder.toString());
                 } catch (InvalidProtocolBufferException e) {


### PR DESCRIPTION
## Overview
If the metadata schema is null, trying to read the corresponding entry throws a NPE.  This PR fixes the issue.
