### PR TITLE
Bump up commons-io to 2.11.0 & git-commit-id to 4.9.10

### DIFF
--- a/corfudb-tools/pom.xml
+++ b/corfudb-tools/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.11.0</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <netty.version>4.1.77.Final</netty.version>
         <netty.tcnative.version>2.0.52.Final</netty.tcnative.version>
         <protobuf.version>3.6.1</protobuf.version>
-        <commons.io.version>2.8.0</commons.io.version>
+        <commons.io.version>2.11.0</commons.io.version>
         <lombok.version>1.18.24</lombok.version>
         <guava.version>28.0-jre</guava.version>
         <junit.jupiter.version>5.7.1</junit.jupiter.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.0.2</version>
+                <version>4.9.10</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
Needed for upgrade compatibility since previous revert reverted this necessary library update as well.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
