### PR TITLE
Populate the ProtobufDescriptorTable using the RegistryTable.

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -139,10 +139,8 @@ public class DynamicProtobufSerializer implements ISerializer {
             String protoFileName = fileDescriptorProto.getPayload().getFileDescriptor().getName();
             // Since corfu_options is something within repo, the path gets truncated on insert.
             // However dynamicProtobufSerializer fails since the full path is needed.
-            if (protoFileName.equals("corfu_options.proto")) {
-                fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto.getPayload().getFileDescriptor());
-                // Until the truncating issue can be addressed, manually add both paths.
-                protoFileName = "corfudb/runtime/corfu_options.proto";
+            if (protoFileName.equals("corfudb/runtime/corfu_options.proto")) {
+                fdProtoMap.putIfAbsent("corfu_options.proto", fileDescriptorProto.getPayload().getFileDescriptor());
             }
             fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto.getPayload().getFileDescriptor());
             identifyMessageTypesinFileDescriptorProto(fileDescriptorProto.getPayload().getFileDescriptor());


### PR DESCRIPTION
## Overview

Description:
We recently changed the way how TableRegistry registers table schema and descriptors when opening a table (see #2966). FileDescriptorProtos are now stored in a new table call ProtobufDescriptorTable. In the case of Upgrade, when opening a table registered before Upgrade, because the table's information is only registered to RegistryTable, Corfu fails to find it in ProtobufDescriptorTable. This PR adds a function to populate and synchronize ProtobufDescriptorTable from RegistryTable.

Why should this be merged: 
Current TableRegistry has a backward compatibility issue. 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
