### PR TITLE
[Backport] Exclude CP Entries from AddressSpaceView Cache

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -455,6 +455,13 @@ public class AddressSpaceView extends AbstractView {
             return loadedValue;
         }
 
+        // Exclude all checkpoint entries, which might be 25MB and cause OOM.
+        // These entries don't need to be cached because they are not used when
+        // rolling forward/backwards to materialize a snapshot.
+        if (loadedValue.hasCheckpointMetadata()) {
+            return loadedValue;
+        }
+
         try {
             return cache.get(address, () -> loadedValue);
         } catch (ExecutionException | UncheckedExecutionException e) {

--- a/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/AddressSpaceViewTest.java
@@ -1,30 +1,30 @@
 package org.corfudb.runtime.view;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-
 import com.google.common.cache.Cache;
 import com.google.common.collect.ContiguousSet;
 import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.Range;
-
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
 import org.corfudb.common.compression.Codec;
 import org.corfudb.infrastructure.LogUnitServerAssertions;
 import org.corfudb.infrastructure.TestLayoutBuilder;
+import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.wireprotocol.ILogData;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.MetricsUtils;
-import org.corfudb.util.Sleep;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Created by mwei on 2/1/16.
@@ -102,6 +102,46 @@ public class AddressSpaceViewTest extends AbstractViewTest {
 
         assertThat(rt.getAddressSpaceView().getReadCache().size()).isLessThan(maxCacheSize);
 
+    }
+
+    @Test
+    public void checkpointEntryNotCached() {
+        setupNodes();
+        final int oneMb = 1_000_000;
+
+        CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
+                .builder()
+                .maxCacheEntries(oneMb)
+                .build();
+
+        CorfuRuntime rt = CorfuRuntime.fromParameters(params)
+                .parseConfigurationString(getDefaultConfigurationString())
+                .connect();
+
+        CorfuRuntime checkpointRt = CorfuRuntime.fromParameters(params)
+                .parseConfigurationString(getDefaultConfigurationString())
+                .connect();
+
+        AddressSpaceView addressSpaceView = rt.getAddressSpaceView();
+
+        // write a checkpoint entry by checkpoint runtime
+        String streamName = "test-stream";
+        UUID streamId = CorfuRuntime.getStreamID(streamName);
+        UUID checkpointId = UUID.randomUUID();
+        IStreamView sv = checkpointRt.getStreamsView().get(streamId);
+        long address = checkpointRt.getSequencerView().query(streamId);
+        Map<CheckpointEntry.CheckpointDictKey, String> mdKV = new HashMap<>();
+        mdKV.put(CheckpointEntry.CheckpointDictKey.START_TIME, "The perfect time");
+        mdKV.put(CheckpointEntry.CheckpointDictKey.START_LOG_ADDRESS, Long.toString(address + 1));
+        CheckpointEntry cp1 = new CheckpointEntry(CheckpointEntry.CheckpointEntryType.START,
+                "checkpointAuthor", checkpointId, streamId, mdKV, null);
+        long cpAddress = sv.append(cp1, null, null);
+
+        // read the cp entry
+        ILogData ldRead = addressSpaceView.read(cpAddress);
+        assertThat(ldRead).isNotNull();
+        ILogData ldCache = addressSpaceView.getReadCache().getIfPresent(cpAddress);
+        assertThat(ldCache).isNull();
     }
 
     @Test


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
