### PR TITLE
Lower Number of Test Iterations

### DIFF
--- a/test/src/test/java/org/corfudb/CorfuTestParameters.java
+++ b/test/src/test/java/org/corfudb/CorfuTestParameters.java
@@ -93,9 +93,9 @@ public class CorfuTestParameters {
 
         // Iterations
         NUM_ITERATIONS_VERY_LOW = 10;
-        NUM_ITERATIONS_LOW = 100;
-        NUM_ITERATIONS_MODERATE = 1000;
-        NUM_ITERATIONS_LARGE = 10_000;
+        NUM_ITERATIONS_LOW = 50;
+        NUM_ITERATIONS_MODERATE = 300;
+        NUM_ITERATIONS_LARGE = 1500;
 
         // Concurrency
         CONCURRENCY_ONE = 1;

--- a/test/src/test/java/org/corfudb/integration/StreamingPatternsIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingPatternsIT.java
@@ -52,7 +52,7 @@ public class StreamingPatternsIT extends AbstractIT {
     private final String defaultTableName = "table_default";
     private final String defaultTag = "sample_streamer_1";
 
-    private final int sleepTime = 100;
+    private final int sleepTime = 300;
 
     private Table<Uuid, SampleTableAMsg, Uuid> tableDefault;
 


### PR DESCRIPTION
## Overview
For most of the tests a higher iteration rate doesn't lead to a
higher testing fidelity. This patch lowers the default iteration
parameters because CI is really slow and times out intermittently.

Why should this be merged: Improves CI stability 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
