### PR TITLE
Make Lock Operations in LR Atomic.

### DIFF
--- a/test/src/test/java/org/corfudb/utils/LockStoreTest.java
+++ b/test/src/test/java/org/corfudb/utils/LockStoreTest.java
@@ -1,0 +1,289 @@
+package org.corfudb.utils;
+
+import com.google.protobuf.Message;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.utils.lock.Lock;
+import org.corfudb.utils.lock.LockDataTypes;
+import org.corfudb.utils.lock.persistence.LockStore;
+import org.corfudb.utils.lock.persistence.LockStoreException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+
+public class LockStoreTest extends AbstractViewTest {
+
+    private static final String LOCK_GROUP = "Test Group";
+    private static final String LOCK_NAME = "Test Name";
+    private static final int TASK_EXECUTE_TIMEOUT = 20;
+    private static final String LOCK_TABLE_NAME = "LOCK";
+    private static final int LOCK_LEASE_DURATION_LONG_SECONDS = 300;
+    private static final int DELAY_MS = 10000;
+    private boolean acquired1 = false;
+    private boolean acquired2 = false;
+    private boolean renewed1 = false;
+    private boolean renewed2 = false;
+    private List<LockDataTypes.LockId> expiredLockIds1 = new ArrayList<>();
+    private List<LockDataTypes.LockId> expiredLockIds2 = new ArrayList<>();
+    private CorfuRuntime runtime1;
+    private CorfuRuntime runtime2;
+    private final LockDataTypes.LockId lockId = LockDataTypes.LockId.newBuilder()
+        .setLockGroup(LOCK_GROUP).setLockName(LOCK_NAME).build();
+
+    @Before
+    public void setUp() {
+        runtime1 = getDefaultRuntime();
+        runtime2 = getNewRuntime(getDefaultNode()).connect();
+    }
+
+    private void cleanupAfterIteration() {
+        clearLockTable(runtime1);
+        acquired1 = false;
+        acquired2 = false;
+        renewed1 = false;
+        renewed2 = false;
+        expiredLockIds1.clear();
+        expiredLockIds2.clear();
+    }
+
+    @After
+    public void cleanUp() {
+        cleanupAfterIteration();
+        runtime1.shutdown();
+        runtime2.shutdown();
+    }
+
+    private void clearLockTable(CorfuRuntime runtime) {
+        CorfuStore corfuStore = new CorfuStore(runtime);
+        Table<LockDataTypes.LockId, LockDataTypes.LockData, Message> lockTable =
+            corfuStore.getTable(CORFU_SYSTEM_NAMESPACE, LOCK_TABLE_NAME);
+        lockTable.clearAll();
+    }
+
+    private void executeAcquireOrRenewConcurrently(LockStore lockStore1,
+        LockStore lockStore2, boolean renew) throws Exception {
+
+        if (renew) {
+            scheduleConcurrently(f -> {
+                try {
+                    renewed1 = lockStore1.renew(lockId);
+                } catch (LockStoreException le) {
+                    renewed1 = false;
+                }
+            });
+            scheduleConcurrently(f -> {
+                try {
+                    renewed2 = lockStore2.renew(lockId);
+                } catch (LockStoreException le) {
+                    renewed2 = false;
+                }
+            });
+        } else {
+            scheduleConcurrently(f -> {
+                try {
+                    acquired1 = lockStore1.acquire(lockId);
+                } catch (LockStoreException le) {
+                    acquired1 = false;
+                }
+            });
+
+            scheduleConcurrently(f -> {
+                try {
+                    acquired2 = lockStore2.acquire(lockId);
+                } catch (LockStoreException le) {
+                    acquired2 = false;
+                }
+            });
+        }
+        executeScheduled(2, TASK_EXECUTE_TIMEOUT, TimeUnit.SECONDS);
+    }
+
+    // Two runtimes try to acquire a lock with the same lock id concurrently.
+    // Verify that only one of them succeeds.
+    // Repeat this operation multiple times to expose race in this workflow,
+    // if any.  Each iteration clears the lock table and creates a new
+    // LockStore instance to exercise the init scenario.
+    @Test
+    public void testAcquireConcurrently() throws Exception {
+        for (int i=0; i<PARAMETERS.NUM_ITERATIONS_LOW; i++) {
+
+            LockStore lockStore1 = new LockStore(runtime1, UUID.randomUUID());
+            LockStore lockStore2 = new LockStore(runtime2, UUID.randomUUID());
+
+            executeAcquireOrRenewConcurrently(lockStore1, lockStore2, false);
+
+            Assert.assertTrue(acquired1 || acquired2);
+            Assert.assertFalse(acquired1 && acquired2);
+
+            cleanupAfterIteration();
+        }
+    }
+
+    // Two runtimes try to acquire a lock with the same lock id concurrently.
+    // Verify that only one of them succeeds.
+    // Repeat this operation multiple times to expose race in this workflow,
+    // if any.
+    // Lock table is not cleared between iterations and the LockStore
+    // instance is reused.  This test simulates the case where acquire() is
+    // invoked even if there is a lock in the table(there is a lock owner).
+    @Test
+    public void testRepeatedAcquire() throws Exception {
+        Lock.setLeaseDuration(LOCK_LEASE_DURATION_LONG_SECONDS);
+
+        LockStore lockStore1 = new LockStore(runtime1, UUID.randomUUID());
+        LockStore lockStore2 = new LockStore(runtime2, UUID.randomUUID());
+
+        executeAcquireOrRenewConcurrently(lockStore1, lockStore2, false);
+
+        Assert.assertTrue(acquired1 || acquired2);
+        Assert.assertFalse(acquired1 && acquired2);
+
+        CorfuStore corfuStore1 = new CorfuStore(runtime1);
+        LockDataTypes.LockData existingLockData = null;
+        try (TxnContext txn = corfuStore1.txn(CORFU_SYSTEM_NAMESPACE)) {
+             existingLockData = lockStore1.get(lockId, txn).get();
+            txn.commit();
+        }
+
+        for (int i=0; i<PARAMETERS.NUM_ITERATIONS_LOW; i++) {
+            executeAcquireOrRenewConcurrently(lockStore1, lockStore2, false);
+            Assert.assertFalse(acquired1 || acquired2);
+
+            LockDataTypes.LockData currentLockData = null;
+            try (TxnContext txn = corfuStore1.txn(CORFU_SYSTEM_NAMESPACE)) {
+                currentLockData = lockStore1.get(lockId, txn).get();
+                txn.commit();
+            }
+
+            Assert.assertEquals(currentLockData.getLeaseOwnerId(),
+                existingLockData.getLeaseOwnerId());
+            Assert.assertTrue(Objects.equals(currentLockData, existingLockData));
+        }
+    }
+
+
+    // Two runtimes try to renew an acquired lock concurrently.  Verify that
+    // only one of them succeeds and only the current owner of the lock can
+    // renew it.
+    // Repeat this operation multiple times to expose race in this workflow,
+    // if any.  Each iteration clears the lock table and creates a new
+    // LockStore instance to exercise the (init+renew) scenario.
+    @Test
+    public void testRenewalBySameNode() throws Exception {
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LOW; i++) {
+            LockStore lockStore1 = new LockStore(runtime1, UUID.randomUUID());
+            LockStore lockStore2 = new LockStore(runtime2, UUID.randomUUID());
+
+            executeAcquireOrRenewConcurrently(lockStore1, lockStore2, false);
+
+            Assert.assertTrue(acquired1 || acquired2);
+            Assert.assertFalse(acquired1 && acquired2);
+
+            CorfuStore corfuStore1 = new CorfuStore(runtime1);
+            LockDataTypes.LockData dataBeforeRenewal = null;
+            try (TxnContext txn = corfuStore1.txn(CORFU_SYSTEM_NAMESPACE)) {
+                dataBeforeRenewal = lockStore1.get(lockId, txn).get();
+                txn.commit();
+            }
+
+            // Renew the lock
+            executeAcquireOrRenewConcurrently(lockStore1, lockStore2, true);
+            Assert.assertTrue(renewed1 || renewed2);
+            Assert.assertFalse(renewed1 && renewed2);
+
+            LockDataTypes.LockData dataAfterRenewal = null;
+            try (TxnContext txn = corfuStore1.txn(CORFU_SYSTEM_NAMESPACE)) {
+                dataAfterRenewal = lockStore1.get(lockId, txn).get();
+                txn.commit();
+            }
+
+            Assert.assertTrue(Objects.equals(
+                dataBeforeRenewal.getLeaseOwnerId(),
+                dataAfterRenewal.getLeaseOwnerId()));
+            Assert.assertEquals(
+                dataBeforeRenewal.getLeaseRenewalNumber()+1,
+                dataAfterRenewal.getLeaseRenewalNumber());
+
+            cleanupAfterIteration();
+        }
+    }
+
+    // Two runtimes find the lock with expired lease.  Verify that both get
+    // the same result.
+    // Repeat this operation multiple times to expose race in this workflow,
+    // if any.  Each iteration clears the lock table and creates a new
+    // LockStore instance to avoid carrying forward the in-mem
+    // 'observedLocks' map inside LockStore.
+    @Test
+    public void testFilterExpiredLocks() throws Exception {
+
+        Lock.setLeaseDuration((int)PARAMETERS.TIMEOUT_SHORT.getSeconds());
+
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_VERY_LOW; i++) {
+            LockStore lockStore1 = new LockStore(runtime1, UUID.randomUUID());
+            LockStore lockStore2 = new LockStore(runtime2, UUID.randomUUID());
+
+            // Acquire a lock and verify that only a single client succeeds
+            executeAcquireOrRenewConcurrently(lockStore1, lockStore2, false);
+            Assert.assertTrue(acquired1 || acquired2);
+            Assert.assertFalse(acquired1 && acquired2);
+
+            // Filter the locks with expired lease.  The first invocation
+            // just adds the lock to the in-mem 'observedLocks' map inside
+            // LockStore.  So this invocation will not detect the lock as
+            // expired.
+            scheduleConcurrently(f -> {
+                expiredLockIds1.addAll(
+                    lockStore1.filterLocksWithExpiredLeases(
+                        Collections.singletonList(lockId)));
+            });
+            scheduleConcurrently(f -> {
+                expiredLockIds2.addAll(lockStore2.filterLocksWithExpiredLeases(
+                    Collections.singletonList(lockId)));
+            });
+            executeScheduled(2, TASK_EXECUTE_TIMEOUT, TimeUnit.SECONDS);
+            Assert.assertTrue(expiredLockIds1.isEmpty());
+            Assert.assertTrue(expiredLockIds2.isEmpty());
+
+            // Wait till the duration of the lock lease expiry + an
+            // additional delay of 10ms.
+            // LockStore detects a lock as expired if (the duration between
+            // the time it was first read - lease expiry time) is before the
+            // current system clock time.  So adding an arbitrary 10ms so
+            // that the lock is detected as
+            // expired.
+            Thread.sleep(PARAMETERS.TIMEOUT_SHORT.toMillis() + DELAY_MS);
+
+            // Filter again and verify that the expired lock is returned
+            scheduleConcurrently(f -> {
+                expiredLockIds1.addAll(
+                    lockStore1.filterLocksWithExpiredLeases(
+                        Collections.singletonList(lockId)));
+            });
+            scheduleConcurrently(f -> {
+                expiredLockIds2.addAll(lockStore2.filterLocksWithExpiredLeases(
+                    Collections.singletonList(lockId)));
+            });
+            executeScheduled(2, TASK_EXECUTE_TIMEOUT, TimeUnit.SECONDS);
+
+            Assert.assertEquals(1, expiredLockIds1.size());
+            Assert.assertEquals(1, expiredLockIds2.size());
+            Assert.assertTrue(Objects.equals(expiredLockIds1.get(0),
+                expiredLockIds2.get(0)));
+
+            cleanupAfterIteration();
+        }
+    }
+}

--- a/utils/src/main/java/org/corfudb/utils/lock/persistence/LockStore.java
+++ b/utils/src/main/java/org/corfudb/utils/lock/persistence/LockStore.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.*;
 import org.corfudb.utils.CommonTypes.Uuid;
+import org.corfudb.utils.lock.LockDataTypes;
 import org.corfudb.utils.lock.LockDataTypes.LockData;
 import org.corfudb.utils.lock.LockDataTypes.LockId;
 
@@ -44,7 +45,7 @@ public class LockStore {
     private final Table<LockId, LockData, Message> table;
 
     private final Uuid clientId;
-    // Corfu store to access data from the Lock table.
+
     private final CorfuStore corfuStore;
 
     /**
@@ -67,7 +68,7 @@ public class LockStore {
                 LockId.class,
                 LockData.class,
                 null,
-                TableOptions.builder().build());
+                TableOptions.fromProtoSchema(LockDataTypes.LockData.class));
 
         this.clientId = Uuid.newBuilder()
                 .setMsb(clientUuid.getMostSignificantBits())
@@ -89,38 +90,47 @@ public class LockStore {
      * @throws LockStoreException
      */
     public boolean acquire(LockId lockId) throws LockStoreException {
-        Optional<LockData> lockInDatastore = get(lockId);
-
-        if (!lockInDatastore.isPresent()) {
-            LockData newLockData = LockData.newBuilder()
+        try (TxnContext txnContext = corfuStore.txn(NAMESPACE)) {
+            Optional<LockData> lockInDatastore = get(lockId, txnContext);
+            if (!lockInDatastore.isPresent()) {
+                LockData newLockData = LockData.newBuilder()
                     .setLockId(lockId)
                     .setLeaseOwnerId(clientId)
                     .setLeaseRenewalNumber(0)
                     .setLeaseAcquisitionNumber(0)
                     .build();
-            // if no lock present acquire(create) the lock in datastore
-            create(lockId, newLockData);
-            log.debug("Lock: {} Client:{} acquired lock. No pre-existing lease in datastore.", lockId, clientId);
-            return true;
-        } else {
-            if (isRevocable(lockId)) {
-                LockData newLockData = LockData.newBuilder()
+                // if no lock present acquire(create) the lock in datastore
+                log.info("LockStore: create lock record for : {}",
+                    lockId.getLockName());
+                putLockRecord(lockId, newLockData, txnContext);
+                txnContext.commit();
+                log.debug("Lock: {} Client:{} acquired lock. No pre-existing lease in datastore.", lockId, clientId);
+                return true;
+            } else {
+                if (isRevocable(lockId, lockInDatastore)) {
+                    LockData newLockData = LockData.newBuilder()
                         .setLockId(lockId)
                         .setLeaseOwnerId(clientId)
                         .setLeaseRenewalNumber(0)
                         .setLeaseAcquisitionNumber(lockInDatastore.get().getLeaseAcquisitionNumber() + 1)
                         .build();
-                // acquire(update) the lock in data store if it is stale
-                update(lockId, newLockData);
-                log.debug("Lock: {} Client:{} acquired lock {}. Expired lease in datastore: {} ", lockId, clientId, newLockData, lockInDatastore.get());
-                return true;
-            } else {
-                // cannot acquire if some other client holds the lock (non stale)
-                log.debug("Lock: {} Client:{} could not acquire lock. Lease in datastore: {}", lockId, clientId, lockInDatastore.get());
-                return false;
+                    // acquire(update) the lock in data store if it is stale
+                    putLockRecord(lockId, newLockData, txnContext);
+                    txnContext.commit();
+                    log.debug("Lock: {} Client:{} acquired lock {}. Expired lease in datastore: {} ", lockId, clientId, newLockData, lockInDatastore.get());
+                    return true;
+                } else {
+                    // cannot acquire if some other client holds the lock (non stale)
+                    log.debug("Lock: {} Client:{} could not acquire lock. Lease in datastore: {}", lockId, clientId, lockInDatastore.get());
+                    return false;
+                }
             }
+        } catch (Exception e) {
+            log.error("Exception during acquire of lock" + lockId, e);
+            throw new LockStoreException("Exception during lock acquire", e);
         }
     }
+
 
     /**
      * A client can renew it's lease if it is still the owner of
@@ -131,26 +141,34 @@ public class LockStore {
      * @throws LockStoreException
      */
     public boolean renew(LockId lockId) throws LockStoreException {
-        Optional<LockData> lockInDatastore = get(lockId);
+        try (TxnContext txnContext = corfuStore.txn(NAMESPACE)) {
+            Optional<LockData> lockInDatastore = get(lockId, txnContext);
 
-        if (!lockInDatastore.isPresent()) {
-            // client had never acquire the lock. This should not happen!
-            log.debug("Lock: {} Client:{} could not renew lease. No lock in database.", lockId, clientId);
-            return false;
-        } else if (!lockInDatastore.get().getLeaseOwnerId().equals(clientId)) {
-            // the lease was revoked by another client
-            log.debug("Lock: {} Client:{} could not renew lease.Lease in datastore: {}", lockId, clientId, lockInDatastore.get());
-            return false;
-        } else {
-            // renew the lease
-            LockData newLockData = LockData.newBuilder()
+            if (!lockInDatastore.isPresent()) {
+                // client had never acquire the lock. This should not happen!
+                log.debug("Lock: {} Client:{} could not renew lease. No lock in database.", lockId, clientId);
+                return false;
+            } else if (!lockInDatastore.get().getLeaseOwnerId().equals(clientId)) {
+                // the lease was revoked by another client
+                log.debug("Lock: {} Client:{} could not renew lease.Lease in datastore: {}", lockId, clientId, lockInDatastore.get());
+                return false;
+            } else {
+                // renew the lease
+                LockData newLockData = LockData.newBuilder()
                     .setLockId(lockId)
                     .setLeaseOwnerId(lockInDatastore.get().getLeaseOwnerId())
                     .setLeaseRenewalNumber(lockInDatastore.get().getLeaseRenewalNumber() + 1)
+                    .setLeaseAcquisitionNumber(lockInDatastore.get().getLeaseAcquisitionNumber())
                     .build();
-            update(lockId, newLockData);
-            log.debug("Lock: {} Client:{} renewed lease, new lock is {}.", lockId, clientId, newLockData);
-            return true;
+                putLockRecord(lockId, newLockData, txnContext);
+                txnContext.commit();
+                log.debug("Lock: {} Client:{} renewed lease, new lock is {}.",
+                    lockId, clientId, newLockData);
+                return true;
+            }
+        } catch (Exception e) {
+            log.error("Exception during renewal of lock" + lockId, e);
+            throw new LockStoreException("Exception during lock renewal", e);
         }
     }
 
@@ -164,16 +182,18 @@ public class LockStore {
      */
     public Collection<LockId> filterLocksWithExpiredLeases(Collection<LockId> lockIds) throws LockStoreException {
         Collection<LockId> revocableLeases = new ArrayList<>();
-        try {
-            // find the leases that can be revoked
-            for (LockId lockId: lockIds) {
-                if (isRevocable(lockId)) {
+
+        for (LockId lockId : lockIds) {
+            try (TxnContext txnContext = corfuStore.txn(NAMESPACE)) {
+                Optional<LockData> lockInDataStore = get(lockId, txnContext);
+                if (isRevocable(lockId, lockInDataStore)) {
                     revocableLeases.add(lockId);
                 }
+            } catch (Exception e) {
+                log.error("Client: {} Exception.", clientId, e);
+                throw new LockStoreException(
+                    "Exception while getting expired leases for client " + clientId, e);
             }
-        } catch (Exception e) {
-            log.error("Client: {} Exception.", clientId, e);
-            throw new LockStoreException("Exception while getting expired leases for client " + clientId, e);
         }
         return revocableLeases;
     }
@@ -181,38 +201,15 @@ public class LockStore {
     /***** HELPER METHODS ******/
 
     /**
-     * Creates a lock record.
+     * Creates or Updates a lock record.
      *
      * @param lockId
      * @param lockMetaData
      * @throws LockStoreException
      */
-    private void create(LockId lockId, LockData lockMetaData) throws LockStoreException {
-        try (TxnContext txnContext = corfuStore.txn(NAMESPACE)) {
-            log.info("LockStore: create lock record for : {}", lockId.getLockName());
-            txnContext.putRecord(table, lockId, lockMetaData, null);
-            txnContext.commit();
-        } catch (Exception e) {
-            log.error("Lock: {} Exception during create.", lockId, e);
-            throw new LockStoreException("Exception while creating lock " + lockId, e);
-        }
-    }
-
-    /**
-     * Updates a lock record.
-     *
-     * @param lockId
-     * @param lockMetaData
-     * @throws LockStoreException
-     */
-    private void update(LockId lockId, LockData lockMetaData) throws LockStoreException {
-        try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-            txn.putRecord(table, lockId, lockMetaData, null);
-            txn.commit();
-        } catch (Exception e) {
-            log.error("Lock: {} Exception during update.", lockId, e);
-            throw new LockStoreException("Exception while updating lock " + lockId, e);
-        }
+    private void putLockRecord(LockId lockId, LockData lockMetaData,
+        TxnContext txnContext) {
+        txnContext.putRecord(table, lockId, lockMetaData, null);
     }
 
     /**
@@ -223,18 +220,12 @@ public class LockStore {
      * @throws LockStoreException
      */
     @VisibleForTesting
-    public Optional<LockData> get(LockId lockId) throws LockStoreException {
-        try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-            CorfuStoreEntry record = txn.getRecord(TABLE_NAME, lockId);
-            txn.commit();
-            if (record.getPayload() != null) {
-                return Optional.of((LockData) record.getPayload());
-            } else {
-                return Optional.empty();
-            }
-        } catch (Exception e) {
-            log.error("Lock: {} Exception during get.", lockId, e);
-            throw new LockStoreException("Exception while getting data for lock " + lockId, e);
+    public Optional<LockData> get(LockId lockId, TxnContext txn) {
+        CorfuStoreEntry record = txn.getRecord(TABLE_NAME, lockId);
+        if (record.getPayload() != null) {
+            return Optional.of((LockData) record.getPayload());
+        } else {
+            return Optional.empty();
         }
     }
 
@@ -245,30 +236,33 @@ public class LockStore {
      * @return
      * @throws LockStoreException
      */
-    private boolean isRevocable(LockId lockId) throws LockStoreException {
-        Optional<LockData> lockInDatastore = get(lockId);
-        if (lockInDatastore.isPresent()) {
-            ObservedLock observedLock = observedLocks.get(lockId);
-            if ((observedLock == null) || (!observedLock.lockData.equals(lockInDatastore.get()))) {
-                // If the lock has not been observed before or the lock in data store
-                // is not the same as the previously observed lock for that key, update the observation
-                // lease is not expired yet.
-                log.info("LockStore: new observed lock");
-                observedLocks.put(lockId, new ObservedLock(lockInDatastore.get(), Instant.now()));
-                return false;
-            } else {
-                // check if the lease has expired
-                boolean leaseExpired = observedLock.timestamp.isBefore(Instant.now().minusSeconds(leaseDuration));
-                log.info("LockStore: check if lease is expired : {}", leaseExpired);
-                if (leaseExpired) {
-                    log.debug("LockStore: lock {} lease is expired, leaseDuration={}, timestamp={}, and now={}",
-                            lockId, leaseDuration, observedLock.timestamp, Instant.now());
-                }
-                return leaseExpired;
-            }
+    private boolean isRevocable(LockId lockId,
+                                Optional<LockData> lockDataOptional) {
+
+        if (!lockDataOptional.isPresent()) {
+            // No lock in the database.  Return.
+            return false;
+        }
+
+        ObservedLock observedLock = observedLocks.get(lockId);
+        if (observedLock == null ||
+            !observedLock.lockData.equals(lockDataOptional.get())) {
+            // If the lock has not been observed before or the lock in data store
+            // is not the same as the previously observed lock for that key, update the observation
+            // lease is not expired yet.
+            log.info("LockStore: new observed lock");
+            observedLocks.put(lockId, new ObservedLock(lockDataOptional.get(),
+                Instant.now()));
+            return false;
         } else {
-            log.info("LockStore: lockId {} not present in store", lockId.getLockName());
-            return true;
+            // check if the lease has expired
+            boolean leaseExpired = observedLock.timestamp.isBefore(Instant.now().minusSeconds(leaseDuration));
+            log.info("LockStore: check if lease is expired : {}", leaseExpired);
+            if (leaseExpired) {
+                log.debug("LockStore: lock {} lease is expired, leaseDuration={}, timestamp={}, and now={}",
+                    lockId, leaseDuration, observedLock.timestamp, Instant.now());
+            }
+            return leaseExpired;
         }
     }
 


### PR DESCRIPTION
Make Lock Operations in LR Atomic.

Description:
Making the read-update-write path in Lock operations atomic. The lock is currently only used in LogReplication(LR) but has been implemented in a generic way.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
