### PR TITLE
Handle TX Abort due to Concurrent Access on LR Startup

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -175,8 +175,8 @@ public class LogReplicationSinkManager implements DataReceiver {
         try {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
-                    dataConsistent.set(isDataConsistent);
                     logReplicationMetadataManager.setDataConsistentOnStandby(isDataConsistent);
+                    dataConsistent.set(isDataConsistent);
                 } catch (TransactionAbortedException tae) {
                     log.error("Error while attempting to setDataConsistent in SinkManager's init", tae);
                     throw new RetryNeededException();
@@ -590,15 +590,22 @@ public class LogReplicationSinkManager implements DataReceiver {
         // If in APPLY phase do not unfreeze or shadow streams could be lost. This change was done near the release
         // date we don't know if we would be able to recover from this (test this scenario)
         // TODO: check if we'd recover from trim in shadow streams by the protocol itself
-        if (snapshotWriter.getPhase() == StreamsSnapshotWriter.Phase.TRANSFER_PHASE) {
-            log.warn("Leadership lost while in TRANSFER phase. Trigger snapshot sync plugin end, to avoid effects of" +
+        if (rxState == RxState.SNAPSHOT_SYNC) {
+            if (snapshotWriter.getPhase() == StreamsSnapshotWriter.Phase.TRANSFER_PHASE) {
+                log.warn("Leadership lost while in TRANSFER phase. Trigger " +
+                    "snapshot sync plugin end, to avoid effects of" +
                     "delayed restarts of snapshot sync.");
-            log.info("Run onSnapshotSyncEnd :: {}", snapshotSyncPlugin.getClass().getSimpleName());
-            snapshotSyncPlugin.onSnapshotSyncEnd(runtime);
-            log.info("Completed onSnapshotSyncEnd :: {}", snapshotSyncPlugin.getClass().getSimpleName());
-        } else {
-            log.warn("Leadership lost while in APPLY phase. Note that snapshot sync end plugin might not " +
+                log.info("Run onSnapshotSyncEnd :: {}",
+                    snapshotSyncPlugin.getClass().getSimpleName());
+                snapshotSyncPlugin.onSnapshotSyncEnd(runtime);
+                log.info("Completed onSnapshotSyncEnd :: {}",
+                    snapshotSyncPlugin.getClass().getSimpleName());
+            } else {
+                log.warn("Leadership lost while in APPLY phase. Note that snapshot sync end plugin might not " +
                     "have been ran.");
+            }
+        } else {
+            log.info("Leadership lost while in Log Entry Sync State");
         }
     }
 


### PR DESCRIPTION
During startup, the discovery service can write to the table of streams
to replicate.  If multiple LRs are starting concurrently, they can hit a
TX abort, causing the startup to fail.  Add retries around this block to
address the issue.

Also add retries during setup of the topology config id.


Why should this be merged:  Bug Fix




## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
