### PR TITLE
Update jackson-databind to 2.13.3 (#3261)

### DIFF
--- a/cmdlets/pom.xml
+++ b/cmdlets/pom.xml
@@ -93,12 +93,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.12.6</version>
+            <version>2.13.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-smile</artifactId>
-            <version>2.12.6</version>
+            <version>2.13.3</version>
         </dependency>
     </dependencies>
 

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -36,12 +36,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.12.6</version>
+            <version>2.13.3</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
-            <version>2.12.6</version>
+            <version>2.13.3</version>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>


### PR DESCRIPTION
Addresses CVE-2020-36518

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
