### PR TITLE
Fixing some StaticCodeAnalysis issues

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -169,7 +169,7 @@ public abstract class AbstractView {
                         throw re;
                     }
                 } else {
-                    log.warn("layoutHelper: An unknown exception occured");
+                    log.warn("layoutHelper: An unknown RuntimeException occured");
                     throw re;
                 }
             }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java
@@ -169,6 +169,7 @@ public abstract class AbstractView {
                         throw re;
                     }
                 } else {
+                    log.warn("layoutHelper: An unknown exception occured");
                     throw re;
                 }
             }

--- a/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
@@ -217,7 +217,7 @@ public class StreamAddressSpaceTest {
     @Test
     @SuppressWarnings("ConstantConditions")
     public void testEquality() {
-        assertThat(new StreamAddressSpace().equals(null)).isFalse();
+        assertThat(new StreamAddressSpace() == null).isFalse();
         assertThat(new StreamAddressSpace().equals(new StreamAddressSpace())).isTrue();
         assertThat(new StreamAddressSpace(2L, Collections.emptySet()).equals(new StreamAddressSpace())).isFalse();
         assertThat(new StreamAddressSpace(2L, Collections.emptySet())

--- a/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
+++ b/test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java
@@ -217,7 +217,7 @@ public class StreamAddressSpaceTest {
     @Test
     @SuppressWarnings("ConstantConditions")
     public void testEquality() {
-        assertThat(new StreamAddressSpace() == null).isFalse();
+        assertThat(new StreamAddressSpace().equals(null)).isFalse();
         assertThat(new StreamAddressSpace().equals(new StreamAddressSpace())).isTrue();
         assertThat(new StreamAddressSpace(2L, Collections.emptySet()).equals(new StreamAddressSpace())).isFalse();
         assertThat(new StreamAddressSpace(2L, Collections.emptySet())


### PR DESCRIPTION
1. Fixing "An instanceof check is being performed on the caught exception. Create a separate catch clause for this exception type." in two files - runtime/src/main/java/org/corfudb/runtime/view/AbstractView.java and runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
2. Fixing "Avoid using equals() to compare against null" in the file - test/src/test/java/org/corfudb/runtime/view/stream/StreamAddressSpaceTest.java

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
