### PR TITLE
Fix package name in queue.proto

### DIFF
--- a/runtime/proto/queue.proto
+++ b/runtime/proto/queue.proto
@@ -1,16 +1,17 @@
-syntax = "proto2";
+syntax = "proto3";
 
+package org.corfudb.runtime;
 option java_package = "org.corfudb.runtime";
 
 message CorfuQueueIdMsg {
-    optional int64 txSequence = 1;
-    optional int64 entryId = 2;
+    int64 txSequence = 1;
+    int64 entryId = 2;
 }
 
 message CorfuGuidMsg {
-    optional int64 instanceId = 1;
+    int64 instanceId = 1;
 }
 
 message CorfuQueueMetadataMsg {
-    optional int64 txSequence = 1;
+    int64 txSequence = 1;
 }

--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -143,7 +143,12 @@ public class DynamicProtobufSerializer implements ISerializer {
      */
     private void identifyMessageTypesinFileDescriptorProto(FileDescriptorProto fileDescriptorProto) {
         for (DescriptorProtos.DescriptorProto descriptorProto : fileDescriptorProto.getMessageTypeList()) {
-            String messageName = fileDescriptorProto.getPackage() + "." + descriptorProto.getName();
+            String messageName;
+            if (fileDescriptorProto.getPackage() == null || fileDescriptorProto.getPackage().equals("")) {
+                messageName = descriptorProto.getName();
+            } else {
+                messageName = fileDescriptorProto.getPackage() + "." + descriptorProto.getName();
+            }
             messagesFdProtoNameMap.putIfAbsent(messageName, fileDescriptorProto.getName());
         }
     }
@@ -191,7 +196,13 @@ public class DynamicProtobufSerializer implements ISerializer {
      */
     private String getMessageName(Any message) {
         String typeUrl = message.getTypeUrl();
-        return typeUrl.substring(typeUrl.lastIndexOf('.') + 1);
+        String messageName = typeUrl.substring(typeUrl.lastIndexOf('.') + 1);
+        if (messageName.contains("/")) {
+            // In case the message lacks package name
+            // E.g. typeUrl: type.googleapis.com/TableName
+            messageName = messageName.substring(messageName.lastIndexOf("/") + 1);
+        }
+        return messageName;
     }
 
     /**


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
1. queue.proto does not set package correctly.
2. The message name should be generated correctly without a package name.

Related issue(s) (if applicable): #<number>

In `DynamicProtobufSerializer`, the key in `messagesFdProtoNameMap` is `.CorfuGuidMsg` but `getFullMessageName` returns `CorfuGuidMsg` (without prefix dot)

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
