### PR TITLE
Dont throw exception on server resets

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
@@ -56,7 +56,7 @@ public class MeterRegistryProvider {
 
         private static void init(Supplier<Optional<MeterRegistry>> meterRegistrySupplier) {
             if (meterRegistry.isPresent()) {
-                throw new IllegalStateException("Registry has already been initialized.");
+               log.warn("Registry has already been initialized.");
             }
             meterRegistry = meterRegistrySupplier.get();
         }


### PR DESCRIPTION
## Overview

Description:

When the Corfu server is being reset the registry for JVM is still present, so its inaccurate to throw the exception.
