### PR TITLE
Fix getChildPIDs method in AbstractIT

### DIFF
--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -54,8 +54,8 @@ public class AbstractIT extends AbstractCorfuTest {
     private static final String KILL_COMMAND = "pkill -9 -P ";
     private static final String FORCE_KILL_ALL_CORFU_COMMAND = "jps | grep -e CorfuServer -e CorfuInterClusterReplicationServer|awk '{print $1}'| xargs kill -9";
 
-    private static final int SHUTDOWN_RETRIES = 10;
-    private static final long SHUTDOWN_RETRY_WAIT = 500;
+    private static final int SHUTDOWN_RETRIES = 20;
+    private static final long SHUTDOWN_RETRY_WAIT = 1000;
 
     // Config the msg size for log replication data
     // sent from active cluster to the standby cluster.


### PR DESCRIPTION
## Overview

Description: This commit fixes the getChildPIDs method in AbstactIT. Formerly the return statement in finally clause conceals all the exceptions, and the recursive call for child PIDs does not work since it always produces ConcurrentModificationException.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
