### PR TITLE
Remove timestamp from infra metrics logs

### DIFF
--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -31,7 +31,7 @@
         </triggeringPolicy>
         <encoder>
             <pattern>
-                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %msg%n%xException
+                %msg%n%xException
             </pattern>
         </encoder>
     </appender>


### PR DESCRIPTION
## Overview

Description:

The timestamp should be removed for each line because now it is a part of a message (in milliseconds). This notation follows the line protocol. 