### PR TITLE
LogReplication: set DataConsistent to false on snapshotStart marker

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -399,6 +399,8 @@ public class LogReplicationSinkManager implements DataReceiver {
         // Signal start of snapshot sync to the writer, so data can be cleared (on old snapshot syncs)
         snapshotWriter.reset(topologyId, timestamp);
 
+        setDataConsistentWithRetry(false);
+
         // Update lastTransferDone with the new snapshot transfer timestamp.
         baseSnapshotTimestamp = entry.getMetadata().getSnapshotTimestamp();
 
@@ -479,7 +481,6 @@ public class LogReplicationSinkManager implements DataReceiver {
 
     private synchronized void startSnapshotApply(LogReplication.LogReplicationEntryMsg entry) {
         log.debug("Entry Start Snapshot Sync Apply, id={}", entry.getMetadata().getSyncRequestId());
-        setDataConsistentWithRetry(false);
         snapshotWriter.startSnapshotSyncApply();
         completeSnapshotApply(entry);
         ongoingApply.set(false);

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -227,9 +227,9 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         dstTestRuntime.parseConfigurationString(DESTINATION_ENDPOINT);
         dstTestRuntime.connect();
 
-        logReplicationMetadataManager = new LogReplicationMetadataManager(dstTestRuntime, 0, ACTIVE_CLUSTER_ID);
+        logReplicationMetadataManager = new LogReplicationMetadataManager(dstTestRuntime, 0, REMOTE_CLUSTER_ID);
         expectedAckTimestamp = new AtomicLong(Long.MAX_VALUE);
-        testConfig.clear();
+        testConfig.clear().setRemoteClusterId(REMOTE_CLUSTER_ID);
     }
 
     private void cleanEnv() {
@@ -411,6 +411,9 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         // Verify Data on Destination site
         log.debug("****** Verify Data on Destination");
 
+        //verify isDataConsistent is true
+        sourceDataSender.checkStatusOnStandby(true);
+
         // Because t2 should not have been replicated remove from expected list
         srcDataForVerification.get(t2).clear();
 
@@ -448,6 +451,9 @@ public class LogReplicationIT extends AbstractIT implements Observer {
 
         // Verify Data on Destination site
         log.debug("****** Verify Data on Destination");
+
+        //verify isDataConsistent is true
+        sourceDataSender.checkStatusOnStandby(true);
         // Because t2 should not have been replicated remove from expected list
         srcDataForVerification.get(t2).clear();
         verifyData(dstCorfuTables, srcDataForVerification);
@@ -1023,6 +1029,9 @@ public class LogReplicationIT extends AbstractIT implements Observer {
 
         log.debug("****** Snapshot Sync COMPLETE");
 
+        //verify isDataConsistent is true
+        sourceDataSender.checkStatusOnStandby(true);
+
         testConfig.setWaitOn(WAIT.ON_ACK_TS);
 
         // Verify Data on Destination site
@@ -1528,6 +1537,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         private boolean deleteOP = false;
         private WAIT waitOn = WAIT.ON_ACK;
         private boolean timeoutMetadataResponse = false;
+        private String remoteClusterId = null;
         
         public TestConfig clear() {
             dropMessageLevel = 0;
@@ -1538,6 +1548,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
             writingSrc = false;
             writingDst = false;
             deleteOP = false;
+            remoteClusterId = null;
             return this;
         }
     }


### PR DESCRIPTION
## Overview

Description:
set isDataConsistent flag while processing the snapshot_start marker.

Why should this be merged: 

During the snapshot Sync, LR clears regular streams in 2 places so the data on standby is not polluted by local writes:
1. During transfer phase: Clear streams that have data to be replicated
2. During apply phase: Clear streams that have local writes on standby, but no writes on active.

Currently, the isDataConsistent flag is set to false during the apply phase, which can lead to inconsistent view of data as streams are cleared in transfer phase. This PR fixes this issue by marking dataConsistent flag to false as soon as standby sees the snapshot_Start marker.



Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
