### PR TITLE
Persist EPOCH in LogEntry

### DIFF
--- a/infrastructure/proto/log_format.proto
+++ b/infrastructure/proto/log_format.proto
@@ -46,6 +46,7 @@ message LogEntry {
     // less than 4-bytes to encode, since the codecType
     // range is positive and fits in a byte
     optional int32 codecType = 19;
+    optional int64 epoch = 20;
 }
 
 message LogHeader {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -478,6 +478,7 @@ public class StreamLogFiles implements StreamLog {
 
         logData.setBackpointerMap(getUUIDLongMap(entry.getBackpointersMap()));
         logData.setGlobalAddress(entry.getGlobalAddress());
+        logData.setEpoch(entry.getEpoch());
 
         if (entry.hasThreadId()) {
             logData.setThreadId(entry.getThreadId());
@@ -879,6 +880,7 @@ public class StreamLogFiles implements StreamLog {
                 .setCodecType(entry.getPayloadCodecType().getId())
                 .setData(ByteString.copyFrom(data))
                 .setGlobalAddress(address)
+                .setEpoch(entry.getEpoch())
                 .addAllStreams(getStrUUID(entry.getStreams()))
                 .putAllBackpointers(getStrLongMap(entry.getBackpointerMap()));
 


### PR DESCRIPTION
## Overview

Description:  'Epoch' is one of several fields captured by the ILogData metadata map.
We have a bug where the epoch (metadata) is never persisted as part of LogEntry.
Therefore, entries read from disk (no longer available in the server's cache) do not have the epoch and are
returned to client's as epoch -1 (for instance in the case of StreamListeners).


Why should this be merged: bug fix, incorrect epoch returned on client's callbacks. Several clients rely on the timestamp to determine if it's higher or not. 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
