### PR TITLE
Sleep between retries

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Action.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Action.java
@@ -2,15 +2,13 @@ package org.corfudb.infrastructure.orchestrator;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.util.Sleep;
 
 import javax.annotation.Nonnull;
-import java.time.Duration;
+import java.util.concurrent.TimeUnit;
 
 /**
- *
  * A workflow action. All workflow actions must extend this class.
- *
+ * <p>
  * Created by Maithem on 10/25/17.
  */
 
@@ -19,10 +17,11 @@ public abstract class Action {
 
     ActionStatus status = ActionStatus.CREATED;
 
-    private final Duration retryInterval = Duration.ofMillis(300);
+    private final long retryInterval = 300L;
 
     /**
      * Returns the name of this action.
+     *
      * @return Name of action
      */
     @Nonnull
@@ -30,6 +29,7 @@ public abstract class Action {
 
     /**
      * The implementation of the action
+     *
      * @param runtime A runtime that the action will use to execute
      * @throws Exception
      */
@@ -39,7 +39,7 @@ public abstract class Action {
      * Execute the action.
      */
     @Nonnull
-    public void execute(@Nonnull CorfuRuntime runtime, int numRetry) {
+    public void execute(@Nonnull CorfuRuntime runtime, int numRetry) throws InterruptedException {
         for (int x = 0; x < numRetry; x++) {
             try {
                 changeStatus(ActionStatus.STARTED);
@@ -51,13 +51,14 @@ public abstract class Action {
                         getName(), x, e);
                 changeStatus(ActionStatus.ERROR);
                 runtime.invalidateLayout();
-                Sleep.sleepUninterruptibly(retryInterval);
+                TimeUnit.MILLISECONDS.sleep(retryInterval);
             }
         }
     }
 
     /**
      * Get the status of this action.
+     *
      * @return ActionStatus
      */
     public ActionStatus getStatus() {
@@ -66,6 +67,7 @@ public abstract class Action {
 
     /**
      * Changes the status of this action
+     *
      * @param newStatus the new status
      */
     void changeStatus(ActionStatus newStatus) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Action.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Action.java
@@ -2,8 +2,10 @@ package org.corfudb.infrastructure.orchestrator;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.util.Sleep;
 
 import javax.annotation.Nonnull;
+import java.time.Duration;
 
 /**
  *
@@ -16,6 +18,8 @@ import javax.annotation.Nonnull;
 public abstract class Action {
 
     ActionStatus status = ActionStatus.CREATED;
+
+    private final Duration retryInterval = Duration.ofMillis(300);
 
     /**
      * Returns the name of this action.
@@ -47,6 +51,7 @@ public abstract class Action {
                         getName(), x, e);
                 changeStatus(ActionStatus.ERROR);
                 runtime.invalidateLayout();
+                Sleep.sleepUninterruptibly(retryInterval);
             }
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Orchestrator.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/orchestrator/Orchestrator.java
@@ -264,7 +264,11 @@ public class Orchestrator {
 
             long workflowEnd = System.currentTimeMillis();
             log.info("run: Completed workflow {} in {} ms", workflow.getId(), workflowEnd - workflowStart);
-        } catch (Exception e) {
+        }
+        catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+        catch (Exception e) {
             log.error("run: Encountered an error while running workflow {}", workflow.getId(), e);
         } finally {
             activeWorkflows.remove(workflow.getId());


### PR DESCRIPTION
## Overview

Description:
When we retry actions during clustering workflows, we do not wait between retries. It's unlikely that intermittent server or router issues are resolved within the microseconds. Sometimes the complex clustering workflows like restore fail in production due to this.