### PR TITLE
Nested Secondary Index Alias Support

### DIFF
--- a/runtime/proto/corfu_options.proto
+++ b/runtime/proto/corfu_options.proto
@@ -17,8 +17,15 @@ message SchemaOptions {
     optional bool is_federated = 4;
     // Tag tables with unique stream listener tags for selectivity in receiving change notifications.
     repeated string stream_tag = 5;
-    // String of comma-separated nested secondary keys
-    optional string nested_secondary_keys = 6;
+    // Nested Secondary Key (repeated field)
+    repeated NestedSecondaryIndex nested_secondary_key = 6;
+}
+
+message NestedSecondaryIndex {
+    // Full Qualified Name / Path
+    required string index_path = 1;
+    // Index Name (alias)
+    optional string index_name = 2;
 }
 
 // Field options to be extended in the user's protobuf fields.

--- a/runtime/proto/example_schemas.proto
+++ b/runtime/proto/example_schemas.proto
@@ -29,8 +29,8 @@ message ExampleValue {
     fixed64 anotherKey = 2 [(org.corfudb.runtime.schema).secondary_key = true];
     Uuid uuid = 3 [(org.corfudb.runtime.schema).secondary_key = true];
     fixed64 entryIndex = 4;
-    NonPrimitiveValue non_primitive_field_level_0 = 5 [(org.corfudb.runtime.schema).nested_secondary_keys =
-                                                   "non_primitive_field_level_0.key_1_level_1, non_primitive_field_level_0.key_2_level_1.key_1_level_2"];
+    NonPrimitiveValue non_primitive_field_level_0 = 5 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "non_primitive_field_level_0.key_1_level_1"},
+                                                      (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "non_primitive_field_level_0.key_2_level_1.key_1_level_2"}];
 }
 
 message NonPrimitiveValue {
@@ -45,30 +45,30 @@ message NonPrimitiveNestedValue {
 
 message InvalidExampleValue {
     string field1 = 1;
-    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_keys =
-                                                   "field1.key1Level1, field2.key2Level1.key1Level2"];
+    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field1.key1Level1"},
+                                 (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2.key2Level1.key1Level2"}];
 }
 
 message InvalidNestedSecondaryIndex {
     string field1 = 1;
-    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_keys =
-                                  "field2.key_1_level_1, field2.key_2_level_1.deprecated"];
+    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2.key_1_level_1"},
+                                 (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2.key_2_level_1.deprecated"}];
 }
 
 message InvalidFullNestedSecondaryIndex {
     string field1 = 1;
-    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_keys =
-                                  "field2.key_1_level_1.key_1_level_2, field2.key_2_level_1.key_1_level_2"];
+    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2.key_1_level_1.key_1_level_2"},
+                                 (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2.key_2_level_1.key_1_level_2"}];
 }
 
 message NotNestedSecondaryIndex {
     string field1 = 1;
-    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_keys = "field2"];
-    fixed64 field3 = 3 [(org.corfudb.runtime.schema).nested_secondary_keys = "field3"];
+    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2"}];
+    fixed64 field3 = 3 [(org.corfudb.runtime.schema).nested_secondary_key = {index_path: "field3"}];
 }
 
 message ClassRoom {
-    repeated Student students = 1 [(org.corfudb.runtime.schema).nested_secondary_keys = "students.age"];
+    repeated Student students = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "students.age"}];
     Infrastructure classInfra = 2;
 }
 
@@ -80,7 +80,38 @@ message Student {
 message Person {
     string name = 1;
     fixed64 age = 2;
-    PhoneNumber phoneNumber = 3 [(org.corfudb.runtime.schema).nested_secondary_keys = "phoneNumber.mobile"];
+    PhoneNumber phoneNumber = 3 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "phoneNumber.mobile"}];
+    Children children = 4;
+}
+
+message InvalidAdultDefaultIndexName {
+    Person person = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.age"},
+                      (org.corfudb.runtime.schema).nested_secondary_key = { index_path:"person.children.child.age"}];
+    Company work = 2;
+}
+
+message InvalidAdultCustomIndexName {
+    Person person = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.age" index_name: "howOld"},
+                      (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.children.child.age" index_name: "howOld"}];
+    Company work = 2;
+}
+
+message Adult {
+    Person person = 1 [
+                       // Default Index Name will be 'age'
+                       (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.age"},
+                       // Explicit (custom) Index Name
+                       (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.children.child.age" index_name: "kidsAge" }];
+    Company work = 2;
+}
+
+message Children {
+    repeated Child child = 1;
+}
+
+message Child {
+    string name = 1;
+    fixed64 age = 2;
 }
 
 message PhoneNumber {
@@ -89,11 +120,11 @@ message PhoneNumber {
 }
 
 message Office {
-    repeated Department departments = 1 [(org.corfudb.runtime.schema).nested_secondary_keys = "departments.members.phoneNumbers"];
+    repeated Department departments = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "departments.members.phoneNumbers"}];
 }
 
 message Company {
-    repeated Office office = 1 [(org.corfudb.runtime.schema).nested_secondary_keys = "office.departments"];
+    repeated Office office = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "office.departments"}];
 }
 
 message Department {
@@ -107,7 +138,8 @@ message Member {
 }
 
 message School {
-    repeated ClassRoom classRooms = 1 [(org.corfudb.runtime.schema).nested_secondary_keys = "classRooms.classInfra.numberDesks, classRooms.classInfra.others"];
+    repeated ClassRoom classRooms = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "classRooms.classInfra.numberDesks"},
+                                      (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "classRooms.classInfra.others"}];
 }
 
 message Infrastructure {
@@ -117,7 +149,7 @@ message Infrastructure {
 }
 
 message Network {
-    repeated Device devices = 1 [(org.corfudb.runtime.schema).nested_secondary_keys = "devices.router"];
+    repeated Device devices = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "devices.router"}];
 }
 
 message Device {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Index.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Index.java
@@ -46,27 +46,41 @@ public class Index {
      */
     public static class Spec<K, V, I> {
         private final Name name;
+        private final Name alias;
         private final MultiValueFunction<K, V, I> indexFunction;
 
         public Spec(Name name, Function<K, V, I> indexFunction) {
+            this(name, name, indexFunction);
+        }
+
+        public Spec(Name name, Name alias, Function<K, V, I> indexFunction) {
             this.name = name;
+            this.alias = alias;
             this.indexFunction =
                     (k, v) -> Collections.singletonList(indexFunction.apply(k, v));
         }
 
-        public Spec(Name name, MultiValueFunction<K, V, I> indexFunction) {
+        public Spec(Name name, Name alias, MultiValueFunction<K, V, I> indexFunction) {
             this.name = name;
+            this.alias = alias;
             this.indexFunction = indexFunction;
+        }
+
+        public Spec(Name name, MultiValueFunction<K, V, I> indexFunction) {
+            this(name, name, indexFunction);
         }
 
         public Name getName() {
             return name;
         }
 
+        public Name getAlias() {
+            return alias;
+        }
+
         public MultiValueFunction<K, V, I> getMultiValueIndexFunction() {
             return indexFunction;
         }
-
 
         @Override
         public boolean equals(Object o) {
@@ -88,8 +102,7 @@ public class Index {
      * @param <K> type of the record key associated with {@code Index}.
      * @param <V> type of the record value associated with {@code Index}.
      */
-    public interface Registry<K, V>
-            extends Iterable<Spec<K, V, ?>> {
+    public interface Registry<K, V> extends Iterable<Spec<K, V, ?>> {
 
         Registry<?, ?> EMPTY = new Registry<Object, Object>() {
             @Override


### PR DESCRIPTION

## Overview

Description: 

Support access to secondary indexes through a given alias instead
of secondary index full path.

A custom alias can be specified upon protoBuf definition, otherwise the alias
defaults to the name of the last attribute in the multi-level secondary key path.

Why should this be merged: client request


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
