### PR TITLE
Introduce KeyDynamicProtobufSerializer and OpaqueCorfuDynamicRecord

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/OpaqueCorfuDynamicRecord.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/OpaqueCorfuDynamicRecord.java
@@ -1,0 +1,76 @@
+package org.corfudb.runtime.collections;
+
+import com.google.protobuf.ByteString;
+import lombok.Getter;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class OpaqueCorfuDynamicRecord {
+
+    /**
+     * TypeUrl generated for the value on serialization and populated in the Any message.
+     */
+    @Getter
+    private final String payloadTypeUrl;
+
+    /**
+     * Payload of the value stored in the CorfuTable.
+     */
+    @Getter
+    public final ByteString payload;
+
+    /**
+     * TypeUrl generated for the metadata on serialization and populated in the Any message.
+     */
+    @Getter
+    private final String metadataTypeUrl;
+
+    /**
+     * Payload of the metadata stored in the CorfuTable.
+     */
+    @Getter
+    public final ByteString metadata;
+
+    public OpaqueCorfuDynamicRecord(@Nonnull String payloadTypeUrl,
+                              @Nonnull ByteString payload,
+                              @Nullable String metadataTypeUrl,
+                              @Nullable ByteString metadata) {
+        this.payloadTypeUrl = payloadTypeUrl;
+        this.payload = payload;
+        this.metadataTypeUrl = metadataTypeUrl;
+        this.metadata = metadata;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(payloadTypeUrl, payload, metadataTypeUrl, metadata);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!(obj instanceof OpaqueCorfuDynamicRecord)) {
+            return false;
+        }
+        OpaqueCorfuDynamicRecord opaqueCorfuDynamicRecord = (OpaqueCorfuDynamicRecord) obj;
+
+        // Compare the payload.
+        boolean payloadMatch = payloadTypeUrl.equals(opaqueCorfuDynamicRecord.payloadTypeUrl)
+                && payload.equals(opaqueCorfuDynamicRecord.payload);
+
+        // Compare the metadata.
+        boolean metadataMatch = metadata.equals(opaqueCorfuDynamicRecord.metadata);
+
+        // Compare the metadata typeUrl. The typeUrl is null if there is no metadata.
+        boolean metadataTypeUrlMatch;
+        if (metadataTypeUrl == null) {
+            metadataTypeUrlMatch = opaqueCorfuDynamicRecord.metadataTypeUrl == null;
+        } else {
+            metadataTypeUrlMatch = metadataTypeUrl.equals(opaqueCorfuDynamicRecord.metadataTypeUrl);
+        }
+
+        return payloadMatch && metadataTypeUrlMatch && metadataMatch;
+    }
+
+}

--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -84,7 +84,7 @@ public class DynamicProtobufSerializer implements ISerializer {
      * This map is generated on initialization.
      * Maps the Message name to the name of the FileDescriptorProto containing it.
      */
-    private final ConcurrentMap<String, String> messagesFdProtoNameMap = new ConcurrentHashMap<>();
+    protected final ConcurrentMap<String, String> messagesFdProtoNameMap = new ConcurrentHashMap<>();
 
     /**
      * This is used as a file descriptor cache. Used for optimization.
@@ -211,7 +211,7 @@ public class DynamicProtobufSerializer implements ISerializer {
      * @return FileDescriptor.
      * @throws DescriptorValidationException If FileDescriptor construction fails.
      */
-    private FileDescriptor getDescriptor(String name) throws DescriptorValidationException {
+    protected FileDescriptor getDescriptor(String name) throws DescriptorValidationException {
 
         if (fileDescriptorMap.containsKey(name)) {
             return fileDescriptorMap.get(name);
@@ -243,7 +243,7 @@ public class DynamicProtobufSerializer implements ISerializer {
      * @param message Any message.
      * @return Message name.
      */
-    private String getMessageName(Any message) {
+    protected String getMessageName(Any message) {
         String typeUrl = message.getTypeUrl();
         String messageName = typeUrl.substring(typeUrl.lastIndexOf('.') + 1);
         if (messageName.contains("/")) {
@@ -262,7 +262,7 @@ public class DynamicProtobufSerializer implements ISerializer {
      * @param message Any message.
      * @return Full name of the message.
      */
-    private String getFullMessageName(Any message) {
+    protected String getFullMessageName(Any message) {
         String typeUrl = message.getTypeUrl();
         return typeUrl.substring(typeUrl.lastIndexOf('/') + 1);
     }

--- a/runtime/src/main/java/org/corfudb/util/serializer/KeyDynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/KeyDynamicProtobufSerializer.java
@@ -1,0 +1,135 @@
+package org.corfudb.util.serializer;
+
+import com.google.protobuf.Any;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufInputStream;
+import io.netty.buffer.ByteBufOutputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata;
+import org.corfudb.runtime.collections.CorfuDynamicKey;
+import org.corfudb.runtime.collections.OpaqueCorfuDynamicRecord;
+import org.corfudb.runtime.exceptions.SerializerException;
+
+import java.io.IOException;
+
+@Slf4j
+public class KeyDynamicProtobufSerializer extends DynamicProtobufSerializer {
+
+    public KeyDynamicProtobufSerializer(CorfuRuntime corfuRuntime) {
+        super(corfuRuntime);
+    }
+
+    /**
+     * Deserialize an object from a given byte buffer.
+     *
+     * @param b The bytebuf to deserialize.
+     * @return The deserialized object.
+     */
+    @Override
+    public Object deserialize(ByteBuf b, CorfuRuntime rt) {
+
+        try (ByteBufInputStream bbis = new ByteBufInputStream(b)) {
+            ProtobufSerializer.MessageType type = ProtobufSerializer.MessageType.valueOf(bbis.readInt());
+            int size = bbis.readInt();
+            byte[] data = new byte[size];
+            bbis.readFully(data);
+            CorfuStoreMetadata.Record corfuRecord = CorfuStoreMetadata.Record.parseFrom(data);
+            Any payload = corfuRecord.getPayload();
+
+            String fullMessageName = getFullMessageName(payload);
+            if (!messagesFdProtoNameMap.containsKey(fullMessageName)) {
+                log.error("messagesFdProtoNameMap doesn't contain the message type {} of payload {}." +
+                                "Please check if the related table is properly opened with correct schema.",
+                        fullMessageName, payload);
+                log.error("messagesFdProtoNameMap keySet is {}", messagesFdProtoNameMap.keySet());
+            }
+
+            if (type.equals(ProtobufSerializer.MessageType.KEY)) {
+                Descriptors.FileDescriptor valueFileDescriptor
+                        = getDescriptor(messagesFdProtoNameMap.get(fullMessageName));
+                Descriptors.Descriptor valueDescriptor = valueFileDescriptor.findMessageTypeByName(getMessageName(payload));
+                DynamicMessage value = DynamicMessage.parseFrom(valueDescriptor, payload.getValue());
+                return new CorfuDynamicKey(payload.getTypeUrl(), value);
+            }
+
+            String metadataTypeUrl = null;
+            ByteString metaDataByteString = null;
+            if (corfuRecord.hasMetadata()) {
+                Any anyMetadata = corfuRecord.getMetadata();
+                metadataTypeUrl = anyMetadata.getTypeUrl();
+                metaDataByteString = anyMetadata.getValue();
+
+                String fullMetadataMessageName = getFullMessageName(anyMetadata);
+                if (!messagesFdProtoNameMap.containsKey(fullMetadataMessageName)) {
+                    log.error("messagesFdProtoNameMap doesn't contain the message type {} of metadata {}." +
+                                    "Please check if the related table is properly opened with correct schema.",
+                            fullMetadataMessageName, anyMetadata);
+                    log.error("messagesFdProtoNameMap keySet is {}", messagesFdProtoNameMap.keySet());
+                }
+            }
+            return new OpaqueCorfuDynamicRecord(payload.getTypeUrl(), payload.getValue(), metadataTypeUrl, metaDataByteString);
+
+        } catch (IOException | Descriptors.DescriptorValidationException ie) {
+            log.error("Exception during deserialization!", ie);
+            throw new SerializerException(ie);
+        }
+    }
+
+    /**
+     * Serialize an object into a given byte buffer.
+     *
+     * @param o The object to serialize.
+     * @param b The bytebuf to serialize it into.
+     */
+    @Override
+    public void serialize(Object o, ByteBuf b) {
+
+        CorfuStoreMetadata.Record corfuRecord;
+        ProtobufSerializer.MessageType messageType;
+
+        if (o instanceof OpaqueCorfuDynamicRecord) {
+            OpaqueCorfuDynamicRecord opaqueRecord = (OpaqueCorfuDynamicRecord) o;
+
+            Any message = Any.newBuilder()
+                    .setTypeUrl(opaqueRecord.getPayloadTypeUrl())
+                    .setValue(opaqueRecord.getPayload())
+                    .build();
+            CorfuStoreMetadata.Record.Builder recordBuilder = CorfuStoreMetadata.Record.newBuilder()
+                    .setPayload(message);
+            if (opaqueRecord.getMetadata() != null) {
+                Any metadata = Any.newBuilder()
+                        .setTypeUrl(opaqueRecord.getMetadataTypeUrl())
+                        .setValue(opaqueRecord.getMetadata())
+                        .build();
+                recordBuilder.setMetadata(metadata);
+            }
+            corfuRecord = recordBuilder.build();
+            messageType = ProtobufSerializer.MessageType.VALUE;
+        } else {
+            CorfuDynamicKey corfuKey = (CorfuDynamicKey) o;
+            Any message = Any.newBuilder()
+                    .setTypeUrl(corfuKey.getKeyTypeUrl())
+                    .setValue(corfuKey.getKey().toByteString())
+                    .build();
+            corfuRecord = CorfuStoreMetadata.Record.newBuilder()
+                    .setPayload(message)
+                    .build();
+            messageType = ProtobufSerializer.MessageType.KEY;
+        }
+        byte[] data = corfuRecord.toByteArray();
+
+        try (ByteBufOutputStream bbos = new ByteBufOutputStream(b)) {
+            bbos.writeInt(messageType.val);
+            bbos.writeInt(data.length);
+            bbos.write(data);
+        } catch (IOException ie) {
+            log.error("Exception during serialization!", ie);
+            throw new SerializerException(ie);
+        }
+    }
+
+}

--- a/runtime/src/main/java/org/corfudb/util/serializer/KeyDynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/KeyDynamicProtobufSerializer.java
@@ -16,6 +16,13 @@ import org.corfudb.runtime.exceptions.SerializerException;
 
 import java.io.IOException;
 
+/**
+ * This Protobuf serializer class is based on the {@link DynamicProtobufSerializer}. The difference
+ * is that this KeyDynamicProtobufSerializer uses {@link OpaqueCorfuDynamicRecord} which has
+ * ByteString-format message payload. For the use cases where deserializing Any message from ByteString
+ * is not required (such as compactor), this serializer has lower memory usage ({@link DynamicMessage} has overhead)
+ * and is more efficient.
+ */
 @Slf4j
 public class KeyDynamicProtobufSerializer extends DynamicProtobufSerializer {
 
@@ -63,6 +70,7 @@ public class KeyDynamicProtobufSerializer extends DynamicProtobufSerializer {
                 metadataTypeUrl = anyMetadata.getTypeUrl();
                 metaDataByteString = anyMetadata.getValue();
 
+                // Check message type to detect any wrong schema / schema corruption
                 String fullMetadataMessageName = getFullMessageName(anyMetadata);
                 if (!messagesFdProtoNameMap.containsKey(fullMetadataMessageName)) {
                     log.error("messagesFdProtoNameMap doesn't contain the message type {} of metadata {}." +

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.runtime.checkpoint;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.runtime.view.TableRegistry.getFullyQualifiedTableName;
 import static org.junit.Assert.fail;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.reflect.TypeToken;
@@ -27,18 +28,30 @@ import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CheckpointWriter;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.MultiCheckpointWriter;
+import org.corfudb.runtime.collections.CorfuDynamicKey;
+import org.corfudb.runtime.collections.CorfuRecord;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.collections.OpaqueCorfuDynamicRecord;
 import org.corfudb.runtime.collections.StreamingMap;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.WriteSizeException;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.ObjectOpenOption;
 import org.corfudb.runtime.view.StreamOptions;
 import org.corfudb.runtime.view.stream.AddressMapStreamView;
 import org.corfudb.runtime.view.stream.IStreamView;
+import org.corfudb.test.SampleAppliance;
+import org.corfudb.test.SampleSchema;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.KeyDynamicProtobufSerializer;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -773,6 +786,90 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         final long cont3Recordffset = startAddress + 3;
         cpEntry = (CheckpointEntry) r.getAddressSpaceView().read(cont3Recordffset).getPayload(r);
         assertThat(((CheckpointEntry) cpEntry).getSmrEntries().getUpdates().size()).isEqualTo(23);
+    }
+
+    @Test
+    public void checkpointWithoutDeserializingValueTest() throws Exception {
+        final String streamName = "mystream9";
+        final UUID streamId = CorfuRuntime.getStreamID(streamName);
+        final String namespace = "test";
+        final int numKeys = 123;
+
+        // Create and populate the test table
+        CorfuStore corfuStoreWriter = new CorfuStore(r);
+        Table table = corfuStoreWriter.openTable(namespace, streamName,
+                SampleSchema.Uuid.class,
+                SampleSchema.FirewallRule.class, SampleSchema.ManagedMetadata.class,
+                TableOptions.builder().build());
+        TxnContext txn = corfuStoreWriter.txn(namespace);
+        Map<SampleSchema.Uuid, CorfuRecord<SampleSchema.FirewallRule, SampleSchema.ManagedMetadata>> mockedMap = new HashMap<>();
+        for (int i = 0; i < numKeys; i++) {
+            SampleSchema.Uuid uuid = SampleSchema.Uuid.newBuilder().setLsb(i).setMsb(i).build();
+            SampleSchema.FirewallRule firewallRuleVal = SampleSchema.FirewallRule.newBuilder()
+                    .setRuleId(i).setRuleName("test_rule_" + i)
+                    .setInput(
+                            SampleAppliance.Appliance.newBuilder().setEndpoint("localhost_" + i))
+                    .setOutput(
+                            SampleAppliance.Appliance.newBuilder().setEndpoint("localhost_" + i))
+                    .build();
+            SampleSchema.ManagedMetadata metadata = SampleSchema.ManagedMetadata
+                    .newBuilder().setCreateUser("test_use_" + i).build();
+            txn.putRecord(table, uuid, firewallRuleVal, metadata);
+            mockedMap.put(uuid, new CorfuRecord<>(firewallRuleVal, metadata));
+        }
+        txn.commit();
+
+        // Open the table using KeyDynamicProtobufSerializer and perform checkpointing
+        setRuntime();
+        ISerializer serializer = new KeyDynamicProtobufSerializer(r);
+        r.getSerializers().registerSerializer(serializer);
+        CorfuTable<CorfuDynamicKey, OpaqueCorfuDynamicRecord> corfuTable = r.getObjectsView().build()
+                .setTypeToken(new TypeToken<CorfuTable<CorfuDynamicKey, OpaqueCorfuDynamicRecord>>() {})
+                .setStreamName(getFullyQualifiedTableName(namespace, streamName))
+                .setSerializer(serializer)
+                .addOpenOption(ObjectOpenOption.NO_CACHE)
+                .open();
+        CheckpointWriter cpw = new CheckpointWriter(r, streamId, "author", corfuTable);
+        cpw.setSerializer(serializer);
+
+        r.getObjectsView().TXBuild()
+                .type(TransactionType.SNAPSHOT)
+                .build()
+                .begin();
+        Token snapshot = TransactionalContext
+                .getCurrentContext()
+                .getSnapshotTimestamp();
+        try {
+            cpw.startCheckpoint(snapshot);
+            cpw.appendObjectState(corfuTable.entryStream());
+            cpw.finishCheckpoint();
+        } finally {
+            r.getObjectsView().TXEnd();
+        }
+
+        // Read the checkpointed table, verify that the table entries are intact
+        setRuntime();
+        CorfuStore corfuStoreReader = new CorfuStore(r);
+        Table<SampleSchema.Uuid, SampleSchema.FirewallRule, SampleSchema.ManagedMetadata> tableRead =
+                corfuStoreReader.openTable(
+                        namespace, streamName,
+                        SampleSchema.Uuid.class,
+                        SampleSchema.FirewallRule.class, SampleSchema.ManagedMetadata.class,
+                        TableOptions.builder().build());
+        TxnContext txnReader = corfuStoreReader.txn(namespace);
+
+        assertThat(mockedMap.size()).isEqualTo(tableRead.count());
+        for (Map.Entry<SampleSchema.Uuid, CorfuRecord<SampleSchema.FirewallRule, SampleSchema.ManagedMetadata>>
+                entry : mockedMap.entrySet()) {
+            CorfuStoreEntry<SampleSchema.Uuid, SampleSchema.FirewallRule, SampleSchema.ManagedMetadata> entryRead =
+                    txnReader.getRecord(tableRead, entry.getKey());
+            assertThat(entryRead.getPayload().getRuleId())
+                    .isEqualTo(entry.getValue().getPayload().getRuleId());
+            assertThat(entryRead.getPayload().getInput().getEndpoint())
+                    .isEqualTo(entry.getValue().getPayload().getInput().getEndpoint());
+            assertThat(entryRead.getMetadata().getCreateUser())
+                    .isEqualTo(entry.getValue().getMetadata().getCreateUser());
+        }
     }
 
     private int getSerializedSMREntrySize(

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -39,7 +39,6 @@ import org.corfudb.runtime.view.stream.AddressMapStreamView;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.serializer.ISerializer;
-import org.corfudb.util.serializer.Serializers;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
Deserializing CorfuDynamicRecord can be expensive. Protobuf DynamicMessage
comes with a high memory overhead. Also there are some functionalities that
doesn't require deserializing CorfuDynamicRecord, such as Compactor. The
new serializer and opaque record will allow to keep the payload and metadata
in ByteString format and only deserialize the Key message.

## Overview

Description:

Why should this be merged: 
Reduce compactor's memory usage due to DynamicMessage's overhead

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
