### PR TITLE
Remove Verbose Log Error

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -120,8 +120,6 @@ public class LogData implements IMetadata, ILogData {
                         } catch (Throwable throwable) {
                             log.error("Exception caught at address {}, {}, {}",
                                     getGlobalAddress(), getStreams(), getType());
-                            log.error("Raw data buffer {}",
-                                    serializedBuf.resetReaderIndex().toString(Charset.defaultCharset()));
                             throw throwable;
                         } finally {
                             serializedBuf.release();


### PR DESCRIPTION
## Overview

This log error dumps the binary which is noisy and can lead to OOM in the case of applications with small heap size.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
