### PR TITLE
Retain metrics on restarts

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MeterRegistryProvider.java
@@ -155,6 +155,7 @@ public class MeterRegistryProvider {
      */
     public static synchronized void close() {
         meterRegistry.close();
+        meterRegistry.getRegistries().forEach(meterRegistry::remove);
         provider.ifPresent(RegistryProvider::close);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
@@ -156,7 +156,12 @@ public class CorfuServerNode implements AutoCloseable {
 
         CompletableFuture.allOf(shutdownFutures).join();
         shutdownService.shutdown();
-        MeterRegistryProvider.close();
+        // If it's the server who initialized the registry - shut it down
+        MeterRegistryProvider.getMetricType().ifPresent(type -> {
+            if (type == MeterRegistryProvider.MetricType.SERVER) {
+                MeterRegistryProvider.close();
+            }
+        });
         log.info("close: Server shutdown and resources released");
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -955,7 +955,13 @@ public class CorfuRuntime {
         if (parameters.shutdownNettyEventLoop) {
             nettyEventLoop.shutdownGracefully();
         }
-        MeterRegistryProvider.close();
+
+        // If it's the client who initialized the registry - shut it down
+        MeterRegistryProvider.getMetricType().ifPresent(type -> {
+            if (type == MeterRegistryProvider.MetricType.CLIENT) {
+                MeterRegistryProvider.close();
+            }
+        });
     }
 
     /**

--- a/test/src/test/resources/logback-test-corfu-metrics.xml
+++ b/test/src/test/resources/logback-test-corfu-metrics.xml
@@ -30,7 +30,7 @@
         </triggeringPolicy>
         <encoder>
             <pattern>
-                %msg%n%xException
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %msg%n%xException
             </pattern>
         </encoder>
     </appender>
@@ -51,11 +51,7 @@
     <logger name="io.netty.util.internal" level="INFO"/>
     <logger name="io.netty.buffer" level="INFO"/>
 
-    <logger name="org.corfudb.metricsdata" level="INFO">
-        <!--<appender-ref ref="MetricsRollingFile" />-->
-    </logger>
-
-    <logger name="org.corfudb.metricsdata1" level="DEBUG" additivity="false">
+    <logger name="org.corfudb.metricsdata" level="DEBUG" additivity="false">
         <appender-ref ref="AsyncMetricsRollingFile" />
     </logger>
 


### PR DESCRIPTION
## Overview

Description:

This patch cleans up the resource management of the MeterRegistryProvider.
It fixes the bug where the metrics stop printing after the resets (due to the CompositeMeterRegistry getting closed and never re-initialized again). 
This patch also allows instantiating only either server or client registry and allows only the respective entity to close it, which fixes the potential bug in which the server's runtime can shut down the server metrics. 

The fix is tested by deploying a  server with metrics enabled, verifying that the metrics are printing, then resetting a server and verifying that the metrics are printing again. 
Additional testing can be done on the actual infra in the cluster formation scenarios. 

Closes #3164 