### PR TITLE
Revert "StreamingManager: Double stream threads for perf issues (#3050)"

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -367,12 +367,12 @@ public class CorfuRuntime {
         /*
          * Total number of threads in Polling Executor Pool (shared across all listeners)
          */
-        private int streamingPollingThreadPoolSize = 4;
+        private int streamingPollingThreadPoolSize = 2;
 
         /*
          * Total number of threads in Notification Executor Pool (shared across all listeners)
          */
-        private int streamingNotificationThreadPoolSize = 8;
+        private int streamingNotificationThreadPoolSize = 4;
 
         /*
          * Total time in milliseconds to block for new updates to appear in the queue, if empty.


### PR DESCRIPTION
It is better to change the client side values instead of defaults here.

This reverts commit 36a76f470dd39d663d63acd664624f90fab4c4fc.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
