### PR TITLE
[DO NOT MERGE] Change Handshake RPC to simulate a future change

### DIFF
--- a/common/src/main/java/org/corfudb/common/util/CompatibilityVectorUtils.java
+++ b/common/src/main/java/org/corfudb/common/util/CompatibilityVectorUtils.java
@@ -71,7 +71,8 @@ public class CompatibilityVectorUtils {
     public enum Feature {
         // Comma separated enum values indicating each feature along with their sequence number.
         // FEATURE_A(0),
-        ;
+        // Rolling Upgrade: A test futuristic feature
+        HANDSHAKE_V1(99999);
 
         /**
          * Contains the vectors representing the Corfu features enabled so far.

--- a/runtime/proto/service/base.proto
+++ b/runtime/proto/service/base.proto
@@ -21,11 +21,17 @@ message PingResponseMsg {
 message HandshakeRequestMsg {
   UuidMsg client_id = 1;
   UuidMsg server_id = 2;
+
+  // Rolling Upgrade: A test field to simulate a futuristic field
+  bool rollingUpgradeRequest = 999;
 }
 
 // Response sent by server in the handshake stage.
 message HandshakeResponseMsg {
   UuidMsg server_id = 1;
+
+  // Rolling Upgrade: A test field to simulate a futuristic field
+  bool rollingUpgradeResponse = 999;
 }
 
 message RestartRequestMsg {

--- a/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolBase.java
+++ b/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolBase.java
@@ -131,6 +131,7 @@ public final class CorfuProtocolBase {
                 .setHandshakeRequest(HandshakeRequestMsg.newBuilder()
                         .setClientId(getUuidMsg(clientId))
                         .setServerId(getUuidMsg(nodeId))
+                        .setRollingUpgradeRequest(true)
                         .build())
                 .build();
     }
@@ -146,6 +147,7 @@ public final class CorfuProtocolBase {
         return ResponsePayloadMsg.newBuilder()
                 .setHandshakeResponse(HandshakeResponseMsg.newBuilder()
                         .setServerId(getUuidMsg(nodeId))
+                        .setRollingUpgradeResponse(true)
                         .build())
                 .build();
     }


### PR DESCRIPTION
## Overview

Description: This commit changes the existing Handshake RPC to simulate a futuristic RPC change at Corfu in the next major releases.

- Add a field in request and response enums
- Generate a new compatibility vector feature for Handshake
- Update handshake process to log the new information

The branch `master-sync-for-rolling-upgrade` will have only those commits that are pushed for internal testing.

Why should this be merged: We need it to test the Rolling upgrade. **Please DON'T merge it.** It is open for reviews only.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
