### PR TITLE
Table: Fail delete if called on a non-existent key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.github.artsok</groupId>
+            <artifactId>rerunner-jupiter</artifactId>
+            <version>LATEST</version>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -1,31 +1,25 @@
 package org.corfudb.runtime.collections;
 
-import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
-import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.Queue;
 import org.corfudb.runtime.object.ICorfuVersionPolicy;
-import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.CorfuGuidGenerator;
 import org.corfudb.util.serializer.ISerializer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.AbstractMap;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -42,8 +36,6 @@ import java.util.stream.Stream;
  */
 @Slf4j
 public class Table<K extends Message, V extends Message, M extends Message> {
-
-    private final CorfuRuntime corfuRuntime;
 
     private final CorfuTable<K, CorfuRecord<V, M>> corfuTable;
 
@@ -101,7 +93,6 @@ public class Table<K extends Message, V extends Message, M extends Message> {
      * @param versionPolicy           versioning policy
      * @param streamTags              set of UUIDs representing the streamTags
      */
-    @Nonnull
     public Table(@Nonnull final TableParameters<K, V, M> tableParameters,
                  @Nonnull final CorfuRuntime corfuRuntime,
                  @Nonnull final ISerializer serializer,
@@ -109,7 +100,6 @@ public class Table<K extends Message, V extends Message, M extends Message> {
                  @NonNull final ICorfuVersionPolicy.VersionPolicy versionPolicy,
                  @NonNull final Set<UUID> streamTags) {
 
-        this.corfuRuntime = corfuRuntime;
         this.namespace = tableParameters.getNamespace();
         this.fullyQualifiedTableName = tableParameters.getFullyQualifiedTableName();
         this.streamUUID = CorfuRuntime.getStreamID(this.fullyQualifiedTableName);
@@ -169,10 +159,13 @@ public class Table<K extends Message, V extends Message, M extends Message> {
      * Delete a record mapped to the specified key.
      *
      * @param key Key.
-     * @return Previously stored Corfu Record.
+     * @return Previously stored Corfu Record. Throws NoSuchElementException if key is not found.
      */
     @Nullable
     CorfuRecord<V, M> deleteRecord(@Nonnull final K key) {
+        if (!corfuTable.containsKey(key)) {
+            throw new NoSuchElementException("deleteRecord failed as key "+key.toString()+" does not exist");
+        }
         return corfuTable.remove(key);
     }
 

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
@@ -36,6 +36,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -261,6 +262,45 @@ public class CorfuStoreShimTest extends AbstractViewTest {
                 assertThat(entry.getPayload()).isExactlyInstanceOf(SampleSchema.EventInfo.class);
                 assertThat(entry.getMetadata()).isExactlyInstanceOf(ManagedResources.class);
             }
+        }
+    }
+
+    /**
+     * Fail delete operation if called on a non-existent key.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void failDeleteOnNonExistentKey() throws Exception {
+        // Get a Corfu Runtime instance.
+        CorfuRuntime corfuRuntime = getDefaultRuntime();
+
+        // Creating Corfu Store using a connected corfu client.
+        CorfuStoreShim corfuStore = new CorfuStoreShim(corfuRuntime);
+
+        // Define a namespace for the table.
+        final String nsxManager = "nsx-manager";
+        // Define table name.
+        final String tableName = "EventInfo";
+
+        // Create & Register the table.
+        // This is required to initialize the table for the current corfu client.
+        Table<SampleSchema.Uuid, SampleSchema.EventInfo, ManagedResources> table = corfuStore.openTable(
+                nsxManager,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.EventInfo.class,
+                ManagedResources.class,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        UUID uuid1 = UUID.nameUUIDFromBytes("1".getBytes());
+        SampleSchema.Uuid key1 = SampleSchema.Uuid.newBuilder()
+                .setMsb(uuid1.getMostSignificantBits()).setLsb(uuid1.getLeastSignificantBits())
+                .build();
+        try (ManagedTxnContext txn = corfuStore.tx(nsxManager)) {
+            txn.delete(table, key1);
+            assertThatThrownBy(txn::commit).isExactlyInstanceOf(NoSuchElementException.class);
         }
     }
 

--- a/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
+++ b/test/src/test/java/org/corfudb/runtime/concurrent/CorfuQueueTxTest.java
@@ -39,6 +39,7 @@ import org.junit.Test;
  * Created by hisundar on 5/30/19.
  */
 @Slf4j
+@SuppressWarnings("checkstyle:magicnumber")
 public class CorfuQueueTxTest extends AbstractTransactionsTest {
     static int myTable = 0;
     @Override
@@ -362,4 +363,3 @@ public class CorfuQueueTxTest extends AbstractTransactionsTest {
         queueOutOfOrderedByTransaction(TransactionType.OPTIMISTIC, false);
     }
 }
-

--- a/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CompileProxyTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Created by mwei on 11/11/16.
  */
+@SuppressWarnings("checkstyle:magicnumber")
 public class CompileProxyTest extends AbstractViewTest {
     
     @Test

--- a/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/replication/ChainReplicationProtocolTest.java
@@ -18,7 +18,6 @@ import org.junit.Test;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -27,6 +26,7 @@ import static org.assertj.core.api.Assertions.fail;
  * <p>
  * Created by mwei on 4/11/17.
  */
+@SuppressWarnings("checkstyle:magicnumber")
 public class ChainReplicationProtocolTest extends AbstractReplicationProtocolTest {
 
     /**


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
If we do not fail deletes on non-existent keys, that results in extra SMR operations which confuses stream listeners who aren't expecting duplicate delete operations.


Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
