### PR TITLE
GetHighestSequenceNumber API filter HOLE entries

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -240,6 +240,11 @@ public class CorfuRuntime {
         private boolean metricsEnabled = true;
 
         /*
+         * Number of entries read in a single batch to compute highest sequence number (based on data entries and not holes)
+         */
+        int highestSequenceNumberBatchSize = 4;
+
+        /*
          * Total time in milliseconds for polling task to block until buffer space is available.
          */
         private long streamingPollingBlockingTimeMs = 5;
@@ -301,6 +306,7 @@ public class CorfuRuntime {
             private PriorityLevel priorityLevel = PriorityLevel.NORMAL;
             private Codec.Type codecType = Codec.Type.ZSTD;
             private boolean metricsEnabled = true;
+            private int highestSequenceNumberBatchSize = 4;
             private long streamingPollingBlockingTimeMs = 5;
             private int streamingQueueSize = 100;
             private int streamingPollingThreadPoolSize = 2;
@@ -551,6 +557,11 @@ public class CorfuRuntime {
 
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder metricsEnabled(boolean enabled) {
                 this.metricsEnabled = enabled;
+                return this;
+            }
+
+            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder highestSequenceNumberBatchSize(int highestSequenceNumberBatchSize) {
+                this.highestSequenceNumberBatchSize = highestSequenceNumberBatchSize;
                 return this;
             }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -1,22 +1,29 @@
 package org.corfudb.runtime.collections;
 
+import com.google.common.collect.Iterables;
 import com.google.protobuf.Message;
 import lombok.Getter;
-import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata.TableName;
 import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
 import org.corfudb.runtime.Queue;
+import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.util.Utils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.UUID;
 
 /**
  * CorfuStore is a protobuf API layer that provides all the features of CorfuDB.
@@ -28,12 +35,13 @@ import java.util.concurrent.atomic.AtomicLong;
  * <p>
  * Created by zlokhandwala on 2019-08-02.
  */
+@Slf4j
 public class CorfuStore {
 
     @Getter
     private final CorfuRuntime runtime;
 
-    private final Optional<AtomicLong> openTableCounter;
+    private final CorfuStoreMetrics corfuStoreMetrics;
 
     /**
      * Creates a new CorfuStore.
@@ -55,9 +63,7 @@ public class CorfuStore {
     public CorfuStore(@Nonnull final CorfuRuntime runtime, boolean enableTxLogging) {
         runtime.setTransactionLogging(enableTxLogging);
         this.runtime = runtime;
-        openTableCounter = MeterRegistryProvider.getInstance()
-                .map(registry ->
-                        registry.gauge("open_tables.count", new AtomicLong(0L)));
+        this.corfuStoreMetrics = new CorfuStoreMetrics();
     }
 
     /**
@@ -104,7 +110,7 @@ public class CorfuStore {
         long startTime = System.nanoTime();
         Table table =
                 runtime.getTableRegistry().openTable(namespace, tableName, kClass, vClass, mClass, tableOptions);
-        openTableCounter.ifPresent(count -> count.getAndIncrement());
+        corfuStoreMetrics.recordTableCount();
         long elapsedTime = System.nanoTime() - startTime;
         table.getMetrics().recordTableOpenTime(elapsedTime);
         return table;
@@ -218,7 +224,11 @@ public class CorfuStore {
     }
 
     /**
-     * Return the address of the latest updated made in this table.
+     * Return the address of the latest update made in this table.
+     *
+     * Note: we can't deliberately return the tail of the stream map
+     * as this entry might be a HOLE, we need to filter and return only that
+     * corresponding to the last DATA entry.
      *
      * @param namespace - namespace that this table belongs to.
      * @param tableName - table name of this table without the namespace prefixed in.
@@ -226,11 +236,49 @@ public class CorfuStore {
      */
     public long getHighestSequence(@Nonnull final String namespace,
                                    @Nonnull final String tableName) {
-        return this.runtime.getSequencerView().query(
-                CorfuRuntime.getStreamID(
-                        TableRegistry.getFullyQualifiedTableName(namespace, tableName)
-                )
-        );
+
+        // Overall strategy:
+        // (1) Retrieve streams full address map from sequencer
+        // (2) Read entries in reverse to confirm it's a DATA type entry (for optimization
+        // read in batches). A batch size of 4 is guaranteed to suit one edge case case scenario: i.e.,
+        // consecutive checkpoints enforcing holes (3 rounds of CP accumulate before trim happens == 3 holes)
+
+        long startTime = System.nanoTime();
+        UUID streamId = CorfuRuntime.getStreamID(
+                TableRegistry.getFullyQualifiedTableName(namespace, tableName));
+        StreamAddressSpace streamAddressSpace = this.runtime.getSequencerView()
+                .getStreamAddressSpace(new StreamAddressRange(streamId, Address.MAX, Address.NON_ADDRESS));
+
+        int numBatches = 0;
+
+        if (streamAddressSpace.size() != 0) {
+            NavigableSet<Long> addresses = streamAddressSpace.copyAddressesToSet(Address.MAX).descendingSet();
+            Iterable<List<Long>> batches = Iterables.partition(addresses,
+                    runtime.getParameters().getHighestSequenceNumberBatchSize());
+
+            for (List<Long> batch : batches) {
+                numBatches++;
+                // TODO: We can optimize this such that actual data is not transferred back to the client,
+                //  we require an API that inspects the data at the remote and indicates whether its an actual DATA
+                //  entry or a HOLE, e.g.: Map<Long, DataType> entryTypes = runtime.getAddressSpaceView().getDataType(batch)
+                Map<Long, ILogData> entries = runtime.getAddressSpaceView().read(batch);
+                for (Long address : batch) {
+                    if (!entries.get(address).isHole()) {
+                        corfuStoreMetrics.recordBatchReads(numBatches);
+                        corfuStoreMetrics.recordNumberReads(numBatches*runtime.getParameters().getHighestSequenceNumberBatchSize());
+                        corfuStoreMetrics.recordHighestSequenceNumberDuration(System.nanoTime() - startTime);
+                        return address;
+                    }
+                }
+            }
+        }
+
+        corfuStoreMetrics.recordBatchReads(numBatches);
+        corfuStoreMetrics.recordNumberReads(numBatches*runtime.getParameters().getHighestSequenceNumberBatchSize());
+        corfuStoreMetrics.recordHighestSequenceNumberDuration(System.nanoTime() - startTime);
+        log.debug("Stream[{}${}][{}]no DATA entry found. Highest sequence number corresponds to trim mark={}",
+                namespace, tableName, Utils.toReadableId(streamId), streamAddressSpace.getTrimMark());
+        return streamAddressSpace.getTrimMark();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreMetrics.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreMetrics.java
@@ -1,0 +1,83 @@
+package org.corfudb.runtime.collections;
+
+import com.google.gson.JsonObject;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
+
+import java.util.Optional;
+
+public class CorfuStoreMetrics {
+    // Keep track of the number of read entries to compute a stream's highestSequenceNumber
+    private final Optional<DistributionSummary> numberBatchReads;
+    private final Optional<DistributionSummary> numberReads;
+    private final TimingHistogram highestSequenceNumberDuration;
+
+    private final Optional<Counter> openTableCounter;
+
+    public void recordBatchReads(int numBatches) {
+        numberBatchReads.ifPresent(counter -> counter.record(numBatches));
+    }
+
+    public void recordNumberReads(int reads) {
+        numberReads.ifPresent(counter -> counter.record(reads));
+    }
+
+    public void recordTableCount() {
+        openTableCounter.ifPresent(Counter::increment);
+    }
+
+    public void recordHighestSequenceNumberDuration(long elapsedTime) {
+        highestSequenceNumberDuration.update(elapsedTime);
+    }
+
+    /**
+     * Constructor to initialize the metric registry.
+     */
+    CorfuStoreMetrics() {
+        Optional<MeterRegistry> registryProvider = MeterRegistryProvider.getInstance();
+        this.numberBatchReads = registryProvider.map(registry -> DistributionSummary
+                .builder("highestSeqNum.numberBatchReads")
+                .publishPercentiles(0.95, 0.99)
+                .description("Number of batches read before finding highest DATA sequence number")
+                .register(registry));
+        this.numberReads = registryProvider.map(registry ->
+                        DistributionSummary
+                                .builder("highestSeqNum.numberReads")
+                                .publishPercentiles(0.95, 0.99)
+                                .description("Number of addresses read in batches before finding highest DATA sequence number")
+                                .register(registry));
+        this.openTableCounter = registryProvider.map(registry ->
+                registry.counter("open_tables.count"));
+
+        this.highestSequenceNumberDuration = new TimingHistogram("highestSequenceNumberDuration", "CorfuStore");
+    }
+
+    /**
+     * Method to pretty print the metrics into a JSON object.
+     * @return metrics as jsonObject
+     */
+    public JsonObject toJsonObject() {
+        JsonObject json = new JsonObject();
+        json.addProperty("numberBatchReads_count", numberBatchReads.map(DistributionSummary::count).orElse(0L));
+        json.addProperty("numberBatchReads_max", numberBatchReads.map(DistributionSummary::max).orElse(0.0));
+        json.addProperty("numberBatchReads_mean", numberBatchReads.map(DistributionSummary::mean).orElse(0.0));
+        json.addProperty("numberReads_count", numberReads.map(DistributionSummary::count).orElse(0L));
+        json.addProperty("numberReads_max", numberReads.map(DistributionSummary::max).orElse(0.0));
+        json.addProperty("numberReads_mean", numberReads.map(DistributionSummary::mean).orElse(0.0));
+        json.addProperty("openTableCounter", openTableCounter.map(Counter::count).orElse(0.0));
+        json.add("highestSequenceNumberDuration", highestSequenceNumberDuration.asJsonObject());
+        return json;
+    }
+
+    /**
+     * Metrics as a simple string
+     *
+     * @return Json string representation of the metrics.
+     */
+    @Override
+    public String toString() {
+        return this.toJsonObject().toString();
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAlreadyStartedException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/TransactionAlreadyStartedException.java
@@ -9,6 +9,6 @@ package org.corfudb.runtime.exceptions;
  */
 public class TransactionAlreadyStartedException extends RuntimeException {
     public TransactionAlreadyStartedException(String message) {
-        super("An exsiting transaction is still in progress. "+message);
+        super("An existing transaction is still in progress. " + message);
     }
 }


### PR DESCRIPTION
## Overview

Description: current getHighestSequenceNumber returns highest sequence number regardless of it being a DATA or HOLE entry. This patch allows this API to distinguish and retrieve highest sequence number of a valid DATA entry. 

Why should this be merged: client request

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
