### PR TITLE
Log Replication: Bug fix + More Lock logging

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/replication/ReadWaitHoleFillPolicy.java
@@ -74,8 +74,8 @@ public class ReadWaitHoleFillPolicy implements IHoleFillPolicy {
                 }
 
                 // Otherwise try again.
-                log.debug("peekUntilHoleFillRequired: Attempted read at address {}, "
-                        + "but data absent. Retrying.", address);
+                log.trace("peekUntilHoleFillRequired: Attempted read at address {}, "
+                            + "but data absent. Retrying.", address);
                 throw new RetryNeededException();
             }).setOptions(x -> x.setMaxRetryThreshold(retryWaitThreshold)).run();
         } catch (InterruptedException ie) {

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -50,6 +50,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
     private final static long shortInterval = 1L;
     private final static long mediumInterval = 10L;
+    private final static long lockInterval = 6L;
     private final static int firstBatch = 10;
     private final static int secondBatch = 15;
     private final static int thirdBatch = 20;
@@ -971,7 +972,12 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         txnContext.clear(activeLockTable);
         txnContext.commit();
         log.info("Active's lock is released!");
-        TimeUnit.SECONDS.sleep(shortInterval);
+        TimeUnit.SECONDS.sleep(lockInterval);
+
+        // Release Active's lock again
+        txnContext = activeCorfuStore.txn(CORFU_SYSTEM_NAMESPACE);
+        txnContext.clear(activeLockTable);
+        txnContext.commit();
 
         for (int i = secondBatch; i < thirdBatch; i++) {
             activeRuntime.getObjectsView().TXBegin();

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -16,9 +16,11 @@ import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.proto.RpcCommon;
 import org.corfudb.util.Sleep;
+import org.corfudb.utils.lock.LockDataTypes;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.IntPredicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 
 /**
@@ -42,6 +45,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CorfuReplicationClusterConfigIT extends AbstractIT {
     public final static String nettyPluginPath = "src/test/resources/transport/nettyConfig.properties";
     private final static String streamName = "Table001";
+    private static final String LOCK_TABLE_NAME = "LOCK";
+
 
     private final static long shortInterval = 1L;
     private final static long mediumInterval = 10L;
@@ -72,6 +77,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     private CorfuStore activeCorfuStore;
     private CorfuStore standbyCorfuStore;
     private Table<RpcCommon.UuidMsg, RpcCommon.UuidMsg, RpcCommon.UuidMsg> configTable;
+    private Table<LockDataTypes.LockId, LockDataTypes.LockData, Message> activeLockTable;
 
     @Before
     public void setUp() throws Exception {
@@ -113,6 +119,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                 RpcCommon.UuidMsg.class, RpcCommon.UuidMsg.class, RpcCommon.UuidMsg.class,
                 TableOptions.builder().build()
         );
+
+        activeLockTable = activeCorfuStore.openTable(
+                CORFU_SYSTEM_NAMESPACE,
+                LOCK_TABLE_NAME,
+                LockDataTypes.LockId.class,
+                LockDataTypes.LockData.class,
+                null,
+                TableOptions.builder().build());
 
         activeCorfuStore.openTable(LogReplicationMetadataManager.NAMESPACE,
                 REPLICATION_STATUS_TABLE,
@@ -889,6 +903,87 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                 .isEqualTo(LogReplicationMetadata.SnapshotSyncInfo.SnapshotSyncType.FORCED);
         assertThat(replicationStatusVal.getSnapshotSyncInfo().getStatus())
                 .isEqualTo(LogReplicationMetadata.SyncStatus.COMPLETED);
+    }
+
+
+    /**
+     * This test verifies active's lock release
+     * <p>
+     * 1. Init with corfu 9000 active and 9001 standby
+     * 2. Write 10 entries to active map
+     * 3. Start log replication: Node 9010 - active, Node 9020 - standby
+     * 4. Wait for Snapshot Sync, both maps have size 10
+     * 5. Write 5 more entries to active map, to verify Log Entry Sync
+     * 6. Revoke active's lock and wait for 10 sec
+     * 7. Write 5 more entries to active map
+     * 8. Verify data will not be replicated, since active's lock is released
+     */
+    @Test
+    public void testActiveLockRelease() throws Exception {
+        // Write 10 entries to active map
+        for (int i = 0; i < firstBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(firstBatch);
+        assertThat(mapStandby.size()).isZero();
+
+        log.info("Before log replication, append {} entries to active map. Current active corfu" +
+                        "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        activeReplicationServer = runReplicationServer(activeReplicationServerPort, nettyPluginPath);
+        standbyReplicationServer = runReplicationServer(standbyReplicationServerPort, nettyPluginPath);
+        log.info("Replication servers started, and replication is in progress...");
+
+        // Wait until data is fully replicated
+        waitForReplication(size -> size == firstBatch, mapStandby, firstBatch);
+        log.info("After full sync, both maps have size {}. Current active corfu[{}] log tail " +
+                        "is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Write 5 entries to active map
+        for (int i = firstBatch; i < secondBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(secondBatch);
+
+        // Wait until data is fully replicated again
+        waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
+        log.info("After delta sync, both maps have size {}. Current active corfu[{}] log tail " +
+                        "is {}, standby corfu[{}] log tail is {}", secondBatch, activeClusterCorfuPort,
+                activeRuntime.getAddressSpaceView().getLogTail(), standbyClusterCorfuPort,
+                standbyRuntime.getAddressSpaceView().getLogTail());
+
+        // Verify data
+        for (int i = 0; i < secondBatch; i++) {
+            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+        }
+        log.info("Log replication succeeds without config change!");
+
+        // Release Active's lock
+        TxnContext txnContext = activeCorfuStore.txn(CORFU_SYSTEM_NAMESPACE);
+        txnContext.clear(activeLockTable);
+        txnContext.commit();
+        log.info("Active's lock is released!");
+        TimeUnit.SECONDS.sleep(shortInterval);
+
+        for (int i = secondBatch; i < thirdBatch; i++) {
+            activeRuntime.getObjectsView().TXBegin();
+            mapActive.put(String.valueOf(i), i);
+            activeRuntime.getObjectsView().TXEnd();
+        }
+        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        log.info("Active map has {} entries now!", thirdBatch);
+
+        // Standby map should still have secondBatch size
+        log.info("Standby map should still have {} size", secondBatch);
+        assertThat(mapStandby.size()).isEqualTo(secondBatch);
     }
 
     private void waitForReplication(IntPredicate verifier, CorfuTable table, int expected) {

--- a/utils/src/main/java/org/corfudb/utils/lock/persistence/LockStore.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/persistence/LockStore.java
@@ -40,9 +40,9 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 @Slf4j
 public class LockStore {
     // Namespace used by locks
-    private static final String namespace = CORFU_SYSTEM_NAMESPACE;
+    private static final String NAMESPACE = CORFU_SYSTEM_NAMESPACE;
     // Locks table name
-    private static final String tableName = "LOCK";
+    private static final String TABLE_NAME = "LOCK";
     private final Table<LockId, LockData, Message> table;
 
     private final Uuid clientId;
@@ -51,7 +51,7 @@ public class LockStore {
     /**
      * Cache of all the observed locks/leases. Contains the last timestamp at which the lock was last observed.
      */
-    private Map<LockId, ObservedLock> observedLocks = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<LockId, ObservedLock> observedLocks = new ConcurrentHashMap<>();
 
     /**
      * Constructor
@@ -63,8 +63,8 @@ public class LockStore {
      */
     public LockStore(CorfuRuntime runtime, UUID clientUuid) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         this.corfuStore = new CorfuStore(runtime);
-        this.table = this.corfuStore.openTable(namespace,
-                tableName,
+        this.table = this.corfuStore.openTable(NAMESPACE,
+                TABLE_NAME,
                 LockId.class,
                 LockData.class,
                 null,
@@ -194,7 +194,7 @@ public class LockStore {
     private void create(LockId lockId, LockData lockMetaData, CorfuStoreMetadata.Timestamp timestamp) throws LockStoreException {
         try {
             log.info("LockStore: create lock record for : {}", lockId.getLockName());
-            TxnContext txnContext = corfuStore.txn(namespace, IsolationLevel.snapshot(timestamp));
+            TxnContext txnContext = corfuStore.txn(NAMESPACE, IsolationLevel.snapshot(timestamp));
             txnContext.putRecord(table, lockId, lockMetaData, null);
             txnContext.commit();
         } catch (Exception e) {
@@ -213,7 +213,7 @@ public class LockStore {
      */
     private void update(LockId lockId, LockData lockMetaData, CorfuStoreMetadata.Timestamp timestamp) throws LockStoreException {
         try {
-            TxnContext txn = corfuStore.txn(namespace, IsolationLevel.snapshot(timestamp));
+            TxnContext txn = corfuStore.txn(NAMESPACE, IsolationLevel.snapshot(timestamp));
             txn.putRecord(table, lockId, lockMetaData, null);
             txn.commit();
         } catch (Exception e) {
@@ -232,7 +232,7 @@ public class LockStore {
      */
     private Optional<LockData> get(LockId lockId, CorfuStoreMetadata.Timestamp timestamp) throws LockStoreException {
         try {
-            CorfuRecord record = corfuStore.query(namespace).getRecord(tableName, timestamp, lockId);
+            CorfuRecord record = corfuStore.query(NAMESPACE).getRecord(TABLE_NAME, timestamp, lockId);
             if (record != null) {
                 return Optional.of((LockData) record.getPayload());
             } else {
@@ -254,7 +254,7 @@ public class LockStore {
     @VisibleForTesting
     public Optional<LockData> get(LockId lockId) throws LockStoreException {
         try {
-            CorfuRecord record = corfuStore.query(namespace).getRecord(tableName, lockId);
+            CorfuRecord record = corfuStore.query(NAMESPACE).getRecord(TABLE_NAME, lockId);
             if (record != null) {
                 return Optional.of((LockData) record.getPayload());
             } else {


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Fixed a bug that log replication can not stop when the distributed lock is released.
Added an IT to test lock release scenario.
Added more logging around lock state transition.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
