### PR TITLE
Better CI integration of a docker build

### DIFF
--- a/.ci/generator-docker-build.sh
+++ b/.ci/generator-docker-build.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+./mvnw -pl generator --also-make -DskipTests -Dmaven.javadoc.skip=true -T 1C clean package
+
+CORFU_VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+
+cd generator
+
+# Docker build
+docker build --network=host \
+  -t corfudb/generator:"${CORFU_VERSION}" \
+  -t corfudb-universe/generator:"${CORFU_VERSION}" \
+  .

--- a/.ci/infrastructure-docker-build.sh
+++ b/.ci/infrastructure-docker-build.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+
+PROFILE=$1
+if [ -z "$PROFILE" ]; then
+  echo "Please provide a profile name: 'docker' or 'compatibility'"
+  exit 1
+fi
+
+# Clean up project
+./mvnw clean
+
+# Build cmdlets
+./mvnw -pl cmdlets,corfudb-tools,infrastructure --also-make -DskipTests -Dmaven.javadoc.skip=true -T 1C package
+
+# Copy corfu binaries into target directory
+cp -r ./bin ./infrastructure/target/
+cp -r ./corfu_scripts ./infrastructure/target/
+cp -r ./scripts ./infrastructure/target/
+
+CORFU_VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+
+cp -r ./cmdlets/target/cmdlets-"${CORFU_VERSION}"-shaded.jar ./infrastructure/target/
+cp -r ./corfudb-tools/target/corfudb-tools-"${CORFU_VERSION}"-shaded.jar ./infrastructure/target/
+
+# Docker build
+cd ./infrastructure
+
+CMD_LINE="docker build "
+CMD_LINE+="--network=host "
+CMD_LINE+="--build-arg CORFU_JAR=infrastructure-${CORFU_VERSION}-shaded.jar "
+CMD_LINE+="--build-arg CMDLETS_JAR=cmdlets-${CORFU_VERSION}-shaded.jar "
+CMD_LINE+="--build-arg CORFU_TOOLS_JAR=corfudb-tools-${CORFU_VERSION}-shaded.jar "
+
+if [ "$PROFILE" = "docker" ]; then
+  CMD_LINE+="-t corfudb/corfu-server:${CORFU_VERSION} -t corfudb-universe/corfu-server:${CORFU_VERSION}"
+else
+  CMD_LINE+="-t corfudb/corfu-server:latest"
+fi
+
+CMD_LINE="$CMD_LINE ."
+
+$CMD_LINE

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -35,7 +35,8 @@ jobs:
         continue-on-error: true
 
       - name: Prepare top of trunk docker image
-        run: ./mvnw clean install -DskipTests -Pcompatibility -Dmaven.javadoc.skip=true -T 1C
+        run: .ci/infrastructure-docker-build.sh compatibility
+        shell: bash
 
       - name: Pull docker image built from master parent commit
         run: docker pull corfudb/corfu-server:0.3.1-SNAPSHOT

--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Build universe-core
         working-directory: ./universe
-        run: rm -r ~/.m2/repository/org/corfudb && ./gradlew clean publishToMavenLocal
+        run: rm -rf ~/.m2/repository/org/corfudb && ./gradlew clean publishToMavenLocal
 
       - name: Run version compatibility tests
         working-directory: ./tests

--- a/.github/workflows/injection-framework-test.yml
+++ b/.github/workflows/injection-framework-test.yml
@@ -35,7 +35,9 @@ jobs:
         continue-on-error: true
 
       - name: Prepare top of trunk docker image
-        run: .ci/infrastructure-docker-build.sh docker
+        run: |
+          .ci/infrastructure-docker-build.sh docker
+          .ci/generator-docker-build.sh
         shell: bash
 
       - name: Set corfu server version env variable

--- a/.github/workflows/injection-framework-test.yml
+++ b/.github/workflows/injection-framework-test.yml
@@ -35,7 +35,8 @@ jobs:
         continue-on-error: true
 
       - name: Prepare top of trunk docker image
-        run: ./mvnw clean package -DskipTests -Pdocker -Dmaven.javadoc.skip=true -T 1C
+        run: .ci/infrastructure-docker-build.sh docker
+        shell: bash
 
       - name: Set corfu server version env variable
         run: echo "CORFU_SERVER_VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> $GITHUB_ENV

--- a/.github/workflows/publish-corfu.yml
+++ b/.github/workflows/publish-corfu.yml
@@ -42,7 +42,8 @@ jobs:
         continue-on-error: true
 
       - name: Prepare Corfu
-        run: ./mvnw clean install -Pdocker -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip -T 1C
+        run: .ci/infrastructure-docker-build.sh docker
+        shell: bash
 
       - name: Publish corfu artifacts
         working-directory: ./

--- a/.github/workflows/universe-test.yml
+++ b/.github/workflows/universe-test.yml
@@ -31,7 +31,8 @@ jobs:
         continue-on-error: true
 
       - name: Prepare Corfu
-        run: ./mvnw clean install -Pdocker -DskipTests -Dmaven.javadoc.skip=true -Dcheckstyle.skip -T 1C
+        run: .ci/infrastructure-docker-build.sh docker
+        shell: bash
 
       - name: Run universe tests
         run: ./mvnw -pl :universe verify -Puniverse -Dmaven.javadoc.skip=true

--- a/.github/workflows/universe-test.yml
+++ b/.github/workflows/universe-test.yml
@@ -35,4 +35,6 @@ jobs:
         shell: bash
 
       - name: Run universe tests
-        run: ./mvnw -pl :universe --also-make -Puniverse -Dmaven.javadoc.skip=true verify
+        run: |
+          ./mvnw -Dmaven.javadoc.skip=true -DskipTests -T 1C clean install
+          ./mvnw -pl :universe -Puniverse -Dmaven.javadoc.skip=true verify

--- a/.github/workflows/universe-test.yml
+++ b/.github/workflows/universe-test.yml
@@ -35,4 +35,4 @@ jobs:
         shell: bash
 
       - name: Run universe tests
-        run: ./mvnw -pl :universe verify -Puniverse -Dmaven.javadoc.skip=true
+        run: ./mvnw -pl :universe --also-make -Puniverse -Dmaven.javadoc.skip=true verify

--- a/cmdlets/pom.xml
+++ b/cmdlets/pom.xml
@@ -21,6 +21,11 @@
             <artifactId>runtime</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.corfudb</groupId>
+            <artifactId>infrastructure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- External Dependencies -->
         <!-- fix protobuf dependency issue -->

--- a/docs/dockerized-corfu.md
+++ b/docs/dockerized-corfu.md
@@ -1,20 +1,16 @@
 ## Dockerized corfu
 
-Corfu is available as Docker image. The image uses `alpine` as the base image.
-Corfu repository is [here](https://cloud.docker.com/u/corfudb/repository/docker/corfudb/corfu-server)
+CorfuDb is available as a Docker image. The image uses `alpine` as a base image.
+CorfuDb repository [is available on docker hub](https://hub.docker.com/repository/docker/corfudb/corfu-server)
 
 #### Building corfu image
-`./mvnw -pl infrastructure -DskipTests -Pdocker clean package`
+`.ci/infrastructure-docker-build.sh docker`
  
 #### Deploying corfu image
-`./mvnw -pl infrastructure -DskipTests -Pdocker clean deploy`
+`./mvnw -pl infrastructure -DskipTests clean deploy`
 
 #### Pulling the image (particular version)
-`docker pull corfudb/corfu-server:0.3.0-SNAPSHOT`
+`docker pull corfudb/corfu-server:${CORFU_VERSION}`
  
 #### Running corfu server
-`docker run -ti corfudb/corfu-server:0.3.0-SNAPSHOT`
-
-P.S.
-The new Docker image does not support any cmdlets.
-If required the cmdlets can be added to the new Docker image in the future.
+`docker run -ti corfudb/corfu-server:${CORFU_VERSION}`

--- a/generator/pom.xml
+++ b/generator/pom.xml
@@ -33,46 +33,6 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-        <profile>
-            <id>docker</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <executions>
-                            <execution>
-                                <id>Docker build</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>docker</executable>
-                                    <arguments>
-                                        <argument>build</argument>
-                                        <argument>--network=host</argument>
-                                        <argument>-t</argument>
-                                        <argument>
-                                            corfudb/generator:${project.version}
-                                        </argument>
-                                        <argument>-t</argument>
-                                        <argument>
-                                            corfudb-universe/generator:${project.version}
-                                        </argument>
-                                        <argument>.</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -19,297 +19,6 @@
         <docopt.version>0.6.0.20150202</docopt.version>
     </properties>
 
-    <profiles>
-        <profile>
-            <id>docker</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.3.0</version>
-                        <executions>
-                            <execution>
-                                <id>copy</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.corfudb</groupId>
-                                    <artifactId>cmdlets</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>jar</type>
-                                    <classifier>shaded</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <destFileName>cmdlets-${project.version}-shaded.jar</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>true</overWriteSnapshots>
-                        </configuration>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <executions>
-                            <!-- Copy corfu binaries into the target directory-->
-                            <execution>
-                                <id>Corfu bin tools</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>cp</executable>
-                                    <arguments>
-                                        <argument>-r</argument>
-                                        <argument>${session.executionRootDirectory}/bin</argument>
-                                        <argument>target</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>Corfu scripts</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>cp</executable>
-                                    <arguments>
-                                        <argument>-r</argument>
-                                        <argument>${session.executionRootDirectory}/corfu_scripts</argument>
-                                        <argument>target</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>Corfu utilities</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>cp</executable>
-                                    <arguments>
-                                        <argument>-r</argument>
-                                        <argument>${session.executionRootDirectory}/scripts</argument>
-                                        <argument>target</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>Corfu browser tools</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>cp</executable>
-                                    <arguments>
-                                        <argument>
-                                            ${session.executionRootDirectory}/corfudb-tools/target/corfudb-tools-${project.version}-shaded.jar
-                                        </argument>
-                                        <argument>target</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>Docker build</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>docker</executable>
-                                    <arguments>
-                                        <argument>build</argument>
-                                        <argument>--network=host</argument>
-                                        <argument>--build-arg</argument>
-                                        <argument>
-                                            CORFU_JAR=infrastructure-${project.version}-shaded.jar
-                                        </argument>
-                                        <argument>--build-arg</argument>
-                                        <argument>
-                                            CMDLETS_JAR=cmdlets-${project.version}-shaded.jar
-                                        </argument>
-                                        <argument>--build-arg</argument>
-                                        <argument>
-                                            CORFU_TOOLS_JAR=corfudb-tools-${project.version}-shaded.jar
-                                        </argument>
-                                        <argument>-t</argument>
-                                        <argument>
-                                            corfudb/corfu-server:${project.version}
-                                        </argument>
-                                        <argument>-t</argument>
-                                        <argument>
-                                            corfudb-universe/corfu-server:${project.version}
-                                        </argument>
-                                        <argument>.</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>compatibility</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-dependency-plugin</artifactId>
-                        <version>3.3.0</version>
-                        <executions>
-                            <execution>
-                                <id>copy</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>copy</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.corfudb</groupId>
-                                    <artifactId>cmdlets</artifactId>
-                                    <version>${project.version}</version>
-                                    <type>jar</type>
-                                    <classifier>shaded</classifier>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <destFileName>cmdlets-${project.version}-shaded.jar</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>true</overWriteSnapshots>
-                        </configuration>
-                    </plugin>
-
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>3.0.0</version>
-                        <executions>
-                            <!-- Copy corfu binaries into the target directory-->
-                            <execution>
-                                <id>Corfu tools</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>cp</executable>
-                                    <arguments>
-                                        <argument>-r</argument>
-                                        <argument>${session.executionRootDirectory}/bin</argument>
-                                        <argument>target</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>Corfu scripts</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>cp</executable>
-                                    <arguments>
-                                        <argument>-r</argument>
-                                        <argument>${session.executionRootDirectory}/corfu_scripts</argument>
-                                        <argument>target</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>Corfu utilities</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>cp</executable>
-                                    <arguments>
-                                        <argument>-r</argument>
-                                        <argument>${session.executionRootDirectory}/scripts</argument>
-                                        <argument>target</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>Corfu browser tools</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>cp</executable>
-                                    <arguments>
-                                        <argument>
-                                            ${session.executionRootDirectory}/corfudb-tools/target/corfudb-tools-${project.version}-shaded.jar
-                                        </argument>
-                                        <argument>target</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-
-                            <execution>
-                                <id>Docker build</id>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>docker</executable>
-                                    <arguments>
-                                        <argument>build</argument>
-                                        <argument>--network=host</argument>
-                                        <argument>--build-arg</argument>
-                                        <argument>
-                                            CORFU_JAR=infrastructure-${project.version}-shaded.jar
-                                        </argument>
-                                        <argument>--build-arg</argument>
-                                        <argument>
-                                            CORFU_TOOLS_JAR=corfudb-tools-${project.version}-shaded.jar
-                                        </argument>
-                                        <argument>--build-arg</argument>
-                                        <argument>
-                                            CMDLETS_JAR=cmdlets-${project.version}-shaded.jar
-                                        </argument>
-                                        <argument>-t</argument>
-                                        <argument>
-                                            corfudb/corfu-server:latest
-                                        </argument>
-                                        <argument>.</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-
     <build>
         <plugins>
             <plugin>
@@ -325,14 +34,17 @@
                         <configuration>
                             <protocVersion>3.6.1</protocVersion>
                             <includeStdTypes>true</includeStdTypes>
+                            <addProtoSources>inputs</addProtoSources>
+                            <includeMavenTypes>direct</includeMavenTypes>
+
+                            <inputDirectories>
+                                <inputDirectory>proto</inputDirectory>
+                            </inputDirectories>
                             <includeDirectories>
                                 <includeDirectory>../runtime/proto</includeDirectory>
                                 <includeDirectory>proto</includeDirectory>
                             </includeDirectories>
-                            <inputDirectories>
-                                <include>../runtime/proto</include>
-                                <include>proto</include>
-                            </inputDirectories>
+
                             <outputTargets>
                                 <outputTarget>
                                     <type>java</type>
@@ -379,31 +91,6 @@
                     <shadedArtifactAttached>true</shadedArtifactAttached>
                     <shadedClassifierName>shaded</shadedClassifierName>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>com.github.os72</groupId>
-                <artifactId>protoc-jar-maven-plugin</artifactId>
-                <version>3.11.1</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <protocVersion>3.6.1</protocVersion>
-                            <includeStdTypes>true</includeStdTypes>
-                            <addProtoSources>inputs</addProtoSources>
-                            <includeMavenTypes>direct</includeMavenTypes>
-                            <inputDirectories>
-                                <inputDirectory>proto</inputDirectory>
-                            </inputDirectories>
-                            <outputDirectory>
-                                target/generated-sources
-                            </outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -463,12 +150,12 @@
             <artifactId>utils</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>org.corfudb</groupId>
-            <artifactId>cmdlets</artifactId>
-            <version>${project.version}</version>
-        </dependency>
         <!-- External Dependencies-->
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
         <dependency>
             <groupId>com.offbytwo</groupId>
             <artifactId>docopt</artifactId>

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -155,7 +155,7 @@
                                     <classifier>shaded</classifier>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <destFileName>infrastructure-${version}-shaded.jar</destFileName>
+                                    <destFileName>infrastructure-${project.version}-shaded.jar</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <netty.tcnative.version>2.0.51.Final</netty.tcnative.version>
         <protobuf.version>3.6.1</protobuf.version>
         <commons.io.version>2.8.0</commons.io.version>
-        <lombok.version>1.18.18</lombok.version>
+        <lombok.version>1.18.24</lombok.version>
         <guava.version>28.0-jre</guava.version>
         <junit.jupiter.version>5.7.1</junit.jupiter.version>
         <mockito.version>1.10.19</mockito.version>
@@ -372,23 +372,11 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.10.1</version>
                 <configuration>
                     <compilerVersion>1.8</compilerVersion>
                     <source>1.8</source>
@@ -427,6 +415,14 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
                 <configuration>
                     <aggregate>true</aggregate>
                     <additionalparam>-Xdoclint:none</additionalparam>


### PR DESCRIPTION
## Overview

Description:
- Docker build process has been extracted from maven and now is in .ci/infrastructure-docker-build.sh which makes build process more flexible simple and straightforward
- protobuf plugin fix
- migrate to a newer version of maven-compiler-plugin  (the old version didn't print the reason of compilation error in case of lombok annotation-processing failures)
- Lombok needed to be updated because it caused compilation error in the result of fix in the protobuf plugin  

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
