### PR TITLE
Exclude CP Entries from AddressSpaceView Cache

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -446,6 +446,13 @@ public class AddressSpaceView extends AbstractView {
             return loadedValue;
         }
 
+        // Exclude all checkpoint entries, which might be 25MB and cause OOM.
+        // These entries don't need to be cached because they are not used when
+        // rolling forward/backwards to materialize a snapshot.
+        if (loadedValue.hasCheckpointMetadata()) {
+            return loadedValue;
+        }
+
         try {
             return cache.get(address, () -> loadedValue);
         } catch (ExecutionException | UncheckedExecutionException e) {


### PR DESCRIPTION
## Overview

Description:

New checkpoint entry batch policy introduced large checkpoint entry, which can be more than 25MB
Exclude all checkpoint entry from the addressSpaceView cache (read cache) to avoid OOM

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
