### PR TITLE
Fix namespace and tableName validation in CorfuStoreBrowserMain.  Update README.

### DIFF
--- a/corfudb-tools/README
+++ b/corfudb-tools/README
@@ -9,9 +9,9 @@ definitions or proto files to serialize/deserialize the data.
 --------
 Browser
 --------
-The CorfuStore Browser supports the following operations -
-The browser supports read operation which reads and outputs all entries in a
-given table and namespace, or list tables in a given namespace.
+The browser supports read operations which reads and outputs all entries in a
+given table and namespace, list tables in a given namespace, list stream tags
+for a table or all known stream tags, etc.
 
 1. showTable to read and output all entries in a given table and namespace.
 It can be invoked like the below example-
@@ -23,10 +23,10 @@ org.corfudb.browser.CorfuStoreBrowserMain
 --namespace=sample_namespace
 --tablename=sample_tablename
 --tlsEnabled=true
---keystore=/config/cluster-manager/corfu/private/keystore.jks
---ks_password=/config/cluster-manager/corfu/private/keystore.password
---truststore=/config/cluster-manager/corfu/public/truststore.jks
---truststore_password=/config/cluster-manager/corfu/public/truststore.password
+--keystore=<path to keystore file>
+--ks_password=<path to keystore password file>
+--truststore=<path to truststore file>
+--truststore_password=<path to truststore password file>
 
 2. listTables to list all table names in a given namespace(all namespaces if the
 namespace param is null)-
@@ -37,19 +37,33 @@ org.corfudb.browser.CorfuBrowserMain
 --operation=listTables
 --namespace=sample_namespace
 --tlsEnabled=true
---keystore=/config/cluster-manager/corfu/private/keystore.jks
---ks_password=/config/cluster-manager/corfu/private/keystore.password
---truststore=/config/cluster-manager/corfu/public/truststore.jks
---truststore_password=/config/cluster-manager/corfu/public/truststore.password
+--keystore=<path to keystore file>
+--ks_password=<path to keystore password file>
+--truststore=<path to truststore file>
+--truststore_password=<path to truststore password file>
 
 Keystore and truststore parameters are not required if tls is disabled.
 
 For usage help,
 java -cp "corfudb-tools-0.3.0-SNAPSHOT-shaded.jar" org.corfudb.browser.CorfuStoreBrowserMain <--help|-h>
 
-TODO(pmajmudar): Add a user script to invoke the browser.
 
 -------
 Editor
 -------
-Coming Soon
+editTable to edit the value associated with a key in a given table and
+namespace-
+java -cp "corfudb-tools-0.3.0-SNAPSHOT-shaded.jar" --Dlogback.configurationFile=logback.prod.xml
+org.corfudb.browser.CorfuBrowserMain
+--host=10.160.29.112
+--port=9000
+--operation=editTable
+--namespace=sample_namespace
+--tablename=sample_tablename
+--keyToEdit=<json string representing the key to edit>
+--newRecord=<json string representing the new value>
+--tlsEnabled=true
+--keystore=<path to keystore file>
+--ks_password=<path to keystore password file>
+--truststore=<path to truststore file>
+--truststore_password=<path to truststore password file>

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserMain.java
@@ -41,8 +41,9 @@ public class CorfuStoreBrowserMain {
         "[--diskPath=<pathToTempDirForLargeTables>] "+
         "[--numItems=<numItems>] "+
         "[--batchSize=<itemsPerTransaction>] "+
-        "[--itemSize=<sizeOfEachRecordValue>] "+
-        "[--tlsEnabled=<tls_enabled>]\n"
+        "[--itemSize=<sizeOfEachRecordValue>] "
+        + "[--keyToEdit=<keyToEdit>] [--newRecord=<newRecord>]"
+        + "[--tlsEnabled=<tls_enabled>]\n"
         + "Options:\n"
         + "--host=<host>   Hostname\n"
         + "--port=<port>   Port\n"
@@ -122,29 +123,29 @@ public class CorfuStoreBrowserMain {
 
             switch (Enum.valueOf(OperationType.class, operation)) {
                 case listTables:
-                    Preconditions.checkArgument(isEmptyOrNull(namespace),
-                        "Namespace is null");
+                    Preconditions.checkArgument(isValid(namespace),
+                        "Namespace is null or empty.");
                     browser.listTables(namespace);
                     break;
                 case infoTable:
-                    Preconditions.checkArgument(isEmptyOrNull(namespace),
-                        "Namespace is null");
-                    Preconditions.checkArgument(isEmptyOrNull(tableName),
-                        "Table name is null");
+                    Preconditions.checkArgument(isValid(namespace),
+                        "Namespace is null or empty.");
+                    Preconditions.checkArgument(isValid(tableName),
+                        "Table name is null or empty.");
                     browser.printTableInfo(namespace, tableName);
                     break;
                 case dropTable:
-                    Preconditions.checkArgument(isEmptyOrNull(namespace),
-                        "Namespace is null");
-                    Preconditions.checkArgument(isEmptyOrNull(tableName),
-                        "Table name is null");
+                    Preconditions.checkArgument(isValid(namespace),
+                        "Namespace is null or empty.");
+                    Preconditions.checkArgument(isValid(tableName),
+                        "Table name is null or empty.");
                     browser.dropTable(namespace, tableName);
                     break;
                 case showTable:
-                    Preconditions.checkArgument(isEmptyOrNull(namespace),
-                        "Namespace is null");
-                    Preconditions.checkArgument(isEmptyOrNull(tableName),
-                        "Table name is null");
+                    Preconditions.checkArgument(isValid(namespace),
+                        "Namespace is null or empty.");
+                    Preconditions.checkArgument(isValid(tableName),
+                        "Table name is null or empty.");
                     browser.printTable(namespace, tableName);
                     break;
                 case editTable:
@@ -156,12 +157,12 @@ public class CorfuStoreBrowserMain {
                     if (opts.get("--newRecord") != null) {
                         newRecord = String.valueOf(opts.get("--newRecord"));
                     }
-                    Preconditions.checkArgument(isEmptyOrNull(namespace),
-                        "Namespace is null");
-                    Preconditions.checkArgument(isEmptyOrNull(tableName),
-                        "Table name is null");
+                    Preconditions.checkArgument(isValid(namespace),
+                        "Namespace is null or empty.");
+                    Preconditions.checkArgument(isValid(tableName),
+                        "Table name is null or empty.");
                     Preconditions.checkNotNull(keyToEdit,
-                        "Key To Edit is Null");
+                        "Key To Edit is Null.");
                     Preconditions.checkNotNull(newRecord,
                         "New Record is null");
                     browser.editRecord(namespace, tableName, keyToEdit, newRecord);
@@ -179,10 +180,10 @@ public class CorfuStoreBrowserMain {
                     if (opts.get("--itemSize") != null) {
                         itemSize = Integer.parseInt(opts.get("--itemSize").toString());
                     }
-                    Preconditions.checkArgument(isEmptyOrNull(namespace),
-                        "Namespace is null");
-                    Preconditions.checkArgument(isEmptyOrNull(tableName),
-                        "Table name is null");
+                    Preconditions.checkArgument(isValid(namespace),
+                        "Namespace is null or empty.");
+                    Preconditions.checkArgument(isValid(tableName),
+                        "Table name is null or empty.");
                     browser.loadTable(namespace, tableName, numItems, batchSize, itemSize);
                     break;
                 case listenOnTable:
@@ -190,10 +191,10 @@ public class CorfuStoreBrowserMain {
                     if (opts.get("--numItems") != null) {
                         numItems = Integer.parseInt(opts.get("--numItems").toString());
                     }
-                    Preconditions.checkArgument(isEmptyOrNull(namespace),
-                        "Namespace is null");
-                    Preconditions.checkArgument(isEmptyOrNull(tableName),
-                        "Table name is null");
+                    Preconditions.checkArgument(isValid(namespace),
+                        "Namespace is null or empty.");
+                    Preconditions.checkArgument(isValid(tableName),
+                        "Table name is null or empty.");
                     browser.listenOnTable(namespace, tableName, numItems);
                     break;
                 case listTags:
@@ -209,10 +210,10 @@ public class CorfuStoreBrowserMain {
                     }
                     break;
                 case listTagsForTable:
-                    Preconditions.checkArgument(isEmptyOrNull(namespace),
-                        "Namespace is null");
-                    Preconditions.checkArgument(isEmptyOrNull(tableName),
-                        "Table name is null");
+                    Preconditions.checkArgument(isValid(namespace),
+                        "Namespace is null or empty.");
+                    Preconditions.checkArgument(isValid(tableName),
+                        "Table name is null or empty.");
                     browser.listTagsForTable(namespace, tableName);
                     break;
                 case listTagsMap:
@@ -230,7 +231,7 @@ public class CorfuStoreBrowserMain {
         }
     }
 
-    private static boolean isEmptyOrNull(String str) {
-        return (str == null || str.isEmpty());
+    private static boolean isValid(final String str) {
+        return str != null && !str.isEmpty();
     }
 }


### PR DESCRIPTION
Fix the validation of user-provided namespace and tablename in CorfuStoreBrowserMain.

Also update the README with sample usage of the editor command.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
