### PR TITLE
Pass corfu server version into universe-tests 3.2.1

### DIFF
--- a/.github/workflows/injection-framework-test.yml
+++ b/.github/workflows/injection-framework-test.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Prepare top of trunk docker image
         run: ./mvnw clean package -DskipTests -Pdocker -Dmaven.javadoc.skip=true -T 1C
 
+      - name: Set corfu server version env variable
+        run: echo "CORFU_SERVER_VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> $GITHUB_ENV
+
       - uses: actions/checkout@v2
         with:
           repository: 'CorfuDB/corfudb-cloud'
@@ -44,6 +47,10 @@ jobs:
       - name: Build universe-core
         working-directory: ./universe
         run: rm -rf ~/.m2/repository/org/corfudb && ./gradlew clean publishToMavenLocal
+
+      - name: Set corfu server version
+        working-directory: ./tests
+        run: ./gradlew setCorfuServerVersion -Pcorfu.server.version=${{ env.CORFU_SERVER_VERSION }}
 
       - name: Run injection framework with universe framework
         working-directory: ./tests


### PR DESCRIPTION
## Overview

Description: Pass corfu server version into universe-tests.

Why should this be merged: Prevents the 'universe-tests' suite from failing.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
