### PR TITLE
Reduce Sequencer Logs

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -827,8 +827,6 @@ public class SequencerServer extends AbstractServer {
                         .getAddressesInRange(getStreamAddressRange(streamAddressRange));
                 requestedAddressSpaces.put(streamId, addressesInRange);
             } else {
-                log.warn("getStreamsAddressesMap: address space map is not present for stream {}." +
-                        " Verify this is a valid stream.", streamId);
                 requestedAddressSpaces.put(streamId, new StreamAddressSpace(Address.NON_EXIST, Collections.EMPTY_SET));
             }
         }


### PR DESCRIPTION
## Overview

Description: With UFO on 'open' all streams are verified against the registry table,
so there is no need to warn on unexisting streams (they exist but are empty).

Why should this be merged: Log spew

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
