### PR TITLE
[Cherrypick to corfu-0.3.2.2] Make Restore non-transactional (#3249)

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -285,6 +285,11 @@ public class CorfuRuntime {
         int checkpointBatchSize = 50;
 
         /*
+         * The maximum number of SMR entries that will be grouped in a MultiSMREntry during Restore
+         */
+        int restoreBatchSize = 50;
+
+        /*
          * Stream Batch Size: number of addresses to fetch in advance when stream address discovery mechanism
          * relies on address maps instead of follow backpointers, i.e., followBackpointersEnabled = false;
          */
@@ -406,6 +411,7 @@ public class CorfuRuntime {
             private int trimRetry = 2;
             private int checkpointRetries = 5;
             private int checkpointBatchSize = 50;
+            private int restoreBatchSize = 50;
             private int streamBatchSize = 10;
             private int checkpointReadBatchSize = 5;
             private Duration runtimeGCPeriod = Duration.ofMinutes(20);
@@ -642,6 +648,11 @@ public class CorfuRuntime {
                 return this;
             }
 
+            public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder restoreBatchSize(int restoreBatchSize) {
+                this.restoreBatchSize = restoreBatchSize;
+                return this;
+            }
+
             public CorfuRuntimeParameters.CorfuRuntimeParametersBuilder streamBatchSize(int streamBatchSize) {
                 this.streamBatchSize = streamBatchSize;
                 return this;
@@ -739,6 +750,7 @@ public class CorfuRuntime {
                 corfuRuntimeParameters.setTrimRetry(trimRetry);
                 corfuRuntimeParameters.setCheckpointRetries(checkpointRetries);
                 corfuRuntimeParameters.setCheckpointBatchSize(checkpointBatchSize);
+                corfuRuntimeParameters.setRestoreBatchSize(restoreBatchSize);
                 corfuRuntimeParameters.setStreamBatchSize(streamBatchSize);
                 corfuRuntimeParameters.setCheckpointReadBatchSize(checkpointReadBatchSize);
                 corfuRuntimeParameters.setRuntimeGCPeriod(runtimeGCPeriod);


### PR DESCRIPTION
Restoring tables using transactions could cause high memory
usage after restore. Today Restore is performed while all client
JVMs are shut down. This means restore could never encounter conflicts
so it can be made non-transactional. After this change, the backed-up
Corfu and restored Corfu have exact same stream views and there will
be no more large transactions after restore.


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
