### PR TITLE
Streaming API Trim Exceptions Bug Fix - 2

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static org.corfudb.runtime.view.ObjectsView.LOG_REPLICATOR_STREAM_ID;
 import static org.corfudb.runtime.view.ObjectsView.TRANSACTION_STREAM_ID;
 
 @Slf4j
@@ -169,11 +170,11 @@ public class LogReplicationAckReader {
     }
 
     private long getTxStreamTail(Map<UUID, Long> tailMap) {
-        if (tailMap.containsKey(TRANSACTION_STREAM_ID)) {
-            return tailMap.get(TRANSACTION_STREAM_ID);
+        if (tailMap.containsKey(LOG_REPLICATOR_STREAM_ID)) {
+            return tailMap.get(LOG_REPLICATOR_STREAM_ID);
         }
 
-        log.warn("Tx Stream tail not present in sequencer, id={}", TRANSACTION_STREAM_ID);
+        log.warn("Tx Stream tail not present in sequencer, id={}", LOG_REPLICATOR_STREAM_ID);
         return Address.NON_ADDRESS;
     }
 
@@ -321,7 +322,7 @@ public class LogReplicationAckReader {
         long totalEntries = 0;
 
         if (upperBoundary > lowerBoundary) {
-            StreamAddressRange range = new StreamAddressRange(TRANSACTION_STREAM_ID, upperBoundary, lowerBoundary);
+            StreamAddressRange range = new StreamAddressRange(LOG_REPLICATOR_STREAM_ID, upperBoundary, lowerBoundary);
             StreamAddressSpace txStreamAddressSpace = runtime.getSequencerView().getStreamAddressSpace(range);
             // Count how many entries are present in the Tx Stream (this can include holes,
             // valid entries and invalid entries), but we count them all (equal weight).

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
@@ -308,7 +308,7 @@ public class StreamsLogEntryReader implements LogEntryReader {
         public TxOpaqueStream(CorfuRuntime rt) {
             //create an opaque stream for transaction stream
             this.rt = rt;
-            txStream = new OpaqueStream(rt.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID));
+            txStream = new OpaqueStream(rt.getStreamsView().get(ObjectsView.LOG_REPLICATOR_STREAM_ID));
             streamUpTo();
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamManager.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamManager.java
@@ -242,6 +242,7 @@ public class StreamManager {
 
             StreamOptions options = StreamOptions.builder()
                     .cacheEntries(false)
+                    .isCheckpointCapable(false)
                     .build();
 
             this.txnStream = runtime.getStreamsView()

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingManager.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingManager.java
@@ -2,13 +2,20 @@ package org.corfudb.runtime.collections;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.StreamingException;
+import org.corfudb.runtime.exceptions.TrimmedException;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.TableRegistry;
+import org.corfudb.runtime.view.stream.StreamAddressSpace;
+import org.corfudb.util.Utils;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -83,6 +90,10 @@ public class StreamingManager {
             throw new IllegalArgumentException("subscribe: Buffer size cannot be less than 1.");
         }
 
+        // Before starting, validate that the address to seek to is not already behind the trim mark,
+        // otherwise, throw a TrimmedException (wrapped in Streaming Exception)
+        validateSyncAddress(namespace, streamTag, lastAddress);
+
         if (subscriptions.containsKey(streamListener)) {
             // Multiple subscribers subscribing to same namespace and table is allowed
             // as long as the hashcode() and equals() method of the listeners are different.
@@ -100,8 +111,23 @@ public class StreamingManager {
         notificationExecutor.submit(new StreamNotificationTask(this, subscription, notificationExecutor, runtime.getParameters()));
 
         log.info("Subscribed stream listener {}, numSubscribers: {}, streamTag: {}, lastAddress: {}, " +
-                "namespace {}, tables {}", streamListener, subscriptions.size(), streamTag, lastAddress,
+                        "namespace {}, tables {}", streamListener, subscriptions.size(), streamTag, lastAddress,
                 namespace, tablesOfInterest);
+    }
+
+    private void validateSyncAddress(String namespace, String streamTag, long lastAddress) {
+        long syncAddress = lastAddress + 1;
+
+        UUID txnStreamId = TableRegistry.getStreamIdForStreamTag(namespace, streamTag);
+        StreamAddressSpace streamAddressSpace = runtime.getSequencerView()
+                .getStreamAddressSpace(new StreamAddressRange(txnStreamId, Address.MAX, syncAddress));
+
+        if (syncAddress <= streamAddressSpace.getTrimMark()) {
+            TrimmedException te = new TrimmedException(String.format("Subscription Stream[%s$tag:%s][%s] :: sync start address falls " +
+                    "behind trim mark. This will incur in data loss for data in the space [%s, %s] (inclusive)",
+                    namespace, streamTag, Utils.toReadableId(txnStreamId), syncAddress, streamAddressSpace.getTrimMark()));
+            throw new StreamingException(te);
+        }
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -38,7 +38,13 @@ public class ObjectsView extends AbstractView {
      * The Transaction stream is used to log/write successful transactions from different clients.
      * Transaction data and meta data can be obtained by reading this stream.
      */
+    @Deprecated
     public static final UUID TRANSACTION_STREAM_ID = CorfuRuntime.getStreamID("Transaction_Stream");
+
+    // We are temporarily naming this stream with the same name as TRANSACTION_STREAM_ID to avoid breaking LR code
+    // while transition to UFO is completed (once migration is complete to UFO this stream can be renamed)
+    // add a prefix to the name: e.g., org.corfudb.logreplication.transactionstream
+    public static final UUID LOG_REPLICATOR_STREAM_ID = CorfuRuntime.getStreamID("Transaction_Stream");
 
     @Getter
     @Setter

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AddressMapStreamView.java
@@ -381,8 +381,8 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
      * @return whether this stream is capable of being checkpointed
      */
     private boolean isCheckpointCapable() {
-        return !getId().equals(ObjectsView.TRANSACTION_STREAM_ID)
-                && getStreamOptions().isCheckpointCapable();
+        // Subscription tag streams are not checkpoint(able) (used for streaming) this is set on the StreamSubscription
+        return getStreamOptions().isCheckpointCapable();
     }
 
     @Override
@@ -400,7 +400,7 @@ public class AddressMapStreamView extends AbstractQueuedStreamView {
             // but we need to consider the case when the 'syncUpTo' address falls below the trim mark, so we correctly
             // report the TrimmedException allowing consumers to know that data is no longer available from this point.
             // We could throw the TrimmedException directly or in this case let remainingUpTo discover it for us.
-            if (getCurrentGlobalPosition() <= streamAddressSpace.getTrimMark()) {
+            if (getCurrentGlobalPosition() < streamAddressSpace.getTrimMark()) {
                 // If pointer is -1L we must return the known trim mark or the trimmed exception will be lost
                 return getCurrentGlobalPosition() == Address.NON_ADDRESS ? streamAddressSpace.getTrimMark() : getCurrentGlobalPosition();
             } else  {

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -232,7 +232,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
             consumerRts.add(consumerRt);
 
-            IStreamView txStream = consumerRt.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID);
+            IStreamView txStream = consumerRt.getStreamsView().get(ObjectsView.LOG_REPLICATOR_STREAM_ID);
 
             int counter = 0;
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -138,6 +138,10 @@ public class LogReplicationAbstractIT extends AbstractIT {
     }
 
     public void testEndToEndSnapshotAndLogEntrySyncUFO() throws Exception {
+        // TODO: when ObjectsView.TRANSACTION_STREAM_ID is removed or LOG_REPLICATOR_STREAM_ID name is changed,
+        //  change these tests such that UFO tables used in the tests have the is_federated tag set,
+        //  as these will determine which tables will be written to the LOG_REPLICATOR_STREAM_ID
+        //  (for now, it is not required as they're written to the same TRANSACTION_STREAM_ID from legacy impl.)
         testEndToEndSnapshotAndLogEntrySyncUFO(1);
     }
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -301,7 +301,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
             long tail = Utils.getLogAddressSpace(rt
                     .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
-                    .get(ObjectsView.TRANSACTION_STREAM_ID).getTail();
+                    .get(ObjectsView.LOG_REPLICATOR_STREAM_ID).getTail();
             expectedAckTimestamp = Math.max(tail, expectedAckTimestamp);
         }
 
@@ -700,7 +700,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         expectedAckMessages = Utils.getLogAddressSpace(srcDataRuntime
                 .getLayoutView().getRuntimeLayout())
                 .getAddressMap()
-                .get(ObjectsView.TRANSACTION_STREAM_ID).getTail();
+                .get(ObjectsView.LOG_REPLICATOR_STREAM_ID).getTail();
 
         LogReplicationFSM fsm = startLogEntrySync(replicateTables, WAIT.ON_ACK);
 

--- a/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
@@ -254,7 +254,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
                 .cacheEntries(false)
                 .build();
 
-        IStreamView txStream = rt.getStreamsView().getUnsafe(ObjectsView.TRANSACTION_STREAM_ID, options);
+        IStreamView txStream = rt.getStreamsView().getUnsafe(ObjectsView.LOG_REPLICATOR_STREAM_ID, options);
         List<ILogData> dataList = txStream.remaining();
         log.debug("\ndataList size " + dataList.size());
         for (ILogData data : txStream.remaining()) {
@@ -456,7 +456,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
         generateTransactions(srcTables, srcHashMap, NUM_TRANSACTIONS, srcDataRuntime, NUM_KEYS);
 
         // Open a tx stream
-        IStreamView txStream = srcTestRuntime.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID);
+        IStreamView txStream = srcTestRuntime.getStreamsView().get(ObjectsView.LOG_REPLICATOR_STREAM_ID);
         long tail = srcDataRuntime.getAddressSpaceView().getLogTail();
         Stream<ILogData> stream = txStream.streamUpTo(tail);
         Iterator iterator = stream.iterator();

--- a/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/StreamViewTest.java
@@ -129,6 +129,7 @@ public class StreamViewTest extends AbstractViewTest {
     public void testRemainingUpToWithTrim() {
         StreamOptions options = StreamOptions.builder()
                 .ignoreTrimmed(true)
+                .isCheckpointCapable(false)
                 .build();
 
         IStreamView txStream = runtime.getStreamsView().get(ObjectsView.TRANSACTION_STREAM_ID, options);


### PR DESCRIPTION
## Overview

Description:
Fix an incorrect TrimmedException which derives from the case of 'tagged' streams which do not receive updates over a long period of time. This leads to a state in which the last synced point (globalPointer) will fall below the log trim mark. In this case, we should not throw a TrimmedException as it is up to date and the pointer has not moved because there are no actual updates. 

- Also move LR in the direction of its own dedicated transaction stream, as this will disappear soon. 

Why should this be merged: bug fix


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
