### PR TITLE
Add ownership validation table schema option

### DIFF
--- a/runtime/proto/corfu_options.proto
+++ b/runtime/proto/corfu_options.proto
@@ -19,6 +19,8 @@ message SchemaOptions {
     repeated string stream_tag = 5;
     // Nested Secondary Key (repeated field)
     repeated NestedSecondaryIndex nested_secondary_key = 6;
+    // Should the entry of table be validated for ownership
+    optional bool ownership_validation = 7;
 }
 
 message NestedSecondaryIndex {

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
@@ -457,6 +457,8 @@ public class CorfuStoreTest extends AbstractViewTest {
 
         assertThat(tableRegistry.getRegistryTable().get(tableNameProto).getMetadata().getTableOptions().getStreamTag(0)).isEqualTo(streamTag1);
         assertThat(tableRegistry.getRegistryTable().get(tableNameProto).getMetadata().getTableOptions().getStreamTag(1)).isEqualTo(streamTag2);
+
+        assertThat(tableRegistry.getRegistryTable().get(tableNameProto).getMetadata().getTableOptions().getOwnershipValidation()).isTrue();
     }
 
     /**

--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -67,6 +67,7 @@ message SampleTableAMsg {
     option (org.corfudb.runtime.table_schema).stream_tag = "sample_streamer_1";
     option (org.corfudb.runtime.table_schema).stream_tag = "sample_streamer_2";
     option (org.corfudb.runtime.table_schema).requires_backup_support = true;
+    option (org.corfudb.runtime.table_schema).ownership_validation = true;
     option (org.corfudb.runtime.table_schema).is_federated = true;
 
     optional string payload = 1;


### PR DESCRIPTION
## Overview

Description:

Added ownership validation table schema option

Why should this be merged: 



Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
