### PR TITLE
CorfuGuid: Always ensure MSB is 0 for unit test ordering

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/CorfuGuidGenerator.java
@@ -44,7 +44,7 @@ class CorfuGuid {
         this.uniqueInstanceId = uniqueInstanceId;
     }
 
-    private static final long TIMESTAMP_MSB_MASK = 0x000000FFffFF0000L;
+    private static final long TIMESTAMP_MSB_MASK = 0x0000007FffFF0000L;
     private static final long TIMESTAMP_LSB_MASK = 0x000000000000FFffL;
     private static final long INSTANCE_ID_MASK   = 0x000000000000FFffL;
     private static final int CORRECTION_MASK     = MAX_CORRECTION;


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Since the guid returns a signed long, the sign bit derived
from the timestamp should be kept 0 for unit tests which
need the guid to be ordered monotonically.

Note that this does not break CorfuQueue since the ordering in there 
comes from the sequencer tail

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
