### PR TITLE
StreamListener expose Timestamp for Re-Subscription

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStreamEntries.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStreamEntries.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.collections;
 
 import lombok.Getter;
+import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
 
 import java.util.List;
 import java.util.Map;
@@ -14,10 +15,20 @@ import java.util.Map;
  * created by hisundar on 2019-10-22
  */
 public class CorfuStreamEntries {
+
     @Getter
     private final Map<TableSchema, List<CorfuStreamEntry>> entries;
 
-    public CorfuStreamEntries(Map<TableSchema, List<CorfuStreamEntry>> entries) {
+    /*
+     Represents the timestamp for the retrieved entries. In the event of failures,
+     clients can re-subscribe starting from this timestamp, in order to avoid data loss or
+     the need to re-sync all the data.
+     */
+    @Getter
+    private final Timestamp timestamp;
+
+    public CorfuStreamEntries(Map<TableSchema, List<CorfuStreamEntry>> entries, Timestamp timestamp) {
         this.entries = entries;
+        this.timestamp = timestamp;
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamManager.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamManager.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
 import org.corfudb.runtime.exceptions.StreamSubscriptionException;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.ObjectsView;
@@ -272,7 +273,11 @@ public class StreamManager {
                                     ).collect(Collectors.toList())));
 
                     if (!entries.isEmpty()) {
-                        CorfuStreamEntries callbackResult = new CorfuStreamEntries(entries);
+                        Timestamp timestamp = Timestamp.newBuilder()
+                                .setSequence(logData.getGlobalAddress())
+                                .setEpoch(epoch)
+                                .build();
+                        CorfuStreamEntries callbackResult = new CorfuStreamEntries(entries, timestamp);
                         log.trace("{}::onNext with {} updates", listener.toString(), entries.size());
                         long onNextStart = System.nanoTime();
                         listener.onNext(callbackResult);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamSubscription.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamSubscription.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
 import org.corfudb.runtime.view.StreamOptions;
 import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.runtime.view.stream.IStreamView;
@@ -137,7 +138,12 @@ public class StreamSubscription<K extends Message, V extends Message, M extends 
             return true;
         }
 
-        return streamBuffer.offer(new CorfuStreamEntries(streamEntries), maxBlockTime, TimeUnit.NANOSECONDS);
+        Timestamp timestamp = Timestamp.newBuilder()
+                .setSequence(logData.getGlobalAddress())
+                .setEpoch(epoch)
+                .build();
+
+        return streamBuffer.offer(new CorfuStreamEntries(streamEntries, timestamp), maxBlockTime, TimeUnit.NANOSECONDS);
     }
 
     /**


### PR DESCRIPTION
## Overview

Description: subscribers need a means to know the last synced timestamp. If an error occurs (for instance, a poison pill) they can attempt to re-subscribe from this point (instead of having to sync the complete space or use a timestamp which could incur in data loss).  

Why should this be merged: requirement from clients. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
