### PR TITLE
Adding metrics for compactor

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
@@ -22,29 +22,31 @@ Logger name should be "org.corfudb.client.metricsdata".
 
 ### Current metrics collected for Corfu Runtime:
 
-*   **runtime.fetch_layout.timer**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes a client to fetch a layout from Corfu layout servers.
-*   **chain_replication.write**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes a client to write log data (or a hole) into every Corfu logunit server.
-*   **open_tables.count**: Number of currently open tables in the Corfu store.
-*   **stream_sub.delivery.timer**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to deliver a notification to a particular stream listener via a registered callback. 
-*   **stream_sub.polling.timer**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to poll the updates of the TX stream for a particular stream listener. 
-*   **vlo.read.timer**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to access the state of the corfu object backed by a particular stream id. 
-*   **vlo.write.timer**: Time in milliseconds (mean, max, sum, 0.5 F0p, 0.95p, 0.99p) it takes to mutate the state of the corfu object backed by a particular stream id.
-*   **vlo.tx.timer**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to execute a transaction on the corfu object backed by a particular stream id.
-*   **vlo.no_rollback_exception.count**: Number of times we were unable to roll back the particular stream by applying undo records in the reverse order.
-*   **vlo.sync.rate**: Rate of updates applied/unapplied (mean, max and throughput) to a particular stream, distinguished by a type of update (apply and undo).
-*   **vlo.read.rate**: Rate of access to the internal state of the corfu object (mean, max and throughput) backed by a particular stream, distinguished by a type of access (optimistic and pessimistic).
-*   **address_space.read_cache.avg_entry_size**: The estimated average size of an entry in the address space cache, in bytes.
-*   **address_space.read_cache.miss_ratio**: Ratio of cache read requests which were misses to the Corfu client address space.
-*   **address_space.read_cache.load_count**: The total number of times that Corfu client address space cache reads resulted in the load of new values.
-*   **address_space.read_cache.load_exception_count**: The number of times Corfu client address space cache lookups threw an exception while loading a new value.
-*   **address_space.read_cache.size**: The number of entries in the address space cache.
-*   **address_space.read.latency**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes a client to read an object from an address or a range of addresses.
-*   **address_space.write.latency**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes a client to write the given log data using a token.
-*   **address_space.log_data.size.bytes**: A size estimate distribution in bytes (mean, max, 0.50p, 0.95p, 0.99p) of the log data payload read or written through the address space API.
-*   **sequencer.query**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to query the current global tail token in the sequencer or the tails of multiple streams.
-*   **sequencer.next**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to get the next token in the sequencer for the particular streams.
-*   **sequencer.tx_resolution**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to acquire a token for a number of streams if there are no transactional conflicts.
-*   **sequencer.stream_address_range**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to retrieve the address space for the multiple streams.
+* **runtime.fetch_layout.timer**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes a client to fetch a layout from Corfu layout servers.
+* **chain_replication.write**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes a client to write log data (or a hole) into every Corfu logunit server.
+* **open_tables.count**: Number of currently open tables in the Corfu store.
+* **stream_sub.delivery.timer**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to deliver a notification to a particular stream listener via a registered callback. 
+* **stream_sub.polling.timer**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to poll the updates of the TX stream for a particular stream listener. 
+* **vlo.read.timer**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to access the state of the corfu object backed by a particular stream id. 
+* **vlo.write.timer**: Time in milliseconds (mean, max, sum, 0.5 F0p, 0.95p, 0.99p) it takes to mutate the state of the corfu object backed by a particular stream id.
+* **vlo.tx.timer**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to execute a transaction on the corfu object backed by a particular stream id.
+* **vlo.no_rollback_exception.count**: Number of times we were unable to roll back the particular stream by applying undo records in the reverse order.
+* **vlo.sync.rate**: Rate of updates applied/unapplied (mean, max and throughput) to a particular stream, distinguished by a type of update (apply and undo).
+* **vlo.sync.read_entries**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the number of updates of a stream to be sync'd.
+* **vlo.sync.read_size**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the total size of the updates of a stream to be sync'd.
+* **vlo.read.rate**: Rate of access to the internal state of the corfu object (mean, max and throughput) backed by a particular stream, distinguished by a type of access (optimistic and pessimistic).
+* **address_space.read_cache.avg_entry_size**: The estimated average size of an entry in the address space cache, in bytes.
+* **address_space.read_cache.miss_ratio**: Ratio of cache read requests which were misses to the Corfu client address space.
+* **address_space.read_cache.load_count**: The total number of times that Corfu client address space cache reads resulted in the load of new values.
+* **address_space.read_cache.load_exception_count**: The number of times Corfu client address space cache lookups threw an exception while loading a new value.
+* **address_space.read_cache.size**: The number of entries in the address space cache.
+* **address_space.read.latency**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes a client to read an object from an address or a range of addresses.
+* **address_space.write.latency**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes a client to write the given log data using a token.
+* **address_space.log_data.size.bytes**: A size estimate distribution in bytes (mean, max, 0.50p, 0.95p, 0.99p) of the log data payload read or written through the address space API.
+* **sequencer.query**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to query the current global tail token in the sequencer or the tails of multiple streams.
+* **sequencer.next**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to get the next token in the sequencer for the particular streams.
+* **sequencer.tx_resolution**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to acquire a token for a number of streams if there are no transactional conflicts.
+* **sequencer.stream_address_range**: Time in milliseconds (mean, max, sum, 0.50p, 0.95p, 0.99p) it takes to retrieve the address space for the multiple streams.
 
 ### Current metrics collected for Corfu Server:
 
@@ -71,5 +73,7 @@ Logger name should be "org.corfudb.client.metricsdata".
 *   **layout-management-view.consensus**: Time in milliseconds (mean, max, 0.50p, 0.95p, 0.99p) it takes for a particular node to reach consensus on a new layout.
 *   **corfu.infrastructure.message-handler***: Time in milliseconds (mean, max, sum, 0.5p, 0.95p, 0.99p) it takes for a particular Corfu server to process the particular incoming RPC.
 
-
-
+### Current metrics collected for Corfu Compactor:
+* **checkpoint.timer**: Time in microseconds (mean, max, sum, 0.5p, 0.95p, 0.99p) it takes for a single stream to be checkpointed.
+* **checkpoint.write.entries**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the number of entries of a stream that are checkpointed.
+* **checkpoint.write.size**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the total size of the entries of a stream that are checkpointed.


### PR DESCRIPTION
    checkpoint.timer: total checkpoint time per table
    checkpoint.write.size: size of the entries to be checkpointed
    checkpoint.write.entries: number of entries to be checkpointed
    vlo.sync.read-size: size of the updates while syncing
    vlo.sync.read-entries: number of updates while syncing

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
