### PR TITLE
CorfuBrowser tool tag support

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserMain.java
@@ -3,13 +3,9 @@ package org.corfudb.browser;
 import java.util.Map;
 import java.util.Optional;
 
-import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.collections.CorfuDynamicKey;
-import org.corfudb.runtime.collections.CorfuDynamicRecord;
-import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.util.GitRepositoryState;
 import org.docopt.Docopt;
 
@@ -27,7 +23,11 @@ public class CorfuStoreBrowserMain {
         infoTable,
         showTable,
         listenOnTable,
-        dropTable
+        dropTable,
+        listTags,
+        listTablesForTag,
+        listTagsForTable,
+        listTagsMap
     }
 
     private static final String USAGE = "Usage: corfu-browser --host=<host> " +
@@ -43,9 +43,10 @@ public class CorfuStoreBrowserMain {
         + "Options:\n"
         + "--host=<host>   Hostname\n"
         + "--port=<port>   Port\n"
-        + "--operation=<listTables|infoTable|showTable|dropTable|loadTable|listenOnTable> Operation\n"
+        + "--operation=<listTables|infoTable|showTable|dropTable|loadTable|listenOnTable|listTags|listTagsMap|listTablesForTag|listTagsForTable> Operation\n"
         + "--namespace=<namespace>   Namespace\n"
         + "--tablename=<tablename>   Table Name\n"
+        + "--tag=<tag>  Stream tag of interest\n"
         + "--keystore=<keystore_file> KeyStore File\n"
         + "--ks_password=<keystore_password> KeyStore Password\n"
         + "--truststore=<truststore_file> TrustStore File\n"
@@ -145,6 +146,26 @@ public class CorfuStoreBrowserMain {
                         numItems = Integer.parseInt(opts.get("--numItems").toString());
                     }
                     browser.listenOnTable(namespace, tableName, numItems);
+                    break;
+                case listTags:
+                    browser.listStreamTags();
+                    break;
+                case listTablesForTag:
+                    if (opts.get("--tag") != null) {
+                        String streamTag = opts.get("--tag").toString();
+                        browser.listTablesForTag(streamTag);
+                    } else {
+                        log.warn("The '--tag' flag was not specified. Displaying all streams tags and their tables.");
+                        browser.listTagToTableMap();
+                    }
+                    break;
+                case listTagsForTable:
+                    browser.listTagsForTable(namespace, tableName);
+                    break;
+                case listTagsMap:
+                    browser.listTagToTableMap();
+                    break;
+                default:
                     break;
             }
         } catch (Throwable t) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -557,7 +557,7 @@ public class StreamLogFiles implements StreamLog {
     private Metadata parseMetadata(FileChannel fileChannel, String segmentFile) throws IOException {
         long actualMetaDataSize = fileChannel.size() - fileChannel.position();
         if (actualMetaDataSize < METADATA_SIZE) {
-            log.error("Meta data has wrong size. Actual size: {}, expected: {}",
+            log.error("Metadata has wrong size. Actual size: {}, expected: {}",
                     actualMetaDataSize, METADATA_SIZE
             );
             return null;

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserIT.java
@@ -5,11 +5,15 @@ import com.google.protobuf.UnknownFieldSet;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Paths;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.util.serializer.Serializers;
@@ -25,6 +29,8 @@ import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.test.SampleAppliance;
 import org.corfudb.test.SampleSchema;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class CorfuStoreBrowserIT extends AbstractIT {
 
@@ -161,6 +167,98 @@ public class CorfuStoreBrowserIT extends AbstractIT {
         runtime.shutdown();
         // TODO: Remove this once serializers move into the runtime
         Serializers.clearCustomSerializers();
+    }
+
+    /**
+     * Test Corfu Browser stream tags APIs (tag list & tags to table names mapping)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testBrowserTagsOperations() throws Exception {
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost,
+                corfuStringNodePort);
+
+        final String namespace = "UT-namespace";
+        final String tableBaseName = "table";
+
+        Map<String, List<String>> expectedTableNameToTags = populateRegistryTable(namespace, tableBaseName);
+        Map<String, List<String>> expectedTagToTableNames = new HashMap<>();
+        expectedTableNameToTags.forEach((tName, tags) -> {
+            tags.forEach(tag -> {
+                if (expectedTagToTableNames.containsKey(tag)) {
+                    expectedTagToTableNames.computeIfPresent(tag, (key, tNames) -> {
+                        tNames.add(tName);
+                        return tNames;
+                    });
+                } else {
+                    List<String> listTableNames = new ArrayList<>();
+                    listTableNames.add(tName);
+                    expectedTagToTableNames.put(tag, listTableNames);
+                }
+            });
+        });
+
+        runtime = createRuntime(singleNodeEndpoint);
+        CorfuStoreBrowser browser = new CorfuStoreBrowser(runtime);
+
+        // (1) List Stream Tags
+        Set<String> tagsInRegistry = browser.listStreamTags();
+        assertThat(tagsInRegistry.size()).isEqualTo(expectedTagToTableNames.keySet().size());
+        assertThat(tagsInRegistry).containsOnly(expectedTagToTableNames.keySet().toArray(new String[0]));
+
+        // (2) Show Stream Tag Maps (tags to table names)
+        Map<String, List<CorfuStoreMetadata.TableName>> tagToTableNames = browser.listTagToTableMap();
+        assertThat(tagToTableNames.size()).isEqualTo(expectedTagToTableNames.keySet().size());
+        assertThat(tagToTableNames.keySet()).containsOnly(expectedTagToTableNames.keySet().toArray(new String[0]));
+        tagToTableNames.forEach((tag, tableNames) -> assertThat(tableNames.size()).isEqualTo(expectedTagToTableNames.get(tag).size()));
+
+        // (3) List Tables for a given stream tag
+        final String streamTag = "sample_streamer_2";
+        List<CorfuStoreMetadata.TableName> tablesForStreamTag = browser.listTablesForTag(streamTag);
+        assertThat(tablesForStreamTag.size()).isEqualTo(expectedTagToTableNames.get(streamTag).size());
+        tablesForStreamTag.forEach(table -> assertThat(expectedTagToTableNames.get(streamTag)).contains(table.getTableName()));
+
+        // (4) List tags for a given table
+        final String tableName = tableBaseName + 0; // Pick first created table which corresponds to SampleTableAMsg Schema (2 tags)
+        Set<String> tags = browser.listTagsForTable(namespace, tableName);
+        assertThat(tags.size()).isEqualTo(expectedTableNameToTags.get(tableName).size());
+        assertThat(tags).containsExactly(expectedTableNameToTags.get(tableName).toArray(new String[0]));
+
+        runtime.shutdown();
+        Serializers.clearCustomSerializers();
+
+        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
+    }
+
+    private Map<String, List<String>> populateRegistryTable(String namespace, String tableBaseName) throws Exception {
+        // Start a Corfu runtime & CorfuStore
+        runtime = createRuntime(singleNodeEndpoint);
+        CorfuStore store = new CorfuStore(runtime);
+
+        Map<String, List<String>> tableNameToTags = new HashMap<>();
+
+        // Create 12 tables, each with different combinations among 4 different tags (some with no tags).
+        // Tags are determined by the value types (refer to sample_schema.proto for defined tags of each type)
+        final int totalTables = 12;
+        // Refer to sample_schema.proto
+        List<Class> valueTypes = Arrays.asList(SampleSchema.SampleTableAMsg.class, SampleSchema.SampleTableBMsg.class,
+                SampleSchema.SampleTableCMsg.class, SampleSchema.SampleTableDMsg.class);
+        Map<Class, List<String>> expectedTagsPerValues =  new HashMap<>();
+        expectedTagsPerValues.put(SampleSchema.SampleTableAMsg.class, Arrays.asList("sample_streamer_1", "sample_streamer_2"));
+        expectedTagsPerValues.put(SampleSchema.SampleTableBMsg.class, Arrays.asList("sample_streamer_2", "sample_streamer_3"));
+        expectedTagsPerValues.put(SampleSchema.SampleTableCMsg.class, Collections.EMPTY_LIST);
+        expectedTagsPerValues.put(SampleSchema.SampleTableDMsg.class, Arrays.asList("sample_streamer_4"));
+
+        for (int index = 0; index < totalTables; index++) {
+            store.openTable(namespace, tableBaseName + index,
+                    SampleSchema.Uuid.class, valueTypes.get(index % valueTypes.size()), SampleSchema.Uuid.class,
+                    TableOptions.builder().build());
+            tableNameToTags.put(tableBaseName + index, expectedTagsPerValues.get(valueTypes.get(index % valueTypes.size())));
+        }
+
+        runtime.shutdown();
+        return tableNameToTags;
     }
 
     /**


### PR DESCRIPTION
## Overview

Description: add operation that provides visibility into the system's stream tags, to avoid abuse use and ease debugging. 

We are adding 4 new operations: listTags, listTagsMap, listTagsForTable & listTablesForTag.

Why should this be merged: required in initial stages to facilitate UFO migration.  


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
