### PR TITLE
Expose Stream Tag option as input to the Browser/Editor tool.

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -201,8 +201,7 @@ public class CorfuStoreBrowserEditor {
             getTable(namespace, tablename);
         int tableSize = table.size();
         System.out.println("Table " + tablename + " in namespace " + namespace +
-            "with ID " + streamUUID.toString() + " has " + tableSize + " " +
-                "entries");
+            " with ID " + streamUUID.toString() + " has " + tableSize + " entries");
         System.out.println("\n======================\n");
         return tableSize;
     }
@@ -244,7 +243,7 @@ public class CorfuStoreBrowserEditor {
      * @param tablename - table name without the namespace
      * @return - number of entries in the table before clearing the table
      */
-    public int dropTable(String namespace, String tablename) {
+    public int clearTable(String namespace, String tablename) {
         System.out.println("\n======================\n");
         String fullName = TableRegistry.getFullyQualifiedTableName(namespace, tablename);
         UUID streamUUID = UUID.nameUUIDFromBytes(fullName.getBytes());
@@ -254,8 +253,8 @@ public class CorfuStoreBrowserEditor {
                 getTable(namespace, tablename);
             int tableSize = table.size();
             System.out.println("Table " + tablename + " in namespace " + namespace
-                + "with ID " + streamUUID.toString() + " with " + tableSize +
-                "entries will be dropped...");
+                + " with ID " + streamUUID.toString() + " with " + tableSize +
+                " entries will be dropped...");
             table.clear();
             runtime.getObjectsView().TXEnd();
             System.out.println("Table cleared successfully");
@@ -617,6 +616,6 @@ public class CorfuStoreBrowserEditor {
         // Remove last continuation characters for a clean output ', '
         formatMapping = formatMapping.substring(0, formatMapping.length() - 2);
         System.out.println("Tag: " + tag + " --- Total Tables: " + tables.size()
-            + "TableNames: " + formatMapping);
+            + " TableNames: " + formatMapping);
     }
 }

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
@@ -24,7 +24,7 @@ public class CorfuStoreBrowserEditorMain {
         infoTable,
         showTable,
         listenOnTable,
-        dropTable,
+        clearTable,
         listAllProtos,
         editTable,
         listTags,
@@ -42,12 +42,12 @@ public class CorfuStoreBrowserEditorMain {
         "[--numItems=<numItems>] "+
         "[--batchSize=<itemsPerTransaction>] "+
         "[--itemSize=<sizeOfEachRecordValue>] "
-        + "[--keyToEdit=<keyToEdit>] [--newRecord=<newRecord>]"
+        + "[--keyToEdit=<keyToEdit>] [--newRecord=<newRecord>] [--tag=<tag>]"
         + "[--tlsEnabled=<tls_enabled>]\n"
         + "Options:\n"
         + "--host=<host>   Hostname\n"
         + "--port=<port>   Port\n"
-        + "--operation=<listTables|infoTable|showTable|dropTable" +
+        + "--operation=<listTables|infoTable|showTable|clearTable" +
         "|editTable|loadTable|listenOnTable|listTags|listTagsMap" +
         "|listTablesForTag|listTagsForTable|listAllProtos> Operation\n"
         + "--namespace=<namespace>   Namespace\n"
@@ -135,12 +135,12 @@ public class CorfuStoreBrowserEditorMain {
                         "Table name is null or empty.");
                     browser.printTableInfo(namespace, tableName);
                     break;
-                case dropTable:
+                case clearTable:
                     Preconditions.checkArgument(isValid(namespace),
                         "Namespace is null or empty.");
                     Preconditions.checkArgument(isValid(tableName),
                         "Table name is null or empty.");
-                    browser.dropTable(namespace, tableName);
+                    browser.clearTable(namespace, tableName);
                     break;
                 case showTable:
                     Preconditions.checkArgument(isValid(namespace),

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
@@ -141,7 +141,7 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
         // Invoke tableInfo and verify size
         Assert.assertEquals(browser.printTableInfo(namespace, tableName), one);
         // Invoke dropTable and verify size
-        Assert.assertEquals(browser.dropTable(namespace, tableName), one);
+        Assert.assertEquals(browser.clearTable(namespace, tableName), one);
         // Invoke tableInfo and verify size
         Assert.assertEquals(browser.printTableInfo(namespace, tableName), 0);
         // TODO: Remove this once serializers move into the runtime


### PR DESCRIPTION
Stream Tag was not available as an input parameter to the browser/editor tool from the CLI.  Add this option.

Why should this be merged:  To support query operations based on stream tag. 


