### PR TITLE
PersistedStreamingMap: Fix put API Bug

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointTest.java
@@ -710,7 +710,8 @@ public class CheckpointTest extends AbstractObjectTest {
 
         final int numKeys = 303;
         for (int x = 0; x < numKeys; x++) {
-            diskBackedMap.put(String.valueOf(x), "payload" + x);
+            String oldValue = diskBackedMap.put(String.valueOf(x), "payload" + x);
+            assertThat(oldValue).isNull();
         }
 
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
@@ -736,5 +737,10 @@ public class CheckpointTest extends AbstractObjectTest {
 
         assertThat(Iterators.elementsEqual(newDiskBackedMap.entryStream().iterator(),
                 diskBackedMap.entryStream().iterator())).isTrue();
+
+        // Over write a key and verify that the previous value can be retrieved
+        String oldValue = diskBackedMap.put(String.valueOf(0), "payload0Prime");
+        assertThat(oldValue).isEqualTo("payload0");
+        assertThat(diskBackedMap.get(String.valueOf(0))).isEqualTo("payload0Prime");
     }
 }


### PR DESCRIPTION
## Overview

When PersistedStreamingMap::put is called, if the key is being
overwritten, then the old value should be returned and not
the new one. If it is not being overwritten, then null is
returned.

Why should this be merged: Improves - for an approximation API - correctness. 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
