### PR TITLE
Incorrectly Computed Commit Address and Data Loss

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -194,7 +194,8 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
                         }
                     }
                 },
-                o -> accessMethod.access(o));
+                o -> accessMethod.access(o),
+                a -> {});
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -1,12 +1,14 @@
 package org.corfudb.runtime.object.transactions;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
+
+import com.google.common.base.Preconditions;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -75,12 +77,6 @@ public abstract class AbstractTransactionalContext implements
     public static final long ABORTED_ADDRESS = -3L;
 
     /**
-     * Constant for committing a transaction which did not
-     * modify the log at all.
-     */
-    public static final long NOWRITE_ADDRESS = -4L;
-
-    /**
      * The ID of the transaction. This is used for tracking only, it is
      * NOT recorded in the log.
      */
@@ -112,6 +108,9 @@ public abstract class AbstractTransactionalContext implements
     @Getter
     public long commitAddress = AbstractTransactionalContext.UNCOMMITTED_ADDRESS;
 
+    @Getter
+    private final List<PreCommitListener> preCommitListeners = new ArrayList<>();
+
     /**
      * The parent context of this transaction, if in a nested transaction.
      */
@@ -132,18 +131,9 @@ public abstract class AbstractTransactionalContext implements
     private final ConflictSetInfo readSetInfo = new ConflictSetInfo();
 
     /**
-     * A future which gets completed when this transaction commits.
-     * It is completed exceptionally when the transaction aborts.
-     */
-    @Getter
-    public CompletableFuture<Boolean> completionFuture =
-            new CompletableFuture<>();
-
-    /**
      * Cache of last known position of streams accessed in this transaction.
      */
-    @Getter
-    private final Map<UUID, Long> knownStreamPosition = new HashMap<>();
+    protected final Map<UUID, Long> knownStreamsPosition = new HashMap<>();
 
     AbstractTransactionalContext(Transaction transaction) {
         transactionID = Utils.genPseudorandomUUID();
@@ -151,6 +141,17 @@ public abstract class AbstractTransactionalContext implements
         this.startTime = System.currentTimeMillis();
         this.parentContext = TransactionalContext.getCurrentContext();
         AbstractTransactionalContext.log.debug("TXBegin[{}]", this);
+    }
+
+    protected void updateKnownStreamPosition(UUID streamId, long position) {
+        Long val = knownStreamsPosition.get(streamId);
+        if (val != null) {
+            Preconditions.checkState(val == position, "inconsistent stream positions %s and %s",
+                    val, position);
+            return;
+        }
+
+        knownStreamsPosition.put(streamId, position);
     }
 
     /**
@@ -260,18 +261,12 @@ public abstract class AbstractTransactionalContext implements
      */
     public abstract void addPreCommitListener(PreCommitListener preCommitListener);
 
-    @Getter
-    private List<PreCommitListener> preCommitListeners = new ArrayList<>();
-
     /**
      * Commit the transaction to the log.
      *
      * @throws TransactionAbortedException If the transaction is aborted.
      */
-    public long commitTransaction() throws TransactionAbortedException {
-        completionFuture.complete(true);
-        return NOWRITE_ADDRESS;
-    }
+    public abstract long commitTransaction() throws TransactionAbortedException;
 
     /**
      * Forcefully abort the transaction.
@@ -279,8 +274,17 @@ public abstract class AbstractTransactionalContext implements
     public void abortTransaction(TransactionAbortedException ae) {
         AbstractTransactionalContext.log.debug("TXAbort[{}]", this);
         commitAddress = ABORTED_ADDRESS;
-        completionFuture
-                .completeExceptionally(ae);
+    }
+
+    /**
+     * Retrieves the max address that has been read in this transaction.
+     * @return highest sequence number observed while reading
+     */
+    protected long getMaxAddressRead() {
+        if (knownStreamsPosition.isEmpty()) {
+            return Address.NON_ADDRESS;
+        }
+        return Collections.max(knownStreamsPosition.values());
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -86,8 +86,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
 
                             // Obtain the stream position as when transaction context last
                             // remembered it.
-                            long streamReadPosition = getKnownStreamPosition()
-                                    .getOrDefault(proxy.getStreamID(), ts);
+                            long streamReadPosition = knownStreamsPosition.getOrDefault(proxy.getStreamID(), ts);
 
                             return (
                                     (stream == null || stream.isStreamCurrentContextThreadCurrentContext())
@@ -103,12 +102,9 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                             // committed changes, or apply forward committed changes.
                             syncWithRetryUnsafe(o, getSnapshotTimestamp(), proxy,
                                     o::setUncommittedChanges);
-
-                            // Update the global positions map. The value obtained from underlying
-                            // object must be under object's write-lock.
-                            getKnownStreamPosition().put(proxy.getStreamID(), o.getVersionUnsafe());
                         },
-                        accessFunction::access
+                        accessFunction::access,
+                        version -> updateKnownStreamPosition(proxy.getStreamID(), version)
         );
     }
 
@@ -249,7 +245,7 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         // subscription, the later could lead to data loss scenarios.
         if (getWriteSetInfo().getWriteSet().getEntryMap().isEmpty()) {
             log.trace("Commit[{}] Read-only commit (no write)", this);
-            return getMaxAddress(getReadSetInfo());
+            return getMaxAddressRead();
         }
 
         Set<UUID> affectedStreamsIds = new HashSet<>(getWriteSetInfo()
@@ -297,18 +293,9 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
 
         log.trace("Commit[{}] Acquire address {}", this, address);
 
-        super.commitTransaction();
         commitAddress = address;
         log.trace("Commit[{}] Written to {}", this, address);
         return address;
-    }
-
-    private long getMaxAddress(ConflictSetInfo readSetInfo) {
-        long maxAddress = AbstractTransactionalContext.NOWRITE_ADDRESS;
-        for (ICorfuSMRProxyInternal proxy : readSetInfo.getConflicts().keySet()) {
-            maxAddress = Long.max(maxAddress, proxy.getUnderlyingObject().getVersionUnsafe());
-        }
-        return maxAddress;
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/SnapshotTransactionalContext.java
@@ -1,14 +1,10 @@
 package org.corfudb.runtime.object.transactions;
 
-import com.google.common.collect.ImmutableSet;
-
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 
-import lombok.Getter;
-
 import org.corfudb.protocols.logprotocol.SMREntry;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.ICorfuSMRAccess;
 import org.corfudb.runtime.object.ICorfuSMRProxyInternal;
@@ -24,12 +20,6 @@ import org.corfudb.runtime.object.ICorfuSMRProxyInternal;
  */
 public class SnapshotTransactionalContext extends AbstractTransactionalContext {
 
-    /** In a snapshot transaction, no proxies are ever modified.
-     *
-     */
-    @Getter
-    private Set<ICorfuSMRProxyInternal> modifiedProxies = ImmutableSet.of();
-
     public SnapshotTransactionalContext(Transaction transaction) {
         super(transaction);
     }
@@ -41,17 +31,23 @@ public class SnapshotTransactionalContext extends AbstractTransactionalContext {
     public <R, T extends ICorfuSMR<T>> R access(ICorfuSMRProxyInternal<T> proxy,
                                                 ICorfuSMRAccess<R, T> accessFunction,
                                                 Object[] conflictObject) {
-
         // In snapshot transactions, there are no conflicts.
         // Hence, we do not need to add this access to a conflict set
         // do not add: addToReadSet(proxy, conflictObject);
         return proxy.getUnderlyingObject().access(o -> o.getVersionUnsafe()
                         == getSnapshotTimestamp().getSequence()
                         && !o.isOptimisticallyModifiedUnsafe(),
-                o -> {
-                    syncWithRetryUnsafe(o, getSnapshotTimestamp(), proxy, null);
-                },
-                o -> accessFunction.access(o));
+                o -> syncWithRetryUnsafe(o, getSnapshotTimestamp(), proxy, null),
+                accessFunction::access,
+                version -> updateKnownStreamPosition(proxy.getStreamID(), version));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long commitTransaction() throws TransactionAbortedException {
+        return getMaxAddressRead();
     }
 
     /**


### PR DESCRIPTION
## Overview
When a read only transaction commits it should return the max
stream tail observed among all streams accessed, because it
guarantees that, time cannot regress beyond that point. This
patch fixes a concurrency bug where the stream tails are accessed
at a different version than the commit, thus create gaps in
the snapshot. An incorrectly returned snapshot can cause data
loss when clients try to use the Txn.commit snapshot to listen
to new updates.

Why should this be merged: Fixes data loss issues.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
