### PR TITLE
Enable function to print log metadata map on Browser

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -8,6 +8,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -26,6 +27,8 @@ import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.wireprotocol.ILogData;
+import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
@@ -91,6 +94,24 @@ public class CorfuStoreBrowserEditor {
         dynamicProtobufSerializer =
             new DynamicProtobufSerializer(runtime);
         runtime.getSerializers().registerSerializer(dynamicProtobufSerializer);
+    }
+
+    /**
+     * Print ILogData metadata map for a given address
+     *
+     * @param address specific address to read metadata map from
+     * @return
+     */
+    public EnumMap<IMetadata.LogUnitMetadataType, Object> printMetadataMap(long address) {
+        ILogData data = runtime.getAddressSpaceView().read(address);
+        System.out.println("\n========== Metadata Map ==========\n");
+        for(Map.Entry<IMetadata.LogUnitMetadataType, Object> entry : data.getMetadataMap().entrySet()) {
+            System.out.println(entry.getKey() + "  :: " + entry.getValue());
+        }
+        System.out.println("\n==================================\n");
+
+
+        return data.getMetadataMap();
     }
 
     /**
@@ -319,7 +340,7 @@ public class CorfuStoreBrowserEditor {
                 CorfuDynamicRecord oldRecord = table.get(dynamicKey);
 
                 if (oldRecord == null) {
-                    log.warn("Unexpedted Null Value found for key {} in table " +
+                    log.warn("Unexpected Null Value found for key {} in table " +
                             "{} and namespace {}.  Stream Id {}", keyToEdit, tableName,
                         namespace, streamUUID);
                 } else {

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
@@ -31,7 +31,8 @@ public class CorfuStoreBrowserEditorMain {
         listTags,
         listTablesForTag,
         listTagsForTable,
-        listTagsMap
+        listTagsMap,
+        printMetadataMap
     }
 
     private static final String USAGE = "Usage: corfu-browser --host=<host> " +
@@ -41,6 +42,7 @@ public class CorfuStoreBrowserEditorMain {
         "[--truststore=<truststore_file>] [--truststore_password=<truststore_password>] " +
         "[--diskPath=<pathToTempDirForLargeTables>] "+
         "[--numItems=<numItems>] "+
+        "[--address=<address>] "+
         "[--batchSize=<itemsPerTransaction>] "+
         "[--itemSize=<sizeOfEachRecordValue>] "
         + "[--keyToEdit=<keyToEdit>] [--newRecord=<newRecord>] [--tag=<tag>]"
@@ -61,6 +63,7 @@ public class CorfuStoreBrowserEditorMain {
         + "--truststore_password=<truststore_password> Truststore Password\n"
         + "--diskPath=<pathToTempDirForLargeTables> Path to Temp Dir\n"
         + "--numItems=<numItems> Total Number of items for loadTable\n"
+        + "--address=<address> Log global address\n"
         + "--batchSize=<batchSize> Number of records per transaction for loadTable\n"
         + "--itemSize=<itemSize> Size of each item's payload for loadTable\n"
         + "--keyToEdit=<keyToEdit> Key of the record to edit\n"
@@ -239,6 +242,13 @@ public class CorfuStoreBrowserEditorMain {
                 case listAllProtos:
                     browser.printAllProtoDescriptors();
                     break;
+                case printMetadataMap:
+                    if (opts.get("--address") != null) {
+                        long address = Integer.parseInt(opts.get("--address").toString());
+                        browser.printMetadataMap(address);
+                    } else {
+                        log.error("Print metadata map for a specific address. Specify using tag --address");
+                    }
                 default:
                     break;
             }


### PR DESCRIPTION
## Overview

Description: provide an additional functionality on CorfuBrowser so it prints LogData metadata map. 

Print looks like this:

========== Metadata Map ==========

BACKPOINTER_MAP  :: {e05e7a5c-333e-38da-a19f-a682f52e9821=6, a60dd28c-7cc4-335f-bfc6-90c91ed57e39=6, 6d260a60-08ea-3faf-a0b3-43f4fa45ae2a=6, e751df29-358c-34ac-9501-6c8dfb6ace12=6}
GLOBAL_ADDRESS  :: 7
CLIENT_ID  :: f98577f5-b522-41f1-817f-fbdf1a1d11b2
THREAD_ID  :: 13
EPOCH  :: 0
PAYLOAD_CODEC  :: ZSTD

==================================

Why should this be merged: This will allow debugging in cases where logic depends on metadata information (for instance timestamp retrieval used in streaming). 

Related issue(s) (if applicable): client bug


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
