### PR TITLE
A way of creating immutable corfu compactor config

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/compactor/CorfuStoreCompactorMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/compactor/CorfuStoreCompactorMain.java
@@ -31,8 +31,7 @@ public class CorfuStoreCompactorMain {
     private int retryCheckpointing = 1;
 
     public CorfuStoreCompactorMain(String[] args) {
-        this.config = new CorfuStoreCompactorConfig();
-        config.parseAndBuildRuntimeParameters(args);
+        this.config = new CorfuStoreCompactorConfig(args);
 
         CorfuRuntime cpRuntime = (CorfuRuntime.fromParameters(
                 config.getParams())).parseConfigurationString(config.getNodeLocator().toEndpointUrl()).connect();

--- a/runtime/src/main/java/org/corfudb/runtime/DistributedCompactor.java
+++ b/runtime/src/main/java/org/corfudb/runtime/DistributedCompactor.java
@@ -64,7 +64,7 @@ import static org.corfudb.runtime.view.TableRegistry.getFullyQualifiedTableName;
 public class DistributedCompactor {
     private final CorfuRuntime runtime;
     private final CorfuRuntime cpRuntime;
-    private final String persistedCacheRoot;
+    private final Optional<String> persistedCacheRoot;
     private final boolean isClient;
 
     private final String clientName;
@@ -99,7 +99,7 @@ public class DistributedCompactor {
         }
     }
 
-    public DistributedCompactor(CorfuRuntime corfuRuntime, CorfuRuntime cpRuntime, String persistedCacheRoot) {
+    public DistributedCompactor(CorfuRuntime corfuRuntime, CorfuRuntime cpRuntime, Optional<String> persistedCacheRoot) {
         this.runtime = corfuRuntime;
         this.cpRuntime = cpRuntime;
         this.persistedCacheRoot = persistedCacheRoot;
@@ -110,7 +110,7 @@ public class DistributedCompactor {
     public DistributedCompactor(CorfuRuntime corfuRuntime) {
         this.runtime = corfuRuntime;
         this.cpRuntime = null;
-        this.persistedCacheRoot = null;
+        this.persistedCacheRoot = Optional.empty();
         this.isClient = true;
         this.clientName = corfuRuntime.getParameters().getClientName();
     }
@@ -304,11 +304,11 @@ public class DistributedCompactor {
                         .setStreamName(getFullyQualifiedTableName(tableName.getNamespace(), tableName.getTableName()))
                         .setSerializer(serializer)
                         .addOpenOption(ObjectOpenOption.NO_CACHE);
-        if (persistedCacheRoot != null && !persistedCacheRoot.equals(EMPTY_STRING)) {
-            final String persistentCacheDirName = String.format("compactor_%s_%s",
+        if (persistedCacheRoot.isPresent()) {
+            String persistentCacheDirName = String.format("compactor_%s_%s",
                     tableName.getNamespace(), tableName.getTableName());
-            final Path persistedCacheLocation = Paths.get(persistedCacheRoot).resolve(persistentCacheDirName);
-            final Supplier<StreamingMap<CorfuDynamicKey, OpaqueCorfuDynamicRecord>> mapSupplier =
+            Path persistedCacheLocation = Paths.get(persistedCacheRoot.get()).resolve(persistentCacheDirName);
+            Supplier<StreamingMap<CorfuDynamicKey, OpaqueCorfuDynamicRecord>> mapSupplier =
                     () -> new PersistedStreamingMap<>(
                             persistedCacheLocation, PersistedStreamingMap.getPersistedStreamingMapOptions(),
                             serializer, rt);

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/DistributedCompactorTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/DistributedCompactorTest.java
@@ -306,11 +306,11 @@ public class DistributedCompactorTest extends AbstractViewTest {
         compactorLeaderServices1.setLeader(true);
         compactorLeaderServices1.trimAndTriggerDistributedCheckpointing();
         DistributedCompactor distributedCompactor1 =
-                new DistributedCompactor(runtime0, cpRuntime0, Optional.ofNullable(null));
+                new DistributedCompactor(runtime0, cpRuntime0, Optional.empty());
         DistributedCompactor distributedCompactor2 =
-                new DistributedCompactor(runtime1, cpRuntime1, Optional.ofNullable(null));
+                new DistributedCompactor(runtime1, cpRuntime1, Optional.empty());
         DistributedCompactor distributedCompactor3 =
-                new DistributedCompactor(runtime2, cpRuntime2, Optional.ofNullable(null));
+                new DistributedCompactor(runtime2, cpRuntime2, Optional.empty());
 
         int count1 = distributedCompactor1.startCheckpointing();
         int count2 = distributedCompactor2.startCheckpointing();
@@ -332,7 +332,7 @@ public class DistributedCompactorTest extends AbstractViewTest {
         compactorLeaderServices1.setLeader(true);
         compactorLeaderServices1.trimAndTriggerDistributedCheckpointing();
 
-        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, Optional.ofNullable(null));
+        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, Optional.empty());
         distributedCompactor.startCheckpointing();
 
         compactorLeaderServices1.finishCompactionCycle();
@@ -378,7 +378,7 @@ public class DistributedCompactorTest extends AbstractViewTest {
         compactorLeaderServices1.setLeader(true);
         compactorLeaderServices1.trimAndTriggerDistributedCheckpointing();
 
-        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, Optional.ofNullable(null));
+        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, Optional.empty());
         distributedCompactor.startCheckpointing();
 
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -404,7 +404,7 @@ public class DistributedCompactorTest extends AbstractViewTest {
         compactorLeaderServices1.trimAndTriggerDistributedCheckpointing();
         compactorLeaderServices1.setLeader(false);
 
-        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, Optional.ofNullable(null));
+        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, Optional.empty());
         distributedCompactor.startCheckpointing();
 
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -446,7 +446,7 @@ public class DistributedCompactorTest extends AbstractViewTest {
                 LIVENESS_TIMEOUT, TimeUnit.MILLISECONDS);
 
         DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0,
-                Optional.ofNullable(null));
+                Optional.empty());
         distributedCompactor.startCheckpointing();
 
         try {
@@ -485,7 +485,7 @@ public class DistributedCompactorTest extends AbstractViewTest {
                 LIVENESS_TIMEOUT, TimeUnit.MILLISECONDS);
 
         DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0,
-                Optional.ofNullable(null));
+                Optional.empty());
 
         try {
             TimeUnit.MILLISECONDS.sleep(WAIT_IN_SYNC_STATE);

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/DistributedCompactorTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/DistributedCompactorTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -305,11 +306,11 @@ public class DistributedCompactorTest extends AbstractViewTest {
         compactorLeaderServices1.setLeader(true);
         compactorLeaderServices1.trimAndTriggerDistributedCheckpointing();
         DistributedCompactor distributedCompactor1 =
-                new DistributedCompactor(runtime0, cpRuntime0, null);
+                new DistributedCompactor(runtime0, cpRuntime0, Optional.ofNullable(null));
         DistributedCompactor distributedCompactor2 =
-                new DistributedCompactor(runtime1, cpRuntime1, null);
+                new DistributedCompactor(runtime1, cpRuntime1, Optional.ofNullable(null));
         DistributedCompactor distributedCompactor3 =
-                new DistributedCompactor(runtime2, cpRuntime2, null);
+                new DistributedCompactor(runtime2, cpRuntime2, Optional.ofNullable(null));
 
         int count1 = distributedCompactor1.startCheckpointing();
         int count2 = distributedCompactor2.startCheckpointing();
@@ -331,7 +332,7 @@ public class DistributedCompactorTest extends AbstractViewTest {
         compactorLeaderServices1.setLeader(true);
         compactorLeaderServices1.trimAndTriggerDistributedCheckpointing();
 
-        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, null);
+        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, Optional.ofNullable(null));
         distributedCompactor.startCheckpointing();
 
         compactorLeaderServices1.finishCompactionCycle();
@@ -377,7 +378,7 @@ public class DistributedCompactorTest extends AbstractViewTest {
         compactorLeaderServices1.setLeader(true);
         compactorLeaderServices1.trimAndTriggerDistributedCheckpointing();
 
-        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, null);
+        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, Optional.ofNullable(null));
         distributedCompactor.startCheckpointing();
 
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -403,7 +404,7 @@ public class DistributedCompactorTest extends AbstractViewTest {
         compactorLeaderServices1.trimAndTriggerDistributedCheckpointing();
         compactorLeaderServices1.setLeader(false);
 
-        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, null);
+        DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0, Optional.ofNullable(null));
         distributedCompactor.startCheckpointing();
 
         ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -445,7 +446,7 @@ public class DistributedCompactorTest extends AbstractViewTest {
                 LIVENESS_TIMEOUT, TimeUnit.MILLISECONDS);
 
         DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0,
-                null);
+                Optional.ofNullable(null));
         distributedCompactor.startCheckpointing();
 
         try {
@@ -484,7 +485,7 @@ public class DistributedCompactorTest extends AbstractViewTest {
                 LIVENESS_TIMEOUT, TimeUnit.MILLISECONDS);
 
         DistributedCompactor distributedCompactor = new DistributedCompactor(runtime0, cpRuntime0,
-                null);
+                Optional.ofNullable(null));
 
         try {
             TimeUnit.MILLISECONDS.sleep(WAIT_IN_SYNC_STATE);


### PR DESCRIPTION
## Overview
A way of creating an immutable Corfu compactor config which is more resistant to input errors

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
