### PR TITLE
Advance Stream Tags on Checkpoint

### DIFF
--- a/generator/src/main/java/org/corfudb/generator/operations/CheckpointOperation.java
+++ b/generator/src/main/java/org/corfudb/generator/operations/CheckpointOperation.java
@@ -24,7 +24,7 @@ public class CheckpointOperation extends Operation {
         try {
             MultiCheckpointWriter<CorfuTable<String, String>> mcw = new MultiCheckpointWriter<>();
             mcw.addAllMaps(state.getMaps());
-            Token trimAddress = mcw.appendCheckpoints(state.getRuntime(), "Maithem");
+            Token trimAddress = mcw.appendCheckpoints(state.getRuntime(), "checkpointer");
             state.updateTrimMark(trimAddress);
             TimeUnit.SECONDS.sleep(30);
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
@@ -185,7 +185,6 @@ final public class StreamAddressSpace {
         while (iterator.hasNext()) {
             long current = iterator.next();
             if (current <= newTrimMark) {
-                log.info("trim: stream trim mark moved from {} to {}", this.trimMark, current);
                 this.trimMark = current;
                 break;
             }

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -86,7 +86,7 @@ public class WorkflowIT extends AbstractIT {
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(table);
 
-        Token prefix = mcw.appendCheckpoints(runtime, "Maithem");
+        Token prefix = mcw.appendCheckpoints(runtime, "checkpointer");
 
         runtime.getAddressSpaceView().prefixTrim(prefix);
 

--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -8,6 +8,7 @@ import "google/protobuf/descriptor.proto";
 import "sample_appliance.proto";
 
 message FirewallRule {
+    option (org.corfudb.runtime.table_schema).stream_tag = "firewall_tag";
     optional int64 rule_id = 1 [(org.corfudb.runtime.schema).secondary_key = true];
     optional string rule_name = 2 [(org.corfudb.runtime.schema).secondary_key = true];
     optional org.corfudb.test.Appliance input = 3;


### PR DESCRIPTION
## Overview
Advance stream tags on checkpoint for UFO tables. Since stream tags
represent streams and are not checkpointed, the tag's stream trim
mark can't be used to detect trim gaps since they are always
uninitialized. This patch advances all streams that represent
a tag for a particular stream on checkpoint, that way stream listeners
that listen on tags can efficiently detect whether a trim is detected
or not.

Why should this be merged: Enables efficient detection of trim gaps.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
