### PR TITLE
Streaming API TrimmedExceptions fix due to runtimeGC

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractStreamContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractStreamContext.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.util.Utils;
 
 
 /** A data class which keeps data for each stream context.
@@ -79,8 +80,8 @@ public abstract class AbstractStreamContext implements
      */
     protected void validateGlobalPointerPosition(long globalPointer) {
         if (globalPointer < gcTrimMark && globalPointer > Address.NON_ADDRESS) {
-            throw new TrimmedException(String.format("Global pointer position[%s] is in GC trim range. GC Trim mark: [%s]. This address is trimmed from the log.",
-                    globalPointer, gcTrimMark));
+            throw new TrimmedException(String.format("Stream[%s] global pointer position[%s] is in GC trim range. " +
+                            "GC Trim mark: [%s]. This address is trimmed from the log.", Utils.toReadableId(id), globalPointer, gcTrimMark));
         }
     }
 


### PR DESCRIPTION
## Overview

Description: correct corner case for streaming API when th number of updates is zero for a listener and the runtimeGC kicks in modifying boundary conditions (gcTrimMark). 

Why should this be merged: customer bug

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
