### PR TITLE
Use Native Epoll Transport

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServer.java
@@ -85,7 +85,7 @@ public class CorfuServer {
                     + "              The name of the network interface.\n"
                     + " -i <channel-implementation>, --implementation <channel-implementation>   "
                     + "              The type of channel to use (auto, nio, epoll, kqueue)"
-                    + "[default: nio].\n"
+                    + "[default: auto].\n"
                     + " -m, --memory                                                             "
                     + "              Run the unit in-memory (non-persistent).\n"
                     + "              Data will be lost when the server exits!\n"

--- a/runtime/src/main/java/org/corfudb/runtime/RuntimeParameters.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RuntimeParameters.java
@@ -108,7 +108,7 @@ public class RuntimeParameters {
          * The type of socket which {@link NettyClientRouter}s should use. By default,
          * an NIO based implementation is used.
          */
-        public ChannelImplementation socketType = ChannelImplementation.NIO;
+        public ChannelImplementation socketType = ChannelImplementation.AUTO;
 
         /**
          * The {@link EventLoopGroup} which {@link NettyClientRouter}s will use.

--- a/runtime/src/main/java/org/corfudb/runtime/RuntimeParametersBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/RuntimeParametersBuilder.java
@@ -25,7 +25,7 @@ public class RuntimeParametersBuilder {
     protected Duration connectionTimeout = Duration.ofMillis(500);
     protected Duration connectionRetryRate = Duration.ofSeconds(1);
     protected UUID clientId = UUID.randomUUID();
-    protected ChannelImplementation socketType = ChannelImplementation.NIO;
+    protected ChannelImplementation socketType = ChannelImplementation.AUTO;
     protected EventLoopGroup nettyEventLoop;
     protected String nettyEventLoopThreadFormat = "netty-%d";
     protected int nettyEventLoopThreads = 0;


### PR DESCRIPTION
## Overview
This patch allows for selecting an efficient transport implementation
during runtime. For example, when running on linux, EpollSocketChannel
will be used instead of NioServerSocketChannel, this allows for
better performance and reduced GC pressure.

Why should this be merged: Reduces GC pressure 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
