### PR TITLE
Upgrade netty 4.1.77 & grpc 1.46.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
 
         <!-- Dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>
-        <netty.version>4.1.75.Final</netty.version>
-        <netty.tcnative.version>2.0.51.Final</netty.tcnative.version>
+        <netty.version>4.1.77.Final</netty.version>
+        <netty.tcnative.version>2.0.52.Final</netty.tcnative.version>
         <protobuf.version>3.6.1</protobuf.version>
         <commons.io.version>2.8.0</commons.io.version>
         <lombok.version>1.18.24</lombok.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -24,7 +24,7 @@
         <annotations.api.version>6.0.53</annotations.api.version>
         <ehcahce.sizeOf.version>0.4.0</ehcahce.sizeOf.version>
 
-        <grpc.version>1.45.1</grpc.version>
+        <grpc.version>1.46.0</grpc.version>
     </properties>
 
     <build>


### PR DESCRIPTION

## Overview

Description:

Why should this be merged: 
Address security vulnerability CVE-2022-24823

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
