### PR TITLE
Remove Trim Mark Comparison in StreamAddressSpace.addAddress

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
@@ -141,7 +141,13 @@ final public class StreamAddressSpace {
      * @param address address to add.
      */
     public void addAddress(long address) {
-        if (address <= this.trimMark || Address.nonAddress(address)) {
+        // Temporarily log error on trim mark comparison, as throwing an exception
+        // unveils an underlying issue in the reset workflow (wipe data + data transfer in colibri)
+        if (address <= this.trimMark) {
+            log.error("IllegalArgumentException :: Address={}, TrimMark={}", address, this.trimMark);
+        }
+
+        if (Address.nonAddress(address)) {
             throw new IllegalArgumentException("Address=" + address + " TrimMark=" + this.trimMark);
         }
         bitmap.addLong(address);


### PR DESCRIPTION
## Overview

Description:

- Due to underlying bug in server reset: data wipe + data transfer
(data seems to be available for scan and address spaces are populated
before data transfer starts).

Why should this be merged: unblock Corfu merge (still to be brought back and fix underlying bug)

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
