### PR TITLE
Remove Transaction Logging and Transaction Stream

### DIFF
--- a/infrastructure/proto/sample.proto
+++ b/infrastructure/proto/sample.proto
@@ -13,6 +13,7 @@ message IntValue {
 
 message IntValueTag {
     option (org.corfudb.runtime.table_schema).stream_tag = "test";
+    option (org.corfudb.runtime.table_schema).is_federated = true;
     int32 value = 2;
 }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -371,7 +371,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                     // heavily on the cache (hence can be smaller)
                     .maxCacheEntries(serverContext.getLogReplicationCacheMaxSize()/2)
                     .build())
-                    .setTransactionLogging(true)
                     .parseConfigurationString(localCorfuEndpoint).connect();
         }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -995,18 +995,6 @@ public class CorfuRuntime {
     }
 
     /**
-     * If enabled, successful transactions will be written to a special transaction stream
-     * (i.e. TRANSACTION_STREAM_ID)
-     *
-     * @param enable indicates if transaction logging is enabled
-     * @return corfu runtime object
-     */
-    public CorfuRuntime setTransactionLogging(boolean enable) {
-        this.getObjectsView().setTransactionLogging(enable);
-        return this;
-    }
-
-    /**
      * Parse a configuration string and get a CorfuRuntime.
      *
      * @param configurationString The configuration string to parse.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -49,22 +49,10 @@ public class CorfuStore {
     /**
      * Creates a new CorfuStore.
      *
-     * @param runtime Connected instance of the Corfu Runtime.
+     * @param runtime         Connected instance of the Corfu Runtime.
      */
     @Nonnull
     public CorfuStore(@Nonnull final CorfuRuntime runtime) {
-        this(runtime, true);
-    }
-
-    /**
-     * Creates a new CorfuStore.
-     *
-     * @param runtime         Connected instance of the Corfu Runtime.
-     * @param enableTxLogging
-     */
-    @Nonnull
-    public CorfuStore(@Nonnull final CorfuRuntime runtime, boolean enableTxLogging) {
-        runtime.setTransactionLogging(enableTxLogging);
         this.runtime = runtime;
         this.corfuStoreMetrics = new CorfuStoreMetrics();
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -1,7 +1,5 @@
 package org.corfudb.runtime.object.transactions;
 
-import static org.corfudb.runtime.view.ObjectsView.TRANSACTION_STREAM_ID;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -251,13 +249,8 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
         Set<UUID> affectedStreamsIds = new HashSet<>(getWriteSetInfo()
                 .getWriteSet().getEntryMap().keySet());
 
-        // Write to transaction streams pertaining to the streamTags and
-        // global transaction stream if transaction logging is enabled.
-        // With stream tagging being introduced, the latter is only for backward compatibility.
-        if (transaction.isLoggingEnabled()) {
-            affectedStreamsIds.addAll(getWriteSetInfo().getStreamTags());
-            affectedStreamsIds.add(TRANSACTION_STREAM_ID);
-        }
+        // Write to streams corresponding to the streamTags
+        affectedStreamsIds.addAll(getWriteSetInfo().getStreamTags());
 
         UUID[] affectedStreams = affectedStreamsIds.toArray(new UUID[affectedStreamsIds.size()]);
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/Transaction.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/Transaction.java
@@ -49,10 +49,6 @@ public class Transaction {
         TransactionalContext.newContext(type.get.apply(this));
     }
 
-    public boolean isLoggingEnabled() {
-        return runtime.getObjectsView().isTransactionLogging();
-    }
-
     /**
      * Verifies that this transaction has a valid snapshot and context.
      */

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -39,18 +39,12 @@ import java.util.concurrent.ConcurrentHashMap;
 @Slf4j
 public class ObjectsView extends AbstractView {
 
-    /**
-     * The Transaction stream is used to log/write successful transactions from different clients.
-     * Transaction data and meta data can be obtained by reading this stream.
-     */
-    @Deprecated
-    public static final UUID TRANSACTION_STREAM_ID = CorfuRuntime.getStreamID("Transaction_Stream");
+    private static final String LOG_REPLICATOR_STREAM_NAME =
+        "LR_Transaction_Stream";
 
-    // We are temporarily naming this stream with the same name as TRANSACTION_STREAM_ID to avoid breaking LR code
-    // while transition to UFO is completed (once migration is complete to UFO this stream can be renamed)
-    // add a prefix to the name: e.g., org.corfudb.logreplication.transactionstream
     public static final StreamTagInfo LOG_REPLICATOR_STREAM_INFO =
-            new StreamTagInfo("Transaction_Stream", CorfuRuntime.getStreamID("Transaction_Stream"));
+            new StreamTagInfo(LOG_REPLICATOR_STREAM_NAME,
+                CorfuRuntime.getStreamID(LOG_REPLICATOR_STREAM_NAME));
 
     /**
      * @return the ID of the log replicator stream.
@@ -58,10 +52,6 @@ public class ObjectsView extends AbstractView {
     public static UUID getLogReplicatorStreamId() {
         return LOG_REPLICATOR_STREAM_INFO.getStreamId();
     }
-
-    @Getter
-    @Setter
-    boolean transactionLogging = false;
 
     @Getter
     Map<ObjectID, Object> objectCache = new ConcurrentHashMap<>();

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.util.serializer.Serializers;
 
 @Slf4j
@@ -44,8 +45,7 @@ public class LogReplicationTest {
 //                .tlsEnabled(true)
                 .build();
 
-        runtime = CorfuRuntime.fromParameters(params)
-                .setTransactionLogging(true);
+        runtime = CorfuRuntime.fromParameters(params);
         runtime.parseConfigurationString(endpoint);
         runtime.registerSystemDownHandler(() -> {throw new RuntimeException("Disconnected from database. Terminating thread.");});
 
@@ -58,6 +58,7 @@ public class LogReplicationTest {
         table1 = runtime.getObjectsView()
                 .build()
                 .setStreamName("Table001")
+                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {
                 })
                 .setSerializer(Serializers.PRIMITIVE)
@@ -65,6 +66,7 @@ public class LogReplicationTest {
         table2 = runtime.getObjectsView()
                 .build()
                 .setStreamName("Table002")
+                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {
                 })
                 .setSerializer(Serializers.PRIMITIVE)
@@ -72,6 +74,7 @@ public class LogReplicationTest {
         table3 = runtime.getObjectsView()
                 .build()
                 .setStreamName("Table003")
+                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {
                 })
                 .setSerializer(Serializers.PRIMITIVE)

--- a/test/src/test/java/org/corfudb/integration/CorfuLongRunningClientIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuLongRunningClientIT.java
@@ -219,11 +219,11 @@ public class CorfuLongRunningClientIT extends AbstractIT {
                     .builder()
                     .build();
 
-            client1 = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+            client1 = CorfuRuntime.fromParameters(params);
             client1.parseConfigurationString(DEFAULT_HOST + ":" + DEFAULT_PORT);
             client1.connect();
 
-            client2 = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+            client2 = CorfuRuntime.fromParameters(params);
             client2.parseConfigurationString(DEFAULT_HOST + ":" + DEFAULT_PORT);
             client2.connect();
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -115,15 +115,16 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                 .builder()
                 .build();
 
-        activeRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+        activeRuntime = CorfuRuntime.fromParameters(params);
         activeRuntime.parseConfigurationString(activeCorfuEndpoint).connect();
 
-        standbyRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+        standbyRuntime = CorfuRuntime.fromParameters(params);
         standbyRuntime.parseConfigurationString(standbyCorfuEndpoint).connect();
 
         mapActive = activeRuntime.getObjectsView()
                 .build()
                 .setStreamName(streamName)
+                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                 .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
                 })
                 .open();
@@ -131,6 +132,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         mapStandby = standbyRuntime.getObjectsView()
                 .build()
                 .setStreamName(streamName)
+                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                 .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
                 })
                 .open();
@@ -762,6 +764,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         CorfuTable<String, Integer> noisyMap = activeRuntime.getObjectsView()
                 .build()
                 .setStreamName(streamName+"noisy")
+                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                 .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
                 })
                 .open();
@@ -1464,12 +1467,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                 .builder()
                 .build();
 
-        CorfuRuntime backupRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+        CorfuRuntime backupRuntime = CorfuRuntime.fromParameters(params);
         backupRuntime.parseConfigurationString(backupCorfuEndpoint).connect();
 
         CorfuTable<String, Integer> mapBackup = backupRuntime.getObjectsView()
                 .build()
                 .setStreamName(streamName)
+                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                 .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
                 })
                 .open();

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -697,8 +697,8 @@ public class CorfuStoreIT extends AbstractIT {
             // Stream tags for tableA
             expectedTableUpdates.add(TableRegistry.getStreamIdForStreamTag(namespace, "sample_streamer_1"));
             expectedTableUpdates.add(TableRegistry.getStreamIdForStreamTag(namespace, "sample_streamer_2"));
-            expectedTableUpdates.add(ObjectsView.TRANSACTION_STREAM_ID);
-
+            // This is a federated table so add Log Replicator Stream Id
+            expectedTableUpdates.add(ObjectsView.getLogReplicatorStreamId());
             assertThat(expectedTableUpdates.size()).isEqualTo(backpointerMap.size());
             expectedTableUpdates.forEach(table -> assertThat(backpointerMap.keySet()).contains(table));
         } finally {

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -44,6 +44,7 @@ import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.runtime.view.SMRObject;
 import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.util.Sleep;
@@ -370,11 +371,11 @@ public class LogReplicationAbstractIT extends AbstractIT {
                     .builder()
                     .build();
 
-            activeRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+            activeRuntime = CorfuRuntime.fromParameters(params);
             activeRuntime.parseConfigurationString(activeEndpoint);
             activeRuntime.connect();
 
-            standbyRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+            standbyRuntime = CorfuRuntime.fromParameters(params);
             standbyRuntime.parseConfigurationString(standbyEndpoint);
             standbyRuntime.connect();
 
@@ -414,6 +415,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
         mapA = activeRuntime.getObjectsView()
                 .build()
                 .setStreamName(streamA)
+                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                 .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
                 })
                 .open();
@@ -421,6 +423,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
         mapAStandby = standbyRuntime.getObjectsView()
                 .build()
                 .setStreamName(streamA)
+                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                 .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
                 })
                 .open();
@@ -695,7 +698,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
                     .setTypeToken(new TypeToken<CorfuTable<CorfuDynamicKey, CorfuDynamicRecord>>() {})
                     .setStreamName(fullTableName)
                     .setSerializer(dynamicProtoBufSerializer);
-            
+
             mcw = new MultiCheckpointWriter<>();
             mcw.addMap(corfuTableBuilder.open());
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -195,7 +195,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
                 .builder()
                 .build();
 
-        srcDataRuntime = CorfuRuntime.fromParameters(params).setTransactionLogging(true);
+        srcDataRuntime = CorfuRuntime.fromParameters(params);
         srcDataRuntime.parseConfigurationString(SOURCE_ENDPOINT);
         srcDataRuntime.connect();
 
@@ -255,6 +255,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
             CorfuTable<Long, Long> table = rt.getObjectsView()
                     .build()
                     .setStreamName(name)
+                    .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                     .setTypeToken(new TypeToken<CorfuTable<Long, Long>>() {
                     })
                     .setSerializer(Serializers.PRIMITIVE)

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -109,27 +109,27 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
 
         srcDataRuntime = CorfuRuntime.fromParameters(params);
         srcDataRuntime.parseConfigurationString(DEFAULT_ENDPOINT);
-        srcDataRuntime.setTransactionLogging(true).connect();
+        srcDataRuntime.connect();
 
         srcTestRuntime = CorfuRuntime.fromParameters(params);
         srcTestRuntime.parseConfigurationString(DEFAULT_ENDPOINT);
-        srcTestRuntime.setTransactionLogging(true).connect();
+        srcTestRuntime.connect();
 
         readerRuntime = CorfuRuntime.fromParameters(params);
         readerRuntime.parseConfigurationString(DEFAULT_ENDPOINT);
-        readerRuntime.setTransactionLogging(true).connect();
+        readerRuntime.connect();
 
         writerRuntime = CorfuRuntime.fromParameters(params);
         writerRuntime.parseConfigurationString(WRITER_ENDPOINT);
-        writerRuntime.setTransactionLogging(true).connect();
+        writerRuntime.connect();
 
         dstDataRuntime = CorfuRuntime.fromParameters(params);
         dstDataRuntime.parseConfigurationString(WRITER_ENDPOINT);
-        dstDataRuntime.setTransactionLogging(true).connect();
+        dstDataRuntime.connect();
 
         dstTestRuntime = CorfuRuntime.fromParameters(params);
         dstTestRuntime.parseConfigurationString(WRITER_ENDPOINT);
-        dstTestRuntime.setTransactionLogging(true).connect();
+        dstTestRuntime.connect();
     }
 
     public static void openStreams(HashMap<String, CorfuTable<Long, Long>> tables, CorfuRuntime rt) {
@@ -150,6 +150,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
             CorfuTable<Long, Long> table = rt.getObjectsView()
                     .build()
                     .setStreamName(name)
+                    .setStreamTags(ObjectsView.getLogReplicatorStreamId())
                     .setTypeToken(new TypeToken<CorfuTable<Long, Long>>() {
                     })
                     .setSerializer(serializer)
@@ -439,7 +440,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         openStreams(srcTables, srcDataRuntime);
         generateTransactions(srcTables, srcHashMap, NUM_TRANSACTIONS, srcDataRuntime, NUM_KEYS);
 
-        // Open a tx stream
+        // Open the log replication stream
         IStreamView txStream = srcTestRuntime.getStreamsView().get(ObjectsView.getLogReplicatorStreamId());
         long tail = srcDataRuntime.getAddressSpaceView().getLogTail();
         Stream<ILogData> stream = txStream.streamUpTo(tail);

--- a/test/src/test/java/org/corfudb/integration/StreamingIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingIT.java
@@ -21,7 +21,6 @@ import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TableSchema;
 import org.corfudb.runtime.collections.TxnContext;
-import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.exceptions.StreamingException;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.TableRegistry;
@@ -243,7 +242,7 @@ public class StreamingIT extends AbstractIT {
 
         // Subscribe to streaming updates from the table using customized buffer size.
         StreamListenerImpl listener1 = new StreamListenerImpl("stream_listener_1");
-        store.subscribeListener(listener1, "test_namespace", "sample_streamer_1",
+        store.subscribeListener(listener1, "test_namespace", defaultTag,
                 Collections.singletonList("tableA"), ts1, bufferSize);
 
         // After a brief wait verify that the listener gets all the updates.
@@ -268,7 +267,7 @@ public class StreamingIT extends AbstractIT {
 
         // Add another subscriber to the same table starting now.
         StreamListenerImpl listener2 = new StreamListenerImpl("stream_listener_2");
-        store.subscribeListener(listener2, "test_namespace", "sample_streamer_1",
+        store.subscribeListener(listener2, "test_namespace", defaultTag,
                 Collections.singletonList("tableA"), null);
 
         TxnContext tx = store.txn("test_namespace");
@@ -344,7 +343,6 @@ public class StreamingIT extends AbstractIT {
 
         // Start a Corfu runtime.
         runtime = createRuntime(singleNodeEndpoint);
-        runtime.setTransactionLogging(true);
 
         CorfuStore store = new CorfuStore(runtime);
 
@@ -487,7 +485,7 @@ public class StreamingIT extends AbstractIT {
         CountDownLatch latch = new CountDownLatch(numRecords);
         // Subscribe to streaming updates from tableA using listenerCommon
         PrevValueStreamer listenerCommon = new PrevValueStreamer<Uuid, SampleTableAMsg, Uuid>(store, ns, tn, latch);
-        store.subscribeListener(listenerCommon, ns, "sample_streamer_1",
+        store.subscribeListener(listenerCommon, ns, defaultTag,
                 Collections.singletonList(tn));
         for (int i = 0; i < numRecords; i++) {
             try (TxnContext tx = store.txn(namespace)) {
@@ -518,7 +516,6 @@ public class StreamingIT extends AbstractIT {
         // Start a Corfu runtime.
         runtime = createRuntime(singleNodeEndpoint);
 
-        runtime.setTransactionLogging(true);
         CorfuStore store = new CorfuStore(runtime);
 
         // Record the initial timestamp.
@@ -641,7 +638,6 @@ public class StreamingIT extends AbstractIT {
         // Start a Corfu runtime.
         runtime = createRuntime(singleNodeEndpoint);
 
-        runtime.setTransactionLogging(true);
         CorfuStore store = new CorfuStore(runtime);
 
         // Record the initial timestamp.
@@ -679,7 +675,7 @@ public class StreamingIT extends AbstractIT {
             } else {
                 listeners[i] = new StreamListenerImpl("listener" + i);
             }
-            store.subscribeListener(listeners[i], "test_namespace", "sample_streamer_1",
+            store.subscribeListener(listeners[i], "test_namespace", defaultTag,
                     Collections.singletonList("tableA"), ts1, bufferSize);
         }
 
@@ -731,13 +727,13 @@ public class StreamingIT extends AbstractIT {
 
         // Subscribe to streaming updates, while table has not been yet updated
         StreamListenerImpl listener1 = new StreamListenerImpl("stream_listener_1");
-        store.subscribeListener(listener1, namespace, "sample_streamer_1",
+        store.subscribeListener(listener1, namespace, defaultTag,
                 Collections.singletonList(tableName), ts1);
 
         // Wait for a while, so we are sure the subscriber poller has run
         TimeUnit.MILLISECONDS.sleep(sleepTime);
 
-        assertThatThrownBy(() -> store.subscribeListener(listener1, namespace, "sample_streamer_1",
+        assertThatThrownBy(() -> store.subscribeListener(listener1, namespace, defaultTag,
                 Collections.singletonList(tableName), ts1)).isExactlyInstanceOf(StreamingException.class);
 
         // Make some updates to the table
@@ -811,14 +807,14 @@ public class StreamingIT extends AbstractIT {
         // onwards (no data loss or need to sync a full snapshot)
         CountDownLatch latch = new CountDownLatch(1);
         StreamListenerImpl listener1 = new StreamListenerImpl("stream_listener_1", numUpdates/2, latch);
-        store.subscribeListener(listener1, namespace, "sample_streamer_1",
+        store.subscribeListener(listener1, namespace, defaultTag,
                 Collections.singletonList(tableNameA), ts1);
 
         // Wait for a while, so we are sure the subscriber poller has run
         TimeUnit.MILLISECONDS.sleep(sleepTime);
 
         // Confirm subscribe was successful
-        assertThatThrownBy(() -> store.subscribeListener(listener1, namespace, "sample_streamer_1",
+        assertThatThrownBy(() -> store.subscribeListener(listener1, namespace, defaultTag,
                 Collections.singletonList(tableNameA), ts1)).isExactlyInstanceOf(StreamingException.class);
 
         // Make some updates to both tables
@@ -856,7 +852,7 @@ public class StreamingIT extends AbstractIT {
         }
 
         // Re-subscribe from the last synced point and verify we catch up on the correct differential
-        store.subscribeListener(listener1, namespace, "sample_streamer_1",
+        store.subscribeListener(listener1, namespace, defaultTag,
                 Collections.singletonList(tableNameA), listener1.getTimestamp());
 
         // Wait for a while, so we are sure the subscriber poller has run
@@ -896,7 +892,6 @@ public class StreamingIT extends AbstractIT {
         // Start a Corfu runtime.
         runtime = createRuntime(singleNodeEndpoint);
 
-        runtime.setTransactionLogging(true);
         CorfuStore store = new CorfuStore(runtime);
 
         // Record the initial timestamp.
@@ -1251,7 +1246,6 @@ public class StreamingIT extends AbstractIT {
 
         // Start a Corfu runtime.
         runtime = createRuntime(singleNodeEndpoint);
-        runtime.setTransactionLogging(true);
 
         CorfuStore store = new CorfuStore(runtime);
 
@@ -1269,7 +1263,8 @@ public class StreamingIT extends AbstractIT {
 
         // Subscribe to streaming updates
         StreamListenerImpl listener = new StreamListenerImpl("stream_listener");
-        store.subscribeListener(listener, namespace, "sample_streamer_1", Collections.singletonList(tableName));
+        store.subscribeListener(listener, namespace, defaultTag,
+            Collections.singletonList(tableName));
 
         // Update same key multiple times within the same transaction
         try (TxnContext tx = store.txn(namespace)) {

--- a/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/TransactionStreamIT.java
@@ -81,7 +81,6 @@ public class TransactionStreamIT extends AbstractIT {
 
             CorfuRuntime consumerRt = CorfuRuntime.fromParameters(params)
                     .parseConfigurationString(DEFAULT_ENDPOINT)
-                    .setTransactionLogging(true)
                     .connect();
 
             consumerRts.add(consumerRt);
@@ -117,7 +116,6 @@ public class TransactionStreamIT extends AbstractIT {
 
         CorfuRuntime producersRt = CorfuRuntime.fromParameters(params)
                 .parseConfigurationString(DEFAULT_ENDPOINT)
-                .setTransactionLogging(true)
                 .connect();
 
         // Spawn writers, where each thread creates a table and starts

--- a/test/src/test/java/org/corfudb/runtime/BackupRestoreIT.java
+++ b/test/src/test/java/org/corfudb/runtime/BackupRestoreIT.java
@@ -104,25 +104,21 @@ public class BackupRestoreIT extends AbstractIT {
 
         srcDataRuntime = CorfuRuntime
                 .fromParameters(params)
-                .setTransactionLogging(true)
                 .parseConfigurationString(SOURCE_ENDPOINT)
                 .connect();
 
         backupRuntime = CorfuRuntime
                 .fromParameters(params)
-                .setTransactionLogging(true)
                 .parseConfigurationString(SOURCE_ENDPOINT)
                 .connect();
 
         restoreRuntime = CorfuRuntime
                 .fromParameters(params)
-                .setTransactionLogging(true)
                 .parseConfigurationString(DESTINATION_ENDPOINT)
                 .connect();
 
         destDataRuntime = CorfuRuntime
                 .fromParameters(params)
-                .setTransactionLogging(true)
                 .parseConfigurationString(DESTINATION_ENDPOINT)
                 .connect();
     }
@@ -666,7 +662,7 @@ public class BackupRestoreIT extends AbstractIT {
         assertThat(ex.getCause().getClass()).isEqualTo(TransactionAbortedException.class);
         assertThat(ex.getCause().getCause().getClass()).isEqualTo(TrimmedException.class);
 
-        // Verify that backup tar file exists
+        // Verify that backup tar file does not exist
         File backupTarFile = new File(BACKUP_TAR_FILE_PATH);
         assertThat(backupTarFile).doesNotExist();
 

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionContextTest.java
@@ -39,7 +39,7 @@ public class WriteAfterWriteTransactionContextTest extends AbstractTransactionCo
     @Test
     public void concurrentModificationsCauseAbort()
     {
-        getRuntime().setTransactionLogging(true);
+        getRuntime();
 
         getMap();
 


### PR DESCRIPTION
With stream tags, transaction stream(and hence transaction logging) are
no longer required.

Why should this be merged:  Code Cleanup

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
