### PR TITLE
Fix Cache Stats Reporting

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/CacheMetrics.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/CacheMetrics.java
@@ -1,0 +1,65 @@
+package org.corfudb.common.metrics.micrometer;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheStats;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.Optional;
+
+/**
+ * Since guava's cache metrics maintain running totals of different stats (i.e., they always increase) this class
+ * registers one gauge per metric that gets restarted every time its polled/reported thus only reporting the cache
+ * stats only within the reporting duration.
+ */
+
+
+public class CacheMetrics {
+
+    @Data
+    @AllArgsConstructor
+    private static class CacheStatsContainer {
+        CacheStats snapshot;
+    }
+
+    public static void register(Optional<MeterRegistry> metricsRegistry, Cache<?, ?> cache, String cacheName) {
+
+        if (metricsRegistry.isPresent()) {
+
+            Gauge.builder(cacheName, new CacheStatsContainer(cache.stats()), data -> {
+                CacheStats currentSnapshot = cache.stats();
+                data.snapshot = currentSnapshot.minus(data.snapshot);
+                return data.snapshot.hitRate();
+            }).tags("result", "hitRate")
+                    .strongReference(true)
+                    .register(metricsRegistry.get());
+
+            Gauge.builder(cacheName, new CacheStatsContainer(cache.stats()), data -> {
+                CacheStats currentSnapshot = cache.stats();
+                data.snapshot = currentSnapshot.minus(data.snapshot);
+                return data.snapshot.requestCount();
+            }).tags("result", "requestCount")
+                    .strongReference(true)
+                    .register(metricsRegistry.get());
+
+            Gauge.builder(cacheName, new CacheStatsContainer(cache.stats()), data -> {
+                CacheStats currentSnapshot = cache.stats();
+                data.snapshot = currentSnapshot.minus(data.snapshot);
+                return data.snapshot.evictionCount();
+            }).tags("result", "evictionCount")
+                    .strongReference(true)
+                    .register(metricsRegistry.get());
+
+            Gauge.builder(cacheName, new CacheStatsContainer(cache.stats()), data -> {
+                CacheStats currentSnapshot = cache.stats();
+                data.snapshot = currentSnapshot.minus(data.snapshot);
+                return data.snapshot.averageLoadPenalty();
+            }).tags("result", "averageLoadPenalty")
+                    .strongReference(true)
+                    .register(metricsRegistry.get());
+        }
+
+    }
+}

--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/JVMMetrics.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/JVMMetrics.java
@@ -45,8 +45,7 @@ public final class JVMMetrics {
                 long delta = current - data.safepointCount;
                 data.safepointCount = current;
                 return delta;
-            }).baseUnit(TimeUnit.MILLISECONDS.toString())
-                    .strongReference(true)
+            }).strongReference(true)
                     .register(metricsRegistry.get());
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/AddressSpaceView.java
@@ -13,8 +13,10 @@ import com.google.common.util.concurrent.UncheckedExecutionException;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.cache.GuavaCacheMetrics;
 import io.netty.handler.timeout.TimeoutException;
+import lombok.Data;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.common.metrics.micrometer.CacheMetrics;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.protocols.wireprotocol.DataType;
@@ -115,9 +117,8 @@ public class AddressSpaceView extends AbstractView {
                 .build();
 
         Optional<MeterRegistry> metricsRegistry = MeterRegistryProvider.getInstance();
-        metricsRegistry.map(registry -> GuavaCacheMetrics.monitor(registry, readCache, "address_space.read_cache"));
-        MicroMeterUtils.gauge("address_space.read_cache.hit_ratio", readCache, cache -> cache.stats().hitRate());
-        
+        CacheMetrics.register(metricsRegistry, readCache, "address_space.read_cache");
+
         if (!runtime.getParameters().isCacheEntryMetricsDisabled()) {
             MicroMeterUtils.gauge("address_space.read_cache.size", readCache, cache -> cache.size());
             MicroMeterUtils.gauge("address_space.read_cache.avg_entry_size", readCache, cache -> calculateEstimatedAvgEntrySize());


### PR DESCRIPTION
## Overview

This patch makes the cache stats reflect relative stats within
the reporting duration as opposed to having a running total since
the cache was instantiated.
Why should this be merged: 

Related issue(s) (if applicable): Reporting cache stats since the cache instantiation isn't helpful when trying to debug issues that happen in short time windows. This patch makes the stats reporting for a specific time window (i.e., poll period). 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
