### PR TITLE
TxnContext: Don't log a warning on empty transactions

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
@@ -826,7 +826,7 @@ public class TxnContext implements AutoCloseable {
                 tablesInTxn.values().forEach(t -> t.getMetrics().recordReadWriteTxnTime(startTxSample));
                 break;
             default:
-                log.warn("UNKNOWN TxnType! Started a transaction but no operations done?!");
+                log.trace("Started a transaction but neither read nor writes were actually done");
                 break;
         }
 


### PR DESCRIPTION
Some logic might result in commit() being called on
a transaction with no reads or writes.
Treat this as a normal case and avoid logging a warning
to reduce noise in the logs.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
