### PR TITLE
CorfuStoreBrowser: Fix printing of all schemas in registry table 

### DIFF
--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
@@ -211,11 +211,40 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
      * @throws IOException
      */
     @Test
-    public void loaderTest() throws IOException {
+    public void loaderTest() throws IOException, InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         final String namespace = "namespace";
         final String tableName = "table";
         runSinglePersistentServer(corfuSingleNodeHost,
                 corfuStringNodePort);
+        final long keyUuid = 10L;
+        final long ruleIdVal = 50L;
+        final long metaUuid = 100L;
+
+        runtime = createRuntime(singleNodeEndpoint);
+        CorfuStore store = new CorfuStore(runtime);
+        final Table<SampleSchema.Uuid, SampleSchema.FirewallRule, SampleSchema.Uuid> table = store.openTable(
+                namespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.FirewallRule.class,
+                SampleSchema.Uuid.class,
+                TableOptions.fromProtoSchema(SampleSchema.FirewallRule.class));
+
+        SampleSchema.Uuid uuidKey = SampleSchema.Uuid.newBuilder().setLsb(keyUuid)
+                .setMsb(keyUuid).build();
+        SampleSchema.FirewallRule firewallRuleVal = SampleSchema.FirewallRule.newBuilder()
+                .setRuleId(ruleIdVal).setRuleName("Test Rule")
+                .setInput(
+                        SampleAppliance.Appliance.newBuilder().setEndpoint("localhost"))
+                .setOutput(
+                        SampleAppliance.Appliance.newBuilder().setEndpoint("localhost"))
+                .build();
+        SampleSchema.Uuid uuidMeta = SampleSchema.Uuid.newBuilder().setLsb(metaUuid)
+                .setMsb(metaUuid).build();
+        TxnContext tx = store.txn(namespace);
+        tx.putRecord(table, uuidKey, firewallRuleVal, uuidMeta);
+        tx.commit();
+        runtime.shutdown();
 
         // Start a Corfu runtime
         runtime = createRuntime(singleNodeEndpoint);


### PR DESCRIPTION
Because registry table's TableDescriptors uses Any protobuf
type the browser fails to print the registry table which
makes it hard to figure out what the schemas are in any given setup.
This fix avoids using the JsonPrinter for the
TableDescriptor since there is a known issue.
CorfuStoreBrowser: fix up loader to re-use table entry
Minor fixes and comments from reviewers

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
