### PR TITLE
Metadata Revision Field fix

### DIFF
--- a/runtime/proto/example_schemas.proto
+++ b/runtime/proto/example_schemas.proto
@@ -4,10 +4,10 @@ package org.corfudb.runtime;
 option java_package = "org.corfudb.runtime";
 
 import "corfu_options.proto";
-import "google/protobuf/descriptor.proto";
+import "google/protobuf/wrappers.proto";
 
 message ManagedMetadata {
-    int64 revision = 1;
+    .google.protobuf.Int64Value revision = 1;
     int64 create_time = 2;
     string create_user = 3;
     int64 last_modified_time = 4;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -215,7 +215,7 @@ public class CorfuStore {
     }
 
     /**
-     * Return the address of the latest updated made in this table.
+     * Return the address of the latest update made in this table.
      *
      * @param namespace - namespace that this table belongs to.
      * @param tableName - table name of this table without the namespace prefixed in.

--- a/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/Layout.java
@@ -363,7 +363,7 @@ public class Layout {
             }
 
             @Override
-            public IStreamView  getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
+            public IStreamView getStreamView(CorfuRuntime r, UUID streamId, StreamOptions options) {
                 return new ThreadSafeStreamView(r, streamId, options);
             }
 

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Iterables;
 import com.google.protobuf.Any;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
+import com.google.protobuf.WrappersProto;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
@@ -490,23 +491,27 @@ public class CorfuStoreTest extends AbstractViewTest {
         FileDescriptor firewallFileDescriptor = FirewallRule.getDescriptor().getFile();
         FileDescriptor schemaMetadataFileDescriptor = CorfuOptions.getDescriptor();
         FileDescriptor googleDescriptor = DescriptorProto.getDescriptor().getFile();
+        FileDescriptor wrapperDescriptor = WrappersProto.getDescriptor().getFile();
 
         byte[] data = message.toByteArray();
         byte[] applianceSchemaBytes = applianceFileDescriptor.toProto().toByteArray();
         byte[] firewallSchemaBytes = firewallFileDescriptor.toProto().toByteArray();
         byte[] metadataSchemaBytes = schemaMetadataFileDescriptor.toProto().toByteArray();
         byte[] googleSchemaBytes = googleDescriptor.toProto().toByteArray();
+        byte[] wrapperSchemaBytes = wrapperDescriptor.toProto().toByteArray();
 
         FileDescriptorProto applianceSchemaProto = FileDescriptorProto.parseFrom(applianceSchemaBytes);
         FileDescriptorProto firewallSchemaProto = FileDescriptorProto.parseFrom(firewallSchemaBytes);
         FileDescriptorProto metadataSchemaProto = FileDescriptorProto.parseFrom(metadataSchemaBytes);
         FileDescriptorProto googleDescriptorProto = FileDescriptorProto.parseFrom(googleSchemaBytes);
+        FileDescriptorProto wrapperDescriptorProto = FileDescriptorProto.parseFrom(wrapperSchemaBytes);
 
         FileDescriptorSet fileDescriptorSet = FileDescriptorSet.newBuilder()
                 .addFile(applianceSchemaProto)
                 .addFile(firewallSchemaProto)
                 .addFile(metadataSchemaProto)
                 .addFile(googleDescriptorProto)
+                .addFile(wrapperDescriptorProto)
                 .build();
 
         Map<String, FileDescriptorProto> fileDescriptorProtoMap = new HashMap<>();

--- a/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
@@ -180,9 +180,6 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
                         // TableOptions includes option to choose - Memory/Disk based corfu table.
                         TableOptions.builder().build());
 
-        UuidMsg key = UuidMsg.newBuilder().setLsb(0L).setMsb(0L).build();
-        ExampleSchemas.ManagedMetadata value = ExampleSchemas.ManagedMetadata.newBuilder().setCreateUser("simpleValue").build();
-
         Table<Queue.CorfuGuidMsg, ExampleSchemas.ExampleValue, Queue.CorfuQueueMetadataMsg> corfuQueue =
                 shimStore.openQueue(someNamespace, "testQueue",
                         ExampleSchemas.ExampleValue.class,
@@ -222,9 +219,7 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
         // After all concurrent transactions are complete, validate that number of Queue entries
         // are the same as the number of successful transactions.
         List<Table.CorfuQueueRecord> records;
-        try (ManagedTxnContext query = shimStore.txn(someNamespace)) {
-            records = corfuQueue.entryList();
-        }
+        records = corfuQueue.entryList();
         assertThat(validator.size()).isEqualTo(records.size());
 
         // Also validate that the order of the queue matches that of the commit order.

--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -5,6 +5,7 @@ option java_package = "org.corfudb.test";
 
 import "corfu_options.proto";
 import "google/protobuf/descriptor.proto";
+import "google/protobuf/wrappers.proto";
 import "sample_appliance.proto";
 
 message FirewallRule {
@@ -28,7 +29,7 @@ message ManagedResources {
 }
 
 message ManagedMetadata {
-    optional int64 revision = 1;
+    optional .google.protobuf.Int64Value revision = 1;
     optional int64 create_time = 2;
     optional string create_user = 3;
     optional int64 last_modified_time = 4;


### PR DESCRIPTION
## Overview

Description:

Revision field should be a non-primitive type such that we can differentiate
an unset field from a field that is explicitly set to the default value (0L).

**Bug**: if we can't differentiate when the revision field was unset (where its value defaults to 0) from the case when the revision field is explicitly set to 0 (case of primitives), we could erroneously bump a revision even though it's stale. Consider the following example, revision is currently at 5, someone setting it explicitly to 0, would currently not get a StaleRevisionException but instead bump the version to 6 and commit successfully, though a stale revision was specified. This PR fixes this issue.

Why should this be merged: current bug in the revision field.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
