### PR TITLE
Fix Cluster Id Logs

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -38,7 +38,6 @@ import org.corfudb.util.CFUtils;
 import org.corfudb.util.GitRepositoryState;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Sleep;
-import org.corfudb.util.UuidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1088,7 +1087,7 @@ public class CorfuRuntime {
         if (clusterId == null) {
             clusterId = layout.getClusterId();
             if (clusterId != null) {
-                log.info("Connected to new cluster {}", UuidUtils.asBase64(clusterId));
+                log.info("Connected to new cluster {}", clusterId);
             }
         } else if (!clusterId.equals(layout.getClusterId())) {
             // We connected but got a cluster id we didn't expect.

--- a/runtime/src/main/java/org/corfudb/runtime/exceptions/WrongClusterException.java
+++ b/runtime/src/main/java/org/corfudb/runtime/exceptions/WrongClusterException.java
@@ -3,7 +3,6 @@ package org.corfudb.runtime.exceptions;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import lombok.Getter;
-import org.corfudb.util.UuidUtils;
 
 public class WrongClusterException extends RuntimeException {
 
@@ -23,9 +22,9 @@ public class WrongClusterException extends RuntimeException {
     public WrongClusterException(@Nullable UUID expectedCluster,
                                  @Nullable UUID actualCluster) {
         super("Expected: "
-            + ((expectedCluster == null) ? "null" : UuidUtils.asBase64(expectedCluster))
+            + ((expectedCluster == null) ? "null" : expectedCluster)
             + " Actual: "
-            + ((actualCluster == null) ? "null" : UuidUtils.asBase64(actualCluster)));
+            + ((actualCluster == null) ? "null" : actualCluster));
         this.expectedCluster = expectedCluster;
         this.actualCluster = actualCluster;
     }


### PR DESCRIPTION
## Overview
The cluster ID is specified as a UUID in the layout, but it is being
logged as a base64 number which makes it harder to correlate the log
messages with the layout information.


Why should this be merged: Improves logging consistency and improves debugging 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
