### PR TITLE
Improve Metrics Collection and Reporting

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/JVMMetrics.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/JVMMetrics.java
@@ -2,17 +2,22 @@ package org.corfudb.common.metrics.micrometer;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
 import lombok.Data;
 import lombok.Getter;
 import sun.management.HotspotRuntimeMBean;
 import sun.management.ManagementFactoryHelper;
 
-/** Provides JVM level metrics. */
+/**
+ * Provides JVM level metrics.
+ */
 
 public final class JVMMetrics {
 
-    @Getter(lazy=true)
+    @Getter(lazy = true)
     private final static HotspotRuntimeMBean runtimeMBean = ManagementFactoryHelper.getHotspotRuntimeMBean();
 
     @Data
@@ -31,14 +36,18 @@ public final class JVMMetrics {
                 long delta = current - data.safepointTime;
                 data.safepointTime = current;
                 return delta;
-            }).strongReference(true).register(metricsRegistry.get());
+            }).baseUnit(TimeUnit.MILLISECONDS.toString())
+                    .strongReference(true)
+                    .register(metricsRegistry.get());
 
             Gauge.builder("jvm.safe_point_count", safePointStats, data -> {
                 long current = getRuntimeMBean().getSafepointCount();
                 long delta = current - data.safepointCount;
                 data.safepointCount = current;
                 return delta;
-            }).strongReference(true).register(metricsRegistry.get());
+            }).baseUnit(TimeUnit.MILLISECONDS.toString())
+                    .strongReference(true)
+                    .register(metricsRegistry.get());
         }
     }
 }

--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/LoggingMeterRegistryWithHistogramSupport.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/registries/LoggingMeterRegistryWithHistogramSupport.java
@@ -173,6 +173,6 @@ public class LoggingMeterRegistryWithHistogramSupport extends StepMeterRegistry 
 
     @Override
     protected TimeUnit getBaseTimeUnit() {
-        return TimeUnit.MILLISECONDS;
+        return TimeUnit.MICROSECONDS;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/BatchProcessor.java
@@ -99,11 +99,11 @@ public class BatchProcessor implements AutoCloseable {
         processorService.submit(this::process);
     }
 
-    private void recordRunnable(Runnable fsyncRunnable, Optional<Timer> fsyncTimer) {
-        if (fsyncTimer.isPresent()) {
-            fsyncTimer.get().record(fsyncRunnable);
+    private void recordRunnable(Runnable runnable, Optional<Timer> timer) {
+        if (timer.isPresent()) {
+            timer.get().record(runnable);
         } else {
-            fsyncRunnable.run();
+            runnable.run();
         }
     }
 


### PR DESCRIPTION
## Overview

- Change metrics from milliseconds to microseconds (prevents reporting
  0's for sub-millisecond metrics)
- Unify cache metrics types


Why should this be merged: Improves metrics reporting 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
