### PR TITLE
Test LR behavior against disk based tables

### DIFF
--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
@@ -56,14 +56,27 @@ public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
      */
     @Test
     public void testLogReplicationEndToEnd() throws Exception {
-        System.out.println("\n Using plugin :: " + pluginConfigFilePath);
-        testEndToEndSnapshotAndLogEntrySyncUFO();
+        log.debug("Using plugin :: {}", pluginConfigFilePath);
+        testEndToEndSnapshotAndLogEntrySyncUFO(false);
     }
 
     @Test
     public void testSnapshotSyncMultipleTables() throws Exception {
-        System.out.println("\n Using plugin :: " + pluginConfigFilePath);
+        log.debug("Using plugin :: {}", pluginConfigFilePath);
         final int totalNumMaps = 3;
-        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps);
+        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, false);
+    }
+
+    @Test
+    public void testDiskBasedLogReplicationEndToEnd() throws Exception {
+        log.debug("Using plugin :: {}", pluginConfigFilePath);
+        testEndToEndSnapshotAndLogEntrySyncUFO(true);
+    }
+
+    @Test
+    public void testDiskBasedSnapshotSyncMultipleTables() throws Exception {
+        log.debug("Using plugin :: {}", pluginConfigFilePath);
+        final int totalNumMaps = 3;
+        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, true);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -96,7 +96,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     public void testStandbyClusterReset() throws Exception {
         // (1) Snapshot and Log Entry Sync
         log.debug(">>> (1) Start Snapshot and Log Entry Sync");
-        testEndToEndSnapshotAndLogEntrySyncUFO();
+        testEndToEndSnapshotAndLogEntrySyncUFO(false);
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
@@ -134,7 +134,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
         // (1) Snapshot and Log Entry Sync
         log.debug(">>> (1) Start Snapshot and Log Entry Sync");
-        testEndToEndSnapshotAndLogEntrySyncUFO();
+        testEndToEndSnapshotAndLogEntrySyncUFO(false);
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
@@ -275,7 +275,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             setupActiveAndStandbyCorfu();
 
             log.debug("Open map on active and standby");
-            openMaps(DefaultLogReplicationConfigAdapter.MAP_COUNT);
+            openMaps(DefaultLogReplicationConfigAdapter.MAP_COUNT, false);
 
             // Subscribe to standby map 'Table002' (standbyIndex) to stop Standby LR as soon as updates are received,
             // forcing snapshot sync apply to be interrupted and resumed after LR standby is restarted

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.fail;
 import com.google.common.reflect.TypeToken;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -159,15 +161,11 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
     }
 
-    public void testEndToEndSnapshotAndLogEntrySyncUFO() throws Exception {
-        // TODO: when ObjectsView.TRANSACTION_STREAM_ID is removed or LOG_REPLICATOR_STREAM_ID name is changed,
-        //  change these tests such that UFO tables used in the tests have the is_federated tag set,
-        //  as these will determine which tables will be written to the LOG_REPLICATOR_STREAM_ID
-        //  (for now, it is not required as they're written to the same TRANSACTION_STREAM_ID from legacy impl.)
-        testEndToEndSnapshotAndLogEntrySyncUFO(1);
+    public void testEndToEndSnapshotAndLogEntrySyncUFO(boolean diskBased) throws Exception {
+        testEndToEndSnapshotAndLogEntrySyncUFO(1, diskBased);
     }
 
-    public void testEndToEndSnapshotAndLogEntrySyncUFO(int totalNumMaps) throws Exception {
+    public void testEndToEndSnapshotAndLogEntrySyncUFO(int totalNumMaps, boolean diskBased) throws Exception {
         // For the purpose of this test, standby should only update status 2 times:
         // (1) When starting snapshot sync apply : is_data_consistent = false
         // (2) When completing snapshot sync apply : is_data_consistent = true
@@ -196,7 +194,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
                     LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
             log.info(">> Open map(s) on active and standby");
-            openMaps(totalNumMaps);
+            openMaps(totalNumMaps, diskBased);
 
             log.info(">> Write data to active CorfuDB before LR is started ...");
             // Add Data for Snapshot Sync
@@ -387,20 +385,27 @@ public class LogReplicationAbstractIT extends AbstractIT {
         }
     }
 
-    public void openMaps(int mapCount) throws Exception {
+    public void openMaps(int mapCount, boolean diskBased) throws Exception {
         mapNameToMapActive = new HashMap<>();
         mapNameToMapStandby = new HashMap<>();
+        Path pathActive = null;
+        Path pathStandby = null;
 
         for(int i=1; i <= mapCount; i++) {
             String mapName = TABLE_PREFIX + i;
 
+            if (diskBased) {
+                pathActive = Paths.get(com.google.common.io.Files.createTempDir().getAbsolutePath());
+                pathStandby = Paths.get(com.google.common.io.Files.createTempDir().getAbsolutePath());
+            }
+
             Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapActive = corfuStoreActive.openTable(
                     NAMESPACE, mapName, Sample.StringKey.class, Sample.IntValueTag.class, Sample.Metadata.class,
-                    TableOptions.fromProtoSchema(Sample.IntValueTag.class));
+                    TableOptions.fromProtoSchema(Sample.IntValueTag.class, TableOptions.builder().persistentDataPath(pathActive).build()));
 
             Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapStandby = corfuStoreStandby.openTable(
                     NAMESPACE, mapName, Sample.StringKey.class, Sample.IntValueTag.class, Sample.Metadata.class,
-                    TableOptions.fromProtoSchema(Sample.IntValueTag.class));
+                    TableOptions.fromProtoSchema(Sample.IntValueTag.class, TableOptions.builder().persistentDataPath(pathStandby).build()));
 
             mapNameToMapActive.put(mapName, mapActive);
             mapNameToMapStandby.put(mapName, mapStandby);


### PR DESCRIPTION
## Overview

Description: 

Previously all the LR related integration tests are running against in memory tables. This change will config the CorfuReplicationE2EIT to run with disk-based tables.

Why should this be merged: 

Prepare for the potential usage of LR for non-config Corfu.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
