### PR TITLE
Add Support for Editing Records in CorfuStore Tables.

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserMain.java
@@ -3,6 +3,7 @@ package org.corfudb.browser;
 import java.util.Map;
 import java.util.Optional;
 
+import com.google.common.base.Preconditions;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.runtime.CorfuRuntime;
@@ -25,6 +26,7 @@ public class CorfuStoreBrowserMain {
         listenOnTable,
         dropTable,
         listAllProtos,
+        editTable,
         listTags,
         listTablesForTag,
         listTagsForTable,
@@ -44,7 +46,9 @@ public class CorfuStoreBrowserMain {
         + "Options:\n"
         + "--host=<host>   Hostname\n"
         + "--port=<port>   Port\n"
-        + "--operation=<listTables|infoTable|showTable|dropTable|loadTable|listenOnTable|listTags|listTagsMap|listTablesForTag|listTagsForTable|listAllProtos> Operation\n"
+        + "--operation=<listTables|infoTable|showTable|dropTable" +
+        "|editTable|loadTable|listenOnTable|listTags|listTagsMap" +
+        "|listTablesForTag|listTagsForTable|listAllProtos> Operation\n"
         + "--namespace=<namespace>   Namespace\n"
         + "--tablename=<tablename>   Table Name\n"
         + "--tag=<tag>  Stream tag of interest\n"
@@ -56,6 +60,8 @@ public class CorfuStoreBrowserMain {
         + "--numItems=<numItems> Total Number of items for loadTable\n"
         + "--batchSize=<batchSize> Number of records per transaction for loadTable\n"
         + "--itemSize=<itemSize> Size of each item's payload for loadTable\n"
+        + "--keyToEdit=<keyToEdit> Key of the record to edit\n"
+        + "--newRecord=<newRecord> New Editted record to insert\n"
         + "--tlsEnabled=<tls_enabled>";
 
     public static void main(String[] args) {
@@ -113,18 +119,52 @@ public class CorfuStoreBrowserMain {
             String tableName = Optional.ofNullable(opts.get("--tablename"))
                     .map(Object::toString)
                     .orElse(null);
+
             switch (Enum.valueOf(OperationType.class, operation)) {
                 case listTables:
+                    Preconditions.checkArgument(isEmptyOrNull(namespace),
+                        "Namespace is null");
                     browser.listTables(namespace);
                     break;
                 case infoTable:
+                    Preconditions.checkArgument(isEmptyOrNull(namespace),
+                        "Namespace is null");
+                    Preconditions.checkArgument(isEmptyOrNull(tableName),
+                        "Table name is null");
                     browser.printTableInfo(namespace, tableName);
                     break;
                 case dropTable:
+                    Preconditions.checkArgument(isEmptyOrNull(namespace),
+                        "Namespace is null");
+                    Preconditions.checkArgument(isEmptyOrNull(tableName),
+                        "Table name is null");
                     browser.dropTable(namespace, tableName);
                     break;
                 case showTable:
+                    Preconditions.checkArgument(isEmptyOrNull(namespace),
+                        "Namespace is null");
+                    Preconditions.checkArgument(isEmptyOrNull(tableName),
+                        "Table name is null");
                     browser.printTable(namespace, tableName);
+                    break;
+                case editTable:
+                    String keyToEdit = null;
+                    String newRecord = null;
+                    if (opts.get("--keyToEdit") != null) {
+                        keyToEdit = String.valueOf(opts.get("--keyToEdit"));
+                    }
+                    if (opts.get("--newRecord") != null) {
+                        newRecord = String.valueOf(opts.get("--newRecord"));
+                    }
+                    Preconditions.checkArgument(isEmptyOrNull(namespace),
+                        "Namespace is null");
+                    Preconditions.checkArgument(isEmptyOrNull(tableName),
+                        "Table name is null");
+                    Preconditions.checkNotNull(keyToEdit,
+                        "Key To Edit is Null");
+                    Preconditions.checkNotNull(newRecord,
+                        "New Record is null");
+                    browser.editRecord(namespace, tableName, keyToEdit, newRecord);
                     break;
                 case loadTable:
                     int numItems = 1000;
@@ -139,6 +179,10 @@ public class CorfuStoreBrowserMain {
                     if (opts.get("--itemSize") != null) {
                         itemSize = Integer.parseInt(opts.get("--itemSize").toString());
                     }
+                    Preconditions.checkArgument(isEmptyOrNull(namespace),
+                        "Namespace is null");
+                    Preconditions.checkArgument(isEmptyOrNull(tableName),
+                        "Table name is null");
                     browser.loadTable(namespace, tableName, numItems, batchSize, itemSize);
                     break;
                 case listenOnTable:
@@ -146,6 +190,10 @@ public class CorfuStoreBrowserMain {
                     if (opts.get("--numItems") != null) {
                         numItems = Integer.parseInt(opts.get("--numItems").toString());
                     }
+                    Preconditions.checkArgument(isEmptyOrNull(namespace),
+                        "Namespace is null");
+                    Preconditions.checkArgument(isEmptyOrNull(tableName),
+                        "Table name is null");
                     browser.listenOnTable(namespace, tableName, numItems);
                     break;
                 case listTags:
@@ -161,6 +209,10 @@ public class CorfuStoreBrowserMain {
                     }
                     break;
                 case listTagsForTable:
+                    Preconditions.checkArgument(isEmptyOrNull(namespace),
+                        "Namespace is null");
+                    Preconditions.checkArgument(isEmptyOrNull(tableName),
+                        "Table name is null");
                     browser.listTagsForTable(namespace, tableName);
                     break;
                 case listTagsMap:
@@ -176,5 +228,9 @@ public class CorfuStoreBrowserMain {
             log.error("Error in Browser Execution.", t);
             throw t;
         }
+    }
+
+    private static boolean isEmptyOrNull(String str) {
+        return (str == null || str.isEmpty());
     }
 }

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -146,6 +146,11 @@
             <artifactId>protobuf-java</artifactId>
             <version>3.6.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java-util</artifactId>
+            <version>3.6.1</version>
+        </dependency>
         <!--grpc dependencies-->
         <dependency>
             <groupId>io.grpc</groupId>

--- a/runtime/proto/corfu_store_metadata.proto
+++ b/runtime/proto/corfu_store_metadata.proto
@@ -19,11 +19,16 @@ message TableName {
     string table_name = 2;
 }
 
-// Descriptor to provide self describing schemas for the records.
+// Describe the protos in a file.
 message TableDescriptors {
     // File Descriptor protobufs map.
     // Contains file descriptors of key, value, metadata and their dependencies.
     map<string, google.protobuf.FileDescriptorProto> fileDescriptors = 1;
+
+    // 'Any' representing the key, value and metadata of a table
+    google.protobuf.Any key = 2;
+    google.protobuf.Any value = 3;
+    google.protobuf.Any metadata = 4;
 }
 
 // Metadata.

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserIT.java
@@ -1,5 +1,7 @@
 package org.corfudb.integration;
 
+import com.google.protobuf.Any;
+import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.UnknownFieldSet;
 
 import java.io.IOException;
@@ -409,7 +411,8 @@ public class CorfuStoreBrowserIT extends AbstractIT {
         CorfuStoreBrowser browser = new CorfuStoreBrowser(runtime);
         // Invoke listTables and verify table count
         final int three = 3;
-        Assert.assertEquals(three, browser.printTableInfo(TableRegistry.CORFU_SYSTEM_NAMESPACE,
+        Assert.assertEquals(three,
+            browser.printTableInfo(TableRegistry.CORFU_SYSTEM_NAMESPACE,
         TableRegistry.REGISTRY_TABLE_NAME));
         Assert.assertEquals(1, browser.printTableInfo(namespace, tableName));
         // Todo: Remove this once serializers move into the runtime
@@ -480,6 +483,88 @@ public class CorfuStoreBrowserIT extends AbstractIT {
         Assert.assertEquals(1, browser.printTable(namespace, tableName));
 
         // Todo: Remove this once serializers move into the runtime
+        Serializers.clearCustomSerializers();
+        runtime.shutdown();
+    }
+
+    @Test
+    public void editorTest() throws IOException, NoSuchMethodException,
+        IllegalAccessException, InvocationTargetException {
+        final String namespace = "namespace";
+        final String tableName = "table";
+        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost,
+            corfuStringNodePort);
+
+        // Start a Corfu runtime
+        runtime = createRuntime(singleNodeEndpoint);
+
+        CorfuStore store = new CorfuStore(runtime);
+
+        final Table<SampleSchema.Uuid, SampleSchema.Uuid, SampleSchema.Uuid> table1 = store.openTable(
+            namespace,
+            tableName,
+            SampleSchema.Uuid.class,
+            SampleSchema.Uuid.class,
+            SampleSchema.Uuid.class,
+            TableOptions.builder().build());
+
+        final long keyUuid = 1L;
+        final long valueUuid = 3L;
+        final long metadataUuid = 5L;
+
+        SampleSchema.Uuid uuidKey = SampleSchema.Uuid.newBuilder()
+            .setMsb(keyUuid)
+            .setLsb(keyUuid)
+            .build();
+        SampleSchema.Uuid uuidVal = SampleSchema.Uuid.newBuilder()
+            .setMsb(valueUuid)
+            .setLsb(valueUuid)
+            .build();
+        SampleSchema.Uuid metadata = SampleSchema.Uuid.newBuilder()
+            .setMsb(metadataUuid)
+            .setLsb(metadataUuid)
+            .build();
+        TxnContext tx = store.txn(namespace);
+        tx.putRecord(table1, uuidKey, uuidVal, metadata);
+        tx.commit();
+        runtime.shutdown();
+
+        runtime = createRuntime(singleNodeEndpoint);
+        CorfuStoreBrowser browser = new CorfuStoreBrowser(runtime);
+        // Invoke listTables and verify table count
+        Assert.assertEquals(browser.listTables(namespace), 1);
+
+        // Edit the record changing value from 3L -> 5L
+        String keyString = "{\"msb\": \"1\", \"lsb\": \"1\"}";
+        String newValString = "{\"msb\": \"5\", \"lsb\": \"5\"}";
+        final long newVal = 5L;
+        SampleSchema.Uuid newValUuid = SampleSchema.Uuid.newBuilder()
+            .setMsb(newVal)
+            .setLsb(newVal)
+            .build();
+
+        CorfuDynamicRecord editedRecord = browser.editRecord(namespace,
+            tableName, keyString, newValString);
+        Assert.assertNotNull(editedRecord);
+
+        DynamicMessage dynamicValMessage = DynamicMessage.newBuilder(newValUuid)
+            .build();
+        String valTypeUrl = Any.pack(newValUuid).getTypeUrl();
+        DynamicMessage dynamicMetadataMessage = DynamicMessage.newBuilder(metadata)
+            .build();
+        String metadataTypeUrl = Any.pack(metadata).getTypeUrl();
+        CorfuDynamicRecord expectedRecord = new CorfuDynamicRecord(valTypeUrl,
+            dynamicValMessage, metadataTypeUrl, dynamicMetadataMessage);
+
+        Assert.assertEquals(expectedRecord, editedRecord);
+
+        // Try to edit a record corresponding to a non-existent key and
+        // verify it is a no-op
+        keyString = "{\"msb\": \"2\", \"lsb\": \"2\"}";
+        Assert.assertNull(browser.editRecord(namespace, tableName, keyString,
+            newValString));
+        
+        // TODO: Remove this once serializers move into the runtime
         Serializers.clearCustomSerializers();
         runtime.shutdown();
     }


### PR DESCRIPTION
Add Support for Editing Records in CorfuStore Tables.

Description:
Allow editing the record corresponding to a given key in a CorfuStore table.

CorfuStore tables contain records in protobuf format.  To construct a protobuf from the JSON string inputs, use type information stored in TableRegistry.

Why should this be merged: Editing an existing record is a key requirement for debugging and troubleshooting.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
