### PR TITLE
Bug fix onSnapshotSyncPlugin

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationServer.java
@@ -229,6 +229,10 @@ public class LogReplicationServer extends AbstractServer {
         isLeader.set(leader);
     }
 
+    public void stopSink() {
+        sinkManager.stopOnLeadershipLoss();
+    }
+
     public synchronized void setActive(boolean active) {
         isActive.set(active);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -587,6 +587,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         isLeader.set(false);
         // Signal Log Replication Server/Sink to stop receiving messages, leadership loss
         interClusterReplicationService.getLogReplicationServer().setLeadership(false);
+        interClusterReplicationService.getLogReplicationServer().stopSink();
         recordLockRelease();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -753,7 +753,7 @@ public class LogReplicationMetadataManager {
      * Retrieve the current snapshot sync cycle Id
      */
     public long getCurrentSnapshotSyncCycleId() {
-        return queryMetadata( LogReplicationMetadataType.CURRENT_SNAPSHOT_CYCLE_ID);
+        return queryMetadata(LogReplicationMetadataType.CURRENT_SNAPSHOT_CYCLE_ID);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -338,7 +338,6 @@ public class StreamsSnapshotWriter implements SnapshotWriter {
                 updateLog(txnContext, smrEntries, streamId);
                 CorfuStoreMetadata.Timestamp ts = txnContext.commit();
                 log.debug("Applied shadow stream for stream {} on address :: {}", streamId, ts.getSequence());
-                smrEntries.forEach(e -> log.debug("Applied shadow stream for {}, SMR Entry :: method {}, updates {}", streamId, e.getSMRMethod(), e.getSMRUpdates(streamId)));
             }
 
             log.debug("Process entries count={}", smrEntries.size());


### PR DESCRIPTION
## Overview

Description:

- Fix regression onSnapshotSyncEnd validation (read MSB and not LSB)
- Add call to onSnapshotSyncEnd on leadership loss

Why should this be merged: onSnapshotSyncEnd never called due to a regression causing checkpointer/trimmer to be freezes and overtime lead applications to OOM. Client bug.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
