### PR TITLE
Integration Test for onSnapshotSyncPlugin

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultSnapshotSyncPlugin.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultSnapshotSyncPlugin.java
@@ -1,7 +1,21 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
+import com.google.protobuf.StringValue;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.ExampleSchemas;
+import org.corfudb.runtime.ExampleSchemas.SnapshotSyncPluginValue;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.util.retry.IRetry;
+import org.corfudb.util.retry.IntervalRetry;
+import org.corfudb.util.retry.RetryNeededException;
+import org.junit.Assert;
+
+import java.util.UUID;
 
 /**
  * Default Snapshot Sync Plugin
@@ -11,13 +25,60 @@ import org.corfudb.runtime.CorfuRuntime;
 @Slf4j
 public class DefaultSnapshotSyncPlugin implements ISnapshotSyncPlugin {
 
+    public static final String NAMESPACE = "corfu-IT";
+    public static final String TABLE_NAME = "dummyTable";
+    public static final String TAG = "snapshotSyncPlugin";
+    public static final UUID DEFAULT_UUID = UUID.fromString("00000000-0000-0000-0000-000000000000");
+    public static final String ON_START_VALUE = "Hello I executed the start! Checkpoint is freezed!";
+    public static final String ON_END_VALUE = "I executed the end! Checkpoint unfreezed, bye!";
+
     @Override
     public void onSnapshotSyncStart(CorfuRuntime runtime) {
-        log.debug("onSnapshotSyncStart :: OK");
+        try {
+            updateDummyTable(runtime, ON_START_VALUE);
+            log.debug("onSnapshotSyncStart :: OK");
+        } catch (Exception e) {
+            log.error("Error while attempting to start snapshot sync");
+            Assert.fail();
+        }
     }
 
     @Override
     public void onSnapshotSyncEnd(CorfuRuntime runtime) {
-        log.debug("onSnapshotSyncEnd :: OK");
+        try {
+            updateDummyTable(runtime, ON_END_VALUE);
+            log.debug("onSnapshotSyncEnd :: OK");
+        } catch (Exception e) {
+            log.error("Error while attempting to end snapshot sync");
+            Assert.fail();
+        }
+    }
+
+    private void updateDummyTable(CorfuRuntime runtime, String updateValue) {
+        try {
+            CorfuStore store = new CorfuStore(runtime);
+            Table<ExampleSchemas.Uuid, SnapshotSyncPluginValue, SnapshotSyncPluginValue> table = store.openTable(NAMESPACE, TABLE_NAME,
+                    ExampleSchemas.Uuid.class, SnapshotSyncPluginValue.class,
+                    SnapshotSyncPluginValue.class, TableOptions.fromProtoSchema(SnapshotSyncPluginValue.class));
+            IRetry.build(IntervalRetry.class, () -> {
+                try(TxnContext txn = store.txn(NAMESPACE)) {
+                    txn.putRecord(table, ExampleSchemas.Uuid.newBuilder()
+                                    .setLsb(DEFAULT_UUID.getLeastSignificantBits())
+                                    .setMsb(DEFAULT_UUID.getMostSignificantBits())
+                                    .build(),
+                            SnapshotSyncPluginValue.newBuilder().setValue(updateValue).build(),
+                            SnapshotSyncPluginValue.newBuilder().setValue(updateValue).build());
+                    txn.commit();
+                } catch (TransactionAbortedException tae) {
+                    log.error("Error while attempting to connect to update dummy table in onSnapshotSyncStart.", tae);
+                    throw new RetryNeededException();
+                }
+                return null;
+            }).run();
+            log.debug("onSnapshotSyncStart :: OK");
+        } catch (Exception e) {
+            log.error("Error while attempting to start snapshot sync");
+            Assert.fail();
+        }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/LogReplicationPluginConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/LogReplicationPluginConfig.java
@@ -26,12 +26,12 @@ import java.util.Properties;
 public class LogReplicationPluginConfig {
 
     // Transport Plugin
-    public static final String DEFAULT_JAR_PATH = "/infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar";
+    public static final String DEFAULT_JAR_PATH = "/infrastructure/target/infrastructure-0.3.1-SNAPSHOT.jar";
     public static final String DEFAULT_SERVER_CLASSNAME = "org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationServerChannelAdapter";
     public static final String DEFAULT_CLIENT_CLASSNAME = "org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationClientChannelAdapter";
 
     // Stream Fetcher Plugin
-    public static final String DEFAULT_STREAM_FETCHER_JAR_PATH = "/target/infrastructure-0.3.0-SNAPSHOT.jar";
+    public static final String DEFAULT_STREAM_FETCHER_JAR_PATH = "/target/infrastructure-0.3.1-SNAPSHOT.jar";
     public static final String DEFAULT_STREAM_FETCHER_CLASSNAME = "org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter";
 
     // Topology Manager Plugin

--- a/runtime/proto/example_schemas.proto
+++ b/runtime/proto/example_schemas.proto
@@ -19,6 +19,11 @@ message Uuid {
     fixed64 lsb = 2;
 }
 
+message SnapshotSyncPluginValue {
+    option (org.corfudb.runtime.table_schema).stream_tag = "snapshotSyncPlugin";
+    string value = 1;
+}
+
 message ClusterUuidMsg {
     option (org.corfudb.runtime.table_schema).stream_tag = "cluster_manager_test";
     fixed64 msb = 1;

--- a/test/src/test/resources/transport/grpcConfig.properties
+++ b/test/src/test/resources/transport/grpcConfig.properties
@@ -1,16 +1,16 @@
 # Transport Plugin Configuration
-transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+transport_adapter_JAR_path=../infrastructure/target/infrastructure-0.3.1-SNAPSHOT.jar
 transport_adapter_server_class_name=org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationServerChannelAdapter
 transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationClientChannelAdapter
 
 # Stream Fetcher Plugin Configuration
-stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.1-SNAPSHOT.jar
 stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter
 
 # Topology Manager Plugin Configuration
-topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.3.1-SNAPSHOT.jar
 topology_manager_adapter_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager
 
 # Snapshot Sync Configuration (Plugin)
-snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.0-SNAPSHOT.jar
+snapshot_sync_plugin_JAR_path=../infrastructure/target/infrastructure-0.3.1-SNAPSHOT.jar
 snapshot_sync_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultSnapshotSyncPlugin


### PR DESCRIPTION
## Overview

Description: this change adds a test to validate that onSnapshotSyncPlugin is being called before and after snapshot sync is completed. 

Why should this be merged: increase code coverage and catch potential issues in plugin call at the starts and end of snapshot sync.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
