### PR TITLE
Bug Fix nested secondary indexes for unset values

### DIFF
--- a/runtime/proto/example_schemas.proto
+++ b/runtime/proto/example_schemas.proto
@@ -120,6 +120,46 @@ message Adult {
     repeated Address addresses = 3 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "addresses.unique_address_id" index_name: "address"}];
 }
 
+message SportsProfessional {
+    Person person  = 1;
+    // Non-Repeated Field followed by oneOf non-primitive sub-field
+    Hobby profession = 3 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "profession.basket" index_name: "basketPlayers"},
+                             (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "profession.baseball" index_name: "baseballPlayers"}];
+    // Repeated Field followed by oneOf non-primitive sub-field
+    repeated Hobby hobby = 4 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "hobby.basket" index_name: "basketAsHobby"},
+                             (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "hobby.baseball" index_name: "baseballAsHobby"}];
+    // Repeated Field followed by repeated field sub-field
+    repeated TrainingPlan training = 5 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "training.exercises" }];
+}
+
+message TrainingPlan {
+    repeated Exercise exercises = 1;
+    string date = 2;
+}
+
+message Exercise {
+    string name = 1;
+    fixed64 repetitions = 2;
+    fixed64 weight = 3;
+}
+
+message Hobby {
+    oneof sport {
+        Basketball basket = 1;
+        Baseball baseball = 2;
+    }
+}
+
+message Basketball {
+     fixed64 players = 1;
+     string team = 2;
+}
+
+message Baseball {
+    fixed64 balls = 1;
+    string pitchersName = 2;
+}
+
 message Children {
     repeated Child child = 1;
 }


### PR DESCRIPTION
## Overview

Description:

Fix a bug where unset 'oneOf' sub-fields throw a NullPointerException, also
verified unset fields work in the context of;
- Repeatead/Repeated indexes
- Repeated/Non-primitive 'oneOf'
- Non-repetated/Non-primitive 'oneOf'


Why should this be merged: bug reported by clients with secondary indexes

Related issue(s) (if applicable): Internal Report


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
