### PR TITLE
Graceful shutdown of the PartitionAgent scheduler

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -535,6 +535,7 @@ public class LogUnitServer extends AbstractServer {
         executor.shutdown();
         logCleaner.shutdown();
         batchWriter.close();
+        streamLog.close();
     }
 
     @VisibleForTesting

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
@@ -77,6 +77,10 @@ public final class FileSystemAgent {
         instance = Optional.of(new FileSystemAgent(config));
     }
 
+    public static void shutdown() {
+        PartitionAgent.shutdown();
+    }
+
     public static ResourceQuota getResourceQuota() {
         Supplier<IllegalStateException> err = () -> new IllegalStateException(NOT_CONFIGURED_ERR_MSG);
         return instance.orElseThrow(err).logSizeQuota;
@@ -245,6 +249,13 @@ public final class FileSystemAgent {
             private final boolean readOnly;
             private final long availableSpace;
             private final long totalSpace;
+        }
+
+        /**
+         * Clean up
+         */
+        public static void shutdown() {
+            scheduler.shutdown();
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/FileSystemAgent.java
@@ -24,6 +24,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
@@ -193,6 +194,7 @@ public final class FileSystemAgent {
         // A single thread scheduler that has a single instance of execution at any given time.
         private static final ScheduledExecutorService scheduler =
                 Executors.newSingleThreadScheduledExecutor();
+        private static ScheduledFuture<?> scheduledFuture = null;
 
         public PartitionAgent(FileSystemConfig config) {
             this.config = config;
@@ -209,7 +211,7 @@ public final class FileSystemAgent {
          * seconds after the previous set task is completed.
          */
         private void initializeScheduler(){
-            scheduler.scheduleWithFixedDelay(
+            scheduledFuture = scheduler.scheduleWithFixedDelay(
                     this::setPartitionAttribute, NO_DELAY, UPDATE_INTERVAL, SECONDS
             );
         }
@@ -255,7 +257,9 @@ public final class FileSystemAgent {
          * Clean up
          */
         public static void shutdown() {
-            scheduler.shutdown();
+            if (scheduledFuture != null) {
+                scheduledFuture.cancel(true);
+            }
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -193,6 +193,7 @@ public class InMemoryStreamLog implements StreamLog {
     @Override
     public void close() {
         logCache = new HashMap<>();
+        FileSystemAgent.shutdown();
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -1228,6 +1228,7 @@ public class StreamLogFiles implements StreamLog {
 
     @Override
     public void close() {
+        FileSystemAgent.shutdown();
         for (SegmentHandle fh : writeChannels.values()) {
             fh.close();
         }


### PR DESCRIPTION
## Overview

Description:
Without this shutdown, the scheduler in PartitionAgent keeps trying to run its task even when the LogUnitServer is shutdown.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
