### PR TITLE
Hide Stream Bitmap Implementation

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -316,7 +316,7 @@ public class LogReplicationAckReader {
             // Count how many entries are present in the Tx Stream (this can include holes,
             // valid entries and invalid entries), but we count them all (equal weight).
             // An invalid entry, is a transactional entry with no streams to replicate (which will be ignored)
-            totalEntries = txStreamAddressSpace.getAddressMap().getLongCardinality();
+            totalEntries = txStreamAddressSpace.size();
         }
 
         log.trace("getTxStreamTotalEntries:: entries={} in range ({}, {}]", totalEntries, lowerBoundary, upperBoundary);

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import static org.corfudb.protocols.CorfuProtocolCommon.DEFAULT_UUID;
 import static org.corfudb.protocols.CorfuProtocolCommon.getStreamsAddressResponse;
@@ -228,8 +227,8 @@ public class LogUnitServerTest {
         );
 
         Map<UUID, StreamAddressSpace> tails = ImmutableMap.of(
-                UUID.randomUUID(), new StreamAddressSpace(-1L, Roaring64NavigableMap.bitmapOf(32L)),
-                UUID.randomUUID(), new StreamAddressSpace(-1L, Roaring64NavigableMap.bitmapOf(11L))
+                UUID.randomUUID(), new StreamAddressSpace(-1L, Collections.singleton(32L)),
+                UUID.randomUUID(), new StreamAddressSpace(-1L, Collections.singleton(11L))
         );
 
         StreamsAddressResponse expectedResponse = new StreamsAddressResponse(32L, tails);
@@ -261,8 +260,7 @@ public class LogUnitServerTest {
         assertEquals(expectedResponse.getAddressMap().size(), provided.getAddressMap().size());
 
         provided.getAddressMap().forEach((id, addressSpace) -> {
-            assertEquals(expectedResponse.getAddressMap().get(id).getTrimMark(), addressSpace.getTrimMark());
-            assertEquals(expectedResponse.getAddressMap().get(id).getAddressMap(), addressSpace.getAddressMap());
+            assertEquals(expectedResponse.getAddressMap().get(id), addressSpace);
         });
     }
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -29,7 +29,6 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import java.io.ObjectInputStream;
 import java.util.ArrayList;
@@ -325,9 +324,9 @@ public class SequencerServerTest {
         long globalTailA = 0;
         long globalTailB = 1;
         StreamAddressSpace streamAddressSpaceA = new StreamAddressSpace(Address.NON_ADDRESS,
-                Roaring64NavigableMap.bitmapOf(globalTailA));
-        StreamAddressSpace streamAddressSpaceB = new StreamAddressSpace(Address.ABORTED,
-                Roaring64NavigableMap.bitmapOf(globalTailB));
+                Collections.singleton(globalTailA));
+        StreamAddressSpace streamAddressSpaceB = new StreamAddressSpace(Address.NON_ADDRESS,
+                Collections.singleton(globalTailB));
         tailMap.put(streamA, streamAddressSpaceA);
         tailMap.put(streamB, streamAddressSpaceB);
 
@@ -390,9 +389,9 @@ public class SequencerServerTest {
         long globalTailA = 0;
         long globalTailB = 1;
         StreamAddressSpace streamAddressSpaceA = new StreamAddressSpace(Address.NON_ADDRESS,
-                Roaring64NavigableMap.bitmapOf(globalTailA));
-        StreamAddressSpace streamAddressSpaceB = new StreamAddressSpace(Address.ABORTED,
-                Roaring64NavigableMap.bitmapOf(globalTailB));
+                Collections.singleton(globalTailA));
+        StreamAddressSpace streamAddressSpaceB = new StreamAddressSpace(Address.NON_ADDRESS,
+                Collections.singleton(globalTailB));
         tailMap.put(streamA, streamAddressSpaceA);
         tailMap.put(streamB, streamAddressSpaceB);
         long bootstrapMsgEpoch = 1;
@@ -434,8 +433,7 @@ public class SequencerServerTest {
 
         // Verify the values. Note that global tail is of streamB as it was greater than streamA.
         assertEquals(globalTailB, response.getPayload().getStreamsAddressResponse().getLogTail());
-        assertEquals(Roaring64NavigableMap.bitmapOf(globalTailA),
-                responseStreamAddressSpace.getAddressMap());
+        assertEquals(new StreamAddressSpace(Collections.singleton(globalTailA)), responseStreamAddressSpace);
         assertEquals(Address.NON_ADDRESS, responseStreamAddressSpace.getTrimMark());
 
 
@@ -470,17 +468,15 @@ public class SequencerServerTest {
                         getStreamAddressSpace(uuidToStreamAddressSpacePairMsg.getAddressSpace());
                 assertEquals(globalTailB,
                         finalResponse.getPayload().getStreamsAddressResponse().getLogTail());
-                assertEquals(Roaring64NavigableMap.bitmapOf(globalTailA),
-                        responseStreamAddressSpaceA.getAddressMap());
+                assertEquals(new StreamAddressSpace(Collections.singleton(globalTailA)), responseStreamAddressSpaceA);
                 assertEquals(Address.NON_ADDRESS, responseStreamAddressSpaceA.getTrimMark());
             } else {
                 StreamAddressSpace responseStreamAddressSpaceB =
                         getStreamAddressSpace(uuidToStreamAddressSpacePairMsg.getAddressSpace());
                 assertEquals(globalTailB,
                         finalResponse.getPayload().getStreamsAddressResponse().getLogTail());
-                assertEquals(Roaring64NavigableMap.bitmapOf(globalTailB),
-                        responseStreamAddressSpaceB.getAddressMap());
-                assertEquals(Address.ABORTED, responseStreamAddressSpaceB.getTrimMark());
+                assertEquals(new StreamAddressSpace(Collections.singleton(globalTailB)), responseStreamAddressSpaceB);
+                assertEquals(Address.NON_ADDRESS, responseStreamAddressSpaceB.getTrimMark());
             }
         });
 
@@ -630,9 +626,9 @@ public class SequencerServerTest {
         long globalTailB = 1;
 
         StreamAddressSpace streamAddressSpaceA = new StreamAddressSpace(1L,
-                Roaring64NavigableMap.bitmapOf(globalTailA));
+                Collections.singleton(globalTailA));
         StreamAddressSpace streamAddressSpaceB = new StreamAddressSpace(2L,
-                Roaring64NavigableMap.bitmapOf(globalTailB));
+                Collections.singleton(globalTailB));
         tailMap.put(streamA, streamAddressSpaceA);
         tailMap.put(streamB, streamAddressSpaceB);
         long sequencerEpoch = 1;

--- a/runtime/proto/rpc_common.proto
+++ b/runtime/proto/rpc_common.proto
@@ -49,13 +49,7 @@ message LayoutMsg {
  *       no longer present and that was subsumed by a checkpoint).
  */
 message StreamAddressSpaceMsg {
-  // Holds the last trimmed address for this stream.
-  // Note: keeping the last trimmed address is required in order to properly set the stream tail on sequencer resets
-  // when a stream has been checkpointed and trimmed and there are no further updates to this stream.
-  int64 trim_mark = 1;
-
-  // Holds the complete map of addresses for this stream.
-  // Note: currently of type Roaring64NavigableMap.
+  // Holds the last trimmed address for this stream and complete map of addresses for this stream.
   bytes address_map = 2;
 }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/Address.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Address.java
@@ -51,11 +51,6 @@ public class Address {
     /** The maximum address. */
     public static final long MAX = Long.MAX_VALUE;
 
-    /** Aborted request constant. Used to indicate an attempted read, but
-     * was rejected at the request of the client.
-     */
-    public static final long ABORTED = -2L;
-
     /** Not found constant. Used to indicate that a search for an entry
      * did not result in a entry.
      */

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -397,7 +397,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         // Retrieve address space from current log unit server (write path)
         StreamAddressSpace addressSpace = s1.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(minAddress + 1);
+        assertThat(addressSpace.size()).isEqualTo(minAddress + 1);
 
         // Instantiate new log unit server (restarts) so the log is read and address maps are rebuilt.
         LogUnitServer newServer = new LogUnitServer(new ServerContextBuilder()
@@ -408,7 +408,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         // Retrieve address space from new initialized log unit server (bootstrap path)
         addressSpace = newServer.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(minAddress + 1);
+        assertThat(addressSpace.size()).isEqualTo(minAddress + 1);
 
         // Trim the log, and verify that trim mark is updated on log unit
         newServer.prefixTrim(trimMark);
@@ -417,7 +417,7 @@ public class LogUnitServerTest extends AbstractServerTest {
         // Retrieve address space from current log unit server (after a prefix trim)
         addressSpace = newServer.getStreamAddressSpace(streamID);
         assertThat(addressSpace.getTrimMark()).isEqualTo(trimMark);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(maxAddress - trimMark);
+        assertThat(addressSpace.size()).isEqualTo(maxAddress - trimMark);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -10,7 +10,6 @@ import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.junit.Before;
 import org.junit.Test;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -244,9 +243,9 @@ public class SequencerServerTest extends AbstractServerTest {
         // This one should not be updated
         long newTailC = tailC - 1;
 
-        tailMap.put(streamA, new StreamAddressSpace(Address.NON_ADDRESS, Roaring64NavigableMap.bitmapOf(newTailA)));
-        tailMap.put(streamB, new StreamAddressSpace(Address.NON_ADDRESS, Roaring64NavigableMap.bitmapOf(newTailB)));
-        tailMap.put(streamC, new StreamAddressSpace(Address.NON_ADDRESS, Roaring64NavigableMap.bitmapOf(newTailC)));
+        tailMap.put(streamA, new StreamAddressSpace(Address.NON_ADDRESS, Collections.singleton(newTailA)));
+        tailMap.put(streamB, new StreamAddressSpace(Address.NON_ADDRESS, Collections.singleton(newTailB)));
+        tailMap.put(streamC, new StreamAddressSpace(Address.NON_ADDRESS, Collections.singleton(newTailC)));
 
         // Modifying the sequencerEpoch to simulate sequencer reset.
         server.setSequencerEpoch(-1L);
@@ -331,7 +330,7 @@ public class SequencerServerTest extends AbstractServerTest {
                 getBootstrapSequencerRequestMsg(
                         Collections.singletonMap(streamA, new StreamAddressSpace(
                                 Address.NON_ADDRESS,
-                                Roaring64NavigableMap.bitmapOf(num)
+                                Collections.singleton(num)
                         )),
                         num,
                         newEpoch,

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -805,8 +805,8 @@ public class ServerRestartIT extends AbstractIT {
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpace.getTrimMark()).isEqualTo(cpAddress.getSequence());
 
-            assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(expectedAddresses.size());
-            expectedAddresses.forEach(address -> assertThat(addressSpace.getAddressMap().contains(address)).isTrue());
+            assertThat(addressSpace.size()).isEqualTo(expectedAddresses.size());
+            expectedAddresses.forEach(address -> assertThat(addressSpace.contains(address)).isTrue());
         } finally {
             if (r != null) r.shutdown();
             if (runtimeRestart != null) runtimeRestart.shutdown();

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -420,7 +420,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Verify address space and trim mark is properly set for the given stream (should be 7 which  is the start log address
             // for the existing checkpoint)
             assertThat(addressSpaceA.getTrimMark()).isEqualTo(snapshotAddress);
-            assertThat(addressSpaceA.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceA.size()).isEqualTo(insertions);
 
             // Fetch Address Space for the given stream S2
             StreamAddressSpace addressSpaceB =  Utils.getLogAddressSpace(runtimeRestart
@@ -431,7 +431,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Verify address space and trim mark is properly set for the given stream (should be 7 which  is the start log address
             // for the existing checkpoint)
             assertThat(addressSpaceB.getTrimMark()).isEqualTo(snapshotAddress);
-            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertionsB);
+            assertThat(addressSpaceB.size()).isEqualTo(insertionsB);
 
             // Open mapB after restart (verify it loads from checkpoint)
             Map<String, Integer> mapBRestart = createMap(runtimeRestart, stream2);
@@ -544,7 +544,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpaceA.getTrimMark()).isEqualTo(snapshotAddress);
-            assertThat(addressSpaceA.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceA.size()).isEqualTo(insertions);
 
             // Open mapA after restart (verify it loads from checkpoint)
             Map<String, Integer> mapARestart = createMap(runtimeRestart, streamNameA);
@@ -635,7 +635,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpaceB.getTrimMark()).isEqualTo(Address.NON_EXIST);
-            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceB.size()).isEqualTo(insertions);
 
             // Open mapB new runtime
             Map<String, Integer> mapBNewRuntime = createMap(rt2, streamNameB);
@@ -661,7 +661,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Verify address space and trim mark is properly set for the given stream.
             assertThat(addressSpaceB.getTrimMark()).isEqualTo(Address.NON_EXIST);
-            assertThat(addressSpaceB.getAddressMap().getLongCardinality()).isEqualTo(insertions);
+            assertThat(addressSpaceB.size()).isEqualTo(insertions);
 
             // Open mapB after restart
             Map<String, Integer> mapBRestart = createMap(runtimeRestart, streamNameB);

--- a/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -538,16 +538,16 @@ public class LogUnitHandlerTest extends AbstractClientTest {
         // Get Stream's Address Space
         StreamAddressSpace addressSpace = client.getLogAddressSpace().join().getAddressMap().get(streamId);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(numEntries);
-        assertThat(addressSpace.getAddressMap().contains(addressOne));
+        assertThat(addressSpace.size()).isEqualTo(numEntries);
+        assertThat(addressSpace.contains(addressOne));
 
         // Get Log Address Space (stream's address space + log tail)
         CompletableFuture<StreamsAddressResponse> cfLog = client.getLogAddressSpace();
         StreamsAddressResponse response = cfLog.get();
         addressSpace = response.getAddressMap().get(streamId);
         assertThat(addressSpace.getTrimMark()).isEqualTo(Address.NON_EXIST);
-        assertThat(addressSpace.getAddressMap().getLongCardinality()).isEqualTo(numEntries);
-        assertThat(addressSpace.getAddressMap().contains(addressOne));
+        assertThat(addressSpace.size()).isEqualTo(numEntries);
+        assertThat(addressSpace.contains(addressOne));
         assertThat(response.getLogTail()).isEqualTo(addressTwo);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
@@ -306,11 +306,11 @@ public class UtilsTest {
     UUID s3Id = UUID.randomUUID();
     final long nodeBGlobalTail = 205;
 
-    StreamAddressSpace s2IdPartial =
-            new StreamAddressSpace(30l, nodeALogAddressSpace.get(s2Id).getAddressMap());
-    s2IdPartial.addAddress(201);
-    s2IdPartial.addAddress(202);
-    s2IdPartial.addAddress(203);
+    StreamAddressSpace s2IdPartial = nodeALogAddressSpace.get(s2Id).copy();
+    s2IdPartial.trim(30L);
+    s2IdPartial.addAddress(201L);
+    s2IdPartial.addAddress(202L);
+    s2IdPartial.addAddress(203L);
 
     Map<UUID, StreamAddressSpace> nodeBLogAddressSpace =
             ImmutableMap.of(s2Id, s2IdPartial, s3Id, getRandomStreamSpace(nodeAGlobalTail - 1));

--- a/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
@@ -5,8 +5,8 @@ import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.junit.Test;
-import org.roaringbitmap.longlong.Roaring64NavigableMap;
 
 import java.util.UUID;
 
@@ -117,14 +117,14 @@ public class SequencerViewTest extends AbstractViewTest {
         UUID streamA = UUID.nameUUIDFromBytes("stream A".getBytes());
         // Request 3 tokens on the Sequencer.
         final int tokenCount = 3;
-        Roaring64NavigableMap expectedMap = new Roaring64NavigableMap();
-        for (int i = 0; i < tokenCount; i++) {
+        StreamAddressSpace expectedMap = new StreamAddressSpace();
+        for (long i = 0; i < tokenCount; i++) {
             r.getSequencerView().next(streamA);
-            expectedMap.add(i);
+            expectedMap.addAddress(i);
         }
         // Request StreamAddressSpace should succeed.
         assertThat(r.getSequencerView().getStreamAddressSpace(
-                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)).getAddressMap())
+                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)))
                 .isEqualTo(expectedMap);
 
         // Increment the epoch.
@@ -136,7 +136,7 @@ public class SequencerViewTest extends AbstractViewTest {
         // Request StreamAddressSpace should fail with a WrongEpochException initially
         // This is then retried internally and returned with a valid response.
         assertThat(r.getSequencerView().getStreamAddressSpace(
-                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)).getAddressMap())
+                new StreamAddressRange(streamA,  tokenCount, Address.NON_ADDRESS)))
                 .isEqualTo(expectedMap);
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
@@ -1,13 +1,23 @@
 package org.corfudb.runtime.view.stream;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-
-import java.util.stream.IntStream;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.util.Collections;
 import java.util.stream.LongStream;
+
+import com.google.common.collect.ImmutableSet;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import io.netty.buffer.Unpooled;
 import org.corfudb.runtime.view.Address;
 import org.junit.Test;
 
+@SuppressWarnings("checkstyle:magicnumber")
 public class StreamAddressSpaceTest {
 
     @Test
@@ -16,7 +26,7 @@ public class StreamAddressSpaceTest {
         StreamAddressSpace streamA = new StreamAddressSpace();
 
         final int numStreamAEntries = 100;
-        IntStream.range(0, numStreamAEntries).forEach(streamA::addAddress);
+        LongStream.range(0, numStreamAEntries).forEach(streamA::addAddress);
 
         assertThat(streamA.getTrimMark()).isEqualTo(Address.NON_ADDRESS);
         assertThat(streamA.getTail()).isEqualTo(numStreamAEntries - 1);
@@ -25,7 +35,7 @@ public class StreamAddressSpaceTest {
 
         StreamAddressSpace streamB = new StreamAddressSpace();
         final int numStreamBEntries = 130;
-        IntStream.range(0, numStreamBEntries).forEach(streamB::addAddress);
+        LongStream.range(0, numStreamBEntries).forEach(streamB::addAddress);
         final long streamBTrimMark = 40;
         streamB.trim(streamBTrimMark);
 
@@ -40,7 +50,138 @@ public class StreamAddressSpaceTest {
         assertThat(streamA.getTail()).isEqualTo(numStreamBEntries - 1);
 
         LongStream.range(streamBTrimMark + 1, numStreamBEntries).forEach(address ->
-                assertThat(streamA.getAddressMap().contains(address)).isTrue()
+                assertThat(streamA.contains(address)).isTrue()
         );
+    }
+
+    @Test
+    public void constructorTest() {
+        StreamAddressSpace obj1 = new StreamAddressSpace(5L, Collections.emptySet());
+        assertThat(obj1.getTrimMark()).isEqualTo(5L);
+        assertThat(obj1.size()).isEqualTo(0L);
+
+        StreamAddressSpace obj2 = new StreamAddressSpace(5L, Collections.singleton(6L));
+        assertThat(obj2.getTrimMark()).isEqualTo(5L);
+        assertThat(obj2.size()).isEqualTo(1L);
+        assertThat(obj2.contains(6L)).isTrue();
+
+        StreamAddressSpace obj3 = new StreamAddressSpace(Collections.singleton(6L));
+        assertThat(obj3.getTrimMark()).isEqualTo(Address.NON_ADDRESS);
+        assertThat(obj3.size()).isEqualTo(1L);
+        assertThat(obj3.contains(6L)).isTrue();
+    }
+
+    @Test
+    public void selectTest() {
+        StreamAddressSpace obj1 = new StreamAddressSpace(5L, Collections.emptySet());
+        assertThrows(IllegalArgumentException.class, () -> obj1.select(0));
+        obj1.trim(5L);
+        assertThrows(IllegalArgumentException.class, () -> obj1.select(0));
+        obj1.addAddress(6L);
+        assertThat(obj1.contains(6L)).isTrue();
+        assertThat(obj1.select(0)).isEqualTo(6L);
+        obj1.addAddress(8L);
+        obj1.trim(6L);
+        assertThat(obj1.select(0)).isEqualTo(8L);
+        obj1.trim(8L);
+        assertThrows(IllegalArgumentException.class, () -> obj1.select(0));
+    }
+
+    @Test
+    public void testConstructorTrim() {
+        StreamAddressSpace obj1 = new StreamAddressSpace(2L, ImmutableSet.of(1L, 2L, 3L, 4L));
+        assertThat(obj1.size()).isEqualTo(2);
+        assertThat(obj1.contains(1L)).isFalse();
+        assertThat(obj1.contains(2L)).isFalse();
+        assertThat(obj1.contains(3L)).isTrue();
+        assertThat(obj1.contains(4L)).isTrue();
+        assertThat(obj1.contains(-1L)).isFalse();
+    }
+
+    @Test
+    public void testTrim() {
+        StreamAddressSpace obj1 = new StreamAddressSpace(ImmutableSet.of(1L, 2L, 3L, 4L));
+        assertThat(obj1.size()).isEqualTo(4);
+        assertThat(obj1.contains(1L)).isTrue();
+        assertThat(obj1.contains(2L)).isTrue();
+        assertThat(obj1.contains(3L)).isTrue();
+        assertThat(obj1.contains(4L)).isTrue();
+
+        obj1.trim(2L);
+        assertThat(obj1.size()).isEqualTo(2);
+        assertThat(obj1.contains(1L)).isFalse();
+        assertThat(obj1.contains(2L)).isFalse();
+        assertThat(obj1.contains(3L)).isTrue();
+        assertThat(obj1.contains(4L)).isTrue();
+
+        obj1.trim(4L);
+        assertThat(obj1.size()).isEqualTo(0);
+        assertThat(obj1.contains(3L)).isFalse();
+        assertThat(obj1.contains(4L)).isFalse();
+
+    }
+
+    @Test
+    public void testCopy() {
+        StreamAddressSpace obj1 = new StreamAddressSpace();
+        StreamAddressSpace obj1Copy = obj1.copy();
+        assertThat(obj1Copy.getTrimMark()).isEqualTo(obj1.getTrimMark());
+        assertThat(obj1Copy.size()).isEqualTo(obj1.size());
+        assertNotSame(obj1Copy, obj1);
+
+        StreamAddressSpace obj2 = new StreamAddressSpace(ImmutableSet.of(1L, 2L));
+        StreamAddressSpace obj2Copy = obj2.copy();
+        assertThat(obj2Copy.getTrimMark()).isEqualTo(obj2.getTrimMark());
+        assertThat(obj2Copy.size()).isEqualTo(obj2.size());
+        assertThat(obj2Copy.contains(1L)).isTrue();
+        assertThat(obj2Copy.contains(2L)).isTrue();
+        assertNotSame(obj2Copy, obj2);
+    }
+
+    @Test
+    public void testToArray() {
+        StreamAddressSpace obj1 = new StreamAddressSpace(3, ImmutableSet.of(1L, 2L, 3L, 4L, 5L));
+        assertThat(obj1.toArray()).containsExactly(4L, 5L);
+        obj1.trim(5);
+        assertThat(obj1.toArray()).isEmpty();
+    }
+
+    @Test
+    public void testEquality() {
+        assertThat(new StreamAddressSpace().equals(null)).isFalse();
+        assertThat(new StreamAddressSpace().equals(new StreamAddressSpace())).isTrue();
+        assertThat(new StreamAddressSpace(2L, Collections.EMPTY_SET).equals(new StreamAddressSpace())).isFalse();
+        assertThat(new StreamAddressSpace(2L, Collections.EMPTY_SET)
+                .equals(new StreamAddressSpace(2L, Collections.EMPTY_SET))).isTrue();
+        // TODO(Maithem): Re-enable after this fix https://github.com/RoaringBitmap/RoaringBitmap/pull/451
+        //assertThat(new StreamAddressSpace(2L, Collections.EMPTY_SET)
+          //      .equals(new StreamAddressSpace(2L, ImmutableSet.of(1L, 2L)))).isTrue();
+        assertThat(new StreamAddressSpace(ImmutableSet.of(1L, 2L))
+                .equals(new StreamAddressSpace(ImmutableSet.of(1L, 2L)))).isTrue();
+    }
+
+    @Test
+    public void testStreamSerialization() throws Exception {
+        StreamAddressSpace obj1 = new StreamAddressSpace(3, ImmutableSet.of(1L, 2L, 3L, 4L, 5L));
+
+        ByteBuf buf = Unpooled.buffer();
+        DataOutput output = new ByteBufOutputStream(buf);
+        obj1.serialize(output);
+        DataInputStream inputStream = new DataInputStream(new ByteBufInputStream(buf));
+        StreamAddressSpace deserialized = StreamAddressSpace.deserialize(inputStream);
+
+        assertThat(obj1.getTrimMark()).isEqualTo(deserialized.getTrimMark());
+        assertThat(obj1.size()).isEqualTo(deserialized.size());
+        assertThat(obj1.toArray()).isEqualTo(deserialized.toArray());
+    }
+
+    @Test
+    public void testToString() {
+        StreamAddressSpace sas = new StreamAddressSpace();
+        assertThat(sas.toString()).isEqualTo("[-6, -6]@-1 size 0");
+        sas.addAddress(4L);
+        assertThat(sas.toString()).isEqualTo("[4, 4]@-1 size 1");
+        sas.trim(4L);
+        assertThat(sas.toString()).isEqualTo("[-6, -6]@4 size 0");
     }
 }


### PR DESCRIPTION
## Overview
This refactor hides the stream's bitmap implementation from the
consumers. It also improves code robustness and fixes some bugs
related to directly consuming the bitmap. Furthermore, this change will
allow for easily changing the implementation to optimize encoding
and certain APIs.

Why should this be merged: Improves code quality and allows for future optimizations. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
