### PR TITLE
Change to use debug when closing a tx without commit()

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
@@ -815,7 +815,7 @@ public class TxnContext implements AutoCloseable {
         if (TransactionalContext.isInTransaction()) {
             AbstractTransactionalContext rootContext = TransactionalContext.getRootContext();
             rootContext.setTxnContext(null);
-            log.warn("closing {} transaction without calling commit()!", rootContext);
+            log.trace("closing {} transaction without calling commit()!", rootContext);
 
             if (iDidNotStartCorfuTxn) {
                 log.warn("close() called on an inner transaction not started by CorfuStore");


### PR DESCRIPTION

## Overview

Description:
Change to use debug when closing a tx without commit()

Why should this be merged: 
It's reported that there are many warn logs when closing a tx.
It should be downgraded to debug.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
