### PR TITLE
Flaky test fix: updateLayoutOnFailure

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/ReconfigurationEventHandlerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/ReconfigurationEventHandlerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.corfudb.infrastructure.management.ReconfigurationEventHandler;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.clients.TestRule;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.ConservativeFailureHandlerPolicy;
 import org.corfudb.runtime.view.IReconfigurationHandlerPolicy;
@@ -58,15 +57,9 @@ public class ReconfigurationEventHandlerTest extends AbstractViewTest {
         Set<String> failedServers = new HashSet<>();
         failedServers.add(getEndpoint(SERVERS.PORT_2));
 
-        // Exclude SERVER 2 from the Quorum of this test layout to prevent it from getting a
-        // falsely positive response from sealMinServerSet() method.
-        addClientRule(corfuRuntime, SERVERS.ENDPOINT_2, new TestRule().always().drop());
-
         IReconfigurationHandlerPolicy failureHandlerPolicy = new ConservativeFailureHandlerPolicy();
         boolean succeed = ReconfigurationEventHandler.handleFailure(failureHandlerPolicy,
                 originalLayout, corfuRuntime, failedServers);
-
-        clearClientRules(corfuRuntime);
 
         // Verify that handleFailure correctly returns true.
         assertThat(succeed).isEqualTo(true);


### PR DESCRIPTION
## Overview

Description: 
* updateLayoutOnFailure: Previously we were using configured rules to avoid unexpected server endpoints to get sealed by sealMinServerSet(), but it would slow down the test and in some cases the node healing would happen and increase the server epoch, which made the test intermittently fails. Removed the rule configuration in this test to make the test more stable.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
