### PR TITLE
CorfuStoreBrowser: Batch deletion capability

### DIFF
--- a/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreBrowserEditorIT.java
@@ -4,6 +4,8 @@ import com.google.protobuf.Any;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.UnknownFieldSet;
 
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Paths;
@@ -17,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.corfudb.browser.CorfuStoreBrowserEditor;
+import org.corfudb.browser.CorfuStoreBrowserEditorMain;
 import org.corfudb.protocols.wireprotocol.IMetadata;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
@@ -635,13 +638,83 @@ public class CorfuStoreBrowserEditorIT extends AbstractIT {
 
         Assert.assertEquals(expectedRecord, editedRecord);
 
+        final int batchSize = 10000;
         // Now test deleteRecord capability
-        assertThat(browser.deleteRecord(namespace, tableName, keyString)).isEqualTo(1);
+        assertThat(browser.deleteRecords(namespace, tableName, Arrays.asList(keyString), batchSize)).isEqualTo(1);
         // Try to edit the deleted key and verify it is a no-op
         Assert.assertNull(browser.editRecord(namespace, tableName, keyString,
             newValString));
         // Try to delete a deleted key and verify it is a no-op
-        assertThat(browser.deleteRecord(namespace, tableName, keyString)).isZero();
+        assertThat(browser.deleteRecords(namespace, tableName, Arrays.asList(keyString), batchSize)).isZero();
+        runtime.shutdown();
+    }
+
+    /**
+     * Put all the records to be deleted in a file and test the batched deletion capability
+     *
+     * @throws IOException
+     * @throws NoSuchMethodException
+     * @throws IllegalAccessException
+     * @throws InvocationTargetException
+     */
+    @Test
+    public void batchedDeletionTest() throws IOException, NoSuchMethodException,
+            IllegalAccessException, InvocationTargetException {
+        final String namespace = "namespace";
+        final String tableName = "table";
+        runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
+
+        // Start a Corfu runtime
+        runtime = createRuntime(singleNodeEndpoint);
+
+        CorfuStore store = new CorfuStore(runtime);
+
+        final Table<SampleSchema.Uuid, SampleSchema.Uuid, SampleSchema.Uuid> table1 = store.openTable(
+                namespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.Uuid.class,
+                SampleSchema.Uuid.class,
+                TableOptions.fromProtoSchema(SampleSchema.Uuid.class));
+
+        final int numRecords = PARAMETERS.NUM_ITERATIONS_MODERATE;
+        List<String> recordsAsJson = new ArrayList<>(numRecords);
+        try (TxnContext tx = store.txn(namespace)) {
+            for (int i = 0; i < numRecords; i++) {
+                SampleSchema.Uuid simpleRecord = SampleSchema.Uuid.newBuilder()
+                        .setMsb(i)
+                        .setLsb(0)
+                        .build();
+                tx.putRecord(table1, simpleRecord, simpleRecord, simpleRecord);
+                StringBuilder keyBuilder = new StringBuilder();
+                keyBuilder.append("{\"msb\": \"")
+                        .append(i)
+                        .append("\", \"lsb\": \"0\"}");
+                recordsAsJson.add(keyBuilder.toString());
+            }
+            tx.commit();
+        }
+        // Now also write all the records out to a file
+        final String pathToRecordsToDelete = CORFU_LOG_PATH + File.separator + "recordsToDelete";
+        FileWriter writer = new FileWriter(pathToRecordsToDelete);
+        for (String jsonRecord: recordsAsJson) {
+            writer.write(jsonRecord + System.lineSeparator());
+        }
+        writer.close();
+
+        runtime.shutdown();
+        final String []args = {
+                "--host=" + corfuSingleNodeHost,
+                "--port=" + corfuStringNodePort,
+                "--operation=deleteRecord",
+                "--tablename=" + tableName,
+                "--namespace=" + namespace,
+                "--keysToDeleteFilePath=" + pathToRecordsToDelete,
+                "--batchSize=" + (numRecords / 10)
+        };
+
+        int deletedRecordCount = CorfuStoreBrowserEditorMain.mainMethod(args);
+        assertThat(deletedRecordCount).isEqualTo(numRecords);
         runtime.shutdown();
     }
 


### PR DESCRIPTION
Why should this be merged: 
When users want to delete a large number of records
doing it one by one ends up being extremely slow
Instead add support for batch transactional
deletion capability.
+Test case code coverage.

Related issue(s) (if applicable): #3274 

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
