### PR TITLE
Collect PersistedMap timer only at every nth call to get and put

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MicroMeterUtils.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MicroMeterUtils.java
@@ -130,6 +130,13 @@ public class MicroMeterUtils {
         return MeterRegistryProvider.getInstance().map(Timer::start);
     }
 
+    public static Optional<Timer.Sample> startTimer(Optional<Counter> counter, int sampleAt) {
+        if (counter.isPresent() && counter.get().count() % sampleAt == 0) {
+            return MeterRegistryProvider.getInstance().map(Timer::start);
+        }
+        return Optional.empty();
+    }
+
     public static void measure(double measuredValue, String name, String... tags) {
         Optional<DistributionSummary> summary = createOrGetDistSummary(name, tags);
         summary.ifPresent(s -> s.record(measuredValue));


### PR DESCRIPTION
## Overview

Description:
Collecting the timer at every nth call reduces the number of System.currentTimeMillis().

Why should this be merged:
Since get() and put() methods will be called multiple times for getKeySet() operation, having System.currentTimeMillis(), reduces performance in some systems.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
