### PR TITLE
Fix time key issue

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/TimingHistogram.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TimingHistogram.java
@@ -20,7 +20,7 @@ public class TimingHistogram {
         this.timer = MeterRegistryProvider.getInstance().map(registry ->
                 DistributionSummary
                         .builder(metricName)
-                        .tag("time", tag)
+                        .tag("time_key", tag)
                         .publishPercentiles(0.50, 0.95, 0.99)
                         .publishPercentileHistogram()
                         .baseUnit("s")


### PR DESCRIPTION
## Overview

InfluxDB convention does not allow 'time' as a key, hence we see exceptions in client logs. 