### PR TITLE
Add 'stream_tag' to replication status table

### DIFF
--- a/infrastructure/proto/log_replication_metadata.proto
+++ b/infrastructure/proto/log_replication_metadata.proto
@@ -42,6 +42,8 @@ message LogReplicationMetadataVal {
  * Active Site sets the completionPercent, Standby sets the dataConsistent boolean
  */
 message ReplicationStatusVal {
+  option (org.corfudb.runtime.table_schema).stream_tag = "lr_status";
+
   uint64 remainingEntriesToSend = 1;
   bool dataConsistent = 2;
   enum SyncType {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -241,7 +241,9 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 runtime.shutdown();
             }
 
-            interClusterReplicationService.close();
+            if (interClusterReplicationService != null) {
+                interClusterReplicationService.close();
+            }
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -46,7 +46,8 @@ public class LogReplicationMetadataManager {
 
     public static final String NAMESPACE = CORFU_SYSTEM_NAMESPACE;
     public static final String METADATA_TABLE_PREFIX_NAME = "CORFU-REPLICATION-WRITER-";
-    private static final String REPLICATION_STATUS_TABLE = "LogReplicationStatus";
+    public static final String REPLICATION_STATUS_TABLE = "LogReplicationStatus";
+    public static final String LR_STATUS_STREAM_TAG = "lr_status";
     private static final String REPLICATION_EVENT_TABLE_NAME = "LogReplicationEventTable";
     private static final String LR_STREAM_TAG = "log_replication";
 


### PR DESCRIPTION
## Overview

Description:

Enable use case where clients of LR can stream on replication status table.

Why should this be merged:  client request

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
