### PR TITLE
Snapshot writer notify data change on 'clear' tables

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -174,7 +174,7 @@ public class StreamsSnapshotWriter implements SnapshotWriter {
             }
 
             SMREntry entry = new SMREntry("clear", new Array[0], Serializers.PRIMITIVE);
-            txnContext.logUpdate(streamToClear, entry);
+            txnContext.logUpdate(streamToClear, entry, dataStreamToTagsMap.get(streamID));
         }
     }
 
@@ -241,9 +241,9 @@ public class StreamsSnapshotWriter implements SnapshotWriter {
      * Write a list of SMR entries to the specified stream log.
      *
      * @param smrEntries
-     * @param shadowStreamUuid
+     * @param streamId
      */
-    private void updateLog(TxnContext txnContext, List<SMREntry> smrEntries, UUID shadowStreamUuid) {
+    private void updateLog(TxnContext txnContext, List<SMREntry> smrEntries, UUID streamId) {
         Map<LogReplicationMetadataType, Long> metadataMap = logReplicationMetadataManager.queryMetadata(txnContext, LogReplicationMetadataType.TOPOLOGY_CONFIG_ID,
                 LogReplicationMetadataType.LAST_SNAPSHOT_STARTED, LogReplicationMetadataType.LAST_SNAPSHOT_TRANSFERRED_SEQUENCE_NUMBER);
         long persistedTopologyConfigId = metadataMap.get(LogReplicationMetadataType.TOPOLOGY_CONFIG_ID);
@@ -261,7 +261,7 @@ public class StreamsSnapshotWriter implements SnapshotWriter {
         logReplicationMetadataManager.appendUpdate(txnContext, LogReplicationMetadataType.LAST_SNAPSHOT_STARTED, srcGlobalSnapshot);
 
         for (SMREntry smrEntry : smrEntries) {
-            txnContext.logUpdate(shadowStreamUuid, smrEntry, dataStreamToTagsMap.get(shadowStreamUuid));
+            txnContext.logUpdate(streamId, smrEntry, dataStreamToTagsMap.get(streamId));
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
@@ -236,7 +236,7 @@ public class LogReplicationClientRouter implements IClientRouter {
             } catch (Exception e) {
                 outstandingRequests.remove(requestId);
                 log.error("sendMessageAndGetCompletable: Remove request {} to {} due to exception! Message:{}",
-                        requestId, remoteClusterId, payload, e);
+                        requestId, remoteClusterId, payload.getPayloadCase(), e);
                 cf.completeExceptionally(e);
                 return cf;
             }
@@ -249,7 +249,7 @@ public class LogReplicationClientRouter implements IClientRouter {
                 if (e.getCause() instanceof TimeoutException) {
                     outstandingRequests.remove(requestId);
                     log.debug("sendMessageAndGetCompletable: Remove request {} to {} due to timeout! Message:{}",
-                            requestId, remoteClusterId, TextFormat.shortDebugString(payload));
+                            requestId, remoteClusterId, payload.getPayloadCase());
                 }
                 return null;
             });


### PR DESCRIPTION
## Overview

Description:

With streaming enabled on standby/sink and assuming data could be written on standby before replication starts, we need to also notify of table 'clear' operations (done on snapshot sync start to reset the log) as this could trigger application logic that acts upon the data written before replication (for example refresh an UI, etc). 

Why should this be merged: Customer Bug
