### PR TITLE
Apply updates to a stream atomically during Snapshot Sync

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationRuntimeParameters.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationRuntimeParameters.java
@@ -43,6 +43,9 @@ public class LogReplicationRuntimeParameters extends RuntimeParameters {
     // Log Replication Channel Context
     private IChannelContext channelContext;
 
+    // Max write size(in bytes) for LR's runtime
+    private int maxWriteSize;
+
     public static LogReplicationRuntimeParametersBuilder builder() {
         return new LogReplicationRuntimeParametersBuilder();
     }
@@ -56,6 +59,7 @@ public class LogReplicationRuntimeParameters extends RuntimeParameters {
         private long topologyConfigId;
         private LogReplicationConfig replicationConfig;
         private IChannelContext channelContext;
+        private int maxWriteSize;
 
         private LogReplicationRuntimeParametersBuilder() {
         }
@@ -92,6 +96,11 @@ public class LogReplicationRuntimeParameters extends RuntimeParameters {
 
         public LogReplicationRuntimeParameters.LogReplicationRuntimeParametersBuilder channelContext(IChannelContext channelContext) {
             this.channelContext = channelContext;
+            return this;
+        }
+
+        public LogReplicationRuntimeParameters.LogReplicationRuntimeParametersBuilder maxWriteSize(int maxWriteSize) {
+            this.maxWriteSize = maxWriteSize;
             return this;
         }
 
@@ -249,6 +258,7 @@ public class LogReplicationRuntimeParameters extends RuntimeParameters {
             runtimeParameters.setPluginFilePath(pluginFilePath);
             runtimeParameters.setChannelContext(channelContext);
             runtimeParameters.setReplicationConfig(replicationConfig);
+            runtimeParameters.setMaxWriteSize(maxWriteSize);
             return runtimeParameters;
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -265,6 +265,15 @@ public class ServerContext implements AutoCloseable {
     }
 
     /**
+     * Get the max write size of a transaction for LR's runtime.
+     * @return max write size of a transaction
+     */
+    public int getMaxWriteSize() {
+        String val = getServerConfig(String.class, "--max-write-size");
+        return val == null ? Integer.MAX_VALUE : Integer.parseInt(val);
+    }
+
+    /**
      * Cleanup the DataStore files with names that are prefixes of the specified
      * fileName when so that the number of these files don't exceed the user-defined
      * retention limit. Cleanup is always done on files with lower epochs.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
@@ -49,6 +49,7 @@ public class CorfuInterClusterReplicationServer implements Runnable {
                     + "\tlog_replication_server (-l <path>|-m) [-nsN] [-a <address>|-q <interface-name>] "
                     + "[--snapshot-batch=<batch-size>] "
                     + "[--max-replication-data-message-size=<msg-size>] "
+                    + "[--max-write-size=<max-write-size>] "
                     + "[--lock-lease=<lease-duration>]"
                     + "[-c <ratio>] [-d <level>] [-p <seconds>] "
                     + "[--lrCacheSize=<cache-num-entries>]"
@@ -174,7 +175,9 @@ public class CorfuInterClusterReplicationServer implements Runnable {
                     + " --lrCacheSize=<cache-num-entries>"
                     + "              Cache max number of entries.\n                              "
                     + " --max-replication-data-message-size=<msg-size>                           "
-                    + "              The max size of replication data message in bytes.\n   "
+                    + "              Max size of replication data message in bytes. \n   "
+                    + " --max-write-size=<max-write-size>"
+                    + "              Max size of a write in a single corfu transaction.  Integer.MAX_VALUE by default\n "
                     + "                                                                          "
                     + " --lock-lease=<lease-duration>                                            "
                     + "              Lock lease duration in seconds\n                            "
@@ -293,7 +296,6 @@ public class CorfuInterClusterReplicationServer implements Runnable {
             // Address is specified by the user.
             opts.put("--bind-to-all-interfaces", false);
         }
-
         return new ServerContext(opts);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -376,6 +376,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                     // This runtime is used for the LockStore, Metadata Manager and Log Entry Sync, which don't rely
                     // heavily on the cache (hence can be smaller)
                     .maxCacheEntries(serverContext.getLogReplicationCacheMaxSize()/2)
+                    .maxWriteSize(serverContext.getMaxWriteSize())
                     .build())
                     .parseConfigurationString(localCorfuEndpoint).connect();
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -136,6 +136,7 @@ public class CorfuReplicationManager {
                             .ksPasswordFile(corfuRuntime.getParameters().getKsPasswordFile())
                             .trustStore(corfuRuntime.getParameters().getTrustStore())
                             .tsPasswordFile(corfuRuntime.getParameters().getTsPasswordFile())
+                            .maxWriteSize(corfuRuntime.getParameters().getMaxWriteSize())
                             .build();
                     CorfuLogReplicationRuntime replicationRuntime = new CorfuLogReplicationRuntime(parameters,
                             metadataManager, replicationConfigManager);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -88,6 +88,7 @@ public class LogReplicationSourceManager {
                 .systemDownHandler(params.getSystemDownHandler())
                 .tlsEnabled(params.isTlsEnabled())
                 .cacheDisabled(true)
+                .maxWriteSize(params.getMaxWriteSize())
                 .build());
         runtime.parseConfigurationString(params.getLocalCorfuEndpoint()).connect();
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -64,7 +64,9 @@ public class LogReplicationMetadataManager {
 
     private final String metadataTableName;
 
+    @Getter
     private final CorfuRuntime runtime;
+
     private final String localClusterId;
 
     private final Table<ReplicationStatusKey, ReplicationStatusVal, Message> replicationStatusTable;

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -332,6 +332,17 @@ public class AbstractIT extends AbstractCorfuTest {
                 .runServer();
     }
 
+    public Process runReplicationServerCustomMaxWriteSize(int port,
+        String pluginConfigFilePath, int maxWriteSize) throws IOException {
+        return new CorfuReplicationServerRunner()
+            .setHost(DEFAULT_HOST)
+            .setPort(port)
+            .setPluginConfigFilePath(pluginConfigFilePath)
+            .setMsg_size(MSG_SIZE)
+            .setMaxWriteSize(maxWriteSize)
+            .runServer();
+    }
+
     public Process runDefaultServer() throws IOException {
         return new CorfuServerRunner()
                 .setHost(DEFAULT_HOST)
@@ -548,6 +559,7 @@ public class AbstractIT extends AbstractCorfuTest {
         private String logPath = null;
         private int msg_size = 0;
         private Integer lockLeaseDuration;
+        private int maxWriteSize = 0;
 
         /**
          * Create a command line string according to the properties set for a Corfu Server
@@ -594,6 +606,10 @@ public class AbstractIT extends AbstractCorfuTest {
 
             if (lockLeaseDuration != null) {
                 command.append(" --lock-lease=").append(lockLeaseDuration);
+            }
+
+            if (maxWriteSize != 0) {
+                command.append(" --max-write-size=").append(maxWriteSize);
             }
 
             command.append(" -d ").append(logLevel).append(" ")

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
@@ -1,0 +1,328 @@
+package org.corfudb.integration;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.proto.Sample;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TableSchema;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.test.SampleSchema;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test the behavior of transaction batching on the Sink.
+ * During snapshot sync, all entries to be applied are grouped in a single
+ * transaction and applied atomically.  However, if the size of
+ * updates to apply increases the runtime's maxWriteSize threshold, they are
+ * applied in multiple transactions in chunks.
+ *
+ * This suite tests this behavior and verifies that snapshot writes on the Sink
+ * contain multiple(possibly all) updates in a single transaction.
+ */
+@Slf4j
+public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
+
+    private Map<String, Table<Sample.StringKey, SampleSchema.ValueFieldTagOne,
+        Sample.Metadata>> mapNameToMapActive = new HashMap<>();
+
+    private Map<String, Table<Sample.StringKey, SampleSchema.ValueFieldTagOne,
+        Sample.Metadata>> mapNameToMapStandby = new HashMap<>();
+
+    private static final int NUM_ENTRIES_PER_TABLE = 20;
+    private static final int MAX_WRITE_SIZE = 7000;
+
+    /**
+     * With the max write size of MAX_WRITE_SIZE, it was empirically
+     * determined that 20 entries in a table had a serialized size of 5.5K
+     * approx.  Hence, a snapshot sync with this much data will be applied in
+     * a single transaction.
+     * @throws Exception
+     */
+    @Test
+    public void testAtomicSnapshotSyncWithoutChunking() throws Exception {
+        testTxChunking(NUM_ENTRIES_PER_TABLE, 1);
+    }
+
+    /**
+     * With the max write size of SEVEN_THOUSAND, it was empirically
+     * determined that 20 entries in a table had a serialized size of 5.5K
+     * approx.  Hence, a snapshot sync with twice the data(40 entries) will be
+     * applied in 2 transactions.
+     * @throws Exception
+     */
+    @Test
+    public void testSnapshotSyncWithChunking() throws Exception {
+        testTxChunking(2*NUM_ENTRIES_PER_TABLE, 2);
+    }
+
+    private void testTxChunking(int numEntriesToWrite,
+                                int expectedStreamingUpdatesPerTable) throws Exception {
+        log.debug("Setup Source and Sink Corfu's");
+        setupActiveAndStandbyCorfu();
+
+        log.debug("Open map on Source and Sink");
+        openMaps(2, false);
+
+        // The max size of a payload in a transaction.
+        int maxWriteSize = MAX_WRITE_SIZE;
+
+        log.debug("Write data to Source CorfuDB before LR is started ...");
+        writeOnSender(0, numEntriesToWrite);
+
+        log.debug("Verify data exists on the Source and none on the Sink");
+        // Confirm data does exist on Active Cluster
+        verifyDataOnSender(numEntriesToWrite);
+
+        // Confirm data does not exist on Standby Cluster
+        verifyDataOnReceiver(0);
+
+        // Subscribe to replication status table on Sink (to be sure data
+        // change on status are captured)
+        int totalStandbyStatusUpdates = 2;
+        corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+            LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
+            LogReplicationMetadata.ReplicationStatusKey.class,
+            LogReplicationMetadata.ReplicationStatusVal.class,
+            null,
+            TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+
+        CountDownLatch statusUpdateLatch = new CountDownLatch(totalStandbyStatusUpdates);
+        ReplicationStatusListener standbyListener =
+            new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+            LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
+
+        // Calculate the expected total number of streaming updates across all
+        // tables
+        int totalStreamingUpdates =
+            expectedStreamingUpdatesPerTable * mapNameToMapStandby.size();
+
+        CountDownLatch streamingUpdatesLatch =
+            new CountDownLatch(totalStreamingUpdates);
+        StreamingUpdateListener streamingUpdateListener =
+            new StreamingUpdateListener(streamingUpdatesLatch);
+        corfuStoreStandby.subscribeListener(streamingUpdateListener,
+            DefaultLogReplicationConfigAdapter.NAMESPACE,
+            DefaultLogReplicationConfigAdapter.TAG_ONE);
+
+        startLogReplicatorServersWithCustomMaxWriteSize(maxWriteSize);
+
+        log.debug("Wait for snapshot sync to finish");
+        statusUpdateLatch.await();
+        streamingUpdatesLatch.await();
+
+        // Verify that updates were received for all replicated tables with data
+        Assert.assertEquals(mapNameToMapStandby.size(),
+            streamingUpdateListener.getTableNameToUpdatesMap().size());
+
+        mapNameToMapStandby.keySet().forEach(key ->
+            Assert.assertTrue(streamingUpdateListener.getTableNameToUpdatesMap()
+                .containsKey(key)));
+
+
+        // Verify that the right number of entries are contained in the
+        // streaming update.  Also verify that the first entry is a 'clear'
+        // followed by all updates.
+        for (List<List<CorfuStreamEntry<Sample.StringKey,
+            SampleSchema.ValueFieldTagOne, Sample.Metadata>>> outerList :
+            streamingUpdateListener.getTableNameToUpdatesMap().values()) {
+
+            Assert.assertEquals(expectedStreamingUpdatesPerTable, outerList.size());
+
+            int totalEntriesReceived = 0;
+            List<CorfuStreamEntry<Sample.StringKey,
+                SampleSchema.ValueFieldTagOne, Sample.Metadata>> updateEntries =
+                new ArrayList<>();
+
+            for (int i=0; i<outerList.size(); i++) {
+                // If the snapshot apply was chunked, the first entry in the
+                // first chunk must be a 'clear'
+                if (i == 0) {
+                    Assert.assertEquals(CorfuStreamEntry.OperationType.CLEAR,
+                        outerList.get(i).get(0).getOperation());
+                    updateEntries.addAll(outerList.get(i).subList(1,
+                        outerList.get(i).size()));
+                } else {
+                  updateEntries.addAll(outerList.get(i));
+                }
+                totalEntriesReceived += outerList.get(i).size();
+            }
+            // The total entries received must be equal to (numUpdates + clear)
+            Assert.assertEquals(numEntriesToWrite+1, totalEntriesReceived);
+
+            updateEntries.forEach(entry -> Assert.assertEquals(
+                CorfuStreamEntry.OperationType.UPDATE, entry.getOperation()));
+        }
+
+        verifyDataOnReceiver(numEntriesToWrite);
+
+        corfuStoreStandby.unsubscribeListener(standbyListener);
+        corfuStoreStandby.unsubscribeListener(streamingUpdateListener);
+        shutDown();
+    }
+
+    @Override
+    public void openMaps(int mapCount, boolean diskBased) throws Exception {
+        mapNameToMapActive = new HashMap<>();
+        mapNameToMapStandby = new HashMap<>();
+
+        for (int i = 1; i <= mapCount; i++) {
+            String mapName = TABLE_PREFIX + i;
+
+            Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Sample.Metadata> mapActive =
+                corfuStoreActive.openTable(NAMESPACE, mapName,
+                    Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
+                    Sample.Metadata.class, TableOptions.fromProtoSchema(
+                        SampleSchema.ValueFieldTagOne.class));
+
+            Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Sample.Metadata> mapStandby =
+                corfuStoreStandby.openTable(NAMESPACE, mapName,
+                    Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
+                    Sample.Metadata.class, TableOptions.fromProtoSchema(
+                        SampleSchema.ValueFieldTagOne.class));
+
+            mapNameToMapActive.put(mapName, mapActive);
+            mapNameToMapStandby.put(mapName, mapStandby);
+
+            assertThat(mapActive.count()).isEqualTo(0);
+            assertThat(mapStandby.count()).isEqualTo(0);
+        }
+    }
+
+    private void writeOnSender(int startIndex, int totalEntries) {
+        int maxIndex = totalEntries + startIndex;
+
+        for(Map.Entry<String, Table<Sample.StringKey,
+            SampleSchema.ValueFieldTagOne, Sample.Metadata>> entry :
+            mapNameToMapActive.entrySet()) {
+
+            Table<Sample.StringKey, SampleSchema.ValueFieldTagOne,
+                Sample.Metadata> map = entry.getValue();
+
+            for (int i = startIndex; i < maxIndex; i++) {
+                Sample.StringKey stringKey = Sample.StringKey.newBuilder()
+                    .setKey(String.valueOf(i)).build();
+                SampleSchema.ValueFieldTagOne value = SampleSchema
+                    .ValueFieldTagOne.newBuilder()
+                    .setPayload(String.valueOf(i)).build();
+                Sample.Metadata metadata = Sample.Metadata.newBuilder()
+                    .setMetadata("Metadata_" + i).build();
+                try (TxnContext txn = corfuStoreActive.txn(NAMESPACE)) {
+                    txn.putRecord(map, stringKey, value, metadata);
+                    txn.commit();
+                }
+            }
+        }
+    }
+
+    private void verifyDataOnSender(int expectedSize) {
+        for(Map.Entry<String, Table<Sample.StringKey,
+            SampleSchema.ValueFieldTagOne, Sample.Metadata>> entry :
+            mapNameToMapActive.entrySet()) {
+            Table<Sample.StringKey, SampleSchema.ValueFieldTagOne,
+                Sample.Metadata> map = entry.getValue();
+            Assert.assertEquals(expectedSize, map.count());
+        }
+    }
+
+    private void verifyDataOnReceiver(long expectedSize) {
+        for(Map.Entry<String, Table<Sample.StringKey,
+            SampleSchema.ValueFieldTagOne, Sample.Metadata>> entry :
+            mapNameToMapStandby.entrySet()) {
+
+            Table<Sample.StringKey, SampleSchema.ValueFieldTagOne,
+                Sample.Metadata> map = entry.getValue();
+            Assert.assertEquals(expectedSize, map.entryStream().count());
+        }
+    }
+
+    private void startLogReplicatorServersWithCustomMaxWriteSize(
+        int maxWriteSize) throws Exception {
+        activeReplicationServer =
+            runReplicationServerCustomMaxWriteSize(activeReplicationServerPort,
+                pluginConfigFilePath, maxWriteSize);
+
+        // Start Log Replication Server on Sink Site
+        standbyReplicationServer =
+            runReplicationServerCustomMaxWriteSize(standbyReplicationServerPort,
+                pluginConfigFilePath, maxWriteSize);
+    }
+
+    private void shutDown() {
+        executorService.shutdownNow();
+
+        if (activeCorfu != null) {
+            activeCorfu.destroy();
+        }
+
+        if (standbyCorfu != null) {
+            standbyCorfu.destroy();
+        }
+
+        if (activeReplicationServer != null) {
+            activeReplicationServer.destroy();
+        }
+
+        if (standbyReplicationServer != null) {
+            standbyReplicationServer.destroy();
+        }
+    }
+
+    private class StreamingUpdateListener implements StreamListener {
+        private CountDownLatch countdownLatch;
+
+        @Getter
+        private Map<String,
+            List<List<CorfuStreamEntry<Sample.StringKey,
+                SampleSchema.ValueFieldTagOne, Sample.Metadata>>>>
+            tableNameToUpdatesMap = new HashMap<>();
+
+        StreamingUpdateListener(CountDownLatch latch) {
+            countdownLatch = latch;
+        }
+
+        @Override
+        public void onNext(CorfuStreamEntries results) {
+            for (Map.Entry<TableSchema, List<CorfuStreamEntry>> entry :
+                results.getEntries().entrySet()) {
+
+                List<CorfuStreamEntry<Sample.StringKey,
+                    SampleSchema.ValueFieldTagOne, Sample.Metadata>> tableEntries =
+                    new ArrayList<>();
+                entry.getValue().forEach(tableEntry -> tableEntries.add(tableEntry));
+
+                List<List<CorfuStreamEntry<Sample.StringKey,
+                    SampleSchema.ValueFieldTagOne, Sample.Metadata>>>
+                    existingEntries =
+                    tableNameToUpdatesMap.getOrDefault(
+                        entry.getKey().getTableName(), new ArrayList<>());
+
+                existingEntries.add(tableEntries);
+                tableNameToUpdatesMap.putIfAbsent(entry.getKey().getTableName(),
+                    existingEntries);
+            }
+            countdownLatch.countDown();
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            log.error("Error in stream listener", throwable);
+        }
+    }
+}


### PR DESCRIPTION
## Overview
Currently, snapshot sync updates received for a stream are not applied atomically on the Sink.  First, a stream is cleared.  In a subsequent transaction, the updates(SMR entries) are applied one-by-one, each in a separate transaction.

This increases the window during which applications observe inconsistent data.

This window can be minimized by atomically clearing + applying all(if possible) updates.  If the size of the transaction exceeds CorfuRuntime's MAX_WRITE_SIZE, the updates can be applied in batches.

Why should this be merged:  Reduces the time for which data is inconsistent during snapshot sync.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
