### PR TITLE
Optimize scanAndFilter for Immutable Objects

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -68,7 +68,7 @@ public class CorfuTable<K, V> implements ICorfuTable<K, V>, ICorfuSMR<CorfuTable
     // gets block on parallel stream, because the pool is exhausted with threads that are trying to acquire the VLO
     // look, which creates a circular dependency. In other words, a deadlock.
 
-    private final static ForkJoinPool pool = new ForkJoinPool(Math.max(Runtime.getRuntime().availableProcessors() - 1, 1),
+    protected final static ForkJoinPool pool = new ForkJoinPool(Math.max(Runtime.getRuntime().availableProcessors() - 1, 1),
             pool -> {
                 final ForkJoinWorkerThread worker = ForkJoinPool.defaultForkJoinWorkerThreadFactory.newThread(pool);
                 worker.setName("CorfuTable-Forkjoin-pool-" + worker.getPoolIndex());

--- a/runtime/src/main/java/org/corfudb/util/ImmutableListSetWrapper.java
+++ b/runtime/src/main/java/org/corfudb/util/ImmutableListSetWrapper.java
@@ -124,6 +124,6 @@ public class ImmutableListSetWrapper<E> extends AbstractSet<E> implements Set<E>
 
     @Override
     public Stream<E> parallelStream() {
-        return internalList.stream();
+        return internalList.parallelStream();
     }
 }


### PR DESCRIPTION
## Overview
Table.java, which is a wrapper on top of CorfuTable only allows for
immutable objects types - protobuf types - and doesn't need a
write lock to execute the scan queries. This patch reduces locking
by allowing multiple threads to execute the scan simultaneously on
different versions of the Table.


Why should this be merged: Reduces locking for concurrent scanning queries. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
