### PR TITLE
Fix LR's sync status entry counting

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -109,6 +109,7 @@ public class LogReplicationSourceManager {
 
         this.logReplicationFSM.setTopologyConfigId(params.getTopologyConfigId());
         this.ackReader.setLogEntryReader(this.logReplicationFSM.getLogEntryReader());
+        this.ackReader.setLogEntrySender(this.logReplicationFSM.getLogEntrySender());
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -187,6 +187,7 @@ public class LogReplicationFSM {
     /**
      * Log Entry Sender (send incremental updates to remote cluster)
      */
+    @Getter
     private final LogEntrySender logEntrySender;
 
     /**
@@ -242,7 +243,7 @@ public class LogReplicationFSM {
         // Create transmitters to be used by the the sync states (Snapshot and LogEntry) to read and send data
         // through the callbacks provided by the application
         snapshotSender = new SnapshotSender(runtime, snapshotReader, dataSender, readProcessor, config.getMaxNumMsgPerBatch(), this);
-        logEntrySender = new LogEntrySender(logEntryReader, dataSender, readProcessor, this);
+        logEntrySender = new LogEntrySender(logEntryReader, dataSender, this);
 
         // Initialize Log Replication 5 FSM states - single instance per state
         initializeStates(snapshotSender, logEntrySender, dataSender);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
@@ -29,17 +29,17 @@ public class LogEntrySender {
     /*
      * Implementation of Log Entry Reader. Default implementation reads at the stream layer.
      */
-    private LogEntryReader logEntryReader;
+    private final LogEntryReader logEntryReader;
 
     /*
      * Implementation of buffering messages and sending/resending messages
      */
-    private SenderBufferManager dataSenderBufferManager;
+    private final SenderBufferManager dataSenderBufferManager;
 
     /*
      * Log Replication FSM (to insert internal events)
      */
-    private LogReplicationFSM logReplicationFSM;
+    private final LogReplicationFSM logReplicationFSM;
 
     private volatile boolean taskActive = false;
 
@@ -56,11 +56,10 @@ public class LogEntrySender {
      * @param logEntryReader    log entry logreader implementation
      * @param dataSender        implementation of a data sender, both snapshot and log entry, this represents
      *                          the application callback for data transmission
-     * @param readProcessor     post read processing logic
      * @param logReplicationFSM log replication FSM to insert events upon message acknowledgement
      */
     public LogEntrySender(LogEntryReader logEntryReader, DataSender dataSender,
-                          ReadProcessor readProcessor, LogReplicationFSM logReplicationFSM) {
+                          LogReplicationFSM logReplicationFSM) {
 
         this.logEntryReader = logEntryReader;
         this.logReplicationFSM = logReplicationFSM;
@@ -166,5 +165,9 @@ public class LogEntrySender {
 
     public void updateTopologyConfigId(long topologyConfigId) {
         dataSenderBufferManager.updateTopologyConfigId(topologyConfigId);
+    }
+
+    public int getPendingACKQueueSize() {
+        return dataSenderBufferManager.getPendingMessages().getSize();
     }
 }


### PR DESCRIPTION
## Overview

Description:

LR's sync status remaining entries to send counting logic is not able to check if the entries in the range (LastAckedTimestamp, txStreamTail] contains interested streams to replicate.

When there are many noisy streams in the system, the LastAckedTimestamp is static and we will repeatedly count those entries in the range (LastAckedTimestamp, currentTxStreamProcessedTs]

so the range [currentTxStreamProcessedTs, txStreamTail] seems to be more accurate. But in this way, we also need to count the numbers if we have sent the entries but yet to receive ack in the range (LastAckedTimestamp, currentTxStreamProcessedTs], which would be the size of the pendingQueue.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
