### PR TITLE
Adding additional metrics required to measure compactor's performance -

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
@@ -22,37 +22,41 @@
 
 ### Current metrics collected for Corfu Runtime:
 
-*   **runtime.fetch\_layout.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to fetch a layout from Corfu layout servers.
-*   **chain\_replication.write**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to write log data (or a hole) into every Corfu logunit server.
-*   **open\_tables.count**: Number of currently open tables in the Corfu store.
-*   **highestSeqNum.numberBatchReads**: Number of batches read before finding highest DATA sequence number
-*   **highestSeqNum.numberReads**: Number of addresses read in batches before finding highest DATA sequence number
-*   **highestSequenceNumberDuration**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to complete the latest update.
-*   <del>**stream\_sub.delivery.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to deliver a notification to a particular stream listener via a registered callback.</del>
-*   <del>**stream\_sub.polling.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to poll the updates of the TX stream for a particular stream listener.</del>
-*   <del>**vlo.read.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to access the state of the corfu object backed by a particular stream id.</del>
-*   <del>**vlo.write.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to mutate the state of the corfu object backed by a particular stream id.</del>
-*   **vlo.tx.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to execute a transaction on the corfu object backed by a particular stream id.
-*   **vlo.no\_rollback\_exception.count**: Number of times we were unable to roll back the particular stream by applying undo records in the reverse order.
-*   <del>**vlo.sync.rate**: Rate of updates applied/unapplied (mean, max and throughput) to a particular stream, distinguished by a type of update (apply and undo).</del>
-*   <del>**vlo.read.rate**: Rate of access to the internal state of the corfu object (mean, max and throughput) backed by a particular stream, distinguished by a type of access (optimistic and pessimistic).</del>
-*   **address_space.read_cache.avg_entry_size**: The estimated average size of an entry in the address space cache, in bytes.
-*   <del>**address\_space.read\_cache.miss\_ratio**: Ratio of cache read requests which were misses to the Corfu client address space.</del>
-*   <del>**address\_space.read\_cache.load\_count**: The total number of times that Corfu client address space cache reads resulted in the load of new values.</del>
-*   <del>**address\_space.read\_cache.load\_exception\_count**: The number of times Corfu client address space cache lookups threw an exception while loading a new value.</del>
-*   **address_space.read_cache.size**: The number of entries in the address space cache.
-*   **address\_space.read\_cache.hit\_ratio**: The hit ratio of Corfu client address space cache.
-*   <del>**address\_space.read.latency**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to read an object from an address or a range of addresses.</del>
-*   <del>**address\_space.write.latency**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to write the given log data using a token.</del>
-*   **address\_space.log\_data.size.bytes**: A size estimate distribution in bytes (mean, max, 0.50p, 0.99p) of the log data payload read or written through the address space API.
-*   **sequencer.query**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to query the current global tail token in the sequencer or the tails of multiple streams.
-*   **sequencer.next**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to get the next token in the sequencer for the particular streams.
-*   **sequencer.tx\_resolution**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to acquire a token for a number of streams if there are no transactional conflicts.
-*   **sequencer.stream\_address\_range**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to retrieve the address space for the multiple streams.
-*   **stream.poll.duration**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to poll transaction updates
-*   **stream.notify.duration**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to send notification to client with the pre-registered callback
-*   <del>**vlo.sync.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to sync a stream.</del>
-*   **stream\_sub.queueDuration.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to wait in the queue.
+* **runtime.fetch\_layout.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to fetch a layout from Corfu layout servers.
+* **chain\_replication.write**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to write log data (or a hole) into every Corfu logunit server.
+* **open\_tables.count**: Number of currently open tables in the Corfu store.
+* **highestSeqNum.numberBatchReads**: Number of batches read before finding highest DATA sequence number
+* **highestSeqNum.numberReads**: Number of addresses read in batches before finding highest DATA sequence number
+* **highestSequenceNumberDuration**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to complete the latest update.
+* <del>**stream\_sub.delivery.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to deliver a notification to a particular stream listener via a registered callback.</del>
+* <del>**stream\_sub.polling.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to poll the updates of the TX stream for a particular stream listener.</del>
+* <del>**vlo.read.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to access the state of the corfu object backed by a particular stream id.</del>
+* <del>**vlo.write.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to mutate the state of the corfu object backed by a particular stream id.</del>
+* **vlo.tx.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to execute a transaction on the corfu object backed by a particular stream id.
+* **vlo.no\_rollback\_exception.count**: Number of times we were unable to roll back the particular stream by applying undo records in the reverse order.
+* <del>**vlo.sync.rate**: Rate of updates applied/unapplied (mean, max and throughput) to a particular stream, distinguished by a type of update (apply and undo).</del>
+* <del>**vlo.read.rate**: Rate of access to the internal state of the corfu object (mean, max and throughput) backed by a particular stream, distinguished by a type of access (optimistic and pessimistic).</del>
+* **vlo.sync.read\_entries**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the number of updates of a stream to be sync'd.
+* **vlo.sync.read\_size**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the total size of the updates of a stream to be sync'd.
+* **address_space.read_cache.avg_entry_size**: The estimated average size of an entry in the address space cache, in bytes.
+* <del>**address\_space.read\_cache.miss\_ratio**: Ratio of cache read requests which were misses to the Corfu client address space.</del>
+* <del>**address\_space.read\_cache.load\_count**: The total number of times that Corfu client address space cache reads resulted in the load of new values.</del>
+* <del>**address\_space.read\_cache.load\_exception\_count**: The number of times Corfu client address space cache lookups threw an exception while loading a new value.</del>
+* **address_space.read_cache.size**: The number of entries in the address space cache.
+* **address\_space.read\_cache.hit\_ratio**: The hit ratio of Corfu client address space cache.
+* <del>**address\_space.read.latency**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to read an object from an address or a range of addresses.</del>
+* <del>**address\_space.write.latency**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to write the given log data using a token.</del>
+* **address\_space.log\_data.size.bytes**: A size estimate distribution in bytes (mean, max, 0.50p, 0.99p) of the log data payload read or written through the address space API.
+* **sequencer.query**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to query the current global tail token in the sequencer or the tails of multiple streams.
+* **sequencer.next**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to get the next token in the sequencer for the particular streams.
+* **sequencer.tx\_resolution**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to acquire a token for a number of streams if there are no transactional conflicts.
+* **sequencer.stream\_address\_range**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to retrieve the address space for the multiple streams.
+* **stream.poll.duration**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to poll transaction updates
+* **stream.notify.duration**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to send notification to client with the pre-registered callback
+* <del>**vlo.sync.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to sync a stream.</del>
+* **stream\_sub.queueDuration.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to wait in the queue.
+* **corfu_table.read.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to read from the corfu table's map.
+* **corfu_table.write.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to write to the corfu table's map.
 
 ### Current metrics collected for Corfu Server:
 
@@ -99,3 +103,9 @@
 *   **writeTxn**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to do this write-only transaction.
 *   **readTxn**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to do this read-only transaction.
 *   **readWriteTxn**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to do this read/write transaction.
+
+### Current metrics collected for Corfu Compactor:
+* **checkpoint.timer**: Time in microseconds (mean, max, sum, 0.5p, 0.95p, 0.99p) it takes for a single stream to be checkpointed.
+* **checkpoint.write\_entries**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the number of entries of a stream that are checkpointed.
+* **checkpoint.write\_size**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the total size of the entries of a stream that are checkpointed.
+

--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
@@ -16,47 +16,47 @@
 *   **logreplication.snapshot.duration.seconds**: Duration of completing a snapshot sync in seconds (throughput, mean and max).
 *   **logreplication.acks**: Number of acks, distinguished by replication type (snapshot, logentry).
 *   **logreplication.messages**: Number of messages sent, distinguished by replication type (snapshot, logentry).
-*   **logreplication.opaque.count_per_message**: Number of opaque entries per message (rate, mean, max).
+*   **logreplication.opaque.count\_per\_message**: Number of opaque entries per message (rate, mean, max).
 *   **logreplication.opaque.count\_total**: Number of overall opaque entries (rate, mean, max).
 *   **logreplication.opaque.count\_valid**: Number of valid opaque entries (rate, mean, max).
 
 ### Current metrics collected for Corfu Runtime:
 
-* **runtime.fetch\_layout.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to fetch a layout from Corfu layout servers.
-* **chain\_replication.write**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to write log data (or a hole) into every Corfu logunit server.
-* **open\_tables.count**: Number of currently open tables in the Corfu store.
-* **highestSeqNum.numberBatchReads**: Number of batches read before finding highest DATA sequence number
-* **highestSeqNum.numberReads**: Number of addresses read in batches before finding highest DATA sequence number
-* **highestSequenceNumberDuration**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to complete the latest update.
-* <del>**stream\_sub.delivery.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to deliver a notification to a particular stream listener via a registered callback.</del>
-* <del>**stream\_sub.polling.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to poll the updates of the TX stream for a particular stream listener.</del>
-* <del>**vlo.read.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to access the state of the corfu object backed by a particular stream id.</del>
-* <del>**vlo.write.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to mutate the state of the corfu object backed by a particular stream id.</del>
-* **vlo.tx.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to execute a transaction on the corfu object backed by a particular stream id.
-* **vlo.no\_rollback\_exception.count**: Number of times we were unable to roll back the particular stream by applying undo records in the reverse order.
-* <del>**vlo.sync.rate**: Rate of updates applied/unapplied (mean, max and throughput) to a particular stream, distinguished by a type of update (apply and undo).</del>
-* <del>**vlo.read.rate**: Rate of access to the internal state of the corfu object (mean, max and throughput) backed by a particular stream, distinguished by a type of access (optimistic and pessimistic).</del>
-* **vlo.sync.read\_entries**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the number of updates of a stream to be sync'd.
-* **vlo.sync.read\_size**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the total size of the updates of a stream to be sync'd.
-* **address_space.read_cache.avg_entry_size**: The estimated average size of an entry in the address space cache, in bytes.
-* <del>**address\_space.read\_cache.miss\_ratio**: Ratio of cache read requests which were misses to the Corfu client address space.</del>
-* <del>**address\_space.read\_cache.load\_count**: The total number of times that Corfu client address space cache reads resulted in the load of new values.</del>
-* <del>**address\_space.read\_cache.load\_exception\_count**: The number of times Corfu client address space cache lookups threw an exception while loading a new value.</del>
-* **address_space.read_cache.size**: The number of entries in the address space cache.
-* **address\_space.read\_cache.hit\_ratio**: The hit ratio of Corfu client address space cache.
-* <del>**address\_space.read.latency**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to read an object from an address or a range of addresses.</del>
-* <del>**address\_space.write.latency**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to write the given log data using a token.</del>
-* **address\_space.log\_data.size.bytes**: A size estimate distribution in bytes (mean, max, 0.50p, 0.99p) of the log data payload read or written through the address space API.
-* **sequencer.query**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to query the current global tail token in the sequencer or the tails of multiple streams.
-* **sequencer.next**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to get the next token in the sequencer for the particular streams.
-* **sequencer.tx\_resolution**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to acquire a token for a number of streams if there are no transactional conflicts.
-* **sequencer.stream\_address\_range**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to retrieve the address space for the multiple streams.
-* **stream.poll.duration**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to poll transaction updates
-* **stream.notify.duration**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to send notification to client with the pre-registered callback
-* <del>**vlo.sync.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to sync a stream.</del>
-* **stream\_sub.queueDuration.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to wait in the queue.
-* **corfu_table.read.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to read from the corfu table's map.
-* **corfu_table.write.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to write to the corfu table's map.
+*   **runtime.fetch\_layout.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to fetch a layout from Corfu layout servers.
+*   **chain\_replication.write**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to write log data (or a hole) into every Corfu logunit server.
+*   **open\_tables.count**: Number of currently open tables in the Corfu store.
+*   **highestSeqNum.numberBatchReads**: Number of batches read before finding highest DATA sequence number
+*   **highestSeqNum.numberReads**: Number of addresses read in batches before finding highest DATA sequence number
+*   **highestSequenceNumberDuration**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to complete the latest update.
+*   <del>**stream\_sub.delivery.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to deliver a notification to a particular stream listener via a registered callback.</del>
+*   <del>**stream\_sub.polling.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to poll the updates of the TX stream for a particular stream listener.</del>
+*   <del>**vlo.read.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to access the state of the corfu object backed by a particular stream id.</del>
+*   <del>**vlo.write.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to mutate the state of the corfu object backed by a particular stream id.</del>
+*   **vlo.tx.timer**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to execute a transaction on the corfu object backed by a particular stream id.
+*   **vlo.no\_rollback\_exception.count**: Number of times we were unable to roll back the particular stream by applying undo records in the reverse order.
+*   <del>**vlo.sync.rate**: Rate of updates applied/unapplied (mean, max and throughput) to a particular stream, distinguished by a type of update (apply and undo).</del>
+*   <del>**vlo.read.rate**: Rate of access to the internal state of the corfu object (mean, max and throughput) backed by a particular stream, distinguished by a type of access (optimistic and pessimistic).</del>
+*   **vlo.sync.read\_entries**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the number of updates of a stream to be sync'd.
+*   **vlo.sync.read\_size**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the total size of the updates of a stream to be sync'd.
+*   **address\_space.read\_cache.avg\_entry\_size**: The estimated average size of an entry in the address space cache, in bytes.
+*   <del>**address\_space.read\_cache.miss\_ratio**: Ratio of cache read requests which were misses to the Corfu client address space.</del>
+*   <del>**address\_space.read\_cache.load\_count**: The total number of times that Corfu client address space cache reads resulted in the load of new values.</del>
+*   <del>**address\_space.read\_cache.load\_exception\_count**: The number of times Corfu client address space cache lookups threw an exception while loading a new value.</del>
+*   **address\_space.read\_cache.size**: The number of entries in the address space cache.
+*   **address\_space.read\_cache.hit\_ratio**: The hit ratio of Corfu client address space cache.
+*   <del>**address\_space.read.latency**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to read an object from an address or a range of addresses.</del>
+*   <del>**address\_space.write.latency**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes a client to write the given log data using a token.</del>
+*   **address\_space.log\_data.size.bytes**: A size estimate distribution in bytes (mean, max, 0.50p, 0.99p) of the log data payload read or written through the address space API.
+*   **sequencer.query**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to query the current global tail token in the sequencer or the tails of multiple streams.
+*   **sequencer.next**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to get the next token in the sequencer for the particular streams.
+*   **sequencer.tx\_resolution**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to acquire a token for a number of streams if there are no transactional conflicts.
+*   **sequencer.stream\_address\_range**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to retrieve the address space for the multiple streams.
+*   **stream.poll.duration**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to poll transaction updates
+*   **stream.notify.duration**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to send notification to client with the pre-registered callback
+*   <del>**vlo.sync.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to sync a stream.</del>
+*   **stream\_sub.queueDuration.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to wait in the queue.
+*   **corfu\_table.read.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to read from the corfu table's map.
+*   **corfu\_table.write.timer**: Time in microseconds(mean, max, sum, 0.50p, 0.99p) it takes to write to the corfu table's map.
 
 ### Current metrics collected for Corfu Server:
 
@@ -104,8 +104,8 @@
 *   **readTxn**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to do this read-only transaction.
 *   **readWriteTxn**: Time in microseconds (mean, max, sum, 0.50p, 0.99p) it takes to do this read/write transaction.
 
-### Current metrics collected for Corfu Compactor:
-* **checkpoint.timer**: Time in microseconds (mean, max, sum, 0.5p, 0.95p, 0.99p) it takes for a single stream to be checkpointed.
-* **checkpoint.write\_entries**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the number of entries of a stream that are checkpointed.
-* **checkpoint.write\_size**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the total size of the entries of a stream that are checkpointed.
+### Current metrics collected for Corfu Compactor
 
+*   **checkpoint.timer**: Time in microseconds (mean, max, sum, 0.5p, 0.95p, 0.99p) it takes for a single stream to be checkpointed.
+*   **checkpoint.write\_entries**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the number of entries of a stream that are checkpointed.
+*   **checkpoint.write\_size**: A distribution summary (mean, max, 0.50p, 0.95p, 0.99p) of the total size of the entries of a stream that are checkpointed.

--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -7,6 +7,7 @@ import io.netty.buffer.Unpooled;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.protocols.logprotocol.CheckpointEntry;
 import org.corfudb.protocols.logprotocol.MultiSMREntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
@@ -25,6 +26,7 @@ import org.corfudb.util.serializer.ProtobufSerializer;
 import org.corfudb.util.serializer.Serializers;
 
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -173,6 +175,10 @@ public class CheckpointWriter<T extends StreamingMap> {
             int entryCount = appendObjectState(entries);
             finishCheckpoint();
             long cpDuration = System.currentTimeMillis() - start;
+            MicroMeterUtils.time(Duration.ofMillis(cpDuration), "checkpoint.timer",
+                    "streamId", streamId.toString());
+            MicroMeterUtils.measure(numBytes, "checkpoint.write_size");
+            MicroMeterUtils.measure(entryCount, "checkpoint.write_entries");
             log.info("appendCheckpoint: completed checkpoint for {}, entries({}), " +
                             "cpSize({}) bytes at snapshot {} in {} ms",
                     streamId, entryCount, numBytes, snapshotTimestamp, cpDuration);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -219,6 +219,7 @@ public class CorfuTable<K, V> implements ICorfuTable<K, V>, ICorfuSMR<CorfuTable
     @Override
     @Accessor
     public V get(@ConflictParameter Object key) {
+
         return mainMap.get(key);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
@@ -39,6 +39,9 @@ import java.util.stream.StreamSupport;
 @Slf4j
 public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
 
+    public static final String DISK_BACKED = "diskBacked";
+    public static final String TRUE = "true";
+
     static {
         RocksDB.loadLibrary();
     }
@@ -159,7 +162,7 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
         } finally {
             keyPayload.release();
             MicroMeterUtils.time(Duration.ofMillis(System.currentTimeMillis() - start), "corfu_table.read.timer",
-                    "diskBacked", "true");
+                    DISK_BACKED, TRUE);
         }
     }
 
@@ -193,7 +196,7 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
             valuePayload.release();
         }
         MicroMeterUtils.time(Duration.ofMillis(System.currentTimeMillis() - start), "corfu_table.write.timer",
-                "diskBacked", "true");
+                DISK_BACKED, TRUE);
         return value;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
@@ -4,6 +4,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.util.serializer.ISerializer;
@@ -16,6 +17,7 @@ import org.rocksdb.RocksDBException;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -141,6 +143,7 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
      */
     @Override
     public V get(@NonNull Object key) {
+        long start = System.currentTimeMillis();
         final ByteBuf keyPayload = Unpooled.buffer();
         serializer.serialize(key, keyPayload);
 
@@ -155,6 +158,8 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
             throw new UnrecoverableCorfuError(ex);
         } finally {
             keyPayload.release();
+            MicroMeterUtils.time(Duration.ofMillis(System.currentTimeMillis() - start), "corfu_table.read.timer",
+                    "diskBacked", "true");
         }
     }
 
@@ -163,6 +168,7 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
      */
     @Override
     public V put(@NonNull K key, @NonNull V value) {
+        long start = System.currentTimeMillis();
         final ByteBuf keyPayload = Unpooled.buffer();
         final ByteBuf valuePayload = Unpooled.buffer();
         serializer.serialize(key, keyPayload);
@@ -186,7 +192,8 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
             keyPayload.release();
             valuePayload.release();
         }
-
+        MicroMeterUtils.time(Duration.ofMillis(System.currentTimeMillis() - start), "corfu_table.write.timer",
+                "diskBacked", "true");
         return value;
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
@@ -3,7 +3,6 @@ package org.corfudb.runtime.collections;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.util.ImmutableListSetWrapper;
 
-import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,6 +19,8 @@ import java.util.stream.Stream;
  */
 public class StreamingMapDecorator<K, V> implements ContextAwareMap<K, V> {
 
+    public static final String DISK_BACKED = "diskBacked";
+    public static final String FALSE = "false";
     final Map<K, V> mapImpl;
 
     public StreamingMapDecorator() {
@@ -84,7 +85,7 @@ public class StreamingMapDecorator<K, V> implements ContextAwareMap<K, V> {
     @Override
     public V get(Object key) {
         return MicroMeterUtils.time(() -> mapImpl.get(key), "corfu_table.read.timer",
-                "diskBacked", "false");
+                DISK_BACKED, FALSE);
     }
 
     /**
@@ -93,7 +94,7 @@ public class StreamingMapDecorator<K, V> implements ContextAwareMap<K, V> {
     @Override
     public V put(K key, V value) {
         return MicroMeterUtils.time(() -> mapImpl.put(key, value), "corfu_table.write.timer",
-                "diskBacked", "false");
+                DISK_BACKED, FALSE);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/StreamingMapDecorator.java
@@ -1,7 +1,9 @@
 package org.corfudb.runtime.collections;
 
+import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.util.ImmutableListSetWrapper;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -81,7 +83,8 @@ public class StreamingMapDecorator<K, V> implements ContextAwareMap<K, V> {
      */
     @Override
     public V get(Object key) {
-        return mapImpl.get(key);
+        return MicroMeterUtils.time(() -> mapImpl.get(key), "corfu_table.read.timer",
+                "diskBacked", "false");
     }
 
     /**
@@ -89,7 +92,8 @@ public class StreamingMapDecorator<K, V> implements ContextAwareMap<K, V> {
      */
     @Override
     public V put(K key, V value) {
-        return mapImpl.put(key, value);
+        return MicroMeterUtils.time(() -> mapImpl.put(key, value), "corfu_table.write.timer",
+                "diskBacked", "false");
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -680,6 +681,8 @@ public class VersionLockedObject<T extends ICorfuSMR<T>> {
                 ? "Optimistic" : "to " + timestamp);
         long syncTo = (timestamp == Address.OPTIMISTIC) ? Address.MAX : timestamp;
 
+        AtomicLong numBytes = new AtomicLong();
+        AtomicLong numEntries = new AtomicLong();
         Runnable syncStreamRunnable = () ->
                 stream.streamUpTo(syncTo)
                         .forEachOrdered(entry -> {
@@ -693,6 +696,8 @@ public class VersionLockedObject<T extends ICorfuSMR<T>> {
                                     upcallResults.put(entry.getGlobalAddress(), res == null
                                             ? NullValue.NULL_VALUE : res);
                                     pendingUpcalls.remove(entry.getGlobalAddress());
+                                    numEntries.getAndIncrement();
+                                    numBytes.getAndAdd(entry.getSerializedSize()==null ? 0: entry.getSerializedSize());
                                 }
                                 entry.setUpcallResult(res);
                             } catch (Exception e) {
@@ -702,6 +707,10 @@ public class VersionLockedObject<T extends ICorfuSMR<T>> {
                         });
         MicroMeterUtils.time(syncStreamRunnable, "vlo.sync.timer",
                 "streamId", getID().toString());
+        MicroMeterUtils.measure(numBytes.longValue(), "vlo.sync.read_size");
+        MicroMeterUtils.measure(numEntries.longValue(), "vlo.sync.read_entries");
+        log.info("Sync completed for {}, entries({}), size({}) bytes" +
+                getID().toString(), numEntries.longValue(), numBytes.longValue());
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -696,10 +696,10 @@ public class VersionLockedObject<T extends ICorfuSMR<T>> {
                                     upcallResults.put(entry.getGlobalAddress(), res == null
                                             ? NullValue.NULL_VALUE : res);
                                     pendingUpcalls.remove(entry.getGlobalAddress());
-                                    numEntries.getAndIncrement();
-                                    numBytes.getAndAdd(entry.getSerializedSize()==null ? 0: entry.getSerializedSize());
                                 }
                                 entry.setUpcallResult(res);
+                                numEntries.getAndIncrement();
+                                numBytes.getAndAdd(entry.getSerializedSize()==null ? 0: entry.getSerializedSize());
                             } catch (Exception e) {
                                 log.error("Sync[{}] Error: Couldn't execute upcall due to {}", this, e);
                                 throw new UnrecoverableCorfuError(e);
@@ -709,8 +709,6 @@ public class VersionLockedObject<T extends ICorfuSMR<T>> {
                 "streamId", getID().toString());
         MicroMeterUtils.measure(numBytes.longValue(), "vlo.sync.read_size");
         MicroMeterUtils.measure(numEntries.longValue(), "vlo.sync.read_entries");
-        log.info("Sync completed for {}, entries({}), size({}) bytes" +
-                getID().toString(), numEntries.longValue(), numBytes.longValue());
     }
 
     /**


### PR DESCRIPTION

## Overview

Description:Adding additional metrics required to measure compactor's performance -
1. checkpoint.timer - Tracks the time taken to checkpoint each stream
2. checkpoint.write_size, checkpoint.write_entries, vlo.sync.read_size, vlo.sync.read_entries - Helps track the i/o activity done by the compactor
3. corfu_table metrics - Can help distinguish performance of diskBacked and non-diskBacked reads and writes

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
