### PR TITLE
WriteAfterWriteTransactional: Don't track reads

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteAfterWriteTransactionalContext.java
@@ -42,8 +42,7 @@ public class WriteAfterWriteTransactionalContext
      *                          available.
      */
     public void addToReadSet(ICorfuSMRProxyInternal proxy, Object[] conflictObjects) {
-        // CorfuStore.txn() maps any TX to write-write TX, keep track of read-set to
-        // resolve valid snapshot across all accessed streams.
-        getReadSetInfo().add(proxy, conflictObjects);
+        // no-op: since WRITE_AFTER_WRITE transaction type only need to detect write-write conflicts there
+        // is no need to track the the read set
     }
 }


### PR DESCRIPTION
## Overview

Since the WRITE_AFTER_WRITE transaction type only need to detect
write-write conflicts there is no need to track the the read set.

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
