### PR TITLE
PersistedStreamingMap Optimizations

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/VersionLockedObject.java
@@ -597,7 +597,9 @@ public class VersionLockedObject<T extends ICorfuSMR<T>> {
             IUndoRecordFunction<T> undoRecordTarget =
                     undoRecordFunctionMap.get(entry.getSMRMethod());
             // If there was no previously calculated undo entry
-            if (undoRecordTarget != null) {
+            // The undo records shouldn't be computed for objects with a MONOTONIC version
+            // policy because they simply don't sync backwards to older versions.
+            if (undoRecordTarget != null && object.getVersionPolicy() != ICorfuVersionPolicy.MONOTONIC) {
                 // Calculate the undo record.
                 entry.setUndoRecord(undoRecordTarget
                         .getUndoRecord(object.getContext(context), entry.getSMRArguments()));


### PR DESCRIPTION
## Overview

This patch introduces a couple of optimizations that target metrics and Rocksdb:
- PersistedStreamingMap: Disable Synchronous Writes
- VersionLockedObject: Unnecessary Computation of Undo Records

Why should this be merged: Improves PersistedStreamingMap's performance

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
