### PR TITLE
TableRegistry: Use GitRepo version to detect Protobuf file changes

### DIFF
--- a/runtime/proto/corfu_store_metadata.proto
+++ b/runtime/proto/corfu_store_metadata.proto
@@ -57,4 +57,5 @@ message ProtobufFileName {
 
 message ProtobufFileDescriptor {
     google.protobuf.FileDescriptorProto file_descriptor = 1;
+    fixed64 version = 2;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -283,7 +283,7 @@ public class TableRegistry {
      *
      * @param allTableDescriptors  - A map of all the names of the protobuf files with their
      *                               protobuf file descriptors.
-     * @return true if a schema changes was detected and new schema was updated, false otherwise
+     * @return true if a schema change was detected and new schema was updated, false otherwise
      */
     private boolean tryUpdateTableSchemas(Map<ProtobufFileName,
                                           CorfuRecord<ProtobufFileDescriptor, TableMetadata>> allTableDescriptors) {
@@ -350,8 +350,8 @@ public class TableRegistry {
             // Version the protobuf file so that we can detect if there is a schema change
             // this is needed to overcome the bug where protobuf file descriptor maps
             // are not deterministically constructed. So we can tell if we are coming up after
-            // a fresh upgrade, we conservatively we record the git repo version in each proto file
-            // and update it if this version were to change.
+            // a fresh upgrade, we conservatively record the git repo version in each proto file
+            // and update it if this version were to be different.
             long corfuCodeVersion = GitRepositoryState.getCorfuSourceCodeVersion();
             ProtobufFileName protoFileName = ProtobufFileName.newBuilder()
                     .setFileName(fileDescriptorProto.getName()).build();

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -30,6 +30,7 @@ import org.corfudb.runtime.object.ICorfuVersionPolicy;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.ObjectsView.StreamTagInfo;
+import org.corfudb.util.GitRepositoryState;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.ProtobufSerializer;
 
@@ -253,12 +254,11 @@ public class TableRegistry {
             }
             try {
                 this.runtime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
+                boolean protoFileChanged = tryUpdateTableSchemas(allDescriptors);
                 CorfuRecord<TableDescriptors, TableMetadata> oldRecord = this.registryTable.get(tableNameKey);
-                if (oldRecord == null) {
+                if (oldRecord == null || protoFileChanged) {
                     this.registryTable.put(tableNameKey,
                         new CorfuRecord<>(tableDescriptors, metadataBuilder.build()));
-
-                    allDescriptors.forEach(this::recordNewSchema);
                 }
                 this.runtime.getObjectsView().TXEnd();
                 break;
@@ -281,28 +281,43 @@ public class TableRegistry {
      * (Note that oldProto means existing schema previously opened)
      * WARNING: This method MUST be invoked within a transaction.
      *
-     * @param protoName - name of the protobuf file
-     * @param newProtoFd - descriptor of the protobuf file that is being inserted.
+     * @param allTableDescriptors  - A map of all the names of the protobuf files with their
+     *                               protobuf file descriptors.
+     * @return true if a schema changes was detected and new schema was updated, false otherwise
      */
-    private void recordNewSchema(ProtobufFileName protoName,
-                                    CorfuRecord<ProtobufFileDescriptor, TableMetadata> newProtoFd) {
-        final CorfuRecord<ProtobufFileDescriptor, TableMetadata> currentSchema = this.protobufDescriptorTable.get(protoName);
-        if (currentSchema == null) {
-            // If schema is not present, add to protobufDescriptorTable, otherwise,
-            // we assume schema definitions only change between upgrades/migration for which
-            // dedicated APIs are available
-            this.protobufDescriptorTable.put(protoName, newProtoFd);
-        } else {
-            if (log.isTraceEnabled() && !protoName.getFileName().startsWith("google/protobuf")
-                    && !currentSchema.getPayload().getFileDescriptor()
+    private boolean tryUpdateTableSchemas(Map<ProtobufFileName,
+                                          CorfuRecord<ProtobufFileDescriptor, TableMetadata>> allTableDescriptors) {
+        boolean schemaChangeDetected = false;
+        for (Map.Entry<ProtobufFileName, CorfuRecord<ProtobufFileDescriptor, TableMetadata>> e :
+                allTableDescriptors.entrySet()) {
+            ProtobufFileName protoName = e.getKey();
+            CorfuRecord<ProtobufFileDescriptor, TableMetadata> newProtoFd = e.getValue();
+            final CorfuRecord<ProtobufFileDescriptor, TableMetadata> currentSchema =
+                    this.protobufDescriptorTable.get(protoName);
+            /** Known bug: Protobuf FileDescriptor maps are not deterministically constructed **
+            if (log.isTraceEnabled() && currentSchema != null &&
+                    !protoName.getFileName().startsWith("google/protobuf") &&
+                    !currentSchema.getPayload().getFileDescriptor()
                     .equals(newProtoFd.getPayload().getFileDescriptor())) {
                 log.trace("registerTable: Schema update detected for table {}! " +
                                 "Old schema is {}, new schema is {}", protoName,
                         currentSchema.getPayload().getFileDescriptor(),
                         newProtoFd.getPayload().getFileDescriptor());
-
+            } Uncomment and run once the above bug is either fixed or has a workaround */
+            if (currentSchema != null &&
+                    currentSchema.getPayload().getVersion() == newProtoFd.getPayload().getVersion()) {
+                continue; // old schema is same as the new schema, avoid doing an expensive I/O
+            } // else this process is running a new code version, conservatively update the schemas
+            schemaChangeDetected = true;
+            this.protobufDescriptorTable.put(protoName, newProtoFd);
+            if (currentSchema != null) {
+                log.info("Schema change in {}: {} -> {}", protoName,
+                        currentSchema.getPayload().getVersion(), newProtoFd.getPayload().getVersion());
+                log.debug("Old Descriptor {}", currentSchema.getPayload().getFileDescriptor());
+                log.debug("New Descriptor {}", newProtoFd.getPayload().getFileDescriptor());
             }
         }
+        return schemaChangeDetected;
     }
 
     /**
@@ -332,9 +347,19 @@ public class TableRegistry {
             tableDescriptorsBuilder.putFileDescriptors(fileDescriptorProto.getName(),
                     FileDescriptorProto.getDefaultInstance());
 
+            // Version the protobuf file so that we can detect if there is a schema change
+            // this is needed to overcome the bug where protobuf file descriptor maps
+            // are not deterministically constructed. So we can tell if we are coming up after
+            // a fresh upgrade, we conservatively we record the git repo version in each proto file
+            // and update it if this version were to change.
+            long corfuCodeVersion = GitRepositoryState.getCorfuSourceCodeVersion();
+            ProtobufFileName protoFileName = ProtobufFileName.newBuilder()
+                    .setFileName(fileDescriptorProto.getName()).build();
+            ProtobufFileDescriptor protoFd = ProtobufFileDescriptor.newBuilder()
+                    .setFileDescriptor(fileDescriptorProto)
+                    .setVersion(corfuCodeVersion)
+                    .build();
             // Add the actual descriptor into a common pool of descriptors to avoid duplication
-            ProtobufFileName protoFileName = ProtobufFileName.newBuilder().setFileName(fileDescriptorProto.getName()).build();
-            ProtobufFileDescriptor protoFd = ProtobufFileDescriptor.newBuilder().setFileDescriptor(fileDescriptorProto).build();
             allDescriptors.putIfAbsent(protoFileName, new CorfuRecord<>(protoFd, null));
 
             // Add all unvisited dependencies to the deque.

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
@@ -1149,7 +1149,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
                 .setNamespace(someNamespace)
                 .setTableName(tableNamePrefix + "0")
                 .build();
-        final Collection<CorfuRecord<ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>> records =
+        Collection<CorfuRecord<ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>> records =
                 corfuRuntime.getTableRegistry().getProtobufDescriptorTable().values();
 
         shimStore.openTable(
@@ -1169,7 +1169,8 @@ public class CorfuStoreShimTest extends AbstractViewTest {
                 corfuRuntime.getTableRegistry().getProtobufDescriptorTable().size();
         final Collection<CorfuRecord<ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>>
                 recordsAfterChange = corfuRuntime.getTableRegistry().getProtobufDescriptorTable().values();
-        assertThat(numProtoFiles).isEqualTo(numProtoFilesAfterChange);
+        records = corfuRuntime.getTableRegistry().getProtobufDescriptorTable().values(); // refresh descriptor table
+        assertThat(numProtoFiles).isEqualTo(numProtoFilesAfterChange - 1); // we added new protofile logdata
         assertThat(records).containsExactlyElementsOf(recordsAfterChange);
     }
 


### PR DESCRIPTION
Currently if a protobuf file has changed we do not capture the
latest changes in the ProtobufDescriptor table.
This can cause issues if the key's type has changed since the
compactor depends on the key's type to make its KeyDynamicProtobuf
But since the protobuf map comparison is not deterministic
we version the protobuf file descriptor and on first open
after upgrade we just update the schema.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #3221 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
