### PR TITLE
Reduce Protobuf LogData Payload Size

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/CorfuProtocolLogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/CorfuProtocolLogData.java
@@ -29,7 +29,7 @@ public final class CorfuProtocolLogData {
         logData.doSerialize(buf);
 
         return LogDataMsg.newBuilder()
-                .setEntry(ByteString.copyFrom(buf.resetReaderIndex().array()))
+                .setEntry(ByteString.copyFrom(buf.array(), buf.readerIndex(), buf.readableBytes()))
                 .build();
     }
 


### PR DESCRIPTION
Since the backing array of a ByteBuf can be larger than the number of bytes written, this PR reduces unnecessary copying of data when serializing LogData into Protobuf by using appropriate bounds.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
