### PR TITLE
Create Codacy coverage reporter action

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,42 @@
+name: Code Coverage Reporter
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build_and_analysis:
+    # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: run unit tests
+        run: ./mvnw clean test -pl \!samples -am -Dmaven.javadoc.skip=true -T 1C
+
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: ./coverage/target/site/jacoco-aggregate/jacoco.xml

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ![logo](https://github.com/CorfuDB/CorfuDB/blob/master/resources/corfu.png "Corfu")
 
 [![Join the chat at https://gitter.im/CorfuDB/CorfuDB](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/CorfuDB/CorfuDB?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![codecov](https://codecov.io/gh/CorfuDB/CorfuDB/branch/master/graph/badge.svg)](https://codecov.io/gh/CorfuDB/CorfuDB)
 [![Github Actions](https://github.com/CorfuDB/CorfuDB/actions/workflows/pull_request.yml/badge.svg)](https://github.com/CorfuDB/CorfuDB/actions)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/48cc2949fabb427fbee7bfca9b872561)](https://www.codacy.com/gh/CorfuDB/CorfuDB/dashboard?utm_source=github.com&utm_medium=referral&utm_content=CorfuDB/CorfuDB&utm_campaign=Badge_Coverage)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/83bcbf63024b4937999c9b0348672abf)](https://app.codacy.com/gh/CorfuDB/CorfuDB?utm_source=github.com&utm_medium=referral&utm_content=CorfuDB/CorfuDB&utm_campaign=Badge_Grade_Settings)
 
 Corfu is a consistency platform designed around the abstraction

--- a/pom.xml
+++ b/pom.xml
@@ -390,19 +390,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--Plugin used for code coverage integration with Github-->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>cobertura-maven-plugin</artifactId>
-                <version>2.7</version>
-                <configuration>
-                    <formats>
-                        <format>html</format>
-                        <format>xml</format>
-                    </formats>
-                    <check/>
-                </configuration>
-            </plugin>
             <!-- Add a license to all files using mvn license:format -->
             <plugin>
                 <groupId>com.mycila</groupId>


### PR DESCRIPTION
## Overview

Description: This commit creates an action that generates code coverage report, and sends it to the [Codacy dashboard ](https://app.codacy.com/gh/CorfuDB/CorfuDB/dashboard?branch=codacy-codecoverage)automatically for every pull request. 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
