### PR TITLE
Add numOfEntries as a threshold in checkpointer's batching strategy

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -158,6 +158,11 @@ public class CorfuRuntime {
         int checkpointRetries = 5;
 
         /*
+         * The maximum number of SMR entries that will be grouped in a CheckpointEntry.CONTINUATION
+         */
+        int checkpointBatchSize = 50;
+
+        /*
          * Stream Batch Size: number of addresses to fetch in advance when stream address discovery mechanism
          * relies on address maps instead of follow backpointers, i.e., followBackpointersEnabled = false;
          */
@@ -282,6 +287,7 @@ public class CorfuRuntime {
             private int writeRetry = 5;
             private int trimRetry = 2;
             private int checkpointRetries = 5;
+            private int checkpointBatchSize = 50;
             private int streamBatchSize = 10;
             private int checkpointReadBatchSize = 5;
             private Duration runtimeGCPeriod = Duration.ofMinutes(20);
@@ -490,6 +496,11 @@ public class CorfuRuntime {
                 return this;
             }
 
+            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder checkpointBatchSize(int checkpointBatchSize) {
+                this.checkpointBatchSize = checkpointBatchSize;
+                return this;
+            }
+
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder streamBatchSize(int streamBatchSize) {
                 this.streamBatchSize = streamBatchSize;
                 return this;
@@ -615,6 +626,7 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setWriteRetry(writeRetry);
                 corfuRuntimeParameters.setTrimRetry(trimRetry);
                 corfuRuntimeParameters.setCheckpointRetries(checkpointRetries);
+                corfuRuntimeParameters.setCheckpointBatchSize(checkpointBatchSize);
                 corfuRuntimeParameters.setStreamBatchSize(streamBatchSize);
                 corfuRuntimeParameters.setCheckpointReadBatchSize(checkpointReadBatchSize);
                 corfuRuntimeParameters.setRuntimeGCPeriod(runtimeGCPeriod);

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -310,10 +310,9 @@ public class WorkflowIT extends AbstractIT {
         // +1 because of extra NO_OP entry added by checkpointer
         assertThat(runtime.getAddressSpaceView().getTrimMark().getSequence()).isEqualTo(entriesCount+1);
 
-        /* 2 Checkpoint entries for the start and end.
-+         * 1000 entries being checkpointed into just 1 entry after removing the batchSize dependency
-+         */
-        final int checkpointEntriesCount = 3;
+        // 2 Checkpoint entries for the start and end.
+        // 1000 entries being checkpointed = 20 checkpoint entries due to batch size of 50.
+        final int checkpointEntriesCount = 22;
 
         // Write another batch of 1_000 entries.
         for (int i = 0; i < entriesCount; i++) {

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -712,6 +712,69 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         }
     }
 
+    /** Test the CheckpointWriter batch size.
+     *
+     * CheckpointWriter aggregates a batch of SMREntries into one
+     * CheckpointEntry. This test verifies that only given number
+     * of SMR entries (batchSize) will be grouped in one checkpoint
+     * entry.
+     */
+    @Test
+    @SuppressWarnings("checkstyle:magicnumber")
+    public void checkpointBatchSizeTest() throws Exception {
+        final String streamName = "mystream8";
+        final UUID streamId = CorfuRuntime.getStreamID(streamName);
+        final int numKeys = 123;
+
+        StreamingMap<String, String> m = instantiateStringMap(streamName);
+
+        for (int i = 0; i < numKeys; i++) {
+            // each entry is 1 KB
+            String key = String.valueOf(i);
+            String payload = getRandomStringOfSize(1 << 10);
+            m.put(key, payload);
+        }
+
+        // disable payload compression
+        getRuntime().getParameters().setCodecType(Codec.Type.NONE);
+        CheckpointWriter cpw = new CheckpointWriter(r, streamId, "author", m);
+        cpw.setSerializer(serializer);
+
+        // Write all CP data.
+        r.getObjectsView().TXBuild()
+                .type(TransactionType.SNAPSHOT)
+                .build()
+                .begin();
+        Token snapshot = TransactionalContext
+                .getCurrentContext()
+                .getSnapshotTimestamp();
+        try {
+            cpw.startCheckpoint(snapshot);
+            cpw.appendObjectState(m.entryStream());
+            cpw.finishCheckpoint();
+        } finally {
+            r.getObjectsView().TXEnd();
+        }
+
+        // check the number of SMR entries in each CheckpointEntry is 50, 50, and 23
+        setRuntime();
+        long startAddress = snapshot.getSequence() + 1;
+        assertThat(r.getAddressSpaceView().read(startAddress).getCheckpointType())
+                .isEqualTo(CheckpointEntry.CheckpointEntryType.START);
+
+        final long contRecordffset = startAddress + 1;
+        LogEntry cpEntry = (CheckpointEntry) r.getAddressSpaceView().read(contRecordffset).getPayload(r);
+        assertThat(((CheckpointEntry) cpEntry).getSmrEntries().getUpdates().size()).isEqualTo(50);
+
+        final long cont2Recordffset = startAddress + 2;
+        cpEntry = (CheckpointEntry) r.getAddressSpaceView().read(cont2Recordffset).getPayload(r);
+        assertThat(((CheckpointEntry) cpEntry).getSmrEntries().getUpdates().size()).isEqualTo(50);
+
+        final long cont3Recordffset = startAddress + 3;
+        cpEntry = (CheckpointEntry) r.getAddressSpaceView().read(cont3Recordffset).getPayload(r);
+        assertThat(((CheckpointEntry) cpEntry).getSmrEntries().getUpdates().size()).isEqualTo(23);
+    }
+
     private int getSerializedSMREntrySize(
             String key, String value, Function<Object, Object> keyMutator, Function<Object, Object> valueMutator, ISerializer serializer) {
         ByteBuf b = Unpooled.buffer();


### PR DESCRIPTION
When checkpointer batches SMR entries, comparing only serialized and compressed
entry size could cause OOM since it might read too many entries into memory before
serialization and compression. Add new threshold numOfEntries as a quick fix.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
