### PR TITLE
Set TestServerRouter sendMessage to debug to reduce log flood

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
+++ b/test/src/test/java/org/corfudb/infrastructure/TestServerRouter.java
@@ -85,11 +85,11 @@ public class TestServerRouter implements IServerRouter {
                 .allMatch(x -> x.evaluate(newResponse, this))) {
             if (ctx instanceof TestChannelContext) {
                 ctx.writeAndFlush(newResponse);
-                log.info("sendResponse: Sent {} - {}", response.getPayload().getPayloadCase(),
+                log.debug("sendResponse: Sent {} - {}", response.getPayload().getPayloadCase(),
                         TextFormat.shortDebugString(response.getHeader()));
             } else {
                 this.protoResponseMessages.add(newResponse);
-                log.info("sendResponse: Added response - {} to protoResponseMessages List.",
+                log.debug("sendResponse: Added response - {} to protoResponseMessages List.",
                         TextFormat.shortDebugString(response.getHeader()));
             }
         }


### PR DESCRIPTION
## Overview

Description:

Floods logs hampering debugging. Reducing to debug
Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
