### PR TITLE
Clear the sequencer server cache on resets

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -486,6 +486,7 @@ public class SequencerServer extends AbstractServer {
         // It is necessary because we reset the sequencer.
         if (!bootstrapWithoutTailsUpdate) {
             globalLogTail = req.getPayload().getBootstrapSequencerRequest().getGlobalTail();
+            cache.clearCache();
             cache = sequencerFactoryHelper.getSequencerServerCache(
                     cache.getCacheSize(),
                     globalLogTail - 1

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServerCache.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServerCache.java
@@ -212,6 +212,14 @@ public class SequencerServerCache implements AutoCloseable {
         return true;
     }
 
+    /**
+     * Clear the cache
+     */
+    public void clearCache() {
+        cacheEntries.clear();
+        conflictKeys.clear();
+    }
+
     @Override
     public void close() {
         MicroMeterUtils.removeGaugesWithNoTags(windowSizeName, conflictKeysCounterName);


### PR DESCRIPTION
## Overview

Description:

Sequencer server priority queue-based cache is initialized with an initial capacity probably in order to save the CPU cycles when reallocating the internal dynamically-sized array (on every cache put). Thus we allocate a significantly sized object in the constructor. When we reset the sequencer server, if we don't clear the cache of the previous SequencerServerCache instance beforehand, we intermittently end up with two very large priority queues. It has caused an OOM error in one of the small setups. 