### PR TITLE
Bump netty and grpc versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <!-- Dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>
         <netty.version>4.1.73.Final</netty.version>
-        <netty.tcnative.version>2.0.44.Final</netty.tcnative.version>
+        <netty.tcnative.version>2.0.48.Final</netty.tcnative.version>
         <protobuf.version>3.6.1</protobuf.version>
         <commons.io.version>2.8.0</commons.io.version>
         <lombok.version>1.18.18</lombok.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -25,7 +25,7 @@
         <annotations.api.version>6.0.53</annotations.api.version>
         <ehcahce.sizeOf.version>0.4.0</ehcahce.sizeOf.version>
 
-        <grpc.version>1.41.0</grpc.version>
+        <grpc.version>1.44.0</grpc.version>
     </properties>
 
     <build>


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
Bump netty and grpc versions to avoid vulnerabilities.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
