### PR TITLE
Introduce Compatibility Vector for RPCs

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -41,6 +41,17 @@
             <artifactId>zstd-jni</artifactId>
             <version>1.3.7-3</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>3.6.1</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.classic.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/common/src/main/java/org/corfudb/common/util/CompatibilityVectorUtils.java
+++ b/common/src/main/java/org/corfudb/common/util/CompatibilityVectorUtils.java
@@ -1,0 +1,130 @@
+package org.corfudb.common.util;
+
+import com.google.protobuf.ByteString;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Arrays;
+import java.util.BitSet;
+
+/**
+ * A collection of {@link BitSet}s representing the Corfu features enabled so far.
+ * <p>
+ * Creates the Compatibility Vectors that contain the information about the Corfu features enabled
+ * so far as per the current stage of the code during the compile time of the class.
+ * The vectors are of type {@link ByteString} in which each bit will represent if the corresponding
+ * feature is enabled or not based on its value (0 or 1).
+ * <p>
+ * Client-Server Transmission:
+ * The BitSet values are already converted to the ByteString format and are accessed through
+ * {@link #getCompatibilityVectors()} method. These will be set in the Protobuf header
+ * HeaderMsg.ProtocolVersionMsg value (of both RequestMsg and ResponseMsg),
+ * and sent to the receiver. The receiver will then check whether the specific features are set or
+ * not using {@link CompatibilityVectorUtils#isFeatureEnabled(Feature, ByteString)} method.
+ * <p>
+ * For adding new Features:
+ * - <b>Introduce</b> them by creating an entry in this class's {@link Feature} enum structure.
+ * <p>
+ * Created by cgudisagar on 5/3/21.
+ */
+@Slf4j
+public class CompatibilityVectorUtils {
+
+    // Prevent class from being instantiated
+    private CompatibilityVectorUtils() {
+    }
+
+    /**
+     * @return a {@link ByteString} of vectors representing the Corfu features enabled so far.
+     */
+    public static ByteString getCompatibilityVectors() {
+        return Feature.vectors;
+    }
+
+    /**
+     * Checks if the feature is enabled in the given byte array or not.
+     *
+     * @param feature the {@link Feature} enum value to be checked
+     * @param vectors the {@link ByteString} that contains the bits of the Corfu features
+     * @return a boolean value that denotes if the feature is enabled or not.
+     */
+    @SuppressWarnings("unused") // it will be used in future
+    public static boolean isFeatureEnabled(Feature feature, ByteString vectors) {
+        int featureNumber = feature.getNumber();
+
+        // If the feature number (0-indexed) is greater than or equal the bytes length,
+        // or if it is a negative value, then the feature is not enabled.
+        if (featureNumber >= 8 * vectors.size() || featureNumber < 0)
+            return false;
+
+        // Check if the bit is set in the vector
+        // = ((corresponding byte) AND (1 only on the index of the bit) !=0)
+        // & 0xff to prevent a possible int promotion error while using bytes with
+        // shifts and bitwise operators
+        return (((vectors.byteAt((featureNumber) / 8) & 0xff) & (1 << ((featureNumber) % 8))) != 0);
+    }
+
+    /**
+     * This enum loads when {@link #getCompatibilityVectors()} is called
+     * for the first time. It gives a thread-safe lazy-initialization because the class loader
+     * guarantees that all static initialization is complete before getting access to the class.
+     */
+    public enum Feature {
+        // Comma separated enum values indicating each feature along with their sequence number.
+        // FEATURE_A(0),
+        ;
+
+        /**
+         * Contains the vectors representing the Corfu features enabled so far.
+         */
+        private static final ByteString vectors = generateVectors();
+
+        private final int number;
+
+        /**
+         * A constructor to initiate the enum value along with its sequence number
+         *
+         * @param number the sequence number of the enum
+         */
+        @SuppressWarnings("unused")
+        // it will be used in future
+        Feature(int number) {
+            if (number < 0)
+                throw new IllegalArgumentException("Enum number should be a non negative integer." +
+                        " The current value is " + number + ".");
+            this.number = number;
+        }
+
+        private static ByteString generateVectors() {
+            Feature[] features = Feature.values();
+
+            // Though initializing with the length is optional, it improves performance.
+            BitSet bitSet = new BitSet(features.length);
+
+            for (Feature feature : features) {
+                bitSet.set(feature.getNumber());
+            }
+
+            if (features.length > 0) {
+                log.info("generateVectors: Enabled features are {}", Arrays.toString(features));
+                log.info("generateVectors: Compatibility vectors are {}", bitSet);
+            }
+
+
+            return ByteString.copyFrom(bitSet.toByteArray());
+        }
+
+        /**
+         * Get the sequence number of the enum entry
+         *
+         * @return the sequence number of the enum entry
+         */
+        private int getNumber() {
+            return this.number;
+        }
+
+        @Override
+        public String toString() {
+            return this.number + ": " + super.toString();
+        }
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -63,6 +63,7 @@ import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getTrimLogRespo
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getTrimMarkResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getUpdateCommittedTailResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getWriteLogResponseMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getDefaultProtocolVersionMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getHeaderMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getResponseMsg;
@@ -468,7 +469,11 @@ public class LogUnitServer extends AbstractServer {
     @Override
     public void sealServerWithEpoch(long epoch) {
         RequestMsg batchProcessorReq = getRequestMsg(
-                HeaderMsg.newBuilder().setEpoch(epoch).setPriority(PriorityLevel.HIGH).build(),
+                HeaderMsg.newBuilder()
+                        .setVersion(getDefaultProtocolVersionMsg())
+                        .setEpoch(epoch)
+                        .setPriority(PriorityLevel.HIGH)
+                        .build(),
                 getSealRequestMsg(epoch)
         );
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static org.corfudb.protocols.CorfuProtocolCommon.getUuidMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getDefaultProtocolVersionMsg;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
 
 /**
@@ -179,6 +180,7 @@ public class LogReplicationClientRouter implements IClientRouter {
             @Nonnull String nodeId) {
 
         HeaderMsg.Builder header = HeaderMsg.newBuilder()
+                .setVersion(getDefaultProtocolVersionMsg())
                 .setIgnoreClusterId(true)
                 .setIgnoreEpoch(true);
 

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/ServerHandshakeHandlerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/ServerHandshakeHandlerTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure;
 
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.corfudb.common.util.CompatibilityVectorUtils;
 import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
 import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
@@ -89,6 +90,7 @@ public class ServerHandshakeHandlerTest {
                 .setVersion(
                      ProtocolVersionMsg.newBuilder()
                     .setCorfuSourceCodeVersion(FAKE_CLIENT_VERSION)
+                    .setCapabilityVector(CompatibilityVectorUtils.getCompatibilityVectors())
                     .build())
                 .setRequestId(requestCounter.incrementAndGet())
                 .setPriority(PriorityLevel.NORMAL)

--- a/runtime/proto/service/corfu_message.proto
+++ b/runtime/proto/service/corfu_message.proto
@@ -22,7 +22,10 @@ enum PriorityLevel {
 }
 
 message ProtocolVersionMsg {
-  repeated fixed64 capability_vector = 1;
+  // An array of bytes to represent the features supported so far.
+  // 1 byte = 8 bits = 8 Features
+  // Helps to check the compatibility of features across different versions of the code.
+  bytes capability_vector = 1;
   // A field for indicating the version of Corfu client/server, from which
   // the RPC message is sending from. It is populated from GitRepositoryState class.
   int64 corfu_source_code_version = 2;

--- a/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolMessage.java
+++ b/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolMessage.java
@@ -2,6 +2,7 @@ package org.corfudb.protocols.service;
 
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.common.util.CompatibilityVectorUtils;
 import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
 import org.corfudb.runtime.proto.ServerErrors.ServerErrorMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.PriorityLevel;
@@ -51,6 +52,7 @@ public final class CorfuProtocolMessage {
     public static ProtocolVersionMsg getDefaultProtocolVersionMsg() {
         return ProtocolVersionMsg.newBuilder()
                 .setCorfuSourceCodeVersion(GitRepositoryState.getCorfuSourceCodeVersion())
+                .setCapabilityVector(CompatibilityVectorUtils.getCompatibilityVectors())
                 .build();
     }
 

--- a/runtime/src/test/java/org/corfudb/runtime/ClientHandshakeHandlerTest.java
+++ b/runtime/src/test/java/org/corfudb/runtime/ClientHandshakeHandlerTest.java
@@ -3,6 +3,7 @@ package org.corfudb.runtime;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.embedded.EmbeddedChannel;
+import org.corfudb.common.util.CompatibilityVectorUtils;
 import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
 import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.protocols.wireprotocol.ClientHandshakeHandler;
@@ -97,20 +98,21 @@ public class ClientHandshakeHandlerTest {
         // Get a HandshakeResponseMsg whose corfu_source_code_version set in the header is different
         // from that at client side.
         ResponseMsg response = getResponseMsg(
-                HeaderMsg.newBuilder()
-                        .setVersion(
-                                ProtocolVersionMsg.newBuilder()
-                                        .setCorfuSourceCodeVersion(FAKE_SERVER_VERSION)
-                                        .build())
-                        .setRequestId(requestCounter.incrementAndGet())
-                        .setPriority(PriorityLevel.NORMAL)
-                        .setEpoch(0L)
-                        .setClusterId(getUuidMsg(DEFAULT_UUID))
-                        .setClientId(getUuidMsg(DEFAULT_UUID))
-                        .setIgnoreClusterId(false)
-                        .setIgnoreEpoch(true)
-                        .build(),
-                getHandshakeResponseMsg(SERVER_NODEID)
+            HeaderMsg.newBuilder()
+                .setVersion(
+                    ProtocolVersionMsg.newBuilder()
+                        .setCorfuSourceCodeVersion(FAKE_SERVER_VERSION)
+                        .setCapabilityVector(CompatibilityVectorUtils.getCompatibilityVectors())
+                        .build())
+                .setRequestId(requestCounter.incrementAndGet())
+                .setPriority(PriorityLevel.NORMAL)
+                .setEpoch(0L)
+                .setClusterId(getUuidMsg(DEFAULT_UUID))
+                .setClientId(getUuidMsg(DEFAULT_UUID))
+                .setIgnoreClusterId(false)
+                .setIgnoreEpoch(true)
+                .build(),
+            getHandshakeResponseMsg(SERVER_NODEID)
         );
 
         when(mockChannelContext.pipeline()).thenReturn(mockChannelPipeline);


### PR DESCRIPTION
## Overview

Description: We introduce the compatibility vectors for communicating the information about features that are supported by the sender and receiver. We represent each feature as an enum value in a Java file and set its corresponding enum number's index to 1 in the BitSet and store it in Protobuf's ByteString format. The BitSet values will be the same across both the client and the server of a particular version.

Why should this be merged: Enables features compatibility checks for rolling upgrades.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
