### PR TITLE
Remove Unnecessary Debug Statements

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
@@ -96,17 +96,9 @@ public class TxnContext implements AutoCloseable {
         if (TransactionalContext.isInTransaction()) {
             TxnContext txnContext = TransactionalContext.getRootContext().getTxnContext();
             if (!allowNestedTransactions) {
-                log.error("Nested transactions are disabled & current thread already has a transaction started at...");
-                for (StackTraceElement st : TransactionalContext.getRootContext().getBeginTxnStackTrace()) {
-                    log.error("{}", st);
-                }
                 throw new TransactionAlreadyStartedException(TransactionalContext.getRootContext().toString());
             }
             if (txnContext != null) {
-                log.error("Cannot start new CorfuStore transaction in this thread without ending previous one at...");
-                for (StackTraceElement st : TransactionalContext.getRootContext().getBeginTxnStackTrace()) {
-                    log.error("{}", st);
-                }
                 throw new TransactionAlreadyStartedException(TransactionalContext.getRootContext().toString());
             }
             this.startTxSample = MeterRegistryProvider.getInstance().map(Timer::start);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -125,13 +125,6 @@ public abstract class AbstractTransactionalContext implements
     @Setter
     private TxnContext txnContext;
 
-    /**
-     * To help triage transactions that are started but not ended, track the stack trace of the caller.
-     */
-    @Setter
-    @Getter
-    private StackTraceElement[] beginTxnStackTrace;
-
     @Getter
     private final WriteSetInfo writeSetInfo = new WriteSetInfo();
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/TransactionalContext.java
@@ -78,7 +78,6 @@ public class TransactionalContext {
         log.debug("New TransactionalContext created: [{}]", context);
         getTransactionStack().addFirst(context);
         // For debugging transaction already started issues, store the call stack trace.
-        context.setBeginTxnStackTrace(Thread.currentThread().getStackTrace());
         return context;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -270,9 +270,6 @@ public class TableRegistry {
                         log.warn("Protobuf file list changed for {} table {}. Prev list {}, new list {}",
                             namespace, tableName, oldRecord.getPayload().getFileDescriptorsMap().keySet(),
                             tableDescriptors.getFileDescriptorsMap().keySet());
-                        for (StackTraceElement st : Thread.currentThread().getStackTrace()) {
-                            log.debug("{}", st);
-                        }
                         schemaChanged = true;
                     }
 


### PR DESCRIPTION
## Overview
Filling a stacktrace is expensive and using getStackTrace() for
logging a message before an exception is thrown is superfluous
because the exception being thrown already has the stack trace
filled.

Why should this be merged: Remove unnecessary logging statements that contribute to latency

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
