### PR TITLE
Avoid sharing custom serializers among runtime instances

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -91,7 +91,7 @@ public class CorfuStoreBrowserEditor {
         this.diskPath = diskPath;
         dynamicProtobufSerializer =
             new DynamicProtobufSerializer(runtime);
-        Serializers.registerSerializer(dynamicProtobufSerializer);
+        runtime.getSerializers().registerSerializer(dynamicProtobufSerializer);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/MultiObjectSMREntry.java
@@ -196,7 +196,7 @@ public class MultiObjectSMREntry extends LogEntry implements ISMRConsumable {
                 ByteBuf buf = Unpooled.wrappedBuffer(streamUpdatesBuf);
                 byte magicByte = buf.readByte(); //
                 checkState(magicByte == CorfuSerializer.corfuPayloadMagic, "Not a ICorfuSerializable object");// strip magic
-                MultiSMREntry multiSMREntry = (MultiSMREntry) MultiSMREntry.deserialize(buf, null, isOpaque());
+                MultiSMREntry multiSMREntry = (MultiSMREntry) MultiSMREntry.deserialize(buf, runtime, isOpaque());
                 multiSMREntry.setGlobalAddress(getGlobalAddress());
                 streamBuffers.remove(id);
                 return multiSMREntry;

--- a/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
+++ b/runtime/src/main/java/org/corfudb/protocols/logprotocol/SMREntry.java
@@ -16,7 +16,6 @@ import lombok.ToString;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.serializer.CorfuSerializer;
 import org.corfudb.util.serializer.ISerializer;
-import org.corfudb.util.serializer.Serializers;
 
 /**
  * Created by mwei on 1/8/16.
@@ -123,7 +122,7 @@ public class SMREntry extends LogEntry implements ISMRConsumable {
         Object[] arguments = new Object[numArguments];
 
         if (!opaque) {
-            serializerType = Serializers.getSerializer(serializerId);
+            serializerType = rt.getSerializers().getSerializer(serializerId);
         } else {
             this.serializerId = serializerId;
         }

--- a/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
+++ b/runtime/src/main/java/org/corfudb/protocols/wireprotocol/LogData.java
@@ -85,6 +85,7 @@ public class LogData implements IMetadata, ILogData {
         if (value instanceof LogEntry) {
             if (!Address.isAddress(((LogEntry) value).getGlobalAddress())) {
                 ((LogEntry) value).setGlobalAddress(getGlobalAddress());
+                ((LogEntry) value).setRuntime(runtime);
             }
             return value;
         }

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -38,6 +38,7 @@ import org.corfudb.util.CFUtils;
 import org.corfudb.util.GitRepositoryState;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.Sleep;
+import org.corfudb.util.serializer.Serializers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,6 +68,121 @@ import java.util.stream.Collectors;
 @Slf4j
 @Accessors(chain = true)
 public class CorfuRuntime {
+
+    /**
+     * The parameters used to configure this {@link CorfuRuntime}.
+     */
+    @Getter
+    private final CorfuRuntimeParameters parameters;
+
+    /**
+     * The {@link EventLoopGroup} provided to netty routers.
+     */
+    @Getter
+    private final EventLoopGroup nettyEventLoop;
+
+    /**
+     * A view of the layout service in the Corfu server instance.
+     */
+    @Getter(lazy = true)
+    private final LayoutView layoutView = new LayoutView(this);
+    /**
+     * A view of the sequencer server in the Corfu server instance.
+     */
+    @Getter(lazy = true)
+    private final SequencerView sequencerView = new SequencerView(this);
+    /**
+     * A view of the address space in the Corfu server instance.
+     */
+    @Getter(lazy = true)
+    private final AddressSpaceView addressSpaceView = new AddressSpaceView(this);
+    /**
+     * A view of streamsView in the Corfu server instance.
+     */
+    @Getter(lazy = true)
+    private final StreamsView streamsView = new StreamsView(this);
+
+    /**
+     * Views of objects in the Corfu server instance.
+     */
+    @Getter(lazy = true)
+    private final ObjectsView objectsView = new ObjectsView(this);
+    /**
+     * A view of the Layout Manager to manage reconfigurations of the Corfu Cluster.
+     */
+    @Getter(lazy = true)
+    private final LayoutManagementView layoutManagementView = new LayoutManagementView(this);
+    /**
+     * A view of the Management Service.
+     */
+    @Getter(lazy = true)
+    private final ManagementView managementView = new ManagementView(this);
+
+    /**
+     * CorfuStore's table registry cache for Table lifecycle management.
+     */
+    private final AtomicReference<TableRegistry> tableRegistry = new AtomicReference<>(null);
+
+    /**
+     * List of initial set of layout servers, i.e., servers specified in
+     * connection string on bootstrap.
+     */
+    @Getter
+    private volatile List<String> bootstrapLayoutServers;
+
+    /**
+     * List of known layout servers, refreshed on each fetchLayout.
+     */
+    @Getter
+    private volatile List<String> layoutServers;
+
+    /**
+     * Node Router Pool.
+     */
+    @Getter
+    private NodeRouterPool nodeRouterPool;
+
+    /**
+     * A completable future containing a layout, when completed.
+     */
+    public volatile CompletableFuture<Layout> layout;
+
+    /**
+     * The {@link UUID} of the cluster we are currently connected to, or null, if
+     * there is no cluster yet.
+     */
+    @Getter
+    public volatile UUID clusterId;
+
+    @Getter
+    final ViewsGarbageCollector garbageCollector = new ViewsGarbageCollector(this);
+
+    /**
+     * Notifies that the runtime is no longer used
+     * and async retries to fetch the layout can be stopped.
+     */
+    @Getter
+    private volatile boolean isShutdown = false;
+
+
+    /**
+     * This thread is used by fetchLayout to find a new layout in the system
+     */
+    final ExecutorService runtimeExecutor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat("CorfuRuntime-%d")
+            .build());
+
+    /**
+     * Latest layout seen by the runtime.
+     */
+    private volatile Layout latestLayout = null;
+
+    /**
+     * A set of serializers used to serialize/deserialize data
+     */
+    @Getter
+    private final Serializers serializers = new Serializers();
 
     /**
      * A class which holds parameters and settings for the {@link CorfuRuntime}.
@@ -637,115 +753,6 @@ public class CorfuRuntime {
             }
         }
     }
-
-    /**
-     * The parameters used to configure this {@link CorfuRuntime}.
-     */
-    @Getter
-    private final CorfuRuntimeParameters parameters;
-
-    /**
-     * The {@link EventLoopGroup} provided to netty routers.
-     */
-    @Getter
-    private final EventLoopGroup nettyEventLoop;
-
-    /**
-     * A view of the layout service in the Corfu server instance.
-     */
-    @Getter(lazy = true)
-    private final LayoutView layoutView = new LayoutView(this);
-    /**
-     * A view of the sequencer server in the Corfu server instance.
-     */
-    @Getter(lazy = true)
-    private final SequencerView sequencerView = new SequencerView(this);
-    /**
-     * A view of the address space in the Corfu server instance.
-     */
-    @Getter(lazy = true)
-    private final AddressSpaceView addressSpaceView = new AddressSpaceView(this);
-    /**
-     * A view of streamsView in the Corfu server instance.
-     */
-    @Getter(lazy = true)
-    private final StreamsView streamsView = new StreamsView(this);
-
-    /**
-     * Views of objects in the Corfu server instance.
-     */
-    @Getter(lazy = true)
-    private final ObjectsView objectsView = new ObjectsView(this);
-    /**
-     * A view of the Layout Manager to manage reconfigurations of the Corfu Cluster.
-     */
-    @Getter(lazy = true)
-    private final LayoutManagementView layoutManagementView = new LayoutManagementView(this);
-    /**
-     * A view of the Management Service.
-     */
-    @Getter(lazy = true)
-    private final ManagementView managementView = new ManagementView(this);
-
-    /**
-     * CorfuStore's table registry cache for Table lifecycle management.
-     */
-    private final AtomicReference<TableRegistry> tableRegistry = new AtomicReference<>(null);
-
-    /**
-     * List of initial set of layout servers, i.e., servers specified in
-     * connection string on bootstrap.
-     */
-    @Getter
-    private volatile List<String> bootstrapLayoutServers;
-
-    /**
-     * List of known layout servers, refreshed on each fetchLayout.
-     */
-    @Getter
-    private volatile List<String> layoutServers;
-
-    /**
-     * Node Router Pool.
-     */
-    @Getter
-    private NodeRouterPool nodeRouterPool;
-
-    /**
-     * A completable future containing a layout, when completed.
-     */
-    public volatile CompletableFuture<Layout> layout;
-
-    /**
-     * The {@link UUID} of the cluster we are currently connected to, or null, if
-     * there is no cluster yet.
-     */
-    @Getter
-    public volatile UUID clusterId;
-
-    @Getter
-    final ViewsGarbageCollector garbageCollector = new ViewsGarbageCollector(this);
-
-    /**
-     * Notifies that the runtime is no longer used
-     * and async retries to fetch the layout can be stopped.
-     */
-    @Getter
-    private volatile boolean isShutdown = false;
-
-
-    /**
-     * This thread is used by fetchLayout to find a new layout in the system
-     */
-    final ExecutorService runtimeExecutor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
-            .setDaemon(true)
-            .setNameFormat("CorfuRuntime-%d")
-            .build());
-
-    /**
-     * Latest layout seen by the runtime.
-     */
-    private volatile Layout latestLayout = null;
 
     /**
      * Register SystemDownHandler.

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -123,11 +123,11 @@ public class TableRegistry {
             // are shared across all runtime's and not overwritten (if multiple runtime's exist).
             // This aims to overcome a current design limitation where the serializers are static and not
             // per runtime (to be changed).
-            protoSerializer = Serializers.getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
+            protoSerializer = runtime.getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
         } catch (SerializerException se) {
             // This means the protobuf serializer had not been registered yet.
             protoSerializer = new ProtobufSerializer(new ConcurrentHashMap<>());
-            Serializers.registerSerializer(protoSerializer);
+            runtime.getSerializers().registerSerializer(protoSerializer);
         }
         this.protobufSerializer = protoSerializer;
         this.registryTable = this.runtime.getObjectsView().build()
@@ -397,7 +397,7 @@ public class TableRegistry {
     private <T extends Message> void addTypeToClassMap(T msg) {
         String typeUrl = getTypeUrl(msg.getDescriptorForType());
         // Register the schemas to schema table.
-        ((ProtobufSerializer)Serializers.getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE))
+        ((ProtobufSerializer)runtime.getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE))
                 .getClassMap().put(typeUrl, msg.getClass());
     }
 

--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -106,12 +106,12 @@ public class DynamicProtobufSerializer implements ISerializer {
         // Create or get a protobuf serializer to read the table registry.
         ISerializer protobufSerializer;
         try {
-            protobufSerializer = Serializers.getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
+            protobufSerializer = corfuRuntime.getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
         } catch (SerializerException se) {
             // This means the protobuf serializer had not been registered yet.
             log.info("Protobuf Serializer not found. Create and register a new one.");
             protobufSerializer = createProtobufSerializer();
-            Serializers.registerSerializer(protobufSerializer);
+            corfuRuntime.getSerializers().registerSerializer(protobufSerializer);
         }
 
         // Open the Registry Table and cache its contents
@@ -159,7 +159,7 @@ public class DynamicProtobufSerializer implements ISerializer {
         });
 
         // Remove the protobuf serializer
-        Serializers.clearCustomSerializers();
+        corfuRuntime.getSerializers().clearCustomSerializers();
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/Serializers.java
@@ -41,14 +41,14 @@ public class Serializers {
         serializersMap.put(QUEUE_SERIALIZER.getType(), QUEUE_SERIALIZER);
     }
 
-    private static final Map<Byte, ISerializer> customSerializers = new HashMap<>();
+    private final Map<Byte, ISerializer> customSerializers = new HashMap<>();
 
     /**
      * Return the serializer byte.
      * @param type A byte that tags a serializer
      * @return     A serializer that corresponds to the type byte
      */
-    public static ISerializer getSerializer(Byte type) {
+    public ISerializer getSerializer(Byte type) {
         if (type <= SYSTEM_SERIALIZERS_COUNT) {
             if (serializersMap.containsKey(type)) {
                 return serializersMap.get(type);
@@ -64,7 +64,7 @@ public class Serializers {
      * Register a serializer.
      * @param serializer Serializer to register
      */
-    public static synchronized void registerSerializer(ISerializer serializer) {
+    public synchronized void registerSerializer(ISerializer serializer) {
         if (serializer.getType() > SYSTEM_SERIALIZERS_COUNT) {
             customSerializers.put(serializer.getType(), serializer);
         } else {
@@ -77,12 +77,12 @@ public class Serializers {
     /**
      * Clear custom serializers.
      */
-    public static synchronized void clearCustomSerializers() {
+    public synchronized void clearCustomSerializers() {
         customSerializers.clear();
     }
 
     @VisibleForTesting
-    public static synchronized void removeSerializer(ISerializer serializer) {
+    public synchronized void removeSerializer(ISerializer serializer) {
         customSerializers.remove(serializer.getType());
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
@@ -144,8 +144,6 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
         Assert.assertEquals(browser.clearTable(namespace, tableName), one);
         // Invoke tableInfo and verify size
         Assert.assertEquals(browser.printTableInfo(namespace, tableName), 0);
-        // TODO: Remove this once serializers move into the runtime
-        Serializers.clearCustomSerializers();
     }
 
     /**
@@ -168,8 +166,6 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
         CorfuStoreBrowserEditor browser = new CorfuStoreBrowserEditor(runtime);
         Assert.assertEquals(browser.loadTable(namespace, tableName, numItems, batchSize, itemSize), batchSize);
         runtime.shutdown();
-        // TODO: Remove this once serializers move into the runtime
-        Serializers.clearCustomSerializers();
     }
 
     /**
@@ -229,7 +225,6 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
         assertThat(tags).containsExactly(expectedTableNameToTags.get(tableName).toArray(new String[0]));
 
         runtime.shutdown();
-        Serializers.clearCustomSerializers();
 
         assertThat(shutdownCorfuServer(corfuServer)).isTrue();
     }
@@ -285,7 +280,6 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
         assertThat(browser.printAllProtoDescriptors()).isEqualTo(expectedFiles);
 
         runtime.shutdown();
-        Serializers.clearCustomSerializers();
 
         assertThat(shutdownCorfuServer(corfuServer)).isTrue();
     }
@@ -354,8 +348,6 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
                 record.getPayload().getUnknownFields());
         }
         runtime.shutdown();
-        // TODO: Remove this once serializers move into the runtime
-        Serializers.clearCustomSerializers();
     }
 
     /**
@@ -415,8 +407,6 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
             browser.printTableInfo(TableRegistry.CORFU_SYSTEM_NAMESPACE,
         TableRegistry.REGISTRY_TABLE_NAME));
         Assert.assertEquals(1, browser.printTableInfo(namespace, tableName));
-        // Todo: Remove this once serializers move into the runtime
-        Serializers.clearCustomSerializers();
     }
 
     /**
@@ -470,8 +460,7 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
         TxnContext tx = store.txn(namespace);
         tx.putRecord(table, uuidKey, uuidVal, metadata);
         tx.commit();
-        // Todo: Remove this once serializers move into the runtime
-        Serializers.clearCustomSerializers();
+
         runtime.shutdown();
 
         runtime = createRuntime(singleNodeEndpoint);
@@ -481,8 +470,6 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
         // Verify table count
         Assert.assertEquals(1, browser.printTable(namespace, tableName));
 
-        // Todo: Remove this once serializers move into the runtime
-        Serializers.clearCustomSerializers();
         runtime.shutdown();
     }
 
@@ -561,9 +548,6 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
         keyString = "{\"msb\": \"2\", \"lsb\": \"2\"}";
         Assert.assertNull(browser.editRecord(namespace, tableName, keyString,
             newValString));
-
-        // TODO: Remove this once serializers move into the runtime
-        Serializers.clearCustomSerializers();
         runtime.shutdown();
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -135,7 +135,7 @@ public class CorfuStoreIT extends AbstractIT {
         runtime = createRuntime(singleNodeEndpoint);
 
         ISerializer dynamicProtobufSerializer = new DynamicProtobufSerializer(runtime);
-        Serializers.registerSerializer(dynamicProtobufSerializer);
+        runtime.getSerializers().registerSerializer(dynamicProtobufSerializer);
 
         CorfuTable<CorfuDynamicKey, CorfuDynamicRecord> corfuTable = runtime.getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<CorfuDynamicKey, CorfuDynamicRecord>>() {
@@ -190,7 +190,7 @@ public class CorfuStoreIT extends AbstractIT {
 
         runtime.getAddressSpaceView().prefixTrim(trimPoint);
         runtime.getAddressSpaceView().gc();
-        Serializers.clearCustomSerializers();
+        runtime.getSerializers().clearCustomSerializers();
         runtime.shutdown();
 
         // PHASE 3
@@ -244,12 +244,12 @@ public class CorfuStoreIT extends AbstractIT {
         trimToken = Token.min(trimToken, token);
 
         // Save the regular serializer first..
-        ISerializer protobufSerializer = Serializers.getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
+        ISerializer protobufSerializer = runtimeC.getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
 
         // Must register dynamicProtobufSerializer *AFTER* the getTableRegistry() call to ensure that
         // the serializer does not go back to the regular ProtobufSerializer
         ISerializer dynamicProtobufSerializer = new DynamicProtobufSerializer(runtimeC);
-        Serializers.registerSerializer(dynamicProtobufSerializer);
+        runtimeC.getSerializers().registerSerializer(dynamicProtobufSerializer);
 
         for (CorfuStoreMetadata.TableName tableName : tableRegistry.listTables(null)) {
             String fullTableName = TableRegistry.getFullyQualifiedTableName(
@@ -289,7 +289,7 @@ public class CorfuStoreIT extends AbstractIT {
         }
         // Lastly restore the regular protobuf serializer and undo the dynamic protobuf serializer
         // otherwise the test cannot continue beyond this point.
-        Serializers.registerSerializer(protobufSerializer);
+        runtimeC.getSerializers().registerSerializer(protobufSerializer);
         return trimToken;
     }
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -512,12 +512,12 @@ public class LogReplicationAbstractIT extends AbstractIT {
                 CorfuStoreMetadata.TableMetadata>> tableRegistryCT = tableRegistry.getRegistryTable();
 
         // Save the regular serializer first..
-        ISerializer protoBufSerializer = Serializers.getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
+        ISerializer protoBufSerializer = cpRuntime.getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
 
         // Must register dynamicProtoBufSerializer *AFTER* the getTableRegistry() call to ensure that
         // the serializer does not go back to the regular ProtoBufSerializer
         ISerializer dynamicProtoBufSerializer = new DynamicProtobufSerializer(cpRuntime);
-        Serializers.registerSerializer(dynamicProtoBufSerializer);
+        cpRuntime.getSerializers().registerSerializer(dynamicProtoBufSerializer);
 
         // First checkpoint the TableRegistry system table
         MultiCheckpointWriter<CorfuTable> mcw = new MultiCheckpointWriter<>();
@@ -549,7 +549,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
         // Lastly restore the regular protoBuf serializer and undo the dynamic protoBuf serializer
         // otherwise the test cannot continue beyond this point.
-        Serializers.registerSerializer(protoBufSerializer);
+        cpRuntime.getSerializers().registerSerializer(protoBufSerializer);
 
         // Trim
         log.debug("**** Trim Log @address=" + trimMark);
@@ -566,12 +566,12 @@ public class LogReplicationAbstractIT extends AbstractIT {
                 CorfuStoreMetadata.TableMetadata>> tableRegistryCT = tableRegistry.getRegistryTable();
 
         // Save the regular serializer first..
-        ISerializer protoBufSerializer = Serializers.getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
+        ISerializer protoBufSerializer = cpRuntime.getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
 
         // Must register dynamicProtoBufSerializer *AFTER* the getTableRegistry() call to ensure that
         // the serializer does not go back to the regular ProtoBufSerializer
         ISerializer dynamicProtoBufSerializer = new DynamicProtobufSerializer(cpRuntime);
-        Serializers.registerSerializer(dynamicProtoBufSerializer);
+        cpRuntime.getSerializers().registerSerializer(dynamicProtoBufSerializer);
 
         // First checkpoint the TableRegistry system table
         MultiCheckpointWriter<CorfuTable> mcw = new MultiCheckpointWriter<>();
@@ -601,7 +601,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
         // Lastly restore the regular protoBuf serializer and undo the dynamic protoBuf serializer
         // otherwise the test cannot continue beyond this point.
-        Serializers.registerSerializer(protoBufSerializer);
+        cpRuntime.getSerializers().registerSerializer(protoBufSerializer);
 
         // Trim
         log.debug("**** Trim Log @address=" + trimMark);

--- a/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
@@ -697,9 +697,8 @@ public class ReplicationReaderWriterIT extends AbstractIT {
         //verify data with hashtable
         openStreams(dstTables, dstDataRuntime, NUM_STREAMS, serializer);
 
-        Serializers.registerSerializer(serializer);
+        dstDataRuntime.getSerializers().registerSerializer(serializer);
         verifyData("after log writing at dst", dstTables, srcHashMap);
-        Serializers.removeSerializer(serializer);
 
         cleanUp();
     }

--- a/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
@@ -37,9 +37,9 @@ public class TransactionStreamIT extends AbstractIT {
      *
      * Extract the updates from the MultiObjectSMREntry and updates the counters map
      */
-    private void ConsumeDelta(Map<UUID, Integer> map, List<ILogData> deltas) {
+    private void ConsumeDelta(Map<UUID, Integer> map, List<ILogData> deltas, CorfuRuntime rt) {
         for (ILogData ld : deltas) {
-            MultiObjectSMREntry multiObjSmr = (MultiObjectSMREntry) ld.getPayload(null);
+            MultiObjectSMREntry multiObjSmr = (MultiObjectSMREntry) ld.getPayload(rt);
             for (Map.Entry<UUID, MultiSMREntry> multiSMREntry : multiObjSmr.getEntryMap().entrySet()) {
                 for (SMREntry update : multiSMREntry.getValue().getUpdates()) {
                     int key = (int) update.getSMRArguments()[0];
@@ -97,7 +97,7 @@ public class TransactionStreamIT extends AbstractIT {
                 List<ILogData> entries = txStream.remaining();
 
                 if (!entries.isEmpty()) {
-                    ConsumeDelta(counters, entries);
+                    ConsumeDelta(counters, entries, consumerRt);
                 }
 
                 consumed += entries.size();

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -730,7 +730,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
     }
 
     private StreamingMap<String, Long> instantiateMap(String streamName) {
-        Serializers.registerSerializer(serializer);
+        r.getSerializers().registerSerializer(serializer);
         return r.getObjectsView()
                 .build()
                 .setStreamName(streamName)
@@ -740,7 +740,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
     }
 
     private StreamingMap<String, String> instantiateStringMap(String streamName) {
-        Serializers.registerSerializer(serializer);
+        r.getSerializers().registerSerializer(serializer);
         return r.getObjectsView()
                 .build()
                 .setStreamName(streamName)
@@ -914,7 +914,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         final String streamA = "streamA";
         final int entries = 10;
 
-        Serializers.registerSerializer(serializer);
+        r.getSerializers().registerSerializer(serializer);
         Map<String, String> mA =  r.getObjectsView()
                 .build()
                 .setStreamName(streamA)
@@ -1069,6 +1069,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
 
         // New Runtime
         CorfuRuntime rt2 = getNewRuntime(getDefaultNode()).connect();
+        rt2.getSerializers().registerSerializer(serializer);
         Map<String, Long> mA2 = rt2.getObjectsView()
                 .build()
                 .setStreamName(streamA)

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -40,7 +40,7 @@ public class CheckpointTest extends AbstractObjectTest {
     Map<String, Long> openMap(CorfuRuntime rt, String mapName) {
         final byte serializerByte = (byte) 20;
         ISerializer serializer = new CPSerializer(serializerByte);
-        Serializers.registerSerializer(serializer);
+        rt.getSerializers().registerSerializer(serializer);
         return (CorfuTable<String, Long>)
                 instantiateCorfuObject(
                         rt,

--- a/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/CorfuSMRObjectProxyTest.java
@@ -102,7 +102,7 @@ public class CorfuSMRObjectProxyTest extends AbstractObjectTest {
     public void canUseCustomSerializer() throws Exception {
         //Register a custom serializer and use it with an SMR object
         ISerializer customSerializer = new CustomSerializer((byte) (Serializers.SYSTEM_SERIALIZERS_COUNT + 1));
-        Serializers.registerSerializer(customSerializer);
+        getDefaultRuntime().getSerializers().registerSerializer(customSerializer);
         CorfuRuntime r = getDefaultRuntime();
 
         Map<String, String> test = r.getObjectsView().build()
@@ -126,7 +126,7 @@ public class CorfuSMRObjectProxyTest extends AbstractObjectTest {
     @Test
     public void doesNotResetSerializerIfMapAlreadyExists() throws Exception {
         ISerializer customSerializer = new CustomSerializer((byte) (Serializers.SYSTEM_SERIALIZERS_COUNT + 1));
-        Serializers.registerSerializer(customSerializer);
+        getDefaultRuntime().getSerializers().registerSerializer(customSerializer);
         CorfuRuntime r = getDefaultRuntime();
 
         Map<String, String> test = r.getObjectsView().build()

--- a/test/src/test/java/org/corfudb/runtime/view/stream/OpaqueStreamTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/OpaqueStreamTest.java
@@ -34,7 +34,7 @@ public class OpaqueStreamTest extends AbstractViewTest {
         CorfuRuntime rt = getDefaultRuntime();
 
         ISerializer customSerializer = new CustomSerializer((byte) (Serializers.SYSTEM_SERIALIZERS_COUNT + 2));
-        Serializers.registerSerializer(customSerializer);
+        rt.getSerializers().registerSerializer(customSerializer);
 
         UUID streamId = CorfuRuntime.getStreamID("stream1");
 
@@ -56,7 +56,7 @@ public class OpaqueStreamTest extends AbstractViewTest {
         rt.getObjectsView().TXEnd();
 
 
-        Serializers.removeSerializer(customSerializer);
+        rt.getSerializers().removeSerializer(customSerializer);
 
         CorfuRuntime rt2 = getNewRuntime(getDefaultNode()).connect();
 
@@ -79,7 +79,7 @@ public class OpaqueStreamTest extends AbstractViewTest {
     public void extractAndGenerate() {
         CorfuRuntime runtime = getDefaultRuntime();
         ISerializer customSerializer = new CustomSerializer((byte) (Serializers.SYSTEM_SERIALIZERS_COUNT + 2));
-        Serializers.registerSerializer(customSerializer);
+        runtime.getSerializers().registerSerializer(customSerializer);
 
         UUID streamId = UUID.randomUUID();
 
@@ -97,7 +97,7 @@ public class OpaqueStreamTest extends AbstractViewTest {
         }
         runtime.getObjectsView().TXEnd();
 
-        Serializers.removeSerializer(customSerializer);
+        runtime.getSerializers().removeSerializer(customSerializer);
 
         CorfuRuntime newRuntime = getNewRuntime(getDefaultNode()).connect();
 
@@ -112,7 +112,7 @@ public class OpaqueStreamTest extends AbstractViewTest {
         CorfuRuntime rt = getDefaultRuntime();
 
         ISerializer customSerializer = new CustomSerializer((byte) (Serializers.SYSTEM_SERIALIZERS_COUNT + 2));
-        Serializers.registerSerializer(customSerializer);
+        rt.getSerializers().registerSerializer(customSerializer);
 
         UUID streamId = CorfuRuntime.getStreamID("stream1");
 
@@ -137,7 +137,7 @@ public class OpaqueStreamTest extends AbstractViewTest {
 
         rt.getAddressSpaceView().prefixTrim(token);
 
-        Serializers.removeSerializer(customSerializer);
+        rt.getSerializers().removeSerializer(customSerializer);
 
         CorfuRuntime rt2 = getNewRuntime(getDefaultNode()).connect();
 

--- a/test/src/test/java/org/corfudb/util/serializer/SerializersTest.java
+++ b/test/src/test/java/org/corfudb/util/serializer/SerializersTest.java
@@ -1,6 +1,9 @@
 package org.corfudb.util.serializer;
 
 import org.corfudb.CustomSerializer;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,13 +11,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * This test class verifies that multiple custom serializers can be registered.
  */
-public class SerializersTest {
+public class SerializersTest extends AbstractViewTest {
+
+    public CorfuRuntime corfuRuntime;
+
+    @Before
+    public void setRuntime() throws Exception {
+        corfuRuntime = getDefaultRuntime().connect();
+    }
 
     @Test (expected = RuntimeException.class)
     public void registerSerializerWithInvalidTypeTest() {
         final byte SERIALIZER_TYPE0 = 10;
         ISerializer customSerializer = new CustomSerializer(SERIALIZER_TYPE0);
-        Serializers.registerSerializer(customSerializer);
+        corfuRuntime.getSerializers().registerSerializer(customSerializer);
     }
 
     @Test
@@ -25,10 +35,10 @@ public class SerializersTest {
         ISerializer customSerializer1 = new CustomSerializer(type1);
         ISerializer customSerializer2 = new CustomSerializer(type2);
 
-        Serializers.registerSerializer(customSerializer1);
-        Serializers.registerSerializer(customSerializer2);
+        corfuRuntime.getSerializers().registerSerializer(customSerializer1);
+        corfuRuntime.getSerializers().registerSerializer(customSerializer2);
 
-        assertThat(Serializers.getSerializer(type1)).isEqualTo(customSerializer1);
-        assertThat(Serializers.getSerializer(type2)).isEqualTo(customSerializer2);
+        assertThat(corfuRuntime.getSerializers().getSerializer(type1)).isEqualTo(customSerializer1);
+        assertThat(corfuRuntime.getSerializers().getSerializer(type2)).isEqualTo(customSerializer2);
     }
 }


### PR DESCRIPTION
Different corfu runtime instances can have different custom serializers based on
the opened tables. The existing serializers is a static member shared by all
corfu runtimes in a JVM which is problematic when multiple runtimes register
their own custom serialzier.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
