### PR TITLE
Update logback to 1.2.11 (#3246)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <revision>0.3.2-SNAPSHOT</revision>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <logback.classic.version>1.2.3</logback.classic.version>
+        <logback.classic.version>1.2.11</logback.classic.version>
 
         <!-- Dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>


### PR DESCRIPTION
This addresses
CVE-2021-42550 as per https://nvd.nist.gov/vuln/detail/CVE-2021-42550

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
