### PR TITLE
Add support for restoring tagged tables from a full backup

### DIFF
--- a/runtime/proto/corfu_store_metadata.proto
+++ b/runtime/proto/corfu_store_metadata.proto
@@ -29,6 +29,8 @@ message TableDescriptors {
     google.protobuf.Any key = 2;
     google.protobuf.Any value = 3;
     google.protobuf.Any metadata = 4;
+
+    option (org.corfudb.runtime.table_schema).requires_backup_support = true;
 }
 
 // Metadata.
@@ -58,4 +60,6 @@ message ProtobufFileName {
 message ProtobufFileDescriptor {
     google.protobuf.FileDescriptorProto file_descriptor = 1;
     fixed64 version = 2;
+
+    option (org.corfudb.runtime.table_schema).requires_backup_support = true;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -161,14 +161,14 @@ public class TableRegistry {
                 TableName.class,
                 TableDescriptors.class,
                 TableMetadata.class,
-                TableOptions.<TableName, TableDescriptors>builder().build());
+                TableOptions.fromProtoSchema(TableDescriptors.class));
 
             registerTable(CORFU_SYSTEM_NAMESPACE,
                 PROTOBUF_DESCRIPTOR_TABLE_NAME,
                 ProtobufFileName.class,
                 ProtobufFileDescriptor.class,
                 TableMetadata.class,
-                TableOptions.<ProtobufFileName, ProtobufFileDescriptor>builder().build());
+                TableOptions.fromProtoSchema(ProtobufFileDescriptor.class));
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/runtime/src/test/java/org/corfudb/security/tls/ReloadableTrustManagerTest.java
+++ b/runtime/src/test/java/org/corfudb/security/tls/ReloadableTrustManagerTest.java
@@ -102,6 +102,12 @@ public class ReloadableTrustManagerTest {
         assertTrue(ctx.isExpired());
     }
 
+    @Test
+    public void testCertExpiryCheckDisabled(){
+        TlsUtils.CertStoreConfig.TrustStoreConfig trustStore = SERVER_TRUST_WITH_CLIENT;
+        assertTrue(trustStore.isCertExpiryCheckEnabled());
+    }
+
     private X509Certificate getCertificate(Path certFile) throws Exception {
         String clientCert = new String(Files.readAllBytes(certFile));
         clientCert = clientCert.trim();

--- a/runtime/src/test/java/org/corfudb/security/tls/TlsUtilsTest.java
+++ b/runtime/src/test/java/org/corfudb/security/tls/TlsUtilsTest.java
@@ -1,6 +1,5 @@
 package org.corfudb.security.tls;
 
-import org.corfudb.security.tls.TlsUtils.CertStoreConfig.TrustStoreConfig;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
@@ -13,7 +12,6 @@ import java.util.function.Consumer;
 import static org.corfudb.security.tls.TlsTestContext.CLIENT_TRUST_WITH_SERVER;
 import static org.corfudb.security.tls.TlsTestContext.FAKE_LOCATION_AND_PASS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class TlsUtilsTest {
@@ -56,12 +54,6 @@ public class TlsUtilsTest {
         checkTaskError(async, (IllegalStateException ex) -> {
             assertEquals(expectedErrorMessage, ex.getMessage());
         });
-    }
-
-    @Test
-    public void testCertExpiryCheckDisabled(){
-        TrustStoreConfig trustStore = TlsTestContext.SERVER_TRUST_WITH_CLIENT;
-        assertTrue(trustStore.isCertExpiryCheckEnabled());
     }
 
     private <T> void checkTaskError(CompletableFuture<T> async, Consumer<IllegalStateException> errHandler) {


### PR DESCRIPTION
## Overview

Description:
The new restore mode 'PARTIAL_TAGGED' supports restoring
tables which have 'requires_backup_support' tag using a
full backup file. This PR also adds the backup tag to
RegistryTable and ProtobufDescriptorTable to avoid tables
which are opened after three compaction cycles from being
skip-checkpointed and trimmed.

Why should this be merged: 
New restore mode requested by users.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
