### PR TITLE
Increase the SYSTEM_DOWN_RETRIES of corfu browser/editor to 60

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditorMain.java
@@ -93,7 +93,7 @@ public class CorfuStoreBrowserEditorMain {
             String operation = opts.get("--operation").toString();
 
             final int SYSTEM_EXIT_ERROR_CODE = 1;
-            final int SYSTEM_DOWN_RETRIES = 5;
+            final int SYSTEM_DOWN_RETRIES = 60;
             CorfuRuntime.CorfuRuntimeParameters.CorfuRuntimeParametersBuilder
                 builder = CorfuRuntime.CorfuRuntimeParameters.builder()
                 .cacheDisabled(true)


### PR DESCRIPTION
## Overview

Description:
Increase the SYSTEM_DOWN_RETRIES of corfu browser/editor to 60

Why should this be merged: 
There are new usages of corfu editor invoked by programs.
We have seen that the old SYSTEM_DOWN_RETRIES(5) is too
small and can be exausted too quickly.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
