### PR TITLE
LogReplication: change query response behaviour on standby

### DIFF
--- a/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogReplication.java
+++ b/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogReplication.java
@@ -163,10 +163,10 @@ public final class CorfuProtocolLogReplication {
     }
 
     public static ResponseMsg getLeadershipResponse(
-            HeaderMsg header, boolean isLeader, String nodeId) {
+            HeaderMsg header, boolean isLeader, String nodeId, boolean isStandby) {
         LogReplication.LogReplicationLeadershipResponseMsg request = LogReplication.LogReplicationLeadershipResponseMsg
                 .newBuilder()
-                .setIsLeader(isLeader)
+                .setIsLeader(isLeader && isStandby)
                 .setNodeId(nodeId).build();
         ResponsePayloadMsg payload = ResponsePayloadMsg.newBuilder()
                 .setLrLeadershipResponse(request).build();


### PR DESCRIPTION
## Overview

Description:

Issue: We put up a guard on the STANDBY side to check if the role is standby before processing the leadership/negotiation/log_entry requests, drop the request if not standby. (https://github.com/CorfuDB/CorfuDB/commit/6df67c81226a980b48b1628d6a85166a5339fd65)
Before this guard, the remote cluster would process the requests even when the role was none/invalid. This creates an issues when the cluster's role changes to standby thereby resetting metadata when the remote is the middle of replicating entries.

But, dropping the request has an issue that the Leadership and Negotiation queries are blocking calls, so for active to proceed, the remote node has to respond back and not just drop the request.

The PR aims at this new behaviour of leadership and negotiation queries:
1. Leadership query will always return a response...isLeader will only be set to true when the node's role is STANDBY and it is the leader.
2. Negotiation query will always return a response irrespective of the role of the cluster. But since log_replication msgs are NOT blocking calls, they will be ignored if the cluster's role is not Standby.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
