### PR TITLE
Upload compatibility test logs to GitHub Action

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -145,6 +145,13 @@ jobs:
         working-directory: ./tests
         run: ./gradlew clean test -Dtags=version-compatibility
 
+      - name: Upload compatibility test logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: compatibility-test-logs
+          retention-days: 3
+          path: ./tests/build/logs
+
   injection_framework_test:
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## Overview

Description:  This patch will make compatibility test logs available in GitHub Action

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
