### PR TITLE
LogReplication: Drop request when cluster not standby

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -336,6 +336,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         logReplicationServerHandler = new LogReplicationServer(serverContext, logReplicationConfig,
             logReplicationMetadataManager, localCorfuEndpoint, topologyDescriptor.getTopologyConfigId(), localNodeId);
         logReplicationServerHandler.setActive(localClusterDescriptor.getRole().equals(ClusterRole.ACTIVE));
+        logReplicationServerHandler.setStandby(localClusterDescriptor.getRole().equals(ClusterRole.STANDBY));
 
         interClusterReplicationService = new CorfuInterClusterReplicationServerNode(serverContext,
             logReplicationServerHandler, logReplicationConfig);
@@ -637,6 +638,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
 
         // Update replication server, in case there is a role change
         logReplicationServerHandler.setActive(localClusterDescriptor.getRole().equals(ClusterRole.ACTIVE));
+        logReplicationServerHandler.setStandby(localClusterDescriptor.getRole().equals(ClusterRole.STANDBY));
 
         // On Topology Config Change, only if this node is the leader take action
         if (isLeader.get()) {


### PR DESCRIPTION
## Overview

Description:
Scenario: cluster1 is ACTIVE and cluster2 is STANDBY. There is a topology change notification after which cluster2 gets demoted from STANDBY to NONE/INVALID role; Active stops replication to cluster2 and cluster2's role changes to NONE/INVALID.
Let's say there is another topology change where cluster 2 is reinstated as a STANDBY, and cluster1 receives this before cluster2. Active starts replication to cluster2, and cluster2, even though not standby from cluster2's perspective, processes the msg because currently we don't have a guard checking for the role on the recipient side. Fixing this.

The Behaviour should be that cluster2 ignores/drops the requests until cluster2 knows that it is STANDBY.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
