### PR TITLE
Streaming API Bug Fix

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -828,6 +828,7 @@ public class SequencerServer extends AbstractServer {
             } else {
                 log.warn("getStreamsAddressesMap: address space map is not present for stream {}." +
                         " Verify this is a valid stream.", streamId);
+                requestedAddressSpaces.put(streamId, new StreamAddressSpace(Address.NON_EXIST, Collections.EMPTY_SET));
             }
         }
 


### PR DESCRIPTION
## Overview

Description:

With current code, subscribing to an empty table will cause a NPE and furthermore the subscriber
will be automatically unsubscribed, therefore, future updates are lost. Fix to this bug + test.

Why should this be merged: bug currently encountered by clients

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
