### PR TITLE
log replication: fix when Source misses an ACK for logEntry from Sink

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
@@ -84,8 +84,7 @@ public class LogEntrySinkBufferManager extends SinkBufferManager {
             LogReplicationEntryMetadataMsg metadata = entry.getMetadata();
             if (metadata.getTimestamp() <= lastProcessedSeq) {
                 buffer.remove(metadata.getPreviousTimestamp());
-            } else if (metadata.getPreviousTimestamp() <= lastProcessedSeq) {
-                sinkManager.processMessage(entry);
+            } else if (metadata.getPreviousTimestamp() <= lastProcessedSeq && sinkManager.processMessage(entry)) {
                 ackCnt++;
                 buffer.remove(lastProcessedSeq);
                 lastProcessedSeq = getCurrentSeq(entry);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -145,16 +145,8 @@ public class LogEntryWriter {
             lastMsgTs = srcGlobalSnapshot;
         }
 
-        // Skip entries that have already been processed
-        if (msg.getMetadata().getTimestamp() <= lastMsgTs) {
-            log.warn("Ignore Log Entry. Received message with timestamp {} is smaller than lastMsgTs {}.",
-                    msg.getMetadata().getTimestamp(), lastMsgTs);
-            return Address.NON_ADDRESS;
-        } else {
-            //process the new entries, i.e., msg.timestamp > lastMsgTs
-            processMsg(msg);
-            return lastMsgTs;
-        }
+        processMsg(msg);
+        return lastMsgTs;
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -495,22 +495,22 @@ public class LogReplicationSinkManager implements DataReceiver {
     /**
      * While processing an in order message, the buffer will callback and process the message
      * @param message
+     * @return true if msg was processed else false.
      */
-    public void processMessage(LogReplication.LogReplicationEntryMsg message) {
+    public boolean processMessage(LogReplication.LogReplicationEntryMsg message) {
         log.trace("Received dataMessage by Sink Manager. Total [{}]", rxMessageCounter);
 
         switch (rxState) {
             case LOG_ENTRY_SYNC:
-                logEntryWriter.apply(message);
-                break;
+                return logEntryWriter.apply(message) != Address.NON_ADDRESS;
 
             case SNAPSHOT_SYNC:
                 processSnapshotMessage(message);
-                break;
+                return true;
 
             default:
                 log.error("Wrong state {}.", rxState);
-                break;
+                return false;
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
@@ -134,9 +134,10 @@ public abstract class SinkBufferManager {
         // This message contains entries that haven't been applied yet
         if (preTs <= lastProcessedSeq && currentTs > lastProcessedSeq) {
             log.debug("Received in order message={}, lastProcessed={}", currentTs, lastProcessedSeq);
-            sinkManager.processMessage(dataMessage);
-            ackCnt++;
-            lastProcessedSeq = getCurrentSeq(dataMessage);
+            if (sinkManager.processMessage(dataMessage)) {
+                ackCnt++;
+                lastProcessedSeq = getCurrentSeq(dataMessage);
+            }
             processBuffer();
         } else if (currentTs > lastProcessedSeq && buffer.size() < maxSize) {
             log.debug("Received unordered message, currentTs={}, lastProcessed={}", currentTs, lastProcessedSeq);

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -105,7 +105,7 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
     @Override
     public CompletableFuture<LogReplicationEntryMsg> send(LogReplicationEntryMsg message) {
         log.trace("Send message: " + message.getMetadata().getEntryType() + " for:: " + message.getMetadata().getTimestamp());
-        if (ifDropMsg > 0 && msgCnt == droppingNum || (dropACKLevel == 2 && message.getMetadata().getTimestamp() >= lastAckDropped)) {
+        if (ifDropMsg > 0 && msgCnt == droppingNum || dropACKLevel == 2 && message.getMetadata().getTimestamp() >= lastAckDropped) {
             log.info("****** Drop msg {} log entry ts {}",  msgCnt, message.getMetadata().getTimestamp());
             if (ifDropMsg == DROP_MSG_ONCE) {
                 droppingNum += DROP_INCREMENT;


### PR DESCRIPTION
## Overview


**Please review the new PR: https://github.com/CorfuDB/CorfuDB/pull/3174**
This PR is just for reference

> Scenario :
> 
> Active is in log_entry sync and is sending a batch of log-entries (a.k.a msg) to standby. Let's say active has sent and received ACKs until D10, and has sent D11 to standby.
> Then there is a leadership change on Standby, and the old standby leader notifies the active of the same.
> Active stops the replication and finds the new standby leader and sends a negotiation msg.
> Active has a pendingMsgQueue that keeps track of outstanding msgs that are resent until an ACK is received for it. So active resends D11 which is now routed to the new standby leader (since active has found the new standby leader)
> Now, there is a possibility that active receives the negotiation response before standby can processes D11 and send an ACK.
> And after receiving the negotiation msg, when active resets all relevant in-memory states (including the pendingMsgQueue) before starting the replication, active looses the information that D11 had been sent and an ACK was received for the same.
> Now the metadata on active and standby do not match..essentially the prevTs on active (D10) and the lastProcessedTs on standby (D11), which can lead to msgs being ignored by standby.
> The root cause here is that the active continues to send msgs to standby even after it gives a signal to stop replication. Solution is to clear the PendingMsgQueue when active receives a signal to stop replication.
> Another issue is that the lastProcessedTs on the standby is updated even when the msg is ignored. And it is this lastProcessedTs that is sent in ACK. Result of this is that active thinks data is being replicated while in reality, Standby is ignoring the msgs.
> Changing this and updating lastProcessedTs only when the msg is processed.
> If in case there is a scenario where the msg gets continuously ignored for some reason, the lastProcessed will not increase and the active would know about it. This will then be reflected in the "remainingEntries to be replicated", which would prevent a switchover thereby preventing data loss.
> 

Why should this be merged: 
This change handles the above scenario.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ x] There are no TODOs left in the code
- [x ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x ] Change is covered by automated tests
- [ x] Public API has Javadoc
