### PR TITLE
Exclude proto files from Jacoco coverage reporter

### DIFF
--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -51,7 +51,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.3</version>
+                <version>${jacoco.version}</version>
                 <executions>
                     <execution>
                         <id>report-aggregate</id>
@@ -63,6 +63,23 @@
                             <excludes>
                                 <exclude>**/*$CORFUSMR.*</exclude>
                                 <exclude>**/format/*</exclude>
+
+                                <!-- All packages that contain proto keyword -->
+                                <exclude>**/proto/**</exclude>
+                                <!-- Classes with Msg in their name (Rename ObservableAckMsg?) -->
+                                <exclude>**/*Msg*</exclude>
+
+                                <!-- Runtime specific protobuf files -->
+                                <exclude>org/corfudb/runtime/CorfuOptions*</exclude>
+                                <exclude>org/corfudb/runtime/CorfuStoreMetadata*</exclude>
+                                <exclude>org/corfudb/runtime/ExampleSchemas*</exclude>
+                                <exclude>org/corfudb/runtime/Queue*</exclude>
+                                <exclude>org/corfudb/runtime/LogReplication*</exclude>
+
+                                <!-- Infrastructure specific protobuf files -->
+                                <exclude>org/corfudb/infrastructure/log/LogFormat*</exclude>
+                                <exclude>org/corfudb/infrastructure/logreplication/LogReplicationTransport*</exclude>
+                                <exclude>org/corfudb/infrastructure/logreplication/LogReplicationChannelGrpc*</exclude>
                             </excludes>
                         </configuration>
                     </execution>

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,3 @@
+# add @lombok.Generated annotations to all generated nodes where possible;
+# useful for JaCoCo (which has built in support), or other style checkers and code coverage tools:
+lombok.addLombokGeneratedAnnotation = true

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <mockito.version>1.10.19</mockito.version>
         <assertj.version>3.19.0</assertj.version>
         <zero.allocation.hashing.version>0.8</zero.allocation.hashing.version>
+        <jacoco.version>0.8.8</jacoco.version>
     </properties>
 
     <scm>
@@ -274,9 +275,9 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <groupId>@project.groupId@</groupId>
+                    <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>@project.version@</version>
+                    <version>${jacoco.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.sonarsource.scanner.maven</groupId>
@@ -464,7 +465,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.6</version>
+                <version>${jacoco.version}</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
## Overview

Description: Currently proto auto-generated files are showing less coverage for the repository. 
This commit helps in reducing the percentage and getting more realistic values by excluding the proto files.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
