### PR TITLE
Update registry table when CorfuRecord changed

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
@@ -32,6 +32,7 @@ import org.corfudb.test.SampleSchema;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -1203,5 +1204,108 @@ public class CorfuStoreShimTest extends AbstractViewTest {
             CorfuStoreMetadata.Timestamp ts = txnContext.commit();
             assertThat(ts.getSequence()).isPositive();
         }
+    }
+
+    /**
+     * This test verifies that registry table will be updated when a table is opened
+     * again with different schema options.
+     */
+    @Test
+    public void testRegistryTableUpdateOnRecordChange() throws Exception {
+        // Get a Corfu Runtime instance.
+        CorfuRuntime corfuRuntime = getDefaultRuntime();
+
+        // Creating Corfu Store using a connected corfu client.
+        CorfuStoreShim shimStore = new CorfuStoreShim(corfuRuntime);
+
+        // Define a namespace for the table.
+        final String someNamespace = "some-namespace";
+        // Define table name.
+        final String tableName = "EventInfo";
+
+        // Create & Register the table.
+        // This is required to initialize the table for the current corfu client.
+        shimStore.openTable(
+                someNamespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.SampleTableAMsg.class,
+                null,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        CorfuStoreMetadata.TableName tableNameKey =
+                CorfuStoreMetadata.TableName.newBuilder()
+                        .setNamespace(someNamespace)
+                        .setTableName(tableName)
+                        .build();
+        CorfuRecord<CorfuStoreMetadata.TableDescriptors, CorfuStoreMetadata.TableMetadata> record
+                = corfuRuntime.getTableRegistry().getRegistryTable().get(tableNameKey);
+        CorfuOptions.SchemaOptions options = record.getMetadata().getTableOptions();
+
+        assertThat(options.getIsFederated()).isTrue();
+        assertThat(options.getRequiresBackupSupport()).isTrue();
+        assertThat(options.getStreamTag(0)).isEqualTo("sample_streamer_1");
+        assertThat(options.getStreamTag(1)).isEqualTo("sample_streamer_2");
+
+        // Open the same table again with different schema options, verify that registry table
+        // gets updated
+        shimStore.openTable(
+                someNamespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.SampleTableBMsg.class,
+                null,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        record = corfuRuntime.getTableRegistry().getRegistryTable().get(tableNameKey);
+        options = record.getMetadata().getTableOptions();
+
+        assertThat(options.getIsFederated()).isTrue();
+        assertThat(options.getRequiresBackupSupport()).isFalse();
+        assertThat(options.getStreamTag(0)).isEqualTo("sample_streamer_2");
+        assertThat(options.getStreamTag(1)).isEqualTo("sample_streamer_3");
+
+        // Open the same table again with different schema options, verify that registry table
+        // gets updated
+        shimStore.openTable(
+                someNamespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.SampleTableBMsg.class,
+                null,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        record = corfuRuntime.getTableRegistry().getRegistryTable().get(tableNameKey);
+        options = record.getMetadata().getTableOptions();
+
+        assertThat(options.getIsFederated()).isTrue();
+        assertThat(options.getRequiresBackupSupport()).isFalse();
+        assertThat(options.getStreamTagCount()).isEqualTo(2);
+        assertThat(options.getStreamTag(0)).isEqualTo("sample_streamer_2");
+        assertThat(options.getStreamTag(1)).isEqualTo("sample_streamer_3");
+
+        // Open the same table again with different schema options, verify that registry table
+        // gets updated
+        shimStore.openTable(
+                someNamespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.SampleTableEMsg.class,
+                null,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        record = corfuRuntime.getTableRegistry().getRegistryTable().get(tableNameKey);
+        options = record.getMetadata().getTableOptions();
+
+        assertThat(options.getIsFederated()).isTrue();
+        assertThat(options.getRequiresBackupSupport()).isFalse();
+        assertThat(options.getStreamTagCount()).isEqualTo(1);
+        assertThat(options.getStreamTag(0)).isEqualTo("sample_streamer_4");
+        assertThat(options.getSecondaryKeyCount()).isEqualTo(1);
+        assertThat(options.getSecondaryKey(0).getIndexPath()).isEqualTo("event_time");
     }
 }

--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -97,6 +97,16 @@ message SampleTableDMsg {
     optional string payload = 1;
 }
 
+message SampleTableEMsg {
+    option (org.corfudb.runtime.table_schema).stream_tag = "sample_streamer_4";
+    option (org.corfudb.runtime.table_schema).requires_backup_support = false;
+    option (org.corfudb.runtime.table_schema).is_federated = true;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "event_time"};
+
+    optional string payload = 1;
+    optional int64 event_time = 2;
+}
+
 extend google.protobuf.MessageOptions {
     optional ManagedResourceOptionsMsg mgoptions = 54312;
 }


### PR DESCRIPTION
Registry table needs to be updated when CorfuRecord for a table is changed, even if there is already an entry for that table. This change is for rolling upgrade and dynamic streams consideration on LR.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
