### PR TITLE
Fix possible NPE if a "disable cert expiry check file" parameter is not present in ServerContext

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CorfuServerNode.java
@@ -28,6 +28,7 @@ import org.corfudb.util.GitRepositoryState;
 
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLEngine;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
@@ -294,10 +295,15 @@ public class CorfuServerNode implements AutoCloseable {
                             context.getServerConfig(String.class, ConfigParamNames.KEY_STORE_PASS_FILE)
                     );
 
+                    Path certExpiryFile = context
+                            .<String>getServerConfig(ConfigParamNames.DISABLE_CERT_EXPIRY_CHECK_FILE)
+                            .map(Paths::get)
+                            .orElse(TrustStoreConfig.DEFAULT_DISABLE_CERT_EXPIRY_CHECK_FILE);
+
                     TrustStoreConfig trustStoreConfig = TrustStoreConfig.from(
                             context.getServerConfig(String.class, ConfigParamNames.TRUST_STORE),
                             context.getServerConfig(String.class, ConfigParamNames.TRUST_STORE_PASS_FILE),
-                            Paths.get(context.getServerConfig(String.class, ConfigParamNames.DISABLE_CERT_EXPIRY_CHECK_FILE))
+                            certExpiryFile
                     );
 
                     sslContext = SslContextConstructor.constructSslContext(

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationServerChannelAdapter.java
@@ -28,6 +28,7 @@ import org.corfudb.security.tls.TlsUtils.CertStoreConfig.TrustStoreConfig;
 
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLEngine;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -191,10 +192,15 @@ public class NettyLogReplicationServerChannelAdapter extends IServerChannelAdapt
                             context.getServerConfig(String.class, ConfigParamNames.KEY_STORE_PASS_FILE)
                     );
 
+                    Path certExpiryFile = context
+                            .<String>getServerConfig(ConfigParamNames.DISABLE_CERT_EXPIRY_CHECK_FILE)
+                            .map(Paths::get)
+                            .orElse(TrustStoreConfig.DEFAULT_DISABLE_CERT_EXPIRY_CHECK_FILE);
+
                     TrustStoreConfig trustStoreConfig = TrustStoreConfig.from(
                             context.getServerConfig(String.class, ConfigParamNames.TRUST_STORE),
                             context.getServerConfig(String.class, ConfigParamNames.TRUST_STORE_PASS_FILE),
-                            Paths.get(context.getServerConfig(String.class, ConfigParamNames.DISABLE_CERT_EXPIRY_CHECK_FILE))
+                            certExpiryFile
                     );
 
                     sslContext = SslContextConstructor.constructSslContext(true, keyStoreConfig, trustStoreConfig);


### PR DESCRIPTION

## Overview
The code can throw NPE in case if a parameter is not set

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
