### PR TITLE
update pom.xml to support maven over 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <repositories>
         <repository>
             <id>clojars.org</id>
-            <url>http://clojars.org/repo</url>
+            <url>https://clojars.org/repo</url>
         </repository>
 
         <repository>


### PR DESCRIPTION
## Overview

Description:

Maven removed http support for repositories to prevent Possible Man-In-The-Middle-Attack after version 3.8.1, update pom.xml to support new versions of Maven. 

Maven release notes: 
https://maven.apache.org/docs/3.8.1/release-notes.html 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
