### PR TITLE
Log Replication: Flush pending messages on replication stop

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -121,6 +121,7 @@ public class InLogEntrySyncState implements LogReplicationState {
         // as snapshot sync is triggered by the app which handles separate listeners
         // for log entry sync and snapshot sync (app can handle this)
         logEntrySender.stop();
+        logEntrySender.getDataSenderBufferManager().getPendingMessages().clear();
         if (!logEntrySyncFuture.isDone()) {
             try {
                 logEntrySyncFuture.get();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -193,6 +193,7 @@ public class InSnapshotSyncState implements LogReplicationState {
      */
     private void cancelSnapshotSync(String cancelCause) {
         snapshotSender.stop();
+        snapshotSender.getDataSenderBufferManager().getPendingMessages().clear();
         if (!transmitFuture.isDone()) {
             try {
                 transmitFuture.get();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntrySinkBufferManager.java
@@ -84,8 +84,7 @@ public class LogEntrySinkBufferManager extends SinkBufferManager {
             LogReplicationEntryMetadataMsg metadata = entry.getMetadata();
             if (metadata.getTimestamp() <= lastProcessedSeq) {
                 buffer.remove(metadata.getPreviousTimestamp());
-            } else if (metadata.getPreviousTimestamp() <= lastProcessedSeq) {
-                sinkManager.processMessage(entry);
+            } else if (metadata.getPreviousTimestamp() <= lastProcessedSeq && sinkManager.processMessage(entry)) {
                 ackCnt++;
                 buffer.remove(lastProcessedSeq);
                 lastProcessedSeq = getCurrentSeq(entry);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -495,22 +495,22 @@ public class LogReplicationSinkManager implements DataReceiver {
     /**
      * While processing an in order message, the buffer will callback and process the message
      * @param message
+     * @return true if msg was processed else false.
      */
-    public void processMessage(LogReplication.LogReplicationEntryMsg message) {
+    public boolean processMessage(LogReplication.LogReplicationEntryMsg message) {
         log.trace("Received dataMessage by Sink Manager. Total [{}]", rxMessageCounter);
 
         switch (rxState) {
             case LOG_ENTRY_SYNC:
-                logEntryWriter.apply(message);
-                break;
+                return logEntryWriter.apply(message);
 
             case SNAPSHOT_SYNC:
                 processSnapshotMessage(message);
-                break;
+                return true;
 
             default:
                 log.error("Wrong state {}.", rxState);
-                break;
+                return false;
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
@@ -134,9 +134,10 @@ public abstract class SinkBufferManager {
         // This message contains entries that haven't been applied yet
         if (preTs <= lastProcessedSeq && currentTs > lastProcessedSeq) {
             log.debug("Received in order message={}, lastProcessed={}", currentTs, lastProcessedSeq);
-            sinkManager.processMessage(dataMessage);
-            ackCnt++;
-            lastProcessedSeq = getCurrentSeq(dataMessage);
+            if (sinkManager.processMessage(dataMessage)) {
+                ackCnt++;
+                lastProcessedSeq = getCurrentSeq(dataMessage);
+            }
             processBuffer();
         } else if (currentTs > lastProcessedSeq && buffer.size() < maxSize) {
             log.debug("Received unordered message, currentTs={}, lastProcessed={}", currentTs, lastProcessedSeq);
@@ -147,6 +148,11 @@ public abstract class SinkBufferManager {
          * Send Ack with lastProcessedSeq
          */
         if (shouldAck()) {
+            //TODO: we create an ACK using the metadata of the last recevied msg, and then override
+            // the timestamp with lastProcessedTs. So the rest of the ACK metadata does not match
+            // with the ACK.Timestamp().
+            // Currently its fine since active only consumes the ACK.timestamp()...but if the behaviour
+            // changes on active, we need to change it here as well
             LogReplicationEntryMetadataMsg metadata = generateAckMetadata(dataMessage);
             log.trace("Sending an ACK {}", metadata);
             return getLrEntryAckMsg(metadata);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication.replication.send;
 
 import io.micrometer.core.instrument.Tag;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.infrastructure.logreplication.DataSender;
@@ -34,6 +35,7 @@ public class LogEntrySender {
     /*
      * Implementation of buffering messages and sending/resending messages
      */
+    @Getter
     private final SenderBufferManager dataSenderBufferManager;
 
     /*

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -53,6 +53,7 @@ public class SnapshotSender {
 
     private CorfuRuntime runtime;
     private SnapshotReader snapshotReader;
+    @Getter
     private SenderBufferManager dataSenderBufferManager;
     private LogReplicationFSM fsm;
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -21,6 +21,7 @@ import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryType;
 import org.corfudb.runtime.LogReplication.LogReplicationMetadataResponseMsg;
 import org.corfudb.runtime.collections.CorfuTable;
+import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.runtime.view.ObjectsView;
 import org.corfudb.util.Utils;
 import org.corfudb.util.serializer.Serializers;
@@ -35,14 +36,17 @@ import java.util.Observable;
 import java.util.Observer;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static java.lang.Thread.sleep;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.corfudb.integration.LogReplicationReaderWriterIT.ckStreamsAndTrim;
+import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
 
 /**
  * Test the core components of log replication, namely, Snapshot Sync and Log Entry Sync,
@@ -115,6 +119,8 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     private HashMap<String, HashMap<Long, Long>> srcDataForVerification = new HashMap<>();
     private HashMap<String, HashMap<Long, Long>> dstDataForVerification = new HashMap<>();
 
+    LogReplicationSourceManager logReplicationSourceManager;
+
     private CorfuRuntime srcTestRuntime;
 
     private CorfuRuntime dstTestRuntime;
@@ -139,7 +145,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     private long expectedAckMessages = 0;
 
     // Set per test according to the expected ACK's timestamp.
-    private long expectedAckTimestamp = Long.MAX_VALUE;
+    private volatile AtomicLong expectedAckTimestamp;
 
     // Set per test according to the expected number of errors in a test
     private int expectedErrors = 1;
@@ -167,6 +173,8 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     private final String t0 = TABLE_PREFIX + 0;
     private final String t1 = TABLE_PREFIX + 1;
     private final String t2 = TABLE_PREFIX + 2;
+
+    private final CountDownLatch blockUntilFSMTransition = new CountDownLatch(1);
 
     /**
      * Setup Test Environment
@@ -220,6 +228,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         dstTestRuntime.connect();
 
         logReplicationMetadataManager = new LogReplicationMetadataManager(dstTestRuntime, 0, ACTIVE_CLUSTER_ID);
+        expectedAckTimestamp = new AtomicLong(Long.MAX_VALUE);
         testConfig.clear();
     }
 
@@ -300,12 +309,8 @@ public class LogReplicationIT extends AbstractIT implements Observer {
                     cntDelete++;
                 }
             }
-            rt.getObjectsView().TXEnd();
-            long tail = Utils.getLogAddressSpace(rt
-                    .getLayoutView().getRuntimeLayout())
-                    .getAddressMap()
-                    .get(ObjectsView.getLogReplicatorStreamId()).getTail();
-            expectedAckTimestamp = Math.max(tail, expectedAckTimestamp);
+            Long tail = rt.getObjectsView().TXEnd();
+            expectedAckTimestamp.set(Math.max(tail, expectedAckTimestamp.get()));
         }
 
         if (cntDelete > 0) {
@@ -318,9 +323,6 @@ public class LogReplicationIT extends AbstractIT implements Observer {
             for (String name : tables0.keySet()) {
                 CorfuTable<Long, Long> table = tables0.get(name);
                 CorfuTable<Long, Long> mapKeys = tables1.get(name);
-
-                //System.out.print("\nTable[" + name + "]: " + table.keySet().size() + " keys; Expected "
-                //        + mapKeys.size() + " keys");
 
                 assertThat(mapKeys.keySet().containsAll(table.keySet())).isTrue();
                 assertThat(table.keySet().containsAll(mapKeys.keySet())).isTrue();
@@ -380,7 +382,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
      */
     @Test
     public void testSnapshotAndLogEntrySyncThroughManager() throws Exception {
-        testSnapshotSyncAndLogEntrySync(0, false);
+        testSnapshotSyncAndLogEntrySync(0, false, 0);
     }
 
     /**
@@ -741,11 +743,9 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         testConfig.setDeleteOP(true);
         testConfig.setWaitOn(WAIT.ON_ACK);
 
-        HashSet<WAIT> waitHashSet = new HashSet<>();
-        waitHashSet.add(WAIT.ON_ACK);
-        startLogEntrySync(crossTables, waitHashSet, false);
+        startLogEntrySync(crossTables, WAIT.ON_ACK, false);
 
-        expectedAckTimestamp = Long.MAX_VALUE;
+        expectedAckTimestamp.set(Long.MAX_VALUE);
 
         // Because t2 is not specified as a replicated table, we should not see it on the destination
         srcDataForVerification.get(t2).clear();
@@ -757,8 +757,8 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         log.debug("****** Verify Data on Destination");
         // Verify Destination
         verifyData(dstCorfuTables, srcDataForVerification);
-        expectedAckTimestamp = srcDataRuntime.getAddressSpaceView().getLogTail();
-        assertThat(expectedAckTimestamp).isEqualTo(logReplicationMetadataManager.getLastProcessedLogEntryTimestamp());
+        expectedAckTimestamp.set(srcDataRuntime.getAddressSpaceView().getLogTail());
+        assertThat(expectedAckTimestamp.get()).isEqualTo(logReplicationMetadataManager.getLastProcessedLogEntryTimestamp());
         verifyPersistedSnapshotMetadata();
         verifyPersistedLogEntryMetadata();
 
@@ -823,7 +823,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         // Replicate the only table we created, block until 2 messages are received,
         // then enforce a trim on the log.
         expectedSinkReceivedMessages = RX_MESSAGES_LIMIT;
-        expectedAckTimestamp = -1;
+        expectedAckTimestamp.set(-1);
         testConfig.setWaitOn(WAIT.ON_ACK_TS);
 
         LogReplicationSourceManager sourceManager = startSnapshotSync(srcCorfuTables.keySet(),
@@ -832,7 +832,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         // KWrite a checkpoint and trim
         Token token = ckStreamsAndTrim(srcDataRuntime, srcCorfuTables);
         srcDataRuntime.getAddressSpaceView().invalidateServerCaches();
-        expectedAckTimestamp = srcDataRuntime.getAddressSpaceView().getLogTail();
+        expectedAckTimestamp.set(srcDataRuntime.getAddressSpaceView().getLogTail());
 
         log.debug("\n****** Wait until an Trimmed Error happens");
         blockUntilExpectedValueReached.acquire();
@@ -979,7 +979,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     @Test
     public void testSnapshotSyncLongDurationApply() throws Exception {
         final int numCyclesToDelayApply = 3;
-        testSnapshotSyncAndLogEntrySync(numCyclesToDelayApply, false);
+        testSnapshotSyncAndLogEntrySync(numCyclesToDelayApply, false, 0);
     }
 
     /**
@@ -988,10 +988,10 @@ public class LogReplicationIT extends AbstractIT implements Observer {
      */
     @Test
     public void testSnapshotSyncDelayedApplyResponse() throws Exception {
-        testSnapshotSyncAndLogEntrySync(0, true);
+        testSnapshotSyncAndLogEntrySync(0, true, 0);
     }
 
-    private void testSnapshotSyncAndLogEntrySync(int numCyclesToDelayApply, boolean delayResponse) throws Exception {
+    private void testSnapshotSyncAndLogEntrySync(int numCyclesToDelayApply, boolean delayResponse, int dropAcksLevel) throws Exception {
         // Setup two separate Corfu Servers: source (active) and destination (standby)
         setupEnv();
 
@@ -1010,9 +1010,10 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         log.debug("****** Verify No Data in Destination");
         verifyNoData(dstCorfuTables);
 
-        expectedAckTimestamp = Long.MAX_VALUE;
+        expectedAckTimestamp.set(Long.MAX_VALUE);
         testConfig.setDelayedApplyCycles(numCyclesToDelayApply);
         testConfig.setTimeoutMetadataResponse(delayResponse);
+        testConfig.setDropAckLevel(dropAcksLevel);
 
         // Start Snapshot Sync (through Source Manager)
         Set<WAIT> conditions = new HashSet<>();
@@ -1029,7 +1030,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         verifyData(dstCorfuTables, srcDataForVerification);
 
         blockUntilExpectedAckTs.acquire();
-        expectedAckTimestamp = srcDataRuntime.getAddressSpaceView().getLogTail() + NUM_KEYS;
+        expectedAckTimestamp.set(srcDataRuntime.getAddressSpaceView().getLogTail() + NUM_KEYS_LARGE);
 
         // Write Extra Data (for incremental / log entry sync)
         generateTXData(srcCorfuTables, srcDataForVerification, NUM_KEYS_LARGE, srcDataRuntime, NUM_KEYS*2);
@@ -1045,6 +1046,153 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         verifyPersistedSnapshotMetadata();
         verifyPersistedLogEntryMetadata();
     }
+
+
+    /**
+     * Test Log Entry (delta) Sync for the case where the ACKs are arbitrarily dropped
+     * for a fixed number of times at the Source. This will test that LR is
+     * (i) not impacted by dropped ACKs
+     * (ii) Source resends msgs for which it hasn't received the ACKs
+     * (iii) Sink handles the already seen and processed msgs.
+     */
+    @Test
+    public void testLogEntrySyncWithAckDrops() throws Exception {
+        // Write data in transaction to t0 and t1
+        Set<String> crossTables = new HashSet<>();
+        crossTables.add(t0);
+        crossTables.add(t1);
+
+        // Writes transactions to t0, t1 and t2 + transactions across 'crossTables'
+        writeCrossTableTransactions(crossTables, true);
+
+        // Start Log Entry Sync
+        expectedAckMessages = NUM_KEYS * WRITE_CYCLES;
+        testConfig.clear().setDropAckLevel(1);
+
+        startLogEntrySync(crossTables, WAIT.ON_ACK);
+
+        // Verify Data on Destination site
+        log.debug("****** Verify Data on Destination");
+        // Because t2 is not specified as a replicated table, we should not see it on the destination
+        srcDataForVerification.get(t2).clear();
+
+        // Verify Destination
+        verifyData(dstCorfuTables, srcDataForVerification);
+        cleanEnv();
+    }
+
+
+    /**
+     * Test Log Entry (delta) Sync for the case where messages are arbitrarily dropped at the
+     * destination and ACKs are arbitrarily dropped at the source. This tests
+     * (i) messages dropped at the destination is resent. This would also test that Sink handles out of order messages.
+     * (ii) messages for which ACKs were dropped at the source are resent and Sink handles already processed data.
+     */
+    @Test
+    public void testLogEntrySyncWithMsgDropsAndAckDrops() throws Exception {
+        // Write data in transaction to t0 and t1
+        Set<String> crossTables = new HashSet<>();
+        crossTables.add(t0);
+        crossTables.add(t1);
+
+        writeCrossTableTransactions(crossTables, true);
+
+        // Start Log Entry Sync
+        expectedAckMessages =  NUM_KEYS*WRITE_CYCLES;
+
+        testConfig.clear().setDropMessageLevel(1);
+        testConfig.setDropAckLevel(1);
+
+        startLogEntrySync(crossTables, WAIT.ON_ACK);
+
+        // Verify Data on Destination site
+        log.debug("****** Verify Data on Destination");
+
+        // Because t2 is not specified as a replicated table, we should not see it on the destination
+        srcDataForVerification.get(t2).clear();
+
+        // Verify Destination
+        verifyData(dstCorfuTables, srcDataForVerification);
+        cleanEnv();
+    }
+
+    /**
+     *  Test Log_Entry (delta) Sync for the case where an ACK gets dropped at the Source, and
+     *  immediately, the Source gets REPLICATION_STOP event. We then emulate negotiation and overall
+     *  FSM transitions from LOG_ENTRY SYNC -> INITIALIZED (Negotiation happens around here) -> LOG_ENTRY SYCN.
+     *  This tests that on replication_stop event, the pending queue is cleared. This ensures that msgs are not
+     *  resent after the REPLICATION_STOP event, and the data is replicated after the last run of log_entry sync
+     *
+     *  Also, tests that an ACK is always sent for all msg resends, and also,
+     *  if a msg is ignored by Sink for any reason, the ACK sent by Sink should not be for the ignored msg
+     **/
+    @Test
+    public void testLogEntrySyncWithFSMChangeAndWithAckDrop() throws Exception {
+        // Write data in transaction to t0 and t1
+        Set<String> crossTables = new HashSet<>();
+        crossTables.add(t0);
+        crossTables.add(t1);
+
+        // Writes transactions to t0, t1 and t2 + transactions across 'crossTables'
+        writeCrossTableTransactions(crossTables, true);
+
+        // Start Log Entry Sync
+        expectedAckMessages = NUM_KEYS * WRITE_CYCLES;
+        testConfig.clear().setDropAckLevel(2);
+
+        Set<WAIT> waitCondition = new HashSet<>();
+        waitCondition.add(WAIT.NONE);
+        startLogEntrySync(crossTables, waitCondition, true, () -> changeState());
+
+        blockUntilFSMTransition.await();
+
+        checkStateChange(logReplicationSourceManager.getLogReplicationFSM(),
+                LogReplicationStateType.INITIALIZED, true);
+        testConfig.clear();
+
+        // add a listner to ACKs received. This is used to unblock the current thread before the final verification.
+        ackMessages = sourceDataSender.getAckMessages();
+        ackMessages.addObserver(this);
+
+        // simulate negotiation. Return metadata from the sink
+        LogReplicationMetadataResponseMsg negotiationResponse = sourceDataSender.getSinkManager()
+                .getLogReplicationMetadataManager()
+                .getMetadataResponse(CorfuMessage.HeaderMsg.newBuilder().build())
+                .getPayload().getLrMetadataResponse();
+
+        logReplicationSourceManager.getLogReplicationFSM().input(
+                new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.LOG_ENTRY_SYNC_REQUEST,
+                        new LogReplicationEventMetadata(LogReplicationEventMetadata.getNIL_UUID(),
+                                negotiationResponse.getLastLogEntryTimestamp(), negotiationResponse.getSnapshotApplied())));
+        checkStateChange(logReplicationSourceManager.getLogReplicationFSM(),
+                LogReplicationStateType.IN_LOG_ENTRY_SYNC, true);
+
+
+        sourceDataSender.resetTestConfig(testConfig);
+
+        expectedAckTimestamp.set(srcDataRuntime.getAddressSpaceView().getLogTail());
+
+        // Block until the expected ACK Timestamp is reached
+        blockUntilExpectedAckTs.acquire();
+
+        // Verify Data on Destination site
+        log.debug("****** Verify Data on Destination");
+        // Because t2 is not specified as a replicated table, we should not see it on the destination
+        srcDataForVerification.get(t2).clear();
+
+        // Verify Destination
+        verifyData(dstCorfuTables, srcDataForVerification);
+        cleanEnv();
+    }
+
+
+    @Test
+    public void testSnapshotSyncWithAckDrops() throws Exception {
+        testSnapshotSyncAndLogEntrySync(0, false, 1);
+        cleanEnv();
+    }
+
+
 
     /* ********************** AUXILIARY METHODS ********************** */
 
@@ -1122,8 +1270,8 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         // Observe metadata responses coming from receiver, until it indicates snapshot sync apply has completed
         blockUntilExpectedMetadataResponse.acquire();
 
-        LogReplicationSourceManager logReplicationSourceManager = setupSourceManagerAndObservedValues(tablesToReplicate,
-                waitConditions);
+        logReplicationSourceManager = setupSourceManagerAndObservedValues(tablesToReplicate,
+                waitConditions, null);
 
         // Start Snapshot Sync
         log.debug("****** Start Snapshot Sync");
@@ -1166,14 +1314,14 @@ public class LogReplicationIT extends AbstractIT implements Observer {
                                                 boolean injectTxData) throws Exception {
         HashSet<WAIT> conditions = new HashSet<>();
         conditions.add(waitCondition);
-        return startLogEntrySync(tablesToReplicate, conditions, injectTxData);
+        return startLogEntrySync(tablesToReplicate, conditions, injectTxData, null);
     }
 
     private LogReplicationFSM startLogEntrySync(Set<String> tablesToReplicate, Set<WAIT> waitConditions,
-                                                boolean injectTxData) throws Exception {
+                                                boolean injectTxData, TransitionSource function) throws Exception {
 
-        LogReplicationSourceManager logReplicationSourceManager = setupSourceManagerAndObservedValues(tablesToReplicate,
-                waitConditions);
+        logReplicationSourceManager = setupSourceManagerAndObservedValues(tablesToReplicate,
+                waitConditions, function);
 
         // Start Log Entry Sync
         log.debug("****** Start Log Entry Sync with src tail " + srcDataRuntime.getAddressSpaceView().getLogTail()
@@ -1187,7 +1335,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         }
 
         blockUntilExpectedAckTs.acquire();
-        expectedAckTimestamp = srcDataRuntime.getAddressSpaceView().getLogTail();
+        expectedAckTimestamp.set(srcDataRuntime.getAddressSpaceView().getLogTail());
 
         // Block until the expected ACK Timestamp is reached
         log.debug("****** Wait until the wait condition is met");
@@ -1201,13 +1349,14 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     }
 
     private LogReplicationSourceManager setupSourceManagerAndObservedValues(Set<String> tablesToReplicate,
-                                                                            Set<WAIT> waitConditions) throws InterruptedException {
+                                                                            Set<WAIT> waitConditions,
+                                                                            TransitionSource function) throws InterruptedException {
 
         LogReplicationConfig config = new LogReplicationConfig(tablesToReplicate, BATCH_SIZE, SMALL_MSG_SIZE);
 
         // Data Sender
         sourceDataSender = new SourceForwardingDataSender(DESTINATION_ENDPOINT, config, testConfig,
-                logReplicationMetadataManager, nettyConfig);
+                logReplicationMetadataManager, nettyConfig, function);
 
         // Source Manager
         LogReplicationSourceManager logReplicationSourceManager = new LogReplicationSourceManager(
@@ -1309,14 +1458,14 @@ public class LogReplicationIT extends AbstractIT implements Observer {
             }
 
             if (testConfig.waitOn == WAIT.ON_ACK || testConfig.waitOn == WAIT.ON_ACK_TS) {
-                verifyExpectedValue(expectedAckTimestamp, logReplicationEntry.getMetadata().getTimestamp());
+                verifyExpectedValue(expectedAckTimestamp.get(), logReplicationEntry.getMetadata().getTimestamp());
                 if (expectedAckMsgType == logReplicationEntry.getMetadata().getEntryType()) {
                     blockUntilExpectedAckType.release();
                 }
 
-                log.debug("expectedAckTs={}, logEntryTs={}", expectedAckTimestamp, logReplicationEntry.getMetadata().getTimestamp());
+                log.debug("expectedAckTs={}, logEntryTs={}", expectedAckTimestamp.get(), logReplicationEntry.getMetadata().getTimestamp());
 
-                if (expectedAckTimestamp == logReplicationEntry.getMetadata().getTimestamp()) {
+                if (expectedAckTimestamp.get() == logReplicationEntry.getMetadata().getTimestamp()) {
                     blockUntilExpectedAckTs.release();
                 }
             }
@@ -1332,8 +1481,23 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     private void verifyPersistedLogEntryMetadata() {
         long lastLogProcessed = logReplicationMetadataManager.getLastProcessedLogEntryTimestamp();
 
-        log.debug("\nlastLogProcessed " + lastLogProcessed + " expectedTimestamp " + expectedAckTimestamp);
-        assertThat(expectedAckTimestamp == lastLogProcessed).isTrue();
+        log.debug("\nlastLogProcessed " + lastLogProcessed + " expectedTimestamp " + expectedAckTimestamp.get());
+        assertThat(expectedAckTimestamp.get() == lastLogProcessed).isTrue();
+    }
+
+    private void changeState() {
+        assertThat(sourceDataSender.getAckMessages().getDataMessage()).isNotNull();
+        LogReplicationEntryMsg ack = sourceDataSender.getAckMessages().getDataMessage();
+
+        logReplicationSourceManager.getLogReplicationFSM().input(new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.REPLICATION_STOP,
+                new LogReplicationEventMetadata(getUUID(ack.getMetadata().getSyncRequestId()), ack.getMetadata().getTimestamp(), ack.getMetadata().getSnapshotTimestamp())));
+
+        blockUntilFSMTransition.countDown();
+    }
+
+    @FunctionalInterface
+    public static interface TransitionSource {
+        void changeState();
     }
 
     public enum WAIT {
@@ -1350,6 +1514,12 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     @Data
     public static class TestConfig {
         private int dropMessageLevel = 0;
+        /**
+         * 0 : No ACKs dropped
+         * 1 : Arbitrarily ACKs are dropped
+         * 2 : An ACK dropped and further messages dropped at Source.
+         * */
+        private int dropAckLevel = 0;
         private int delayedApplyCycles = 0; // Represents the number of cycles for which snapshot sync apply queries
                                             // reply that it has still not completed.
         private boolean trim = false;
@@ -1361,6 +1531,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         
         public TestConfig clear() {
             dropMessageLevel = 0;
+            dropAckLevel = 0;
             delayedApplyCycles = 0;
             timeoutMetadataResponse = false;
             trim = false;

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -22,6 +22,8 @@ import org.corfudb.runtime.view.Address;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * This is an implementation of the DataSender (data path layer) used for testing purposes.
  *
@@ -29,7 +31,7 @@ import java.util.concurrent.CompletableFuture;
  * (for processing).
  */
 @Slf4j
-public class SourceForwardingDataSender implements DataSender {
+public class SourceForwardingDataSender extends AbstractIT implements DataSender {
 
     private final static int DROP_INCREMENT = 4;
 
@@ -60,7 +62,11 @@ public class SourceForwardingDataSender implements DataSender {
 
     private int ifDropMsg;
 
+    private int dropACKLevel;
+
     private int droppingNum = 2;
+
+    private int droppingAcksNum = 2;
 
     private int msgCnt = 0;
 
@@ -69,14 +75,18 @@ public class SourceForwardingDataSender implements DataSender {
     private int countDelayedApplyCycles = 0;
     private boolean timeoutMetadataResponse = false;
 
+    private LogReplicationIT.TransitionSource callbackFunction;
+
     @Getter
     private ObservableValue errors = new ObservableValue(errorCount);
 
     private ObservableValue<LogReplicationMetadataResponseMsg> metadataResponseObservable;
 
+    private long lastAckDropped;
+
     public SourceForwardingDataSender(String destinationEndpoint, LogReplicationConfig config, LogReplicationIT.TestConfig testConfig,
                                       LogReplicationMetadataManager metadataManager,
-                                      String pluginConfigFilePath) {
+                                      String pluginConfigFilePath, LogReplicationIT.TransitionSource function) {
         this.runtime = CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
                 .parseConfigurationString(destinationEndpoint)
                 .connect();
@@ -87,12 +97,15 @@ public class SourceForwardingDataSender implements DataSender {
         this.delayedApplyCycles = testConfig.getDelayedApplyCycles();
         this.metadataResponseObservable = new ObservableValue<>(null);
         this.timeoutMetadataResponse = testConfig.isTimeoutMetadataResponse();
+        this.dropACKLevel = testConfig.getDropAckLevel();
+        this.callbackFunction = function;
+        this.lastAckDropped = Long.MAX_VALUE;
     }
 
     @Override
     public CompletableFuture<LogReplicationEntryMsg> send(LogReplicationEntryMsg message) {
         log.trace("Send message: " + message.getMetadata().getEntryType() + " for:: " + message.getMetadata().getTimestamp());
-        if (ifDropMsg > 0 && msgCnt == droppingNum) {
+        if (ifDropMsg > 0 && msgCnt == droppingNum || dropACKLevel == 2 && message.getMetadata().getTimestamp() >= lastAckDropped) {
             log.info("****** Drop msg {} log entry ts {}",  msgCnt, message.getMetadata().getTimestamp());
             if (ifDropMsg == DROP_MSG_ONCE) {
                 droppingNum += DROP_INCREMENT;
@@ -102,9 +115,26 @@ public class SourceForwardingDataSender implements DataSender {
         }
 
         final CompletableFuture<LogReplicationEntryMsg> cf = new CompletableFuture<>();
+        LogReplicationEntryMsg ack;
 
         // Emulate Channel by directly accepting from the destination, whatever is sent by the source manager
-        LogReplicationEntryMsg ack = destinationLogReplicationManager.receive(message);
+        if (lastAckDropped < message.getMetadata().getTimestamp()) {
+            // resend msg multiple times and assert ack is received for every resend
+            for (int resentTme = 0; resentTme < 2; resentTme++) {
+                ack = destinationLogReplicationManager.receive(message);
+                assertThat(ack.getMetadata().getTimestamp()).isEqualTo(message.getMetadata().getTimestamp());
+            }
+            // test negative scenario: when a msg is ignored by Sink, the ACK received should not be for the ignored msg
+            ack = destinationLogReplicationManager.receive(changeMsgMetadata(message));
+            assertThat(ack.getMetadata().getTimestamp()).isEqualTo(message.getMetadata().getTimestamp());
+        } else {
+            ack = destinationLogReplicationManager.receive(message);
+        }
+
+        if (dropAck(ack, message)) {
+            return cf;
+        }
+
         if (ack != null) {
             cf.complete(ack);
         }
@@ -216,5 +246,51 @@ public class SourceForwardingDataSender implements DataSender {
 
     public ObservableValue<LogReplicationMetadataResponseMsg> getMetadataResponses() {
         return metadataResponseObservable;
+    }
+
+    private boolean dropAck(LogReplicationEntryMsg ack, LogReplicationEntryMsg message){
+        if (dropACKLevel > 0 && msgCnt == droppingAcksNum) {
+            log.info("****** Drop ACK {} for log entry ts {}", ack, message.getMetadata().getTimestamp());
+            if (dropACKLevel == DROP_MSG_ONCE) {
+                droppingAcksNum += DROP_INCREMENT;
+            }
+
+            if (dropACKLevel == 2) {
+                lastAckDropped = message.getMetadata().getTimestamp();
+                callbackFunction.changeState();
+            }
+            return true;
+        }
+        return false;
+    }
+
+    /** Change the msg such that Sink ignores the msg. Used to test that the ACK received is not for this msg,
+     * i.e., the lastProcessedTs on Sink doesn't change when the msg is ignored.
+     **/
+    private LogReplicationEntryMsg changeMsgMetadata(LogReplicationEntryMsg message) {
+        LogReplicationEntryMsg newMessage = LogReplicationEntryMsg.newBuilder().mergeFrom(message)
+                .setMetadata(LogReplication.LogReplicationEntryMetadataMsg.newBuilder().mergeFrom(message.getMetadata())
+                        .setTimestamp(message.getMetadata().getTimestamp() + 1)
+                        .setPreviousTimestamp(message.getMetadata().getPreviousTimestamp() - 1)
+                        .build())
+                .build();
+
+        assertThat(destinationLogReplicationManager.getLogReplicationMetadataManager()
+                .getLastProcessedLogEntryTimestamp())
+                .isGreaterThanOrEqualTo(newMessage.getMetadata().getPreviousTimestamp());
+        assertThat(destinationLogReplicationManager.getLogReplicationMetadataManager()
+                .getLastProcessedLogEntryTimestamp())
+                .isLessThan(newMessage.getMetadata().getTimestamp());
+
+        lastAckDropped = Long.MAX_VALUE;
+
+        return newMessage;
+    }
+
+    public void resetTestConfig(LogReplicationIT.TestConfig testConfig) {
+        this.ifDropMsg = testConfig.getDropMessageLevel();
+        this.delayedApplyCycles = testConfig.getDelayedApplyCycles();
+        this.timeoutMetadataResponse = testConfig.isTimeoutMetadataResponse();
+        this.dropACKLevel = testConfig.getDropAckLevel();
     }
 }


### PR DESCRIPTION
1. Clear pendingMsgs queue on REPLICATION_STOP event
2. On the standby, update lastProcessedTs only when the msg is processed

## Overview

Description:



Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
