### PR TITLE
Streaming: Avoid LogData decompression if not containing any table of interest.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamManager.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamManager.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.collections;
 
+import com.google.common.collect.Sets;
 import com.google.protobuf.Message;
 
 import lombok.AllArgsConstructor;
@@ -256,6 +257,10 @@ public class StreamManager {
                     ILogData logData = txnStream.nextUpTo(Address.MAX);
                     if (logData == null) {
                         break; // Stream is all caught up, sleep for a bit.
+                    }
+                    // Avoid LogData decompression/deserialization if no table of interest contained.
+                    if (Sets.intersection(logData.getStreams(), tablesOfInterest.keySet()).isEmpty()) {
+                        continue;
                     }
                     MultiObjectSMREntry multiObjSMREntry = (MultiObjectSMREntry) logData.getPayload(runtime);
                     long epoch = logData.getEpoch();


### PR DESCRIPTION
## Overview

For CorfuStore streaming, If the LogData polled does not contain any table of interest, avoid decompressing and deserializing the LogData.

Why should this be merged: Address OOM issue and make it more efficient.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
