### PR TITLE
Fix and cleanup for some LR related metrics

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
@@ -8,12 +8,13 @@
 ### Current metrics collected for LR:
 
 *   **logreplication.message.size.bytes**: Message size in bytes (throughput, mean and max), distinguished by replication type (snapshot, logentry).
-*   **logreplication.lock.duration**: Duration of holding a leadership lock in seconds, distinguished by role (active, standby).
+*   **logreplication.lock.duration.nanoseconds**: Duration of holding a leadership lock in nanoseconds, distinguished by role (active, standby).
 *   **logreplication.lock.acquire.count**: Number of times a leadership lock was acquired, distinguised by role (active, standby).
-*   **logreplication.sender.duration.seconds**: Duration of sending a log entry in seconds (throughput, mean and max), distinguished by replication type (snapshot, logentry) and status (success, failure).
-*   **logreplication.rtt.seconds**: Duration of sending a message overall (throughput, mean and max).
+*   **logreplication.sender.duration.nanoseconds**: Duration of sending a log entry in nanoseconds (throughput, mean and max), distinguished by replication type (snapshot, logentry) and status (success, failure).
 *   **logreplication.snapshot.completed.count**: Number of snapshot syncs completed.
-*   **logreplication.snapshot.duration.seconds**: Duration of completing a snapshot sync in seconds (throughput, mean and max).
+*   **logreplication.snapshot.transfer.duration**: Duration of the TRANSFER phase of a snapshot sync in nanoseconds (throughput, mean and max).
+*   **logreplication.snapshot.apply.duration**: Duration of the APPLY phase of a snapshot sync in nanoseconds (throughput, mean and max).
+*   **logreplication.snapshot.duration**: Duration of completing a snapshot sync in nanoseconds (throughput, mean and max).
 *   **logreplication.acks**: Number of acks, distinguished by replication type (snapshot, logentry).
 *   **logreplication.messages**: Number of messages sent, distinguished by replication type (snapshot, logentry).
 *   **logreplication.opaque.count\_per\_message**: Number of opaque entries per message (rate, mean, max).

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -890,7 +890,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     private Optional<LongTaskTimer.Sample> recordLockAcquire(ClusterRole role) {
         return MeterRegistryProvider.getInstance()
                 .map(registry -> registry.more()
-                        .longTaskTimer("logreplication.lock.duration",
+                        .longTaskTimer("logreplication.lock.duration.nanoseconds",
                                 ImmutableList.of(
                                         Tag.of("cluster.role", role.toString().toLowerCase())))
                         .start());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
@@ -1,12 +1,15 @@
 package org.corfudb.infrastructure.logreplication.replication.fsm;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.micrometer.core.instrument.Timer;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationEventMetadata;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.runtime.LogReplication.LogReplicationMetadataResponseMsg;
 
+import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -57,6 +60,8 @@ public class WaitSnapshotApplyState implements LogReplicationState {
     private ScheduledExecutorService snapshotSyncApplyMonitorExecutor;
 
     private volatile AtomicBoolean stopSnapshotApply = new AtomicBoolean(false);
+
+    private Optional<Timer.Sample> snapshotSyncApplyTimerSample = Optional.empty();
 
     /**
      * Constructor
@@ -139,7 +144,22 @@ public class WaitSnapshotApplyState implements LogReplicationState {
             stopSnapshotApply.set(false);
             fsm.getAckReader().markSnapshotSyncInfoOngoing();
         }
+        if (from != this) {
+            snapshotSyncApplyTimerSample = MeterRegistryProvider.getInstance().map(Timer::start);
+        }
         this.fsm.getLogReplicationFSMWorkers().submit(this::verifyStatusOfSnapshotSyncApply);
+    }
+
+    @Override
+    public void onExit(LogReplicationState to) {
+        if (to.getType().equals(LogReplicationStateType.IN_LOG_ENTRY_SYNC)) {
+            snapshotSyncApplyTimerSample
+                    .flatMap(sample -> MeterRegistryProvider.getInstance()
+                            .map(registry -> {
+                                Timer timer = registry.timer("logreplication.snapshot.apply.duration");
+                                return sample.stop(timer);
+                            }));
+        }
     }
 
     private void verifyStatusOfSnapshotSyncApply() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
@@ -105,7 +105,7 @@ public class LogEntrySender {
 
                 if (message != null) {
                     if (MeterRegistryProvider.getInstance().isPresent()) {
-                        dataSenderBufferManager.sendWithBuffering(message, "logreplication.sender.duration.seconds",
+                        dataSenderBufferManager.sendWithBuffering(message, "logreplication.sender.duration.nanoseconds",
                                 Tag.of("replication.type", "logentry"));
                     } else {
                         dataSenderBufferManager.sendWithBuffering(message);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -204,7 +204,7 @@ public class SnapshotSender {
 
         if (MeterRegistryProvider.getInstance().isPresent()) {
             dataSenderBufferManager.sendWithBuffering(logReplicationEntries,
-                    "logreplication.sender.duration.seconds",
+                    "logreplication.sender.duration.nanoseconds",
                     Tag.of("replication.type", "snapshot"));
         } else {
             dataSenderBufferManager.sendWithBuffering(logReplicationEntries);


### PR DESCRIPTION
## Overview

Description:

* Removed `logreplication.rtt` which is never used nor recorded.
* Change the duration related metrics time unit to nanoseconds.
* Make the snapshot duration metrics to include initialization and shadow streams apply period.
* Added two separate metrics for the duration of TRANSFER and APPLY phase of snapshot sync.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
