### PR TITLE
CorfuStore: Print full stack trace if schema has changed

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -209,6 +209,10 @@ public class TableRegistry {
                         .equals(tableDescriptors.getFileDescriptorsMap())) {
                     hasSchemaChanged = true;
                     log.warn("registerTable: Schema update detected for table {}${}", namespace, tableName);
+
+                    for (StackTraceElement st : Thread.currentThread().getStackTrace()) {
+                        log.warn("{}", st);
+                    }
                     log.debug("registerTable: old schema: {}", oldRecord.getPayload().getFileDescriptorsMap());
                     log.debug("registerTable: new schema: {}", tableDescriptors.getFileDescriptorsMap());
                 }


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: Sometimes consumers call openTable() with differing schema definitions unintentionally which can cause tricky bugs later. To help them triage the callers, dump the full stack trace and make some noise when the schema change is detected.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
