### PR TITLE
Fix calculation remaining entries when no deltas are present

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -144,6 +144,7 @@ public class InLogEntrySyncState implements LogReplicationState {
                 // on the tx stream, regardless of ACKs or updates being processed for the tx stream
                 fsm.getAckReader().setSyncType(SyncType.LOG_ENTRY);
                 logEntrySender.reset(fsm.getBaseSnapshot(), fsm.getAckedTimestamp());
+                fsm.getAckReader().setBaseSnapshot(fsm.getAckedTimestamp());
                 fsm.getAckReader().markSnapshotSyncInfoCompleted();
             }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -443,7 +443,7 @@ public class LogReplicationMetadataManager {
      *
      * @param clusterId standby cluster id
      */
-    public void updateSnapshotSyncStatusCompleted(String clusterId, long remainingEntriesToSend) {
+    public void updateSnapshotSyncStatusCompleted(String clusterId, long remainingEntriesToSend, long baseSnapshot) {
         Instant time = Instant.now();
         Timestamp timestamp = Timestamp.newBuilder().setSeconds(time.getEpochSecond())
                 .setNanos(time.getNano()).build();
@@ -459,6 +459,7 @@ public class LogReplicationMetadataManager {
 
                 SnapshotSyncInfo currentSyncInfo = previousSyncInfo.toBuilder()
                         .setStatus(SyncStatus.COMPLETED)
+                        .setBaseSnapshot(baseSnapshot)
                         .setCompletedTime(timestamp)
                         .build();
 


### PR DESCRIPTION
## Overview

Description:

- In the event of log entry sync wherein tx stream is advancing but no update
to replicated streams has ever occurred (currentTxStreamProcessed = -1) the remaining entries
is incorrectly computed, this fixes that edge case.

- On log entry sync re-negotiation base snapshot timestamp can be persisted as part of the replication status.

Why should this be merged: current bug


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
