### PR TITLE
Flaky unit test fix

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CorfuRuntimeTest.java
@@ -129,7 +129,7 @@ public class CorfuRuntimeTest extends AbstractViewTest {
      * Ensures that we will not accept a Layout that is obsolete.
      *
      * Test storyline:
-     * 1. Seal the 3 servers
+     * 1. Seal the cluster with min server set
      * 2. Install a new Layout only on 2 of them
      * 3. Force the client to receive the Layout only from the staled Layout server.
      * 4. Ensure that we will never accept it.
@@ -144,12 +144,12 @@ public class CorfuRuntimeTest extends AbstractViewTest {
         // Seal
         Layout currentLayout = new Layout(rt.getLayoutView().getCurrentLayout());
         currentLayout.setEpoch(currentLayout.getEpoch() + 1);
-        rt.getLayoutView().getRuntimeLayout(currentLayout).sealMinServerSet();
 
-        // Server2 is sealed but will not be able to commit the layout.
+        // Server2 will not be able to commit the layout.
         addClientRule(rt, SERVERS.ENDPOINT_2,
                 new TestRule().always().drop());
 
+        rt.getLayoutView().getRuntimeLayout(currentLayout).sealMinServerSet();
 
         rt.getLayoutView().updateLayout(currentLayout, 0);
 


### PR DESCRIPTION
## Overview

Description: In unit test suite sealMinServerSet() is not guarded by fault detector. In some cases we expect every server in the cluster to be sealed but the test case only waits for min server set. We can use TestRules to avoid this for some cases, but ideally those relies on TestRouter needs to be refactored with mocking as it makes the unit tests not "unit".

Why should this be merged: Fixed the flaky issue in these unit tests:     
* CorfuRuntimeTest -  doesNotUpdateToLayoutWithSmallerEpoch    
* ReconfigurationEventHandlerTest - updateLayoutOnFailure

Related issue(s) (if applicable): #2853  #2915


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
