### PR TITLE
[0.3.2.2] TableRegistry: Use GitRepo version to detect Protobuf file changes

### DIFF
--- a/runtime/proto/corfu_store_metadata.proto
+++ b/runtime/proto/corfu_store_metadata.proto
@@ -57,4 +57,5 @@ message ProtobufFileName {
 
 message ProtobufFileDescriptor {
     google.protobuf.FileDescriptorProto file_descriptor = 1;
+    fixed64 version = 2;
 }

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
@@ -1149,7 +1149,7 @@ public class CorfuStoreShimTest extends AbstractViewTest {
                 .setNamespace(someNamespace)
                 .setTableName(tableNamePrefix + "0")
                 .build();
-        final Collection<CorfuRecord<ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>> records =
+        Collection<CorfuRecord<ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>> records =
                 corfuRuntime.getTableRegistry().getProtobufDescriptorTable().values();
 
         shimStore.openTable(
@@ -1169,7 +1169,8 @@ public class CorfuStoreShimTest extends AbstractViewTest {
                 corfuRuntime.getTableRegistry().getProtobufDescriptorTable().size();
         final Collection<CorfuRecord<ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>>
                 recordsAfterChange = corfuRuntime.getTableRegistry().getProtobufDescriptorTable().values();
-        assertThat(numProtoFiles).isEqualTo(numProtoFilesAfterChange);
+        records = corfuRuntime.getTableRegistry().getProtobufDescriptorTable().values(); // refresh descriptor table
+        assertThat(numProtoFiles).isEqualTo(numProtoFilesAfterChange - 1); // we added new protofile logdata
         assertThat(records).containsExactlyElementsOf(recordsAfterChange);
     }
 


### PR DESCRIPTION
## Overview

Description:


    Currently if a protobuf file has changed we do not capture the
    latest changes in the ProtobufDescriptor table.
    This can cause issues if the key's type has changed since the
    compactor depends on the key's type to make its KeyDynamicProtobuf
    But since the protobuf map comparison is not deterministic
    we version the protobuf file descriptor and on first open
    after upgrade we just update the schema.

Why should this be merged: 

Related issue(s) (if applicable): #3225 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
