### PR TITLE
Disable runtime logs on the server explicitly

### DIFF
--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -53,4 +53,5 @@
     <logger additivity="false" level="debug" name="org.corfudb.metricsdata">
         <appender-ref ref="async_metrics_file"/>
     </logger>
+    <logger name="org.corfudb.client.metricsdata" level="off" />
 </configuration>


### PR DESCRIPTION
In  prod, when `org.apache.logging.log4j` is on the classpath, the default logger is being  created with this line:
`Logger logger = LoggerFactory.getLogger("org.corfudb.client.metricsdata");`
This logger is debug-enabled by default and inherits appenders additively from the logger hierarchy. This results in these metrics logs being logged into corfu.9000.log, which causes a lot of pollution. 
This  patch disables the logging level on this logger by default 