### PR TITLE
Noisy Log Statement for StreamingTask

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingTask.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingTask.java
@@ -157,7 +157,7 @@ public class StreamingTask<K extends Message, V extends Message, M extends Messa
         Preconditions.checkState(stream.hasNext());
         ILogData logData = stream.next();
         Optional<CorfuStreamEntries> streamEntries = transform(logData);
-        log.info("producing {} {} on {}", logData.getGlobalAddress(), logData.getType(), listenerId);
+        log.debug("producing {}@{} {} on {}", logData.getEpoch(), logData.getGlobalAddress(), logData.getType(), listenerId);
 
         streamEntries.ifPresent(e -> MicroMeterUtils.time(() -> listener.onNextEntry(e),
                 "stream.notify.duration",


### PR DESCRIPTION
## Overview

Description: reduce log level for streaming task notifications as it is spewing client logs. 

Why should this be merged: reduce logging output


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
