### PR TITLE
CorfuStreamEntry extends CorfuStoreEntry for brevity

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStreamEntry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStreamEntry.java
@@ -1,7 +1,6 @@
 package org.corfudb.runtime.collections;
 
 import com.google.protobuf.Message;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.SMREntry;
@@ -19,25 +18,31 @@ import javax.annotation.Nonnull;
  * @param <M> - type of the protobuf metadata schema defined by table creation.
  */
 @Slf4j
-@EqualsAndHashCode
-public class CorfuStreamEntry<K extends Message, V extends Message, M extends Message> {
-    /**
-     * Key of the UFO stream entry
-     */
-    @Getter
-    private final K key;
+public class CorfuStreamEntry<K extends Message, V extends Message, M extends Message> extends
+        CorfuStoreEntry<K, V, M> {
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
 
-    /**
-     * Value of the UFO stream entry
-     */
-    @Getter
-    private final V payload;
+        CorfuStreamEntry<K, V, M> that = (CorfuStreamEntry<K, V, M>) o;
 
-    /**
-     * Metadata (ManagedResource) of the UFO stream entry
-     */
-    @Getter
-    private final M metadata;
+        return getOperation() == that.getOperation();
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + getOperation().hashCode();
+        return result;
+    }
 
     /**
      * Defines the type of the operation in this stream
@@ -52,9 +57,7 @@ public class CorfuStreamEntry<K extends Message, V extends Message, M extends Me
     private final OperationType operation;
 
     public CorfuStreamEntry(K key, V payload, M metadata, OperationType operation) {
-        this.key = key;
-        this.payload = payload;
-        this.metadata = metadata;
+        super(key, payload, metadata);
         this.operation = operation;
     }
 


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

This is a pre-requisite for some external projects which need to cast the stream notifications back into a common object.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
