### PR TITLE
CorfuStore: Return -1 as default for getHighestSequence()

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -261,9 +261,9 @@ public class CorfuStore {
         corfuStoreMetrics.recordBatchReads(numBatches);
         corfuStoreMetrics.recordNumberReads(numBatches * runtime.getParameters().getHighestSequenceNumberBatchSize());
         corfuStoreMetrics.recordHighestSequenceNumberDuration(startTime);
-        log.debug("Stream[{}${}][{}] no DATA entry found. Highest sequence number corresponds to trim mark={}",
-                namespace, tableName, Utils.toReadableId(streamId), streamAddressSpace.getTrimMark());
-        return streamAddressSpace.getTrimMark();
+        log.debug("Stream[{}${}][{}] no DATA entry found. Returning -1.",
+                namespace, tableName, Utils.toReadableId(streamId));
+        return -1;
     }
 
     /**


### PR DESCRIPTION
Returning trim mark is problematic for idle tables
since trim makr moves on every checkpoint & trim cycle
impling additional data which is not true.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
