### PR TITLE
LR: replicate registryTable

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -6,6 +6,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,6 +38,10 @@ public class LogReplicationConfig {
 
     // Streaming tags on Sink/Standby (map data stream id to list of tags associated to it)
     private Map<UUID, List<UUID>> dataStreamToTagsMap = new HashMap<>();
+
+    // Merge only streams - We do not clear table when we apply shadow streams, in order to
+    // prevent data loss from local data (i.e., data that is not replicated but local to the site)
+    private Set<UUID> mergeOnlyStreams = new HashSet<>();
 
     // Snapshot Sync Batch Size(number of messages)
     private int maxNumMsgPerBatch;
@@ -73,8 +78,9 @@ public class LogReplicationConfig {
     }
 
     public LogReplicationConfig(Set<String> streamsToReplicate, Map<UUID, List<UUID>> streamingTagsMap,
-                                int maxNumMsgPerBatch, int maxMsgSize) {
+                                Set<UUID> mergeOnlyStreams, int maxNumMsgPerBatch, int maxMsgSize) {
         this(streamsToReplicate, maxNumMsgPerBatch, maxMsgSize);
         this.dataStreamToTagsMap = streamingTagsMap;
+        this.mergeOnlyStreams = mergeOnlyStreams;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -421,6 +421,8 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
 
             Map<UUID, List<UUID>> streamingConfigSink = replicationStreamNameTableManager.getStreamingConfigOnSink();
 
+            Set<UUID> mergeOnlyStreams = LogReplicationStreamNameTableManager.getMergeOnlyStreamIdList();
+
             // TODO pankti: Check if version does not match. If it does not, create an event for site discovery to
             //  do a snapshot sync.
             boolean upgraded = replicationStreamNameTableManager.isUpgraded();
@@ -429,7 +431,10 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 input(new DiscoveryServiceEvent(DiscoveryServiceEvent.DiscoveryServiceEventType.UPGRADE));
             }
 
-            return new LogReplicationConfig(streamsToReplicate, streamingConfigSink, serverContext.getLogReplicationMaxNumMsgPerBatch(),
+            return new LogReplicationConfig(streamsToReplicate,
+                    streamingConfigSink,
+                    mergeOnlyStreams,
+                    serverContext.getLogReplicationMaxNumMsgPerBatch(),
                     serverContext.getLogReplicationMaxDataMessageSize());
         } catch (Throwable t) {
             log.error("Exception when fetching the Replication Config", t);

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -49,7 +49,7 @@ public class ObjectsView extends AbstractView {
     // We are temporarily naming this stream with the same name as TRANSACTION_STREAM_ID to avoid breaking LR code
     // while transition to UFO is completed (once migration is complete to UFO this stream can be renamed)
     // add a prefix to the name: e.g., org.corfudb.logreplication.transactionstream
-    static final StreamTagInfo LOG_REPLICATOR_STREAM_INFO =
+    public static final StreamTagInfo LOG_REPLICATOR_STREAM_INFO =
             new StreamTagInfo("Transaction_Stream", CorfuRuntime.getStreamID("Transaction_Stream"));
 
     /**
@@ -238,7 +238,7 @@ public class ObjectsView extends AbstractView {
     @AllArgsConstructor
     @Getter
     @EqualsAndHashCode
-    static final class StreamTagInfo {
+    public static final class StreamTagInfo {
         @NonNull
         private final String tagName;
         @NonNull

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -134,6 +134,7 @@ public class TableRegistry {
             })
             .setStreamName(getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, REGISTRY_TABLE_NAME))
             .setSerializer(this.protobufSerializer)
+            .setStreamTags(LOG_REPLICATOR_STREAM_INFO.getStreamId())
             .open();
 
         this.protobufDescriptorTable = this.runtime.getObjectsView().build()
@@ -141,6 +142,7 @@ public class TableRegistry {
             })
             .setStreamName(getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, PROTOBUF_DESCRIPTOR_TABLE_NAME))
             .setSerializer(this.protobufSerializer)
+            .setStreamTags(LOG_REPLICATOR_STREAM_INFO.getStreamId())
             .open();
 
         // Register the table schemas to schema table.


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

One stream can have log data on a standby cluster, where nobody opens this stream.
Compactor will not see this stream in the tableRegistry and will trim this stream's data.

Later, the site becomes active, but this stream was trimmed and LR hit trimmed exception.

So we need to replicate tableRegistry across clusters, and it is merge only - we do not wipe out data for this table.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
