### PR TITLE
freeTableData() api to only reset CorfuTable & GC objects

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -148,8 +148,11 @@ public class CorfuStore {
     }
 
     /**
-     * This api is to optimize the use of memory by removing a table from the object cache
-     * so that its entries can be garbage collected.
+     * This api is to optimize the use of memory by only allowing
+     * the underlying corfu table's objects to be garbage collected.
+     * The metadata associated with the table (such as schema) are not freed.
+     * The effects of this function are fully reversible as the
+     * table will be re-synced on the next access.
      * Note that the table entries in the AddressSpaceView's cache may still linger around until
      * timeout or eviction as this method only removes references from ObjectViewCache
      *
@@ -157,8 +160,8 @@ public class CorfuStore {
      * @param tableName name of table
      * @throws java.util.NoSuchElementException thrown if table was not found.
      */
-    public void closeTable(String namespace, String tableName) {
-        runtime.getTableRegistry().closeTable(namespace, tableName);
+    public void freeTableData(String namespace, String tableName) {
+        runtime.getTableRegistry().freeTableData(namespace, tableName);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreShim.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreShim.java
@@ -106,8 +106,8 @@ public class CorfuStoreShim {
      * @param tableName name of the table
      * @throws java.util.NoSuchElementException if the table does not exist.
      */
-    public void closeTable(String namespace, String tableName) {
-        corfuStore.closeTable(namespace, tableName);
+    public void freeTableData(String namespace, String tableName) {
+        corfuStore.freeTableData(namespace, tableName);
     }
 
     /**
@@ -161,6 +161,24 @@ public class CorfuStoreShim {
      */
     public long getHighestSequence(@Nonnull String namespace, @Nonnull String tableName) {
         return corfuStore.getHighestSequence(namespace, tableName);
+    }
+
+    /**
+     * Subscribe to transaction updates on specific tables with the streamTag in the namespace.
+     * Objects returned will honor transactional boundaries.
+     * <p>
+     * This will subscribe to transaction updates starting from the latest state of the log.
+     * <p>
+     * Note: if memory is a consideration consider use the other version of subscribe that is
+     * able to specify the size of buffered transactions entries.
+     *
+     * @param streamListener   callback context
+     * @param namespace        the CorfuStore namespace to subscribe to
+     * @param streamTag        only updates of tables with the stream tag will be polled
+     */
+    public void subscribeListener(@Nonnull StreamListener streamListener, @Nonnull String namespace,
+                                  @Nonnull String streamTag) {
+        corfuStore.subscribeListener(streamListener, namespace, streamTag);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -573,24 +573,20 @@ public class TableRegistry {
     }
 
     /**
-     * Close a table that is already opened.
+     * Allow underlying objects of this table to be garbage collected
+     * while still retaining the metadata of the table.
      *
      * @param namespace Namespace of the table.
      * @param tableName Name of the table.
      * @throws NoSuchElementException - if the table does not exist.
      */
-    public void closeTable(String namespace, String tableName) {
+    public void freeTableData(String namespace, String tableName) {
         String fullyQualifiedTableName = getFullyQualifiedTableName(namespace, tableName);
         Table<Message, Message, Message> table = tableMap.get(fullyQualifiedTableName);
         if (table == null) {
-            throw new NoSuchElementException("closeTable: Did not find any table "+ fullyQualifiedTableName);
+            throw new NoSuchElementException("freeTableData: Did not find any table "+ fullyQualifiedTableName);
         }
-        tableMap.remove(fullyQualifiedTableName);
-        ObjectsView.ObjectID oid = new ObjectsView.ObjectID(table.getStreamUUID(), CorfuTable.class);
-        Object tableObject = runtime.getObjectsView().getObjectCache().remove(oid);
-        if (tableObject == null) {
-            throw new NoSuchElementException("closeTable: No object cache entry for "+ fullyQualifiedTableName);
-        }
+        table.resetTableData(runtime, this.protobufSerializer);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
@@ -154,12 +154,14 @@ public class CorfuStoreShimTest extends AbstractViewTest {
     }
 
     /**
-     * Test that closeTable works and removes table from cache
+     * Test that freeTableData works and removes table from cache
+     * Also validates that the subscribeListener() does not throw any exceptions
+     * if called after freeTableData() is invoked.
      *
      * @throws Exception exception
      */
     @Test
-    public void checkCloseTable() throws Exception {
+    public void checkFreeTableData() throws Exception {
 
         // Get a Corfu Runtime instance.
         CorfuRuntime corfuRuntime = getTestRuntime();
@@ -174,43 +176,11 @@ public class CorfuStoreShimTest extends AbstractViewTest {
 
         // Create & Register the table.
         // This is required to initialize the table for the current corfu client.
-        Table<UuidMsg, ManagedMetadata, ManagedMetadata> table = shimStore.openTable(
+        Table<UuidMsg, ExampleSchemas.ClusterUuidMsg, ManagedMetadata> table = shimStore.openTable(
                 someNamespace,
                 tableName,
                 UuidMsg.class,
-                ManagedMetadata.class,
-                ManagedMetadata.class,
-                // TableOptions includes option to choose - Memory/Disk based corfu table.
-                TableOptions.builder().build());
-
-        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LARGE; i++) {
-            UUID uuid1 = UUID.nameUUIDFromBytes("1".getBytes());
-            UuidMsg key = UuidMsg.newBuilder().setMsb(i)
-                    .build();
-            ManagedMetadata user_1 = ManagedMetadata.newBuilder().setCreateUser("user_1").build();
-
-            ManagedTxnContext txn = shimStore.tx(someNamespace);
-            txn.putRecord(tableName, key,
-                    ManagedMetadata.newBuilder().setCreateUser("abc").build(),
-                    user_1);
-            txn.commit();
-        }
-
-        assertThatThrownBy(() -> shimStore.closeTable("non", "existent"))
-                .isExactlyInstanceOf(NoSuchElementException.class);
-
-        shimStore.closeTable(someNamespace, tableName);
-
-        // Validate externally that the entry vanishes from corfu's object cache
-        ObjectsView.ObjectID oid = new ObjectsView.ObjectID(table.getStreamUUID(), CorfuTable.class);
-        assertThat(corfuRuntime.getObjectsView().getObjectCache().containsKey(oid)).isFalse();
-
-        // Now re-open a table after it is closed to check that it works..
-        table = shimStore.openTable(
-                someNamespace,
-                tableName,
-                UuidMsg.class,
-                ManagedMetadata.class,
+                ExampleSchemas.ClusterUuidMsg.class,
                 ManagedMetadata.class,
                 // TableOptions includes option to choose - Memory/Disk based corfu table.
                 TableOptions.builder().build());
@@ -223,15 +193,47 @@ public class CorfuStoreShimTest extends AbstractViewTest {
 
             ManagedTxnContext txn = shimStore.tx(someNamespace);
             txn.putRecord(table, key,
-                    ManagedMetadata.newBuilder().setCreateUser("abc").build(),
+                    ExampleSchemas.ClusterUuidMsg.newBuilder().setMsb(i).build(),
                     user_1);
+            txn.commit();
+        }
+
+        assertThatThrownBy(() -> shimStore.freeTableData("non", "existent"))
+                .isExactlyInstanceOf(NoSuchElementException.class);
+
+        // Release all the cached objects from the insertions above
+        shimStore.freeTableData(someNamespace, tableName);
+
+        class EmptyStreamListener implements StreamListener {
+            @Override
+            public void onNext(CorfuStreamEntries results) {
+            }
+            @Override
+            public void onError(Throwable throwable) {
+            }
+        }
+        EmptyStreamListener emptyStreamListener = new EmptyStreamListener();
+
+        // verify that subscription does not throw any exceptions because the table was closed
+        shimStore.subscribeListener(emptyStreamListener, someNamespace, "cluster_manager_test");
+
+        // Now simple access the table after free to validate that it works
+        for (int i = 0; i < PARAMETERS.NUM_ITERATIONS_LARGE; i++) {
+            UUID uuid1 = UUID.nameUUIDFromBytes("1".getBytes());
+            UuidMsg key = UuidMsg.newBuilder().setMsb(i)
+                    .build();
+            ManagedTxnContext txn = shimStore.tx(someNamespace);
+            CorfuStoreEntry<UuidMsg, ExampleSchemas.ClusterUuidMsg, ManagedMetadata> record = txn.getRecord(table, key);
+            assertThat(record.getPayload()).isNotNull();
+            assertThat(record.getPayload().getMsb()).isEqualTo(i);
             txn.commit();
         }
 
         // By some future bug should the table disappear from the object cache ensure that
         // the method still fails gracefully with a NoSuchElementException
+        ObjectsView.ObjectID oid = new ObjectsView.ObjectID(table.getStreamUUID(), CorfuTable.class);
         corfuRuntime.getObjectsView().getObjectCache().remove(oid);
-        assertThatThrownBy(() -> shimStore.closeTable(someNamespace, tableName))
+        assertThatThrownBy(() -> shimStore.freeTableData(someNamespace, tableName))
                 .isExactlyInstanceOf(NoSuchElementException.class);
     }
 


### PR DESCRIPTION
Remove closeTable() since removing table metadata
from TableRegistry creates problems for stream
re-subscription since that layer needs the table metadata
So instead modify the api to do a freeTableData()
instead which only removes the Table's **_cached_** records
while retaining all the Table metadata.
Table's cache will get repopulated on the first access
Test case to validate that re-subscription works

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #3258 


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
