### PR TITLE
Avoid log spew during StreamAddressSpace initialization

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
@@ -60,7 +60,7 @@ public class LogMetadata {
         updateGlobalTail(entryAddress);
         // For every stream present in entry update stream tail
         for (UUID streamId : entry.getStreams()) {
-            updateStreamSpace(streamId, entryAddress);
+            updateStreamSpace(streamId, entryAddress, initialize);
         }
 
         // We should also consider checkpoint metadata while updating the tails and stream trim mark.
@@ -81,7 +81,7 @@ public class LogMetadata {
      * @param streamId stream identifier.
      * @param entryAddress stream address.
      */
-    private void updateStreamSpace(UUID streamId, long entryAddress) {
+    private void updateStreamSpace(UUID streamId, long entryAddress, boolean initialize) {
         // Update stream tails
         long currentStreamTail = streamTails.getOrDefault(streamId, Address.NON_ADDRESS);
         streamTails.put(streamId, Math.max(currentStreamTail, entryAddress));
@@ -94,7 +94,7 @@ public class LogMetadata {
                 // The presence of a checkpoint provides a valid trim mark for a stream.
                 return new StreamAddressSpace(Address.NON_EXIST, Collections.singleton(entryAddress));
             }
-            addressSpace.addAddress(entryAddress);
+            addressSpace.addAddress(entryAddress, initialize);
             return addressSpace;
         });
     }

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/StreamAddressSpace.java
@@ -137,13 +137,26 @@ final public class StreamAddressSpace {
 
     /**
      * Add an address to this address space.
+     * By default, the 'initialize' flag is set to false.
      *
      * @param address address to add.
      */
     public void addAddress(long address) {
+        addAddress(address, false);
+    }
+
+    /**
+     * Add an address to this address space.
+     *
+     * @param address address to add.
+     * @param initialize if it's during StreamAddressSpace initialization.
+     */
+    public void addAddress(long address, boolean initialize) {
         // Temporarily log error on trim mark comparison, as throwing an exception
         // unveils an underlying issue in the reset workflow (wipe data + data transfer in colibri)
-        if (address <= this.trimMark) {
+        // During initialization all addresses below the latest checkpoint will be regarded as
+        // trimmed, so don't log errors to avoid log spew
+        if (!initialize && address <= this.trimMark) {
             log.error("IllegalArgumentException :: Address={}, TrimMark={}", address, this.trimMark);
         }
 


### PR DESCRIPTION
## Overview

Description:
During StreamAddressSpace initialization upon corfu server restart,
the stream trim mark is set to the latest checkpoint address. Since
the log files are scanned in reversed order, all previous addresses
will be regarded as trimmed and cause log spew which impacts server
bootstrap performance.

Why should this be merged: 
Avoid log spew

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
