### PR TITLE
Fix InMemoryStreamLog

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
@@ -5,11 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.LogUnitServer;
 import org.corfudb.infrastructure.LogUnitServer.LogUnitServerConfig;
 import org.corfudb.infrastructure.ResourceQuota;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.log.FileSystemAgent.PartitionAgent.PartitionAttribute;
+import org.corfudb.infrastructure.log.StreamLog.PersistenceMode;
 import org.corfudb.runtime.exceptions.LogUnitException;
 
 import java.io.File;
@@ -47,7 +47,7 @@ public final class FileSystemAgent {
 
         long initialLogSize;
         long logSizeLimit;
-        if (config.memoryMode) {
+        if (config.mode == PersistenceMode.MEMORY) {
             initialLogSize = 0;
             logSizeLimit = Long.MAX_VALUE;
 
@@ -133,7 +133,7 @@ public final class FileSystemAgent {
     public static class FileSystemConfig {
         private final Path logDir;
         private final double limitPercentage;
-        private final boolean memoryMode;
+        private final PersistenceMode mode;
 
         public FileSystemConfig(ServerContext serverContext) {
             String limitParam = serverContext.getServerConfig(String.class, "--log-size-quota-percentage");
@@ -145,13 +145,13 @@ public final class FileSystemAgent {
             logDir = Paths.get(logPath, "log");
 
             LogUnitServerConfig luConfig = LogUnitServerConfig.parse(serverContext.getServerConfig());
-            memoryMode = luConfig.isMemoryMode();
+            mode = PersistenceMode.fromBool(luConfig.isMemoryMode());
         }
 
-        public FileSystemConfig(Path logDir, double limitPercentage, boolean memoryMode) {
+        public FileSystemConfig(Path logDir, double limitPercentage, PersistenceMode mode) {
             this.logDir = logDir;
             this.limitPercentage = limitPercentage;
-            this.memoryMode = memoryMode;
+            this.mode = mode;
             checkLimits();
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.LogUnitServer;
+import org.corfudb.infrastructure.LogUnitServer.LogUnitServerConfig;
 import org.corfudb.infrastructure.ResourceQuota;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.log.FileSystemAgent.PartitionAgent.PartitionAttribute;
@@ -43,13 +45,23 @@ public final class FileSystemAgent {
     private FileSystemAgent(FileSystemConfig config) {
         this.config = config;
 
-        long initialLogSize = estimateSize();
-        long logSizeLimit = getLogSizeLimit();
+        long initialLogSize;
+        long logSizeLimit;
+        if (config.memoryMode) {
+            initialLogSize = 0;
+            logSizeLimit = Long.MAX_VALUE;
+
+            partitionAttribute = new PartitionAttribute(false, Long.MAX_VALUE, Long.MAX_VALUE);
+        } else {
+            initialLogSize = estimateSize();
+            logSizeLimit = getLogSizeLimit();
+
+            partitionAttribute = new PartitionAgent(config).getPartitionAttribute();
+        }
 
         logSizeQuota = new ResourceQuota("LogSizeQuota", logSizeLimit);
-        partitionAttribute = new PartitionAgent(config).getPartitionAttribute();
-
         logSizeQuota.consume(initialLogSize);
+
         log.info("FileSystemAgent: {} size is {} bytes, limit {}", config.logDir, initialLogSize, logSizeLimit);
     }
 
@@ -121,6 +133,7 @@ public final class FileSystemAgent {
     public static class FileSystemConfig {
         private final Path logDir;
         private final double limitPercentage;
+        private final boolean memoryMode;
 
         public FileSystemConfig(ServerContext serverContext) {
             String limitParam = serverContext.getServerConfig(String.class, "--log-size-quota-percentage");
@@ -130,11 +143,15 @@ public final class FileSystemAgent {
 
             String logPath = serverContext.getServerConfig(String.class, "--log-path");
             logDir = Paths.get(logPath, "log");
+
+            LogUnitServerConfig luConfig = LogUnitServerConfig.parse(serverContext.getServerConfig());
+            memoryMode = luConfig.isMemoryMode();
         }
 
-        public FileSystemConfig(Path logDir, double limitPercentage) {
+        public FileSystemConfig(Path logDir, double limitPercentage, boolean memoryMode) {
             this.logDir = logDir;
             this.limitPercentage = limitPercentage;
+            this.memoryMode = memoryMode;
             checkLimits();
         }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.log;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.log.FileSystemAgent.FileSystemConfig;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
@@ -9,6 +10,8 @@ import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.view.Address;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -42,6 +45,11 @@ public class InMemoryStreamLog implements StreamLog {
         startingAddress = 0;
         logMetadata = new LogMetadata();
         committedTail = new AtomicLong(Address.NON_ADDRESS);
+
+        Path dummyLogDir = new File(".").toPath().toAbsolutePath();
+        double unlimited = 100;
+        FileSystemConfig config = new FileSystemConfig(dummyLogDir, unlimited, PersistenceMode.MEMORY);
+        FileSystemAgent.init(config);
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -1,7 +1,6 @@
 package org.corfudb.infrastructure.log;
 
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.log.FileSystemAgent.FileSystemConfig;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
@@ -10,8 +9,6 @@ import org.corfudb.runtime.exceptions.OverwriteException;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.view.Address;
 
-import java.io.File;
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -45,10 +42,6 @@ public class InMemoryStreamLog implements StreamLog {
         startingAddress = 0;
         logMetadata = new LogMetadata();
         committedTail = new AtomicLong(Address.NON_ADDRESS);
-
-        Path dummyLogDir = new File(".").toPath().toAbsolutePath();
-        FileSystemConfig config = new FileSystemConfig(dummyLogDir, 100);
-        FileSystemAgent.init(config);
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -1,15 +1,15 @@
 package org.corfudb.infrastructure.log;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
-
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.StreamsAddressResponse;
 import org.corfudb.protocols.wireprotocol.TailsResponse;
 import org.corfudb.runtime.exceptions.OverwriteCause;
 import org.corfudb.runtime.exceptions.TrimmedException;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * An interface definition that specifies an api to interact with a StreamLog.
@@ -167,5 +167,17 @@ public interface StreamLog {
      */
     default long quotaLimitInBytes() {
         return Long.MAX_VALUE;
+    }
+
+    enum PersistenceMode {
+        DISK, MEMORY;
+
+        public static PersistenceMode fromBool(boolean isMemoryMode) {
+            if (isMemoryMode) {
+                return MEMORY;
+            } else {
+                return DISK;
+            }
+        }
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -26,6 +26,7 @@ import org.corfudb.AbstractCorfuTest;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.ServerContextBuilder;
 import org.corfudb.infrastructure.log.FileSystemAgent.FileSystemConfig;
+import org.corfudb.infrastructure.log.StreamLog.PersistenceMode;
 import org.corfudb.infrastructure.log.StreamLogFiles.Checksum;
 import org.corfudb.infrastructure.log.LogFormat.Metadata;
 import org.corfudb.infrastructure.log.LogFormat.LogHeader;
@@ -748,11 +749,11 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
 
 
         final double limit = 100.0;
-        final boolean memoryMode = false;
-        FileSystemAgent.init(new FileSystemConfig(parentDir.toPath(), limit, memoryMode));
+        final PersistenceMode mode = PersistenceMode.DISK;
+        FileSystemAgent.init(new FileSystemConfig(parentDir.toPath(), limit, mode));
         long parentSize = FileSystemAgent.getResourceQuota().getUsed().get();
 
-        FileSystemAgent.init(new FileSystemConfig(childDir.toPath(), limit, memoryMode));
+        FileSystemAgent.init(new FileSystemConfig(childDir.toPath(), limit, mode));
         long childDirSize = FileSystemAgent.getResourceQuota().getUsed().get();
 
         assertThat(parentSize).isEqualTo(parentDirFilePayloadSize + childDirFilePayloadSize);

--- a/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/StreamLogFilesTest.java
@@ -748,10 +748,11 @@ public class StreamLogFilesTest extends AbstractCorfuTest {
 
 
         final double limit = 100.0;
-        FileSystemAgent.init(new FileSystemConfig(parentDir.toPath(), limit));
+        final boolean memoryMode = false;
+        FileSystemAgent.init(new FileSystemConfig(parentDir.toPath(), limit, memoryMode));
         long parentSize = FileSystemAgent.getResourceQuota().getUsed().get();
 
-        FileSystemAgent.init(new FileSystemConfig(childDir.toPath(), limit));
+        FileSystemAgent.init(new FileSystemConfig(childDir.toPath(), limit, memoryMode));
         long childDirSize = FileSystemAgent.getResourceQuota().getUsed().get();
 
         assertThat(parentSize).isEqualTo(parentDirFilePayloadSize + childDirFilePayloadSize);

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -144,7 +144,7 @@ public class AbstractIT extends AbstractCorfuTest {
 
             ProcessBuilder builder = new ProcessBuilder();
             for (Long pid : pidList) {
-                builder.command("sh", "-c", KILL_COMMAND + pid.longValue());
+                builder.command("sh", "-c", KILL_COMMAND + pid);
                 Process p = builder.start();
                 p.waitFor();
             }

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -47,6 +47,8 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
     private final TypeToken<CorfuTable<String, String>> typeTokenStr = new TypeToken<CorfuTable<String, String>>() {
     };
 
+    private final String cpAuthor = "checkpointer-test";
+
     private CorfuRuntime createDefaultRuntimeUsingAddressMaps() {
         CorfuRuntime runtime = createRuntime(DEFAULT_ENDPOINT)
                 .setCacheDisabled(false);
@@ -377,14 +379,14 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Start checkpoint with snapshot time 9 for mapA
             CheckpointWriter<StreamingMap<String, Integer>> cpw = new CheckpointWriter<>(
                     runtime, CorfuRuntime.getStreamID(stream1),
-                    "checkpointer-test", mapA
+                    cpAuthor, mapA
             );
             Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress));
 
             // Start checkpoint with snapshot time 9 for mapB
             CheckpointWriter<StreamingMap<String, Integer>> cpwB = new CheckpointWriter<>(
                     runtime, CorfuRuntime.getStreamID(stream2),
-                    "checkpointer-test", mapB
+                    cpAuthor, mapB
             );
             cpwB.appendCheckpoint(new Token(0, snapshotAddress));
 
@@ -605,8 +607,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Checkpoint A with snapshot @ 9
             CheckpointWriter<StreamingMap<String, Integer>> cpw = new CheckpointWriter<>(
-                    runtime, CorfuRuntime.getStreamID(streamNameA),
-                    "checkpointer-test", mapA);
+                    runtime, CorfuRuntime.getStreamID(streamNameA), cpAuthor, mapA);
             Token cpAddress = cpw.appendCheckpoint(new Token(0, snapshotAddress - 1));
 
             // Trim the log
@@ -716,14 +717,12 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
 
             // Start a CheckpointWriter for streamA
             CheckpointWriter<StreamingMap<String, Integer>> cpwA = new CheckpointWriter<>(
-                    runtime, CorfuRuntime.getStreamID(streamA),
-                    "checkpointer-Test", mA);
+                    runtime, CorfuRuntime.getStreamID(streamA), cpAuthor, mA);
             Token cpTokenA = cpwA.appendCheckpoint();
 
             // Start a CheckpointWriter for streamB
             CheckpointWriter<StreamingMap<String, Integer>> cpwB = new CheckpointWriter<>(
-                    runtime, CorfuRuntime.getStreamID(streamB),
-                    "checkpointer-Test", mB);
+                    runtime, CorfuRuntime.getStreamID(streamB), cpAuthor, mB);
             cpwB.appendCheckpoint();
 
             // Add an update to streamA after checkpoint
@@ -792,7 +791,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Start a CheckpointWriter for streamA (empty)
             CheckpointWriter<StreamingMap<String, Integer>> cpwA = new CheckpointWriter<>(
                     runtime, CorfuRuntime.getStreamID(streamA),
-                    "checkpointer-Test", map);
+                    cpAuthor, map);
             Token cpToken = cpwA.appendCheckpoint();
 
             // Verify Checkpoint Token
@@ -917,7 +916,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
             // Start a CheckpointWriter for streamA
             CheckpointWriter<StreamingMap<String, Integer>> cpwA = new CheckpointWriter<>(
                     runtime, CorfuRuntime.getStreamID(streamA),
-                    "checkpointer-Test", mA);
+                    cpAuthor, mA);
             Token cpTokenA = cpwA.appendCheckpoint();
 
             // Verify Address Maps from Log Unit and Sequencer Tails (first node)


### PR DESCRIPTION
## Overview

Description:
Before #3112 InMemoryStreamLog didn't need any information about the disk, and #3112 tried to read disk info during creation, which caused errors in private infrastructure. I have changed FileSystemAgent in an exact way how it worked before #3112 changes. 

I have added:
Complete integration of "memory mode" into FileSystemAgent.
This fix takes into account that StreamLog can work in "in-memory" mode. 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
