### PR TITLE
Stream Polling Delay Period Fix

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -75,10 +75,6 @@ public class CorfuRuntime {
     @ToString
     public static class CorfuRuntimeParameters extends RuntimeParameters {
 
-        public static CorfuRuntimeParametersBuilder builder() {
-            return new CorfuRuntimeParametersBuilder();
-        }
-
         /*
          * Max size for a write request.
          */
@@ -88,15 +84,6 @@ public class CorfuRuntime {
          * Set the bulk read size.
          */
         int bulkReadSize = 10;
-
-        /*
-         * How much time the Fast Loader has to get the maps up to date.
-         *
-         * <p>Once the timeout is reached, the Fast Loader gives up. Every map that is
-         * not up to date will be loaded through normal path.
-         */
-        Duration fastLoaderTimeout = Duration.ofMinutes(30);
-        // endregion
 
         // region Address Space Parameters
         /*
@@ -248,7 +235,7 @@ public class CorfuRuntime {
         /*
          * Period of time in ms to sleep before next cycle, when poller gets no new data changes.
          */
-        private int streamingPollingIdleWaitTimeMs = 5;
+        private int streamingPollingIdleWaitTimeMs = 50;
 
         /*
          * Capacity of queue shared by by streaming polling and notification tasks.
@@ -276,10 +263,13 @@ public class CorfuRuntime {
         private int streamingNotificationBatchSize = 50;
         // TODO: make it a function of the streaming Queue Size
 
+        public static CorfuRuntimeParametersBuilder builder() {
+            return new CorfuRuntimeParametersBuilder();
+        }
+
         public static class CorfuRuntimeParametersBuilder extends RuntimeParametersBuilder {
             private int maxWriteSize = Integer.MAX_VALUE;
             private int bulkReadSize = 10;
-            private Duration fastLoaderTimeout = Duration.ofMinutes(30);
             private int holeFillRetry = 10;
             private Duration holeFillRetryThreshold = Duration.ofSeconds(1L);
             private Duration holeFillTimeout = Duration.ofSeconds(10);
@@ -302,11 +292,10 @@ public class CorfuRuntime {
             private PriorityLevel priorityLevel = PriorityLevel.NORMAL;
             private Codec.Type codecType = Codec.Type.ZSTD;
             private boolean metricsEnabled = true;
-            private int highestSequenceNumberBatchSize = 4;
             private long streamingPollingBlockingTimeMs = 5;
             private int streamingQueueSize = 100;
             private int streamingPollingThreadPoolSize = 2;
-            private int streamingPollingIdleWaitTimeMs = 5;
+            private int streamingPollingIdleWaitTimeMs = 50;
             private int streamingNotificationThreadPoolSize = 4;
             private long streamingNotificationBlockingTimeMs = 5;
             private int streamingNotificationBatchSize = 50;
@@ -441,11 +430,6 @@ public class CorfuRuntime {
                 return this;
             }
 
-            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder fastLoaderTimeout(Duration fastLoaderTimeout) {
-                this.fastLoaderTimeout = fastLoaderTimeout;
-                return this;
-            }
-
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder holeFillRetry(int holeFillRetry) {
                 this.holeFillRetry = holeFillRetry;
                 return this;
@@ -556,11 +540,6 @@ public class CorfuRuntime {
                 return this;
             }
 
-            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder highestSequenceNumberBatchSize(int highestSequenceNumberBatchSize) {
-                this.highestSequenceNumberBatchSize = highestSequenceNumberBatchSize;
-                return this;
-            }
-
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder streamingPollingBlockingTimeMs(long streamingPollingBlockingTimeMs) {
                 this.streamingPollingBlockingTimeMs = streamingPollingBlockingTimeMs;
                 return this;
@@ -624,7 +603,6 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setBeforeRpcHandler(beforeRpcHandler);
                 corfuRuntimeParameters.setMaxWriteSize(maxWriteSize);
                 corfuRuntimeParameters.setBulkReadSize(bulkReadSize);
-                corfuRuntimeParameters.setFastLoaderTimeout(fastLoaderTimeout);
                 corfuRuntimeParameters.setHoleFillRetry(holeFillRetry);
                 corfuRuntimeParameters.setHoleFillRetryThreshold(holeFillRetryThreshold);
                 corfuRuntimeParameters.setHoleFillTimeout(holeFillTimeout);
@@ -1397,19 +1375,6 @@ public class CorfuRuntime {
     public CorfuRuntime setTrimRetry(int trimRetry) {
         log.warn("setTrimRetry: Deprecated, please set parameters instead");
         parameters.setWriteRetry(trimRetry);
-        return this;
-    }
-
-    /**
-     * Set the timeout of the fast loader, in minutes.
-     *
-     * @param timeout The number of minutes to wait.
-     * @deprecated Deprecated, set using {@link CorfuRuntimeParameters} instead.
-     */
-    @Deprecated
-    public CorfuRuntime setTimeoutInMinutesForFastLoading(int timeout) {
-        log.warn("setTrimRetry: Deprecated, please set parameters instead");
-        parameters.setFastLoaderTimeout(Duration.ofMinutes(timeout));
         return this;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamPollingTask.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamPollingTask.java
@@ -10,7 +10,6 @@ import org.corfudb.runtime.view.stream.IStreamView;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
@@ -46,8 +45,6 @@ class StreamPollingTask implements Runnable {
     // A period of time in ms to sleep before next cycle when poller gets no new data changes.
     private final int pollingIdleWaitTime;
 
-    private final Random randomGenerator;
-
     StreamPollingTask(StreamingManager streamingManager, long lastAddress,
                       StreamSubscription subscription, ScheduledExecutorService executor, CorfuRuntimeParameters params) {
         this.streamingManager = streamingManager;
@@ -57,7 +54,6 @@ class StreamPollingTask implements Runnable {
         this.txnStream = subscription.getTxnStream();
         this.pollingBlockingTime = params.getStreamingPollingBlockingTimeMs();
         this.pollingIdleWaitTime = params.getStreamingPollingIdleWaitTimeMs();
-        this.randomGenerator = new Random();
     }
 
     @Override
@@ -104,7 +100,7 @@ class StreamPollingTask implements Runnable {
         if (updates.isEmpty()) {
             log.trace("pollTxStream :: no updates for {} from {}, listenerId={}", txnStream.getId(),
                     lastReadAddress + 1L, subscription.getListener().getClass().getSimpleName());
-            pollingExecutor.schedule(this, randomGenerator.nextInt(pollingIdleWaitTime), TimeUnit.MILLISECONDS);
+            pollingExecutor.schedule(this, pollingIdleWaitTime, TimeUnit.MILLISECONDS);
             return;
         }
 


### PR DESCRIPTION
## Overview
This patch removes random sleeps between polling and replaces it
with a fixed sleep duration, which makes stream polling follow a
fixed delay schedule. This also reduces the load being generated
by the pollers and makes performance more predictable.

Pre-this patch when the user specifies a poll period of 50ms, the
scheduler will use a random sleep value between [0, 50), this means
that the poller will run every 24.5ms (i.e., expected value of
Random(50)) on average, in essence doubling the frequency, which is
not expected by the user.

Why should this be merged: Performance Fix


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
