### PR TITLE
Migrate artifacts hosting from JFrog to Github Packages

### DIFF
--- a/.github/workflows/publish-corfu.yml
+++ b/.github/workflows/publish-corfu.yml
@@ -12,7 +12,8 @@ jobs:
     if: github.event_name == 'push'
 
     env:
-      JFROG_PASSWORD: ${{ secrets.jfrog_oss_password }}
+      PKG_USERNAME: ${{ secrets.pkg_username }}
+      PUBLISH_TOKEN: ${{ secrets.publish_token }}
       DOCKER_USERNAME: ${{ secrets.docker_username }}
       DOCKER_PASSWORD: ${{ secrets.docker_password }}
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -99,6 +99,10 @@ jobs:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
     runs-on: ubuntu-18.04
 
+    env:
+      PKG_USERNAME: ${{ secrets.pkg_username }}
+      PUBLISH_TOKEN: ${{ secrets.publish_token }}
+
     steps:
       - uses: actions/checkout@v2
 

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,16 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<settings xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.1.0 http://maven.apache.org/xsd/settings-1.1.0.xsd" xmlns="http://maven.apache.org/SETTINGS/1.1.0"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <activeProfiles>
+        <activeProfile>github</activeProfile>
+    </activeProfiles>
+
+    <profiles>
+        <profile>
+            <id>github</id>
+            <repositories>
+                <repository>
+                    <id>github</id>
+                    <url>https://maven.pkg.github.com/corfudb/corfudb</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
     <servers>
         <server>
-            <username>corfudbcloud</username>
-            <password>${env.JFROG_PASSWORD}</password>
-            <id>central</id>
-        </server>
-        <server>
-            <username>corfudbcloud</username>
-            <password>${env.JFROG_PASSWORD}</password>
-            <id>snapshots</id>
+            <id>github</id>
+            <username>${env.PKG_USERNAME}</username>
+            <password>${env.PUBLISH_TOKEN}</password>
         </server>
     </servers>
 </settings>

--- a/annotationProcessor/pom.xml
+++ b/annotationProcessor/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>annotationProcessor</artifactId>
+    <artifactId>annotation-processor</artifactId>
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -197,15 +197,10 @@
 
     <distributionManagement>
         <repository>
-            <id>central</id>
-            <name>corfudbcloud-artifactory-primary-0-releases</name>
-            <url>https://corfudbcloud.jfrog.io/artifactory/corfu-cloud</url>
+            <id>github</id>
+            <name>GitHub CorfuDB Apache Maven Packages</name>
+            <url>https://maven.pkg.github.com/corfudb/corfudb</url>
         </repository>
-        <snapshotRepository>
-            <id>snapshots</id>
-            <name>corfudbcloud-artifactory-primary-0-snapshots</name>
-            <url>https://corfudbcloud.jfrog.io/artifactory/corfu-cloud</url>
-        </snapshotRepository>
     </distributionManagement>
 
     <profiles>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -90,7 +90,7 @@
         </dependency>
         <dependency>
             <groupId>org.corfudb</groupId>
-            <artifactId>annotationProcessor</artifactId>
+            <artifactId>annotation-processor</artifactId>
             <version>${project.version}</version>
         </dependency>
 


### PR DESCRIPTION
## Overview

Description: Our traffic is exceeding the data transfer limit of JFrog free tier limit. We are migrating to Github Packages in this PR.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
