### PR TITLE
Remove Token Information From CorfuStreamEntry

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStreamEntry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStreamEntry.java
@@ -51,24 +51,10 @@ public class CorfuStreamEntry<K extends Message, V extends Message, M extends Me
     @Getter
     private final OperationType operation;
 
-    /**
-     * Version number of the layout at the time of this entry.
-     */
-    @Getter
-    private final long epoch;
-
-    /**
-     * Stream address of this entry
-     */
-    @Getter
-    private final long address;
-
-    public CorfuStreamEntry(K key, V payload, M metadata, long epoch, long address, OperationType operation) {
+    public CorfuStreamEntry(K key, V payload, M metadata, OperationType operation) {
         this.key = key;
         this.payload = payload;
         this.metadata = metadata;
-        this.epoch = epoch;
-        this.address = address;
         this.operation = operation;
     }
 
@@ -76,9 +62,7 @@ public class CorfuStreamEntry<K extends Message, V extends Message, M extends Me
      * Convert a given SMREntry to CorfuStreamEntry.
      */
     public static <K extends Message, V extends Message, M extends Message>
-    CorfuStreamEntry<K, V, M> fromSMREntry(SMREntry entry, final long epoch) {
-        long address = entry.getGlobalAddress();
-
+    CorfuStreamEntry<K, V, M> fromSMREntry(SMREntry entry) {
         OperationType operationType = getOperationType(entry);
         // TODO(sneginhal): Need a way to differentiate between update and create.
         Object[] args = entry.getSMRArguments();
@@ -95,7 +79,7 @@ public class CorfuStreamEntry<K extends Message, V extends Message, M extends Me
             }
         }
 
-        return new CorfuStreamEntry<>(key, payload, metadata, epoch, address, operationType);
+        return new CorfuStreamEntry<>(key, payload, metadata, operationType);
     }
 
     private static OperationType getOperationType(@Nonnull SMREntry entry) {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
@@ -771,8 +771,8 @@ public class TxnContext implements AutoCloseable {
         MultiObjectSMREntry writeSet = rootContext.getWriteSetInfo().getWriteSet();
         final Map<String, List<CorfuStreamEntry>> mutations = new HashMap<>(tablesUpdated.size());
         tablesUpdated.forEach((uuid, table) -> {
-            List<CorfuStreamEntry> writesInTable = writeSet.getSMRUpdates(uuid).stream().map(entry ->
-                    CorfuStreamEntry.fromSMREntry(entry, 0)).collect(Collectors.toList());
+            List<CorfuStreamEntry> writesInTable = writeSet.getSMRUpdates(uuid).stream()
+                    .map(CorfuStreamEntry::fromSMREntry).collect(Collectors.toList());
             mutations.put(table.getFullyQualifiedTableName(), writesInTable);
         });
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingTask.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingTask.java
@@ -123,7 +123,7 @@ public class StreamingTask<K extends Message, V extends Message, M extends Messa
             // Only deserialize the interested streams to reduce overheads.
             List<CorfuStreamEntry> entryList = smrEntries.getSMRUpdates(streamId)
                     .stream()
-                    .map(entry -> CorfuStreamEntry.fromSMREntry(entry, epoch))
+                    .map(CorfuStreamEntry::fromSMREntry)
                     .collect(Collectors.toList());
 
             // Deduplicate entries per stream Id, ordering within a transaction is not guaranteed

--- a/test/src/test/java/org/corfudb/integration/StreamingIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingIT.java
@@ -288,7 +288,7 @@ public class StreamingIT extends AbstractIT {
         CorfuStreamEntries update = updates.getLast();
         assertThat(update.getEntries()).hasSize(1);
         List<CorfuStreamEntry> entry = update.getEntries().values().stream().findFirst().get();
-        assertThat(entry.get(0).getAddress()).isGreaterThan(0L);
+        assertThat(update.getTimestamp().getSequence()).isGreaterThan(0L);
         assertThat(entry).hasSize(1);
         assertThat(entry.get(0).getOperation()).isEqualTo(CorfuStreamEntry.OperationType.DELETE);
         assertThat(entry.get(0).getKey()).isEqualTo(uuid0);
@@ -411,7 +411,8 @@ public class StreamingIT extends AbstractIT {
             results.getEntries().forEach((k, v) -> {
                 v.forEach(entry -> {
                     final CorfuStoreEntry<K, V, M> previousRecord =
-                            getPreviousRecord(namespace, tableName, entry, entry.getEpoch(), entry.getAddress());
+                            getPreviousRecord(namespace, tableName, entry, results.getTimestamp().getEpoch(),
+                                    results.getTimestamp().getSequence());
                     SampleTableAMsg prevMsg = (SampleTableAMsg) previousRecord.getPayload();
                     if (recordCount > 0) {
                         assertThat(prevMsg.getPayload()).isEqualTo("val"+(recordCount - 1));


### PR DESCRIPTION
## Overview
The sequencer and epoch in CorfuStreamEntry are redundant and
incorrectly set for most cases. This patch removes them, so that
clients are forced to rely on the TimeSnapshot in CorfuStreamEntries.

Why should this be merged: Removes redundant and incorrect information
that is passed to callbacks 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
