### PR TITLE
Improve Protobuf RPC HeaderMsg API

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -3,6 +3,8 @@ package org.corfudb.infrastructure;
 import io.netty.channel.ChannelHandlerContext;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
@@ -139,7 +141,7 @@ public abstract class AbstractServer {
     }
 
     private ResponseMsg getNotReadyError(HeaderMsg requestHeader) {
-        HeaderMsg responseHeader = getHeaderMsg(requestHeader, false, true);
+        HeaderMsg responseHeader = getHeaderMsg(requestHeader, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         return getResponseMsg(responseHeader, getNotReadyErrorMsg());
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/IServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/IServerRouter.java
@@ -5,6 +5,9 @@ import io.netty.channel.ChannelHandlerContext;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.CorfuPayloadMsg;
@@ -206,7 +209,7 @@ public interface IServerRouter {
     default void sendWrongEpochError(HeaderMsg requestHeader, ChannelHandlerContext ctx) {
         final long correctEpoch = getServerEpoch();
 
-        HeaderMsg responseHeader = getHeaderMsg(requestHeader, false, true);
+        HeaderMsg responseHeader = getHeaderMsg(requestHeader, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         ResponseMsg response = getResponseMsg(responseHeader, getWrongEpochErrorMsg(correctEpoch));
         sendResponse(response, ctx);
 
@@ -224,7 +227,7 @@ public interface IServerRouter {
      * @param ctx The context of the channel handler.
      */
     default void sendNoBootstrapError(HeaderMsg requestHeader, ChannelHandlerContext ctx) {
-        HeaderMsg responseHeader = getHeaderMsg(requestHeader, false, true);
+        HeaderMsg responseHeader = getHeaderMsg(requestHeader, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         ResponseMsg response = getResponseMsg(responseHeader, getNotBootstrappedErrorMsg());
         sendResponse(response, ctx);
 
@@ -242,7 +245,7 @@ public interface IServerRouter {
      * @param clusterId The current cluster id.
      */
     default void sendWrongClusterError(HeaderMsg requestHeader, ChannelHandlerContext ctx, UuidMsg clusterId) {
-        HeaderMsg responseHeader = getHeaderMsg(requestHeader, false, true);
+        HeaderMsg responseHeader = getHeaderMsg(requestHeader, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         ResponseMsg response = getResponseMsg(responseHeader,
                 getWrongClusterErrorMsg(clusterId, requestHeader.getClusterId()));
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ManagementServer.java
@@ -20,6 +20,8 @@ import org.corfudb.infrastructure.management.ClusterStateContext;
 import org.corfudb.infrastructure.management.FailureDetector;
 import org.corfudb.infrastructure.management.ReconfigurationEventHandler;
 import org.corfudb.infrastructure.orchestrator.Orchestrator;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.protocols.wireprotocol.NodeState;
 import org.corfudb.runtime.CorfuRuntime;
@@ -217,11 +219,11 @@ public class ManagementServer extends AbstractServer {
 
         if (layout == null || layout.getClusterId() == null) {
             log.error("handleBootstrapManagement[{}]: Incomplete layout {}", req.getHeader().getRequestId(), layout);
-            responseHeader = getHeaderMsg(req.getHeader(), false, false);
+            responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.CHECK);
             response = getResponseMsg(responseHeader, getBootstrapManagementResponseMsg(false));
         } else {
             final Layout managementLayout = serverContext.getManagementLayout();
-            responseHeader = getHeaderMsg(req.getHeader(), false, true);
+            responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
 
             if (managementLayout != null) {
                 log.warn("handleBootstrapManagement[{}]: Already bootstrapped with {}, "
@@ -270,7 +272,7 @@ public class ManagementServer extends AbstractServer {
             log.error("handleReportFailure[{}]: Discarding stale detector message received. detectorEpoch:{} " +
                     "latestLayoutEpoch:{}", req.getHeader().getRequestId(), payload.getDetectorEpoch(), layout.getEpoch());
 
-            responseHeader = getHeaderMsg(req.getHeader(), false, false);
+            responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.CHECK);
             response = getResponseMsg(responseHeader, getReportFailureResponseMsg(false));
             r.sendResponse(response, ctx);
             return;
@@ -305,7 +307,7 @@ public class ManagementServer extends AbstractServer {
             response = getResponseMsg(req.getHeader(), getReportFailureResponseMsg(true));
         } else {
             log.error("handleReportFailure[{}]: Failure handling unsuccessful.", req.getHeader().getRequestId());
-            responseHeader = getHeaderMsg(req.getHeader(), false, false);
+            responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.CHECK);
             response = getResponseMsg(responseHeader, getReportFailureResponseMsg(false));
         }
 
@@ -344,7 +346,7 @@ public class ManagementServer extends AbstractServer {
             log.error("handleHealFailure[{}]: Discarding request received... detectorEpoch:{} latestLayoutEpoch:{}",
                     req.getHeader().getRequestId(), payload.getDetectorEpoch(), layout.getEpoch());
 
-            responseHeader = getHeaderMsg(req.getHeader(), false, false);
+            responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.CHECK);
             response = getResponseMsg(responseHeader, getHealFailureResponseMsg(false));
             r.sendResponse(response, ctx);
             return;
@@ -384,7 +386,7 @@ public class ManagementServer extends AbstractServer {
             log.info("handleHealFailure[{}]: healing handling " +
                     "already in progress... Skipping.", req.getHeader().getRequestId());
 
-            responseHeader = getHeaderMsg(req.getHeader(), false, false);
+            responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.CHECK);
             response = getResponseMsg(responseHeader, getHealFailureResponseMsg(false));
             r.sendResponse(response, ctx);
             return;
@@ -394,7 +396,7 @@ public class ManagementServer extends AbstractServer {
             response = getResponseMsg(req.getHeader(), getHealFailureResponseMsg(true));
         } else {
             log.error("handleHealFailure[{}]: healing handling unsuccessful.", req.getHeader().getRequestId());
-            responseHeader = getHeaderMsg(req.getHeader(), false, false);
+            responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.CHECK);
             response = getResponseMsg(responseHeader, getHealFailureResponseMsg(false));
         }
 
@@ -423,7 +425,7 @@ public class ManagementServer extends AbstractServer {
                 .getNode(serverContext.getLocalEndpoint())
                 .orElseGet(this::buildDefaultNodeState);
 
-        HeaderMsg responseHeader = getHeaderMsg(req.getHeader(), false, true);
+        HeaderMsg responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         ResponseMsg response = getResponseMsg(responseHeader, getQueryNodeResponseMsg(nodeState));
         r.sendResponse(response, ctx);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/RequestHandlerMethods.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/RequestHandlerMethods.java
@@ -17,6 +17,8 @@ import javax.annotation.Nonnull;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
@@ -82,7 +84,7 @@ public class RequestHandlerMethods {
             log.error("handle[{}]: Unhandled exception processing {} request",
                     req.getHeader().getRequestId(), req.getPayload().getPayloadCase(), e);
 
-            HeaderMsg responseHeader = getHeaderMsg(req.getHeader(), false, true);
+            HeaderMsg responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
             r.sendResponse(getResponseMsg(responseHeader, getUnknownErrorMsg(e)), ctx);
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -15,6 +15,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.infrastructure.SequencerServerCache.ConflictTxStream;
 import org.corfudb.protocols.CorfuProtocolCommon;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics.SequencerStatus;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
@@ -430,7 +432,7 @@ public class SequencerServer extends AbstractServer {
         log.debug("trimCache: global trim {}, streamsAddressSpace {}", trimMark, streamsAddressMap);
 
         HeaderMsg responseHeader = getHeaderMsg(req.getHeader(),
-                false, true);
+                ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         ResponseMsg response = getResponseMsg(responseHeader, getSequencerTrimResponseMsg());
         r.sendResponse(response, ctx);
     }
@@ -565,7 +567,7 @@ public class SequencerServer extends AbstractServer {
                 streamTailToGlobalTailMap, sequencerEpoch);
 
         HeaderMsg responseHeader = getHeaderMsg(req.getHeader(),
-                false, true);
+                ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         r.sendResponse(getResponseMsg(responseHeader,
                 getBootstrapSequencerResponseMsg(true)), ctx);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
@@ -13,6 +13,8 @@ import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRunti
 import org.corfudb.infrastructure.logreplication.transport.client.ChannelAdapterException;
 import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
 import org.corfudb.infrastructure.logreplication.utils.CorfuMessageConverterUtils;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.runtime.Messages.CorfuMessage;
@@ -262,7 +264,7 @@ public class LogReplicationClientRouter implements IClientRouter {
     @Override
     public  <T> CompletableFuture<T> sendRequestAndGetCompletable(RequestPayloadMsg payload, long epoch, RpcCommon.UuidMsg clusterId,
                                                                   org.corfudb.runtime.proto.service.CorfuMessage.PriorityLevel priority,
-                                                                  boolean ignoreClusterId, boolean ignoreEpoch) {
+                                                                  ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         // This is an empty stub. This method is not being used anywhere in the LR framework.
         return null;
     }
@@ -301,7 +303,7 @@ public class LogReplicationClientRouter implements IClientRouter {
     @Override
     public void sendRequest(RequestPayloadMsg payload, long epoch, RpcCommon.UuidMsg clusterId,
                             org.corfudb.runtime.proto.service.CorfuMessage.PriorityLevel priority,
-                            boolean ignoreClusterId, boolean ignoreEpoch) {
+                            ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         // This is an empty stub. This method is not being used anywhere in the LR framework.
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Orchestrator.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Orchestrator.java
@@ -12,6 +12,8 @@ import org.corfudb.infrastructure.orchestrator.workflows.ForceRemoveWorkflow;
 import org.corfudb.infrastructure.orchestrator.workflows.HealNodeWorkflow;
 import org.corfudb.infrastructure.orchestrator.workflows.RemoveNodeWorkflow;
 import org.corfudb.infrastructure.orchestrator.workflows.RestoreRedundancyMergeSegmentsWorkflow;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.orchestrator.AddNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.ForceRemoveNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.HealNodeRequest;
@@ -166,7 +168,7 @@ public class Orchestrator {
         log.trace("handleQuery[{}]: isActive={} for workflowId={}",
                 req.getHeader().getRequestId(), isActive, workflowId);
 
-        HeaderMsg responseHeader = getHeaderMsg(req.getHeader(), false, true);
+        HeaderMsg responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         ResponseMsg response = getResponseMsg(responseHeader, getQueriedWorkflowResponseMsg(isActive));
         r.sendResponse(response, ctx);
     }
@@ -191,7 +193,7 @@ public class Orchestrator {
                                @Nonnull String endpoint) {
         final UUID id = activeWorkflows.inverse().get(endpoint);
 
-        HeaderMsg responseHeader = getHeaderMsg(req.getHeader(), false, true);
+        HeaderMsg responseHeader = getHeaderMsg(req.getHeader(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         ResponseMsg response;
 
         if (id != null) {

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
@@ -5,6 +5,8 @@ import io.netty.channel.ChannelHandlerContext;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.VersionInfo;
 import org.corfudb.runtime.exceptions.SerializerException;
 import org.corfudb.runtime.exceptions.WrongEpochException;
@@ -67,7 +69,7 @@ public class BaseServerTest {
      * @param ignoreEpoch       indicates if the message is epoch aware
      * @return                  the corresponding HeaderMsg
      */
-    private HeaderMsg getBasicHeader(boolean ignoreClusterId, boolean ignoreEpoch) {
+    private HeaderMsg getBasicHeader(ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(requestCounter.incrementAndGet(), PriorityLevel.NORMAL, 0L,
                 getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ignoreClusterId, ignoreEpoch);
     }
@@ -110,7 +112,7 @@ public class BaseServerTest {
     @Test
     public void testPing() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getPingRequestMsg()
         );
 
@@ -134,7 +136,7 @@ public class BaseServerTest {
     @Test
     public void testSealValidEpoch() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getSealRequestMsg(1L)
         );
 
@@ -159,7 +161,7 @@ public class BaseServerTest {
     @Test
     public void testSealWrongEpoch() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getSealRequestMsg(1L)
         );
 
@@ -186,7 +188,7 @@ public class BaseServerTest {
     @Test
     public void testVersionRequest() throws SerializerException {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getVersionRequestMsg()
         );
 
@@ -217,7 +219,7 @@ public class BaseServerTest {
     @Test
     public void testReset() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getResetRequestMsg()
         );
 
@@ -245,7 +247,7 @@ public class BaseServerTest {
     @Test
     public void testRestart() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getRestartRequestMsg()
         );
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -6,6 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.datastore.DataStore;
 import org.corfudb.infrastructure.datastore.KvDataStore.KvRecord;
 import org.corfudb.protocols.CorfuProtocolCommon;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.PriorityLevel;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
@@ -75,7 +77,7 @@ public class LayoutServerTest {
      * @param ignoreEpoch       indicates if the message is epoch aware
      * @return                  the corresponding HeaderMsg
      */
-    private HeaderMsg getBasicHeader(boolean ignoreClusterId, boolean ignoreEpoch) {
+    private HeaderMsg getBasicHeader(ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(requestCounter.incrementAndGet(), PriorityLevel.NORMAL, 0L,
                 getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ignoreClusterId, ignoreEpoch);
     }
@@ -123,7 +125,7 @@ public class LayoutServerTest {
     public void testBootstrapLayoutAck() throws IOException {
         Layout defaultLayout = getDefaultLayout();
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getBootstrapLayoutRequestMsg(defaultLayout)
         );
 
@@ -148,7 +150,7 @@ public class LayoutServerTest {
     @Test
     public void testBootstrapNullLayout() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getBootstrapLayoutRequestMsg(null)
         );
 
@@ -176,7 +178,7 @@ public class LayoutServerTest {
         l.setClusterId(null);
 
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getBootstrapLayoutRequestMsg(l)
         );
 
@@ -201,7 +203,7 @@ public class LayoutServerTest {
     public void testBootstrappedLayout() throws IOException {
         Layout l = getDefaultLayout();
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getBootstrapLayoutRequestMsg(l)
         );
 
@@ -230,7 +232,7 @@ public class LayoutServerTest {
         Layout defaultLayout = getDefaultLayout();
         long payloadEpoch = 0L;
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getLayoutRequestMsg(payloadEpoch)
         );
 
@@ -257,7 +259,7 @@ public class LayoutServerTest {
     public void testGetLayoutNoBootstrap() {
         long payloadEpoch = 0L;
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getLayoutRequestMsg(payloadEpoch)
         );
 
@@ -273,7 +275,7 @@ public class LayoutServerTest {
         Layout l = getDefaultLayout();
         long wrongEpoch = 5L;
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getLayoutRequestMsg(wrongEpoch)
         );
 
@@ -306,7 +308,7 @@ public class LayoutServerTest {
         long defaultRank = -1L;
 
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getPrepareLayoutRequestMsg(payloadEpoch, phase1Rank)
         );
 
@@ -344,7 +346,7 @@ public class LayoutServerTest {
         long phase1Rank = 5L;
 
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getPrepareLayoutRequestMsg(payloadEpoch, phase1Rank)
         );
 
@@ -365,7 +367,7 @@ public class LayoutServerTest {
         long highestPhase1Rank = 10L;
 
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getPrepareLayoutRequestMsg(payloadEpoch, phase1Rank)
         );
 
@@ -401,7 +403,7 @@ public class LayoutServerTest {
         long phase1Rank = 5L;
 
         RequestMsg proposeRequest = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getProposeLayoutRequestMsg(payloadEpoch, phase1Rank, l)
         );
 
@@ -441,7 +443,7 @@ public class LayoutServerTest {
         long phase1Rank = 5L;
 
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getProposeLayoutRequestMsg(payloadEpoch, phase1Rank, l)
         );
 
@@ -463,7 +465,7 @@ public class LayoutServerTest {
         long defaultRank = -1L;
 
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getProposeLayoutRequestMsg(payloadEpoch, phase1Rank, l)
         );
 
@@ -497,7 +499,7 @@ public class LayoutServerTest {
         l.setEpoch(wrongEpoch);
 
         RequestMsg proposeRequest = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getProposeLayoutRequestMsg(payloadEpoch, phase1Rank, l)
         );
 
@@ -533,7 +535,7 @@ public class LayoutServerTest {
         long wrongProposeRank = 10L;
 
         RequestMsg proposeRequest = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getProposeLayoutRequestMsg(payloadEpoch, wrongProposeRank, l)
         );
 
@@ -568,7 +570,7 @@ public class LayoutServerTest {
         long phase1Rank = 5L;
 
         RequestMsg proposeRequest = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getProposeLayoutRequestMsg(payloadEpoch, phase1Rank, l)
         );
 
@@ -601,7 +603,7 @@ public class LayoutServerTest {
         Layout defaultLayout = getDefaultLayout();
         long payloadEpoch = 0L;
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getCommitLayoutRequestMsg(false, payloadEpoch, defaultLayout)
         );
 
@@ -629,7 +631,7 @@ public class LayoutServerTest {
         Layout defaultLayout = getDefaultLayout();
         long payloadEpoch = 0L;
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getCommitLayoutRequestMsg(false, payloadEpoch, defaultLayout)
         );
 
@@ -649,7 +651,7 @@ public class LayoutServerTest {
         long payloadEpoch = 0L;
         long serverEpoch = 5L;
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getCommitLayoutRequestMsg(false, payloadEpoch, l)
         );
 
@@ -681,7 +683,7 @@ public class LayoutServerTest {
         Layout defaultLayout = getDefaultLayout();
         long payloadEpoch = 0L;
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getCommitLayoutRequestMsg(true, payloadEpoch, defaultLayout)
         );
 
@@ -711,7 +713,7 @@ public class LayoutServerTest {
         long payloadEpoch = 0L;
         long serverEpoch = 5L;
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getCommitLayoutRequestMsg(true, payloadEpoch, l)
         );
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogUnitServerTest.java
@@ -19,6 +19,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.log.StreamLog;
 import org.corfudb.infrastructure.log.StreamLogCompaction;
 import org.corfudb.infrastructure.LogUnitServer.LogUnitServerConfig;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
@@ -106,7 +108,7 @@ public class LogUnitServerTest {
      * @param ignoreEpoch       indicates if the message is epoch aware
      * @return                  the corresponding HeaderMsg
      */
-    private HeaderMsg getBasicHeader(boolean ignoreClusterId, boolean ignoreEpoch) {
+    private HeaderMsg getBasicHeader(ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(requestCounter.incrementAndGet(), PriorityLevel.NORMAL, 1L,
                 getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ignoreClusterId, ignoreEpoch);
     }
@@ -186,7 +188,7 @@ public class LogUnitServerTest {
     @Test
     public void testHandleTail() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getTailRequestMsg(TailRequestMsg.Type.ALL_STREAMS_TAIL)
         );
 
@@ -221,7 +223,7 @@ public class LogUnitServerTest {
     @Test
     public void testHandleLogAddressSpace() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getLogAddressSpaceRequestMsg()
         );
 
@@ -270,7 +272,7 @@ public class LogUnitServerTest {
     @Test
     public void testHandleTrimMark() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getTrimMarkRequestMsg()
         );
 
@@ -295,7 +297,7 @@ public class LogUnitServerTest {
     @Test
     public void testHandleCommittedTail() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getCommittedTailRequestMsg()
         );
 
@@ -322,7 +324,7 @@ public class LogUnitServerTest {
     public void testHandleUpdateCommittedTail() {
         final long tail = 7L;
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getUpdateCommittedTailRequestMsg(tail)
         );
 
@@ -348,7 +350,7 @@ public class LogUnitServerTest {
     @Test
     public void testHandleTrimLog() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getTrimLogRequestMsg(Token.of(0L, 24L))
         );
 
@@ -379,7 +381,7 @@ public class LogUnitServerTest {
                 .filter(address -> address > 9L).collect(Collectors.toList());
 
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getInspectAddressesRequestMsg(addresses)
         );
 
@@ -407,7 +409,7 @@ public class LogUnitServerTest {
     public void testHandleInspectAddressesTrimmed() {
         final List<Long> addresses = LongStream.rangeClosed(1L, 16L).boxed().collect(Collectors.toList());
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getInspectAddressesRequestMsg(addresses)
         );
 
@@ -434,7 +436,7 @@ public class LogUnitServerTest {
         final List<Long> addresses = LongStream.rangeClosed(1L, 16L).boxed().collect(Collectors.toList());
         final long badAddress = 11L;
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getInspectAddressesRequestMsg(addresses)
         );
 
@@ -461,7 +463,7 @@ public class LogUnitServerTest {
         final long endRange = 7L;
 
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getKnownAddressRequestMsg(startRange, endRange)
         );
 
@@ -487,7 +489,7 @@ public class LogUnitServerTest {
     @Test
     public void testHandleCompact() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getCompactRequestMsg()
         );
 
@@ -511,7 +513,7 @@ public class LogUnitServerTest {
     @Test
     public void testHandleFlushCache() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getFlushCacheRequestMsg()
         );
 
@@ -587,7 +589,7 @@ public class LogUnitServerTest {
      */
     private RequestMsg sendAndValidateResetLogUnit(long requestEpoch, long serverEpoch, long watermarkEpoch) {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getResetLogUnitRequestMsg(requestEpoch)
         );
 
@@ -622,7 +624,7 @@ public class LogUnitServerTest {
         final boolean cacheable = true;
 
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getReadLogRequestMsg(addresses, cacheable)
         );
 
@@ -668,7 +670,7 @@ public class LogUnitServerTest {
         final boolean cacheable = false;
 
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getReadLogRequestMsg(addresses, cacheable)
         );
 
@@ -701,7 +703,7 @@ public class LogUnitServerTest {
     @Test
     public void testHandleWriteLog() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getWriteLogRequestMsg(getDefaultLogData(1L))
         );
 
@@ -726,7 +728,7 @@ public class LogUnitServerTest {
     @Test
     public void testHandleRangeWriteLog() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getRangeWriteLogRequestMsg(Collections.singletonList(getDefaultLogData(1L)))
         );
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
@@ -20,6 +20,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.management.ClusterStateContext;
 import org.corfudb.infrastructure.management.ReconfigurationEventHandler;
 import org.corfudb.infrastructure.orchestrator.Orchestrator;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.ClusterState;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.SerializerException;
@@ -99,7 +101,7 @@ public class ManagementServerTest {
      * @param ignoreEpoch       indicates if the message is epoch aware
      * @return                  the corresponding HeaderMsg
      */
-    private HeaderMsg getBasicHeader(boolean ignoreClusterId, boolean ignoreEpoch) {
+    private HeaderMsg getBasicHeader(ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(requestCounter.incrementAndGet(), PriorityLevel.NORMAL, 1L,
                 getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ignoreClusterId, ignoreEpoch);
     }
@@ -203,7 +205,7 @@ public class ManagementServerTest {
     @Test
     public void testOrchestratorRequest() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getQueryWorkflowRequestMsg(DEFAULT_UUID)
         );
 
@@ -221,7 +223,7 @@ public class ManagementServerTest {
         // Here we do not use the API to facilitate creating a scenario where
         // this exception can occur.
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 RequestPayloadMsg.newBuilder()
                     .setBootstrapManagementRequest(
                             BootstrapManagementRequestMsg.newBuilder()
@@ -261,7 +263,7 @@ public class ManagementServerTest {
     @Test
     public void testBootstrapManagementNullClusterId() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getBootstrapManagementRequestMsg(getBasicLayout(1L, null))
         );
 
@@ -289,7 +291,7 @@ public class ManagementServerTest {
     @Test
     public void testBootstrapManagementAlreadyBootstrapped() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getBootstrapManagementRequestMsg(getBasicLayout(1L, DEFAULT_UUID))
         );
 
@@ -317,7 +319,7 @@ public class ManagementServerTest {
     public void testBootstrapManagement() {
         final Layout layout = getBasicLayout(1L, DEFAULT_UUID);
         RequestMsg request = getRequestMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getBootstrapManagementRequestMsg(layout)
         );
 
@@ -344,7 +346,7 @@ public class ManagementServerTest {
     @Test
     public void testManagementLayoutNotBootstrapped() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getManagementLayoutRequestMsg()
         );
 
@@ -363,7 +365,7 @@ public class ManagementServerTest {
     public void testManagementLayout() {
         final Layout layout = getBasicLayout(1L, DEFAULT_UUID);
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getManagementLayoutRequestMsg()
         );
 
@@ -390,7 +392,7 @@ public class ManagementServerTest {
     @Test
     public void testQueryNode() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getQueryNodeRequestMsg()
         );
 
@@ -421,7 +423,7 @@ public class ManagementServerTest {
     @Test
     public void testReportFailureNotBootstrapped() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getReportFailureRequestMsg(1L, new HashSet<>(Collections.singletonList(NODES.get(1))))
         );
 
@@ -444,7 +446,7 @@ public class ManagementServerTest {
     @Test
     public void testReportFailureOldPolling() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getReportFailureRequestMsg(0L, new HashSet<>(Collections.singletonList(NODES.get(1))))
         );
 
@@ -475,7 +477,7 @@ public class ManagementServerTest {
     public void testReportFailure() {
         final String UNRESPONSIVE_NODE = "localhost:9003";
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getReportFailureRequestMsg(1L, new HashSet<>(Arrays.asList(NODES.get(1), UNRESPONSIVE_NODE)))
         );
 
@@ -536,7 +538,7 @@ public class ManagementServerTest {
     @Test
     public void testHealFailureNotBootstrapped() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getHealFailureRequestMsg(1L, new HashSet<>(Collections.singletonList(NODES.get(1))))
         );
 
@@ -559,7 +561,7 @@ public class ManagementServerTest {
     @Test
     public void testHealFailureOldPolling() {
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getHealFailureRequestMsg(0L, new HashSet<>(Collections.singletonList(NODES.get(1))))
         );
 
@@ -590,7 +592,7 @@ public class ManagementServerTest {
     public void testHealFailure() {
         final String UNRESPONSIVE_NODE = "localhost:9003";
         RequestMsg request = getRequestMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getHealFailureRequestMsg(1L, new HashSet<>(Arrays.asList(NODES.get(1), UNRESPONSIVE_NODE)))
         );
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/orchestrator/OrchestratorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/orchestrator/OrchestratorTest.java
@@ -13,6 +13,8 @@ import org.corfudb.infrastructure.orchestrator.workflows.ForceRemoveWorkflow;
 import org.corfudb.infrastructure.orchestrator.workflows.HealNodeWorkflow;
 import org.corfudb.infrastructure.orchestrator.workflows.RemoveNodeWorkflow;
 import org.corfudb.infrastructure.orchestrator.workflows.RestoreRedundancyMergeSegmentsWorkflow;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.orchestrator.AddNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.ForceRemoveNodeRequest;
 import org.corfudb.protocols.wireprotocol.orchestrator.HealNodeRequest;
@@ -88,7 +90,7 @@ public class OrchestratorTest {
      */
     private HeaderMsg getBasicHeader() {
         return getHeaderMsg(requestCounter.incrementAndGet(), PriorityLevel.NORMAL, 1L,
-                getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), true, true);
+                getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolMessage.java
+++ b/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolMessage.java
@@ -30,6 +30,22 @@ public final class CorfuProtocolMessage {
     private CorfuProtocolMessage() {}
 
     /**
+     * An Enum wrapper for the boolean field ignore_cluster_id of HeaderMsg.
+     */
+    public enum ClusterIdCheck {
+        CHECK,
+        IGNORE
+    }
+
+    /**
+     * An Enum wrapper for the boolean field ignore_epoch of HeaderMsg.
+     */
+    public enum EpochCheck {
+        CHECK,
+        IGNORE
+    }
+
+    /**
      * This type map provides clients with the ability to convert
      * between representations of PriorityLevel.
      */
@@ -53,7 +69,7 @@ public final class CorfuProtocolMessage {
      */
     public static HeaderMsg getHeaderMsg(long requestId, CorfuMessage.PriorityLevel priority,
                                          long epoch, UuidMsg clusterId, UuidMsg clientId,
-                                         boolean ignoreClusterId, boolean ignoreEpoch) {
+                                         ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return HeaderMsg.newBuilder()
                 .setVersion(ProtocolVersionMsg.getDefaultInstance())
                 .setRequestId(requestId)
@@ -61,8 +77,8 @@ public final class CorfuProtocolMessage {
                 .setEpoch(epoch)
                 .setClusterId(clusterId)
                 .setClientId(clientId)
-                .setIgnoreClusterId(ignoreClusterId)
-                .setIgnoreEpoch(ignoreEpoch)
+                .setIgnoreClusterId(ignoreClusterId == ClusterIdCheck.IGNORE)
+                .setIgnoreEpoch(ignoreEpoch == EpochCheck.IGNORE)
                 .build();
     }
 
@@ -79,7 +95,7 @@ public final class CorfuProtocolMessage {
      * @return                  a HeaderMsg encoding the provided arguments
      */
     public static HeaderMsg getHeaderMsg(long requestId, CorfuMessage.PriorityLevel priority, long epoch,
-                                         UUID clusterId, UUID clientId, boolean ignoreClusterId, boolean ignoreEpoch) {
+                                         UUID clusterId, UUID clientId, ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(requestId, priority, epoch, getUuidMsg(clusterId),
                 getUuidMsg(clientId), ignoreClusterId, ignoreEpoch);
     }
@@ -95,11 +111,11 @@ public final class CorfuProtocolMessage {
      *                          header, but modifying the ignoreClusterId and ignoreEpoch
      *                          fields with the values provided
      */
-    public static HeaderMsg getHeaderMsg(HeaderMsg header, boolean ignoreClusterId, boolean ignoreEpoch) {
+    public static HeaderMsg getHeaderMsg(HeaderMsg header, ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return HeaderMsg.newBuilder()
                 .mergeFrom(header)
-                .setIgnoreClusterId(ignoreClusterId)
-                .setIgnoreEpoch(ignoreEpoch)
+                .setIgnoreClusterId(ignoreClusterId == ClusterIdCheck.IGNORE)
+                .setIgnoreEpoch(ignoreEpoch == EpochCheck.IGNORE)
                 .build();
     }
 

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/ClientHandshakeHandler.java
@@ -12,6 +12,8 @@ import java.util.UUID;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.runtime.proto.service.Base.HandshakeResponseMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
@@ -166,7 +168,7 @@ public class ClientHandshakeHandler extends ChannelDuplexHandler {
 
         // Note: Some fields in the header are unused during the handshake process.
         HeaderMsg header = getHeaderMsg(0, CorfuMessage.PriorityLevel.NORMAL, 0,
-                DEFAULT_UUID, this.clientId, false, true);
+                DEFAULT_UUID, this.clientId, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         RequestMsg request = getRequestMsg(header, getHandshakeRequestMsg(this.clientId, this.nodeId));
 
         ctx.writeAndFlush(request);

--- a/runtime/src/main/java/org/corfudb/runtime/clients/AbstractClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/AbstractClient.java
@@ -4,6 +4,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.Setter;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.PriorityLevel;
 import org.corfudb.runtime.proto.service.CorfuMessage;
@@ -45,7 +47,7 @@ public abstract class AbstractClient implements IClient {
     }
 
     <T> CompletableFuture<T> sendRequestWithFuture(RequestPayloadMsg payload,
-                                                   boolean ignoreClusterId, boolean ignoreEpoch) {
+                                                   ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         CorfuMessage.PriorityLevel protoPriorityLevel =
                 priorityTypeMap.getOrDefault(priorityLevel, CorfuMessage.PriorityLevel.NORMAL);
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/BaseClient.java
@@ -3,6 +3,8 @@ package org.corfudb.runtime.clients;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.VersionInfo;
 
 import static org.corfudb.protocols.service.CorfuProtocolBase.getPingRequestMsg;
@@ -47,7 +49,7 @@ public class BaseClient extends AbstractClient {
      * the endpoint is reachable, otherwise False or exceptional completion.
      */
     public CompletableFuture<Boolean> ping() {
-        return sendRequestWithFuture(getPingRequestMsg(), true, true);
+        return sendRequestWithFuture(getPingRequestMsg(), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
     }
 
     /**
@@ -57,7 +59,7 @@ public class BaseClient extends AbstractClient {
      * the endpoint restarts successfully, otherwise False or exceptional completion.
      */
     public CompletableFuture<Boolean> restart() {
-        return sendRequestWithFuture(getRestartRequestMsg(), true, true);
+        return sendRequestWithFuture(getRestartRequestMsg(), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
     }
 
     /**
@@ -68,7 +70,7 @@ public class BaseClient extends AbstractClient {
      * the endpoint resets successfully, otherwise False or exceptional completion.
      */
     public CompletableFuture<Boolean> reset() {
-        return sendRequestWithFuture(getResetRequestMsg(), true, true);
+        return sendRequestWithFuture(getResetRequestMsg(), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
     }
 
     /**
@@ -78,7 +80,7 @@ public class BaseClient extends AbstractClient {
      * @return Completable future which returns true on successful epoch set.
      */
     public CompletableFuture<Boolean> sealRemoteServer(long newEpoch) {
-        return sendRequestWithFuture(getSealRequestMsg(newEpoch), false, true);
+        return sendRequestWithFuture(getSealRequestMsg(newEpoch), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     /**
@@ -87,6 +89,6 @@ public class BaseClient extends AbstractClient {
      * @return Completable future which returns {@link VersionInfo} object.
      */
     public CompletableFuture<VersionInfo> getVersionInfo() {
-        return sendRequestWithFuture(getVersionRequestMsg(), true, true);
+        return sendRequestWithFuture(getVersionRequestMsg(), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
@@ -2,6 +2,8 @@ package org.corfudb.runtime.clients;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage;
@@ -51,7 +53,7 @@ public interface IClientRouter {
      */
     <T> CompletableFuture<T> sendRequestAndGetCompletable(CorfuMessage.RequestPayloadMsg payload, long epoch,
                                                           UuidMsg clusterId, CorfuMessage.PriorityLevel priority,
-                                                          boolean ignoreClusterId, boolean ignoreEpoch);
+                                                          ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch);
 
     /**
      * @deprecated [RM]
@@ -73,7 +75,7 @@ public interface IClientRouter {
      * @param ignoreEpoch
      */
     void sendRequest(CorfuMessage.RequestPayloadMsg payload, long epoch, UuidMsg clusterId,
-                     CorfuMessage.PriorityLevel priority, boolean ignoreClusterId, boolean ignoreEpoch);
+                     CorfuMessage.PriorityLevel priority, ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch);
 
     /**
      * Complete a given outstanding request with a completion value.

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LayoutClient.java
@@ -5,6 +5,8 @@ import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nonnull;
 
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.LayoutPrepareResponse;
 import org.corfudb.runtime.view.Layout;
 
@@ -34,7 +36,7 @@ public class LayoutClient extends AbstractClient {
      * @return A future which will be completed with the current layout.
      */
     public CompletableFuture<Layout> getLayout() {
-        return sendRequestWithFuture(getLayoutRequestMsg(getEpoch()), true, true);
+        return sendRequestWithFuture(getLayoutRequestMsg(getEpoch()), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
     }
 
     /**
@@ -45,7 +47,7 @@ public class LayoutClient extends AbstractClient {
      * bootstrap was successful, false otherwise.
      */
     public CompletableFuture<Boolean> bootstrapLayout(Layout l) {
-        return sendRequestWithFuture(getBootstrapLayoutRequestMsg(l), true, true);
+        return sendRequestWithFuture(getBootstrapLayoutRequestMsg(l), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
     }
 
     /**
@@ -58,7 +60,7 @@ public class LayoutClient extends AbstractClient {
      * with OutrankedException.
      */
     public CompletableFuture<LayoutPrepareResponse> prepare(long epoch, long rank) {
-        return sendRequestWithFuture(getPrepareLayoutRequestMsg(epoch, rank), false, true);
+        return sendRequestWithFuture(getPrepareLayoutRequestMsg(epoch, rank), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     /**
@@ -73,7 +75,7 @@ public class LayoutClient extends AbstractClient {
      * with OutrankedException.
      */
     public CompletableFuture<Boolean> propose(long epoch, long rank, Layout layout) {
-        return sendRequestWithFuture(getProposeLayoutRequestMsg(epoch, rank, layout), false, true);
+        return sendRequestWithFuture(getProposeLayoutRequestMsg(epoch, rank, layout), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     /**
@@ -84,7 +86,7 @@ public class LayoutClient extends AbstractClient {
      * @return True, if the commit was successful.
      */
     public CompletableFuture<Boolean> committed(long epoch, Layout layout) {
-        return sendRequestWithFuture(getCommitLayoutRequestMsg(false, epoch, layout), false, true);
+        return sendRequestWithFuture(getCommitLayoutRequestMsg(false, epoch, layout), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     /**
@@ -94,7 +96,7 @@ public class LayoutClient extends AbstractClient {
      * @return true if it was committed, otherwise false.
      */
     public CompletableFuture<Boolean> force(@Nonnull Layout layout) {
-        return sendRequestWithFuture(getCommitLayoutRequestMsg(true, layout.getEpoch(), layout), false, true);
+        return sendRequestWithFuture(getCommitLayoutRequestMsg(true, layout.getEpoch(), layout), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -7,7 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import lombok.Getter;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.InspectAddressesResponse;
@@ -17,7 +18,6 @@ import org.corfudb.protocols.wireprotocol.ReadResponse;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.protocols.wireprotocol.Token;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.proto.service.LogUnit.TailRequestMsg.Type;
 import org.corfudb.util.serializer.Serializers;
 
@@ -72,7 +72,7 @@ public class LogUnitClient extends AbstractClient {
         LogData logData = new LogData(DataType.DATA, payload);
         logData.setBackpointerMap(backpointerMap);
         logData.setGlobalAddress(address);
-        return sendRequestWithFuture(getWriteLogRequestMsg(logData), false, false);
+        return sendRequestWithFuture(getWriteLogRequestMsg(logData), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -82,7 +82,7 @@ public class LogUnitClient extends AbstractClient {
      * @return a completable future which returns true on success.
      */
     public CompletableFuture<Boolean> write(ILogData payload) {
-        return sendRequestWithFuture(getWriteLogRequestMsg((LogData) payload), false, false);
+        return sendRequestWithFuture(getWriteLogRequestMsg((LogData) payload), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -106,7 +106,7 @@ public class LogUnitClient extends AbstractClient {
             }
         }
 
-        return sendRequestWithFuture(getRangeWriteLogRequestMsg(range), false, false);
+        return sendRequestWithFuture(getRangeWriteLogRequestMsg(range), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -128,7 +128,7 @@ public class LogUnitClient extends AbstractClient {
      * @return a completableFuture which returns a ReadResponse on completion.
      */
     public CompletableFuture<ReadResponse> read(List<Long> addresses, boolean cacheable) {
-        return sendRequestWithFuture(getReadLogRequestMsg(addresses, cacheable), false, false);
+        return sendRequestWithFuture(getReadLogRequestMsg(addresses, cacheable), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -139,7 +139,7 @@ public class LogUnitClient extends AbstractClient {
      * @return a completableFuture which returns an InspectAddressesResponse
      */
     public CompletableFuture<InspectAddressesResponse> inspectAddresses(List<Long> addresses) {
-        return sendRequestWithFuture(getInspectAddressesRequestMsg(addresses), false, false);
+        return sendRequestWithFuture(getInspectAddressesRequestMsg(addresses), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -149,7 +149,7 @@ public class LogUnitClient extends AbstractClient {
      * received.
      */
     public CompletableFuture<TailsResponse> getLogTail() {
-        return sendRequestWithFuture(getTailRequestMsg(Type.LOG_TAIL), false, false);
+        return sendRequestWithFuture(getTailRequestMsg(Type.LOG_TAIL), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -159,7 +159,7 @@ public class LogUnitClient extends AbstractClient {
      * received.
      */
     public CompletableFuture<TailsResponse> getAllTails() {
-        return sendRequestWithFuture(getTailRequestMsg(Type.ALL_STREAMS_TAIL), false, false);
+        return sendRequestWithFuture(getTailRequestMsg(Type.ALL_STREAMS_TAIL), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -168,7 +168,7 @@ public class LogUnitClient extends AbstractClient {
      * @return a CompletableFuture which will complete with the committed tail once received.
      */
     public CompletableFuture<Long> getCommittedTail() {
-        return sendRequestWithFuture(getCommittedTailRequestMsg(), false, false);
+        return sendRequestWithFuture(getCommittedTailRequestMsg(), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -178,7 +178,7 @@ public class LogUnitClient extends AbstractClient {
      * @return an empty completableFuture
      */
     public CompletableFuture<Void> updateCommittedTail(long committedTail) {
-        return sendRequestWithFuture(getUpdateCommittedTailRequestMsg(committedTail), false, false);
+        return sendRequestWithFuture(getUpdateCommittedTailRequestMsg(committedTail), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -187,7 +187,7 @@ public class LogUnitClient extends AbstractClient {
      * @return A CompletableFuture which will complete with the address space map for all streams.
      */
     public CompletableFuture<StreamsAddressResponse> getLogAddressSpace() {
-        return sendRequestWithFuture(getLogAddressSpaceRequestMsg(), false, false);
+        return sendRequestWithFuture(getLogAddressSpaceRequestMsg(), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -196,7 +196,7 @@ public class LogUnitClient extends AbstractClient {
      * @return a CompletableFuture for the starting address
      */
     public CompletableFuture<Long> getTrimMark() {
-        return sendRequestWithFuture(getTrimMarkRequestMsg(), false, false);
+        return sendRequestWithFuture(getTrimMarkRequestMsg(), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -207,7 +207,7 @@ public class LogUnitClient extends AbstractClient {
      * @return Known addresses.
      */
     public CompletableFuture<KnownAddressResponse> requestKnownAddresses(long startRange, long endRange) {
-        return sendRequestWithFuture(getKnownAddressRequestMsg(startRange, endRange), false, false);
+        return sendRequestWithFuture(getKnownAddressRequestMsg(startRange, endRange), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -217,21 +217,21 @@ public class LogUnitClient extends AbstractClient {
      * @return an empty completableFuture
      */
     public CompletableFuture<Void> prefixTrim(Token address) {
-        return sendRequestWithFuture(getTrimLogRequestMsg(address), false, false);
+        return sendRequestWithFuture(getTrimLogRequestMsg(address), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
      * Send a compact request that will delete the trimmed parts of the log.
      */
     public CompletableFuture<Void> compact() {
-        return sendRequestWithFuture(getCompactRequestMsg(), false, true);
+        return sendRequestWithFuture(getCompactRequestMsg(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     /**
      * Send a flush cache request that will flush the logunit cache.
      */
     public CompletableFuture<Void> flushCache() {
-        return sendRequestWithFuture(getFlushCacheRequestMsg(), false, true);
+        return sendRequestWithFuture(getFlushCacheRequestMsg(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     /**
@@ -241,6 +241,6 @@ public class LogUnitClient extends AbstractClient {
      * @return a completable future which returns true on success.
      */
     public CompletableFuture<Boolean> resetLogUnit(long epoch) {
-        return sendRequestWithFuture(getResetLogUnitRequestMsg(epoch), false, true);
+        return sendRequestWithFuture(getResetLogUnitRequestMsg(epoch), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/ManagementClient.java
@@ -5,6 +5,9 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nonnull;
+
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.NodeState;
 import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.QueryResponse;
@@ -46,7 +49,7 @@ public class ManagementClient extends AbstractClient {
      * bootstrap was successful, false otherwise.
      */
     public CompletableFuture<Boolean> bootstrapManagement(Layout l) {
-        return sendRequestWithFuture(getBootstrapManagementRequestMsg(l), true, true);
+        return sendRequestWithFuture(getBootstrapManagementRequestMsg(l), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
     }
 
     /**
@@ -57,7 +60,7 @@ public class ManagementClient extends AbstractClient {
      * @return               A future which will return TRUE if completed successfully else returns FALSE.
      */
     public CompletableFuture<Boolean> handleFailure(long detectorEpoch, Set<String> failedNodes) {
-        return sendRequestWithFuture(getReportFailureRequestMsg(detectorEpoch, failedNodes), false, true);
+        return sendRequestWithFuture(getReportFailureRequestMsg(detectorEpoch, failedNodes), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     /**
@@ -68,11 +71,11 @@ public class ManagementClient extends AbstractClient {
      * @return               A future which will be return TRUE if completed successfully else returns FALSE.
      */
     public CompletableFuture<Boolean> handleHealing(long detectorEpoch, Set<String> healedNodes) {
-        return sendRequestWithFuture(getHealFailureRequestMsg(detectorEpoch, healedNodes), false, true);
+        return sendRequestWithFuture(getHealFailureRequestMsg(detectorEpoch, healedNodes), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     public CompletableFuture<NodeState> sendNodeStateRequest() {
-        return sendRequestWithFuture(getQueryNodeRequestMsg(), false, false);
+        return sendRequestWithFuture(getQueryNodeRequestMsg(), ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -81,7 +84,7 @@ public class ManagementClient extends AbstractClient {
      * @return A future which returns the layout persisted by the management server on completion.
      */
     public CompletableFuture<Layout> getLayout() {
-        return sendRequestWithFuture(getManagementLayoutRequestMsg(), false, true);
+        return sendRequestWithFuture(getManagementLayoutRequestMsg(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     /**
@@ -94,7 +97,7 @@ public class ManagementClient extends AbstractClient {
         RequestPayloadMsg payload = getAddNodeRequestMsg(endpoint);
 
         return CFUtils.getUninterruptibly(
-                sendRequestWithFuture(payload, true, true),
+                sendRequestWithFuture(payload, ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 TimeoutException.class
         );
     }
@@ -120,7 +123,7 @@ public class ManagementClient extends AbstractClient {
                 stripeIndex, isLayoutServer, isSequencerServer, isLogUnitServer);
 
         return CFUtils.getUninterruptibly(
-                sendRequestWithFuture(payload, true, true),
+                sendRequestWithFuture(payload, ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 TimeoutException.class
         );
     }
@@ -136,7 +139,7 @@ public class ManagementClient extends AbstractClient {
         RequestPayloadMsg payload = getRestoreRedundancyMergeSegmentsRequestMsg(endpoint);
 
         return CFUtils.getUninterruptibly(
-                sendRequestWithFuture(payload, true, true),
+                sendRequestWithFuture(payload, ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 TimeoutException.class
         );
     }
@@ -151,7 +154,7 @@ public class ManagementClient extends AbstractClient {
         RequestPayloadMsg payload = getQueryWorkflowRequestMsg(workflowId);
 
         return CFUtils.getUninterruptibly(
-                sendRequestWithFuture(payload, true, true),
+                sendRequestWithFuture(payload, ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 TimeoutException.class
         );
     }
@@ -166,7 +169,7 @@ public class ManagementClient extends AbstractClient {
         RequestPayloadMsg payload = getRemoveNodeRequestMsg(endpoint);
 
         return CFUtils.getUninterruptibly(
-                sendRequestWithFuture(payload, true, true),
+                sendRequestWithFuture(payload, ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 TimeoutException.class
         );
     }
@@ -183,7 +186,7 @@ public class ManagementClient extends AbstractClient {
         RequestPayloadMsg payload = getForceRemoveNodeRequestMsg(endpoint);
 
         return CFUtils.getUninterruptibly(
-                sendRequestWithFuture(payload, true, true),
+                sendRequestWithFuture(payload, ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 TimeoutException.class
         );
     }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/NettyClientRouter.java
@@ -1,7 +1,6 @@
 package org.corfudb.runtime.clients;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.TextFormat;
 import io.netty.bootstrap.Bootstrap;
@@ -41,13 +40,14 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.protocols.CorfuProtocolCommon;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.ClientHandshakeHandler;
 import org.corfudb.protocols.wireprotocol.ClientHandshakeHandler.ClientHandshakeEvent;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.protocols.wireprotocol.NettyCorfuMessageDecoder;
 import org.corfudb.protocols.wireprotocol.NettyCorfuMessageEncoder;
-import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
@@ -55,7 +55,6 @@ import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterrupte
 import org.corfudb.runtime.proto.RpcCommon;
 import org.corfudb.runtime.proto.ServerErrors.ServerErrorMsg.ErrorCase;
 import org.corfudb.runtime.proto.service.CorfuMessage;
-import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
 import org.corfudb.runtime.RuntimeParameters;
@@ -509,7 +508,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
             CorfuMessage.RequestPayloadMsg payload,
             long epoch, RpcCommon.UuidMsg clusterId,
             CorfuMessage.PriorityLevel priority,
-            boolean ignoreClusterId, boolean ignoreEpoch) {
+            ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
 
         // Check the connection future. If connected, continue with sending the message.
         // If timed out, return a exceptionally completed with the timeout.
@@ -597,7 +596,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
     @Override
     public void sendRequest(CorfuMessage.RequestPayloadMsg payload, long epoch,
                             RpcCommon.UuidMsg clusterId,
-                            CorfuMessage.PriorityLevel priority, boolean ignoreClusterId, boolean ignoreEpoch) {
+                            CorfuMessage.PriorityLevel priority, ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         // Get the next request ID
         final long thisRequestId = requestID.getAndIncrement();
         RpcCommon.UuidMsg clientId = CorfuProtocolCommon.getUuidMsg(parameters.getClientId());
@@ -750,7 +749,7 @@ public class NettyClientRouter extends SimpleChannelInboundHandler<Object> imple
 
         // Note: the epoch and clusterId are ignored for this message
         sendRequestAndGetCompletable(getPingRequestMsg(), 0, getUuidMsg(DEFAULT_UUID),
-                CorfuMessage.PriorityLevel.NORMAL, true, true);
+                CorfuMessage.PriorityLevel.NORMAL, ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
 
         log.trace("keepAlive: sent ping to {}", this.channel.remoteAddress());
     }

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -1,5 +1,7 @@
 package org.corfudb.runtime.clients;
 
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
@@ -36,7 +38,7 @@ public class SequencerClient extends AbstractClient {
      */
     public CompletableFuture<SequencerMetrics> requestMetrics() {
         return sendRequestWithFuture(getDefaultSequencerMetricsRequestMsg(),
-                false, true);
+                ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     /**
@@ -48,7 +50,7 @@ public class SequencerClient extends AbstractClient {
      */
     public CompletableFuture<TokenResponse> nextToken(List<UUID> streamIDs, long numTokens) {
         return sendRequestWithFuture(getTokenRequestMsg(numTokens, streamIDs),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -60,7 +62,7 @@ public class SequencerClient extends AbstractClient {
     public CompletableFuture<StreamsAddressResponse> getStreamsAddressSpace(
             List<StreamAddressRange> streamsAddressesRange) {
         return sendRequestWithFuture(getStreamsAddressRequestMsg(streamsAddressesRange),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -74,12 +76,12 @@ public class SequencerClient extends AbstractClient {
     public CompletableFuture<TokenResponse> nextToken(List<UUID> streamIDs, long numTokens,
                                                       TxResolutionInfo conflictInfo) {
         return sendRequestWithFuture(getTokenRequestMsg(numTokens, streamIDs, conflictInfo),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     public CompletableFuture<Void> trimCache(Long address) {
         return sendRequestWithFuture(getSequencerTrimRequestMsg(address),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**
@@ -102,8 +104,7 @@ public class SequencerClient extends AbstractClient {
                         initialToken,
                         readyStateEpoch,
                         bootstrapWithoutTailsUpdate),
-                false,
-                false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 
     /**

--- a/runtime/src/test/java/org/corfudb/runtime/clients/BaseHandlerTest.java
+++ b/runtime/src/test/java/org/corfudb/runtime/clients/BaseHandlerTest.java
@@ -5,6 +5,8 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.VersionInfo;
 import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.NoBootstrapException;
@@ -64,7 +66,7 @@ public class BaseHandlerTest {
      * @param ignoreEpoch       indicates if the message is epoch aware
      * @return                  the corresponding HeaderMsg
      */
-    private HeaderMsg getBasicHeader(boolean ignoreClusterId, boolean ignoreEpoch) {
+    private HeaderMsg getBasicHeader(ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(requestCounter.incrementAndGet(), PriorityLevel.NORMAL, 0L,
                 getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ignoreClusterId, ignoreEpoch);
     }
@@ -87,7 +89,7 @@ public class BaseHandlerTest {
     @Test
     public void testHandlePing() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getPingResponseMsg()
         );
 
@@ -105,7 +107,7 @@ public class BaseHandlerTest {
     @Test
     public void testHandleRestart() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getRestartResponseMsg()
         );
 
@@ -123,7 +125,7 @@ public class BaseHandlerTest {
     @Test
     public void testHandleReset() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getResetResponseMsg()
         );
 
@@ -141,7 +143,7 @@ public class BaseHandlerTest {
     @Test
     public void testHandleSeal() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getSealResponseMsg()
         );
 
@@ -159,7 +161,7 @@ public class BaseHandlerTest {
     @Test
     public void testHandleVersionResponse() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getVersionResponseMsg(new VersionInfo(Collections.singletonMap("--address", "localhost"), "localhost"))
         );
 
@@ -182,7 +184,7 @@ public class BaseHandlerTest {
     @Test
     public void testHandleWrongEpochError() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getWrongEpochErrorMsg(2L)
         );
 
@@ -205,7 +207,7 @@ public class BaseHandlerTest {
     public void testHandleWrongClusterError() {
         final UUID EXPECTED_UUID = UUID.randomUUID();
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getWrongClusterErrorMsg(getUuidMsg(EXPECTED_UUID), getUuidMsg(DEFAULT_UUID))
         );
 
@@ -228,7 +230,7 @@ public class BaseHandlerTest {
     @Test
     public void testHandleNotReadyError() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getNotReadyErrorMsg()
         );
 
@@ -247,7 +249,7 @@ public class BaseHandlerTest {
     @Test
     public void testHandleBootstrappedError() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getBootstrappedErrorMsg()
         );
 
@@ -266,7 +268,7 @@ public class BaseHandlerTest {
     @Test
     public void testHandleNotBootstrappedError() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getNotBootstrappedErrorMsg()
         );
 
@@ -285,7 +287,7 @@ public class BaseHandlerTest {
     @Test
     public void testHandleUnknownError() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getUnknownErrorMsg(new Exception("Unknown Exception Test"))
         );
 

--- a/runtime/src/test/java/org/corfudb/runtime/clients/LayoutHandlerTest.java
+++ b/runtime/src/test/java/org/corfudb/runtime/clients/LayoutHandlerTest.java
@@ -2,6 +2,8 @@ package org.corfudb.runtime.clients;
 
 import io.netty.channel.ChannelHandlerContext;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.LayoutPrepareResponse;
 import org.corfudb.runtime.exceptions.OutrankedException;
 import org.corfudb.runtime.exceptions.SerializerException;
@@ -60,7 +62,7 @@ public class LayoutHandlerTest {
      * @param ignoreEpoch       indicates if the message is epoch aware
      * @return                  the corresponding HeaderMsg
      */
-    private HeaderMsg getBasicHeader(boolean ignoreClusterId, boolean ignoreEpoch) {
+    private HeaderMsg getBasicHeader(ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(requestCounter.incrementAndGet(), PriorityLevel.NORMAL, 0L,
                 getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ignoreClusterId, ignoreEpoch);
     }
@@ -85,7 +87,7 @@ public class LayoutHandlerTest {
         Layout defaultLayout = getDefaultLayout();
 
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getLayoutResponseMsg(defaultLayout)
         );
 
@@ -107,7 +109,7 @@ public class LayoutHandlerTest {
         defaultLayout.setLayoutServers(new LinkedList<>());
 
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getLayoutResponseMsg(defaultLayout)
         );
 
@@ -123,12 +125,12 @@ public class LayoutHandlerTest {
     @Test
     public void testBootstrapLayout() {
         ResponseMsg responseACK = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getBootstrapLayoutResponseMsg(true)
         );
 
         ResponseMsg responseNACK = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getBootstrapLayoutResponseMsg(false)
         );
 
@@ -150,11 +152,11 @@ public class LayoutHandlerTest {
         Layout defaultLayout = getDefaultLayout();
         long defaultRank = 5L;
         ResponseMsg responseACK = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getPrepareLayoutResponseMsg(true, defaultRank, defaultLayout)
         );
         ResponseMsg responseREJECT = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getPrepareLayoutResponseMsg(false, defaultRank, defaultLayout)
         );
 
@@ -187,11 +189,11 @@ public class LayoutHandlerTest {
     public void testPropose() {
         long defaultRank = 5L;
         ResponseMsg responseACK = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getProposeLayoutResponseMsg(true, defaultRank)
         );
         ResponseMsg responseREJECT = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getProposeLayoutResponseMsg(false, defaultRank)
         );
 
@@ -215,12 +217,12 @@ public class LayoutHandlerTest {
     @Test
     public void testCommit() {
         ResponseMsg responseACK = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getCommitLayoutResponseMsg(true)
         );
 
         ResponseMsg responseNACK = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getCommitLayoutResponseMsg(false)
         );
 

--- a/runtime/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
+++ b/runtime/src/test/java/org/corfudb/runtime/clients/LogUnitHandlerTest.java
@@ -2,6 +2,8 @@ package org.corfudb.runtime.clients;
 
 import io.netty.channel.ChannelHandlerContext;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.InspectAddressesResponse;
 import org.corfudb.protocols.wireprotocol.KnownAddressResponse;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
@@ -75,7 +77,7 @@ public class LogUnitHandlerTest {
      * @param ignoreEpoch       indicates if the message is epoch aware
      * @return                  the corresponding HeaderMsg
      */
-    private HeaderMsg getBasicHeader(boolean ignoreClusterId, boolean ignoreEpoch) {
+    private HeaderMsg getBasicHeader(ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(requestCounter.incrementAndGet(), PriorityLevel.NORMAL, 0L,
                 getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ignoreClusterId, ignoreEpoch);
     }
@@ -99,7 +101,7 @@ public class LogUnitHandlerTest {
     @Test
     public void testWrite() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getWriteLogResponseMsg()
         );
 
@@ -116,7 +118,7 @@ public class LogUnitHandlerTest {
     @Test
     public void testWriteRange() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getRangeWriteLogResponseMsg()
         );
 
@@ -134,7 +136,7 @@ public class LogUnitHandlerTest {
     public void testRead() {
         ReadResponse rr = new ReadResponse();
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getReadLogResponseMsg(rr.getAddresses())
         );
 
@@ -152,7 +154,7 @@ public class LogUnitHandlerTest {
     public void testInspectAddresses() {
         List<Long> emptyAddresses = new ArrayList<>();
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getInspectAddressesResponseMsg(emptyAddresses)
         );
 
@@ -173,7 +175,7 @@ public class LogUnitHandlerTest {
     public void testTailResponse() {
         TailsResponse sampleTailsResponse = new TailsResponse(0L, 0L, new HashMap<>());
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getTailResponseMsg(sampleTailsResponse.getEpoch(), sampleTailsResponse.getLogTail(),
                         sampleTailsResponse.getStreamTails())
         );
@@ -192,7 +194,7 @@ public class LogUnitHandlerTest {
     public void testGetCommittedTail() {
         long sampleCommittedTail = 5L;
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getCommittedTailResponseMsg(sampleCommittedTail)
         );
 
@@ -209,7 +211,7 @@ public class LogUnitHandlerTest {
     @Test
     public void testUpdateCommittedTail() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getUpdateCommittedTailResponseMsg()
         );
 
@@ -227,7 +229,7 @@ public class LogUnitHandlerTest {
     public void testGetLogAddressSpace() {
         StreamsAddressResponse addressResponse = new StreamsAddressResponse(0L, new HashMap<>());
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getLogAddressSpaceResponseMsg(addressResponse.getLogTail(), addressResponse.getEpoch(),
                         addressResponse.getAddressMap())
         );
@@ -246,7 +248,7 @@ public class LogUnitHandlerTest {
     public void testGetTrimMark() {
         long sampleTrimMark = 5L;
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getTrimMarkResponseMsg(sampleTrimMark)
         );
 
@@ -264,7 +266,7 @@ public class LogUnitHandlerTest {
     public void testRequestKnownAddresses() {
         KnownAddressResponse knownAddressResponse = new KnownAddressResponse(new HashSet<>());
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getKnownAddressResponseMsg(knownAddressResponse.getKnownAddresses())
         );
 
@@ -281,7 +283,7 @@ public class LogUnitHandlerTest {
     @Test
     public void testPrefixTrim() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getTrimLogResponseMsg()
         );
 
@@ -298,7 +300,7 @@ public class LogUnitHandlerTest {
     @Test
     public void testCompact() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getCompactResponseMsg()
         );
 
@@ -315,7 +317,7 @@ public class LogUnitHandlerTest {
     @Test
     public void testFlushCache() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getFlushCacheResponseMsg()
         );
 
@@ -332,7 +334,7 @@ public class LogUnitHandlerTest {
     @Test
     public void testResetLogUnit() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getResetLogUnitResponseMsg()
         );
 
@@ -349,7 +351,7 @@ public class LogUnitHandlerTest {
     @Test
     public void testTrimmedError() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getTrimmedErrorMsg()
         );
 
@@ -367,7 +369,7 @@ public class LogUnitHandlerTest {
     public void testOverwriteError() {
         int causeIdWrittenByHole = OverwriteCause.SAME_DATA.getId();
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getOverwriteErrorMsg(causeIdWrittenByHole)
         );
 
@@ -387,7 +389,7 @@ public class LogUnitHandlerTest {
     public void testDataCorruptionError() {
         long sampleAddress = 5L;
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getDataCorruptionErrorMsg(sampleAddress)
         );
 

--- a/runtime/src/test/java/org/corfudb/runtime/clients/ManagementHandlerTest.java
+++ b/runtime/src/test/java/org/corfudb/runtime/clients/ManagementHandlerTest.java
@@ -6,6 +6,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.NodeState;
 import org.corfudb.protocols.wireprotocol.orchestrator.CreateWorkflowResponse;
 import org.corfudb.protocols.wireprotocol.orchestrator.QueryResponse;
@@ -59,7 +61,7 @@ public class ManagementHandlerTest {
      * @param ignoreEpoch       indicates if the message is epoch aware
      * @return                  the corresponding HeaderMsg
      */
-    private HeaderMsg getBasicHeader(boolean ignoreClusterId, boolean ignoreEpoch) {
+    private HeaderMsg getBasicHeader(ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(requestCounter.incrementAndGet(), PriorityLevel.NORMAL, 0L,
                 getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ignoreClusterId, ignoreEpoch);
     }
@@ -110,8 +112,9 @@ public class ManagementHandlerTest {
     }
 
     private void testHandleReportFailure(boolean handlingSuccessful) {
+        EpochCheck ignoreEpoch = handlingSuccessful ? EpochCheck.IGNORE : EpochCheck.CHECK;
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, handlingSuccessful),
+                getBasicHeader(ClusterIdCheck.CHECK, ignoreEpoch),
                 getReportFailureResponseMsg(handlingSuccessful)
         );
 
@@ -142,8 +145,9 @@ public class ManagementHandlerTest {
     }
 
     private void testHandleHealFailure(boolean handlingSuccessful) {
+        EpochCheck ignoreEpoch = handlingSuccessful ? EpochCheck.IGNORE : EpochCheck.CHECK;
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, handlingSuccessful),
+                getBasicHeader(ClusterIdCheck.CHECK, ignoreEpoch),
                 getHealFailureResponseMsg(handlingSuccessful)
         );
 
@@ -174,8 +178,9 @@ public class ManagementHandlerTest {
     }
 
     private void testHandleManagementBootstrap(boolean bootstrapped) {
+        EpochCheck ignoreEpoch = bootstrapped ? EpochCheck.IGNORE : EpochCheck.CHECK;
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, bootstrapped),
+                getBasicHeader(ClusterIdCheck.CHECK, ignoreEpoch),
                 getBootstrapManagementResponseMsg(bootstrapped)
         );
 
@@ -194,7 +199,7 @@ public class ManagementHandlerTest {
     public void testHandleManagementLayout() {
         final Layout layout = getBasicLayout(ImmutableList.of("localhost:9000"));
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getManagementLayoutResponseMsg(layout)
         );
 
@@ -213,7 +218,7 @@ public class ManagementHandlerTest {
     public void testHandleQueryNode() {
         final NodeState state = NodeState.getNotReadyNodeState("localhost:9000");
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getQueryNodeResponseMsg(state)
         );
 
@@ -232,7 +237,7 @@ public class ManagementHandlerTest {
     public void testHandleOrchestrator() {
         // Test with an ORCHESTRATOR_RESPONSE of type QueryResponse.
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getQueriedWorkflowResponseMsg(true)
         );
 
@@ -247,7 +252,7 @@ public class ManagementHandlerTest {
 
         // Test with an ORCHESTRATOR_RESPONSE of type CreateWorkflowResponse.
         response = getResponseMsg(
-                getBasicHeader(true, true),
+                getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                 getCreatedWorkflowResponseMsg(DEFAULT_UUID)
         );
 

--- a/runtime/src/test/java/org/corfudb/runtime/clients/SequencerHandlerTest.java
+++ b/runtime/src/test/java/org/corfudb/runtime/clients/SequencerHandlerTest.java
@@ -2,6 +2,8 @@ package org.corfudb.runtime.clients;
 
 import io.netty.channel.ChannelHandlerContext;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.Token;
@@ -63,7 +65,7 @@ public class SequencerHandlerTest {
      * @param ignoreEpoch       indicates if the message is epoch aware
      * @return                  the corresponding HeaderMsg
      */
-    private HeaderMsg getBasicHeader(boolean ignoreClusterId, boolean ignoreEpoch) {
+    private HeaderMsg getBasicHeader(ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(requestCounter.incrementAndGet(), CorfuMessage.PriorityLevel.NORMAL, 0L,
                 getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ignoreClusterId, ignoreEpoch);
     }
@@ -117,7 +119,7 @@ public class SequencerHandlerTest {
     public void testTokenResponseEmptyMap() {
         Token token = new Token(0L, 0L);
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getTokenResponseMsg(
                         TokenType.NORMAL,
                         TokenResponse.NO_CONFLICT_KEY,
@@ -151,7 +153,7 @@ public class SequencerHandlerTest {
         Map<UUID, Long> backPointerMap = getTokenResponseDefaultMap();
         Map<UUID, Long> streamTails = getTokenResponseDefaultMap();
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getTokenResponseMsg(
                         TokenType.NORMAL,
                         TokenResponse.NO_CONFLICT_KEY,
@@ -182,11 +184,11 @@ public class SequencerHandlerTest {
     @Test
     public void testBootstrapSequencerResponse() {
         ResponseMsg responseAck = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getBootstrapSequencerResponseMsg(true)
         );
         ResponseMsg responseNack = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getBootstrapSequencerResponseMsg(false)
         );
 
@@ -205,7 +207,7 @@ public class SequencerHandlerTest {
     @Test
     public void testSequencerTrimResponse() {
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getSequencerTrimResponseMsg()
         );
 
@@ -225,15 +227,15 @@ public class SequencerHandlerTest {
         SequencerMetrics sequencerMetricsNotReady = SequencerMetrics.NOT_READY;
         SequencerMetrics sequencerMetricsUnknown = SequencerMetrics.UNKNOWN;
         ResponseMsg responseReady = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getSequencerMetricsResponseMsg(sequencerMetricsReady)
         );
         ResponseMsg responseNotReady = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getSequencerMetricsResponseMsg(sequencerMetricsNotReady)
         );
         ResponseMsg responseUnkown = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getSequencerMetricsResponseMsg(sequencerMetricsUnknown)
         );
 
@@ -255,7 +257,7 @@ public class SequencerHandlerTest {
     public void testSequencerMetricsResponseUnsupported() {
         SequencerMetrics sequencerMetrics = new SequencerMetrics(null);
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, true),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.IGNORE),
                 getSequencerMetricsResponseMsg(sequencerMetrics)
         );
 
@@ -274,7 +276,7 @@ public class SequencerHandlerTest {
         long defaultEpoch = 10L;
 
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getStreamsAddressResponseMsg(defaultLogTail, defaultEpoch, Collections.emptyMap())
         );
 
@@ -301,7 +303,7 @@ public class SequencerHandlerTest {
         Map<UUID, StreamAddressSpace> defaultMap = getDefaultAddressMap();
 
         ResponseMsg response = getResponseMsg(
-                getBasicHeader(false, false),
+                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                 getStreamsAddressResponseMsg(defaultLogTail, defaultEpoch, defaultMap)
         );
 

--- a/test/src/test/java/org/corfudb/infrastructure/AbstractServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/AbstractServerTest.java
@@ -2,6 +2,8 @@ package org.corfudb.infrastructure;
 
 import lombok.Getter;
 import org.corfudb.AbstractCorfuTest;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.clients.BaseHandler;
@@ -77,7 +79,7 @@ public abstract class AbstractServerTest extends AbstractCorfuTest {
     }
 
     public <T> CompletableFuture<T> sendRequest(RequestPayloadMsg payload,
-                                                boolean ignoreClusterId, boolean ignoreEpoch) {
+                                                ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return sendRequestWithClusterId(payload, Layout.INVALID_CLUSTER_ID, ignoreClusterId, ignoreEpoch);
     }
 
@@ -101,14 +103,14 @@ public abstract class AbstractServerTest extends AbstractCorfuTest {
     }
 
     public <T> CompletableFuture<T> sendRequestWithEpoch(RequestPayloadMsg payload, long epoch,
-                                                         boolean ignoreClusterId, boolean ignoreEpoch) {
+                                                         ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         clientRouter.setClientID(testClientId);
         return clientRouter.sendRequestAndGetCompletable(payload, epoch, getUuidMsg(Layout.INVALID_CLUSTER_ID),
                 CorfuMessage.PriorityLevel.NORMAL, ignoreClusterId, ignoreEpoch);
     }
 
     public <T> CompletableFuture<T> sendRequestWithClusterId(RequestPayloadMsg payload, UUID clusterId,
-                                                             boolean ignoreClusterId, boolean ignoreEpoch) {
+                                                             ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         clientRouter.setClientID(testClientId);
         return clientRouter.sendRequestAndGetCompletable(payload, 0L, getUuidMsg(clusterId),
                 CorfuMessage.PriorityLevel.NORMAL, ignoreClusterId, ignoreEpoch);
@@ -125,7 +127,7 @@ public abstract class AbstractServerTest extends AbstractCorfuTest {
     }
 
     public <T> CompletableFuture<T> sendRequestWithClientId(UUID clientId, RequestPayloadMsg payload, UUID clusterId,
-                                                            boolean ignoreClusterId, boolean ignoreEpoch) {
+                                                            ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         clientRouter.setClientID(clientId);
         return clientRouter.sendRequestAndGetCompletable(payload, 0L, getUuidMsg(clusterId),
                 CorfuMessage.PriorityLevel.NORMAL, ignoreClusterId, ignoreEpoch);

--- a/test/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/BaseServerTest.java
@@ -2,6 +2,8 @@ package org.corfudb.infrastructure;
 
 import java.util.concurrent.CompletableFuture;
 import org.corfudb.protocols.service.CorfuProtocolBase;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.runtime.exceptions.WrongEpochException;
 import org.junit.Test;
 
@@ -25,17 +27,17 @@ public class BaseServerTest extends AbstractServerTest {
 
     @Test
     public void testProtoPing() {
-        CompletableFuture<Boolean> res = sendRequest(CorfuProtocolBase.getPingRequestMsg(), true, true);
+        CompletableFuture<Boolean> res = sendRequest(CorfuProtocolBase.getPingRequestMsg(), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
         assertThat(res.join()).isTrue();
     }
 
     @Test
     public void testProtoSeal() {
         // Set the ignoreClusterId and ignoreEpoch to be true for testing purpose.
-        CompletableFuture<Boolean> res = sendRequest(CorfuProtocolBase.getSealRequestMsg(1L), true, true);
+        CompletableFuture<Boolean> res = sendRequest(CorfuProtocolBase.getSealRequestMsg(1L), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
         assertThat(res.join()).isTrue();
         assertThatThrownBy(() -> {
-            sendRequest(CorfuProtocolBase.getSealRequestMsg(0L), true, true).join();
+            sendRequest(CorfuProtocolBase.getSealRequestMsg(0L), ClusterIdCheck.IGNORE, EpochCheck.IGNORE).join();
         }).hasCauseInstanceOf(WrongEpochException.class);
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LayoutServerTest.java
@@ -5,6 +5,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.LayoutPrepareResponse;
 import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.NoBootstrapException;
@@ -542,8 +544,8 @@ public class LayoutServerTest extends AbstractServerTest {
         long newEpoch = baseEpoch + reboot;
         sendRequestWithClusterId(getSealRequestMsg(newEpoch),
                 bootstrappedLayout.getClusterId(),
-                false,
-                true).join();
+                ClusterIdCheck.CHECK,
+                EpochCheck.IGNORE).join();
 
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         layout.setEpoch(newEpoch);
@@ -581,45 +583,45 @@ public class LayoutServerTest extends AbstractServerTest {
 
     private CorfuMessage.RequestMsg getRequest(CorfuMessage.RequestPayloadMsg payloadMsg) {
         CorfuMessage.HeaderMsg header = getHeaderMsg(0, CorfuMessage.PriorityLevel.NORMAL, 0,
-                DEFAULT_UUID, DEFAULT_UUID, true, true);
+                DEFAULT_UUID, DEFAULT_UUID, ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
         return getRequestMsg(header, payloadMsg);
     }
 
     private void bootstrapServer(Layout l) {
-        sendRequest(getBootstrapLayoutRequestMsg(l), true, true).join();
+        sendRequest(getBootstrapLayoutRequestMsg(l), ClusterIdCheck.IGNORE, EpochCheck.IGNORE).join();
     }
 
     private CompletableFuture<Layout> requestLayout(long epoch) {
-        return sendRequest(getLayoutRequestMsg(epoch), true, true);
+        return sendRequest(getLayoutRequestMsg(epoch), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
     }
 
     private CompletableFuture<Boolean> setEpoch(long epoch, UUID clusterId) {
         return sendRequestWithClusterId(getSealRequestMsg(epoch),
-                clusterId, false, true);
+                clusterId, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     private CompletableFuture<LayoutPrepareResponse> sendPrepare(long epoch, long rank, UUID clusterId) {
         return sendRequestWithClusterId(getPrepareLayoutRequestMsg(epoch, rank),
-                clusterId, false, true);
+                clusterId, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     private CompletableFuture<Boolean> sendPropose(long epoch, long rank, Layout layout, UUID clusterId) {
         return sendRequestWithClusterId(getProposeLayoutRequestMsg(epoch, rank, layout),
-                clusterId, false, true);
+                clusterId, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     private CompletableFuture<Boolean> sendCommitted(long epoch, Layout layout, UUID clusterId) {
         return sendRequestWithClusterId(getCommitLayoutRequestMsg(false, epoch, layout),
-                clusterId, false, true);
+                clusterId, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     private CompletableFuture<LayoutPrepareResponse> sendPrepare(UUID clientId, long epoch, long rank, UUID clusterId) {
         return sendRequestWithClientId(clientId, getPrepareLayoutRequestMsg(epoch, rank),
-                clusterId, false, true);
+                clusterId, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     private CompletableFuture<Boolean> sendPropose(UUID clientId, long epoch, long rank, Layout layout, UUID clusterId) {
         return sendRequestWithClientId(clientId, getProposeLayoutRequestMsg(epoch, rank, layout),
-                clusterId, false, true);
+                clusterId, ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/LogUnitCacheTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/LogUnitCacheTest.java
@@ -2,6 +2,8 @@ package org.corfudb.infrastructure;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.DataType;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.ReadResponse;
@@ -79,18 +81,18 @@ public class LogUnitCacheTest extends AbstractServerTest {
         }
 
         // Range write is not cached on server.
-        sendRequest(getRangeWriteLogRequestMsg(payloads), false, false).join();
+        sendRequest(getRangeWriteLogRequestMsg(payloads), ClusterIdCheck.CHECK, EpochCheck.CHECK).join();
 
         // Non-cacheable reads should not affect the data cache on server.
         CompletableFuture<ReadResponse> future =
-                sendRequest(getReadLogRequestMsg(addresses, false), false, false);
+                sendRequest(getReadLogRequestMsg(addresses, false), ClusterIdCheck.CHECK, EpochCheck.CHECK);
 
 
         checkReadResponse(future.join(), size);
         assertThat(logUnitServer.getDataCache().getSize()).isZero();
 
         // Cacheable reads should update the data cache on server.
-        future = sendRequest(getReadLogRequestMsg(addresses, true), false, false);
+        future = sendRequest(getReadLogRequestMsg(addresses, true), ClusterIdCheck.CHECK, EpochCheck.CHECK);
 
         checkReadResponse(future.join(), size);
         assertThat(logUnitServer.getDataCache().getSize()).isEqualTo(size);

--- a/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ManagementServerTest.java
@@ -1,5 +1,7 @@
 package org.corfudb.infrastructure;
 
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.runtime.exceptions.AlreadyBootstrappedException;
 import org.corfudb.runtime.exceptions.NoBootstrapException;
 import org.corfudb.runtime.view.Layout;
@@ -69,15 +71,15 @@ public class ManagementServerTest extends AbstractServerTest {
     @Test
     public void bootstrapManagementServer() {
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
-        sendRequest(getBootstrapLayoutRequestMsg(layout), true, true);
+        sendRequest(getBootstrapLayoutRequestMsg(layout), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
 
         CompletableFuture<Boolean> future = sendRequestWithClusterId(
-                getBootstrapManagementRequestMsg(layout), layout.getClusterId(), true, true);
+                getBootstrapManagementRequestMsg(layout), layout.getClusterId(), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
 
         assertThat(future.join()).isEqualTo(true);
 
         future = sendRequestWithClusterId(
-                getBootstrapManagementRequestMsg(layout), layout.getClusterId(), true, true);
+                getBootstrapManagementRequestMsg(layout), layout.getClusterId(), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
 
         assertThatThrownBy(future::join).hasCauseExactlyInstanceOf(AlreadyBootstrappedException.class);
     }
@@ -89,24 +91,24 @@ public class ManagementServerTest extends AbstractServerTest {
     public void triggerFailureHandler() {
         Layout layout = TestLayoutBuilder.single(SERVERS.PORT_0);
         CompletableFuture<Boolean> future = sendRequest(
-                getBootstrapLayoutRequestMsg(layout), true, true);
+                getBootstrapLayoutRequestMsg(layout), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
 
         assertThat(future.join()).isEqualTo(true);
 
         future = sendRequestWithClusterId(
                 getReportFailureRequestMsg(0L, Collections.emptySet()),
-                layout.getClusterId(), false, true);
+                layout.getClusterId(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
 
         assertThatThrownBy(future::join).hasCauseExactlyInstanceOf(NoBootstrapException.class);
 
         future = sendRequestWithClusterId(
-                getBootstrapManagementRequestMsg(layout), layout.getClusterId(), true, true);
+                getBootstrapManagementRequestMsg(layout), layout.getClusterId(), ClusterIdCheck.IGNORE, EpochCheck.IGNORE);
 
         assertThat(future.join()).isEqualTo(true);
 
         future = sendRequestWithClusterId(
                 getReportFailureRequestMsg(0L, Collections.emptySet()),
-                layout.getClusterId(), false, true);
+                layout.getClusterId(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
 
         assertThat(future.join()).isEqualTo(true);
     }

--- a/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/SequencerServerTest.java
@@ -1,5 +1,7 @@
 package org.corfudb.infrastructure;
 
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.SequencerMetrics;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
@@ -59,7 +61,7 @@ public class SequencerServerTest extends AbstractServerTest {
     @Test
     public void sequencerMetricsRequest() {
         CompletableFuture<SequencerMetrics> cFuture = sendRequest(
-                getDefaultSequencerMetricsRequestMsg(), false, true);
+                getDefaultSequencerMetricsRequestMsg(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
         SequencerMetrics seqMetrics = cFuture.join();
         assertThat(seqMetrics.getSequencerStatus())
                 .isEqualTo(SequencerMetrics.SequencerStatus.READY);
@@ -71,7 +73,7 @@ public class SequencerServerTest extends AbstractServerTest {
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             CompletableFuture<TokenResponse> future = sendRequest(
                     getTokenRequestMsg(1L, Collections.emptyList()),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             Token thisToken = future.join().getToken();
             assertThat(thisToken.getSequence())
                     .isGreaterThan(lastTokenValue);
@@ -85,10 +87,10 @@ public class SequencerServerTest extends AbstractServerTest {
 
             CompletableFuture<TokenResponse> future1 = sendRequest(
                     getTokenRequestMsg(1L, Collections.emptyList()),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             CompletableFuture<TokenResponse> future2 = sendRequest(
                     getTokenRequestMsg(0L, Collections.emptyList()),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             Token thisToken = future1.join().getToken();
             Token checkToken = future2.join().getToken();
 
@@ -105,13 +107,13 @@ public class SequencerServerTest extends AbstractServerTest {
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             CompletableFuture<TokenResponse> future = sendRequest(
                     getTokenRequestMsg(1L, Collections.singletonList(streamA)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
 
             Token thisTokenA = future.join().getToken();
 
             future = sendRequest(
                     getTokenRequestMsg(0L, Collections.singletonList(streamA)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
 
             long checkTokenA = future.join().getStreamTail(streamA);
 
@@ -120,13 +122,13 @@ public class SequencerServerTest extends AbstractServerTest {
 
             future = sendRequest(
                     getTokenRequestMsg(1L, Collections.singletonList(streamB)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
 
             Token thisTokenB = future.join().getToken();
 
             future = sendRequest(
                     getTokenRequestMsg(0L, Collections.singletonList(streamB)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             long checkTokenB = future.join().getStreamTail(streamB);
 
             assertThat(thisTokenB.getSequence())
@@ -134,7 +136,7 @@ public class SequencerServerTest extends AbstractServerTest {
 
             future = sendRequest(
                     getTokenRequestMsg(0L, Collections.singletonList(streamA)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             long checkTokenA2 = future.join().getStreamTail(streamA);
 
             assertThat(checkTokenA2)
@@ -153,12 +155,12 @@ public class SequencerServerTest extends AbstractServerTest {
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
             CompletableFuture<TokenResponse> future = sendRequest(
                     getTokenRequestMsg(1L, Collections.singletonList(streamA)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             Token thisTokenA = future.join().getToken();
 
             future = sendRequest(
                     getTokenRequestMsg(1L, Collections.singletonList(streamA)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             long checkTokenAValue = future.join().getBackpointerMap().get(streamA);
 
             assertThat(thisTokenA.getSequence())
@@ -166,12 +168,12 @@ public class SequencerServerTest extends AbstractServerTest {
 
             future = sendRequest(
                     getTokenRequestMsg(1L, Collections.singletonList(streamB)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             Token thisTokenB = future.join().getToken();
 
             future = sendRequest(
                     getTokenRequestMsg(1L, Collections.singletonList(streamB)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             long checkTokenBValue = future.join().getBackpointerMap().get(streamB);
 
             assertThat(thisTokenB.getSequence())
@@ -181,12 +183,12 @@ public class SequencerServerTest extends AbstractServerTest {
 
             future = sendRequest(
                     getTokenRequestMsg(MULTI_TOKEN, Collections.singletonList(streamA)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             thisTokenA = future.join().getToken();
 
             future = sendRequest(
                     getTokenRequestMsg(1L, Collections.singletonList(streamA)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             checkTokenAValue = future.join().getBackpointerMap().get(streamA);
 
             assertThat(thisTokenA.getSequence() + MULTI_TOKEN - 1)
@@ -195,12 +197,12 @@ public class SequencerServerTest extends AbstractServerTest {
             // check the requesting multiple tokens does not break the back-pointer for the multi-entry
             future = sendRequest(
                     getTokenRequestMsg(1L, Collections.singletonList(streamA)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             thisTokenA = future.join().getToken();
 
             future = sendRequest(
                     getTokenRequestMsg(MULTI_TOKEN, Collections.singletonList(streamA)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
             checkTokenAValue = future.join().getBackpointerMap().get(streamA);
 
             assertThat(thisTokenA.getSequence()).isEqualTo(checkTokenAValue);
@@ -216,23 +218,23 @@ public class SequencerServerTest extends AbstractServerTest {
 
         CompletableFuture<TokenResponse> future = sendRequest(
                 getTokenRequestMsg(1L, Collections.singletonList(streamA)),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
         long tailA = future.join().getToken().getSequence();
 
         future = sendRequest(
                 getTokenRequestMsg(1L, Collections.singletonList(streamB)),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
         long tailB = future.join().getToken().getSequence();
 
         future = sendRequest(
                 getTokenRequestMsg(1L, Collections.singletonList(streamC)),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
 
         long tailC = future.join().getToken().getSequence();
 
         future = sendRequest(
                 getTokenRequestMsg(0L, Collections.emptyList()),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
         long globalTail = future.join().getToken().getSequence();
 
         // Construct new tails
@@ -255,22 +257,22 @@ public class SequencerServerTest extends AbstractServerTest {
                         globalTail + 2,
                         0L,
                         false),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
         future.join();
         future = sendRequest(
                 getTokenRequestMsg(0L, Collections.singletonList(streamA)),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
         assertThat(future.join().getStreamTail(streamA)).isEqualTo(newTailA);
 
         future = sendRequest(
                 getTokenRequestMsg(0L, Collections.singletonList(streamB)),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
         assertThat(future.join().getStreamTail(streamB)).isEqualTo(newTailB);
 
         // We should have the same value than before
         future = sendRequest(
                 getTokenRequestMsg(0L, Collections.singletonList(streamC)),
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
         assertThat(future.join().getStreamTail(streamC)).isEqualTo(newTailC);
     }
 
@@ -293,7 +295,7 @@ public class SequencerServerTest extends AbstractServerTest {
         for (int i = 0; i < num; i++) {
             future = sendRequest(
                     getTokenRequestMsg(1L, Collections.singletonList(streamA)),
-                    false, false);
+                    ClusterIdCheck.CHECK, EpochCheck.CHECK);
         }
 
         future.join();
@@ -309,7 +311,7 @@ public class SequencerServerTest extends AbstractServerTest {
                         newEpoch,
                         true),
                 newEpoch,
-                false, false
+                ClusterIdCheck.CHECK, EpochCheck.CHECK
         );
         assertThat(future1.join()).isEqualTo(true);
         // Sequencer accepts only a full bootstrap message if the epoch is not consecutive.
@@ -322,7 +324,7 @@ public class SequencerServerTest extends AbstractServerTest {
                         newEpoch,
                         true),
                 newEpoch,
-                false, false
+                ClusterIdCheck.CHECK, EpochCheck.CHECK
         );
         assertThat(future1.join()).isEqualTo(false);
         future1 = sendRequestWithEpoch(
@@ -335,7 +337,7 @@ public class SequencerServerTest extends AbstractServerTest {
                         newEpoch,
                         false),
                 newEpoch,
-                false, false
+                ClusterIdCheck.CHECK, EpochCheck.CHECK
         );
 
         assertThat(future1.join()).isEqualTo(true);
@@ -343,7 +345,7 @@ public class SequencerServerTest extends AbstractServerTest {
         future = sendRequestWithEpoch(
                 getTokenRequestMsg(0L, Collections.emptyList()),
                 newEpoch,
-                false, false);
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
         assertThat(future.join())
                 .isEqualTo(new TokenResponse(TokenType.NORMAL, TokenResponse.NO_CONFLICT_KEY,
                         TokenResponse.NO_CONFLICT_STREAM, new Token(newEpoch, num - 1),

--- a/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
+++ b/test/src/test/java/org/corfudb/runtime/clients/TestClientRouter.java
@@ -23,6 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.TestServerRouter;
 import org.corfudb.protocols.CorfuProtocolCommon;
 import org.corfudb.protocols.service.CorfuProtocolMessage;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.CorfuMsg;
 import org.corfudb.protocols.wireprotocol.CorfuMsgType;
 import org.corfudb.runtime.CorfuRuntime;
@@ -289,7 +291,7 @@ public class TestClientRouter implements IClientRouter {
     public  <T> CompletableFuture<T> sendRequestAndGetCompletable(RequestPayloadMsg payload,
                                                                   long epoch, RpcCommon.UuidMsg clusterId,
                                                                   PriorityLevel priority,
-                                                                  boolean ignoreClusterId, boolean ignoreEpoch) {
+                                                                  ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         // Simulate a "disconnected endpoint"
         if (!connected) {
             log.trace("Disconnected endpoint " + host + ":" + port);
@@ -367,7 +369,7 @@ public class TestClientRouter implements IClientRouter {
      */
     @Override
     public void sendRequest(RequestPayloadMsg payload, long epoch, RpcCommon.UuidMsg clusterId,
-                            PriorityLevel priority, boolean ignoreClusterId, boolean ignoreEpoch) {
+                            PriorityLevel priority, ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         final long thisRequestId = requestID.getAndIncrement();
         RpcCommon.UuidMsg protoClientId = CorfuProtocolCommon.getUuidMsg(clientID);
 

--- a/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AbstractViewTest.java
@@ -18,6 +18,8 @@ import org.corfudb.infrastructure.TestServerRouter;
 import org.corfudb.infrastructure.management.FailureDetector;
 import org.corfudb.infrastructure.management.NetworkStretcher;
 import org.corfudb.protocols.service.CorfuProtocolMessage;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 import org.corfudb.runtime.clients.BaseHandler;
@@ -150,7 +152,7 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
      * @param ignoreEpoch       indicates if the message is epoch aware
      * @return                  the corresponding HeaderMsg
      */
-    private HeaderMsg getBasicHeader(boolean ignoreClusterId, boolean ignoreEpoch) {
+    private HeaderMsg getBasicHeader(ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
         return getHeaderMsg(1L, CorfuMessage.PriorityLevel.NORMAL, 0L,
                 getUuidMsg(DEFAULT_UUID), getUuidMsg(DEFAULT_UUID), ignoreClusterId, ignoreEpoch);
     }
@@ -305,17 +307,17 @@ public abstract class AbstractViewTest extends AbstractCorfuTest {
         testServerMap.entrySet().parallelStream()
                 .forEach(e -> {
                     e.getValue().layoutServer.handleMessage(getRequestMsg(
-                                    getBasicHeader(true, true),
+                                    getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                                     getBootstrapLayoutRequestMsg(l)), null, e.getValue().serverRouter);
                     e.getValue().managementServer.handleMessage(getRequestMsg(
-                                    getBasicHeader(true, true),
+                                    getBasicHeader(ClusterIdCheck.IGNORE, EpochCheck.IGNORE),
                                     getBootstrapManagementRequestMsg(l)), null, e.getValue().serverRouter);
                 });
         TestServer primarySequencerNode = testServerMap.get(l.getSequencers().get(0));
         primarySequencerNode.sequencerServer
                 .handleMessage(
                         CorfuProtocolMessage.getRequestMsg(
-                                getBasicHeader(false, false),
+                                getBasicHeader(ClusterIdCheck.CHECK, EpochCheck.CHECK),
                                 getBootstrapSequencerRequestMsg(
                                         Collections.emptyMap(),
                                         0L,


### PR DESCRIPTION
## Overview

Description: The current method of creating a HeaderMsg can be error-prone. A small
tweak to the API is suggested to facilitate the setting of the ignoreEpoch
and ignoreClusterId flags in a HeaderMsg.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
