### PR TITLE
StreamingManager: Double stream threads for perf issues

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -367,12 +367,12 @@ public class CorfuRuntime {
         /*
          * Total number of threads in Polling Executor Pool (shared across all listeners)
          */
-        private int streamingPollingThreadPoolSize = 2;
+        private int streamingPollingThreadPoolSize = 4;
 
         /*
          * Total number of threads in Notification Executor Pool (shared across all listeners)
          */
-        private int streamingNotificationThreadPoolSize = 4;
+        private int streamingNotificationThreadPoolSize = 8;
 
         /*
          * Total time in milliseconds to block for new updates to appear in the queue, if empty.


### PR DESCRIPTION
## Overview

Description:
Current StreamManager design suffers from noisy neighbour problem. If more than 4 subscribers are slow to process notifications then all the other subscribers lag. Increase parallelism as a stop-gap measure.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
