### PR TITLE
Unify Stream Trim Mark Values

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -806,7 +806,7 @@ public class SequencerServer extends AbstractServer {
                         .getAddressesInRange(getStreamAddressRange(streamAddressRange));
                 requestedAddressSpaces.put(streamId, addressesInRange);
             } else {
-                requestedAddressSpaces.put(streamId, new StreamAddressSpace(Address.NON_EXIST, Collections.EMPTY_SET));
+                requestedAddressSpaces.put(streamId, new StreamAddressSpace(Address.NON_ADDRESS, Collections.EMPTY_SET));
             }
         }
 

--- a/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/SequencerViewTest.java
@@ -28,6 +28,22 @@ public class SequencerViewTest extends AbstractViewTest {
     }
 
     @Test
+    public void testEmptyStreamDefaultValues() {
+        CorfuRuntime r = getDefaultRuntime();
+
+        assertThat(r.getSequencerView().query().getSequence()).isEqualTo(Address.NON_ADDRESS);
+        UUID steamId = UUID.randomUUID();
+        assertThat(r.getSequencerView()
+                .getStreamAddressSpace(new StreamAddressRange(steamId, Address.MAX, -1)).getTrimMark())
+                .isEqualTo(Address.NON_ADDRESS);
+        r.getSequencerView().next(steamId);
+        StreamAddressSpace sas = r.getSequencerView()
+                .getStreamAddressSpace(new StreamAddressRange(steamId, Address.MAX, -1));
+        assertThat(sas.getTrimMark()).isEqualTo(Address.NON_ADDRESS);
+        assertThat(sas.toArray()).containsExactly(0L);
+    }
+
+    @Test
     public void canQueryMultipleStreams() {
         CorfuRuntime r = getDefaultRuntime();
 


### PR DESCRIPTION
## Overview
Use the same default value for a stream's trim mark whether it
exists or not.

Why should this be merged: Simplifies code that needs to use the StreamAddressSpace::getTrimMark

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
