### PR TITLE
Change LogData to use Java Supplier over guava

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -1,7 +1,6 @@
 package org.corfudb.protocols.wireprotocol;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import lombok.Getter;
@@ -20,6 +19,7 @@ import org.corfudb.util.serializer.Serializers;
 import java.nio.ByteBuffer;
 import java.util.EnumMap;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 /**
  * Created by mwei on 8/15/16.


### PR DESCRIPTION

## Overview

Description: Minor fix in the imports to use Java's Supplier class over guava's Supplier class.

Why should this be merged: 
The current implementation uses guava based Supplier, it throws IncompatibleClassChangeError when a java based supplier is passed in its place as observed in corfudb-cloud repo test cases. Though both the Suppliers are interchangeable the auto-conversion is not happening in some cases. The time() method expects the Supplier to be a Java-based one and all of its callers already use the Java-based Supplier. This PR changes it to use Java one over guava one.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
