### PR TITLE
CorfuStore: Add support for closeTable() to remove unused tables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <maven.deploy.skip>false</maven.deploy.skip>
-        <revision>0.3.1-SNAPSHOT</revision>
+        <revision>0.3.2-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <logback.classic.version>1.2.3</logback.classic.version>

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -160,6 +160,16 @@ public class CorfuStore {
     }
 
     /**
+     *
+     * @param namespace namespace this table belongs to
+     * @param tableName name of table
+     * @throws java.util.NoSuchElementException thrown if table was not found.
+     */
+    public void closeTable(String namespace, String tableName) {
+        runtime.getTableRegistry().closeTable(namespace, tableName);
+    }
+
+    /**
      * Deletes a table instance. [NOT SUPPORTED.]
      *
      * @param namespace Namespace of the table.

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreShim.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreShim.java
@@ -101,6 +101,16 @@ public class CorfuStoreShim {
     }
 
     /**
+     *
+     * @param namespace the namespace this table belongs to
+     * @param tableName name of the table
+     * @throws java.util.NoSuchElementException if the table does not exist.
+     */
+    public void closeTable(String namespace, String tableName) {
+        corfuStore.closeTable(namespace, tableName);
+    }
+
+    /**
      * Lists all the tables in a particular namespace.
      * Lists all the tables in the database if namespace is null.
      *

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -548,6 +548,27 @@ public class TableRegistry {
     }
 
     /**
+     * Close a table that is already opened.
+     *
+     * @param namespace Namespace of the table.
+     * @param tableName Name of the table.
+     * @throws NoSuchElementException - if the table does not exist.
+     */
+    public void closeTable(String namespace, String tableName) {
+        String fullyQualifiedTableName = getFullyQualifiedTableName(namespace, tableName);
+        Table<Message, Message, Message> table = tableMap.get(fullyQualifiedTableName);
+        if (table == null) {
+            throw new NoSuchElementException("closeTable: Did not find any table "+ fullyQualifiedTableName);
+        }
+        tableMap.remove(fullyQualifiedTableName);
+        ObjectsView.ObjectID oid = new ObjectsView.ObjectID(table.getStreamUUID(), CorfuTable.class);
+        Object tableObject = runtime.getObjectsView().getObjectCache().remove(oid);
+        if (tableObject == null) {
+            throw new NoSuchElementException("closeTable: No object cache entry for "+ fullyQualifiedTableName);
+        }
+    }
+
+    /**
      * Only clears a table, DOES not delete its file descriptors from metadata.
      * This is because if the purpose of the delete is to upgrade from an old schema to a new schema
      * Then we must first purge all SMR entries of the current (old) format from corfu stream.


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: Some clients have a small footprint and only want to consume notifications made on a table.
The would like to open a table only for processing the initial snapshot and then have a way to remove that table from memory so that it does not take up space in the heap.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
