### PR TITLE
Support Selective Streaming on Standby

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -1,10 +1,15 @@
 package org.corfudb.infrastructure.logreplication;
 
+import com.google.common.annotations.VisibleForTesting;
 import lombok.Data;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * This class represents any Log Replication Configuration,
@@ -15,35 +20,29 @@ import java.util.Set;
 @ToString
 public class LogReplicationConfig {
 
-    // Log Replication message timeout time in milliseconds.
+    // Log Replication message timeout time in milliseconds
     public static final int DEFAULT_TIMEOUT_MS = 5000;
 
-    // Log Replication default max number of messages generated at the active cluster for each batch.
+    // Log Replication default max number of messages generated at the active cluster for each batch
     public static final int DEFAULT_MAX_NUM_MSG_PER_BATCH = 10;
 
-    // Log Replication default max data message size is 64MB.
+    // Log Replication default max data message size is 64MB
     public static final int MAX_DATA_MSG_SIZE_SUPPORTED = (64 << 20);
 
-    /**
-     * percentage of log data per log replication message
-     */
+    // Percentage of log data per log replication message
     public static final int DATA_FRACTION_PER_MSG = 90;
 
-    /*
-     * Unique identifiers for all streams to be replicated across sites.
-     */
+    // Unique identifiers for all streams to be replicated across sites
     private Set<String> streamsToReplicate;
 
-    /*
-     * Snapshot Sync Batch Size(number of messages)
-     */
+    // Streaming tags on Sink/Standby (map data stream id to list of tags associated to it)
+    private Map<UUID, List<UUID>> dataStreamToTagsMap = new HashMap<>();
+
+    // Snapshot Sync Batch Size(number of messages)
     private int maxNumMsgPerBatch;
 
-    /*
-     * The Max Size of Log Replication Data Message.
-     */
+    // Max Size of Log Replication Data Message
     private int maxMsgSize;
-
 
     /**
      * The max size of data payload for the log replication message.
@@ -55,6 +54,7 @@ public class LogReplicationConfig {
      *
      * @param streamsToReplicate Unique identifiers for all streams to be replicated across sites.
      */
+    @VisibleForTesting
     public LogReplicationConfig(Set<String> streamsToReplicate) {
         this(streamsToReplicate, DEFAULT_MAX_NUM_MSG_PER_BATCH, MAX_DATA_MSG_SIZE_SUPPORTED);
     }
@@ -70,5 +70,11 @@ public class LogReplicationConfig {
         this.maxNumMsgPerBatch = maxNumMsgPerBatch;
         this.maxMsgSize = maxMsgSize;
         this.maxDataSizePerMsg = maxMsgSize * DATA_FRACTION_PER_MSG / 100;
+    }
+
+    public LogReplicationConfig(Set<String> streamsToReplicate, Map<UUID, List<UUID>> streamingTagsMap,
+                                int maxNumMsgPerBatch, int maxMsgSize) {
+        this(streamsToReplicate, maxNumMsgPerBatch, maxMsgSize);
+        this.dataStreamToTagsMap = streamingTagsMap;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -43,6 +43,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -365,6 +366,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                     .tlsEnabled((Boolean) serverContext.getServerConfig().get("--enable-tls"))
                     .systemDownHandler(() -> System.exit(SYSTEM_EXIT_ERROR_CODE))
                     .build())
+                    .setTransactionLogging(true)
                     .parseConfigurationString(localCorfuEndpoint).connect();
         }
 
@@ -415,16 +417,18 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
 
             Set<String> streamsToReplicate = replicationStreamNameTableManager.getStreamsToReplicate();
 
+            Map<UUID, List<UUID>> streamingConfigSink = replicationStreamNameTableManager.getStreamingConfigOnSink();
+
             // TODO pankti: Check if version does not match. If it does not, create an event for site discovery to
             //  do a snapshot sync.
-            boolean upgraded = replicationStreamNameTableManager
-                .isUpgraded();
+            boolean upgraded = replicationStreamNameTableManager.isUpgraded();
 
             if (upgraded) {
                 input(new DiscoveryServiceEvent(DiscoveryServiceEvent.DiscoveryServiceEventType.UPGRADE));
             }
 
-            return new LogReplicationConfig(streamsToReplicate, serverContext.getLogReplicationMaxNumMsgPerBatch(), serverContext.getLogReplicationMaxDataMessageSize());
+            return new LogReplicationConfig(streamsToReplicate, streamingConfigSink, serverContext.getLogReplicationMaxNumMsgPerBatch(),
+                    serverContext.getLogReplicationMaxDataMessageSize());
         } catch (Throwable t) {
             log.error("Exception when fetching the Replication Config", t);
             throw t;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -1,7 +1,15 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.TableRegistry;
+
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * Default testing implementation of a Log Replication Config Provider
@@ -12,9 +20,12 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
 
     private Set<String> streamsToReplicate;
 
-    private final int totalMapCount = 10;
-    private static final String TABLE_PREFIX = "Table00";
-    private static final String NAMESPACE = "LR-Test";
+    public static final int MAP_COUNT = 10;
+    public static final String TABLE_PREFIX = "Table00";
+    public static final String NAMESPACE = "LR-Test";
+    public static final String TAG_ONE = "tag_one";
+    private final int indexOne = 1;
+    private final int indexTwo = 2;
 
     public DefaultLogReplicationConfigAdapter() {
         streamsToReplicate = new HashSet<>();
@@ -23,7 +34,7 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
         streamsToReplicate.add("Table003");
 
         // Support for UFO
-        for(int i=1; i<=totalMapCount; i++) {
+        for (int i = 1; i <= MAP_COUNT; i++) {
             streamsToReplicate.add(NAMESPACE + "$" + TABLE_PREFIX + i);
         }
     }
@@ -37,5 +48,16 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
     @Override
     public String getVersion() {
         return "version_latest";
+    }
+
+    @Override
+    public Map<UUID, List<UUID>> getStreamingConfigOnSink() {
+        Map<UUID, List<UUID>> streamsToTagsMaps = new HashMap<>();
+        UUID streamTagOneDefaultId = TableRegistry.getStreamIdForStreamTag(NAMESPACE, TAG_ONE);
+        streamsToTagsMaps.put(CorfuRuntime.getStreamID(NAMESPACE + "$" + TABLE_PREFIX + indexOne),
+                Collections.singletonList(streamTagOneDefaultId));
+        streamsToTagsMaps.put(CorfuRuntime.getStreamID(NAMESPACE + "$" + TABLE_PREFIX + indexTwo),
+                Collections.singletonList(streamTagOneDefaultId));
+        return streamsToTagsMaps;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationConfigAdapter.java
@@ -1,6 +1,9 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * This Interface must be implemented by any external
@@ -12,10 +15,19 @@ import java.util.Set;
  */
 public interface ILogReplicationConfigAdapter {
 
-    /*
+    /**
      * Returns a set of fully qualified stream names to replicate
      */
     Set<String> fetchStreamsToReplicate();
 
     String getVersion();
+
+    /**
+     * Returns configuration for streaming on sink (standby)
+     *
+     * This configuration consists of a map containing data stream IDs to stream tags
+     * Note that: since data is not deserialized we have no access to stream tags corresponding
+     * to the replicated data, therefore, this data must be provided by the plugin externally.
+     */
+    Map<UUID, List<UUID>> getStreamingConfigOnSink();
 }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
@@ -102,7 +102,7 @@ public class LogReplicationServerTest {
     }
 
     /**
-     * MAke sure that the server will process {@link LogReplicationEntryMsg}
+     * Make sure that the server will process {@link LogReplicationEntryMsg}
      * and provide an appropriate {@link ResponseMsg} message.
      */
     @Test

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
@@ -344,6 +344,27 @@ public class TxnContext implements AutoCloseable {
     }
 
     /**
+     * Apply a Corfu SMREntry directly to a stream. This can be used for replaying the mutations
+     * directly into the underlying stream bypassing the object layer entirely.
+     *
+     * This API is used for LR feature, as streaming is selectively required on standby (receiver)
+     * by means of a static configuration file.
+     *
+     * @param streamId    - UUID of the stream on which the logUpdate is being added to.
+     * @param updateEntry - the actual State Machine Replicated entry.
+     * @param streamTags - stream tags associated to the given stream id
+     */
+    public void logUpdate(UUID streamId, SMREntry updateEntry, List<UUID> streamTags) {
+        operations.add(() -> {
+            if (streamTags != null) {
+                TransactionalContext.getCurrentContext().logUpdate(streamId, updateEntry, streamTags);
+            } else {
+                TransactionalContext.getCurrentContext().logUpdate(streamId, updateEntry);
+            }
+        });
+    }
+
+    /**
      * Apply a list of Corfu SMREntries directly to a stream. This can be used for replaying the mutations
      * directly into the underlying stream bypassing the object layer entirely.
      *

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -234,6 +234,8 @@ public abstract class AbstractTransactionalContext implements
 
     public abstract void logUpdate(UUID streamId, SMREntry updateEntry);
 
+    public abstract void logUpdate(UUID streamId, SMREntry updateEntry, List<UUID> streamTags);
+
     /**
      * Log a list of SMR updates to the specified Corfu stream log
      *
@@ -351,6 +353,10 @@ public abstract class AbstractTransactionalContext implements
 
     void addToWriteSet(UUID streamId, SMREntry updateEntry) {
         getWriteSetInfo().add(streamId, updateEntry);
+    }
+
+    void addToWriteSet(UUID streamId, SMREntry updateEntry, List<UUID> streamTags) {
+        getWriteSetInfo().add(streamId, updateEntry, streamTags);
     }
 
     public void addToWriteSet(UUID streamId, List<SMREntry> updateEntries) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -183,6 +183,11 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
     }
 
     @Override
+    public void logUpdate(UUID streamId, SMREntry updateEntry, List<UUID> streamTags) {
+        addToWriteSet(streamId, updateEntry, streamTags);
+    }
+
+    @Override
     public void logUpdate(UUID streamId, List<SMREntry> updateEntries) {
         addToWriteSet(streamId, updateEntries);
     }
@@ -294,7 +299,6 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
 
         super.commitTransaction();
         commitAddress = address;
-
         log.trace("Commit[{}] Written to {}", this, address);
         return address;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -89,6 +89,11 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
     }
 
     @Override
+    public void logUpdate(UUID streamId, SMREntry updateEntry, List<UUID> streamTags) {
+        throw new UnsupportedOperationException("Can't modify object during a read-only transaction!");
+    }
+
+    @Override
     public void logUpdate(UUID streamId, List<SMREntry> updateEntries) {
         throw new UnsupportedOperationException("Can't modify object during a read-only transaction!");
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetInfo.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetInfo.java
@@ -47,6 +47,15 @@ public class WriteSetInfo extends ConflictSetInfo {
         }
     }
 
+    public void add(UUID streamId, SMREntry updateEntry, List<UUID> streamTags) {
+        synchronized (getRootContext().getTransactionID()) {
+            this.streamTags.addAll(streamTags);
+            // Add the SMREntry to the list of updates for this stream.
+            writeSet.addTo(streamId, updateEntry);
+        }
+    }
+
+
     public void add(UUID streamId, List<SMREntry> updateEntries) {
         synchronized (getRootContext().getTransactionID()) {
             // add the SMRentry to the list of updates for this stream

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -33,7 +33,6 @@ import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.util.serializer.DynamicProtobufSerializer;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.ProtobufSerializer;
-import org.corfudb.util.serializer.Serializers;
 
 @Slf4j
 public class LogReplicationAbstractIT extends AbstractIT {
@@ -215,7 +214,9 @@ public class LogReplicationAbstractIT extends AbstractIT {
             activeRuntime.parseConfigurationString(activeEndpoint);
             activeRuntime.connect();
 
-            standbyRuntime = new CorfuRuntime(standbyEndpoint).connect();
+            standbyRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+            standbyRuntime.parseConfigurationString(standbyEndpoint);
+            standbyRuntime.connect();
 
             corfuStoreActive = new CorfuStore(activeRuntime);
             corfuStoreStandby = new CorfuStore(standbyRuntime);
@@ -229,7 +230,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
         mapNameToMapActive = new HashMap<>();
         mapNameToMapStandby = new HashMap<>();
 
-        for(int i=1; i<=mapCount; i++) {
+        for(int i=1; i <= mapCount; i++) {
             String mapName = TABLE_PREFIX + i;
 
             Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapActive = corfuStoreActive.openTable(

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -42,7 +42,7 @@ import java.util.concurrent.Semaphore;
 import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.corfudb.integration.ReplicationReaderWriterIT.ckStreamsAndTrim;
+import static org.corfudb.integration.LogReplicationReaderWriterIT.ckStreamsAndTrim;
 
 /**
  * Test the core components of log replication, namely, Snapshot Sync and Log Entry Sync,

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -44,7 +44,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Slf4j
-public class ReplicationReaderWriterIT extends AbstractIT {
+public class LogReplicationReaderWriterIT extends AbstractIT {
     private static final String DEFAULT_ENDPOINT = DEFAULT_HOST + ":" + DEFAULT_PORT;
     private static final int WRITER_PORT = DEFAULT_PORT + 1;
     private static final String WRITER_ENDPOINT = DEFAULT_HOST + ":" + WRITER_PORT;
@@ -95,7 +95,6 @@ public class ReplicationReaderWriterIT extends AbstractIT {
     private final List<LogReplicationEntryMsg> msgQ = new ArrayList<>();
 
     private void setupEnv() throws IOException {
-        // Start node one and populate it with data
         new CorfuServerRunner()
                 .setHost(DEFAULT_HOST)
                 .setPort(DEFAULT_PORT)
@@ -364,14 +363,13 @@ public class ReplicationReaderWriterIT extends AbstractIT {
         LogEntryWriter writer = new LogEntryWriter(config, logReplicationMetadataManager);
 
         if (msgQ.isEmpty()) {
-            log.debug("msgQ is empty");
+            log.debug("msgQ is EMPTY");
         }
 
         for (LogReplicationEntryMsg msg : msgQ) {
             writer.apply(msg);
         }
     }
-
 
     private void accessTxStream(Iterator<ILogData> iterator, int num) {
 
@@ -473,7 +471,6 @@ public class ReplicationReaderWriterIT extends AbstractIT {
         }
     }
 
-
     @Test
     public void testOpenTableAfterTrimWithoutCheckpoint () throws IOException {
         final int offset = 20;
@@ -528,7 +525,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
     }
 
     private void tearDownEnv() {
-        if(srcDataRuntime != null) {
+        if (srcDataRuntime != null) {
             srcDataRuntime.shutdown();
             srcTestRuntime.shutdown();
             readerRuntime.shutdown();
@@ -678,8 +675,6 @@ public class ReplicationReaderWriterIT extends AbstractIT {
 
     @Test
     public void testLogEntryTransferWithSerializer() throws Exception {
-        // setup environment
-        log.debug("\ntest start ok");
         setupEnv();
         ISerializer serializer = new TestSerializer(Byte.MAX_VALUE);
 
@@ -693,7 +688,6 @@ public class ReplicationReaderWriterIT extends AbstractIT {
         //play messages at dst server
         writeLogEntryMsgs(msgQ, srcHashMap.keySet(), writerRuntime);
 
-
         //verify data with hashtable
         openStreams(dstTables, dstDataRuntime, NUM_STREAMS, serializer);
 
@@ -702,6 +696,7 @@ public class ReplicationReaderWriterIT extends AbstractIT {
 
         cleanUp();
     }
+
 
 
     /**

--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -102,3 +102,18 @@ message SampleTableDMsg {
 extend google.protobuf.MessageOptions {
     optional ManagedResourceOptionsMsg mgoptions = 54312;
 }
+
+message ValueFieldTagOne {
+    option (org.corfudb.runtime.table_schema).stream_tag = "tag_one";
+    option (org.corfudb.runtime.table_schema).is_federated = true;
+
+    optional string payload = 1;
+}
+
+message ValueFieldTagOneAndTwo {
+    option (org.corfudb.runtime.table_schema).stream_tag = "tag_one";
+    option (org.corfudb.runtime.table_schema).stream_tag = "tag_two";
+    option (org.corfudb.runtime.table_schema).is_federated = true;
+
+    optional string payload = 1;
+}


### PR DESCRIPTION
## Overview

Description:

In order to support selective streaming on the standby site,
consumers must provide a map of tables of interest and stream tags through
the ILogReplicationConfigAdapter. Only tables given by the adapter
will stream data on the standby (for both snapshot and delta sync).

Why should this be merged:  client feature request


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
