### PR TITLE
Fix skipping of Universe Tests in GitHub Actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -93,4 +93,4 @@ jobs:
         run: ./mvnw clean install -DskipTests -Pdocker -Dmaven.javadoc.skip=true -T 1C
 
       - name: Run universe tests
-        run: ./mvnw -pl :universe verify -Puniverse -DskipTests -Dmaven.javadoc.skip=true
+        run: ./mvnw -pl :universe verify -Puniverse -Dmaven.javadoc.skip=true

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -100,6 +100,15 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>3.0.0-M5</version>
+                        <executions>
+                            <execution>
+                                <id>integration-test</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                         <configuration>
                             <skipITs>false</skipITs>
                             <reuseForks>false</reuseForks>


### PR DESCRIPTION
## Overview

Description: The Universe Tests were getting skipped earlier unintentionally even after mentioning the maven build profile. Adding execution id and execution goals ensured that they are not skipped.

Why should this be merged: This resumes the universal tests in the GitHub Actions.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
