### PR TITLE
FileSystemAgent Scheduler Fix

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
@@ -15,11 +15,9 @@ import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Optional;
 import java.util.concurrent.Executors;
@@ -213,10 +211,8 @@ public final class FileSystemAgent {
                 );
                 log.info("setPartitionAttribute: fetched PartitionAttribute successfully. " +
                         "{}", partitionAttribute);
-            } catch (IOException e) {
-                log.error("setPartitionAttribute: Error while fetching PartitionAttributes. " +
-                        "Reinitializing the scheduler.", e);
-                initializeScheduler();
+            } catch (Exception ex) {
+                log.error("setPartitionAttribute: Error while fetching PartitionAttributes.", ex);
             }
         }
 


### PR DESCRIPTION
When an IO exception is encountered from updating partition attribute
statistics, we reinitialize the scheduler. Since the exception is
caught, this can lead to duplicate tasks being scheduled.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
