### PR TITLE
Fix missing descriptor.proto in DynamicProtobufSerializer

### DIFF
--- a/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
+++ b/runtime/src/main/java/org/corfudb/util/serializer/DynamicProtobufSerializer.java
@@ -150,6 +150,10 @@ public class DynamicProtobufSerializer implements ISerializer {
                 fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto.getPayload().getFileDescriptor());
                 // Until the truncating issue can be addressed, manually add both paths.
                 protoFileName = "corfudb/runtime/corfu_options.proto";
+            } else if (protoFileName.equals("descriptor.proto")) {
+                fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto.getPayload().getFileDescriptor());
+                // Until the truncating issue can be addressed, manually add both paths.
+                protoFileName = "google/protobuf/descriptor.proto";
             }
             fdProtoMap.putIfAbsent(protoFileName, fileDescriptorProto.getPayload().getFileDescriptor());
             identifyMessageTypesinFileDescriptorProto(fileDescriptorProto.getPayload().getFileDescriptor());


### PR DESCRIPTION
## Overview

Description:
descriptor.proto hits the truncation of protobuf name issue. DynamicProtobufSerializer fdProtoMap only has the key descriptor.proto instead of the full name google/protobuf/descriptor.proto, causing deserialization failure.

Why should this be merged: 
It causes compactor failure.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
