### PR TITLE
Modify sampling of PersistedStreamingMap metrics using PRNG

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/MicroMeterUtils.java
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/MicroMeterUtils.java
@@ -133,12 +133,11 @@ public class MicroMeterUtils {
     /**
      * Start sampling conditionally, based on the given rate
      *
-     * @param counter  contains the total count
-     * @param sampleAt rate at which sampling should be done
-     * @return
+     * @param shouldSample start timer if this value is true
+     * @return a sample to be used with the timer
      */
-    public static Optional<Timer.Sample> startTimer(Optional<Counter> counter, int sampleAt) {
-        if (counter.isPresent() && counter.get().count() % sampleAt == 0) {
+    public static Optional<Timer.Sample> startTimer(boolean shouldSample) {
+        if (shouldSample) {
             return MeterRegistryProvider.getInstance().map(Timer::start);
         }
         return Optional.empty();

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
@@ -1,10 +1,8 @@
 package org.corfudb.runtime.collections;
 
-import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import io.netty.util.internal.ThreadLocalRandom;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
@@ -27,6 +25,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -44,11 +43,8 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
 
     public static final String DISK_BACKED = "diskBacked";
     public static final String TRUE = "true";
-    public static final int SAMPLE_SPACE = 1000;
-
-    private final ThreadLocalRandom randomNumberGenerator;
-    private final Optional<Counter> getCounter;
-    private final Optional<Counter> putCounter;
+    public static final int BOUND = 100;
+    public static final int SAMPLING_RATE = 40;
 
     private final WriteOptions writeOptions = new WriteOptions()
             .setDisableWAL(true)
@@ -107,9 +103,6 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
         }
         this.serializer = serializer;
         this.corfuRuntime = corfuRuntime;
-        getCounter = MicroMeterUtils.counter("persisted_map.get.counter");
-        putCounter = MicroMeterUtils.counter("persisted_map.put.counter");
-        randomNumberGenerator = ThreadLocalRandom.current();
     }
 
     /**
@@ -161,8 +154,8 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
      */
     @Override
     public V get(@NonNull Object key) {
-        getCounter.ifPresent(Counter::increment);
-        Optional<Timer.Sample> recordSample = MicroMeterUtils.startTimer(getCounter, randomNumberGenerator.nextInt(SAMPLE_SPACE));
+        Optional<Timer.Sample> recordSample = MicroMeterUtils.startTimer(
+                SAMPLING_RATE > ThreadLocalRandom.current().nextInt(BOUND));
         final ByteBuf keyPayload = Unpooled.buffer();
         serializer.serialize(key, keyPayload);
 
@@ -186,8 +179,8 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
      */
     @Override
     public V put(@NonNull K key, @NonNull V value) {
-        putCounter.ifPresent(Counter::increment);
-        Optional<Timer.Sample> recordSample = MicroMeterUtils.startTimer(putCounter, randomNumberGenerator.nextInt(SAMPLE_SPACE));
+        Optional<Timer.Sample> recordSample = MicroMeterUtils.startTimer(
+                SAMPLING_RATE > ThreadLocalRandom.current().nextInt(BOUND));
         final ByteBuf keyPayload = Unpooled.buffer();
         final ByteBuf valuePayload = Unpooled.buffer();
         serializer.serialize(key, keyPayload);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistedStreamingMap.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Timer;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.util.internal.ThreadLocalRandom;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
@@ -43,8 +44,9 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
 
     public static final String DISK_BACKED = "diskBacked";
     public static final String TRUE = "true";
-    public static final int SAMPLING_RATE = 1000;
+    public static final int SAMPLE_SPACE = 1000;
 
+    private final ThreadLocalRandom randomNumberGenerator;
     private final Optional<Counter> getCounter;
     private final Optional<Counter> putCounter;
 
@@ -107,6 +109,7 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
         this.corfuRuntime = corfuRuntime;
         getCounter = MicroMeterUtils.counter("persisted_map.get.counter");
         putCounter = MicroMeterUtils.counter("persisted_map.put.counter");
+        randomNumberGenerator = ThreadLocalRandom.current();
     }
 
     /**
@@ -159,7 +162,7 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
     @Override
     public V get(@NonNull Object key) {
         getCounter.ifPresent(Counter::increment);
-        Optional<Timer.Sample> recordSample = MicroMeterUtils.startTimer(getCounter, SAMPLING_RATE);
+        Optional<Timer.Sample> recordSample = MicroMeterUtils.startTimer(getCounter, randomNumberGenerator.nextInt(SAMPLE_SPACE));
         final ByteBuf keyPayload = Unpooled.buffer();
         serializer.serialize(key, keyPayload);
 
@@ -184,7 +187,7 @@ public class PersistedStreamingMap<K, V> implements ContextAwareMap<K, V> {
     @Override
     public V put(@NonNull K key, @NonNull V value) {
         putCounter.ifPresent(Counter::increment);
-        Optional<Timer.Sample> recordSample = MicroMeterUtils.startTimer(putCounter, SAMPLING_RATE);
+        Optional<Timer.Sample> recordSample = MicroMeterUtils.startTimer(putCounter, randomNumberGenerator.nextInt(SAMPLE_SPACE));
         final ByteBuf keyPayload = Unpooled.buffer();
         final ByteBuf valuePayload = Unpooled.buffer();
         serializer.serialize(key, keyPayload);


### PR DESCRIPTION
To capture PersistedStreamingMap metrics in all extreme scenarios, such as RocksDB compaction
requires sampling with a PRNG.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
