### PR TITLE
Remove equality check on protoBuf descriptors for every openTable

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
@@ -32,6 +32,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1005,7 +1006,8 @@ public class CorfuStoreShimTest extends AbstractViewTest {
      * ProtobufDescriptorTable should de-duplicate common protobuf file descriptors.
      * This test creates a large number of tables that share protobuf files and validates
      * that de-duplication occurs.
-     * Also exercises schema change validation logic.
+     *
+     * It also verifies that the second registration is omitted.
      * @throws Exception exception
      */
     @Test
@@ -1054,28 +1056,34 @@ public class CorfuStoreShimTest extends AbstractViewTest {
             assertThat(referenceMap.get(fileName.getFileName())).isNotNull();
         }
 
-        // Now update the schemas with different protobuf files
-        final int numProtoFiles = corfuRuntime.getTableRegistry().getProtobufDescriptorTable().size();
-        assertThat(numProtoFiles).isLessThan(numTables);
-        for (int i = 0; i < numTables; i++) {
-            shimStore.openTable(
-                    someNamespace,
-                    tableNamePrefix+i,
-                    UuidMsg.class,
-                    org.corfudb.runtime.proto.LogData.LogDataMsg.class, // this brings in 1 new protobuf file
-                    ManagedMetadata.class,
-                    // TableOptions includes option to choose - Memory/Disk based corfu table.
-                    TableOptions.builder().build());
-        }
+        final int numProtoFiles =
+                corfuRuntime.getTableRegistry().getProtobufDescriptorTable().size();
+        CorfuStoreMetadata.TableName tableName = CorfuStoreMetadata.TableName
+                .newBuilder()
+                .setNamespace(someNamespace)
+                .setTableName(tableNamePrefix+"0")
+                .build();
+        final Collection<CorfuRecord<ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>> records =
+                corfuRuntime.getTableRegistry().getProtobufDescriptorTable().values();
+
+        shimStore.openTable(
+                someNamespace,
+                tableNamePrefix+"0",
+                UuidMsg.class,
+                org.corfudb.runtime.proto.LogData.LogDataMsg.class, // this brings in 1 new protobuf file
+                ManagedMetadata.class,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
         referenceMap.put(org.corfudb.runtime.proto.LogData.LogDataMsg.getDescriptor().getFile().getFullName(),
                 org.corfudb.runtime.proto.LogData.getDescriptor().getFile());
-        for (ProtobufFileName fileName : descriptorTable.keySet()) {
-            if (fileName.getFileName().startsWith("google/protobuf")) {
-                continue; // Do not validate library protos
-            }
-            assertThat(referenceMap.get(fileName.getFileName())).isNotNull();
-        }
-        final int numProtoFiles2 = corfuRuntime.getTableRegistry().getProtobufDescriptorTable().size();
-        assertThat(numProtoFiles2).isEqualTo(numProtoFiles + 1);
+
+        // verify the second registration is omitted.
+        final int numProtoFilesAfterChange =
+                corfuRuntime.getTableRegistry().getProtobufDescriptorTable().size();
+        final Collection<CorfuRecord<ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>>
+                recordsAfterChange = corfuRuntime.getTableRegistry().getProtobufDescriptorTable().values();
+        assertThat(numProtoFiles).isEqualTo(numProtoFilesAfterChange);
+        assertThat(records).containsExactlyElementsOf(recordsAfterChange);
     }
 }


### PR DESCRIPTION
## Overview

Description:

If protoBuf schema is already present, do not attempt to update definitions.
These APIs should be available on upgrade path.

Why should this be merged: current client bug, as 'options' section does not match equality (serialized compared to non-serialized) when they actually do match, leading, to TransactionAbortedException's (conflict) on startup.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
