### PR TITLE
Adding metrics: avg-entry-size in readCache and size of readCache.

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
@@ -33,9 +33,11 @@ Logger name should be "org.corfudb.client.metricsdata".
 * **vlo.no_rollback_exception.count**: Number of times we were unable to roll back the particular stream by applying undo records in the reverse order.
 * **vlo.sync.rate**: Rate of updates applied/unapplied (mean, max and throughput) to a particular stream, distinguished by a type of update (apply and undo).
 * **vlo.read.rate**: Rate of access to the internal state of the corfu object (mean, max and throughput) backed by a particular stream, distinguished by a type of access (optimistic and pessimistic).
+* **address_space.read_cache.avg_entry_size**: The estimated average size of an entry in the address space cache, in bytes.
 * **address_space.read_cache.miss_ratio**: Ratio of cache read requests which were misses to the Corfu client address space.
 * **address_space.read_cache.load_count**: The total number of times that Corfu client address space cache reads resulted in the load of new values.
 * **address_space.read_cache.load_exception_count**: The number of times Corfu client address space cache lookups threw an exception while loading a new value.
+* **address_space.read_cache.size**: The number of entries in the address space cache.
 * **address_space.read.latency**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes a client to read an object from an address or a range of addresses.
 * **address_space.write.latency**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes a client to write the given log data using a token.
 * **address_space.log_data.size.bytes**: A size estimate distribution in bytes (mean, max, 0.50p, 0.95p, 0.99p) of the log data payload read or written through the address space API.

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -117,11 +117,10 @@ public class AddressSpaceView extends AbstractView {
                 .recordStats()
                 .build();
 
-        Optional<MeterRegistry> metricsRegistry = MeterRegistryProvider.getInstance();
         MicroMeterUtils.gauge("address_space.read_cache.hit_ratio", readCache, cache -> cache.stats().hitRate());
-        MicroMeterUtils.gauge("address_space.read_cache.estimated_avg_entry_size",
-                readCache.size() != 0 ? (currentDataSizeInCache.get() / readCache.size()) : 0);
+        MicroMeterUtils.gauge("address_space.read_cache.estimated_avg_entry_size", calculateEstimatedAvgEntrySize());
         MicroMeterUtils.gauge("address_space.read_cache.cache_size", readCache, cache -> cache.size());
+        Optional<MeterRegistry> metricsRegistry = MeterRegistryProvider.getInstance();
         metricsRegistry.map(registry -> GuavaCacheMetrics.monitor(registry, readCache, "address_space.read_cache"));
     }
 
@@ -129,11 +128,19 @@ public class AddressSpaceView extends AbstractView {
         if (log.isTraceEnabled()) {
             log.trace("handleEviction: evicting {} cause {}", notification.getKey(), notification.getCause());
         }
-        updateCurrentDataSizeInCache(currentDataSizeInCache.get(), (notification.getValue().getSizeEstimate()) * -1);
+        updateCurrentDataSizeInCache(currentDataSizeInCache.get(),
+                (notification.getValue().getSizeEstimate()) * -1);
     }
 
     private void updateCurrentDataSizeInCache(long expectedSize, int delta) {
         currentDataSizeInCache.compareAndSet(expectedSize, expectedSize + delta);
+    }
+
+    private double calculateEstimatedAvgEntrySize() {
+        if (readCache.size() == 0) {
+            return 0;
+        }
+        return currentDataSizeInCache.get() / readCache.size();
     }
 
 


### PR DESCRIPTION

## Overview

Description:

Why should this be merged:  This change will help to tune the address space cache without having to analyze the heap dump

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
