### PR TITLE
Fix descriptor not found issue in DynamicProtobufSerializer

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -111,6 +111,14 @@ public class DynamicProtobufSerializer implements ISerializer {
                     fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto);
                     // Until the truncating issue can be addressed, manually add both paths.
                     protoFileName = "corfudb/runtime/corfu_options.proto";
+                } else if (protoFileName.equals("service/log_replication.proto")) {
+                    fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto);
+                    // Until the truncating issue can be addressed, manually add both paths.
+                    protoFileName = "corfudb/runtime/service/log_replication.proto";
+                } else if (protoFileName.equals("service/corfu_message.proto")) {
+                    fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto);
+                    // Until the truncating issue can be addressed, manually add both paths.
+                    protoFileName = "corfudb/runtime/service/corfu_message.proto";
                 }
                 fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto);
                 identifyMessageTypesinFileDescriptorProto(fileDescriptorProto);


### PR DESCRIPTION
When registering some proto file descriptors in DynamicProtobufSerializer,
the full paths are truncated to local path, which leads to the descriptor
not found if searching by the full path.

## Overview

Description:
@hisundar has processed one proto file that had this issue [(code)](https://github.com/CorfuDB/CorfuDB/pull/2379/files#diff-5cfd309540ac6e9f1ffcd86258f78a0daa2683b3d01382f1d39b62eeb93a90a4R108), but recently we saw other proto files having the same issue.
This is an urgent fix. This issue needs to be addressed in a more elegant and systematic way. 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
