### PR TITLE
LR: Fetch the streams to replicate dynamically

### DIFF
--- a/infrastructure/proto/sample.proto
+++ b/infrastructure/proto/sample.proto
@@ -17,6 +17,12 @@ message IntValueTag {
     int32 value = 2;
 }
 
+message IntValueTagNotReplicate {
+    option (org.corfudb.runtime.table_schema).stream_tag = "test";
+    option (org.corfudb.runtime.table_schema).is_federated = false;
+    int32 value = 2;
+}
+
 message Metadata {
     string metadata = 3;
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -1,13 +1,16 @@
 package org.corfudb.infrastructure.logreplication;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import lombok.Data;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.utils.LogReplicationStreams.TableInfo;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -39,16 +42,25 @@ public class LogReplicationConfig {
     // Percentage of log data per log replication message
     public static final int DATA_FRACTION_PER_MSG = 90;
 
-    // Unique identifiers for all streams to be replicated across sites
-    private Set<String> streamsToReplicate;
+    // For querying version table, external plugin, and registry table to update
+    // the set of streams to replicate.
+    private final LogReplicationConfigManager configManager;
 
-    // Streaming tags on Sink/Standby (map data stream id to list of tags associated to it)
-    private Map<UUID, List<UUID>> dataStreamToTagsMap = new HashMap<>();
+    // Unique identifiers for all streams to be replicated across sites
+    private final Set<UUID> streamsToReplicate;
+
+    // Map data stream id to list of tags associated to it
+    private Map<UUID, Set<UUID>> dataStreamToTagsMap = new HashMap<>();
 
     // Set of streams that shouldn't be cleared on snapshot apply phase, as these
     // streams should be the result of "merging" the replicated data (from active) + local data (on standby).
-    // For instance, RegistryTable (to avoid losing local opened tables on standby)
+    // For now, it includes RegistryTable and ProtobufDescriptorTable (to avoid losing local opened tables on standby)
     private Set<UUID> mergeOnlyStreams = new HashSet<>();
+
+    // Set of streams that were previously supposed to be replicated, but no longer needed after
+    // upgrade (is_federated = false). We need to skip applying those streams during replication.
+    // Note: this field is used for Standby under rolling upgrade case.
+    private Set<UUID> noisyStreams = new HashSet<>();
 
     // Snapshot Sync Batch Size(number of messages)
     private int maxNumMsgPerBatch;
@@ -65,43 +77,161 @@ public class LogReplicationConfig {
     private int maxDataSizePerMsg;
 
     /**
-     * Constructor
+     * Constructor that actually initiate the fields
      *
-     * @param streamsToReplicate Unique identifiers for all streams to be replicated across sites.
-     */
-    @VisibleForTesting
-    public LogReplicationConfig(Set<String> streamsToReplicate) {
-        this(streamsToReplicate, DEFAULT_MAX_NUM_MSG_PER_BATCH, MAX_DATA_MSG_SIZE_SUPPORTED, MAX_CACHE_NUM_ENTRIES);
-    }
-
-    /**
-     * Constructor
-     *
-     * @param streamsToReplicate Unique identifiers for all streams to be replicated across sites.
+     * @param fetchedStreams Info for all streams to be replicated across sites.
      * @param maxNumMsgPerBatch snapshot sync batch size (number of entries per batch)
      */
-    public LogReplicationConfig(Set<String> streamsToReplicate, int maxNumMsgPerBatch, int maxMsgSize, int cacheSize) {
-        this.streamsToReplicate = streamsToReplicate;
+    private LogReplicationConfig(Set<TableInfo> fetchedStreams, int maxNumMsgPerBatch, int maxMsgSize,
+                                int cacheSize, LogReplicationConfigManager configManager) {
+        this.streamsToReplicate = new HashSet<>();
+        this.configManager = configManager;
         this.maxNumMsgPerBatch = maxNumMsgPerBatch;
         this.maxMsgSize = maxMsgSize;
         this.maxCacheSize = cacheSize;
         this.maxDataSizePerMsg = maxMsgSize * DATA_FRACTION_PER_MSG / 100;
+        if (configManager != null) {
+            this.noisyStreams.addAll(configManager.fetchNoisyStreams());
+        }
+        updateStreamsToReplicate(fetchedStreams, false);
     }
 
     /**
-     * Constructor
-     *
-     * @param streamsToReplicate Unique identifiers for all streams to be replicated across sites.
-     * @param maxNumMsgPerBatch snapshot sync batch size (number of entries per batch)
+     * Constructor exposed for discovery service to initiate LogReplicationConfig
      */
-    public LogReplicationConfig(Set<String> streamsToReplicate, int maxNumMsgPerBatch, int maxMsgSize) {
-        this(streamsToReplicate, maxNumMsgPerBatch, maxMsgSize, MAX_CACHE_NUM_ENTRIES);
+    public LogReplicationConfig(Set<TableInfo> fetchedStreams,
+                                Set<UUID> mergeOnlyStreams, int maxNumMsgPerBatch, int maxMsgSize,
+                                int cacheSize, LogReplicationConfigManager configManager) {
+        this(fetchedStreams, maxNumMsgPerBatch, maxMsgSize, cacheSize, configManager);
+        this.mergeOnlyStreams = mergeOnlyStreams;
     }
 
-    public LogReplicationConfig(Set<String> streamsToReplicate, Map<UUID, List<UUID>> streamingTagsMap,
-                                Set<UUID> mergeOnlyStreams, int maxNumMsgPerBatch, int maxMsgSize, int cacheSize) {
-        this(streamsToReplicate, maxNumMsgPerBatch, maxMsgSize, cacheSize);
-        this.dataStreamToTagsMap = streamingTagsMap;
-        this.mergeOnlyStreams = mergeOnlyStreams;
+    /**
+     * Constructor used for testing purpose only
+     *
+     * @param fetchedStreams Info for all streams to be replicated across sites
+     * @param maxNumMsgPerBatch snapshot sync batch size (number of entries per batch)
+     */
+    @VisibleForTesting
+    public LogReplicationConfig(Set<TableInfo> fetchedStreams, int maxNumMsgPerBatch, int maxMsgSize) {
+        this(fetchedStreams, maxNumMsgPerBatch, maxMsgSize, MAX_CACHE_NUM_ENTRIES, null);
+    }
+
+    /**
+     * Constructor used for testing purpose only
+     *
+     * @param fetchedStreams Info for all streams to be replicated across sites.
+     */
+    @VisibleForTesting
+    public LogReplicationConfig(Set<TableInfo> fetchedStreams) {
+        this(fetchedStreams, DEFAULT_MAX_NUM_MSG_PER_BATCH, MAX_DATA_MSG_SIZE_SUPPORTED,
+                MAX_CACHE_NUM_ENTRIES, null);
+    }
+
+    /**
+     * This method is supposed to be invoked at the STANDBY side cluster to update the streams to their
+     * tags map during snapshot sync and delta sync.
+     *
+     * @param newStreamTagsMap The newly discovered / collected stream to tags map
+     * @param refresh Boolean field to check if we need to clear the present map. Set to true in Snapshot sync.
+     */
+    public void updateDataStreamToTagsMap(Map<UUID, Set<UUID>> newStreamTagsMap, boolean refresh) {
+        if (refresh) {
+            this.dataStreamToTagsMap.clear();
+        }
+        dataStreamToTagsMap.putAll(newStreamTagsMap);
+    }
+
+    /**
+     * Update the set of stream id for replicate
+     *
+     * @param streamsToReplicate Set of stream id for replicate
+     * @param refresh            True when need to clear current set of stream id
+     */
+    private void updateStreamsToReplicate(Set<TableInfo> streamsToReplicate, boolean refresh) {
+        if (refresh) {
+            this.streamsToReplicate.clear();
+        }
+
+        for (TableInfo info : streamsToReplicate) {
+            // The name field here should be a fully qualified table name
+            if (info.hasField(TableInfo.getDescriptor().findFieldByName("name"))) {
+                this.streamsToReplicate.add(CorfuRuntime.getStreamID(info.getName()));
+            } else if (info.hasField(TableInfo.getDescriptor().findFieldByName("id"))) {
+                this.streamsToReplicate.add(UUID.fromString(info.getId()));
+            }
+        }
+    }
+
+    /**
+     * This method is invoked during snapshot and log entry sync at Standby side to update the
+     * set of stream id to replicate
+     */
+    public void updateStreamsToReplicateStandby(Set<UUID> streamsToReplicate, boolean refresh) {
+        if (refresh) {
+            this.streamsToReplicate.clear();
+        }
+
+        this.streamsToReplicate.addAll(streamsToReplicate);
+    }
+
+    /**
+     * Sync with Info table upon cluster role change (leader node acquired at Active) and
+     * before a new start of snapshot sync. We do this a bit redundantly to avoid any loss
+     * of streams to replicate
+     */
+    public void syncWithInfoTable() {
+        if (configManager == null) {
+            log.warn("configManager is null! skipping sync!");
+            return;
+        }
+
+        Set<TableInfo> fetched = this.configManager.fetchStreamsToReplicate();
+        // We should refresh the stream ids here because this method is called before snapshot
+        // sync and under leadership acquire
+        updateStreamsToReplicate(fetched, true);
+    }
+
+    /**
+     * Sync with RegistryTable before a new start of snapshot sync. We do this a bit redundantly
+     * to avoid loss of any streams to replicate
+     */
+    public void syncWithTableRegistry(long timestamp) {
+        if (configManager == null) {
+            log.warn("configManager is null! skipping sync!");
+            return;
+        }
+
+        Set<TableInfo> registryInfo = configManager.readStreamsToReplicateFromRegistry(timestamp);
+        // We don't refresh the stream ids here because this method is called only before snapshot
+        // sync as a supplementary
+        updateStreamsToReplicate(registryInfo, false);
+    }
+
+    /**
+     * Getter method that returns an immutable copy of streams to replicate
+     */
+    public Set<UUID> getStreamsToReplicate() {
+        return ImmutableSet.copyOf(streamsToReplicate);
+    }
+
+    /**
+     * Getter method that returns an immutable copy of noisy streams
+     */
+    public Set<UUID> getNoisyStreams() {
+        return ImmutableSet.copyOf(noisyStreams);
+    }
+
+    /**
+     * Add a set of streams newly discovered during log entry sync. This new set of streams
+     * should be populated to both InfoTable (stream backed) and in-memory state (this class)
+     *
+     * @param streamIdSet A set of streams newly discovered during log entry sync.
+     */
+    public void addStreams(Set<UUID> streamIdSet) {
+        configManager.addStreamsToInfoTable(streamIdSet);
+        Set<TableInfo> fetched = this.configManager.fetchStreamsToReplicate();
+        updateStreamsToReplicate(fetched, false);
+        log.debug("Added new streams {} to streamIds in config", streamIdSet);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationContext.java
@@ -15,16 +15,16 @@ import org.corfudb.infrastructure.logreplication.transport.IChannelContext;
 public class LogReplicationContext {
 
     @Getter
-    private LogReplicationConfig config;
+    private final LogReplicationConfig config;
 
     @Getter
-    private TopologyDescriptor topology;
+    private final TopologyDescriptor topology;
 
     @Getter
-    private String localCorfuEndpoint;
+    private final String localCorfuEndpoint;
 
     @Getter
-    private IChannelContext channelContext;
+    private final IChannelContext channelContext;
 
     /**
      * Constructor

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
@@ -33,34 +33,6 @@ public abstract class DefaultAdapterForUpgrade implements ILogReplicationConfigA
     String versionString = "version_latest";
     CorfuStore corfuStore;
 
-
-    // Provides the fully qualified names of streams to replicate
-    @Override
-    @SuppressWarnings("checkstyle:printLine")
-    public Set<String> fetchStreamsToReplicate() {
-        if (corfuStore != null) {
-            try {
-                corfuStore.openTable(NAMESPACE, STREAMS_TEST_TABLE,
-                        LogReplicationStreams.TableInfo.class,
-                        LogReplicationStreams.Namespace.class, CommonTypes.Uuid.class,
-                        TableOptions.builder().build());
-            } catch (Exception e) {
-                // Just for wrap this up
-            }
-
-            try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-                Set<LogReplicationStreams.TableInfo> tables = txn.keySet(STREAMS_TEST_TABLE);
-                tables.forEach(table -> streamsToReplicate.add(table.getName()));
-                txn.commit();
-            }
-        } else {
-            for (int i = 1; i <= MAP_COUNT; i++) {
-                streamsToReplicate.add(NAMESPACE + SEPARATOR + TABLE_PREFIX + i);
-            }
-        }
-        return streamsToReplicate;
-    }
-
     @Override
     public String getVersion() {
         if (corfuStore != null) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -39,12 +39,6 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
         }
     }
 
-    // Provides the fully qualified names of streams to replicate
-    @Override
-    public Set<String> fetchStreamsToReplicate() {
-        return streamsToReplicate;
-    }
-
     @Override
     public String getVersion() {
         return "version_latest";

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationConfigAdapter.java
@@ -14,13 +14,13 @@ import java.util.UUID;
  * (2) System's version
  */
 public interface ILogReplicationConfigAdapter {
-
     /**
-     * Returns a set of fully qualified stream names to replicate
+     * Get the version of the product that Log Replicator works for, which should be provided
+     * by an external static file.
      */
-    Set<String> fetchStreamsToReplicate();
-
     String getVersion();
+
+
 
     /**
      * Returns configuration for streaming on sink (standby)

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -171,10 +171,9 @@ public class LogReplicationAckReader {
      */
     private long getMaxReplicatedStreamsTail(Map<UUID, Long> tailMap) {
         long maxTail = Address.NON_ADDRESS;
-        for (String streamName : config.getStreamsToReplicate()) {
-            UUID streamUuid = CorfuRuntime.getStreamID(streamName);
-            if (tailMap.containsKey(streamUuid)) {
-                long streamTail = tailMap.get(streamUuid);
+        for (UUID streamId : config.getStreamsToReplicate()) {
+            if (tailMap.containsKey(streamId)) {
+                long streamTail = tailMap.get(streamId);
                 maxTail = Math.max(maxTail, streamTail);
             }
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -95,7 +95,7 @@ public class LogReplicationSourceManager {
 
         this.config = parameters.getReplicationConfig();
 
-        if (config.getStreamsToReplicate() == null || config.getStreamsToReplicate().isEmpty()) {
+        if (config.getStreamsToReplicate().isEmpty()) {
             // Avoid FSM being initialized if there are no streams to replicate
             throw new IllegalArgumentException("Invalid Log Replication: Streams to replicate is EMPTY");
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -264,7 +264,8 @@ public class LogReplicationFSM {
 
         logReplicationFSMConsumer.submit(this::consume);
 
-        log.info("Log Replication FSM initialized, replicate to remote cluster {}", remoteCluster.getClusterId());
+        log.info("Log Replication FSM initialized, streams to replicate {} to remote cluster {}",
+                config.getStreamsToReplicate(), remoteCluster.getClusterId());
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SnapshotWriter.java
@@ -10,7 +10,5 @@ import java.util.List;
  */
 public interface SnapshotWriter {
     // The snapshot full sync engine will pass a message to the snapshot writer
-    void apply(LogReplicationEntryMsg message) throws Exception;
-
-    void apply(List<LogReplicationEntryMsg> messages) throws Exception;
+    void applyToShadowStreams(LogReplicationEntryMsg message) throws Exception;
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
@@ -12,12 +12,16 @@ import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMetadataMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryType;
+import org.corfudb.runtime.collections.CorfuRecord;
+import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.ObjectsView;
+import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.runtime.view.stream.OpaqueStream;
 
 import javax.annotation.concurrent.NotThreadSafe;
@@ -47,11 +51,16 @@ public class StreamsLogEntryReader implements LogEntryReader {
 
     private final LogReplicationEntryType MSG_TYPE = LogReplicationEntryType.LOG_ENTRY_MESSAGE;
 
-    // Set of UUIDs for the corresponding streams
-    private Set<UUID> streamUUIDs;
+    private final Set<UUID> streamUUIDs;
+
+    private final Set<UUID> confirmedNoisyStreams;
+
+    private final CorfuRuntime runtime;
+
+    private final LogReplicationConfig config;
 
     // Opaque Stream wrapper for the transaction stream
-    private TxOpaqueStream txOpaqueStream;
+    private final TxOpaqueStream txOpaqueStream;
 
     // Snapshot Timestamp on which the log entry reader is based on
     private long globalBaseSnapshot;
@@ -82,20 +91,18 @@ public class StreamsLogEntryReader implements LogEntryReader {
 
     public StreamsLogEntryReader(CorfuRuntime runtime, LogReplicationConfig config) {
         runtime.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
+        this.runtime = runtime;
+        this.config = config;
         this.maxDataSizePerMsg = config.getMaxDataSizePerMsg();
         this.currentProcessedEntryMetadata = new StreamIteratorMetadata(Address.NON_ADDRESS, false);
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
         this.deltaCounter = configureDeltaCounter();
         this.validDeltaCounter = configureValidDeltaCounter();
         this.opaqueEntryCounter = configureOpaqueEntryCounter();
-        Set<String> streams = config.getStreamsToReplicate();
+        this.streamUUIDs = new HashSet<>(config.getStreamsToReplicate());
+        this.confirmedNoisyStreams = new HashSet<>();
 
-        streamUUIDs = new HashSet<>();
-        for (String s : streams) {
-            streamUUIDs.add(CorfuRuntime.getStreamID(s));
-        }
-
-        log.debug("Streams to replicate total={}, stream_names={}, stream_ids={}", streamUUIDs.size(), streams, streamUUIDs);
+        log.debug("Streams to replicate total={}, stream_ids={}", streamUUIDs.size(), streamUUIDs);
 
         //create an opaque stream for transaction stream
         txOpaqueStream = new TxOpaqueStream(runtime);
@@ -124,6 +131,46 @@ public class StreamsLogEntryReader implements LogEntryReader {
         return txMessage;
     }
 
+    private void addDiscoveredStreams(Set<UUID> txEntryStreamIds) {
+        // Get the set of stream ids that we encounter for the first time. i.e. Neither recorded
+        // in LogReplicationConfig nor marked as noisy.
+        Set<UUID> checkIdSet = txEntryStreamIds.stream()
+                .filter(id -> !streamUUIDs.contains(id) && !confirmedNoisyStreams.contains(id))
+                .collect(Collectors.toSet());
+
+        if (checkIdSet.isEmpty()) {
+            return;
+        }
+
+        // Get registry table for checking is_federated flag.
+        CorfuTable<CorfuStoreMetadata.TableName,
+                CorfuRecord<CorfuStoreMetadata.TableDescriptors, CorfuStoreMetadata.TableMetadata>>
+                registryTable = runtime.getTableRegistry().getRegistryTable();
+
+        Set<CorfuStoreMetadata.TableName> checkNameSet = registryTable.keySet().stream()
+                .filter(tableName -> {
+                    UUID streamID = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(tableName));
+                    return checkIdSet.contains(streamID);
+                }).collect(Collectors.toSet());
+
+        Set<UUID> discoveredNewStreams = new HashSet<>();
+        for (CorfuStoreMetadata.TableName tableName : checkNameSet) {
+            CorfuRecord<CorfuStoreMetadata.TableDescriptors, CorfuStoreMetadata.TableMetadata> tableRecord = registryTable.get(tableName);
+
+            UUID discoveredStreamID = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(tableName));
+            if (tableRecord.getMetadata().getTableOptions().getIsFederated()) {
+                streamUUIDs.add(discoveredStreamID);
+                discoveredNewStreams.add(discoveredStreamID);
+            } else {
+                confirmedNoisyStreams.add(discoveredStreamID);
+            }
+        }
+
+        if (!discoveredNewStreams.isEmpty()) {
+            config.addStreams(discoveredNewStreams);
+        }
+    }
+
     /**
      * Verify the transaction entry is valid, i.e., if the entry contains any
      * of the streams to be replicated.
@@ -146,6 +193,10 @@ public class StreamsLogEntryReader implements LogEntryReader {
             return false;
         }
 
+        // For all stream ids present in the log replication stream, inspect those observed for the first
+        // time, and query through table registry whether they are intended to be replicated or not
+        // i.e., whether 'is_federated' flag is set or not.
+        addDiscoveredStreams(txEntryStreamIds);
         // If none of the streams in the transaction entry are specified to be replicated, this is an invalid entry, skip
         if (Collections.disjoint(streamUUIDs, txEntryStreamIds)) {
             log.trace("TX Stream entry[{}] :: contains none of the streams of interest, streams={} [ignored]", entry.getVersion(), txEntryStreamIds);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
@@ -55,9 +55,10 @@ public class StreamsSnapshotReader implements SnapshotReader {
     private final int maxDataSizePerMsg;
     private final Optional<DistributionSummary> messageSizeDistributionSummary;
     private long snapshotTimestamp;
-    private Set<String> streams;
-    private PriorityQueue<String> streamsToSend;
-    private CorfuRuntime rt;
+    private final LogReplicationConfig config;
+    private Set<UUID> streamIDs;
+    private PriorityQueue<UUID> streamIDsToSend;
+    private final CorfuRuntime rt;
     private long preMsgTs;
     private long currentMsgTs;
     private OpaqueStreamIterator currentStreamInfo;
@@ -77,7 +78,8 @@ public class StreamsSnapshotReader implements SnapshotReader {
         this.rt = runtime;
         this.rt.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
         this.maxDataSizePerMsg = config.getMaxDataSizePerMsg();
-        this.streams = config.getStreamsToReplicate();
+        this.config = config;
+        this.streamIDs = config.getStreamsToReplicate();
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
     }
 
@@ -170,7 +172,7 @@ public class StreamsSnapshotReader implements SnapshotReader {
                 }
 
                 if (stream.iterator.hasNext()) {
-                    lastEntry = (OpaqueEntry) stream.iterator.next();
+                    lastEntry = stream.iterator.next();
                 }
 
                 if (lastEntry == null) {
@@ -220,12 +222,11 @@ public class StreamsSnapshotReader implements SnapshotReader {
         // If the currentStreamInfo still has entry to process, it will reuse the currentStreamInfo
         // and process the remaining entries.
         if (currentStreamInfo == null) {
-            while (!streamsToSend.isEmpty()) {
+            while (!streamIDsToSend.isEmpty()) {
                 // Setup a new stream
-                String streamToReplicate = streamsToSend.poll();
-                currentStreamInfo = new OpaqueStreamIterator(streamToReplicate, rt, snapshotTimestamp);
-                log.info("Start Snapshot Sync replication for stream name={}, id={}", streamToReplicate,
-                        CorfuRuntime.getStreamID(streamToReplicate));
+                UUID streamIDToReplicate = streamIDsToSend.poll();
+                currentStreamInfo = new OpaqueStreamIterator(streamIDToReplicate, rt, snapshotTimestamp);
+                log.info("Start Snapshot Sync replication for stream id={}", streamIDToReplicate);
 
                 // If the new stream has entries to be processed, go to the next step
                 if (currentStreamInfo.iterator.hasNext()) {
@@ -240,17 +241,15 @@ public class StreamsSnapshotReader implements SnapshotReader {
 
         if (currentStreamHasNext()) {
             msg = read(currentStreamInfo, syncRequestId);
-            if (msg != null) {
-                messages.add(msg);
-            }
+            messages.add(msg);
         }
 
         if (!currentStreamHasNext()) {
             log.debug("Snapshot log reader finished reading stream id={}, name={}", currentStreamInfo.uuid, currentStreamInfo.name);
             currentStreamInfo = null;
 
-            if (streamsToSend.isEmpty()) {
-                log.info("Snapshot log reader finished reading ALL streams, total={}", streams.size());
+            if (streamIDsToSend.isEmpty()) {
+                log.info("Snapshot log reader finished reading ALL streams, total={}", streamIDs.size());
                 endSnapshotSync = true;
             }
         }
@@ -264,7 +263,10 @@ public class StreamsSnapshotReader implements SnapshotReader {
 
     @Override
     public void reset(long ts) {
-        streamsToSend = new PriorityQueue<>(streams);
+        config.syncWithInfoTable();
+        config.syncWithTableRegistry(ts);
+        streamIDs = config.getStreamsToReplicate();
+        streamIDsToSend = new PriorityQueue<>(streamIDs);
         preMsgTs = Address.NON_ADDRESS;
         currentMsgTs = Address.NON_ADDRESS;
         snapshotTimestamp = ts;
@@ -277,19 +279,19 @@ public class StreamsSnapshotReader implements SnapshotReader {
      * Used to bookkeeping the stream information for the current processing stream
      */
     public static class OpaqueStreamIterator {
-        private String name;
-        private UUID uuid;
-        private Iterator iterator;
+        private final String name;
+        private final UUID uuid;
+        private final Iterator<OpaqueEntry> iterator;
         private long maxVersion; // the max address of the log entries processed for this stream.
 
-        OpaqueStreamIterator(String name, CorfuRuntime rt, long snapshot) {
-            this.name = name;
-            uuid = CorfuRuntime.getStreamID(name);
+        OpaqueStreamIterator(UUID uuid, CorfuRuntime rt, long snapshot) {
+            this.name = uuid.toString();
+            this.uuid = uuid;
             StreamOptions options = StreamOptions.builder()
                     .ignoreTrimmed(false)
                     .cacheEntries(false)
                     .build();
-            Stream stream = (new OpaqueStream(rt.getStreamsView().get(uuid, options))).streamUpTo(snapshot);
+            Stream<OpaqueEntry> stream = (new OpaqueStream(rt.getStreamsView().get(uuid, options))).streamUpTo(snapshot);
             iterator = stream.iterator();
             maxVersion = 0;
          }
@@ -311,14 +313,14 @@ public class StreamsSnapshotReader implements SnapshotReader {
     /**
      * Record a list of SMR entries
      */
-    static private class SMREntryList {
+    private static class SMREntryList {
 
         // The total sizeInBytes of smrEntries in bytes.
         @Getter
-        private int sizeInBytes;
+        private final int sizeInBytes;
 
         @Getter
-        private List<SMREntry> smrEntries;
+        private final List<SMREntry> smrEntries;
 
         public SMREntryList (int size, List<SMREntry> smrEntries) {
             this.sizeInBytes = size;

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 @Slf4j
 public class Table<K extends Message, V extends Message, M extends Message> {
 
+    @Getter
     private CorfuTable<K, CorfuRecord<V, M>> corfuTable;
 
     /**
@@ -141,7 +142,7 @@ public class Table<K extends Message, V extends Message, M extends Message> {
      * @return Corfu Record for key.
      */
     @Nullable
-    CorfuRecord<V, M> get(@Nonnull final K key) {
+    public CorfuRecord<V, M> get(@Nonnull final K key) {
         return corfuTable.get(key);
     }
 
@@ -358,6 +359,17 @@ public class Table<K extends Message, V extends Message, M extends Message> {
      */
     public int count() {
         return corfuTable.size();
+    }
+
+
+    /**
+     * Check if current table contains the given key.
+     *
+     * @param key Key
+     * @return True if current Table contains the given key, and false otherwise.
+     */
+    public boolean containsKey(@Nonnull final K key) {
+        return corfuTable.containsKey(key);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingTask.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/streaming/StreamingTask.java
@@ -33,7 +33,7 @@ import java.util.stream.Collectors;
 
 /**
  * This class represents a Streaming task that is managed by {@link StreamPollingScheduler}. It binds a stream listener
- * {@link StreamListener} to a {@link DeltaStream}, ever time it's scheduled to sync, it will read data for a specific
+ * {@link StreamListener} to a {@link DeltaStream}, every time it's scheduled to sync, it will read data for a specific
  * stream tag, transform it and propagate it to the listener.
  *
  * @param <K> - type of the protobuf KeySchema defined while the table was created.

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -7,7 +7,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.reflect.TypeToken;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -49,6 +48,7 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.utils.LogReplicationStreams.TableInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,6 +69,9 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
     private static final int CORFU_PORT = 9000;
     private static final int TEST_TOPOLOGY_CONFIG_ID = 1;
     private static final String TEST_LOCAL_CLUSTER_ID = "local_cluster";
+    private static final TableInfo TEST_TABLE_INFO = TableInfo.newBuilder()
+            .setName(TEST_STREAM_NAME)
+            .build();
 
     // This semaphore is used to block until the triggering event causes the transition to a new state
     private final Semaphore transitionAvailable = new Semaphore(1, true);
@@ -490,7 +493,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
                 break;
             case STREAMS:
                 // Default implementation used for Log Replication (stream-based)
-                LogReplicationConfig logReplicationConfig = new LogReplicationConfig(Collections.singleton(TEST_STREAM_NAME));
+                LogReplicationConfig logReplicationConfig = new LogReplicationConfig(Collections.singleton(TEST_TABLE_INFO));
                 snapshotReader = new StreamsSnapshotReader(getNewRuntime(getDefaultNode()).connect(),
                         logReplicationConfig);
                 dataSender = new TestDataSender();
@@ -501,7 +504,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(runtime, TEST_TOPOLOGY_CONFIG_ID,
                 TEST_LOCAL_CLUSTER_ID);
-        LogReplicationConfig config = new LogReplicationConfig(new HashSet<>(Arrays.asList(TEST_STREAM_NAME)));
+        LogReplicationConfig config = new LogReplicationConfig(new HashSet<>(Collections.singleton(TEST_TABLE_INFO)));
         LogReplicationConfigManager tableManagerPlugin = new LogReplicationConfigManager(runtime);
         ackReader = new LogReplicationAckReader(metadataManager, config, runtime, TEST_LOCAL_CLUSTER_ID);
         fsm = new LogReplicationFSM(runtime, snapshotReader, dataSender, logEntryReader,

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -10,10 +10,14 @@ import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.Re
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.LogReplicationMetadataKey;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.LogReplicationMetadataVal;
-import org.corfudb.infrastructure.logreplication.proto.Sample;
+import org.corfudb.infrastructure.logreplication.proto.Sample.IntValue;
+import org.corfudb.infrastructure.logreplication.proto.Sample.IntValueTag;
+import org.corfudb.infrastructure.logreplication.proto.Sample.Metadata;
+import org.corfudb.infrastructure.logreplication.proto.Sample.StringKey;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationAckReader;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.ExampleSchemas.ClusterUuidMsg;
@@ -91,16 +95,16 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
     private CorfuRuntime activeRuntime;
     private CorfuRuntime standbyRuntime;
-    private CorfuTable<String, Integer> mapActive;
-    private CorfuTable<String, Integer> mapStandby;
+    private Table<StringKey, IntValue, Metadata> mapActive;
+    private Table<StringKey, IntValue, Metadata> mapStandby;
 
     private CorfuStore activeCorfuStore;
     private CorfuStore standbyCorfuStore;
     private Table<ClusterUuidMsg, ClusterUuidMsg, ClusterUuidMsg> configTable;
     private Table<LockDataTypes.LockId, LockDataTypes.LockData, Message> activeLockTable;
 
-    public Map<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> mapNameToMapActive;
-    public Map<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> mapNameToMapStandby;
+    public Map<String, Table<StringKey, IntValueTag, Metadata>> mapNameToMapActive;
+    public Map<String, Table<StringKey, IntValueTag, Metadata>> mapNameToMapStandby;
 
     public static final String TABLE_PREFIX = "Table00";
 
@@ -121,27 +125,39 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         standbyRuntime = CorfuRuntime.fromParameters(params);
         standbyRuntime.parseConfigurationString(standbyCorfuEndpoint).connect();
 
-        mapActive = activeRuntime.getObjectsView()
-                .build()
-                .setStreamName(streamName)
-                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
-                .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
-                })
-                .open();
-
-        mapStandby = standbyRuntime.getObjectsView()
-                .build()
-                .setStreamName(streamName)
-                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
-                .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
-                })
-                .open();
-
-        assertThat(mapActive.size()).isZero();
-        assertThat(mapStandby.size()).isZero();
-
         activeCorfuStore = new CorfuStore(activeRuntime);
         standbyCorfuStore = new CorfuStore(standbyRuntime);
+
+        mapActive = activeCorfuStore.openTable(
+                NAMESPACE,
+                streamName,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.builder().schemaOptions(
+                                CorfuOptions.SchemaOptions.newBuilder()
+                                        .setIsFederated(true)
+                                        .addStreamTag(ObjectsView.LOG_REPLICATOR_STREAM_INFO.getTagName())
+                                        .build())
+                        .build()
+        );
+
+        mapStandby = standbyCorfuStore.openTable(
+                NAMESPACE,
+                streamName,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.builder().schemaOptions(
+                                CorfuOptions.SchemaOptions.newBuilder()
+                                        .setIsFederated(true)
+                                        .addStreamTag(ObjectsView.LOG_REPLICATOR_STREAM_INFO.getTagName())
+                                        .build())
+                        .build()
+        );
+
+        assertThat(mapActive.count()).isZero();
+        assertThat(mapStandby.count()).isZero();
 
         configTable = activeCorfuStore.openTable(
                 DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
@@ -204,12 +220,15 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     public void testNewConfigWithSwitchRole() throws Exception {
         // Write 10 entries to active map
         for (int i = 0; i < firstBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            // Change to default active standby config
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(firstBatch);
-        assertThat(mapStandby.size()).isZero();
+        assertThat(mapActive.count()).isEqualTo(firstBatch);
+        assertThat(mapStandby.count()).isZero();
 
         log.info("Before log replication, append {} entries to active map. Current active corfu" +
                         "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
@@ -229,11 +248,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Write 5 entries to active map
         for (int i = firstBatch; i < secondBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(secondBatch);
+        assertThat(mapActive.count()).isEqualTo(secondBatch);
 
         // Wait until data is fully replicated again
         waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
@@ -244,7 +265,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Verify data
         for (int i = 0; i < secondBatch; i++) {
-            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+            assertThat(mapStandby.containsKey(StringKey.newBuilder().setKey(String.valueOf(i)).build())).isTrue();
+
         }
         log.info("Log replication succeeds without config change!");
 
@@ -280,6 +302,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         assertThat(replicationStatusVal.getSnapshotSyncInfo().getStatus())
                 .isEqualTo(LogReplicationMetadata.SyncStatus.COMPLETED);
 
+        log.info("Sync status verified before switchover");
+
         // Perform a role switch
         try (TxnContext txn = activeCorfuStore.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
             txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH);
@@ -290,11 +314,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Write 5 more entries to mapStandby
         for (int i = secondBatch; i < thirdBatch; i++) {
-            standbyRuntime.getObjectsView().TXBegin();
-            mapStandby.put(String.valueOf(i), i);
-            standbyRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = standbyCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapStandby, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapStandby.size()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.count()).isEqualTo(thirdBatch);
 
         sleepUninterruptibly(5);
 
@@ -339,8 +365,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Double check after 10 seconds
         TimeUnit.SECONDS.sleep(mediumInterval);
-        assertThat(mapActive.size()).isEqualTo(thirdBatch);
-        assertThat(mapStandby.size()).isEqualTo(thirdBatch);
+        assertThat(mapActive.count()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.count()).isEqualTo(thirdBatch);
 
         // Second Role Switch
         try (TxnContext txn = activeCorfuStore.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
@@ -351,11 +377,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Write 5 more entries to mapStandby
         for (int i = thirdBatch; i < fourthBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(fourthBatch);
+        assertThat(mapActive.count()).isEqualTo(fourthBatch);
 
         // Wait until data is fully replicated again
         waitForReplication(size -> size == fourthBatch, mapStandby, fourthBatch);
@@ -366,8 +394,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Double check after 10 seconds
         TimeUnit.SECONDS.sleep(mediumInterval);
-        assertThat(mapActive.size()).isEqualTo(fourthBatch);
-        assertThat(mapStandby.size()).isEqualTo(fourthBatch);
+        assertThat(mapActive.count()).isEqualTo(fourthBatch);
+        assertThat(mapStandby.count()).isEqualTo(fourthBatch);
 
         // Verify Sync Status
         try (TxnContext txn = activeCorfuStore.txn(LogReplicationMetadataManager.NAMESPACE)) {
@@ -453,10 +481,10 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     }
 
     private void verifyNoDataOnStandbyOpenedTables() {
-        for(Map.Entry<String, Table<Sample.StringKey, Sample.IntValueTag,
-            Sample.Metadata>> entry : mapNameToMapStandby.entrySet()) {
-            Table<Sample.StringKey, Sample.IntValueTag,
-                Sample.Metadata> map = entry.getValue();
+        for(Map.Entry<String, Table<StringKey, IntValueTag,
+            Metadata>> entry : mapNameToMapStandby.entrySet()) {
+            Table<StringKey, IntValueTag,
+                Metadata> map = entry.getValue();
             assertThat(map.count()).isEqualTo(0);
         }
     }
@@ -559,17 +587,17 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
             String mapName = TABLE_PREFIX + i;
 
             if (isActive) {
-                Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapActive = activeCorfuStore.openTable(
-                    NAMESPACE, mapName, Sample.StringKey.class, Sample.IntValueTag.class, Sample.Metadata.class,
-                    TableOptions.fromProtoSchema(Sample.IntValueTag.class));
-                mapNameToMapActive.put(mapName, mapActive);
-                assertThat(mapActive.count()).isEqualTo(0);
+                Table<StringKey, IntValueTag, Metadata> mapActiveTable = activeCorfuStore.openTable(
+                    NAMESPACE, mapName, StringKey.class, IntValueTag.class, Metadata.class,
+                    TableOptions.fromProtoSchema(IntValueTag.class));
+                mapNameToMapActive.put(mapName, mapActiveTable);
+                assertThat(mapActiveTable.count()).isEqualTo(0);
             } else {
-                Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapStandby = standbyCorfuStore.openTable(
-                    NAMESPACE, mapName, Sample.StringKey.class, Sample.IntValueTag.class, Sample.Metadata.class,
-                    TableOptions.fromProtoSchema(Sample.IntValueTag.class));
-                mapNameToMapStandby.put(mapName, mapStandby);
-                assertThat(mapStandby.count()).isEqualTo(0);
+                Table<StringKey, IntValueTag, Metadata> mapStandbyTable = standbyCorfuStore.openTable(
+                    NAMESPACE, mapName, StringKey.class, IntValueTag.class, Metadata.class,
+                    TableOptions.fromProtoSchema(IntValueTag.class));
+                mapNameToMapStandby.put(mapName, mapStandbyTable);
+                assertThat(mapStandbyTable.count()).isEqualTo(0);
             }
         }
     }
@@ -577,25 +605,25 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     private void writeToMaps(boolean active, int startIndex, int totalEntries) {
         int maxIndex = totalEntries + startIndex;
 
-        Map<String, Table<Sample.StringKey, Sample.IntValueTag,
-            Sample.Metadata>> map;
+        Map<String, Table<StringKey, IntValueTag,
+            Metadata>> map;
 
         if (active) {
             map = mapNameToMapActive;
         } else {
             map = mapNameToMapStandby;
         }
-        for(Map.Entry<String, Table<Sample.StringKey, Sample.IntValueTag,
-            Sample.Metadata>> entry : map.entrySet()) {
+        for(Map.Entry<String, Table<StringKey, IntValueTag,
+            Metadata>> entry : map.entrySet()) {
 
             log.debug(">>> Write to active cluster, map={}", entry.getKey());
 
-            Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> table =
+            Table<StringKey, IntValueTag, Metadata> table =
                 entry.getValue();
             for (int i = startIndex; i < maxIndex; i++) {
-                Sample.StringKey stringKey = Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build();
-                Sample.IntValueTag intValueTag = Sample.IntValueTag.newBuilder().setValue(i).build();
-                Sample.Metadata metadata = Sample.Metadata.newBuilder().setMetadata("Metadata_" + i).build();
+                StringKey stringKey = StringKey.newBuilder().setKey(String.valueOf(i)).build();
+                IntValueTag intValueTag = IntValueTag.newBuilder().setValue(i).build();
+                Metadata metadata = Metadata.newBuilder().setMetadata("Metadata_" + i).build();
                 try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
                     txn.putRecord(table, stringKey, intValueTag, metadata);
                     txn.commit();
@@ -688,11 +716,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Write 'N' entries to active map (to ensure nothing happens wrt. the status, as LR is not started on active)
         for (int i = 0; i < firstBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(firstBatch);
+        assertThat(mapActive.count()).isEqualTo(firstBatch);
 
         // Verify Sync Status
         ReplicationStatusKey standbyClusterId = ReplicationStatusKey.newBuilder()
@@ -744,7 +774,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Verify data on Standby
         for (int i = 0; i < firstBatch; i++) {
-            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+            assertThat(mapStandby.containsKey(StringKey.newBuilder().setKey(String.valueOf(i)).build())).isTrue();
         }
 
         while (!standbyStatus.getSnapshotSyncInfo().getStatus().equals(LogReplicationMetadata.SyncStatus.COMPLETED)) {
@@ -814,12 +844,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     public void testNewConfigWithSwitchRoleDuringTransferPhase() throws Exception {
         // Write 50 entry to active map
         for (int i = 0; i < largeBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(largeBatch);
-        assertThat(mapStandby.size()).isZero();
+        assertThat(mapActive.count()).isEqualTo(largeBatch);
+        assertThat(mapStandby.count()).isZero();
 
         log.info("Before log replication, append {} entries to active map. Current active corfu" +
                         "[{}] log tail is {}, standby corfu[{}] log tail is {}", largeBatch, activeClusterCorfuPort,
@@ -832,25 +864,25 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         TimeUnit.SECONDS.sleep(shortInterval);
 
         // Perform a role switch during transfer
-        assertThat(mapStandby.size()).isEqualTo(0);
+        assertThat(mapStandby.count()).isEqualTo(0);
         try (TxnContext txn = activeCorfuStore.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
             txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH);
             txn.commit();
         }
         assertThat(configTable.count()).isOne();
-        assertThat(mapStandby.size()).isEqualTo(0);
+        assertThat(mapStandby.count()).isEqualTo(0);
 
         // Wait until active map size becomes 0
         waitForReplication(size -> size == 0, mapActive, 0);
         log.info("After role switch during transfer phase, both maps have size {}. Current " +
                         "active corfu[{}] log tail is {}, standby corfu[{}] log tail is {}",
-                mapActive.size(), activeClusterCorfuPort, activeRuntime.getAddressSpaceView().getLogTail(),
+                mapActive.count(), activeClusterCorfuPort, activeRuntime.getAddressSpaceView().getLogTail(),
                 standbyClusterCorfuPort, standbyRuntime.getAddressSpaceView().getLogTail());
 
         // Double check after 10 seconds
         TimeUnit.SECONDS.sleep(mediumInterval);
-        assertThat(mapActive.size()).isZero();
-        assertThat(mapStandby.size()).isZero();
+        assertThat(mapActive.count()).isZero();
+        assertThat(mapStandby.count()).isZero();
     }
 
     /**
@@ -868,12 +900,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     public void testNewConfigWithSwitchRoleDuringApplyPhase() throws Exception {
         // Write 50 entry to active map
         for (int i = 0; i < largeBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(largeBatch);
-        assertThat(mapStandby.size()).isZero();
+        assertThat(mapActive.count()).isEqualTo(largeBatch);
+        assertThat(mapStandby.count()).isZero();
 
         log.info("Before log replication, append {} entries to active map. Current active corfu" +
                         "[{}] log tail is {}, standby corfu[{}] log tail is {}", largeBatch, activeClusterCorfuPort,
@@ -901,16 +935,16 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Should finish apply
         waitForReplication(size -> size == largeBatch, mapStandby, largeBatch);
-        assertThat(mapActive.size()).isEqualTo(largeBatch);
+        assertThat(mapActive.count()).isEqualTo(largeBatch);
         log.info("After role switch during apply phase, both maps have size {}. Current " +
                         "active corfu[{}] log tail is {}, standby corfu[{}] log tail is {}",
-                mapActive.size(), activeClusterCorfuPort, activeRuntime.getAddressSpaceView().getLogTail(),
+                mapActive.count(), activeClusterCorfuPort, activeRuntime.getAddressSpaceView().getLogTail(),
                 standbyClusterCorfuPort, standbyRuntime.getAddressSpaceView().getLogTail());
 
         // Double check after 10 seconds
         TimeUnit.SECONDS.sleep(mediumInterval);
-        assertThat(mapActive.size()).isEqualTo(largeBatch);
-        assertThat(mapStandby.size()).isEqualTo(largeBatch);
+        assertThat(mapActive.count()).isEqualTo(largeBatch);
+        assertThat(mapStandby.count()).isEqualTo(largeBatch);
     }
 
     /**
@@ -929,12 +963,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     public void testNewConfigWithTwoActive() throws Exception {
         // Write 10 entries to active map
         for (int i = 0; i < firstBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(firstBatch);
-        assertThat(mapStandby.size()).isZero();
+        assertThat(mapActive.count()).isEqualTo(firstBatch);
+        assertThat(mapStandby.count()).isZero();
 
         log.info("Before log replication, append {} entries to active map. Current active corfu" +
                         "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
@@ -954,11 +990,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Write 5 entries to active map
         for (int i = firstBatch; i < secondBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(secondBatch);
+        assertThat(mapActive.count()).isEqualTo(secondBatch);
 
         // Wait until data is fully replicated again
         waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
@@ -969,7 +1007,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Verify data
         for (int i = 0; i < secondBatch; i++) {
-            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+            assertThat(mapStandby.containsKey(StringKey.newBuilder().setKey(String.valueOf(i)).build())).isTrue();
         }
         log.info("Log replication succeeds without config change!");
 
@@ -984,11 +1022,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Append to mapActive
         for (int i = secondBatch; i < thirdBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        assertThat(mapActive.count()).isEqualTo(thirdBatch);
         log.info("Active map has {} entries now!", thirdBatch);
 
         // Standby map should still have secondBatch size
@@ -997,8 +1037,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Double check after 10 seconds
         TimeUnit.SECONDS.sleep(mediumInterval);
-        assertThat(mapActive.size()).isEqualTo(thirdBatch);
-        assertThat(mapStandby.size()).isEqualTo(secondBatch);
+        assertThat(mapActive.count()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.count()).isEqualTo(secondBatch);
     }
 
     /**
@@ -1017,12 +1057,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     public void testNewConfigWithAllStandby() throws Exception {
         // Write 10 entries to active map
         for (int i = 0; i < firstBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(firstBatch);
-        assertThat(mapStandby.size()).isZero();
+        assertThat(mapActive.count()).isEqualTo(firstBatch);
+        assertThat(mapStandby.count()).isZero();
 
         log.info("Before log replication, append {} entries to active map. Current active corfu" +
                         "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
@@ -1042,11 +1084,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Write 5 entries to active map
         for (int i = firstBatch; i < secondBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(secondBatch);
+        assertThat(mapActive.count()).isEqualTo(secondBatch);
 
         // Wait until data is fully replicated again
         waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
@@ -1057,7 +1101,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Verify data
         for (int i = 0; i < secondBatch; i++) {
-            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+            assertThat(mapStandby.containsKey(StringKey.newBuilder().setKey(String.valueOf(i)).build())).isTrue();
         }
         log.info("Log replication succeeds without config change!");
 
@@ -1071,11 +1115,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         TimeUnit.SECONDS.sleep(mediumInterval);
 
         for (int i = secondBatch; i < thirdBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        assertThat(mapActive.count()).isEqualTo(thirdBatch);
         log.info("Active map has {} entries now!", thirdBatch);
 
         // Standby map should still have secondBatch size
@@ -1084,8 +1130,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Double check after 10 seconds
         TimeUnit.SECONDS.sleep(mediumInterval);
-        assertThat(mapActive.size()).isEqualTo(thirdBatch);
-        assertThat(mapStandby.size()).isEqualTo(secondBatch);
+        assertThat(mapActive.count()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.count()).isEqualTo(secondBatch);
     }
 
     /**
@@ -1105,12 +1151,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     public void testNewConfigWithInvalidClusters() throws Exception {
         // Write 10 entries to active map
         for (int i = 0; i < firstBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(firstBatch);
-        assertThat(mapStandby.size()).isZero();
+        assertThat(mapActive.count()).isEqualTo(firstBatch);
+        assertThat(mapStandby.count()).isZero();
 
         log.info("Before log replication, append {} entries to active map. Current active corfu" +
                         "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
@@ -1130,11 +1178,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Write 5 entries to active map
         for (int i = firstBatch; i < secondBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(secondBatch);
+        assertThat(mapActive.count()).isEqualTo(secondBatch);
 
         // Wait until data is fully replicated again
         waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
@@ -1145,7 +1195,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Verify data
         for (int i = 0; i < secondBatch; i++) {
-            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+            assertThat(mapStandby.containsKey(StringKey.newBuilder().setKey(String.valueOf(i)).build())).isTrue();
         }
         log.info("Log replication succeeds without config change!");
 
@@ -1160,19 +1210,21 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Append to mapActive
         for (int i = secondBatch; i < thirdBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        assertThat(mapActive.count()).isEqualTo(thirdBatch);
 
         // Standby map should still have secondBatch size
         waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
 
         // Double check after 10 seconds
         TimeUnit.SECONDS.sleep(mediumInterval);
-        assertThat(mapActive.size()).isEqualTo(thirdBatch);
-        assertThat(mapStandby.size()).isEqualTo(secondBatch);
+        assertThat(mapActive.count()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.count()).isEqualTo(secondBatch);
         log.info("After {} seconds sleep, double check passed", mediumInterval);
 
         // Change to default active standby config
@@ -1189,8 +1241,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Double check after 10 seconds
         TimeUnit.SECONDS.sleep(mediumInterval);
-        assertThat(mapActive.size()).isEqualTo(thirdBatch);
-        assertThat(mapStandby.size()).isEqualTo(thirdBatch);
+        assertThat(mapActive.count()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.count()).isEqualTo(thirdBatch);
     }
 
     private Table<LogReplicationMetadataKey, LogReplicationMetadataVal, LogReplicationMetadataVal> getMetadataTable(CorfuRuntime runtime) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
@@ -1232,12 +1284,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     public void testEnforceSnapshotSync() throws Exception {
         // Write 10 entries to active map
         for (int i = 0; i < firstBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(firstBatch);
-        assertThat(mapStandby.size()).isZero();
+        assertThat(mapActive.count()).isEqualTo(firstBatch);
+        assertThat(mapStandby.count()).isZero();
 
         log.info("Before log replication, append {} entries to active map. Current active corfu" +
                         "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
@@ -1291,11 +1345,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Write 5 entries to active map
         for (int i = firstBatch; i < secondBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(secondBatch);
+        assertThat(mapActive.count()).isEqualTo(secondBatch);
 
         // Wait until data is fully replicated again
         waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
@@ -1306,16 +1362,18 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Verify data
         for (int i = 0; i < secondBatch; i++) {
-            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+            assertThat(mapStandby.containsKey(StringKey.newBuilder().setKey(String.valueOf(i)).build())).isTrue();
         }
 
         // Append to mapActive
         for (int i = secondBatch; i < thirdBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        assertThat(mapActive.count()).isEqualTo(thirdBatch);
 
         // Perform an enforce full snapshot sync
         try (TxnContext txn = activeCorfuStore.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
@@ -1327,7 +1385,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Standby map should have thirdBatch size, since topology config is resumed.
         waitForReplication(size -> size == thirdBatch, mapStandby, thirdBatch);
-        assertThat(mapStandby.size()).isEqualTo(thirdBatch);
+        assertThat(mapStandby.count()).isEqualTo(thirdBatch);
 
         // Verify that a forced snapshot sync is finished.
         try (TxnContext txn = activeCorfuStore.txn(LogReplicationMetadataManager.NAMESPACE)) {
@@ -1370,12 +1428,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     public void testActiveLockRelease() throws Exception {
         // Write 10 entries to active map
         for (int i = 0; i < firstBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(firstBatch);
-        assertThat(mapStandby.size()).isZero();
+        assertThat(mapActive.count()).isEqualTo(firstBatch);
+        assertThat(mapStandby.count()).isZero();
 
         log.info("Before log replication, append {} entries to active map. Current active corfu" +
                         "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
@@ -1395,11 +1455,13 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Write 5 entries to active map
         for (int i = firstBatch; i < secondBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(secondBatch);
+        assertThat(mapActive.count()).isEqualTo(secondBatch);
 
         // Wait until data is fully replicated again
         waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
@@ -1410,7 +1472,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Verify data
         for (int i = 0; i < secondBatch; i++) {
-            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+            assertThat(mapStandby.containsKey(StringKey.newBuilder().setKey(String.valueOf(i)).build())).isTrue();
         }
         log.info("Log replication succeeds without config change!");
 
@@ -1430,16 +1492,18 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         }
 
         for (int i = secondBatch; i < thirdBatch; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapActive.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = activeCorfuStore.txn(NAMESPACE)) {
+                txn.putRecord(mapActive, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
-        assertThat(mapActive.size()).isEqualTo(thirdBatch);
+        assertThat(mapActive.count()).isEqualTo(thirdBatch);
         log.info("Active map has {} entries now!", thirdBatch);
 
         // Standby map should still have secondBatch size
         log.info("Standby map should still have {} size", secondBatch);
-        assertThat(mapStandby.size()).isEqualTo(secondBatch);
+        assertThat(mapStandby.count()).isEqualTo(secondBatch);
     }
 
     /**
@@ -1469,25 +1533,32 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         CorfuRuntime backupRuntime = CorfuRuntime.fromParameters(params);
         backupRuntime.parseConfigurationString(backupCorfuEndpoint).connect();
+        CorfuStore backupCorfuStore = new CorfuStore(backupRuntime);
 
-        CorfuTable<String, Integer> mapBackup = backupRuntime.getObjectsView()
-                .build()
-                .setStreamName(streamName)
-                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
-                .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
-                })
-                .open();
+        Table<StringKey, IntValue, Metadata> mapBackup = backupCorfuStore.openTable(
+                NAMESPACE,
+                streamName,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.builder().schemaOptions(
+                                CorfuOptions.SchemaOptions.newBuilder()
+                                        .setIsFederated(true)
+                                        .addStreamTag(ObjectsView.LOG_REPLICATOR_STREAM_INFO.getTagName())
+                                        .build())
+                        .build()
+        );
 
-        assertThat(mapBackup.size()).isZero();
+        assertThat(mapBackup.count()).isZero();
 
         // Write 10 entries to active map
-        writeEntries(activeRuntime, 0, firstBatch, mapActive);
+        writeEntries(activeCorfuStore, 0, firstBatch, mapActive);
 
         // Write 50 entries of dummy data to standby map, so we make it have longer corfu log tail.
         // We can also use it to confirm data is wiped during the snapshot sync.
-        writeEntries(standbyRuntime, 0, largeBatch, mapStandby);
-        assertThat(mapActive.size()).isEqualTo(firstBatch);
-        assertThat(mapStandby.size()).isEqualTo(largeBatch);
+        writeEntries(standbyCorfuStore, 0, largeBatch, mapStandby);
+        assertThat(mapActive.count()).isEqualTo(firstBatch);
+        assertThat(mapStandby.count()).isEqualTo(largeBatch);
 
         log.info("Before log replication, append {} entries to active map. Current active corfu" +
                         "[{}] log tail is {}, standby corfu[{}] log tail is {}", firstBatch, activeClusterCorfuPort,
@@ -1507,12 +1578,12 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
                 standbyClusterCorfuPort, standbyRuntime.getAddressSpaceView().getLogTail());
 
         // Write 50 entries to active map
-        writeEntries(activeRuntime, 0, largeBatch, mapActive);
-        assertThat(mapActive.size()).isEqualTo(largeBatch);
+        writeEntries(activeCorfuStore, 0, largeBatch, mapActive);
+        assertThat(mapActive.count()).isEqualTo(largeBatch);
 
         // Write 10 entries to backup map
         // It is a backup of the active cluster when it has 10 entries
-        writeEntries(backupRuntime, 0, firstBatch, mapBackup);
+        writeEntries(backupCorfuStore, 0, firstBatch, mapBackup);
 
         // Wait until data is fully replicated again
         waitForReplication(size -> size == largeBatch, mapStandby, largeBatch);
@@ -1523,7 +1594,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Verify data
         for (int i = 0; i < largeBatch; i++) {
-            assertThat(mapStandby.containsKey(String.valueOf(i))).isTrue();
+            assertThat(mapStandby.containsKey(StringKey.newBuilder().setKey(String.valueOf(i)).build())).isTrue();
         }
 
         // Change the topology - brings up the backup cluster
@@ -1541,8 +1612,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         waitForReplication(size -> size == firstBatch, mapStandby, firstBatch);
 
         // Write 5 entries to backup map
-        writeEntries(backupRuntime, firstBatch, secondBatch, mapBackup);
-        assertThat(mapBackup.size()).isEqualTo(secondBatch);
+        writeEntries(backupCorfuStore, firstBatch, secondBatch, mapBackup);
+        assertThat(mapBackup.count()).isEqualTo(secondBatch);
 
         // Wait until data is fully replicated again
         waitForReplication(size -> size == secondBatch, mapStandby, secondBatch);
@@ -1555,15 +1626,15 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         shutdownCorfuServer(backupReplicationServer);
     }
 
-    private void waitForReplication(IntPredicate verifier, CorfuTable table, int expected) {
+    private void waitForReplication(IntPredicate verifier, Table table, int expected) {
         for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_MODERATE; i++) {
-            log.info("Waiting for replication, table size is {}, expected size is {}", table.size(), expected);
-            if (verifier.test(table.size())) {
+            log.info("Waiting for replication, table size is {}, expected size is {}", table.count(), expected);
+            if (verifier.test(table.count())) {
                 break;
             }
             sleepUninterruptibly(shortInterval);
         }
-        assertThat(verifier.test(table.size())).isTrue();
+        assertThat(verifier.test(table.count())).isTrue();
     }
 
     private void sleepUninterruptibly(long seconds) {
@@ -1574,12 +1645,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         }
     }
 
-    private void writeEntries(CorfuRuntime runtime,
-                              int startIdx, int endIdx, CorfuTable<String, Integer> table) {
+    private void writeEntries(CorfuStore corfuStore,
+                              int startIdx, int endIdx, Table<StringKey, IntValue, Metadata> table) {
         for (int i = startIdx; i < endIdx; i++) {
-            runtime.getObjectsView().TXBegin();
-            table.put(String.valueOf(i), i);
-            runtime.getObjectsView().TXEnd();
+            try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+                txn.putRecord(table, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
     }
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
@@ -3,8 +3,8 @@ package org.corfudb.integration;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
+
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,20 +60,20 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
             stopActiveLogReplicator();
 
             // Checkpoint & Trim on the Standby (so shadow stream get trimmed)
-            checkpointAndTrim(false, Collections.singletonList(mapAStandby));
+            checkpointAndTrim(false, Collections.singletonList(mapAStandby.getCorfuTable()));
 
             // Write Entry's to Active Cluster (while replicator is down)
             log.debug("Write additional entries to active CorfuDB ...");
             writeToActiveNonUFO((numWrites + (numWrites/2)), numWrites/2);
 
             // Confirm data does exist on Active Cluster
-            assertThat(mapA.size()).isEqualTo(numWrites*2);
+            assertThat(mapA.count()).isEqualTo(numWrites*2);
 
             // Confirm new data does not exist on Standby Cluster
-            assertThat(mapAStandby.size()).isEqualTo((numWrites + (numWrites/2)));
+            assertThat(mapAStandby.count()).isEqualTo(numWrites + (numWrites/2));
 
             // Checkpoint & Trim on the Active so we force a snapshot sync on restart
-            checkpointAndTrim(true, Collections.singletonList(mapA));
+            checkpointAndTrim(true, Collections.singletonList(mapA.getCorfuTable()));
 
             log.debug("Start active Log Replicator again ...");
             startActiveLogReplicator();
@@ -81,7 +81,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
             log.debug("Verify Data on Standby ...");
             verifyDataOnStandbyNonUFO((numWrites*2));
 
-            log.debug("Entries :: " + mapAStandby.keySet());
+            log.debug("Entries :: " + mapAStandby.getCorfuTable().keySet());
 
         } finally {
 
@@ -141,18 +141,18 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
             }
 
             // Checkpoint & Trim on the Standby, so we trim the shadow stream
-            checkpointAndTrim(false, Collections.singletonList(mapAStandby));
+            checkpointAndTrim(false, Collections.singletonList(mapAStandby.getCorfuTable()));
 
             // Write Entry's to Active Cluster (while replicator is down)
             log.debug("Write additional entries to active CorfuDB ...");
             writeToActiveNonUFO((numWrites + (numWrites/2)), numWrites/2);
 
             // Confirm data does exist on Active Cluster
-            assertThat(mapA.size()).isEqualTo(numWrites*2);
+            assertThat(mapA.count()).isEqualTo(numWrites*2);
 
             if (stop) {
                 // Confirm new data does not exist on Standby Cluster
-                assertThat(mapAStandby.size()).isEqualTo((numWrites + (numWrites / 2)));
+                assertThat(mapAStandby.count()).isEqualTo(numWrites + (numWrites / 2));
 
                 log.debug("Start active Log Replicator again ...");
                 startActiveLogReplicator();
@@ -162,7 +162,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
             log.debug("Verify Data on Standby ...");
             verifyDataOnStandbyNonUFO((numWrites*2));
 
-            log.debug("Entries :: " + mapAStandby.keySet());
+            log.debug("Entries :: " + mapAStandby.getCorfuTable().keySet());
         } finally {
 
             executorService.shutdownNow();
@@ -199,13 +199,13 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
             writeToActiveNonUFO(0, numWrites);
 
             // Confirm data does exist on Active Cluster
-            assertThat(mapA.size()).isEqualTo(numWrites);
+            assertThat(mapA.count()).isEqualTo(numWrites);
 
             // Confirm data does not exist on Standby Cluster
-            assertThat(mapAStandby.size()).isZero();
+            assertThat(mapAStandby.count()).isZero();
 
             // Checkpoint and Trim Before Starting
-            checkpointAndTrim(true, Arrays.asList(mapA));
+            checkpointAndTrim(true, Collections.singletonList(mapA.getCorfuTable()));
 
             startLogReplicatorServers();
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -9,13 +9,16 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.lang.reflect.InvocationTargetException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.StringJoiner;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -31,6 +34,7 @@ import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.proto.Sample;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.protocols.wireprotocol.Token;
+import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.ExampleSchemas;
@@ -42,6 +46,7 @@ import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
 import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.StreamListener;
 import org.corfudb.runtime.collections.Table;
@@ -105,8 +110,8 @@ public class LogReplicationAbstractIT extends AbstractIT {
     public CorfuRuntime activeRuntime;
     public CorfuRuntime standbyRuntime;
 
-    public CorfuTable<String, Integer> mapA;
-    public CorfuTable<String, Integer> mapAStandby;
+    public Table<Sample.StringKey, Sample.IntValue, Sample.Metadata> mapA;
+    public Table<Sample.StringKey, Sample.IntValue, Sample.Metadata> mapAStandby;
 
     public Map<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> mapNameToMapActive;
     public Map<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> mapNameToMapStandby;
@@ -129,10 +134,10 @@ public class LogReplicationAbstractIT extends AbstractIT {
             writeToActiveNonUFO(0, numWrites);
 
             // Confirm data does exist on Active Cluster
-            assertThat(mapA.size()).isEqualTo(numWrites);
+            assertThat(mapA.count()).isEqualTo(numWrites);
 
             // Confirm data does not exist on Standby Cluster
-            assertThat(mapAStandby.size()).isEqualTo(0);
+            assertThat(mapAStandby.count()).isEqualTo(0);
 
             startLogReplicatorServers();
 
@@ -479,34 +484,48 @@ public class LogReplicationAbstractIT extends AbstractIT {
         }
     }
 
-    public void openMap() {
+    public void openMap() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         // Write to StreamA on Active Site
-        mapA = activeRuntime.getObjectsView()
-                .build()
-                .setStreamName(streamA)
-                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
-                .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
-                })
-                .open();
+        mapA = corfuStoreActive.openTable(
+                NAMESPACE,
+                streamA,
+                Sample.StringKey.class,
+                Sample.IntValue.class,
+                Sample.Metadata.class,
+                TableOptions.builder().schemaOptions(
+                                CorfuOptions.SchemaOptions.newBuilder()
+                                        .setIsFederated(true)
+                                        .addStreamTag(ObjectsView.LOG_REPLICATOR_STREAM_INFO.getTagName())
+                                        .build())
+                        .build()
+        );
 
-        mapAStandby = standbyRuntime.getObjectsView()
-                .build()
-                .setStreamName(streamA)
-                .setStreamTags(ObjectsView.getLogReplicatorStreamId())
-                .setTypeToken(new TypeToken<CorfuTable<String, Integer>>() {
-                })
-                .open();
+        mapAStandby = corfuStoreStandby.openTable(
+                NAMESPACE,
+                streamA,
+                Sample.StringKey.class,
+                Sample.IntValue.class,
+                Sample.Metadata.class,
+                TableOptions.builder().schemaOptions(
+                                CorfuOptions.SchemaOptions.newBuilder()
+                                        .setIsFederated(true)
+                                        .addStreamTag(ObjectsView.LOG_REPLICATOR_STREAM_INFO.getTagName())
+                                        .build())
+                        .build()
+        );
 
-        assertThat(mapA.size()).isEqualTo(0);
-        assertThat(mapAStandby.size()).isEqualTo(0);
+        assertThat(mapA.count()).isEqualTo(0);
+        assertThat(mapAStandby.count()).isEqualTo(0);
     }
 
     public void writeToActiveNonUFO(int startIndex, int totalEntries) {
         int maxIndex = totalEntries + startIndex;
         for (int i = startIndex; i < maxIndex; i++) {
-            activeRuntime.getObjectsView().TXBegin();
-            mapA.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            try (TxnContext txn = corfuStoreActive.txn(NAMESPACE)) {
+                txn.putRecord(mapA, Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        Sample.IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
         }
     }
 
@@ -656,17 +675,20 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
     public void verifyDataOnStandbyNonUFO(int expectedConsecutiveWrites) {
         // Wait until data is fully replicated
-        while (mapAStandby.size() != expectedConsecutiveWrites) {
+        while (mapAStandby.count() != expectedConsecutiveWrites) {
             // Block until expected number of entries is reached
+            log.trace("Map size: {}, expect size: {}",
+                    mapAStandby.count(), expectedConsecutiveWrites);
         }
 
         log.debug("Number updates on Standby :: " + expectedConsecutiveWrites);
 
         // Verify data is present in Standby Site
-        assertThat(mapAStandby.size()).isEqualTo(expectedConsecutiveWrites);
+        assertThat(mapAStandby.count()).isEqualTo(expectedConsecutiveWrites);
 
         for (int i = 0; i < (expectedConsecutiveWrites); i++) {
-            assertThat(mapAStandby.containsKey(String.valueOf(i)));
+            assertThat(mapAStandby.containsKey(Sample.StringKey
+                    .newBuilder().setKey(String.valueOf(i)).build())).isTrue();
         }
     }
 
@@ -794,7 +816,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
         cpRuntime.getSerializers().registerSerializer(protoBufSerializer);
         mcw.addMap(protobufDescriptorTable);
         Token token1 = mcw.appendCheckpoints(cpRuntime, "checkpointer");
-        
+
         mcw.addMap(tableRegistryCT);
         Token token2 = mcw.appendCheckpoints(cpRuntime, "checkpointer");
         Token minToken = Token.min(token1, token2);
@@ -861,5 +883,43 @@ public class LogReplicationAbstractIT extends AbstractIT {
         cpRuntime.getAddressSpaceView().invalidateClientCache();
         cpRuntime.getAddressSpaceView().invalidateServerCaches();
         cpRuntime.getAddressSpaceView().gc();
+    }
+
+    /**
+     * Stream Listener used for testing streaming on standby site. This listener decreases a latch
+     * until all expected updates are received/
+     */
+    public static class StreamingStandbyListener implements StreamListener {
+
+        private final CountDownLatch updatesLatch;
+        public List<CorfuStreamEntry> messages = new ArrayList<>();
+        private final Set<UUID> tablesToListenTo;
+
+        public StreamingStandbyListener(CountDownLatch updatesLatch, Set<UUID> tablesToListenTo) {
+            this.updatesLatch = updatesLatch;
+            this.tablesToListenTo = tablesToListenTo;
+        }
+
+        @Override
+        public synchronized void onNext(CorfuStreamEntries results) {
+            log.info("StreamingStandbyListener:: onNext {} with entry size {}", results, results.getEntries().size());
+
+            results.getEntries().forEach((schema, entries) -> {
+                if (tablesToListenTo.contains(CorfuRuntime.getStreamID(NAMESPACE + "$" + schema.getTableName()))) {
+                    messages.addAll(entries);
+                    entries.forEach(e -> {
+                        if (e.getOperation() == CorfuStreamEntry.OperationType.CLEAR) {
+                            System.out.println("Clear operation for :: " + schema.getTableName() + " on address :: " + results.getTimestamp().getSequence() + " key :: " + e.getKey());
+                        }
+                        updatesLatch.countDown();
+                    });
+                }
+            });
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            log.error("ERROR :: unsubscribed listener");
+        }
     }
 }

--- a/test/src/test/java/org/corfudb/integration/LogReplicationDynamicStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationDynamicStreamIT.java
@@ -1,0 +1,651 @@
+package org.corfudb.integration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusKey;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal;
+import org.corfudb.infrastructure.logreplication.proto.Sample.IntValue;
+import org.corfudb.infrastructure.logreplication.proto.Sample.IntValueTag;
+import org.corfudb.infrastructure.logreplication.proto.Sample.Metadata;
+import org.corfudb.infrastructure.logreplication.proto.Sample.StringKey;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata.TableName;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.test.SampleSchema.OptionTagOne;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.REPLICATION_STATUS_TABLE;
+
+/**
+ * This suite of tests validates the behavior of Log Replication
+ * when the set of streams to replicated is dynamically built by
+ * querying registry table instead of provided by static file.
+ */
+@Slf4j
+public class LogReplicationDynamicStreamIT extends LogReplicationAbstractIT {
+
+    /**
+     * Sets the plugin path before starting any test
+     */
+    @Before
+    public void setupPluginPath() throws Exception {
+        if(runProcess) {
+            File f = new File(nettyConfig);
+            this.pluginConfigFilePath = f.getAbsolutePath();
+        } else {
+            this.pluginConfigFilePath = nettyConfig;
+        }
+
+        // Initiate active and standby runtime and CorfuStore
+        setupActiveAndStandbyCorfu();
+
+        // Open replication status table to for verification purpose
+        corfuStoreActive.openTable(LogReplicationMetadataManager.NAMESPACE,
+                REPLICATION_STATUS_TABLE,
+                ReplicationStatusKey.class,
+                ReplicationStatusVal.class,
+                null,
+                TableOptions.fromProtoSchema(ReplicationStatusVal.class));
+
+        corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+                REPLICATION_STATUS_TABLE,
+                ReplicationStatusKey.class,
+                ReplicationStatusVal.class,
+                null,
+                TableOptions.fromProtoSchema(ReplicationStatusVal.class));
+    }
+
+    /*
+     * Helper methods section begin
+     */
+
+    public void openMapAOnActive() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        // Write to StreamA on Active Site
+        mapA = corfuStoreActive.openTable(
+                NAMESPACE,
+                streamA,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+        assertThat(mapA.count()).isEqualTo(0);
+    }
+
+    public void openMapAOnStandby() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        // Write to StreamA on Active Site
+        mapAStandby = corfuStoreStandby.openTable(
+                NAMESPACE,
+                streamA,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+    }
+
+    public void writeToMap(Table<StringKey, IntValue, Metadata> map, boolean isActive,
+                                   int startIndex, int totalEntries) {
+        int maxIndex = totalEntries + startIndex;
+        CorfuStore corfuStore = isActive ? corfuStoreActive : corfuStoreStandby;
+        for (int i = startIndex; i < maxIndex; i++) {
+            try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+                txn.putRecord(map, StringKey.newBuilder().setKey(String.valueOf(i)).build(),
+                        IntValue.newBuilder().setValue(i).build(), null);
+                txn.commit();
+            }
+        }
+    }
+
+    public void verifyDataOnStandby(Table<StringKey, IntValue, Metadata> mapStandby,
+                                    int expectNumEntries) {
+        // Wait until data is fully replicated
+        while (mapStandby.count() != expectNumEntries) {
+            log.trace("Current map size on Standby:: {}", mapStandby.count());
+            // Block until expected number of entries is reached
+        }
+
+        // Verify data is present in Standby Site
+        assertThat(mapStandby.count()).isEqualTo(expectNumEntries);
+
+        for (int i = 0; i < expectNumEntries; i++) {
+            assertThat(mapStandby.containsKey(StringKey
+                    .newBuilder().setKey(String.valueOf(i)).build())).isTrue();
+            assertThat(mapStandby.get(StringKey
+                    .newBuilder().setKey(String.valueOf(i)).build()).getPayload()).isEqualTo(
+                    IntValue.newBuilder().setValue(i).build()
+            );
+        }
+    }
+
+    public void verifyLogEntrySyncStatus() {
+        ReplicationStatusKey key = ReplicationStatusKey
+                .newBuilder()
+                .setClusterId(DefaultClusterConfig.getStandbyClusterId())
+                .build();
+
+        ReplicationStatusVal replicationStatusVal;
+        try (TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+            replicationStatusVal = (ReplicationStatusVal)txn.getRecord(REPLICATION_STATUS_TABLE, key).getPayload();
+            txn.commit();
+        }
+
+        assertThat(replicationStatusVal.getSyncType())
+                .isEqualTo(LogReplicationMetadata.ReplicationStatusVal.SyncType.LOG_ENTRY);
+        assertThat(replicationStatusVal.getStatus())
+                .isEqualTo(LogReplicationMetadata.SyncStatus.ONGOING);
+
+        assertThat(replicationStatusVal.getSnapshotSyncInfo().getType())
+                .isEqualTo(LogReplicationMetadata.SnapshotSyncInfo.SnapshotSyncType.DEFAULT);
+        assertThat(replicationStatusVal.getSnapshotSyncInfo().getStatus())
+                .isEqualTo(LogReplicationMetadata.SyncStatus.COMPLETED);
+    }
+
+    /*
+     * Helper methods section end
+     */
+
+    /**
+     * Note that we already have basic end-to-end test for snapshot sync
+     * and log entry sync. {@link CorfuReplicationE2EIT} This test here
+     * is mainly for validating their behavior when tables / streams are
+     * only opened at ACTIVE side.
+     *
+     * (1) Set up ACTIVE and STANDBY CorfuRuntime and CorfuStore
+     * (2) Open mapA only at ACTIVE, write some entries to it
+     * (3) Start log replication server for snapshot sync
+     * (4) Open mapA at STANDBY and verify data replicated successfully
+     * (5) Write more entries to mapA at ACTIVE and verify log entry sync at STANDBY
+     */
+    @Test
+    public void testSnapshotAndLogEntrySync() throws Exception {
+        // Open mapA on ACTIVE
+        openMapAOnActive();
+
+        // writeToActive for initial snapshot sync
+        writeToMap(mapA, true, 0, numWrites);
+
+        // Confirm data does exist on Active Cluster
+        assertThat(mapA.count()).isEqualTo(numWrites);
+
+        startLogReplicatorServers();
+
+        // Open mapA on STANDBY after log replication started
+        openMapAOnStandby();
+
+        // Verify succeed of snapshot sync
+        verifyDataOnStandby(mapAStandby, numWrites);
+
+        // Add Delta's for Log Entry Sync
+        writeToMap(mapA, true, numWrites, numWrites / 2);
+
+        // Verify log replication status is log entry sync
+        verifyLogEntrySyncStatus();
+
+        // Verify succeed of log entry sync
+        verifyDataOnStandby(mapAStandby, numWrites + (numWrites / 2));
+    }
+
+    /**
+     * As in dynamic streams implementation, we cannot get the list of streams to
+     * replicate in advance. This test will verify it works correctly when new streams
+     * are opened during log entry sync.
+     *
+     * (1) Perform basic snapshot and log entry sync, leave the clusters in log entry sync state
+     * (2) Open a new stream mapB at ACTIVE, write some entries to it
+     * (3) Verify at the STANDBY that mapB is replicated successfully during log entry sync
+     */
+    @Test
+    public void testNewStreamsInLogEntrySync() throws Exception {
+        // perform basic snapshot and log entry sync, the cluster should be in log entry sync state now
+        testSnapshotAndLogEntrySync();
+
+        // Verify log replication status is log entry sync
+        verifyLogEntrySyncStatus();
+
+        String streamB = "Table002";
+        // open mapB at ACTIVE
+        Table<StringKey, IntValue, Metadata> mapB = corfuStoreActive.openTable(
+                NAMESPACE,
+                streamB,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+
+        writeToMap(mapB, true, 0, numWrites);
+
+        // open mapB at STANDBY
+        Table<StringKey, IntValue, Metadata> mapBStandby = corfuStoreStandby.openTable(
+                NAMESPACE,
+                streamB,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+
+        verifyDataOnStandby(mapBStandby, numWrites);
+    }
+
+    /**
+     * In log entry sync when new streams are opened, we cannot guarantee new entries in registry
+     * table could come before the entries in new streams. The new implementation of LogEntryWriter
+     * will apply entries of those streams later.
+     *
+     * (1) Perform basic snapshot sync and log entry sync, verify the cluster is in log entry sync status
+     * (2) Stop ACTIVE log replicator, such that the new entries in registry table will not be replicated immediately
+     * (3) Open two maps (mapB and mapC) on ACTIVE and write entries to them
+     * (4) Remove their registration from registry table and restart ACTIVE log replicator
+     * (5) Sleep the thread for a while and reopened those two table on ACTIVE, verify they are successfully replicated
+     */
+    @SuppressWarnings("checkstyle:magicnumber")
+    @Test
+    public void testLogEntrySyncPendingEntries() throws Exception {
+        testSnapshotAndLogEntrySync();
+
+        stopActiveLogReplicator();
+
+        verifyLogEntrySyncStatus();
+
+        String streamB = "Table002";
+        String streamC = "Table003";
+        // open mapB and mapC at ACTIVE
+        Table<StringKey, IntValue, Metadata> mapB = corfuStoreActive.openTable(
+                NAMESPACE,
+                streamB,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+
+        Table<StringKey, IntValue, Metadata> mapC = corfuStoreActive.openTable(
+                NAMESPACE,
+                streamC,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+
+        writeToMap(mapB, true, 0, numWrites);
+        writeToMap(mapC, true, 0, numWrites);
+
+        // Remove the entry of mapB and mapC from registry table, such that we can make sure the
+        // entries of registry table will not be replicated before the entries of mapB and mapC
+        activeRuntime.getTableRegistry().getRegistryTable().remove(TableName.newBuilder()
+                .setNamespace(NAMESPACE).setTableName(streamB).build());
+        activeRuntime.getTableRegistry().getRegistryTable().remove(TableName.newBuilder()
+                .setNamespace(NAMESPACE).setTableName(streamC).build());
+
+        startActiveLogReplicator();
+
+        verifyLogEntrySyncStatus();
+
+        Thread.sleep(3000);
+        // open mapB at ACTIVE to register it to registry table again
+        corfuStoreActive.openTable(
+                NAMESPACE,
+                streamB,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+
+        corfuStoreActive.openTable(
+                NAMESPACE,
+                streamC,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+
+
+        // open mapB and mapC at STANDBY
+        Table<StringKey, IntValue, Metadata> mapBStandby = corfuStoreStandby.openTable(
+                NAMESPACE,
+                streamB,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+
+        Table<StringKey, IntValue, Metadata> mapCStandby = corfuStoreStandby.openTable(
+                NAMESPACE,
+                streamC,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+
+        verifyDataOnStandby(mapBStandby, numWrites);
+        verifyDataOnStandby(mapCStandby, numWrites);
+    }
+
+    /**
+     * Before dynamic stream, we clear the whole list of streams to replicate in snapshot
+     * sync. For now, we can only clear local writes on-demand. This test will verify local
+     * writes are cleared (STANDBY consistent with ACTIVE) in snapshot sync.
+     *
+     * (1) Set up ACTIVE and STANDBY corfu, open mapA in both of them
+     * (2) Write some entries to ACTIVE mapA, and write some different entries to STANDBY mapA
+     * (3) Start log replication, verify the STANDBY mapA is consistent with ACTIVE mapA
+     */
+    @Test
+    public void testLocalStreamClearingSnapshotSync() throws Exception {
+        // Open mapA on ACTIVE
+        openMapAOnActive();
+        // Open mapA on STANDBY
+        openMapAOnStandby();
+
+        // Write to mapA on both sides before log replication starts
+        writeToMap(mapA, true, 0, numWrites);
+        writeToMap(mapAStandby, false, 2 * numWrites, numWrites / 2);
+
+        startLogReplicatorServers();
+
+        // Verify succeed of snapshot sync
+        verifyDataOnStandby(mapAStandby, numWrites);
+
+        // Verify old entries are cleared at STANDBY
+        for (int i = 2 * numWrites; i < 2 * numWrites + numWrites / 2; i++) {
+            assertThat(mapAStandby.containsKey(StringKey
+                    .newBuilder().setKey(String.valueOf(i)).build())).isFalse();
+        }
+    }
+
+    /**
+     * Similar to {@link LogReplicationDynamicStreamIT#testLocalStreamClearingSnapshotSync()}
+     * This test will verify local writes are cleared in log entry sync.
+     *
+     * (1) Perform a basic snapshot sync and log entry sync on a single map
+     * (2) Verify the log entry sync status and open a new mapB on STANDBY and write some entries to it
+     * (3) Open mapB on ACTIVE and write some entries to it
+     * (4) Verify mapB on STANDBY is consistent with mapB on ACTIVE
+     */
+    @Test
+    public void testLocalStreamClearingLogEntrySync() throws Exception {
+        // perform basic snapshot and log entry sync, the cluster should be in log entry sync state now
+        testSnapshotAndLogEntrySync();
+
+        // Verify log replication status is log entry sync
+        verifyLogEntrySyncStatus();
+
+        // Open mapB on STANDBY and write entries
+        String streamB = "Table002";
+
+        Table<StringKey, IntValue, Metadata> mapBStandby = corfuStoreStandby.openTable(
+                NAMESPACE,
+                streamB,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+        writeToMap(mapBStandby, false, 2 * numWrites, numWrites / 2);
+
+        // Open mapB on ACTIVE and write entries
+        Table<StringKey, IntValue, Metadata> mapB = corfuStoreActive.openTable(
+                NAMESPACE,
+                streamB,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+        writeToMap(mapB, true, 0, numWrites);
+
+        // Verify succeed of snapshot sync
+        verifyDataOnStandby(mapBStandby, numWrites);
+
+        // Verify old entries are cleared at STANDBY
+        for (int i = 2 * numWrites; i < 2 * numWrites + numWrites / 2; i++) {
+            assertThat(mapAStandby.containsKey(StringKey
+                    .newBuilder().setKey(String.valueOf(i)).build())).isFalse();
+        }
+    }
+
+    /**
+     * We need to clear local writes on STANDBY for streams with is_federated set to be true,
+     * even if those streams are not initially replicated or opened on ACTIVE.
+     *
+     * (1) Open mapA on ACTIVE and mapB on STANDBY, write different entries to them
+     * (2) Start log replication servers
+     * (3) Verify mapA is successfully replicated and mapB is cleared on STANDBY
+     */
+    @Test
+    public void testStandbyLocalWritesClearing() throws Exception {
+        // Open mapA on ACTIVE and write entries
+        openMapAOnActive();
+        writeToMap(mapA, true, 0, numWrites);
+
+        // Open mapB on STANDBY and write entries
+        String streamB = "Table002";
+        Table<StringKey, IntValue, Metadata> mapBStandby = corfuStoreStandby.openTable(
+                NAMESPACE,
+                streamB,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(IntValueTag.class)
+        );
+        writeToMap(mapBStandby, false, 0, numWrites);
+
+        // Start log replication
+        startLogReplicatorServers();
+
+        // Verify mapA is successfully replicated
+        openMapAOnStandby();
+        verifyDataOnStandby(mapAStandby, numWrites);
+
+        // Verify mapB on STANDBY is cleared
+        assertThat(mapBStandby.count()).isEqualTo(0);
+    }
+
+    /**
+     * This test will verify the streams to stream tags map is correctly rebuilt during
+     * snapshot sync.
+     *
+     * (1) Open table with TAG_ONE on ACTIVE and STANDBY
+     * (2) Initiate a testing stream listener and subscribe to TAG_ONE on STANDBY
+     * (3) Write some entries to the table on ACTIVE
+     * (4) Start log replication snapshot sync and verify the test listener received all the updates
+     */
+    @Test
+    public void testStandbyStreamingSnapshotSync() throws Exception {
+        // Open testing map on ACTIVE and STANDBY
+        String streamName = "TableStreaming001";
+
+        Table<StringKey, IntValue, Metadata> mapTagOne = corfuStoreActive.openTable(
+                NAMESPACE,
+                streamName,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(OptionTagOne.class)
+        );
+
+        Table<StringKey, IntValue, Metadata> mapTagOneStandby = corfuStoreStandby.openTable(
+                NAMESPACE,
+                streamName,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(OptionTagOne.class)
+        );
+
+        // Subscribe the testing stream listener
+        UUID streamId = CorfuRuntime.getStreamID(mapTagOne.getFullyQualifiedTableName());
+        CountDownLatch streamingStandbySnapshotCompletion = new CountDownLatch(numWrites);
+        StreamingStandbyListener listener = new StreamingStandbyListener(streamingStandbySnapshotCompletion,
+                Collections.singleton(streamId));
+        corfuStoreStandby.subscribeListener(listener, NAMESPACE, DefaultLogReplicationConfigAdapter.TAG_ONE);
+
+        writeToMap(mapTagOne, true, 0, numWrites);
+
+        // The stream to tags map is rebuilt upon receiving the replicated data
+        startLogReplicatorServers();
+
+        // Verify snapshot sync is succeed and stream listener received all the changes
+        verifyDataOnStandby(mapTagOneStandby, numWrites);
+
+        streamingStandbySnapshotCompletion.await();
+        assertThat(listener.messages.size()).isEqualTo(numWrites);
+    }
+
+    /**
+     * This test will verify the streams to stream tags map is correctly rebuilt during
+     * log entry sync.
+     *
+     * (1) Perform a basic snapshot sync and log entry sync, verify the cluster is in log entry sync state
+     * (2) Open a new map on both ACTIVE and STANDBY with TAG_ONE
+     * (3) Initiate a testing stream listener and subscribe to TAG_ONE on STANDBY
+     * (4) Write some new entries to this new map on ACTIVE
+     * (5) Verify new data get replicated and the stream listener received all the updates
+     */
+    @Test
+    public void testStandbyStreamingLogEntrySync() throws Exception {
+        // perform basic snapshot and log entry sync, the cluster should be in log entry sync state now
+        testSnapshotAndLogEntrySync();
+
+        // Verify log replication status is log entry sync
+        verifyLogEntrySyncStatus();
+
+        // Open testing map on ACTIVE and STANDBY
+        String streamName = "TableStreaming001";
+
+        Table<StringKey, IntValue, Metadata> mapTagOne = corfuStoreActive.openTable(
+                NAMESPACE,
+                streamName,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(OptionTagOne.class)
+        );
+
+        Table<StringKey, IntValue, Metadata> mapTagOneStandby = corfuStoreStandby.openTable(
+                NAMESPACE,
+                streamName,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(OptionTagOne.class)
+        );
+
+        // Subscribe the testing stream listener
+        UUID streamId = CorfuRuntime.getStreamID(mapTagOne.getFullyQualifiedTableName());
+        CountDownLatch streamingStandbySnapshotCompletion = new CountDownLatch(numWrites);
+        StreamingStandbyListener listener = new StreamingStandbyListener(streamingStandbySnapshotCompletion,
+                Collections.singleton(streamId));
+        corfuStoreStandby.subscribeListener(listener, NAMESPACE, DefaultLogReplicationConfigAdapter.TAG_ONE);
+
+        writeToMap(mapTagOne, true, 0, numWrites);
+
+        // Verify snapshot sync succeeded and stream listener received all the changes
+        verifyDataOnStandby(mapTagOneStandby, numWrites);
+
+        streamingStandbySnapshotCompletion.await();
+        assertThat(listener.messages.size()).isEqualTo(numWrites);
+    }
+
+    /**
+     * Similar to {@link LogReplicationDynamicStreamIT#testLogEntrySyncPendingEntries()}, this test will
+     * verify STANDBY streaming against pending entries.
+     *
+     * (1) Perform basic snapshot sync and log entry sync, verify the cluster is in log entry sync status
+     * (2) Stop ACTIVE log replicator, such that the new entries in registry table will not be replicated immediately
+     * (3) Open a new map with TAG_ONE
+     * (4) Remove their registration from registry table and restart ACTIVE log replicator
+     * (5) Sleep the thread for a while and reopen the table, verify replication and streaming status
+     */
+    @SuppressWarnings("checkstyle:magicnumber")
+    @Test
+    public void testStandbyStreamingOnPendingEntries() throws Exception {
+        testSnapshotAndLogEntrySync();
+
+        stopActiveLogReplicator();
+
+        verifyLogEntrySyncStatus();
+
+        String streamName = "TableStreaming001";
+        // open mapTagOne at ACTIVE
+        Table<StringKey, IntValue, Metadata> mapTagOne = corfuStoreActive.openTable(
+                NAMESPACE,
+                streamName,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(OptionTagOne.class)
+        );
+
+        // open mapB at STANDBY
+        Table<StringKey, IntValue, Metadata> mapTagOneStandby = corfuStoreStandby.openTable(
+                NAMESPACE,
+                streamName,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(OptionTagOne.class)
+        );
+
+        writeToMap(mapTagOne, true, 0, numWrites);
+
+        // Remove the entry of mapTagOne from registry table, such that we can make sure the
+        // entries of registry table will not be replicated before the entries of mapTagOne
+        activeRuntime.getTableRegistry().getRegistryTable().remove(TableName.newBuilder()
+                .setNamespace(NAMESPACE).setTableName(streamName).build());
+
+        // Subscribe the testing stream listener
+        UUID streamId = CorfuRuntime.getStreamID(mapTagOne.getFullyQualifiedTableName());
+        CountDownLatch streamingStandbySnapshotCompletion = new CountDownLatch(numWrites);
+        StreamingStandbyListener listener = new StreamingStandbyListener(streamingStandbySnapshotCompletion,
+                Collections.singleton(streamId));
+        corfuStoreStandby.subscribeListener(listener, NAMESPACE, DefaultLogReplicationConfigAdapter.TAG_ONE);
+
+        // Remove the entry of mapTagOne from STANDBY registry table to make sure the log entries
+        // went to pending entries list.
+        standbyRuntime.getTableRegistry().getRegistryTable().remove(TableName.newBuilder()
+                .setNamespace(NAMESPACE).setTableName(streamName).build());
+
+        startActiveLogReplicator();
+
+        verifyLogEntrySyncStatus();
+
+        Thread.sleep(3000);
+        // open mapTagOne at ACTIVE to register it to registry table again
+        corfuStoreActive.openTable(
+                NAMESPACE,
+                streamName,
+                StringKey.class,
+                IntValue.class,
+                Metadata.class,
+                TableOptions.fromProtoSchema(OptionTagOne.class)
+        );
+
+        // Verify log entry sync succeeded and stream listener received all the changes
+        verifyDataOnStandby(mapTagOneStandby, numWrites);
+
+        streamingStandbySnapshotCompletion.await();
+        assertThat(listener.messages.size()).isEqualTo(numWrites);
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -25,6 +25,7 @@ import org.corfudb.runtime.view.StreamOptions;
 import org.corfudb.runtime.view.stream.IStreamView;
 import org.corfudb.util.serializer.ISerializer;
 import org.corfudb.util.serializer.Serializers;
+import org.corfudb.utils.LogReplicationStreams.TableInfo;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -33,6 +34,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
@@ -218,11 +220,11 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         }
     }
 
-    public static void verifyTable(String tag, HashMap<String, CorfuTable<Long, Long>> tables, HashMap<String, CorfuTable<Long, Long>> hashMap) {
+    public static void verifyTable(String tag, Map<String, CorfuTable<Long, Long>> dstTables, Map<String, CorfuTable<Long, Long>> srcTables) {
         log.debug("\n" + tag);
-        for (String name : hashMap.keySet()) {
-            CorfuTable<Long, Long> table = tables.get(name);
-            CorfuTable<Long, Long> mapKeys = hashMap.get(name);
+        for (String name : srcTables.keySet()) {
+            CorfuTable<Long, Long> table = dstTables.get(name);
+            CorfuTable<Long, Long> mapKeys = srcTables.get(name);
             log.debug("table " + name + " key size " + table.keySet().size() +
                     " hashMap size " + mapKeys.size());
 
@@ -262,7 +264,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
 
     public static void readSnapLogMsgs(List<LogReplicationEntryMsg> msgQ, Set<String> streams, CorfuRuntime rt, boolean blockOnSem)  {
         int cnt = 0;
-        LogReplicationConfig config = new LogReplicationConfig(streams, BATCH_SIZE, MAX_MSG_SIZE);
+        LogReplicationConfig config = new LogReplicationConfig(convertStreamNameToInfo(streams), BATCH_SIZE, MAX_MSG_SIZE);
         StreamsSnapshotReader reader = new StreamsSnapshotReader(rt, config);
 
         reader.reset(rt.getAddressSpaceView().getLogTail());
@@ -291,7 +293,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     }
 
     public static void writeSnapLogMsgs(List<LogReplicationEntryMsg> msgQ, Set<String> streams, CorfuRuntime rt) {
-        LogReplicationConfig config = new LogReplicationConfig(streams, BATCH_SIZE, MAX_MSG_SIZE);
+        LogReplicationConfig config = new LogReplicationConfig(convertStreamNameToInfo(streams), BATCH_SIZE, MAX_MSG_SIZE);
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt, 0, PRIMARY_SITE_ID);
         StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, config, logReplicationMetadataManager);
 
@@ -305,10 +307,10 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         writer.reset(topologyConfigId, snapshot);
 
         for (LogReplicationEntryMsg msg : msgQ) {
-            writer.apply(msg);
+            writer.applyToShadowStreams(msg);
         }
 
-        writer.applyShadowStreams();
+        writer.applyToActualStreams();
     }
 
     public static void readLogEntryMsgs(List<LogReplicationEntryMsg> msgQ, Set<String> streams, CorfuRuntime rt) throws TrimmedException {
@@ -317,7 +319,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
 
     public static void readLogEntryMsgs(List<LogReplicationEntryMsg> msgQ, Set<String> streams, CorfuRuntime rt, boolean blockOnce) throws
             TrimmedException {
-        LogReplicationConfig config = new LogReplicationConfig(streams, BATCH_SIZE, MAX_MSG_SIZE);
+        LogReplicationConfig config = new LogReplicationConfig(convertStreamNameToInfo(streams), BATCH_SIZE, MAX_MSG_SIZE);
         StreamsLogEntryReader reader = new StreamsLogEntryReader(rt, config);
         reader.setGlobalBaseSnapshot(Address.NON_ADDRESS, Address.NON_ADDRESS);
 
@@ -347,9 +349,9 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     }
 
     public static void writeLogEntryMsgs(List<LogReplicationEntryMsg> msgQ, Set<String> streams, CorfuRuntime rt) {
-        LogReplicationConfig config = new LogReplicationConfig(streams);
+        LogReplicationConfig config = new LogReplicationConfig(convertStreamNameToInfo(streams));
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt, 0, PRIMARY_SITE_ID);
-        LogEntryWriter writer = new LogEntryWriter(config, logReplicationMetadataManager);
+        LogEntryWriter writer = new LogEntryWriter(config, logReplicationMetadataManager, rt);
 
         if (msgQ.isEmpty()) {
             log.debug("msgQ is EMPTY");
@@ -428,6 +430,19 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         } catch (Exception e) {
             log.debug("caught an exception " + e);
         }
+    }
+
+    private static Set<TableInfo> convertStreamNameToInfo(Set<String> streams) {
+        Set<TableInfo> infoSet = new HashSet<>();
+
+        for (String streamName : streams) {
+            TableInfo info = TableInfo.newBuilder()
+                    .setName(streamName)
+                    .build();
+            infoSet.add(info);
+        }
+
+        return infoSet;
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
@@ -44,7 +44,6 @@ import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;

--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -111,17 +111,17 @@ extend google.protobuf.MessageOptions {
     optional ManagedResourceOptionsMsg mgoptions = 54312;
 }
 
-message ValueFieldTagOne {
-    option (org.corfudb.runtime.table_schema).stream_tag = "tag_one";
-    option (org.corfudb.runtime.table_schema).is_federated = true;
-
+message ValueField {
     optional string payload = 1;
 }
 
-message ValueFieldTagOneAndTwo {
+message OptionTagOneAndTwo {
     option (org.corfudb.runtime.table_schema).stream_tag = "tag_one";
     option (org.corfudb.runtime.table_schema).stream_tag = "tag_two";
     option (org.corfudb.runtime.table_schema).is_federated = true;
+}
 
-    optional string payload = 1;
+message OptionTagOne {
+    option (org.corfudb.runtime.table_schema).stream_tag = "tag_one";
+    option (org.corfudb.runtime.table_schema).is_federated = true;
 }

--- a/utils/proto/log_replication_streams.proto
+++ b/utils/proto/log_replication_streams.proto
@@ -5,6 +5,7 @@ option java_package = "org.corfudb.utils";
 
 message TableInfo {
     string name = 1;
+    string id = 2;
 }
 
 message Namespace {


### PR DESCRIPTION
## Overview

Description:

This change is for 2 purposes: 
* Remove static file plugin for streams to replicate, and reply on registry table to construct the set in flight instead.
   Now ACTIVE and STANDBY cluster will have different workflows to get the streams to replicate:
   * For ACTIVE: We still maintain an in-memory set in `LogReplicationConfig` persisted by INFO_TABLE, which will be the source for fetching that set of streams to replicate. However, INFO_TABLE and the in-memory set will be initialized by querying registry table for the streams' is_federated tags.
   * For STANDBY: 
       * In each snapshot sync we will rebuild the streams to replicate set and data streams to tags map, which is achieved by invoking a preprocess method between the TRANSFER phase and APPLY phase. The preprocess method will apply merge-only streams (registry table, protobuf descriptor table) first, and query the updated registry table to rebuild the stream tags map, and the set of streams to replicate. (Note that we try not to access shadow streams directly as it's error prone especially in CP/trim scenario)
       * In delta sync we use similar preprocess to add on to what we built from last snapshot sync. Every time we detect a change sent for registry table, we will update the set of streams to replicate and stream tags mapping. Note that we introduced pending entries in the case that entries from newly opened tables are replicated before the updates of registry table. In this case, we have to wait until to registry table been updated to rebuild the stream tags map, to avoid data loss of related stream listeners.
* Avoid potential data loss from newly added streams to replicate. (Given that formerly we fetched the set from static file and newly added streams cannot be added to that set)
    * To achieve this we insert several refresh points before snapshot sync and delta sync. Before every snapshot sync, we will inspect the registry table again to see if there is any new streams with is_federated flag set, and add them to INFO_TABLE and update the in-memory state of LogReplicationConfig. For delta sync, we will check the transaction entries to see if there is any newly discovered streams. If so, we update the INFO_TABLE and in-memory state.

Some corner cases specifically handled:
* Local stream clearing: Previously it depends on the static file, with which we could clear all the streams to replicate with local writes on STANDBY at once in snapshot sync. Now we have to do it on-demand in snapshot and log entry syncs. The basic idea is relying on is_federated flag to clear local writes.
* Streaming tasks: The basic idea is we must have the stream to tags map before apply the real updates to the streams, which previously also relies on the static file (since we could know the stream tags in advance). In snapshot sync this is straightforward. In log entry sync we introduced pending entries to avoid apply newly opened streams without knowing their stream tags.
* CorfuRuntime for log replication config: A new CorfuRuntime instance with cache disabled is created specifically for reading the registry table. Since we are accessing registry table from runtime's TableRegistry, and in log replication, the updates of registry table could happen directly without going through runtime, we need to make sure we are reading the up to date registry table each time so the cache has to be disabled.

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
