### PR TITLE
Test Cleanup to make them flexible and reusable.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -24,7 +24,7 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
     public static final String TABLE_PREFIX = "Table00";
     public static final String NAMESPACE = "LR-Test";
     public static final String TAG_ONE = "tag_one";
-    private static final int STREAMING_CONFIG_TABLES_COUNT = 4;
+    private static final int STREAMING_CONFIG_TABLES_COUNT = 3;
 
     public DefaultLogReplicationConfigAdapter() {
         streamsToReplicate = new HashSet<>();

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
@@ -1,21 +1,6 @@
 package org.corfudb.integration;
 
-import com.google.protobuf.Message;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
-import org.corfudb.infrastructure.logreplication.proto.Sample;
-import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.ExampleSchemas;
-import org.corfudb.runtime.collections.CorfuStore;
-import org.corfudb.runtime.collections.CorfuStreamEntry;
-import org.corfudb.runtime.collections.Table;
-import org.corfudb.runtime.collections.TableOptions;
-import org.corfudb.runtime.collections.TxnContext;
-import org.corfudb.test.SampleSchema;
-import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,11 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LR_STATUS_STREAM_TAG;
 
 /**
  * This IT uses a topology of 3 Source clusters and 1 Sink cluster, each with its own Corfu Server.  The 3 Source
@@ -40,19 +20,6 @@ import static org.corfudb.infrastructure.logreplication.replication.receive.LogR
 @Slf4j
 @RunWith(Parameterized.class)
 public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSinkIT {
-
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table1;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table2;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table3;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Source1;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Source2;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Source3;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Sink1;
-
-    private ReplicatedStreamsListener streamsListener;
-    private ReplicatedStreamsListener sourceStreamsListener1;
-    private ReplicatedStreamsListener sourceStreamsListener2;
-    private ReplicatedStreamsListener sourceStreamsListener3;
 
     public CorfuReplicationMultiSourceIT(String pluginConfigFilePath) {
         this.pluginConfigFilePath = pluginConfigFilePath;
@@ -78,7 +45,7 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
     @Before
     public void setUp() throws Exception {
         // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
-        setupSourceAndSinkCorfu();
+        super.setUp(MAX_REMOTE_CLUSTERS, 1);
     }
 
     /**
@@ -100,84 +67,7 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
      */
     @Test
     public void testUpdatesOnReplicatedTables() throws Exception {
-        verifySnapshotAndLogEntrySink();
-    }
-
-    private void verifySnapshotAndLogEntrySink() throws Exception {
-        int numSourceClusters = MAX_REMOTE_CLUSTERS;
-
-        // Open maps on the Source and Destination Sites
-        openMaps();
-        log.debug("Write 3 records locally on each Source Cluster");
-
-        // Write data to all the source sites
-        writeData(corfuStoreSource1, TABLE_1, table1, 0, NUM_RECORDS_IN_TABLE);
-        writeData(corfuStoreSource2, TABLE_2, table2, 0, NUM_RECORDS_IN_TABLE);
-        writeData(corfuStoreSource3, TABLE_3, table3, 0, NUM_RECORDS_IN_TABLE);
-
-        // Register a stream listener on the Sink cluster to listen for incoming replication data writes
-        // During snapshot sync, there will be 1 write(with all entries) for each replicated table with data.  The
-        // listener ignores 'single clear' writes for the countdown latch so there will be 1 write per Source
-        // cluster, i.e., Source Cluster 1's writes to Table001 and so on.
-        CountDownLatch snapshotWritesLatch = new CountDownLatch(numSourceClusters);
-        streamsListener = new ReplicatedStreamsListener(snapshotWritesLatch, true);
-        corfuStoreSink1.subscribeListener(streamsListener, NAMESPACE, STREAM_TAG);
-
-        // Subscribe to updates to the Replication Status table on Sink
-        corfuStoreSink1.openTable(LogReplicationMetadataManager.NAMESPACE,
-            LogReplicationMetadataManager.REPLICATION_STATUS_TABLE, LogReplicationMetadata.ReplicationStatusKey.class,
-            LogReplicationMetadata.ReplicationStatusVal.class, null,
-            TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
-
-        // On startup, an initial default replication status is written for each
-        // remote cluster(NUM_INITIAL_REPLICATION_STATUS_UPDATES).  Subsequently, the table will be updated on
-        // snapshot sync from each Source cluster.
-        int numExpectedUpdates = NUM_INITIAL_REPLICATION_STATUS_UPDATES +
-            calculateSnapshotSyncUpdatesOnSinkStatusTable(numSourceClusters);
-        CountDownLatch statusUpdateLatch = new CountDownLatch(numExpectedUpdates);
-        sinkListener1 = new ReplicationStatusListener(statusUpdateLatch);
-        corfuStoreSink1.subscribeListener(sinkListener1, LogReplicationMetadataManager.NAMESPACE, LR_STATUS_STREAM_TAG);
-
-        startReplicationServers();
-        statusUpdateLatch.await();
-        snapshotWritesLatch.await();
-
-        // There will be 1 Clear + NUM_RECORDS_IN_TABLE Update records for each table
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1, streamsListener.getTableToOpTypeMap().get(TABLE_1).size());
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1, streamsListener.getTableToOpTypeMap().get(TABLE_2).size());
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1, streamsListener.getTableToOpTypeMap().get(TABLE_3).size());
-
-        // Verify the operations are as expected and in the right order
-        List<CorfuStreamEntry.OperationType> expectedOpsList = Arrays.asList(CorfuStreamEntry.OperationType.CLEAR,
-            CorfuStreamEntry.OperationType.UPDATE, CorfuStreamEntry.OperationType.UPDATE,
-            CorfuStreamEntry.OperationType.UPDATE);
-
-        Assert.assertTrue(Objects.equals(expectedOpsList, streamsListener.getTableToOpTypeMap().get(TABLE_1)));
-        Assert.assertTrue(Objects.equals(expectedOpsList, streamsListener.getTableToOpTypeMap().get(TABLE_2)));
-        Assert.assertTrue(Objects.equals(expectedOpsList, streamsListener.getTableToOpTypeMap().get(TABLE_3)));
-
-        // Verify LogEntry Sync by writing and deleting a record each (2 updates)
-        // Set the expected countdown latch to 2
-        CountDownLatch logEntryWritesLatch = new CountDownLatch(2);
-        streamsListener.setCountdownLatch(logEntryWritesLatch);
-        streamsListener.clearTableToOpTypeMap();
-        streamsListener.setSnapshotSync(false);
-
-        log.debug("Add a record on table on Sender-1, Table-1");
-        writeData(corfuStoreSource1, TABLE_1, table1, NUM_RECORDS_IN_TABLE, 1);
-
-        log.debug("Delete a record from Sender-2, Table-2");
-        log.debug("Delete Key2");
-        deleteRecord(corfuStoreSource2, TABLE_2, 2);
-
-        logEntryWritesLatch.await();
-        Assert.assertEquals(1, streamsListener.getTableToOpTypeMap().get(TABLE_1).size());
-        Assert.assertEquals(CorfuStreamEntry.OperationType.UPDATE,
-            streamsListener.getTableToOpTypeMap().get(TABLE_1).get(0));
-
-        Assert.assertEquals(1, streamsListener.getTableToOpTypeMap().get(TABLE_2).size());
-        Assert.assertEquals(CorfuStreamEntry.OperationType.DELETE,
-            streamsListener.getTableToOpTypeMap().get(TABLE_2).get(0));
+        verifySnapshotAndLogEntrySink(false);
     }
 
     /**
@@ -188,143 +78,10 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
      */
     @Test
     public void testRoleChange() throws Exception {
-        verifySnapshotAndLogEntrySink();
-
-        // After a role change, there will be 1 Source cluster
-        int numSourceClusters = 1;
-
-        // Write data to a different table(Table004) on the current Sink.  This table did not have any replicated data
-        // and must be empty.
-        Assert.assertEquals(0, table4Sink1.count());
-        writeData(corfuStoreSink1, TABLE_4, table4Sink1, 0, NUM_RECORDS_IN_TABLE);
-
-        // Subscribe the to-be Sink, now-Source Clusters to replication writes on Table004
-        CountDownLatch snapshotWritesLatch1 = new CountDownLatch(numSourceClusters);
-        sourceStreamsListener1 = new ReplicatedStreamsListener(snapshotWritesLatch1, true);
-        corfuStoreSource1.subscribeListener(sourceStreamsListener1, NAMESPACE, STREAM_TAG, Arrays.asList(TABLE_4));
-
-        CountDownLatch snapshotWritesLatch2 = new CountDownLatch(numSourceClusters);
-        sourceStreamsListener2 = new ReplicatedStreamsListener(snapshotWritesLatch2, true);
-        corfuStoreSource2.subscribeListener(sourceStreamsListener2, NAMESPACE, STREAM_TAG, Arrays.asList(TABLE_4));
-
-        CountDownLatch snapshotWritesLatch3 = new CountDownLatch(numSourceClusters);
-        sourceStreamsListener3 = new ReplicatedStreamsListener(snapshotWritesLatch3, true);
-        corfuStoreSource3.subscribeListener(sourceStreamsListener3, NAMESPACE, STREAM_TAG, Arrays.asList(TABLE_4));
-
-
-        // Verify no data exists on this table on any current Source cluster
-        Assert.assertEquals(0, table4Source1.count());
-        Assert.assertEquals(0, table4Source2.count());
-        Assert.assertEquals(0, table4Source3.count());
-
-        // Perform a role switch.  This will change the topology (3 Source, 1 Sink) -> (3 Sink, 1 Source)
-        Table<ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg> configTable =
-            corfuStoreSource1.openTable(DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
-                ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
-                ExampleSchemas.ClusterUuidMsg.class, TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class));
-
-        try (TxnContext txn = corfuStoreSource1.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
-            txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH,
-                DefaultClusterManager.OP_SWITCH);
-            txn.commit();
-        }
-        assertThat(configTable.count()).isOne();
-        snapshotWritesLatch1.await();
-        snapshotWritesLatch2.await();
-        snapshotWritesLatch3.await();
-
-        // Also verify that Table004 now has replicated data
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE, table4Source1.count());
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE, table4Source2.count());
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE, table4Source3.count());
-    }
-
-    private void setupSourceAndSinkCorfu() throws Exception {
-        sourceCorfu1 = runServer(sourceSiteCorfuPort1, true);
-        sourceCorfu2 = runServer(sourceSiteCorfuPort2, true);
-        sourceCorfu3 = runServer(sourceSiteCorfuPort3, true);
-
-        sinkCorfu1 = runServer(sinkSiteCorfuPort1, true);
-
-        // Setup the runtimes to each Corfu server
-        CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
-            .builder()
-            .build();
-
-        sourceRuntime1 = CorfuRuntime.fromParameters(params);
-        sourceRuntime1.parseConfigurationString(sourceEndpoint1);
-        sourceRuntime1.connect();
-
-        sourceRuntime2 = CorfuRuntime.fromParameters(params);
-        sourceRuntime2.parseConfigurationString(sourceEndpoint2);
-        sourceRuntime2.connect();
-
-        sourceRuntime3 = CorfuRuntime.fromParameters(params);
-        sourceRuntime3.parseConfigurationString(sourceEndpoint3);
-        sourceRuntime3.connect();
-
-        sinkRuntime1 = CorfuRuntime.fromParameters(params);
-        sinkRuntime1.parseConfigurationString(sinkEndpoint1);
-        sinkRuntime1.connect();
-
-        corfuStoreSource1 = new CorfuStore(sourceRuntime1);
-        corfuStoreSource2 = new CorfuStore(sourceRuntime2);
-        corfuStoreSource3 = new CorfuStore(sourceRuntime3);
-        corfuStoreSink1 = new CorfuStore(sinkRuntime1);
-    }
-
-    private void openMaps() throws Exception {
-        // Source tables
-        table1 = corfuStoreSource1.openTable(NAMESPACE, TABLE_1, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table2 = corfuStoreSource2.openTable(NAMESPACE, TABLE_2, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table3 = corfuStoreSource3.openTable(NAMESPACE, TABLE_3, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table4Source1 = corfuStoreSource1.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table4Source2 = corfuStoreSource2.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table4Source3 = corfuStoreSource3.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        // Sink tables
-        corfuStoreSink1.openTable(NAMESPACE, TABLE_1, Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
-            null, TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        corfuStoreSink1.openTable(NAMESPACE, TABLE_2, Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
-            null, TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        corfuStoreSink1.openTable(NAMESPACE, TABLE_3, Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
-            null, TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table4Sink1 = corfuStoreSink1.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-    }
-
-    private void startReplicationServers() throws Exception {
-        sourceReplicationServer1 = runReplicationServer(sourceReplicationPort1, pluginConfigFilePath);
-        sourceReplicationServer2 = runReplicationServer(sourceReplicationPort2, pluginConfigFilePath);
-        sourceReplicationServer3 = runReplicationServer(sourceReplicationPort3, pluginConfigFilePath);
-        sinkReplicationServer1 = runReplicationServer(sinkReplicationPort1, pluginConfigFilePath);
-    }
-
-    @After
-    public void tearDown() {
-        super.tearDown();
-        corfuStoreSink1.unsubscribeListener(streamsListener);
-
+        verifySnapshotAndLogEntrySink(false);
+        log.info("Preparing for role change");
+        prepareTestTopologyForRoleChange(1, MAX_REMOTE_CLUSTERS);
+        log.info("Testing after role change");
+        verifySnapshotAndLogEntrySink(true);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceSinkIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceSinkIT.java
@@ -1,84 +1,84 @@
 package org.corfudb.integration;
 
+import com.google.common.reflect.TypeToken;
+import com.google.protobuf.Message;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.proto.Sample;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata;
+import org.corfudb.runtime.ExampleSchemas;
+import org.corfudb.runtime.MultiCheckpointWriter;
+import org.corfudb.runtime.collections.CorfuDynamicKey;
+import org.corfudb.runtime.collections.CorfuDynamicRecord;
+import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStreamEntries;
 import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.StreamListener;
 import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TableSchema;
 import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.view.SMRObject;
+import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.test.SampleSchema;
+import org.corfudb.util.serializer.DynamicProtobufSerializer;
+import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.ProtobufSerializer;
 import org.junit.After;
+import org.junit.Assert;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 
 import static org.assertj.core.api.Assertions.fail;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LR_STATUS_STREAM_TAG;
 
 @Slf4j
 public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
-    protected final int sourceSiteCorfuPort1 = 9000;
-    protected final int sourceSiteCorfuPort2 = 9002;
-    protected final int sourceSiteCorfuPort3 = 9004;
-    protected final int sinkSiteCorfuPort1 = 9001;
-    protected final int sinkSiteCorfuPort2 = 9003;
-    protected final int sinkSiteCorfuPort3 = 9005;
+    private final List<Integer> sourceCorfuPorts = Arrays.asList(9000, 9002, 9004);
+    private final List<Integer> sinkCorfuPorts = Arrays.asList(9001, 9003, 9005);
 
-    protected final int sourceReplicationPort1 = 9010;
-    protected final int sourceReplicationPort2 = 9011;
-    protected final int sourceReplicationPort3 = 9012;
-    protected final int sinkReplicationPort1 = 9020;
-    protected final int sinkReplicationPort2 = 9021;
-    protected final int sinkReplicationPort3 = 9022;
+    private final List<Integer> sourceReplicationPorts = Arrays.asList(9010, 9011, 9012);
+    private final List<Integer> sinkReplicationPorts = Arrays.asList(9020, 9021, 9022);
 
-    protected Process sourceCorfu1 = null;
-    protected Process sourceCorfu2 = null;
-    protected Process sourceCorfu3 = null;
-    protected Process sinkCorfu1 = null;
-    protected Process sinkCorfu2 = null;
-    protected Process sinkCorfu3 = null;
+    private final List<Process> sourceCorfuProcesses = new ArrayList<>();
+    private final List<Process> sinkCorfuProcesses = new ArrayList<>();
 
-    protected Process sourceReplicationServer1 = null;
-    protected Process sourceReplicationServer2 = null;
-    protected Process sourceReplicationServer3 = null;
-    protected Process sinkReplicationServer1 = null;
-    protected Process sinkReplicationServer2 = null;
-    protected Process sinkReplicationServer3 = null;
+    private final List<Process> sourceReplicationServers = new ArrayList<>();
+    private final List<Process> sinkReplicationServers = new ArrayList<>();
 
-    protected CorfuRuntime sourceRuntime1;
-    protected CorfuRuntime sourceRuntime2;
-    protected CorfuRuntime sourceRuntime3;
-    protected CorfuRuntime sinkRuntime1;
-    protected CorfuRuntime sinkRuntime2;
-    protected CorfuRuntime sinkRuntime3;
+    private List<CorfuRuntime> sourceRuntimes = new ArrayList<>();
+    private List<CorfuRuntime> sinkRuntimes = new ArrayList<>();
 
-    protected CorfuStore corfuStoreSource1;
-    protected CorfuStore corfuStoreSource2;
-    protected CorfuStore corfuStoreSource3;
-    protected CorfuStore corfuStoreSink1;
-    protected CorfuStore corfuStoreSink2;
-    protected CorfuStore corfuStoreSink3;
+    protected List<CorfuStore> sourceCorfuStores = new ArrayList<>();
+    protected List<CorfuStore> sinkCorfuStores = new ArrayList<>();
 
-    protected final String sourceEndpoint1 = DEFAULT_HOST + ":" + sourceSiteCorfuPort1;
-    protected final String sourceEndpoint2 = DEFAULT_HOST + ":" + sourceSiteCorfuPort2;
-    protected final String sourceEndpoint3 = DEFAULT_HOST + ":" + sourceSiteCorfuPort3;
-    protected final String sinkEndpoint1 = DEFAULT_HOST + ":" + sinkSiteCorfuPort1;
-    protected final String sinkEndpoint2 = DEFAULT_HOST + ":" + sinkSiteCorfuPort2;
-    protected final String sinkEndpoint3 = DEFAULT_HOST + ":" + sinkSiteCorfuPort3;
+    private final List<String> sourceEndpoints = new ArrayList<>();
+    private final List<String> sinkEndpoints = new ArrayList<>();
 
-    protected static final String TABLE_1 = "Table001";
-    protected static final String TABLE_2 = "Table002";
-    protected static final String TABLE_3 = "Table003";
-    protected static final String TABLE_4 = "Table004";
+    private int numSourceClusters;
+    private int numSinkClusters;
+
+    private static final String TABLE_1 = "Table001";
+    private static final String TABLE_2 = "Table002";
+    private static final String TABLE_3 = "Table003";
+    protected final List<String> tableNames = Arrays.asList(TABLE_1, TABLE_2, TABLE_3);
+
+    protected final List<Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message>> srcTables = new ArrayList<>();
+    protected final List<Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message>> sinkTables = new ArrayList<>();
 
     protected static final String NAMESPACE = DefaultLogReplicationConfigAdapter.NAMESPACE;
 
@@ -102,12 +102,97 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
 
     protected String pluginConfigFilePath;
 
-    protected ReplicationStatusListener sourceListener1;
+    // Listens to incoming data on streams/tables on a Sink cluster
+    private List<ReplicatedStreamsListener> dataListeners = new ArrayList<>();
+
+    // Listens to replication status updates on a Sink cluster
+    private List<ReplicationStatusListener> replicationStatusListeners = new ArrayList<>();
+
+    /*protected ReplicationStatusListener sourceListener1;
     protected ReplicationStatusListener sourceListener2;
     protected ReplicationStatusListener sourceListener3;
     protected ReplicationStatusListener sinkListener1;
     protected ReplicationStatusListener sinkListener2;
-    protected ReplicationStatusListener sinkListener3;
+    protected ReplicationStatusListener sinkListener3;*/
+
+    protected void setUp(int numSourceClusters, int numSinkClusters) throws Exception {
+        this.numSourceClusters = numSourceClusters;
+        this.numSinkClusters = numSinkClusters;
+        setupSourceAndSinkCorfu(numSourceClusters, numSinkClusters);
+    }
+
+    private void setupSourceAndSinkCorfu(int numSourceClusters, int numSinkClusters) throws Exception {
+        Process process;
+        String endpoint;
+        for (int i = 0; i < numSourceClusters; i++) {
+            process = runServer(sourceCorfuPorts.get(i), true);
+            sourceCorfuProcesses.add(process);
+            endpoint = DEFAULT_HOST + ":" + sourceCorfuPorts.get(i).toString();
+            sourceEndpoints.add(endpoint);
+        }
+
+        for (int i = 0; i < numSinkClusters; i++) {
+            process = runServer(sinkCorfuPorts.get(i), true);
+            sinkCorfuProcesses.add(process);
+            endpoint = DEFAULT_HOST + ":" + sinkCorfuPorts.get(i).toString();
+            sinkEndpoints.add(endpoint);
+        }
+
+        // Setup the runtimes to each Corfu server
+        CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
+            .builder()
+            .build();
+
+        CorfuRuntime runtime;
+        for (int i = 0; i<numSourceClusters; i++) {
+            runtime = CorfuRuntime.fromParameters(params);
+            runtime.parseConfigurationString(sourceEndpoints.get(i));
+            runtime.connect();
+            sourceRuntimes.add(runtime);
+
+            sourceCorfuStores.add(new CorfuStore(runtime));
+        }
+
+        for (int i = 0; i<numSinkClusters; i++) {
+            runtime = CorfuRuntime.fromParameters(params);
+            runtime.parseConfigurationString(sinkEndpoints.get(i));
+            runtime.connect();
+            sinkRuntimes.add(runtime);
+
+            sinkCorfuStores.add(new CorfuStore(runtime));
+        }
+    }
+
+    protected void startReplicationServers() throws Exception {
+        for (int i = 0; i < numSourceClusters; i++) {
+            sourceReplicationServers.add(runReplicationServer(sourceReplicationPorts.get(i), pluginConfigFilePath));
+        }
+
+        for (int i = 0; i < numSinkClusters; i++) {
+            sinkReplicationServers.add(runReplicationServer(sinkReplicationPorts.get(i), pluginConfigFilePath));
+        }
+    }
+
+    protected void openMaps() throws Exception {
+        Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table;
+
+        // Maps are opened as per number of Source sites.  The assumption is that Table001 is opened and written to
+        // on Source 1, Table002 on Source 2 and so on.
+        for (int i = 0; i < numSourceClusters; i++) {
+            table = sourceCorfuStores.get(i).openTable(NAMESPACE, tableNames.get(i), Sample.StringKey.class,
+                SampleSchema.ValueFieldTagOne.class, null,
+                TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+            srcTables.add(table);
+
+            // Open the same tables on the Sink clusters to get stream listener updates.
+            for (int j = 0; j < numSinkClusters; j++) {
+                table = sinkCorfuStores.get(j).openTable(NAMESPACE, tableNames.get(i), Sample.StringKey.class,
+                    SampleSchema.ValueFieldTagOne.class, null,
+                    TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+                sinkTables.add(table);
+            }
+        }
+    }
 
     protected void writeData(CorfuStore corfuStore, String tableName, Table table, int startIndex, int numRecords) {
         for (int i = startIndex; i < (startIndex + numRecords); i++) {
@@ -134,104 +219,335 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
         return numSourceClusters * NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE;
     }
 
+    protected void verifySnapshotAndLogEntrySink(boolean changeRole) throws Exception {
+        // Open maps on the Source and Destination Sites.  Maps are opened as per number of Source sites.  The
+        // assumption is that Table001 is opened and written to on Source 1, Table002 on Source 2 and so on.
+        openMaps();
+
+        log.debug("Write 3 records locally on each Source Cluster");
+
+        // Write data to tables opened on each source cluster
+        for (int i = 0; i < numSourceClusters; i++) {
+            writeData(sourceCorfuStores.get(i), tableNames.get(i), srcTables.get(i), 0, NUM_RECORDS_IN_TABLE);
+        }
+
+        // Register a stream listener on the Sink clusters to listen for incoming replication data writes.
+        // During snapshot sync, there will be 1 write(with all entries) for each replicated table with data.  The
+        // listener ignores 'single clear' writes('clear' on a table from Snapshot sync from another Source which
+        // does not have data on this table) for the countdown latch.  So there will be 1 write per Source cluster,
+        // i.e., Source Cluster 1's writes to Table001 and so on.
+        // Also subscribe to updates on the Replication Status table.
+        List<CountDownLatch> snapshotWritesLatches = new ArrayList<>();
+        CountDownLatch dataLatch;
+        ReplicatedStreamsListener dataListener;
+
+        // On startup, an initial default replication status is written for each remote cluster
+        // (NUM_INITIAL_REPLICATION_STATUS_UPDATES).  Subsequently, the table will be updated on snapshot sync from
+        // each Source cluster.
+        int numExpectedUpdates = NUM_INITIAL_REPLICATION_STATUS_UPDATES +
+            calculateSnapshotSyncUpdatesOnSinkStatusTable(numSourceClusters);
+        List<CountDownLatch> statusLatches = new ArrayList<>();
+        CountDownLatch statusLatch;
+        ReplicationStatusListener statusListener;
+
+        for (int i = 0; i < numSinkClusters; i++) {
+            // Data Listeners.
+            // In the test, the number of tables where updates are applied = numSourceClusters(Source 1 - Table001,
+            // Source2 - Table002..).  So there will be numSourceClusters number of transactions.
+            dataLatch = new CountDownLatch(numSourceClusters);
+            snapshotWritesLatches.add(dataLatch);
+
+            dataListener = new ReplicatedStreamsListener(dataLatch, true);
+            dataListeners.add(dataListener);
+
+            sinkCorfuStores.get(i).subscribeListener(dataListener, NAMESPACE, STREAM_TAG);
+
+            // Replication Status Listeners
+            sinkCorfuStores.get(i).openTable(LogReplicationMetadataManager.NAMESPACE,
+                LogReplicationMetadataManager.REPLICATION_STATUS_TABLE, LogReplicationMetadata.ReplicationStatusKey.class,
+                LogReplicationMetadata.ReplicationStatusVal.class, null,
+                TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+            statusLatch = new CountDownLatch(numExpectedUpdates);
+            statusLatches.add(statusLatch);
+
+            statusListener = new ReplicationStatusListener(statusLatch);
+            replicationStatusListeners.add(statusListener);
+            sinkCorfuStores.get(i).subscribeListener(statusListener, LogReplicationMetadataManager.NAMESPACE,
+                LR_STATUS_STREAM_TAG);
+        }
+
+        if (changeRole) {
+            Table<ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg>
+                configTable = sinkCorfuStores.get(0).openTable(DefaultClusterManager.CONFIG_NAMESPACE,
+                    DefaultClusterManager.CONFIG_TABLE_NAME, ExampleSchemas.ClusterUuidMsg.class,
+                    ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
+                    TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class));
+            try (TxnContext txn = sinkCorfuStores.get(0).txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
+                txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH,
+                    DefaultClusterManager.OP_SWITCH);
+                txn.commit();
+            }
+            Assert.assertEquals(1, configTable.count());
+
+        } else {
+            // Start Log Replication
+            startReplicationServers();
+        }
+
+        // Verify the number of updates and order of operations received on snapshot sync
+        // During snapshot sync, a 'clear' followed by 'update' for each record is received.  So there should be
+        // 1 Clear + NUM_RECORDS_IN_TABLE Update records for each table on each Sink cluster.
+        List<CorfuStreamEntry.OperationType> expectedOpsList = Arrays.asList(CorfuStreamEntry.OperationType.CLEAR,
+            CorfuStreamEntry.OperationType.UPDATE, CorfuStreamEntry.OperationType.UPDATE,
+            CorfuStreamEntry.OperationType.UPDATE);
+        for (int i = 0; i < numSinkClusters; i++) {
+            statusLatches.get(i).await();
+            snapshotWritesLatches.get(i).await();
+
+            for (int j = 0; j < srcTables.size(); j++) {
+                Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1,
+                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(j)).size());
+                Assert.assertTrue(Objects.equals(expectedOpsList,
+                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(j))));
+            }
+        }
+
+        // Verify LogEntry Sync by writing and deleting a record each.
+        // If there are multiple Source clusters, UPDATE and DELETE are done on different tables, each on a separate
+        // Source Cluster.  Number of expected transactions on the Sink = 2 (1 from each Source and table)
+
+        // In case of a topology with a single Source cluster, perform both ops on the same table(because number of
+        // tables opened = number of Source clusters).  During Log Entry Sync, there is transaction batching on the
+        // Source cluster, so both operations will be received and applied in the same transaction on the Sink.
+        // Hence, number of expected transactions = 1;
+        List<CountDownLatch> logEntryWritesLatches = new ArrayList<>();
+        CountDownLatch logEntryWritesLatch;
+        for (int i = 0; i < numSinkClusters; i++) {
+            if (numSourceClusters > 1) {
+                logEntryWritesLatch = new CountDownLatch(2);
+            } else {
+                logEntryWritesLatch = new CountDownLatch(1);
+            }
+            logEntryWritesLatches.add(logEntryWritesLatch);
+            dataListeners.get(i).setCountdownLatch(logEntryWritesLatch);
+            dataListeners.get(i).clearTableToOpTypeMap();
+            dataListeners.get(i).setSnapshotSync(false);
+        }
+        log.info("Add a record on table on Sender-1, Table-1");
+        writeData(sourceCorfuStores.get(0), tableNames.get(0), srcTables.get(0), NUM_RECORDS_IN_TABLE, 1);
+
+        log.info("Delete Key2");
+        if (numSourceClusters > 1) {
+            log.info("Delete a record from Sender-2, Table-2");
+            deleteRecord(sourceCorfuStores.get(1), tableNames.get(1), 2);
+        } else {
+            log.info("Delete a record from Sender-1, Table-1");
+            deleteRecord(sourceCorfuStores.get(0), tableNames.get(0), 2);
+        }
+
+        for (int i = 0; i < numSinkClusters; i++) {
+            logEntryWritesLatches.get(i).await();
+
+            if (numSourceClusters > 1) {
+                // 1 Operation received for each table on the Sink cluster
+                Assert.assertEquals(1, dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).size());
+                Assert.assertEquals(CorfuStreamEntry.OperationType.UPDATE,
+                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).get(0));
+                Assert.assertEquals(1, dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(1)).size());
+                Assert.assertEquals(CorfuStreamEntry.OperationType.DELETE,
+                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(1)).get(0));
+            } else {
+                // 2 operations received for the same table on the Sink cluster
+                Assert.assertEquals(2, dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).size());
+
+                // As these operations are applied in the same transaction, their streaming updates can come in any
+                // order(to be fixed).  We can only verify that both UPDATE and DELETE are received.
+                Assert.assertTrue(dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).contains(
+                    CorfuStreamEntry.OperationType.UPDATE));
+                Assert.assertTrue(dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).contains(
+                    CorfuStreamEntry.OperationType.DELETE));
+            }
+        }
+    }
+
+    /**
+     * On a role change, the number of Source and Sink clusters changes.  The roles of clusters in the topology
+     * change, but the total number of clusters is the same.  Additionally, the expected behavior on snapshot and log
+     * entry sync is the same, only the senders and receivers are different.  This method resets and exchanges the test
+     * state, making it ready for role change, such that the same validation method(verifySnapshotAndLogEntrySync) can
+     * be reused after the change.
+     * @param numNewSourceClusters
+     * @param numNewSinkClusters
+     */
+    protected void prepareTestTopologyForRoleChange(int numNewSourceClusters, int numNewSinkClusters) {
+        // The test workflow is as follows:
+        // 1. verifySnapshotAndLogEntrySync
+        // 2. change the role
+        // 3. verifySnapshotAndLogEntrySync ( with role changed)
+        // Clear data from all Source clusters so that verifySnapshotAndLogEntrySync can re-use existing tables to
+        // write and perform the same validation.
+        for (int i = 0; i < numSourceClusters; i++) {
+            try (TxnContext txn = sourceCorfuStores.get(i).txn(NAMESPACE)) {
+                txn.clear(tableNames.get(i));
+                txn.commit();
+            }
+        }
+
+        for (Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table : srcTables) {
+            Assert.assertEquals(0, table.count());
+        }
+
+        // Verify that no tables on the Sink cluster have data
+        for (Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table : sinkTables) {
+            while(table.count() != 0) {
+
+            }
+        }
+        // Reset/clear the list of tables on Source and Sink
+        srcTables.clear();
+        sinkTables.clear();
+
+        // Unsubscribe the listeners on Sink clusters
+        unsubscribeListeners();
+
+        // Reset/clear the list of listeners
+        dataListeners.clear();
+        replicationStatusListeners.clear();
+
+        // The test workflow is as follows:
+        // 1. verifySnapshotAndLogEntrySync
+        // 2. change the role
+        // 3. verifySnapshotAndLogEntrySync ( with role changed)
+        // verifySnapshotAndLogEntrySync checks the number of data updates received on a snapshot and log entry sync.
+        // It assumes that the Sink table/s are empty when snapshot sync started.
+        // However, in step 3, the streams will have older updates from:
+        // - Step 1 and
+        // - Clear operation done at the beginning of this method
+        // So run a CP+Trim on the to-be Source(current Sink) clusters so that the above redundant updates get
+        // Checkpointed and are not sent.
+        for (int i = 0; i < numSinkClusters; i++) {
+            CorfuRuntime cpRuntime = new CorfuRuntime(sinkEndpoints.get(i)).connect();
+            checkpointAndTrimCorfuStore(cpRuntime);
+        }
+
+        // Exchange source and sink corfu stores
+        List<CorfuStore> tmp = sourceCorfuStores;
+        sourceCorfuStores = sinkCorfuStores;
+        sinkCorfuStores = tmp;
+
+        numSourceClusters = numNewSourceClusters;
+        numSinkClusters = numNewSinkClusters;
+    }
+
+    public void checkpointAndTrimCorfuStore(CorfuRuntime cpRuntime) {
+        // Open Table Registry
+        TableRegistry tableRegistry = cpRuntime.getTableRegistry();
+        CorfuTable<CorfuStoreMetadata.TableName, CorfuRecord<CorfuStoreMetadata.TableDescriptors,
+            CorfuStoreMetadata.TableMetadata>> tableRegistryCT = tableRegistry.getRegistryTable();
+
+        CorfuTable<CorfuStoreMetadata.ProtobufFileName,
+            CorfuRecord<CorfuStoreMetadata.ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>>
+            protobufDescriptorTable =
+            tableRegistry.getProtobufDescriptorTable();
+
+        // Save the regular serializer first..
+        ISerializer protoBufSerializer = cpRuntime.getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
+
+        // Must register dynamicProtoBufSerializer *AFTER* the getTableRegistry() call to ensure that
+        // the serializer does not go back to the regular ProtoBufSerializer
+        ISerializer dynamicProtoBufSerializer = new DynamicProtobufSerializer(cpRuntime);
+        cpRuntime.getSerializers().registerSerializer(dynamicProtoBufSerializer);
+
+        MultiCheckpointWriter<CorfuTable> mcw = new MultiCheckpointWriter<>();
+
+        Token trimMark = null;
+
+        for (CorfuStoreMetadata.TableName tableName : tableRegistry.listTables(null)) {
+            // ProtobufDescriptor table is an internal table which must not
+            // be checkpointed using the DynamicProtobufSerializer
+            if (tableName.getTableName().equals(TableRegistry.PROTOBUF_DESCRIPTOR_TABLE_NAME)) {
+                continue;
+            }
+            String fullTableName = TableRegistry.getFullyQualifiedTableName(
+                tableName.getNamespace(), tableName.getTableName()
+            );
+            SMRObject.Builder<CorfuTable<CorfuDynamicKey, CorfuDynamicRecord>> corfuTableBuilder = cpRuntime.getObjectsView().build()
+                .setTypeToken(new TypeToken<CorfuTable<CorfuDynamicKey, CorfuDynamicRecord>>() {})
+                .setStreamName(fullTableName)
+                .setSerializer(dynamicProtoBufSerializer);
+
+            mcw = new MultiCheckpointWriter<>();
+            mcw.addMap(corfuTableBuilder.open());
+
+            Token token = mcw.appendCheckpoints(cpRuntime, "checkpointer");
+            trimMark = trimMark == null ? token : Token.min(trimMark, token);
+        }
+
+        // Finally checkpoint the ProtobufDescriptor and TableRegistry system
+        // tables
+        // Restore the regular protoBuf serializer and undo the dynamic
+        // protoBuf serializer
+        // otherwise the test cannot continue beyond this point.
+        log.info("Now checkpointing the ProtobufDescriptor and Registry " +
+            "Tables");
+        cpRuntime.getSerializers().registerSerializer(protoBufSerializer);
+        mcw.addMap(protobufDescriptorTable);
+        Token token1 = mcw.appendCheckpoints(cpRuntime, "checkpointer");
+
+        mcw.addMap(tableRegistryCT);
+        Token token2 = mcw.appendCheckpoints(cpRuntime, "checkpointer");
+        Token minToken = Token.min(token1, token2);
+        trimMark = trimMark != null ? Token.min(trimMark, minToken) : minToken;
+
+        cpRuntime.getAddressSpaceView().prefixTrim(trimMark);
+        cpRuntime.getAddressSpaceView().gc();
+
+        // Trim
+        log.debug("**** Trim Log @address=" + trimMark);
+        cpRuntime.getAddressSpaceView().prefixTrim(trimMark);
+        cpRuntime.getAddressSpaceView().invalidateClientCache();
+        cpRuntime.getAddressSpaceView().invalidateServerCaches();
+        cpRuntime.getAddressSpaceView().gc();
+    }
+
+    private void unsubscribeListeners() {
+        for (int i = 0; i < numSinkClusters; i++) {
+            sinkCorfuStores.get(i).unsubscribeListener(dataListeners.get(i));
+            sinkCorfuStores.get(i).unsubscribeListener(replicationStatusListeners.get(i));
+        }
+    }
+
     @After
     public void tearDown() {
-        if (sinkListener1 != null) {
-            corfuStoreSink1.unsubscribeListener(sinkListener1);
-        }
-
-        if (sinkListener2 != null) {
-            corfuStoreSink2.unsubscribeListener(sinkListener2);
-        }
-
-        if (sinkListener3 != null) {
-            corfuStoreSink3.unsubscribeListener(sinkListener3);
-        }
-
-        if (sourceListener1 != null) {
-            corfuStoreSource1.unsubscribeListener(sourceListener1);
-        }
-
-        if (sourceListener2 != null) {
-            corfuStoreSource2.unsubscribeListener(sourceListener2);
-        }
-
-        if (sourceListener3 != null) {
-            corfuStoreSource3.unsubscribeListener(sourceListener3);
-        }
+        unsubscribeListeners();
         shutdownCorfuServers();
         shutdownLogReplicationServers();
 
-        if (sourceRuntime1 != null) {
-            sourceRuntime1.shutdown();
+        for (CorfuRuntime runtime : sourceRuntimes) {
+            runtime.shutdown();
         }
-        if (sourceRuntime2 != null) {
-            sourceRuntime2.shutdown();
+        for (CorfuRuntime runtime : sinkRuntimes) {
+            runtime.shutdown();
         }
-        if (sourceRuntime3 != null) {
-            sourceRuntime3.shutdown();
-        }
-        if (sinkRuntime1 != null) {
-            sinkRuntime1.shutdown();
-        }
-        if (sinkRuntime2 != null) {
-            sinkRuntime2.shutdown();
-        }
-        if (sinkRuntime3 != null) {
-            sinkRuntime3.shutdown();
-        }
-
     }
 
     private void shutdownCorfuServers() {
-        if (sourceCorfu1 != null) {
-            sourceCorfu1.destroy();
+        for (Process process : sourceCorfuProcesses) {
+            process.destroy();
         }
 
-        if (sourceCorfu2 != null) {
-            sourceCorfu2.destroy();
-        }
-
-        if (sourceCorfu3 != null) {
-            sourceCorfu3.destroy();
-        }
-
-        if (sinkCorfu1 != null) {
-            sinkCorfu1.destroy();
-        }
-
-        if (sinkCorfu2 != null) {
-            sinkCorfu2.destroy();
-        }
-
-        if (sinkCorfu3 != null) {
-            sinkCorfu3.destroy();
+        for (Process process : sinkCorfuProcesses) {
+            process.destroy();
         }
     }
 
     private void shutdownLogReplicationServers() {
-        if (sourceReplicationServer1 != null) {
-            sourceReplicationServer1.destroy();
+        for (Process lrProcess : sourceReplicationServers) {
+            lrProcess.destroy();
         }
 
-        if (sourceReplicationServer2 != null) {
-            sourceReplicationServer2.destroy();
-        }
-
-        if (sourceReplicationServer3 != null) {
-            sourceReplicationServer3.destroy();
-        }
-
-        if (sinkReplicationServer1 != null) {
-            sinkReplicationServer1.destroy();
-        }
-
-        if (sinkReplicationServer2 != null) {
-            sinkReplicationServer2.destroy();
-        }
-
-        if (sinkReplicationServer3 != null) {
-            sinkReplicationServer3.destroy();
+        for (Process lrProcess : sinkReplicationServers) {
+            lrProcess.destroy();
         }
     }
 


### PR DESCRIPTION
## Overview
Test Cleanup for Multi Source/Sink tests to make them flexible and reusable.

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
