### PR TITLE
Add Tests for Secondary Indexes on Enum Types

### DIFF
--- a/runtime/proto/example_schemas.proto
+++ b/runtime/proto/example_schemas.proto
@@ -39,6 +39,28 @@ message ExampleValue {
                                                       (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "non_primitive_field_level_0.key_2_level_1.key_1_level_2"}];
 }
 
+message ActivitySchedule {
+    string activity = 1;
+    Time time = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "time.day" index_name: "day" }];
+    Day freeDay = 3 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "freeDay" index_name: "free" }];
+    Day optionalDay = 4 [(org.corfudb.runtime.schema).secondary_key = true];
+}
+
+message Time {
+    int64 hour = 1;
+    Day day = 2;
+}
+
+enum Day {
+    MONDAY = 0;
+    TUESDAY = 1;
+    WEDNESDAY = 2;
+    THURSDAY = 3;
+    FRIDAY = 4;
+    SATURDAY = 5;
+    SUNDAY = 6;
+}
+
 message ExampleTableName {
     option (org.corfudb.runtime.table_schema).stream_tag = "table_name_streamer";
     string namespace = 1;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ManagedTxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ManagedTxnContext.java
@@ -218,6 +218,10 @@ public class ManagedTxnContext implements AutoCloseable {
     /**
      * JoinQuery by a secondary index.
      *
+     * Note: for Enum types the index key should be the ValueDescriptor as this is the way
+     * the protoBuf API deals with enum type field values. For example:
+     * store.getByIndex(table, "dayOfWeek", Days.MONDAY.getValueDescriptor());
+     *
      * @param table     Table object.
      * @param indexName Index name. In case of protobuf-defined secondary index it is the field name.
      * @param indexKey  Key to query.
@@ -233,6 +237,10 @@ public class ManagedTxnContext implements AutoCloseable {
 
     /**
      * JoinQuery by a secondary index given just the full tableName.
+     *
+     * Note: for Enum types the index key should be the ValueDescriptor as this is the way
+     * the protoBuf API deals with enum type field values. For example:
+     * store.getByIndex(table, "dayOfWeek", Days.MONDAY.getValueDescriptor());
      *
      * @param tableName fullyQualified name of the table.
      * @param indexName Index name. In case of protobuf-defined secondary index it is the field name.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamListenerResumeOrDefault.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamListenerResumeOrDefault.java
@@ -9,7 +9,7 @@ import java.util.List;
  * This is an abstract stream listener callback implementation for clients
  * interested in automatic re-subscription upon any error.
  * The re-subscription policy of this implementation is an attempt to
- * optimize and resume streaming from the last processed entry. If and only if
+ * optimize and resume streaming after the last processed entry. If and only if
  * we can't resume from the last processed entry, we subscribe from the latest
  * position in the log (default), which can incur in data loss, as the latest
  * position in the log might have progressed beyond several updates from
@@ -32,6 +32,12 @@ public abstract class StreamListenerResumeOrDefault extends StreamListenerResume
         this(store, namespace, streamTag, null);
     }
 
+    /**
+     * This method contains the subscription policy in case the attempt to 'resume' streaming from
+     * the last processed entry fails. In this case we subscribe from the latest position in the log
+     * (which can incur in data loss, i.e., updates between last processed entry and latest position in the log
+     * would be lost).
+     */
     @Override
     public void subscribeOnResumeError() {
         // Immediately re-subscribe from the latest point in the log, this means there is no interest in

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamListenerResumeOrFullSync.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamListenerResumeOrFullSync.java
@@ -45,6 +45,12 @@ public abstract class StreamListenerResumeOrFullSync extends StreamListenerResum
      */
     protected abstract Timestamp performFullSync();
 
+    /**
+     * This method contains the subscription policy in case the attempt to 'resume' streaming from
+     * the last processed entry fails. In this case, full sync is performed (such that a snapshot
+     * of the tables of interest is captured) and we subscribe from the full sync timestamp
+     * (ensuring no data loss).
+     */
     @Override
     public void subscribeOnResumeError() {
         try {
@@ -56,7 +62,7 @@ public abstract class StreamListenerResumeOrFullSync extends StreamListenerResum
                 store.subscribeListener(this, namespace, streamTag, tablesOfInterest, fullSyncTimestamp);
             }
         } catch (StreamingException se) {
-            log.error("Failed to subscribe listener [tag:{}] {}$[{}]", streamTag, namespace, tablesOfInterest);
+            log.error("Failed to subscribe listener [tag:{}] {}$[{}]. Listener is NOT SUBSCRIBED!", streamTag, namespace, tablesOfInterest);
         } catch (Exception e) {
             log.error("Failed to perform full sync [tag:{}] {}$[{}]. Listener is NOT SUBSCRIBED!", streamTag, namespace,
                     tablesOfInterest);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamListenerResumePolicy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamListenerResumePolicy.java
@@ -38,7 +38,11 @@ abstract class StreamListenerResumePolicy implements StreamListener {
     }
 
     /**
-     * Implementation of re-subscription policy in case resuming subscription from last processed entry fails.
+     * This method contains the subscription policy in case the attempt to 'resume' streaming from
+     * the last processed entry fails. Currently, we have 2 different re-subscription policies:
+     *
+     *   (1) Subscribe from latest position in the log (StreamListenerResumeOrDefault) which can incur in data loss.
+     *   (2) Full Sync and subscribe from the full sync timestamp (no data loss).
      */
     public abstract void subscribeOnResumeError();
 

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreSecondaryIndexTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreSecondaryIndexTest.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.ExampleSchemas;
 import org.corfudb.runtime.ExampleSchemas.ExampleValue;
+import org.corfudb.runtime.ExampleSchemas.ActivitySchedule;
 import org.corfudb.runtime.ExampleSchemas.ManagedMetadata;
 import org.corfudb.runtime.ExampleSchemas.Adult;
 import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
@@ -105,6 +106,91 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
     }
 
     /**
+     * Test secondary indexes set on Enum type
+     */
+    @Test
+    public void testSecondaryIndexesOnEnum() throws Exception {
+        // Get a Corfu Runtime instance.
+        CorfuRuntime corfuRuntime = getTestRuntime();
+
+        // Creating Corfu Store using a connected corfu client.
+        CorfuStoreShim shimStore = new CorfuStoreShim(corfuRuntime);
+
+        // Define a namespace & table name
+        final String someNamespace = "some-namespace";
+        final String tableName = "EnumTable";
+        final String[] activities = new String[] {"basket", "football", "soccer"};
+
+        // Create & Register the table, this table has an Enum field marked as secondary key
+        Table<UuidMsg, ActivitySchedule, ManagedMetadata> activitiesTable = shimStore.openTable(
+                someNamespace,
+                tableName,
+                UuidMsg.class,
+                ActivitySchedule.class,
+                ManagedMetadata.class,
+                TableOptions.builder().build());
+
+        // Populate table with X records
+        final int numRecords = 42;
+        final int daysInAWeek = 7;
+        final ManagedMetadata metadata = ManagedMetadata.newBuilder().setCreateUser("user_UT").build();
+
+        for (int i = 0; i < numRecords; i++) {
+            UUID uuid = UUID.randomUUID();
+            UuidMsg key = UuidMsg.newBuilder()
+                    .setMsb(uuid.getMostSignificantBits()).setLsb(uuid.getLeastSignificantBits())
+                    .build();
+
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
+                ActivitySchedule activity = ActivitySchedule.newBuilder()
+                        .setActivity(activities[i % 3])
+                        .setTime(ExampleSchemas.Time.newBuilder().setDayValue(i % daysInAWeek).build())
+                        .setFreeDay(ExampleSchemas.Day.SUNDAY)
+                        .setOptionalDay(ExampleSchemas.Day.WEDNESDAY)
+                        .build();
+                txn.putRecord(tableName, key, activity, metadata);
+                txn.commit();
+            }
+        }
+
+        // Get by secondary index, retrieve from database all activities programmed for Monday
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
+
+            // Root Enum secondary index
+            List<CorfuStoreEntry<UuidMsg, ActivitySchedule, ManagedMetadata>> sundayOptionalActivities = readWriteTxn
+                    .getByIndex(activitiesTable, "free", ExampleSchemas.Day.SUNDAY.getValueDescriptor());
+            assertThat(sundayOptionalActivities.size()).isEqualTo(numRecords);
+            Iterator<CorfuStoreEntry<UuidMsg, ActivitySchedule, ManagedMetadata>> it = sundayOptionalActivities.iterator();
+            while (it.hasNext()) {
+                CorfuStoreEntry<UuidMsg, ActivitySchedule, ManagedMetadata> entry = it.next();
+                assertThat(entry.getPayload().getFreeDay()).isEqualTo(ExampleSchemas.Day.SUNDAY);
+            }
+
+            // Second Level Enum secondary index
+            List<CorfuStoreEntry<UuidMsg, ActivitySchedule, ManagedMetadata>> mondayActivities = readWriteTxn
+                    .getByIndex(activitiesTable, "day", ExampleSchemas.Day.MONDAY.getValueDescriptor());
+            assertThat(mondayActivities.size()).isEqualTo(numRecords/daysInAWeek);
+            Iterator<CorfuStoreEntry<UuidMsg, ActivitySchedule, ManagedMetadata>> itMonday = mondayActivities.iterator();
+            while (itMonday.hasNext()) {
+                CorfuStoreEntry<UuidMsg, ActivitySchedule, ManagedMetadata> entry = itMonday.next();
+                assertThat(entry.getPayload().getTime().getDay()).isEqualTo(ExampleSchemas.Day.MONDAY);
+            }
+
+            // Root Enum secondary index declared with direct secondary_key keyword (instead of nested)
+            List<CorfuStoreEntry<UuidMsg, ActivitySchedule, ManagedMetadata>> optionalDayActivities = readWriteTxn
+                    .getByIndex(activitiesTable, "optionalDay", ExampleSchemas.Day.WEDNESDAY.getValueDescriptor());
+            assertThat(optionalDayActivities.size()).isEqualTo(numRecords);
+            Iterator<CorfuStoreEntry<UuidMsg, ActivitySchedule, ManagedMetadata>> itOptional = optionalDayActivities.iterator();
+            while (itOptional.hasNext()) {
+                CorfuStoreEntry<UuidMsg, ActivitySchedule, ManagedMetadata> entry = itOptional.next();
+                assertThat(entry.getPayload().getOptionalDay()).isEqualTo(ExampleSchemas.Day.WEDNESDAY);
+            }
+
+            readWriteTxn.commit();
+        }
+    }
+
+    /**
      * Simple example to see how nested secondary indexes work. Please see example_schemas.proto.
      *
      * @throws Exception exception
@@ -149,7 +235,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                     .setMsb(uuid.getMostSignificantBits()).setLsb(uuid.getLeastSignificantBits())
                     .build();
 
-            try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
                 txn.putRecord(tableName, key,
                         ExampleValue.newBuilder()
                                 .setPayload("payload_" + i)
@@ -168,7 +254,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve from database all even entries
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleValue, ManagedMetadata>> entries = readWriteTxn
                     .getByIndex(table, "non_primitive_field_level_0.key_1_level_1", even);
             assertThat(entries.size()).isEqualTo(totalRecords/2);
@@ -184,7 +270,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index from second level (nested), retrieve from database 'upper half'
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleValue, ManagedMetadata>> entries = readWriteTxn
                     .getByIndex(table, "non_primitive_field_level_0.key_2_level_1.key_1_level_2", "upper half");
             assertThat(entries.size()).isEqualTo(totalRecords/2);
@@ -241,7 +327,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                     .setMsb(uuid.getMostSignificantBits()).setLsb(uuid.getLeastSignificantBits())
                     .build();
 
-            try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
                 txn.putRecord(tableName, key,
                         ExampleSchemas.ClassRoom.newBuilder()
                                 // Student 1 per ClassRoom
@@ -259,7 +345,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve from database all classRooms that have young students
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.ClassRoom, ManagedMetadata>> classRooms = readWriteTxn
                     .getByIndex(table, "students.age", youngStudent);
             // Since only even indexed classRooms have youngStudents, we expect half of them to appear
@@ -324,7 +410,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                     .setMsb(id.getMostSignificantBits()).setLsb(id.getLeastSignificantBits())
                     .build();
 
-            try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
                 txn.putRecord(tableName, networkId,
                         ExampleSchemas.Network.newBuilder()
                                 // Device 1
@@ -342,7 +428,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve from database all networks which have RouterA
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Network, ManagedMetadata>> networks = readWriteTxn
                     .getByIndex(table, "devices.router", routerA);
             assertThat(networks.size()).isEqualTo(totalNetworks/2);
@@ -350,7 +436,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve from database all networks which have RouterC
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Network, ManagedMetadata>> networks = readWriteTxn
                     .getByIndex(table, "devices.router", routerC);
             assertThat(networks.size()).isEqualTo(totalNetworks);
@@ -393,7 +479,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         createOffices(departments, totalCompanies, shimStore, someNamespace, tableName);
 
         // Get by secondary index, retrieve from database all Companies that have Department of type 1
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Company, ManagedMetadata>> companiesDepartmentType1 = readWriteTxn
                     .getByIndex(table, "office.departments", departments.get(0));
             assertThat(companiesDepartmentType1.size()).isEqualTo(totalCompanies/2);
@@ -401,7 +487,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve from database all Companies that have Department of Type 4 (all)
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Company, ManagedMetadata>> companiesDepartmentType4 = readWriteTxn
                     .getByIndex(table, "office.departments", departments.get(3));
             assertThat(companiesDepartmentType4.size()).isEqualTo(totalCompanies);
@@ -474,7 +560,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                     .setMsb(id.getMostSignificantBits()).setLsb(id.getLeastSignificantBits())
                     .build();
 
-            try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
                 if (i % 2 == 0) {
                     txn.putRecord(tableName, networkId,
                             ExampleSchemas.Company.newBuilder()
@@ -537,7 +623,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                     .setMsb(uuid.getMostSignificantBits()).setLsb(uuid.getLeastSignificantBits())
                     .build();
 
-            try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
                 txn.putRecord(tableName, key,
                         ExampleSchemas.Person.newBuilder()
                                 .setName("Name_" + i)
@@ -554,7 +640,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve from database all even entries
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Person, ManagedMetadata>> entries = readWriteTxn
                     .getByIndex(table, "phoneNumber.mobile", mobileForEvens);
             assertThat(entries.size()).isEqualTo(people/2);
@@ -562,7 +648,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve from database all entries with common mobile number
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Person, ManagedMetadata>> entries = readWriteTxn
                     .getByIndex(table, "phoneNumber.mobile", mobileCommonBoth);
             assertThat(entries.size()).isEqualTo(people);
@@ -618,7 +704,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                     .setMsb(id.getMostSignificantBits()).setLsb(id.getLeastSignificantBits())
                     .build();
 
-            try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
                 txn.putRecord(tableName, officeId,
                         ExampleSchemas.Office.newBuilder()
                                 // Department 1 per Office
@@ -651,7 +737,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve from database all offices which have an evenPhoneNumber
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Office, ManagedMetadata>> offices = readWriteTxn
                     .getByIndex(table, "departments.members.phoneNumbers", evenPhoneNumber);
             assertThat(offices.size()).isEqualTo(numOffices/2);
@@ -659,7 +745,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve from database all entries with common mobile number
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Office, ManagedMetadata>> offices = readWriteTxn
                     .getByIndex(table, "departments.members.phoneNumbers", commonPhoneNumber);
             assertThat(offices.size()).isEqualTo(numOffices);
@@ -705,7 +791,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         createSchools(shimStore, someNamespace, tableName, numSchools, oddNumDesks, noDesks, others);
 
         // Get by secondary index, retrieve number of schools that have classrooms with odd number of desks
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.School, ManagedMetadata>> schools = readWriteTxn
                     .getByIndex(table, "classRooms.classInfra.numberDesks", oddNumDesks);
             assertThat(schools.size()).isEqualTo(numSchools/2);
@@ -713,7 +799,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve number of schools that have classrooms with no desks
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.School, ManagedMetadata>> schools = readWriteTxn
                     .getByIndex(table, "classRooms.classInfra.numberDesks", noDesks);
             assertThat(schools.size()).isEqualTo(1);
@@ -721,7 +807,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index, retrieve number of schools that have classrooms with computers (repeated primitive field)
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.School, ManagedMetadata>> schools = readWriteTxn
                     .getByIndex(table, "classRooms.classInfra.others", "computers");
             assertThat(schools.size()).isEqualTo(numSchools/others.length);
@@ -743,7 +829,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                     .setMsb(id.getMostSignificantBits()).setLsb(id.getLeastSignificantBits())
                     .build();
 
-            try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
                 txn.putRecord(tableName, schoolId,
                         ExampleSchemas.School.newBuilder()
                                 // ClassRoom 1
@@ -772,7 +858,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 .setMsb(id.getMostSignificantBits()).setLsb(id.getLeastSignificantBits())
                 .build();
 
-        try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
             txn.putRecord(tableName, schoolId,
                     ExampleSchemas.School.newBuilder()
                             // ClassRoom 1
@@ -1085,7 +1171,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                     .setMsb(adultId.getMostSignificantBits()).setLsb(adultId.getLeastSignificantBits())
                     .build();
 
-            try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
                 long adultAge = i % 2 == 0 ? adultBaseAge : adultBaseAge*2;
                 long kidsAge = i % 2 == 0 ? kidsBaseAge : kidsBaseAge*2;
                 txn.putRecord(tableName, adultKey,
@@ -1106,7 +1192,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
 
 
         // Get by secondary index (default alias), retrieve from database all adults with adultsBaseAge
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Adult, ManagedMetadata>> entries = readWriteTxn
                     .getByIndex(adultsTable, "age", adultBaseAge);
             assertThat(entries.size()).isEqualTo(adultCount/2);
@@ -1114,7 +1200,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index (using fully qualified name), retrieve from database all adults with adultsBaseAge
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Adult, ManagedMetadata>> entries = readWriteTxn
                     .getByIndex(adultsTable, "person.age", adultBaseAge);
             assertThat(entries.size()).isEqualTo(adultCount/2);
@@ -1122,7 +1208,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index (custom alias), retrieve from database all adults with kids on age 'kidsBaseAge'
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Adult, ManagedMetadata>> entries = readWriteTxn
                     .getByIndex(adultsTable, "kidsAge", kidsBaseAge);
             assertThat(entries.size()).isEqualTo(adultCount/2);
@@ -1130,7 +1216,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index (fully qualified name), retrieve from database all adults with kids on age 'kidsBaseAge'
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Adult, ManagedMetadata>> entries = readWriteTxn
                     .getByIndex(adultsTable, "person.children.child.age", kidsBaseAge);
             assertThat(entries.size()).isEqualTo(adultCount/2);
@@ -1138,7 +1224,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         }
 
         // Get by secondary index (custom alias), retrieve from database all adults with kids on age '2' (non existent)
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.Adult, ManagedMetadata>> entries = readWriteTxn
                     .getByIndex(adultsTable, "kidsAge", 2);
             assertThat(entries.size()).isZero();
@@ -1237,7 +1323,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 .build();
         ManagedMetadata user = ManagedMetadata.newBuilder().setCreateUser("user_UT").build();
 
-        try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
             txn.putRecord(tableName, key1,
                     ExampleSchemas.NotNestedSecondaryIndex.newBuilder()
                             .setField1("record_1")
@@ -1253,7 +1339,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
             txn.commit();
         }
 
-        try (ManagedTxnContext readWriteTxn = shimStore.txn(someNamespace)) {
+        try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleSchemas.NotNestedSecondaryIndex, ManagedMetadata>> entries = readWriteTxn
                     .getByIndex(table, "field3", 1L);
             assertThat(entries.size()).isEqualTo(1);


### PR DESCRIPTION
## Overview

Description: secondary indexes on an Enum type should be queried based on the ValueDescriptor of the value of interest, this is due to the internal way that protoBuf deals with enum fields. This PR adds a test that shows the correct usage of secondary indexes on first and nested levels over an enum type (for future reference, as it is currently used by clients).

Why should this be merged: example of usage pattern and increase code coverage. 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
