### PR TITLE
[DO NOT REVIEW]Remove Docker layer cache step from CICD

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -13,6 +13,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.runtime.view.stream.StreamAddressSpace;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.IntervalRetry;
@@ -26,9 +27,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-
-import static org.corfudb.runtime.view.ObjectsView.LOG_REPLICATOR_STREAM_ID;
-import static org.corfudb.runtime.view.ObjectsView.TRANSACTION_STREAM_ID;
 
 @Slf4j
 public class LogReplicationAckReader {
@@ -170,11 +168,11 @@ public class LogReplicationAckReader {
     }
 
     private long getTxStreamTail(Map<UUID, Long> tailMap) {
-        if (tailMap.containsKey(LOG_REPLICATOR_STREAM_ID)) {
-            return tailMap.get(LOG_REPLICATOR_STREAM_ID);
+        if (tailMap.containsKey(ObjectsView.getLogReplicatorStreamId())) {
+            return tailMap.get(ObjectsView.getLogReplicatorStreamId());
         }
 
-        log.warn("Tx Stream tail not present in sequencer, id={}", LOG_REPLICATOR_STREAM_ID);
+        log.warn("Tx Stream tail not present in sequencer, id={}", ObjectsView.getLogReplicatorStreamId());
         return Address.NON_ADDRESS;
     }
 
@@ -322,7 +320,7 @@ public class LogReplicationAckReader {
         long totalEntries = 0;
 
         if (upperBoundary > lowerBoundary) {
-            StreamAddressRange range = new StreamAddressRange(LOG_REPLICATOR_STREAM_ID, upperBoundary, lowerBoundary);
+            StreamAddressRange range = new StreamAddressRange(ObjectsView.getLogReplicatorStreamId(), upperBoundary, lowerBoundary);
             StreamAddressSpace txStreamAddressSpace = runtime.getSequencerView().getStreamAddressSpace(range);
             // Count how many entries are present in the Tx Stream (this can include holes,
             // valid entries and invalid entries), but we count them all (equal weight).

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
@@ -308,7 +308,7 @@ public class StreamsLogEntryReader implements LogEntryReader {
         public TxOpaqueStream(CorfuRuntime rt) {
             //create an opaque stream for transaction stream
             this.rt = rt;
-            txStream = new OpaqueStream(rt.getStreamsView().get(ObjectsView.LOG_REPLICATOR_STREAM_ID));
+            txStream = new OpaqueStream(rt.getStreamsView().get(ObjectsView.getLogReplicatorStreamId()));
             streamUpTo();
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -1,7 +1,10 @@
 package org.corfudb.runtime.view;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.Token;
@@ -44,7 +47,15 @@ public class ObjectsView extends AbstractView {
     // We are temporarily naming this stream with the same name as TRANSACTION_STREAM_ID to avoid breaking LR code
     // while transition to UFO is completed (once migration is complete to UFO this stream can be renamed)
     // add a prefix to the name: e.g., org.corfudb.logreplication.transactionstream
-    public static final UUID LOG_REPLICATOR_STREAM_ID = CorfuRuntime.getStreamID("Transaction_Stream");
+    static final StreamTagInfo LOG_REPLICATOR_STREAM_INFO =
+            new StreamTagInfo("Transaction_Stream", CorfuRuntime.getStreamID("Transaction_Stream"));
+
+    /**
+     * @return the ID of the log replicator stream.
+     */
+    public static UUID getLogReplicatorStreamId() {
+        return LOG_REPLICATOR_STREAM_INFO.getStreamId();
+    }
 
     @Getter
     @Setter
@@ -216,6 +227,21 @@ public class ObjectsView extends AbstractView {
 
         public String toString() {
             return "[" + streamID + ", " + type.getSimpleName() + "]";
+        }
+    }
+
+    @AllArgsConstructor
+    @Getter
+    @EqualsAndHashCode
+    static final class StreamTagInfo {
+        @NonNull
+        private final String tagName;
+        @NonNull
+        private final UUID streamId;
+
+        @Override
+        public String toString() {
+            return "[" + tagName + ", " + streamId.toString() + "]";
         }
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -229,7 +229,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
             consumerRts.add(consumerRt);
 
-            IStreamView txStream = consumerRt.getStreamsView().get(ObjectsView.LOG_REPLICATOR_STREAM_ID);
+            IStreamView txStream = consumerRt.getStreamsView().get(ObjectsView.getLogReplicatorStreamId());
 
             int counter = 0;
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -301,7 +301,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
             long tail = Utils.getLogAddressSpace(rt
                     .getLayoutView().getRuntimeLayout())
                     .getAddressMap()
-                    .get(ObjectsView.LOG_REPLICATOR_STREAM_ID).getTail();
+                    .get(ObjectsView.getLogReplicatorStreamId()).getTail();
             expectedAckTimestamp = Math.max(tail, expectedAckTimestamp);
         }
 
@@ -700,7 +700,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         expectedAckMessages = Utils.getLogAddressSpace(srcDataRuntime
                 .getLayoutView().getRuntimeLayout())
                 .getAddressMap()
-                .get(ObjectsView.LOG_REPLICATOR_STREAM_ID).getTail();
+                .get(ObjectsView.getLogReplicatorStreamId()).getTail();
 
         LogReplicationFSM fsm = startLogEntrySync(replicateTables, WAIT.ON_ACK);
 

--- a/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/ReplicationReaderWriterIT.java
@@ -253,7 +253,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
                 .cacheEntries(false)
                 .build();
 
-        IStreamView txStream = rt.getStreamsView().getUnsafe(ObjectsView.LOG_REPLICATOR_STREAM_ID, options);
+        IStreamView txStream = rt.getStreamsView().getUnsafe(ObjectsView.getLogReplicatorStreamId(), options);
         List<ILogData> dataList = txStream.remaining();
         log.debug("\ndataList size " + dataList.size());
         for (ILogData data : txStream.remaining()) {
@@ -455,7 +455,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
         generateTransactions(srcTables, srcHashMap, NUM_TRANSACTIONS, srcDataRuntime, NUM_KEYS);
 
         // Open a tx stream
-        IStreamView txStream = srcTestRuntime.getStreamsView().get(ObjectsView.LOG_REPLICATOR_STREAM_ID);
+        IStreamView txStream = srcTestRuntime.getStreamsView().get(ObjectsView.getLogReplicatorStreamId());
         long tail = srcDataRuntime.getAddressSpaceView().getLogTail();
         Stream<ILogData> stream = txStream.streamUpTo(tail);
         Iterator<ILogData> iterator = stream.iterator();


### PR DESCRIPTION
Log stream tag names and their corresponding UUIDs when opening
a table through the TableRegistry.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
