### PR TITLE
Log Replicator DataConsistent flag 'reset' bug fix

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -615,8 +615,12 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         // Update topology config id in metadata manager
         logReplicationMetadataManager.setupTopologyConfigId(topologyDescriptor.getTopologyConfigId());
 
-        // Reset the Replication Status on Active and Standby
-        resetReplicationStatusTableWithRetry();
+        if (isLeader.get()) {
+            // Reset the Replication Status on Active and Standby only for the leader node
+            // Consider the case of async configuration changes, non-lead nodes could overwrite
+            // the replication status if it has already completed by the lead node
+            resetReplicationStatusTableWithRetry();
+        }
 
         log.debug("Persist new topologyConfigId {}, cluster id={}, role={}", topologyDescriptor.getTopologyConfigId(),
                 localClusterDescriptor.getClusterId(), localClusterDescriptor.getRole());

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -107,7 +107,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
         // (6) Verify Data on Standby after Restart
         log.debug(">>> (6) Verify Data on Standby");
-        verifyDataOnStandby((numWrites*2 + numWrites/2));
+        verifyStandbyData((numWrites*2 + numWrites/2));
     }
 
     /**
@@ -132,7 +132,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
         log.debug(">>> (3) Stop Active Node");
         stopActiveLogReplicator();
 
-        // (4) Sleep Interval so writes keep going through, while standby is down
+        // (4) Sleep Interval so writes keep going through, while active is down
         log.debug(">>> (4) Wait for some time");
         Sleep.sleepUninterruptibly(Duration.ofSeconds(SLEEP_DURATION));
 
@@ -142,7 +142,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
         // (6) Verify Data on Standby after Restart
         log.debug(">>> (6) Verify Data on Standby");
-        verifyDataOnStandby((numWrites*2 + numWrites/2));
+        verifyStandbyData((numWrites*2 + numWrites/2));
     }
 
     @Test
@@ -178,13 +178,13 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             startLogReplicatorServers();
 
             log.debug("Wait ... Snapshot log replication in progress ...");
-            verifyDataOnStandby(numWritesSmaller);
+            verifyStandbyData(numWritesSmaller);
 
             // Add Delta's for Log Entry Sync
             writeToActive(numWritesSmaller, numWritesSmaller / 2);
 
             log.debug("Wait ... Delta log replication in progress ...");
-            verifyDataOnStandby((numWritesSmaller + (numWritesSmaller / 2)));
+            verifyStandbyData((numWritesSmaller + (numWritesSmaller / 2)));
         } finally {
             executorService.shutdownNow();
 
@@ -357,10 +357,10 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             writeToActiveDifferentTypes(0, totalEntries);
 
             // Confirm data does exist on Active Cluster
-            verifyDataOnActive(totalEntries);
+            verifyActiveData(totalEntries);
 
             // Confirm data does not exist on Standby Cluster
-            verifyDataOnStandby(0);
+            verifyStandbyData(0);
 
             // Open a local table on Standby Cluster
             openTable(corfuStoreStandby, "local");
@@ -378,7 +378,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             startLogReplicatorServers();
 
             // Verify Snapshot has successfully replicated
-            verifyDataOnStandby(totalEntries);
+            verifyStandbyData(totalEntries);
 
             // Verify both extra and local table are opened on Standby
             verifyTableOpened(corfuStoreStandby, "local");
@@ -399,7 +399,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             openTable(corfuStoreActive, "extra_delta");
 
             // Verify Delta's are replicated to standby
-            verifyDataOnStandby((totalEntries*2));
+            verifyStandbyData((totalEntries*2));
 
             // Verify tableRegistry's delta is replicated to Standby
             verifyTableOpened(corfuStoreStandby, "extra_delta");
@@ -431,7 +431,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
     }
 
-    private void verifyDataOnActive(int totalEntries) {
+    private void verifyActiveData(int totalEntries) {
         for (Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata> map : mapNameToMapActiveTypeA.values()) {
             assertThat(map.count()).isEqualTo(totalEntries);
         }
@@ -441,7 +441,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
         }
     }
 
-    public void verifyDataOnStandby(int expectedConsecutiveWrites) {
+    public void verifyStandbyData(int expectedConsecutiveWrites) {
         for (Map.Entry<String, Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata>> entry : mapNameToMapStandbyTypeA.entrySet()) {
 
             log.debug("Verify Data on Standby's Table {}", entry.getKey());

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -154,11 +154,10 @@ public class LogReplicationAbstractIT extends AbstractIT {
     }
 
     public void testEndToEndSnapshotAndLogEntrySyncUFO(int totalNumMaps) throws Exception {
-        // For the purpose of this test, standby should only update status 3 times:
-        // (1) When initializing LR : is_data_consistent = false
-        // (2) When starting snapshot sync apply : is_data_consistent = false
-        // (3) When completing snapshot sync apply : is_data_consistent = true
-        final int totalStandbyStatusUpdates = 3;
+        // For the purpose of this test, standby should only update status 2 times:
+        // (1) When starting snapshot sync apply : is_data_consistent = false
+        // (2) When completing snapshot sync apply : is_data_consistent = true
+        final int totalStandbyStatusUpdates = 2;
 
         try {
             log.debug("Setup active and standby Corfu's");
@@ -206,8 +205,10 @@ public class LogReplicationAbstractIT extends AbstractIT {
             verifyDataOnStandby((numWrites + (numWrites / 2)));
 
             // Verify Standby Status Listener received all expected updates (is_data_consistent)
+            log.debug("Wait ... Replication status UPDATE ...");
             statusUpdateLatch.await();
             assertThat(standbyListener.getAccumulatedStatus().size()).isEqualTo(totalStandbyStatusUpdates);
+            // Confirm last updates are set to true (corresponding to snapshot sync completed and log entry sync started)
             assertThat(standbyListener.getAccumulatedStatus().get(standbyListener.getAccumulatedStatus().size() - 1)).isTrue();
             assertThat(standbyListener.getAccumulatedStatus()).contains(false);
         } finally {


### PR DESCRIPTION
## Overview

Description:

Cluster role change notifications are async between nodes, if any node receives onClusterRoleChange
after replication has completed on leader node, the status of this flag will be incorrectly overwritten.

Changing status replication reset to be executed only by leader node.

Why should this be merged: customer bug


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
