### PR TITLE
Add remote leader loss to Negotiation and Replicating State

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -111,7 +111,7 @@ public class LogReplicationServer extends AbstractServer {
                                       @Nonnull IServerRouter router) {
         log.trace("Log Replication Entry received by Server.");
 
-        if (isLeader(request, ctx, router)) {
+        if (isLeader(request, ctx, router, true)) {
             // Forward the received message to the Sink Manager for apply
             LogReplicationEntryMsg ack =
                     sinkManager.receive(request.getPayload().getLrEntry());
@@ -148,7 +148,7 @@ public class LogReplicationServer extends AbstractServer {
                                        @Nonnull IServerRouter router) {
         log.info("Log Replication Metadata Request received by Server.");
 
-        if (isLeader(request, ctx, router)) {
+        if (isLeader(request, ctx, router, false)) {
             LogReplicationMetadataManager metadataMgr = sinkManager.getLogReplicationMetadataManager();
             ResponseMsg response = metadataMgr.getMetadataResponse(getHeaderMsg(request.getHeader()));
             log.info("Send Metadata response :: {}", TextFormat.shortDebugString(response.getPayload()));
@@ -197,13 +197,22 @@ public class LogReplicationServer extends AbstractServer {
      */
     protected synchronized boolean isLeader(@Nonnull RequestMsg request,
                                             @Nonnull ChannelHandlerContext ctx,
-                                            @Nonnull IServerRouter router) {
+                                            @Nonnull IServerRouter router, boolean isLogEntry) {
         // If the current cluster has switched to the active role (no longer the receiver) or it is no longer the leader,
         // skip message processing (drop received message) and nack on leadership (loss of leadership)
         // This will re-trigger leadership discovery on the sender.
         boolean lostLeadership = isActive.get() || !isLeader.get();
 
         if (lostLeadership) {
+
+            if (isLogEntry) {
+                LogReplicationEntryMsg entryMsg = request.getPayload().getLrEntry();
+                LogReplicationEntryType entryType = entryMsg.getMetadata().getEntryType();
+                log.warn("Received message of type {} while NOT LEADER. snapshotSyncSeqNumber={}, ts={}, syncRequestId={}", entryType,
+                        entryMsg.getMetadata().getSnapshotSyncSeqNum(), entryMsg.getMetadata().getTimestamp(),
+                        entryMsg.getMetadata().getSyncRequestId());
+            }
+
             log.warn("This node has changed, active={}, leader={}. Dropping message type={}, id={}", isActive.get(),
                     isLeader.get(), request.getPayload().getPayloadCase(), request.getHeader().getRequestId());
             HeaderMsg responseHeader = getHeaderMsg(request.getHeader());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -141,15 +141,9 @@ public class InSnapshotSyncState implements LogReplicationState {
                         event.getEventId(), transitionEventId);
                 return this;
             case REPLICATION_STOP:
-                /*
-                  Cancel snapshot sync if still in progress.
-                 */
                 cancelSnapshotSync("of a request to stop replication.");
                 return fsm.getStates().get(LogReplicationStateType.INITIALIZED);
             case REPLICATION_SHUTDOWN:
-                /*
-                  Cancel snapshot send if still in progress.
-                 */
                 cancelSnapshotSync("replication terminated.");
                 return fsm.getStates().get(LogReplicationStateType.ERROR);
             default: {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -38,7 +38,7 @@ import java.util.concurrent.TimeUnit;
  * all states in which the leader node on the active cluster can be.
  *
  *
- *                                                       R-LEADER_LOSS
+ *                                                  R-LEADER_LOSS / NOT_FOUND
  *                                             +-------------------------------+
  *                              ON_CONNECTION  |                               |    ON_CONNECTION_DOWN
  *                                    UP       |       ON_CONNECTION_DOWN      |       (NON_LEADER)
@@ -284,6 +284,7 @@ public class CorfuLogReplicationRuntime {
 
     public synchronized void resetRemoteLeaderNodeId() {
         log.debug("Reset remote leader node id");
+        router.resetRemoteLeader();
         leaderNodeId = Optional.empty();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
@@ -1,6 +1,5 @@
 package org.corfudb.infrastructure.logreplication.runtime;
 
-import com.google.protobuf.TextFormat;
 import io.micrometer.core.instrument.Timer;
 import lombok.Getter;
 import lombok.Setter;
@@ -382,7 +381,8 @@ public class LogReplicationClientRouter implements IClientRouter {
 
             // If it is a Leadership Loss Message re-trigger leadership discovery
             if (msg.getPayload().getPayloadCase() == PayloadCase.LR_LEADERSHIP_LOSS) {
-                runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEventType.REMOTE_LEADER_LOSS));
+                String nodeId = msg.getPayload().getLrLeadershipLoss().getNodeId();
+                runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEventType.REMOTE_LEADER_LOSS, nodeId));
                 return;
             }
 
@@ -494,4 +494,12 @@ public class LogReplicationClientRouter implements IClientRouter {
     public Optional<String> getRemoteLeaderNodeId() {
         return runtimeFSM.getRemoteLeaderNodeId();
     }
+
+    public void resetRemoteLeader() {
+        if (channelAdapter != null) {
+            log.debug("Reset remote leader from channel adapter.");
+            channelAdapter.resetRemoteLeader();
+        }
+    }
+
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -78,7 +78,14 @@ public class NegotiatingState implements LogReplicationRuntimeState {
             case NEGOTIATION_FAILED:
                 return this;
             case REMOTE_LEADER_NOT_FOUND:
+                leaderNodeId = Optional.empty();
                 return fsm.getStates().get(LogReplicationRuntimeStateType.VERIFYING_REMOTE_LEADER);
+            case REMOTE_LEADER_LOSS:
+                if (fsm.getRemoteLeaderNodeId().get().equals(event.getNodeId())) {
+                    fsm.resetRemoteLeaderNodeId();
+                    return fsm.getStates().get(LogReplicationRuntimeStateType.VERIFYING_REMOTE_LEADER);
+                }
+                return null;
             case LOCAL_LEADER_LOSS:
                 return fsm.getStates().get(LogReplicationRuntimeStateType.STOPPED);
             case ERROR:

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/ReplicatingState.java
@@ -39,7 +39,7 @@ public class ReplicatingState implements LogReplicationRuntimeState {
                 // Update list of valid connections.
                 fsm.updateDisconnectedNodes(nodeIdDown);
 
-                // If the leader is the node that become unavailable, verify new leader and attempt to reconnect.
+                // If the leader is the node that became unavailable, verify new leader and attempt to reconnect.
                 if (fsm.getRemoteLeaderNodeId().isPresent() && fsm.getRemoteLeaderNodeId().get().equals(nodeIdDown)) {
                     log.warn("Connection to remote leader id={} is down. Attempt to reconnect.", nodeIdDown);
                     fsm.resetRemoteLeaderNodeId();
@@ -51,6 +51,14 @@ public class ReplicatingState implements LogReplicationRuntimeState {
 
                 log.debug("Connection lost to non-leader node {}", nodeIdDown);
                 // If a non-leader node loses connectivity, reconnect async and continue.
+                return null;
+            case REMOTE_LEADER_LOSS:
+                if (fsm.getRemoteLeaderNodeId().get().equals(event.getNodeId())) {
+                    log.warn("Remote node {} lost leadership, stop replication & discover new leader.", event.getNodeId());
+                    fsm.resetRemoteLeaderNodeId();
+                    replicationSourceManager.stopLogReplication();
+                    return fsm.getStates().get(LogReplicationRuntimeStateType.VERIFYING_REMOTE_LEADER);
+                }
                 return null;
             case ON_CONNECTION_UP:
                 // Some node got connected, update connected endpoints

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
@@ -139,4 +139,6 @@ public abstract class IClientChannelAdapter {
     public Optional<String> getRemoteLeader() {
         return getRouter().getRemoteLeaderNodeId();
     }
+
+    public abstract void resetRemoteLeader();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
@@ -46,7 +46,6 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
     private StreamObserver<RequestMsg> requestObserver;
     private StreamObserver<ResponseMsg> responseObserver;
 
-
     /** A {@link CompletableFuture} which is completed when a connection to a remote leader is set,
      * and  messages can be sent to the remote node.
      */
@@ -227,4 +226,8 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
         });
     }
 
+    @Override
+    public void resetRemoteLeader() {
+        // No-op
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationClientChannelAdapter.java
@@ -90,4 +90,9 @@ public class NettyLogReplicationClientChannelAdapter extends IClientChannelAdapt
     public void completeExceptionally(Exception exception) {
         getRouter().completeAllExceptionally(exception);
     }
+
+    @Override
+    public void resetRemoteLeader() {
+        // No-op
+    }
 }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
@@ -17,8 +17,9 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -57,7 +58,7 @@ public class LogReplicationServerTest {
     }
 
     /**
-     * MAke sure that the server will process {@link LogReplicationMetadataRequestMsg}
+     * Make sure that the server will process {@link LogReplicationMetadataRequestMsg}
      * and provide an appropriate {@link ResponseMsg} message.
      */
     @Test
@@ -69,19 +70,19 @@ public class LogReplicationServerTest {
                 .setLrMetadataRequest(metadataRequest).build());
         final ResponseMsg response = ResponseMsg.newBuilder().build();
 
-        doReturn(true).when(lrServer).isLeader(same(request), any(), any());
+        doReturn(true).when(lrServer).isLeader(same(request), any(), any(), anyBoolean());
         doReturn(metadataManager).when(sinkManager).getLogReplicationMetadataManager();
         doReturn(response).when(metadataManager).getMetadataResponse(any());
 
         lrServer.createHandlerMethods().handle(request, mockHandlerContext, mockServerRouter);
 
-        verify(lrServer).isLeader(same(request), any(), any());
+        verify(lrServer).isLeader(same(request), any(), any(), anyBoolean());
         verify(sinkManager).getLogReplicationMetadataManager();
         verify(metadataManager).getMetadataResponse(any());
     }
 
     /**
-     * MAke sure that the server will process {@link LogReplicationLeadershipRequestMsg}
+     * Make sure that the server will process {@link LogReplicationLeadershipRequestMsg}
      * and provide an appropriate {@link ResponseMsg} message.
      */
     @Test
@@ -114,7 +115,7 @@ public class LogReplicationServerTest {
                         .setLrEntry(logEntry).build());
         final LogReplicationEntryMsg ack = LogReplicationEntryMsg.newBuilder().build();
 
-        doReturn(true).when(lrServer).isLeader(same(request), any(), any());
+        doReturn(true).when(lrServer).isLeader(same(request), any(), any(), anyBoolean());
         doReturn(ack).when(sinkManager).receive(same(request.getPayload().getLrEntry()));
 
         lrServer.createHandlerMethods().handle(request, mockHandlerContext, mockServerRouter);


### PR DESCRIPTION
## Overview

Description:

   The remote leader loss event is not currently being processed when in Negotiation or Replicating states. Also, proper stop of replication process is also fixed.

Why should this be merged: bug fix for leadership loss in the middle of log replication

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
