### PR TITLE
CorfuOptions: Move schemaOptions to TableOptions

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -438,7 +438,7 @@ public class CorfuStoreBrowserEditor {
     public int loadTable(String namespace, String tablename, int numItems, int batchSize, int itemSize) {
         CorfuStoreShim store = new CorfuStoreShim(runtime);
         try {
-            TableOptions.TableOptionsBuilder<Object, Object> optionsBuilder = TableOptions.builder();
+            TableOptions.TableOptionsBuilder optionsBuilder = TableOptions.builder();
             if (diskPath != null) {
                 optionsBuilder.persistentDataPath(Paths.get(diskPath));
             }
@@ -447,7 +447,8 @@ public class CorfuStoreBrowserEditor {
                     ExampleTableName.class,
                     ExampleTableName.class,
                     ManagedMetadata.class,
-                    optionsBuilder.build());
+                    TableOptions.fromProtoSchema(ExampleTableName.class, optionsBuilder.build())
+            );
 
             byte[] array = new byte[itemSize];
 
@@ -492,7 +493,7 @@ public class CorfuStoreBrowserEditor {
         CorfuStoreShim store = new CorfuStoreShim(runtime);
         final Table<ExampleTableName, ExampleTableName, ManagedMetadata> table;
         try {
-            TableOptions.TableOptionsBuilder<Object, Object> optionsBuilder = TableOptions.builder();
+            TableOptions.TableOptionsBuilder optionsBuilder = TableOptions.builder();
             if (diskPath != null) {
                 optionsBuilder.persistentDataPath(Paths.get(diskPath));
             }
@@ -501,7 +502,8 @@ public class CorfuStoreBrowserEditor {
                     ExampleTableName.class,
                     ExampleTableName.class,
                     ManagedMetadata.class,
-                    optionsBuilder.build());
+                    TableOptions.fromProtoSchema(ExampleTableName.class, optionsBuilder.build())
+            );
         } catch (Exception ex) {
             log.error("Unable to open table " + namespace + "$" + tableName);
             throw new RuntimeException("Unable to open table.");

--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
@@ -7,6 +7,7 @@ import com.google.common.base.Preconditions;
 import lombok.extern.slf4j.Slf4j;
 
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.util.GitRepositoryState;
 import org.docopt.Docopt;
 
@@ -93,6 +94,7 @@ public class CorfuStoreBrowserEditorMain {
                 .cacheDisabled(true)
                 .systemDownHandler(() -> System.exit(SYSTEM_EXIT_ERROR_CODE))
                 .systemDownHandlerTriggerLimit(SYSTEM_DOWN_RETRIES)
+                .priorityLevel(CorfuMessage.PriorityLevel.HIGH)
                 .tlsEnabled(tlsEnabled);
             if (tlsEnabled) {
                 String keystore = opts.get("--keystore").toString();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -108,7 +108,7 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
             Table<ClusterUuidMsg, ClusterUuidMsg, ClusterUuidMsg> table = corfuStore.openTable(
                     CONFIG_NAMESPACE, CONFIG_TABLE_NAME,
                     ClusterUuidMsg.class, ClusterUuidMsg.class, ClusterUuidMsg.class,
-                    TableOptions.builder().build()
+                    TableOptions.fromProtoSchema(ClusterUuidMsg.class)
             );
             table.clearAll();
         } catch (Exception e) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -77,21 +77,21 @@ public class LogReplicationMetadataManager {
                             LogReplicationMetadataKey.class,
                             LogReplicationMetadataVal.class,
                             null,
-                            TableOptions.builder().build());
+                            TableOptions.fromProtoSchema(LogReplicationMetadataVal.class));
 
             this.replicationStatusTable = this.corfuStore.openTable(NAMESPACE,
                             REPLICATION_STATUS_TABLE,
                             ReplicationStatusKey.class,
                             ReplicationStatusVal.class,
                             null,
-                            TableOptions.builder().build());
+                            TableOptions.fromProtoSchema(ReplicationStatusVal.class));
 
             this.replicationEventTable = this.corfuStore.openTable(NAMESPACE,
                     REPLICATION_EVENT_TABLE_NAME,
                     ReplicationEventKey.class,
                     ReplicationEvent.class,
                     null,
-                    TableOptions.builder().build());
+                    TableOptions.fromProtoSchema(ReplicationEvent.class));
 
             this.localClusterId = localClusterId;
         } catch (Exception e) {

--- a/runtime/proto/corfu_options.proto
+++ b/runtime/proto/corfu_options.proto
@@ -8,7 +8,7 @@ import "google/protobuf/descriptor.proto";
 // Option tags to be used by the CorfuStore consumers to tag special fields to be detected by Corfu.
 message SchemaOptions {
     // Secondary keys to be indexed.
-    optional bool secondary_key = 1;
+    optional bool secondary_key_deprecated = 1;
     // Version number in metadata field.
     optional bool version = 2;
     // Should this table be backed up by Corfu.
@@ -18,12 +18,10 @@ message SchemaOptions {
     // Tag tables with unique stream listener tags for selectivity in receiving change notifications.
     repeated string stream_tag = 5;
     // Nested Secondary Key (repeated field)
-    repeated NestedSecondaryIndex nested_secondary_key = 6;
-    // Should the entry of table be validated for ownership
-    optional bool ownership_validation = 7;
+    repeated SecondaryIndex secondary_key = 6;
 }
 
-message NestedSecondaryIndex {
+message SecondaryIndex {
     // Full Qualified Name / Path
     required string index_path = 1;
     // Index Name (alias)

--- a/runtime/proto/example_schemas.proto
+++ b/runtime/proto/example_schemas.proto
@@ -32,18 +32,24 @@ message ExampleValue {
     option (org.corfudb.runtime.table_schema).is_federated = true;
 
     string payload = 1;
-    fixed64 anotherKey = 2 [(org.corfudb.runtime.schema).secondary_key = true];
-    Uuid uuid = 3 [(org.corfudb.runtime.schema).secondary_key = true];
+    fixed64 anotherKey = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "anotherKey"};
+    Uuid uuid = 3;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "uuid"};
     fixed64 entryIndex = 4;
-    NonPrimitiveValue non_primitive_field_level_0 = 5 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "non_primitive_field_level_0.key_1_level_1"},
-                                                      (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "non_primitive_field_level_0.key_2_level_1.key_1_level_2"}];
+    NonPrimitiveValue non_primitive_field_level_0 = 5;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "non_primitive_field_level_0.key_1_level_1"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "non_primitive_field_level_0.key_2_level_1.key_1_level_2"};
 }
 
 message ActivitySchedule {
     string activity = 1;
-    Time time = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "time.day" index_name: "day" }];
-    Day freeDay = 3 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "freeDay" index_name: "free" }];
-    Day optionalDay = 4 [(org.corfudb.runtime.schema).secondary_key = true];
+    Time time = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "time.day" index_name: "day" };
+    Day freeDay = 3;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "freeDay" index_name: "free" };
+    Day optionalDay = 4;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "optionalDay"};
 }
 
 message Time {
@@ -77,32 +83,37 @@ message NonPrimitiveNestedValue {
     fixed64 level_number = 2;
 }
 
-message InvalidExampleValue {
+message InvalidExampleNonExistentIndexField {
     string field1 = 1;
-    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field1.key1Level1"},
-                                 (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2.key2Level1.key1Level2"}];
+    NonPrimitiveValue field2 = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "field3"};
 }
 
 message InvalidNestedSecondaryIndex {
     string field1 = 1;
-    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2.key_1_level_1"},
-                                 (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2.key_2_level_1.deprecated"}];
+    NonPrimitiveValue field2 = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "field2.key_1_level_1"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "field2.key_2_level_1.deprecated"};
 }
 
 message InvalidFullNestedSecondaryIndex {
     string field1 = 1;
-    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2.key_1_level_1.key_1_level_2"},
-                                 (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2.key_2_level_1.key_1_level_2"}];
+    NonPrimitiveValue field2 = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "field2.key_1_level_1.key_1_level_2"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "field2.key_2_level_1.key_1_level_2"};
 }
 
 message NotNestedSecondaryIndex {
     string field1 = 1;
-    NonPrimitiveValue field2 = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "field2"}];
-    fixed64 field3 = 3 [(org.corfudb.runtime.schema).nested_secondary_key = {index_path: "field3"}];
+    NonPrimitiveValue field2 = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "field2"};
+    fixed64 field3 = 3;
+    option (org.corfudb.runtime.table_schema).secondary_key = {index_path: "field3"};
 }
 
 message ClassRoom {
-    repeated Student students = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "students.age"}];
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "students.age"};
+    repeated Student students = 1;
     Infrastructure classInfra = 2;
 }
 
@@ -112,46 +123,58 @@ message Student {
 }
 
 message Person {
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "phoneNumber.mobile"};
     string name = 1;
     fixed64 age = 2;
-    PhoneNumber phoneNumber = 3 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "phoneNumber.mobile"}];
+    PhoneNumber phoneNumber = 3;
     Children children = 4;
 }
 
 message InvalidAdultDefaultIndexName {
-    Person person = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.age"},
-                      (org.corfudb.runtime.schema).nested_secondary_key = { index_path:"person.children.child.age"}];
+    Person person = 1;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "person.age"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "person.children.child.age"};
     Company work = 2;
 }
 
 message InvalidAdultCustomIndexName {
-    Person person = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.age" index_name: "howOld"},
-                      (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.children.child.age" index_name: "howOld"}];
+    Person person = 1;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "person.age" index_name: "howOld"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "person.children.child.age" index_name: "howOld"};
     Company work = 2;
 }
 
 message Adult {
-    Person person = 1 [
-                       // Default Index Name will be 'age'
-                       (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.age"},
-                       // Explicit (custom) Index Name
-                       (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.children.child.age" index_name: "kidsAge" },
-                       // Index on a non-primitive type (which won't always be set)
-                       (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "person.children.child"}];
-    Company work = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "work.company_id" }];
-    repeated Address addresses = 3 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "addresses.unique_address_id" index_name: "address"}];
+    Person person = 1;
+    // Default Index Name will be 'age'
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "person.age"};
+    // Explicit (custom) Index Name
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "person.children.child.age" index_name: "kidsAge" };
+    // Index on a non-primitive type (which won't always be set)
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "person.children.child"};
+
+    Company work = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "work.company_id" };
+
+    repeated Address addresses = 3;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "addresses.unique_address_id" index_name: "address"};
 }
 
 message SportsProfessional {
     Person person  = 1;
+    Hobby profession = 3;
     // Non-Repeated Field followed by oneOf non-primitive sub-field
-    Hobby profession = 3 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "profession.basket" index_name: "basketPlayers"},
-                             (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "profession.baseball" index_name: "baseballPlayers"}];
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "profession.basket" index_name: "basketPlayers"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "profession.baseball" index_name: "baseballPlayers"};
+
+    repeated Hobby hobby = 4;
     // Repeated Field followed by oneOf non-primitive sub-field
-    repeated Hobby hobby = 4 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "hobby.basket" index_name: "basketAsHobby"},
-                             (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "hobby.baseball" index_name: "baseballAsHobby"}];
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "hobby.basket" index_name: "basketAsHobby"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "hobby.baseball" index_name: "baseballAsHobby"};
+
+    repeated TrainingPlan training = 5;
     // Repeated Field followed by repeated field sub-field
-    repeated TrainingPlan training = 5 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "training.exercises" }];
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "training.exercises" };
 }
 
 message TrainingPlan {
@@ -198,12 +221,14 @@ message PhoneNumber {
 
 message Office {
     string office_nickname = 1;
-    repeated Department departments = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "departments.members.phoneNumbers"}];
+    repeated Department departments = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "departments.members.phoneNumbers"};
 }
 
 message Company {
     Uuid company_id = 1;
-    repeated Office office = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "office.departments"}];
+    repeated Office office = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "office.departments"};
 }
 
 message Department {
@@ -217,8 +242,9 @@ message Member {
 }
 
 message School {
-    repeated ClassRoom classRooms = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "classRooms.classInfra.numberDesks"},
-                                      (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "classRooms.classInfra.others"}];
+    repeated ClassRoom classRooms = 1;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "classRooms.classInfra.numberDesks"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "classRooms.classInfra.others"};
 }
 
 message Infrastructure {
@@ -228,7 +254,8 @@ message Infrastructure {
 }
 
 message Network {
-    repeated Device devices = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "devices.router"}];
+    repeated Device devices = 1;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "devices.router"};
 }
 
 message Device {
@@ -243,18 +270,23 @@ message Router {
 }
 
 message ContactBook {
-    repeated Contact contacts = 1 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "contacts.number"},
-                                  (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "contacts.address.city"},
-                                  (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "contacts.number.mobile"},
-                                  (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "contacts.photo.file"}];
-    ContactBookId id = 2 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "id.uuid"},
-                          (org.corfudb.runtime.schema).nested_secondary_key = { index_path: "id.name"}];
+    repeated Contact contacts = 1;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "contacts.number"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "contacts.address.city"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "contacts.number.mobile"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "contacts.photo.file"};
+
+    ContactBookId id = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "id.uuid"};
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "id.name"};
     oneof type {
-        // If physical Contact Book, brand
-        string brand = 3 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "brand"}];
-        // If virtual Contact Book, application for contacts
-        string application = 4 [(org.corfudb.runtime.schema).nested_secondary_key = { index_path: "application"}];
+        string brand = 3;
+        string application = 4;
     }
+    // If physical Contact Book, brand
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "brand"};
+    // If virtual Contact Book, application for contacts
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "application"};
 }
 
 message ContactBookId {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreShim.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreShim.java
@@ -49,7 +49,8 @@ public class CorfuStoreShim {
                              @Nullable Class<M> mClass,
                              @Nonnull TableOptions tableOptions)
             throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        return corfuStore.openTable(namespace, tableName, kClass, vClass, mClass, tableOptions);
+        return corfuStore.openTable(namespace, tableName, kClass, vClass, mClass,
+                TableOptions.fromProtoSchema(vClass, tableOptions));
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -110,7 +110,9 @@ public class Table<K extends Message, V extends Message, M extends Message> {
                 .setTypeToken(CorfuTable.<K, CorfuRecord<V, M>>getTableType())
                 .setStreamName(this.fullyQualifiedTableName)
                 .setSerializer(serializer)
-                .setArguments(new ProtobufIndexer(tableParameters.getValueSchema()), streamingMapSupplier, versionPolicy)
+                .setArguments(new ProtobufIndexer(tableParameters.getValueSchema(),
+                        tableParameters.getSchemaOptions()),
+                        streamingMapSupplier, versionPolicy)
                 .setStreamTags(streamTags)
                 .open();
         this.keyClass = tableParameters.getKClass();

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TableOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TableOptions.java
@@ -1,7 +1,11 @@
 package org.corfudb.runtime.collections;
 
+import com.google.protobuf.Message;
 import lombok.Builder;
+import org.corfudb.runtime.CorfuOptions;
 
+import javax.annotation.Nonnull;
+import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.util.Optional;
 
@@ -9,16 +13,53 @@ import java.util.Optional;
  * Created by zlokhandwala on 2019-08-09.
  */
 @Builder
-public class TableOptions<K, V> {
-
-    private final Index.Registry<K, V> indexRegistry;
+public class TableOptions {
 
     /**
      * If this path is set, {@link CorfuStore} will utilize disk-backed {@link CorfuTable}.
      */
     private final Path persistentDataPath;
 
+    /**
+     * Capture options like stream tags, backup restore, log replication at Table level
+     */
+    private final CorfuOptions.SchemaOptions schemaOptions;
+
+    public CorfuOptions.SchemaOptions getSchemaOptions() {
+        return schemaOptions;
+    }
+
     public Optional<Path> getPersistentDataPath() {
         return Optional.ofNullable(persistentDataPath);
+    }
+
+    /**
+     * Helper function to extract corfu table schema options from message
+     * and also preserve existing options like persistedPath
+     * @param vClass - the java class created from a .proto message definition
+     * @param tableOptions - old table options to migrate from
+     * @return TableOptions that carry the message options defined within the proto
+     */
+    public static <V extends Message> TableOptions fromProtoSchema(@Nonnull Class<V> vClass,
+                                                                   TableOptions tableOptions)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        TableOptions.TableOptionsBuilder tableOptionsBuilder =
+                new TableOptions.TableOptionsBuilder();
+        if (vClass != null) { // some test cases pass vClass as null to verify behavior
+            V defaultValueMessage = (V) vClass.getMethod("getDefaultInstance").invoke(null);
+            tableOptionsBuilder.schemaOptions(defaultValueMessage
+                    .getDescriptorForType()
+                    .getOptions()
+                    .getExtension(CorfuOptions.tableSchema));
+        }
+        if (tableOptions != null && tableOptions.getPersistentDataPath().isPresent()) {
+            tableOptionsBuilder.persistentDataPath((Path) tableOptions.getPersistentDataPath().get());
+        }
+        return tableOptionsBuilder.build();
+    }
+
+    public static <V extends Message> TableOptions fromProtoSchema(@Nonnull Class<V> vClass)
+            throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        return fromProtoSchema(vClass, null);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TableParameters.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TableParameters.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
+import org.corfudb.runtime.CorfuOptions;
 
 /**
  * Table parameters including table's namespace, fullyQualifiedTableName,
@@ -51,4 +52,9 @@ public class TableParameters<K extends Message, V extends Message, M extends Mes
     // Default metadata instance
     @Getter
     private final M metadataSchema;
+
+    // These schema options are extracted from TableOptions and passed around for feature flags
+    // like stream_tags, secondary indexes, backup_restore, log replication etc
+    @Getter
+    private final CorfuOptions.SchemaOptions schemaOptions;
 }

--- a/samples/proto/person_profile.proto
+++ b/samples/proto/person_profile.proto
@@ -7,12 +7,15 @@ import "corfu_options.proto";
 import "work_experience.proto";
 
 message Name {
-    string first_name = 1 [(org.corfudb.runtime.schema).secondary_key = true];
-    string last_name = 2 [(org.corfudb.runtime.schema).secondary_key = true];
+    string first_name = 1;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "first_name"};
+    string last_name = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "last_name"};
 }
 
 message Person {
-    Name name = 1 [(org.corfudb.runtime.schema).secondary_key = true];
+    Name name = 1;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "name"};
     int32 age = 2;
     samples.protobuf.Experience exp = 3;
 }

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogUpdateAPITest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogUpdateAPITest.java
@@ -54,7 +54,7 @@ public class LogUpdateAPITest extends AbstractViewTest {
         CorfuStore corfuStore1 = new CorfuStore(runtime1);
 
         Table<Uuid, Uuid, Uuid> tableA = corfuStore1.openTable(namespace, tableAName,
-                Uuid.class, Uuid.class, Uuid.class, TableOptions.builder().build());
+                Uuid.class, Uuid.class, Uuid.class, TableOptions.fromProtoSchema(Uuid.class));
 
         UUID uuidA = CorfuRuntime.getStreamID(tableA.getFullyQualifiedTableName());
 
@@ -73,7 +73,7 @@ public class LogUpdateAPITest extends AbstractViewTest {
         CorfuRuntime runtime2 = getNewRuntime(getDefaultNode()).setTransactionLogging(true).connect();
         CorfuStore corfuStore2 = new CorfuStore(runtime2);
         Table<Uuid, Uuid, Uuid> tableC2 = corfuStore2.openTable(namespace, tableCName,
-                Uuid.class, Uuid.class, Uuid.class, TableOptions.builder().build());
+                Uuid.class, Uuid.class, Uuid.class, TableOptions.fromProtoSchema(Uuid.class));
 
         StreamOptions options = StreamOptions.builder()
                 .ignoreTrimmed(false)
@@ -92,7 +92,7 @@ public class LogUpdateAPITest extends AbstractViewTest {
         Iterator<OpaqueEntry> iterator = streamA.iterator();
 
         Table<Uuid, Uuid, Uuid> tableB = corfuStore1.openTable(namespace, tableBName,
-                Uuid.class, Uuid.class, Uuid.class, TableOptions.builder().build());
+                Uuid.class, Uuid.class, Uuid.class, TableOptions.fromProtoSchema(Uuid.class));
 
         UUID uuidB = CorfuRuntime.getStreamID(tableB.getFullyQualifiedTableName());
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -124,7 +124,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         configTable = activeCorfuStore.openTable(
                 DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
                 ClusterUuidMsg.class, ClusterUuidMsg.class, ClusterUuidMsg.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(ClusterUuidMsg.class)
         );
 
         activeLockTable = activeCorfuStore.openTable(
@@ -133,21 +133,21 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                 LockDataTypes.LockId.class,
                 LockDataTypes.LockData.class,
                 null,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(LockDataTypes.LockData.class));
 
         activeCorfuStore.openTable(LogReplicationMetadataManager.NAMESPACE,
                 REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
                 null,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
         standbyCorfuStore.openTable(LogReplicationMetadataManager.NAMESPACE,
                 REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
                 null,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
     }
 
     @After
@@ -908,7 +908,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                     LogReplicationMetadataKey.class,
                     LogReplicationMetadataVal.class,
                     null,
-                    TableOptions.builder().build());
+                    TableOptions.fromProtoSchema(LogReplicationMetadataVal.class));
 
         return metadataTable;
     }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -279,7 +279,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             corfuStore.openTable(
                     NAMESPACE, mapName,
                     Sample.StringKey.class, Sample.IntValueTag.class, Sample.Metadata.class,
-                    TableOptions.builder().build()
+                    TableOptions.fromProtoSchema(Sample.IntValueTag.class)
             );
         } catch (Exception e) {
             throw new RuntimeException(e);
@@ -514,23 +514,23 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             if (i % 2 == 0) {
                 Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata> mapActive = corfuStoreActive.openTable(
                         NAMESPACE, mapName, Sample.StringKey.class, ValueFieldTagOne.class, Sample.Metadata.class,
-                        TableOptions.builder().build());
+                        TableOptions.fromProtoSchema(ValueFieldTagOne.class));
                 mapNameToMapActiveTypeA.put(mapName, mapActive);
 
                 Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata> mapStandby = corfuStoreStandby.openTable(
                         NAMESPACE, mapName, Sample.StringKey.class, ValueFieldTagOne.class, Sample.Metadata.class,
-                        TableOptions.builder().build());
+                        TableOptions.fromProtoSchema(ValueFieldTagOne.class));
                 mapNameToMapStandbyTypeA.put(mapName, mapStandby);
 
             } else {
                 Table<Sample.StringKey, ValueFieldTagOneAndTwo , Sample.Metadata> mapActive = corfuStoreActive.openTable(
                         NAMESPACE, mapName, Sample.StringKey.class, ValueFieldTagOneAndTwo.class, Sample.Metadata.class,
-                        TableOptions.builder().build());
+                        TableOptions.fromProtoSchema(ValueFieldTagOneAndTwo.class));
                 mapNameToMapActiveTypeB.put(mapName, mapActive);
 
                 Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata> mapStandby = corfuStoreStandby.openTable(
                         NAMESPACE, mapName, Sample.StringKey.class, ValueFieldTagOneAndTwo.class, Sample.Metadata.class,
-                        TableOptions.builder().build());
+                        TableOptions.fromProtoSchema(ValueFieldTagOneAndTwo.class));
                 mapNameToMapStandbyTypeB.put(mapName, mapStandby);
             }
         }

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
@@ -22,7 +22,6 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.view.TableRegistry;
-import org.corfudb.util.serializer.Serializers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -160,7 +159,7 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
                 SampleSchema.Uuid.class,
                 SampleSchema.Uuid.class,
                 SampleSchema.Uuid.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(SampleSchema.Uuid.class));
 
         final long keyUuid = 1L;
         final long valueUuid = 3L;
@@ -312,7 +311,7 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
         for (int index = 0; index < totalTables; index++) {
             store.openTable(namespace, tableBaseName + index,
                     SampleSchema.Uuid.class, valueTypes.get(index % valueTypes.size()), SampleSchema.Uuid.class,
-                    TableOptions.builder().build());
+                    TableOptions.fromProtoSchema(valueTypes.get(index % valueTypes.size())));
             tableNameToTags.put(tableBaseName + index, expectedTagsPerValues.get(valueTypes.get(index % valueTypes.size())));
         }
 
@@ -378,7 +377,7 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
                 SampleSchema.Uuid.class,
                 SampleSchema.FirewallRule.class,
                 SampleSchema.Uuid.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(SampleSchema.FirewallRule.class));
 
         SampleSchema.Uuid uuidKey = SampleSchema.Uuid.newBuilder().setLsb(keyUuid)
             .setMsb(keyUuid).build();
@@ -441,7 +440,7 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
                 SampleSchema.Uuid.class,
                 SampleSchema.Uuid.class,
                 null,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(SampleSchema.Uuid.class));
 
         final long keyUuid = 1L;
         final long valueUuid = 3L;
@@ -500,7 +499,10 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
                 SampleSchema.Uuid.class,
                 SampleSchema.Uuid.class,
                 SampleSchema.Uuid.class,
-                TableOptions.builder().persistentDataPath(Paths.get(PARAMETERS.TEST_TEMP_DIR)).build());
+                TableOptions.fromProtoSchema(SampleSchema.Uuid.class,
+                        TableOptions.builder()
+                                .persistentDataPath(Paths.get(PARAMETERS.TEST_TEMP_DIR)).build())
+        );
 
         final long keyUuid = 1L;
         final long valueUuid = 3L;
@@ -552,7 +554,7 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
             SampleSchema.Uuid.class,
             SampleSchema.Uuid.class,
             SampleSchema.Uuid.class,
-            TableOptions.builder().build());
+            TableOptions.fromProtoSchema(SampleSchema.Uuid.class));
 
         final long keyUuid = 1L;
         final long valueUuid = 3L;

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -647,7 +647,7 @@ public class CorfuStoreIT extends AbstractIT {
                     SampleSchema.Uuid.class,
                     SampleSchema.SampleTableAMsg.class,
                     SampleSchema.ManagedMetadata.class,
-                    TableOptions.builder().build());
+                    TableOptions.fromProtoSchema(SampleSchema.SampleTableAMsg.class));
 
             SampleSchema.Uuid key = SampleSchema.Uuid.newBuilder().setLsb(0).setMsb(0).build();
             SampleSchema.SampleTableAMsg value = SampleSchema.SampleTableAMsg.newBuilder().setPayload("Payload Value").build();

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -154,7 +154,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
     }
 
     public void testEndToEndSnapshotAndLogEntrySyncUFO(int totalNumMaps) throws Exception {
-        // For the purpose of this test, standby should on;y update status 3 times:
+        // For the purpose of this test, standby should only update status 3 times:
         // (1) When initializing LR : is_data_consistent = false
         // (2) When starting snapshot sync apply : is_data_consistent = false
         // (3) When completing snapshot sync apply : is_data_consistent = true
@@ -170,7 +170,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
                     LogReplicationMetadata.ReplicationStatusKey.class,
                     LogReplicationMetadata.ReplicationStatusVal.class,
                     null,
-                    TableOptions.builder().build());
+                    TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
             CountDownLatch statusUpdateLatch = new CountDownLatch(totalStandbyStatusUpdates);
             ReplicationStatusListener standbyListener = new ReplicationStatusListener(statusUpdateLatch);
@@ -293,11 +293,11 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
             Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapActive = corfuStoreActive.openTable(
                     NAMESPACE, mapName, Sample.StringKey.class, Sample.IntValueTag.class, Sample.Metadata.class,
-                    TableOptions.builder().build());
+                    TableOptions.fromProtoSchema(Sample.IntValueTag.class));
 
             Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapStandby = corfuStoreStandby.openTable(
                     NAMESPACE, mapName, Sample.StringKey.class, Sample.IntValueTag.class, Sample.Metadata.class,
-                    TableOptions.builder().build());
+                    TableOptions.fromProtoSchema(Sample.IntValueTag.class));
 
             mapNameToMapActive.put(mapName, mapActive);
             mapNameToMapStandby.put(mapName, mapStandby);

--- a/test/src/test/java/org/corfudb/integration/StreamingIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingIT.java
@@ -227,7 +227,7 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, SampleTableAMsg, Uuid> tableA = store.openTable(
                 "test_namespace", "tableA",
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
 
         // Make some updates to the table, more than the buffer size.
@@ -356,7 +356,7 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, SampleTableCMsg, Uuid> tableNoTags = store.openTable(
                 "test_namespace", tableName,
                 Uuid.class, SampleTableCMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableCMsg.class)
         );
 
         // Make some updates to the table, more than the buffer size.
@@ -481,7 +481,7 @@ public class StreamingIT extends AbstractIT {
         // Create two tables.
         Table<Uuid, SampleTableAMsg, Uuid> table = store.openTable(ns, tn,
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(SampleTableAMsg.class));
 
         final int numRecords = PARAMETERS.NUM_ITERATIONS_LOW;
         CountDownLatch latch = new CountDownLatch(numRecords);
@@ -528,13 +528,13 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, SampleTableAMsg, Uuid> tableA = store.openTable(
                 "test_namespace", "tableA",
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
 
         Table<Uuid, SampleTableBMsg, Uuid> tableB = store.openTable(
                 "test_namespace", "tableB",
                 Uuid.class, SampleTableBMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableBMsg.class)
         );
 
         // Make some updates to the tables.
@@ -651,7 +651,7 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, SampleTableAMsg, Uuid> tableA = store.openTable(
                 "test_namespace", "tableA",
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
 
         final int numThread = 2;
@@ -726,7 +726,7 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, SampleTableAMsg, Uuid> tableA = store.openTable(
                 namespace, tableName,
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
 
         // Subscribe to streaming updates, while table has not been yet updated
@@ -794,13 +794,13 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, SampleTableAMsg, Uuid> tableA = store.openTable(
                 namespace, tableNameA,
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
 
         Table<Uuid, SampleTableBMsg, Uuid> tableB = store.openTable(
                 namespace, tableNameB,
                 Uuid.class, SampleTableBMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableBMsg.class)
         );
 
         final int numUpdates = 10;
@@ -906,13 +906,13 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, Uuid, Uuid> n1t1 = store.openTable(
                 namespace, "t1", Uuid.class,
                 Uuid.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(Uuid.class)
         );
 
         Table<Uuid, Uuid, Uuid> n1t2 = store.openTable(
                 namespace, "t2", Uuid.class,
                 Uuid.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(Uuid.class)
         );
 
         // Make an update to the tables in a transaction.
@@ -1152,7 +1152,7 @@ public class StreamingIT extends AbstractIT {
         newStore.openTable(
                 namespace, table2Name,
                 Uuid.class, SampleTableBMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableBMsg.class)
         );
 
         // Attempt to subscribe to 'commonStreamTag', it should still fail as ALL of the tables labeled with this tag
@@ -1165,13 +1165,13 @@ public class StreamingIT extends AbstractIT {
         newStore.openTable(
                 namespace, table3Name,
                 Uuid.class, SampleTableBMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableBMsg.class)
         );
 
         newStore.openTable(
                 namespace, table1Name,
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
 
         // Attempt to register, now that 3 tables have been opened
@@ -1208,7 +1208,7 @@ public class StreamingIT extends AbstractIT {
         store.openTable(
                 namespace, defaultTableName,
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
 
         // Subscribe before any data is written to the tables, to verify the timestamp corresponds to the current state
@@ -1264,7 +1264,7 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, SampleTableAMsg, Uuid> tableA = store.openTable(
                 namespace, tableName,
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
 
         // Subscribe to streaming updates
@@ -1313,7 +1313,7 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, SampleTableAMsg, Uuid> tableA = store.openTable(
                 namespace, defaultTableName,
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
 
         // Make some updates to tableA
@@ -1338,7 +1338,7 @@ public class StreamingIT extends AbstractIT {
         Table<Uuid, SampleTableBMsg, Uuid> tableB = store.openTable(
                 namespace, tableName,
                 Uuid.class, SampleTableBMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableBMsg.class)
         );
 
         for (int index = offset; index < offset + numUpdates; index++) {
@@ -1363,7 +1363,7 @@ public class StreamingIT extends AbstractIT {
 
         readStore.openTable(namespace, defaultTableName,
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
 
         try (TxnContext txn = readStore.txn(namespace, IsolationLevel.snapshot(snapshotTimestamp))) {

--- a/test/src/test/java/org/corfudb/integration/StreamingPatternsIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingPatternsIT.java
@@ -554,7 +554,7 @@ public class StreamingPatternsIT extends AbstractIT {
         tableDefault = store.openTable(
                 namespace, defaultTableName,
                 Uuid.class, SampleTableAMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableAMsg.class)
         );
     }
 
@@ -573,7 +573,7 @@ public class StreamingPatternsIT extends AbstractIT {
         Table<Uuid, SampleTableBMsg, Uuid> randomTable = store.openTable(
                 namespace, "tableRandom",
                 Uuid.class, SampleTableBMsg.class, Uuid.class,
-                TableOptions.builder().build()
+                TableOptions.fromProtoSchema(SampleTableBMsg.class)
         );
 
         for (int index = 0; index < numUpdates; index++) {

--- a/test/src/test/java/org/corfudb/runtime/BackupRestoreIT.java
+++ b/test/src/test/java/org/corfudb/runtime/BackupRestoreIT.java
@@ -170,7 +170,7 @@ public class BackupRestoreIT extends AbstractIT {
                 SampleSchema.Uuid.class,
                 SampleSchema.EventInfo.class,
                 SampleSchema.Uuid.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(SampleSchema.EventInfo.class));
     }
 
     /**
@@ -190,7 +190,7 @@ public class BackupRestoreIT extends AbstractIT {
                 SampleSchema.Uuid.class,
                 SampleSchema.SampleTableAMsg.class,
                 SampleSchema.Uuid.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(SampleSchema.SampleTableAMsg.class));
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -831,7 +831,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         Table table = corfuStoreWriter.openTable(namespace, streamName,
                 SampleSchema.Uuid.class,
                 SampleSchema.FirewallRule.class, SampleSchema.ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(SampleSchema.FirewallRule.class));
         TxnContext txn = corfuStoreWriter.txn(namespace);
         Map<SampleSchema.Uuid, CorfuRecord<SampleSchema.FirewallRule, SampleSchema.ManagedMetadata>> mockedMap = new HashMap<>();
         for (int i = 0; i < numKeys; i++) {
@@ -882,7 +882,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
                         namespace, streamName,
                         SampleSchema.Uuid.class,
                         SampleSchema.FirewallRule.class, SampleSchema.ManagedMetadata.class,
-                        TableOptions.builder().build());
+                        TableOptions.fromProtoSchema(SampleSchema.FirewallRule.class));
         TxnContext txnReader = corfuStoreReader.txn(namespace);
 
         assertThat(mockedMap.size()).isEqualTo(tableRead.count());

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreSecondaryIndexTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreSecondaryIndexTest.java
@@ -63,7 +63,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 ExampleValue.class,
                 ManagedMetadata.class,
                 // TableOptions includes option to choose - Memory/Disk based corfu table.
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleValue.class));
 
         UUID uuid1 = UUID.nameUUIDFromBytes("1".getBytes());
         UuidMsg key1 = UuidMsg.newBuilder()
@@ -128,7 +128,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ActivitySchedule.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ActivitySchedule.class));
 
         // Populate table with X records
         final int numRecords = 42;
@@ -216,7 +216,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleValue.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleValue.class));
 
         // Create 100 records
         final int totalRecords = 100;
@@ -313,7 +313,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 ExampleSchemas.ClassRoom.class,
                 ManagedMetadata.class,
                 // TableOptions includes option to choose - Memory/Disk based corfu table.
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.ClassRoom.class));
 
         // Create records for 40 classRooms
         final int totalClassRooms = 40;
@@ -380,7 +380,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 ExampleSchemas.Network.class,
                 ManagedMetadata.class,
                 // TableOptions includes option to choose - Memory/Disk based corfu table.
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.Network.class));
 
         final int totalNetworks = 10;
 
@@ -470,7 +470,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.Company.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.Company.class));
 
         final int totalCompanies = 100;
 
@@ -607,7 +607,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.Person.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.Person.class));
 
         // Create 10 records
         final int people = 10;
@@ -683,7 +683,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 ExampleSchemas.Office.class,
                 ManagedMetadata.class,
                 // TableOptions includes option to choose - Memory/Disk based corfu table.
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.Office.class));
 
         // Create 10 records
         final int numOffices = 6;
@@ -781,7 +781,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.School.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.School.class));
 
         final int numSchools = 10;
         final long oddNumDesks = 35L;
@@ -926,7 +926,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.ContactBook.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.ContactBook.class));
 
         // Common mobile number (nested repeated field in a 'oneOf' field) which will be present across all contactBooks
         final String commonMobile = "408-2219873";
@@ -1045,13 +1045,13 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
 
     /**
      * Simple example to prove an invalid nested secondary index definition will
-     * throw an error on openTable (the name is invalid from the root of the secondary index).
+     * throw an error on openTable if the schema has an index on a non-existent field
      * Please see example_schemas.proto.
      *
      * @throws Exception exception
      */
     @Test
-    public void testInvalidNestedSecondaryIndexRoot() throws Exception {
+    public void testInvalidSecondaryIndexNonExistentField() throws Exception {
         // Get a Corfu Runtime instance.
         CorfuRuntime corfuRuntime = getTestRuntime();
 
@@ -1062,15 +1062,14 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         final String someNamespace = "some-namespace";
         // Define table name.
         final String tableName = "ManagedMetadata";
-
         // Create & Register the table.
         assertThrows(IllegalArgumentException.class, () -> shimStore.openTable(
                 someNamespace,
                 tableName,
                 UuidMsg.class,
-                ExampleSchemas.InvalidExampleValue.class,
+                ExampleSchemas.InvalidExampleNonExistentIndexField.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build()));
+                TableOptions.fromProtoSchema(ExampleSchemas.InvalidExampleNonExistentIndexField.class)));
     }
 
     /**
@@ -1100,7 +1099,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.InvalidNestedSecondaryIndex.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build()));
+                TableOptions.fromProtoSchema(ExampleSchemas.InvalidNestedSecondaryIndex.class)));
     }
 
     /**
@@ -1124,13 +1123,13 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
         final String tableName = "ManagedMetadata";
 
         // Create & Register the table.
-        assertThrows(UnsupportedOperationException.class, () -> shimStore.openTable(
+        assertThrows(IllegalArgumentException.class, () -> shimStore.openTable(
                 someNamespace,
                 tableName,
                 UuidMsg.class,
                 ExampleSchemas.InvalidFullNestedSecondaryIndex.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build()));
+                TableOptions.fromProtoSchema(ExampleSchemas.InvalidFullNestedSecondaryIndex.class)));
     }
 
     /**
@@ -1161,7 +1160,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.Adult.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.Adult.class));
 
         ManagedMetadata user = ManagedMetadata.newBuilder().setCreateUser("user_UT").build();
 
@@ -1257,7 +1256,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.InvalidAdultDefaultIndexName.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build()));
+                TableOptions.fromProtoSchema(ExampleSchemas.InvalidAdultDefaultIndexName.class)));
     }
 
     /**
@@ -1285,7 +1284,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.InvalidAdultCustomIndexName.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build()));
+                TableOptions.fromProtoSchema(ExampleSchemas.InvalidAdultCustomIndexName.class)));
     }
 
     /**
@@ -1315,7 +1314,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.NotNestedSecondaryIndex.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.NotNestedSecondaryIndex.class));
 
         UUID id = UUID.randomUUID();
         UuidMsg key1 = UuidMsg.newBuilder()
@@ -1370,7 +1369,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.Adult.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.Adult.class));
 
         // Create 1st person, with 'NO' secondary index field set (no age, children, company id or address id)
         ExampleSchemas.Adult ricky = Adult.newBuilder()
@@ -1483,7 +1482,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
                 UuidMsg.class,
                 ExampleSchemas.SportsProfessional.class,
                 ManagedMetadata.class,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(ExampleSchemas.SportsProfessional.class));
 
         // Define a player and set only (1) oneOf type, then query for the unset field to confirm this
         // is indexed as NULL (i.e., not set)

--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -9,16 +9,12 @@ import "sample_appliance.proto";
 
 message FirewallRule {
     option (org.corfudb.runtime.table_schema).stream_tag = "firewall_tag";
-    optional int64 rule_id = 1 [(org.corfudb.runtime.schema).secondary_key = true];
-    optional string rule_name = 2 [(org.corfudb.runtime.schema).secondary_key = true];
+    optional int64 rule_id = 1;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "rule_id" };
+    optional string rule_name = 2;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "rule_name" };
     optional org.corfudb.test.Appliance input = 3;
     optional org.corfudb.test.Appliance output = 4;
-}
-
-message LogicalSwitch {
-    optional int64 switch_id = 1 [(org.corfudb.runtime.schema).secondary_key = true];
-    optional org.corfudb.test.Appliance input = 2;
-    repeated int64 aray = 3 [(org.corfudb.runtime.schema).secondary_key = true];
 }
 
 message ManagedResources {
@@ -32,6 +28,7 @@ message ManagedMetadata {
     optional int64 revision = 1;
     optional int64 create_time = 2;
     optional string create_user = 3;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "application"};
     optional int64 last_modified_time = 4;
     optional string last_modified_user = 5;
 }
@@ -40,9 +37,11 @@ message EventInfo {
     optional uint32 id = 1;
     optional string name = 2;
     optional uint32 port = 3;
-    optional int64 event_time = 4 [(org.corfudb.runtime.schema).secondary_key = true];
+    optional int64 event_time = 4;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "event_time"};
     optional uint32 frequency = 5;
-    optional Uuid uuid = 6 [(org.corfudb.runtime.schema).secondary_key = true];
+    optional Uuid uuid = 6;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "uuid"};
 }
 
 message Uuid {
@@ -69,7 +68,6 @@ message SampleTableAMsg {
     option (org.corfudb.runtime.table_schema).stream_tag = "sample_streamer_1";
     option (org.corfudb.runtime.table_schema).stream_tag = "sample_streamer_2";
     option (org.corfudb.runtime.table_schema).requires_backup_support = true;
-    option (org.corfudb.runtime.table_schema).ownership_validation = true;
     option (org.corfudb.runtime.table_schema).is_federated = true;
 
     optional string payload = 1;
@@ -86,7 +84,6 @@ message SampleTableBMsg {
 
 message SampleTableCMsg {
     option (org.corfudb.runtime.table_schema).requires_backup_support = true;
-    option (org.corfudb.runtime.table_schema).ownership_validation = true;
     option (org.corfudb.runtime.table_schema).is_federated = true;
 
     optional string payload = 1;

--- a/test/src/test/resources/proto/test_schema.proto
+++ b/test/src/test/resources/proto/test_schema.proto
@@ -14,7 +14,8 @@ message EventInfo {
     optional uint32 id = 1;
     optional string name = 2;
     optional uint32 port = 3;
-    optional int64 event_time = 4 [(org.corfudb.runtime.schema).secondary_key = true];
+    optional int64 event_time = 4;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "event_time"};
     optional uint32 frequency = 5;
 }
 


### PR DESCRIPTION
This allows the same proto definition to be used
to open multiple tables having different behavior
in terms of corfu features like stream_tags, replication etc

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
