### PR TITLE
commit() returns >0 address if streams in txn are empty

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -157,6 +157,17 @@ public class ObjectsView extends AbstractView {
             long commitAddress = TransactionalContext.getCurrentContext().commitTransaction();
             MicroMeterUtils.time(Duration.ofMillis(System.currentTimeMillis() - context.getStartTime()),
                     "transaction.duration");
+            if (commitAddress == Address.NON_ADDRESS) {
+                // If no streams were touched or only empty streams were touched, the returned address would be -1
+                // But -1 can be detrimental to stream subscription which is just looking for a safe spot
+                // to resume subscription from, so instead return the address from the snapshot token taken.
+                long snapshotAddress = context.getSnapshotTimestamp().getSequence();
+                if (snapshotAddress >= 0) {
+                    // Perform a read at this address to force materialization.
+                    runtime.getAddressSpaceView().read(snapshotAddress);
+                }
+                return snapshotAddress;
+            }
             return commitAddress;
         } catch (TransactionAbortedException e) {
             log.warn("TXEnd[{}] Aborted Exception ", context, e);

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -557,7 +557,7 @@ public class CorfuStoreIT extends AbstractIT {
         try (TxnContext tx = corfuStore.txn(namespace)) {
             assertThat(tx.getTable(tableNameNoWrites).count()).isEqualTo(0);
             Timestamp readTx = tx.commit();
-            assertThat(readTx.getSequence()).isEqualTo(Address.NON_ADDRESS);
+            assertThat(readTx.getSequence()).isPositive();
         }
 
         assertThat(shutdownCorfuServer(corfuServer)).isTrue();

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
@@ -66,6 +66,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
     private CorfuRuntime getTestRuntime() {
         return getDefaultRuntime();
     }
+
     /**
      * CorfuStoreShim supports read your transactional writes implicitly when reads
      * happen in a write transaction or vice versa
@@ -147,7 +148,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
         }
         try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             UuidMsg key2 = null;
-            assertThatThrownBy( () -> readWriteTxn.putRecord(tableName, key2, null, null))
+            assertThatThrownBy(() -> readWriteTxn.putRecord(tableName, key2, null, null))
                     .isExactlyInstanceOf(IllegalArgumentException.class);
         }
     }
@@ -558,7 +559,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
                 key1,
                 ManagedMetadata.newBuilder().setCreateUser("abc").build(),
                 null);
-               txn.commit();
+        txn.commit();
         txn = shimStore.tx(someNamespace);
         txn.putRecord(table,
                 key1,
@@ -638,7 +639,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
         try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
             txn.putRecord(tableName, key, value,
                     LogReplicationEntryMetadataMsg.newBuilder()
-                            .setTimestamp(one+twelve)
+                            .setTimestamp(one + twelve)
                             .build());
             txn.commit();
         }
@@ -649,7 +650,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
 
         assertThat(entry.getMetadata().getTopologyConfigID()).isEqualTo(twelve);
         assertThat(entry.getMetadata().getSyncRequestId().getMsb()).isEqualTo(one);
-        assertThat(entry.getMetadata().getTimestamp()).isEqualTo(twelve+one);
+        assertThat(entry.getMetadata().getTimestamp()).isEqualTo(twelve + one);
 
         // Rolling Upgrade compatibility test: It should be ok to set a different metadata schema message
         try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
@@ -829,7 +830,8 @@ public class CorfuStoreShimTest extends AbstractViewTest {
         // ----- check nested transactions NOT started by CorfuStore isn't messed up by CorfuStore txn -----
         CorfuTable<String, String>
                 corfuTable = corfuRuntime.getObjectsView().build()
-                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
+                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {
+                })
                 .setStreamName("test")
                 .open();
 
@@ -855,6 +857,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
     /**
      * This test validates that the CorfuQueue api via the CorfuStore layer binds the fate and order of the
      * queue operations with that of its parent transaction.
+     *
      * @throws Exception could be a corfu runtime exception if bad things happen.
      */
     @Test
@@ -890,7 +893,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
         ArrayList<Long> validator = new ArrayList<>(numIterations);
         for (long i = 0L; i < numIterations; i++) {
             ExampleSchemas.ExampleValue queueData = ExampleSchemas.ExampleValue.newBuilder()
-                    .setPayload(""+i)
+                    .setPayload("" + i)
                     .setAnotherKey(i).build();
             final int two = 2;
             try (ManagedTxnContext txn = shimStore.txn(someNamespace)) {
@@ -918,7 +921,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
         // Also validate that the order of the queue matches that of the commit order.
         for (int i = 0; i < validator.size(); i++) {
             log.debug("Entry:" + records.get(i).getRecordId());
-            Long order = ((ExampleSchemas.ExampleValue)records.get(i).getEntry()).getAnotherKey();
+            Long order = ((ExampleSchemas.ExampleValue) records.get(i).getEntry()).getAnotherKey();
             assertThat(order).isEqualTo(validator.get(i));
         }
     }
@@ -1003,7 +1006,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
         final String tableName = "ManagedMetadata";
 
         // Create & Register the table
-        assertThatThrownBy( () -> shimStore.openTable(
+        assertThatThrownBy(() -> shimStore.openTable(
                 someNamespace,
                 tableName,
                 UuidMsg.class,
@@ -1011,7 +1014,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
                 null,
                 TableOptions.builder().build())).isExactlyInstanceOf(IllegalArgumentException.class);
 
-        assertThatThrownBy( () -> shimStore.openTable(
+        assertThatThrownBy(() -> shimStore.openTable(
                 someNamespace,
                 tableName,
                 null,
@@ -1088,8 +1091,9 @@ public class CorfuStoreShimTest extends AbstractViewTest {
      * ProtobufDescriptorTable should de-duplicate common protobuf file descriptors.
      * This test creates a large number of tables that share protobuf files and validates
      * that de-duplication occurs.
-     *
+     * <p>
      * It also verifies that the second registration is omitted.
+     *
      * @throws Exception exception
      */
     @Test
@@ -1119,7 +1123,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
         for (int i = 0; i < numTables; i++) {
             shimStore.openTable(
                     someNamespace,
-                    tableNamePrefix+i,
+                    tableNamePrefix + i,
                     UuidMsg.class,
                     ManagedMetadata.class,
                     ManagedMetadata.class,
@@ -1143,14 +1147,14 @@ public class CorfuStoreShimTest extends AbstractViewTest {
         CorfuStoreMetadata.TableName tableName = CorfuStoreMetadata.TableName
                 .newBuilder()
                 .setNamespace(someNamespace)
-                .setTableName(tableNamePrefix+"0")
+                .setTableName(tableNamePrefix + "0")
                 .build();
         final Collection<CorfuRecord<ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>> records =
                 corfuRuntime.getTableRegistry().getProtobufDescriptorTable().values();
 
         shimStore.openTable(
                 someNamespace,
-                tableNamePrefix+"0",
+                tableNamePrefix + "0",
                 UuidMsg.class,
                 org.corfudb.runtime.proto.LogData.LogDataMsg.class, // this brings in 1 new protobuf file
                 ManagedMetadata.class,
@@ -1167,5 +1171,34 @@ public class CorfuStoreShimTest extends AbstractViewTest {
                 recordsAfterChange = corfuRuntime.getTableRegistry().getProtobufDescriptorTable().values();
         assertThat(numProtoFiles).isEqualTo(numProtoFilesAfterChange);
         assertThat(records).containsExactlyElementsOf(recordsAfterChange);
+    }
+
+    @Test
+    public void validateCommitAlwaysReturnsRealAddress() throws Exception {
+
+        // Get a Corfu Runtime instance.
+        CorfuRuntime corfuRuntime = getTestRuntime();
+        // Creating Corfu Store using a connected corfu client.
+        CorfuStoreShim shimStore = new CorfuStoreShim(corfuRuntime);
+
+        final String someNamespace = "some-namespace";
+        final String tableName = "ManagedMetadata";
+        Table<UuidMsg, ManagedMetadata, ManagedMetadata> table = shimStore.openTable(
+                someNamespace,
+                tableName,
+                UuidMsg.class,
+                ManagedMetadata.class,
+                ManagedMetadata.class,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+        try (ManagedTxnContext txnContext = shimStore.tx(someNamespace)) {
+            txnContext.count(table);
+            CorfuStoreMetadata.Timestamp ts = txnContext.commit();
+            assertThat(ts.getSequence()).isPositive();
+        }
+        try (ManagedTxnContext txnContext = shimStore.tx(someNamespace)) {
+            CorfuStoreMetadata.Timestamp ts = txnContext.commit();
+            assertThat(ts.getSequence()).isPositive();
+        }
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
+++ b/test/src/test/java/org/corfudb/runtime/object/transactions/AbstractTransactionContextTest.java
@@ -93,16 +93,13 @@ public abstract class AbstractTransactionContextTest extends AbstractTransaction
     @Test
     public void ensureEmptyWriteSetIsNotWritten() {
         TXBegin();
-        long result = getRuntime().getObjectsView().TXEnd();
+        getRuntime().getObjectsView().TXEnd();
         ILogData ld =
                 getRuntime()
                         .getAddressSpaceView()
                         .peek(0);
         assertThat(ld)
                 .isNull();
-
-        assertThat(result)
-                .isEqualTo(Address.NON_ADDRESS);
     }
 
     /**


### PR DESCRIPTION
If the streams accessed in a transaction are empty
commit() would return -1 as the commit() address
which makes it impossible to use as a stream
re-subscription point.
So if this corner case is detected, return the address from
transaction's snapshot already obtained from the sequencer

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
