### PR TITLE
Preserve Transaction Boundary on LR Receiver.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -11,8 +11,11 @@ import org.corfudb.runtime.LogReplication.LogReplicationEntryMetadataMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryType;
 import org.corfudb.runtime.collections.TxnContext;
-import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LogReplicationMetadataType;
+import org.corfudb.util.retry.IRetry;
+import org.corfudb.util.retry.IntervalRetry;
+import org.corfudb.util.retry.RetryNeededException;
 
 import javax.annotation.concurrent.NotThreadSafe;
 import java.util.ArrayList;
@@ -31,16 +34,23 @@ import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.REG
 @Slf4j
 public class LogEntryWriter extends SinkWriter {
     private final LogReplicationMetadataManager logReplicationMetadataManager;
-    private final HashMap<UUID, String> streamMap; //the set of streams that log entry writer will work on.
+
+    // The set of streams that log entry writer will work on.
+    private final Map<UUID, String> streamMap;
+
     private final Map<UUID, List<UUID>> dataStreamToTagsMap;
-    private long srcGlobalSnapshot; //the source snapshot that the transaction logs are based
-    private long lastMsgTs; //the timestamp of the last message processed.
+
+    // The source snapshot that the transaction logs are based
+    private long srcGlobalSnapshot;
+
+    // Timestamp of the last message processed.
+    private long lastMsgTs;
 
     public LogEntryWriter(CorfuRuntime rt, LogReplicationConfig config, LogReplicationMetadataManager logReplicationMetadataManager) {
         super(rt);
         this.logReplicationMetadataManager = logReplicationMetadataManager;
-        this.srcGlobalSnapshot = Address.NON_ADDRESS;
-        this.lastMsgTs = Address.NON_ADDRESS;
+        this.srcGlobalSnapshot = logReplicationMetadataManager.getLastAppliedSnapshotTimestamp();
+        this.lastMsgTs = logReplicationMetadataManager.getLastProcessedLogEntryBatchTimestamp();
         this.streamMap = new HashMap<>();
         this.dataStreamToTagsMap = config.getDataStreamToTagsMap();
 
@@ -54,83 +64,137 @@ public class LogEntryWriter extends SinkWriter {
      */
     private void verifyMetadata(LogReplicationEntryMetadataMsg metadata) throws ReplicationWriterException {
         if (metadata.getEntryType() != LogReplicationEntryType.LOG_ENTRY_MESSAGE) {
-            log.error("Wrong message metadata {}, expecting type {} snapshot {}",
-                    TextFormat.shortDebugString(metadata),
-                    LogReplicationEntryType.LOG_ENTRY_MESSAGE, srcGlobalSnapshot);
+            log.error("Wrong message metadata {}, expecting type {} snapshot {}", TextFormat.shortDebugString(metadata),
+                LogReplicationEntryType.LOG_ENTRY_MESSAGE, srcGlobalSnapshot);
             throw new ReplicationWriterException("wrong type of message");
         }
     }
 
     /**
-     * Convert message data to an MultiObjectSMREntry and write to log.
+     * Extract OpaqueEntries from the message and write them to the log.  OpaqueEntries which were already applied
+     * are skipped
+     *
      * @param txMessage
-     * @return true when the msg is appended to the log
+     * @return true when all OpaqueEntries in the msg are appended to the log
      */
-    private boolean processMsg(LogReplicationEntryMsg txMessage) {
+    private boolean applyMsg(LogReplicationEntryMsg txMessage) {
+
         List<OpaqueEntry> opaqueEntryList = CorfuProtocolLogReplication.extractOpaqueEntries(txMessage);
 
-        try (TxnContext txnContext = logReplicationMetadataManager.getTxnContext()) {
+        for (OpaqueEntry opaqueEntry : opaqueEntryList) {
+            try {
+                IRetry.build(IntervalRetry.class, () -> {
+                    try (TxnContext txnContext = logReplicationMetadataManager.getTxnContext()) {
 
-            Map<LogReplicationMetadataType, Long> metadataMap = logReplicationMetadataManager.queryMetadata(
-                    txnContext, LogReplicationMetadataType.TOPOLOGY_CONFIG_ID, LogReplicationMetadataType.LAST_SNAPSHOT_STARTED,
-                    LogReplicationMetadataType.LAST_SNAPSHOT_APPLIED, LogReplicationMetadataType.LAST_LOG_ENTRY_PROCESSED);
-            long persistedTopologyConfigId = metadataMap.get(LogReplicationMetadataType.TOPOLOGY_CONFIG_ID);
-            long persistedSnapshotStart = metadataMap.get(LogReplicationMetadataType.LAST_SNAPSHOT_STARTED);
-            long persistedSnapshotDone = metadataMap.get(LogReplicationMetadataType.LAST_SNAPSHOT_APPLIED);
-            long persistedLogTs = metadataMap.get(LogReplicationMetadataType.LAST_LOG_ENTRY_PROCESSED);
+                        // NOTE: The topology config id should be queried and validated for every opaque entry because the
+                        // Sink could have received concurrent topology config id changes.  Here we are leveraging a
+                        // single read to fetch multiple metadata types.  This will be cleanly handled when the
+                        // Metadata table's schema is changed to use the remote session as the key instead of
+                        // metadata type.
+                        Map<LogReplicationMetadataType, Long> metadataMap =
+                            logReplicationMetadataManager.queryMetadata(txnContext,
+                                LogReplicationMetadataType.TOPOLOGY_CONFIG_ID,
+                                LogReplicationMetadataType.LAST_SNAPSHOT_STARTED,
+                                LogReplicationMetadataType.LAST_SNAPSHOT_APPLIED,
+                                LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED,
+                                LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED);
 
-            long topologyConfigId = txMessage.getMetadata().getTopologyConfigID();
-            long baseSnapshotTs = txMessage.getMetadata().getSnapshotTimestamp();
-            long entryTs = txMessage.getMetadata().getTimestamp();
-            long prevTs = txMessage.getMetadata().getPreviousTimestamp();
+                        long persistedTopologyConfigId =
+                            metadataMap.get(LogReplicationMetadataType.TOPOLOGY_CONFIG_ID);
+                        long persistedSnapshotStart =
+                            metadataMap.get(LogReplicationMetadataType.LAST_SNAPSHOT_STARTED);
+                        long persistedSnapshotDone =
+                            metadataMap.get(LogReplicationMetadataType.LAST_SNAPSHOT_APPLIED);
+                        long persistedBatchTs =
+                            metadataMap.get(LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED);
+                        long persistedOpaqueEntryTs =
+                            metadataMap.get(LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED);
 
-            lastMsgTs = Math.max(persistedLogTs, lastMsgTs);
+                        long topologyConfigId = txMessage.getMetadata().getTopologyConfigID();
+                        long baseSnapshotTs = txMessage.getMetadata().getSnapshotTimestamp();
+                        long prevTs = txMessage.getMetadata().getPreviousTimestamp();
 
-            if (topologyConfigId != persistedTopologyConfigId || baseSnapshotTs != persistedSnapshotStart ||
-                    baseSnapshotTs != persistedSnapshotDone || prevTs != persistedLogTs) {
-                log.warn("Message metadata mismatch. Skip applying message {}, persistedTopologyConfigId={}, persistedSnapshotStart={}, " +
-                                "persistedSnapshotDone={}, persistedLogTs={}", txMessage.getMetadata(), persistedTopologyConfigId,
-                        persistedSnapshotStart, persistedSnapshotDone, persistedLogTs);
+                        // Validate the message metadata with the local metadata table
+                        if (topologyConfigId != persistedTopologyConfigId || baseSnapshotTs != persistedSnapshotStart ||
+                            baseSnapshotTs != persistedSnapshotDone || prevTs != persistedBatchTs) {
+                            log.warn("Message metadata mismatch. Skip applying message {}, persistedTopologyConfigId={}," +
+                                    "persistedSnapshotStart={}, persistedSnapshotDone={}, persistedBatchTs={}",
+                                txMessage.getMetadata(), persistedTopologyConfigId, persistedSnapshotStart,
+                                persistedSnapshotDone, persistedBatchTs);
+                            throw new IllegalArgumentException("Cannot apply log entry message due to metadata mismatch");
+                        }
+
+                        // Skip Opaque entries with timestamp that are not larger than persistedOpaqueEntryTs
+                        if (opaqueEntry.getVersion() <= persistedOpaqueEntryTs) {
+                            log.trace("Skipping entry {} as it is less than the last applied opaque entry {}",
+                                opaqueEntry.getVersion(), persistedOpaqueEntryTs);
+                            return null;
+                        }
+
+                        // LAST_LOG_ENTRY_APPLIED has the timestamp of the last OpaqueEntry applied from a
+                        // batch of opaque entries received.
+                        logReplicationMetadataManager.appendUpdate(txnContext,
+                            LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED, opaqueEntry.getVersion());
+
+                        // CorfuStore uses WriteAfterWriteTransaction type so even though the topology is read
+                        // and validated for each OpaqueEntry, this read will not be used to detect a concurrent
+                        // topology update on the Sink.  So force an update to this key by using the touch() api.
+                        // NOTE: This will be addressed once the schema of the metadata table is updated to have
+                        // all types in a single key (remote session)
+                        logReplicationMetadataManager.touch(txnContext, LogReplicationMetadataType.TOPOLOGY_CONFIG_ID);
+
+                        // If this is the last OpaqueEntry in the message/batch, update LAST_LOG_ENTRY_BATCH_PROCESSED
+                        // with its timestamp
+                        if (opaqueEntry.getVersion() == txMessage.getMetadata().getTimestamp()) {
+                            logReplicationMetadataManager.appendUpdate(txnContext,
+                                LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED,
+                                txMessage.getMetadata().getTimestamp());
+                        }
+
+                        for (UUID streamId : opaqueEntry.getEntries().keySet()) {
+                            if (!streamMap.containsKey(streamId)) {
+                                log.warn("Skip applying log entries for stream {} as it is noisy. The Source and" +
+                                    "Sink sites could be on different versions", streamId);
+                                continue;
+                            }
+
+                            List<SMREntry> smrEntries = opaqueEntry.getEntries().get(streamId);
+                            if (streamId.equals(REGISTRY_TABLE_ID)) {
+                                // Only retain tables that are not present in the registry table
+                                smrEntries = fetchNewEntries(new ArrayList<>(smrEntries));
+                            }
+
+                            for (SMREntry smrEntry : smrEntries) {
+                                // If stream tags exist for the current stream, it means its intended for streaming
+                                // on the Sink (receiver)
+                                txnContext.logUpdate(streamId, smrEntry, dataStreamToTagsMap.get(streamId));
+                            }
+                        }
+                        txnContext.commit();
+                    } catch (TransactionAbortedException tae) {
+                        throw new RetryNeededException();
+                    }
+                    return null;
+                }).run();
+            } catch (IllegalArgumentException e) {
+                log.error("Metadata mismatch detected in entry with sequence " + opaqueEntry.getVersion(), e);
+                return false;
+            } catch (InterruptedException e) {
+                log.error("Could not apply entry with sequence " + opaqueEntry.getVersion());
                 return false;
             }
-
-            // Skip Opaque entries with timestamp that are not larger than persistedTs
-            OpaqueEntry[] newOpaqueEntryList = opaqueEntryList.stream().filter(x -> x.getVersion() > persistedLogTs).toArray(OpaqueEntry[]::new);
-
-            logReplicationMetadataManager.appendUpdate(txnContext, LogReplicationMetadataType.TOPOLOGY_CONFIG_ID, topologyConfigId);
-            logReplicationMetadataManager.appendUpdate(txnContext, LogReplicationMetadataType.LAST_LOG_ENTRY_PROCESSED, entryTs);
-
-            for (OpaqueEntry opaqueEntry : newOpaqueEntryList) {
-                for (UUID streamId : opaqueEntry.getEntries().keySet()) {
-                    if (!streamMap.containsKey(streamId)) {
-                        log.warn("Skip applying log entries for stream {} as it is noisy. LR could be undergoing a rolling upgrade", streamId);
-                        continue;
-                    }
-
-                    List<SMREntry> smrEntries = opaqueEntry.getEntries().get(streamId);
-                    if (streamId.equals(REGISTRY_TABLE_ID)) {
-                        // Only retain tables that are not present in the registry table
-                        smrEntries = fetchNewEntries(new ArrayList<>(smrEntries));
-                    }
-
-                    for (SMREntry smrEntry : smrEntries) {
-                        // If stream tags exist for the current stream, it means its intended for streaming on the Sink (receiver)
-                        txnContext.logUpdate(streamId, smrEntry, dataStreamToTagsMap.get(streamId));
-                    }
-                }
-            }
-            txnContext.commit();
-
-            lastMsgTs = Math.max(entryTs, lastMsgTs);
-            return true;
         }
+        // lastMsgTs always tracks the timestamp of the last Opaque Entry in a LogReplicationEntryMsg which was
+        // successfully applied.  So update it accordingly.
+        lastMsgTs = txMessage.getMetadata().getTimestamp();
+        return true;
     }
 
     /**
      * Apply message at the destination Corfu Cluster
      *
      * @param msg
-     * @return true when the msg is appended to the log
+     * @return true when all transactions(Opaque Entries) in the msg are appended to the log
      * @throws ReplicationWriterException
      */
     public boolean apply(LogReplicationEntryMsg msg) throws ReplicationWriterException {
@@ -148,21 +212,19 @@ public class LogEntryWriter extends SinkWriter {
 
         // A new Delta sync is triggered, setup the new srcGlobalSnapshot and msgQ
         if (msg.getMetadata().getSnapshotTimestamp() > srcGlobalSnapshot) {
-            log.warn("A new log entry sync is triggered with higher snapshot, previous snapshot " +
-                            "is {} and setup the new srcGlobalSnapshot & lastMsgTs as {}",
-                    srcGlobalSnapshot, msg.getMetadata().getSnapshotTimestamp());
+            log.warn("A new log entry sync is triggered with higher snapshot, previous snapshot is {} and setup the " +
+                "new srcGlobalSnapshot & lastMsgTs as {}", srcGlobalSnapshot, msg.getMetadata().getSnapshotTimestamp());
             srcGlobalSnapshot = msg.getMetadata().getSnapshotTimestamp();
             lastMsgTs = srcGlobalSnapshot;
         }
 
-        //If the entry is the expecting entry, process it and process
-        //the messages in the queue.
+        // If the entry is the expected entry, process it and process the messages in the queue.
         if (msg.getMetadata().getPreviousTimestamp() == lastMsgTs) {
-            return processMsg(msg);
+            return applyMsg(msg);
         }
 
-        log.warn("Log entry {} was not processed, prevTs={}, lastMsgTs={}, srcGlobalSnapshot={}", msg.getMetadata().getTimestamp(),
-                msg.getMetadata().getPreviousTimestamp(), lastMsgTs, srcGlobalSnapshot);
+        log.warn("Transactions from {} to {} were not processed.  Last timestamp processed = {}, srcGlobalSnapshot={}",
+            msg.getMetadata().getPreviousTimestamp(), msg.getMetadata().getTimestamp(), lastMsgTs, srcGlobalSnapshot);
         return false;
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -201,11 +201,9 @@ public class LogReplicationSinkManager implements DataReceiver {
 
         snapshotWriter = new StreamsSnapshotWriter(runtime, config, logReplicationMetadataManager);
         logEntryWriter = new LogEntryWriter(runtime, config, logReplicationMetadataManager);
-        logEntryWriter.reset(logReplicationMetadataManager.getLastAppliedSnapshotTimestamp(),
-                logReplicationMetadataManager.getLastProcessedLogEntryTimestamp());
 
         logEntrySinkBufferManager = new LogEntrySinkBufferManager(ackCycleTime, ackCycleCnt, bufferSize,
-                logReplicationMetadataManager.getLastProcessedLogEntryTimestamp(), this);
+                logReplicationMetadataManager.getLastProcessedLogEntryBatchTimestamp(), this);
     }
 
     private ISnapshotSyncPlugin getOnSnapshotSyncPlugin() {
@@ -433,7 +431,7 @@ public class LogReplicationSinkManager implements DataReceiver {
 
         rxState = RxState.LOG_ENTRY_SYNC;
         logEntrySinkBufferManager = new LogEntrySinkBufferManager(ackCycleTime, ackCycleCnt, bufferSize,
-                logReplicationMetadataManager.getLastProcessedLogEntryTimestamp(), this);
+                logReplicationMetadataManager.getLastProcessedLogEntryBatchTimestamp(), this);
         logEntryWriter.reset(entry.getMetadata().getSnapshotTimestamp(), entry.getMetadata().getSnapshotTimestamp());
 
         log.info("Snapshot apply complete, sync_id={}, snapshot={}, state={}", entry.getMetadata().getSyncRequestId(),
@@ -540,7 +538,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      * */
     public void reset() {
         long lastAppliedSnapshotTimestamp = logReplicationMetadataManager.getLastAppliedSnapshotTimestamp();
-        long lastProcessedLogEntryTimestamp = logReplicationMetadataManager.getLastProcessedLogEntryTimestamp();
+        long lastProcessedLogEntryTimestamp = logReplicationMetadataManager.getLastProcessedLogEntryBatchTimestamp();
         log.debug("Reset Sink Manager, lastAppliedSnapshotTs={}, lastProcessedLogEntryTs={}", lastAppliedSnapshotTimestamp,
                 lastProcessedLogEntryTimestamp);
         snapshotWriter.reset(topologyConfigId, lastAppliedSnapshotTimestamp);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
@@ -212,7 +212,6 @@ public class StreamsLogEntryReader implements LogEntryReader {
 
                     lastOpaqueEntry = null;
                 }
-
                 if (!txOpaqueStream.hasNext()) {
                     break;
                 }
@@ -227,7 +226,7 @@ public class StreamsLogEntryReader implements LogEntryReader {
             }
 
             log.trace("Generate LogEntryDataMessage size {} with {} entries for maxDataSizePerMsg {}. lastEntry size {}",
-                    currentMsgSize, opaqueEntryList.size(), maxDataSizePerMsg, lastOpaqueEntry == null ? 0 : currentEntrySize);
+                currentMsgSize, opaqueEntryList.size(), maxDataSizePerMsg, lastOpaqueEntry == null ? 0 : currentEntrySize);
             final double currentMsgSizeSnapshot = currentMsgSize;
 
             messageSizeDistributionSummary.ifPresent(distribution -> distribution.record(currentMsgSizeSnapshot));
@@ -290,6 +289,7 @@ public class StreamsLogEntryReader implements LogEntryReader {
         messageExceededSize = false;
         this.currentProcessedEntryMetadata = new StreamIteratorMetadata(Address.NON_ADDRESS, false);
         setGlobalBaseSnapshot(lastSentBaseSnapshotTimestamp, lastAckedTimestamp);
+        lastOpaqueEntry = null;
     }
 
     @Override

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogEntryWriterTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogEntryWriterTest.java
@@ -1,0 +1,404 @@
+package org.corfudb.infrastructure.logreplication;
+
+import org.corfudb.infrastructure.logreplication.replication.receive.LogEntryWriter;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LogReplicationMetadataType;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.Address;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.times;
+
+@SuppressWarnings("checkstyle:magicnumber")
+public class LogEntryWriterTest extends AbstractViewTest {
+
+    private CorfuRuntime corfuRuntime;
+    private LogReplicationMetadataManager metadataManager;
+    private LogEntryWriter logEntryWriter;
+    private TxnContext txnContext;
+    private TestUtils utils;
+    private int numOpaqueEntries;
+    private int topologyConfigId;
+
+    @Before
+    public void setUp() {
+        corfuRuntime = getDefaultRuntime();
+        LogReplicationConfig replicationConfig = Mockito.mock(LogReplicationConfig.class);
+        metadataManager = Mockito.mock(LogReplicationMetadataManager.class);
+        initMocksForMetadataManager();
+        logEntryWriter = new LogEntryWriter(corfuRuntime, replicationConfig, metadataManager);
+        numOpaqueEntries = 3;
+        topologyConfigId = 5;
+        utils = new TestUtils();
+    }
+
+    /**
+     * This test verifies that Log Entry(delta) updates are applied on the Sink with transaction boundary preserved.
+     * Each OpaqueEntry maps to a transaction on the Source.  Hence, each should be applied on the Sink as a separate
+     * transaction.
+     */
+    @Test
+    public void testLogEntryApplyWithExpectedTx() {
+        LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(1, numOpaqueEntries, Address.NON_ADDRESS,
+            topologyConfigId, Address.NON_ADDRESS);
+
+        Map<LogReplicationMetadataType, Long> metadataMap = constructMetadataMgrMap(topologyConfigId,
+            Address.NON_ADDRESS, Address.NON_ADDRESS, Address.NON_ADDRESS);
+        updateMetadataManagerMap(metadataMap, false);
+
+        // Verify that the message containing the list of opaque entries was applied successfully
+        Assert.assertTrue(logEntryWriter.apply(lrEntryMsg));
+
+        verifyNumberOfTx(numOpaqueEntries);
+
+        // Construct the expected arguments and order with which the metadata updates will be written.  There will be 4
+        // updates - 3 for LAST_LOG_ENTRY_APPLIED and 1 for LAST_LOG_ENTRY_BATCH_PROCESSED
+        List<TxnContext> txnContexts = new ArrayList<>();
+        List<LogReplicationMetadataType> metadataTypes = new ArrayList<>();
+        List<Long> timestamps = new ArrayList<>();
+
+        for(int i = 0; i < numOpaqueEntries + 1; i++) {
+            txnContexts.add(txnContext);
+        }
+
+        for(int i = 0; i < numOpaqueEntries + 1; i++) {
+            // The first 3 metadata updates will be for LAST_LOG_ENTRY_APPLIED
+            if (i < numOpaqueEntries) {
+                metadataTypes.add(LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED);
+                timestamps.add((long)i+1);
+            } else {
+                // The last one will be for LAST_LOG_ENTRY_BATCH_PROCESSED
+                metadataTypes.add(LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED);
+                timestamps.add((long)i);
+            }
+        }
+        verifyMetadataAppliedAndOrder(numOpaqueEntries+1, txnContexts, metadataTypes, timestamps);
+    }
+
+    /**
+     * This test simulates the case that the same payload is received by LogEntryWriter twice and verifies that it is
+     * applied only once.
+     */
+    @Test
+    public void testLogEntryRedundantApply() {
+        testLogEntryApplyWithExpectedTx();
+
+        // Send the same payload again
+        LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(1, numOpaqueEntries, Address.NON_ADDRESS,
+            topologyConfigId, Address.NON_ADDRESS);
+
+        Map<LogReplicationMetadataType, Long> metadataMap = constructMetadataMgrMap(topologyConfigId, numOpaqueEntries,
+            numOpaqueEntries, Address.NON_ADDRESS);
+        updateMetadataManagerMap(metadataMap, true);
+
+        // Verify that the redundant update was not applied
+        Assert.assertFalse(logEntryWriter.apply(lrEntryMsg));
+        verifyNumberOfTx(0);
+
+        List<TxnContext> txnContexts = new ArrayList<>();
+        List<LogReplicationMetadataType> metadataTypes = new ArrayList<>();
+        List<Long> timestamps = new ArrayList<>();
+
+        verifyMetadataAppliedAndOrder(0, txnContexts, metadataTypes, timestamps);
+    }
+
+    /**
+     * This test gives 2 LogEntry messages to the Writer, first with sequence numbers(timestamps) [1-3] and then with
+     * sequence numbers [2-4].  It then verifies that sequence numbers 2 and 3 were skipped during the second
+     * apply phase.
+     */
+    @Test
+    public void testLogEntryApplyWithSequenceNumOverlap() {
+        testLogEntryApplyWithExpectedTx();
+
+        // Construct the next batch with sequence numbers [2-4]
+        int startTs = 2;
+        int endTs = 4;
+        LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(startTs, endTs, numOpaqueEntries, topologyConfigId,
+            Address.NON_ADDRESS);
+
+        Map<LogReplicationMetadataType, Long> metadataMap = constructMetadataMgrMap(topologyConfigId,
+            numOpaqueEntries, numOpaqueEntries, Address.NON_ADDRESS);
+        updateMetadataManagerMap(metadataMap, true);
+
+        Assert.assertTrue(logEntryWriter.apply(lrEntryMsg));
+
+        // As sequence numbers [1-3] were already applied, only the transaction corresponding to sequence number 4
+        // will be applied.  So the total number of times commit is invoked should be 1
+        verifyNumberOfTx(1);
+
+        // Verify that the right metadata was applied - there will be 2 updates, 1 to LAST_LOG_ENTRY_APPLIED and
+        // the other to LAST_LOG_ENTRY_BATCH_PROCESSED
+        List<TxnContext> txnContexts = Arrays.asList(txnContext, txnContext);
+        List<LogReplicationMetadataType> metadataTypes =
+            Arrays.asList(LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED,
+                LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED);
+        List<Long> timestamps = Arrays.asList((long)endTs, (long)endTs);
+        verifyMetadataAppliedAndOrder(2, txnContexts, metadataTypes, timestamps);
+    }
+
+    /**
+     * This test injects a failure after a subset of opaque entries are applied and verifies the expected number of
+     * transactions.  The test first gives a LogReplicationEntryMsg with sequence numbers(timestamps) [1-3] to
+     * LogEntryWriter and injects a failure when sequence number 3 is being applied.  Then another message with
+     * sequence numbers [1-4] is given as an input.  The test then verifies that the right number of transactions were
+     * committed in each case.
+     */
+    @Test
+    public void testLogEntrySyncWithPartialApply() {
+
+        // Construct the message with sequence numbers [1-3]
+        int startTs = 1;
+        LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(startTs, numOpaqueEntries, Address.NON_ADDRESS,
+            topologyConfigId, Address.NON_ADDRESS);
+
+        // Mock the MetadataManager to return metadata matching the one constructed in the message
+        Map<LogReplicationMetadataType, Long> metadataMap = constructMetadataMgrMap(topologyConfigId,
+            Address.NON_ADDRESS, Address.NON_ADDRESS, Address.NON_ADDRESS);
+        updateMetadataManagerMap(metadataMap, false);
+
+        // Throw an exception when sequence number = 3 is being applied.  This will simulate a partial apply.
+        Mockito.doThrow(InterruptedException.class).when(metadataManager).appendUpdate(txnContext,
+            LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED, numOpaqueEntries);
+
+        // Verify that the message containing the list of opaque entries was not applied
+        Assert.assertFalse(logEntryWriter.apply(lrEntryMsg));
+
+        // Verify that 2 transactions were made, 1 each for opaque entries 1 and 2
+        // The number of times commit() is invoked should be equal to 2
+        verifyNumberOfTx(numOpaqueEntries-1);
+
+        // Construct the next batch with sequence numbers [1-4]
+        int endTs = numOpaqueEntries + 1;
+        lrEntryMsg = utils.generateLogEntryMsg(startTs, endTs, Address.NON_ADDRESS, topologyConfigId, Address.NON_ADDRESS);
+
+        // Construct metadata to reflect the previous partial apply
+        metadataMap = constructMetadataMgrMap(topologyConfigId, Address.NON_ADDRESS, numOpaqueEntries-1,
+            Address.NON_ADDRESS);
+        updateMetadataManagerMap(metadataMap, true);
+
+        // Verify that the message was applied successfully.
+        Assert.assertTrue(logEntryWriter.apply(lrEntryMsg));
+
+        // Only 2 entries from the new message will be applied - 3 and 4.
+        verifyNumberOfTx(2);
+
+        // 3 Metadata update are expected - 2 to LAST_LOG_ENTRY_APPLIED and 1 to LAST_LOG_ENTRY_BATCH_PROCESSED
+        List<TxnContext> txnContexts = Arrays.asList(txnContext, txnContext, txnContext);
+        List<LogReplicationMetadataType> metadataTypes =
+            Arrays.asList(LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED,
+                LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED,
+                LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED);
+        List<Long> timestamps = Arrays.asList((long)numOpaqueEntries, (long)endTs, (long)endTs);
+
+        verifyMetadataAppliedAndOrder(3, txnContexts, metadataTypes, timestamps);
+    }
+
+    /**
+     * This test verifies that the log entry is not applied when the timestamps of the last LogEntryMsg applied
+     * differ on the Source and Sink.  It also tests the assumption/requirement that MetadataManager returns
+     * Address.NON_ADDRESS as the init/default value of LAST_LOG_ENTRY_BATCH_PROCESSED.
+     *
+     * The test sets this timestamp to Address.NON_ADDRESS in the Metadata sent by the Source.  Metadata manager on
+     * the Sink has set this value to 0.
+     */
+    @Test
+    public void testApplyWithPrevTsMismatch() {
+
+        int startTs = 1;
+        LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(startTs, numOpaqueEntries, Address.NON_ADDRESS,
+            topologyConfigId, Address.NON_ADDRESS);
+
+        // Construct metadata where the sequence number of the last log entry applied does not match the incoming
+        // message
+        int lastTsInMetadataTable = 0;
+        Map<LogReplicationMetadataType, Long> metadataMap = constructMetadataMgrMap(topologyConfigId, lastTsInMetadataTable,
+            lastTsInMetadataTable, Address.NON_ADDRESS);
+        updateMetadataManagerMap(metadataMap, false);
+
+        // Verify that the data was not applied due to mismatch in the last log entry batch processed timestamps
+        Assert.assertFalse(logEntryWriter.apply(lrEntryMsg));
+
+        // The number of times commit() is invoked should be 0 as validation failed
+        verifyNumberOfTx(0);
+
+        List<TxnContext> txnContexts = new ArrayList<>();
+        List<LogReplicationMetadataType> metadataTypes = new ArrayList<>();
+        List<Long> timestamps = new ArrayList<>();
+
+        verifyMetadataAppliedAndOrder(0, txnContexts, metadataTypes, timestamps);
+    }
+
+    /**
+     * This test verifies that the log entry is not applied when the snapshot timestamp on the Source is lower than
+     * the one on Sink.  It also tests the assumption/requirement that MetadataManager returns
+     * Address.NON_ADDRESS as the init/default value of LAST_SNAPSHOT_APPLIED.
+     *
+     * The test sets this timestamp to Address.NON_ADDRESS in the Metadata sent by the Source.  Metadata manager on
+     *  the Sink has set this value to 0.
+     */
+    @Test
+    public void testApplyWithLowerSnapshotTsOnSource() {
+        int startTs = 1;
+        LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(startTs, numOpaqueEntries, Address.NON_ADDRESS,
+            topologyConfigId, Address.NON_ADDRESS);
+
+        // Construct metadata where the snapshot timestamp from Source(Address.NON_ADDRESS) is lower than the one on
+        // Sink(0)
+        int snapshotTsInMetadataTable = 0;
+        Map<LogReplicationMetadataType, Long> metadataMap = constructMetadataMgrMap(topologyConfigId,
+            Address.NON_ADDRESS, Address.NON_ADDRESS, snapshotTsInMetadataTable);
+        updateMetadataManagerMap(metadataMap, false);
+
+        // Verify that the data was not applied because the snapshot timestamp from Source was lower
+        Assert.assertFalse(logEntryWriter.apply(lrEntryMsg));
+
+        // The number of times commit() is invoked should be 0 as validation failed
+        verifyNumberOfTx(0);
+
+        List<TxnContext> txnContexts = new ArrayList<>();
+        List<LogReplicationMetadataType> metadataTypes = new ArrayList<>();
+        List<Long> timestamps = new ArrayList<>();
+
+        verifyMetadataAppliedAndOrder(0, txnContexts, metadataTypes, timestamps);
+    }
+
+    /**
+     * This test verifies that the log entry is not applied when the snapshot timestamp on the Source is higher than the
+     * one on Sink.
+     * The test sends a message with snapshot ts = 50 and opaque entries with ts [51, 52, 53] and verifies that it
+     * was not applied.  snapshot ts on the Sink = Address.NON_ADDRESS
+     */
+    @Test
+    public void testApplyWithHigherSnapshotTsOnSource() {
+
+        long snapshotTsOnSource = 50;
+        long startTs = 51;
+
+        // Create a message with numOpaqueEntries starting from ts=51
+        LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(startTs, startTs + numOpaqueEntries, snapshotTsOnSource,
+            topologyConfigId, snapshotTsOnSource);
+
+        // Construct metadata on the Sink with default values(Address.NON_Address)
+        Map<LogReplicationMetadataType, Long> metadataMap = constructMetadataMgrMap(topologyConfigId,
+            Address.NON_ADDRESS, Address.NON_ADDRESS, Address.NON_ADDRESS);
+        updateMetadataManagerMap(metadataMap, false);
+
+        // Verify that the log entry message was applied as the incoming snapshot ts is higher
+        Assert.assertFalse(logEntryWriter.apply(lrEntryMsg));
+
+        // The number of times commit() was invoked should be 0 as validation failed
+        verifyNumberOfTx(0);
+
+        List<TxnContext> txnContexts = new ArrayList<>();
+        List<LogReplicationMetadataType> metadataTypes = new ArrayList<>();
+        List<Long> timestamps = new ArrayList<>();
+
+        verifyMetadataAppliedAndOrder(0, txnContexts, metadataTypes, timestamps);
+    }
+
+    /**
+     * This test verifies that mismatch in topology config id on the Source and Sink is handled correctly.  The
+     * incoming message with a different topology config id must not be applied on the Sink.
+     */
+    @Test
+    public void testApplyWithTopologyMismatch() {
+
+        LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(1, numOpaqueEntries, Address.NON_ADDRESS,
+            topologyConfigId, Address.NON_ADDRESS);
+
+        // Construct Sink metadata where the topology config id does not match the value received
+        Map<LogReplicationMetadataType, Long> metadataMap = constructMetadataMgrMap(topologyConfigId+1,
+            Address.NON_ADDRESS, Address.NON_ADDRESS, Address.NON_ADDRESS);
+        updateMetadataManagerMap(metadataMap, false);
+
+        // Verify that the data was not applied due to mismatch in the topology config ids
+        Assert.assertFalse(logEntryWriter.apply(lrEntryMsg));
+
+        // The number of times commit() is invoked should be 0 as validation failed
+        verifyNumberOfTx(0);
+
+        List<TxnContext> txnContexts = new ArrayList<>();
+        List<LogReplicationMetadataType> metadataTypes = new ArrayList<>();
+        List<Long> timestamps = new ArrayList<>();
+
+        verifyMetadataAppliedAndOrder(0, txnContexts, metadataTypes, timestamps);
+    }
+
+    private void verifyNumberOfTx(int numExpectedTx) {
+        // Verify that each opaque entry was applied in a separate transaction
+        // The number of times commit() is invoked should be equal to numOpaqueEntries
+        Mockito.verify(txnContext, times(numExpectedTx)).commit();
+    }
+
+    private void verifyMetadataAppliedAndOrder(int numExpectedInvocations, List<TxnContext> expectedTxnContexts,
+                                               List<LogReplicationMetadataType> expectedMetadataTypes,
+                                               List<Long> expectedTimestamps) {
+
+        ArgumentCaptor<TxnContext> txnContextCaptor = ArgumentCaptor.forClass(TxnContext.class);
+        ArgumentCaptor<LogReplicationMetadataType> metadataTypeCaptor = ArgumentCaptor.forClass(LogReplicationMetadataType.class);
+        ArgumentCaptor<Long> timestampCaptor = ArgumentCaptor.forClass(Long.class);
+
+        Mockito.verify(metadataManager, times(numExpectedInvocations)).appendUpdate(
+            txnContextCaptor.capture(), metadataTypeCaptor.capture(), timestampCaptor.capture());
+
+        List<TxnContext> txnContexts = txnContextCaptor.getAllValues();
+        List<LogReplicationMetadataType> metadataTypes = metadataTypeCaptor.getAllValues();
+        List<Long> timestamps = timestampCaptor.getAllValues();
+
+        for (int i = 0; i < numExpectedInvocations; i++) {
+            Assert.assertEquals(expectedTxnContexts.get(i), txnContexts.get(i));
+            Assert.assertEquals(expectedMetadataTypes.get(i), metadataTypes.get(i));
+            Assert.assertEquals(expectedTimestamps.get(i), timestamps.get(i));
+        }
+    }
+
+    private void updateMetadataManagerMap(Map<LogReplicationMetadataType, Long> metadataMap, boolean reset) {
+        if (reset) {
+            Mockito.reset(metadataManager);
+            initMocksForMetadataManager();
+        }
+        Mockito.doReturn(metadataMap).when(metadataManager).queryMetadata(txnContext,
+            LogReplicationMetadataType.TOPOLOGY_CONFIG_ID, LogReplicationMetadataType.LAST_SNAPSHOT_STARTED,
+            LogReplicationMetadataType.LAST_SNAPSHOT_APPLIED, LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED,
+            LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED);
+    }
+
+    private void initMocksForMetadataManager() {
+        Mockito.doReturn(Address.NON_ADDRESS).when(metadataManager).getLastAppliedSnapshotTimestamp();
+        Mockito.doReturn(Address.NON_ADDRESS).when(metadataManager).getLastProcessedLogEntryBatchTimestamp();
+
+        txnContext = Mockito.mock(TxnContext.class);
+        Mockito.doReturn(txnContext).when(metadataManager).getTxnContext();
+    }
+
+    private Map<LogReplicationMetadataType, Long> constructMetadataMgrMap(long topologyConfigId,
+        long lastTsInBatch, long lastOpaqueEntryTs, long lastSnapshotAppliedTs) {
+        Map<LogReplicationMetadataType, Long> metadataMap = new HashMap<>();
+        metadataMap.put(LogReplicationMetadataType.TOPOLOGY_CONFIG_ID, topologyConfigId);
+        metadataMap.put(LogReplicationMetadataType.LAST_SNAPSHOT_STARTED, Address.NON_ADDRESS);
+        metadataMap.put(LogReplicationMetadataType.LAST_SNAPSHOT_APPLIED, lastSnapshotAppliedTs);
+        metadataMap.put(LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED, lastTsInBatch);
+        metadataMap.put(LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED, lastOpaqueEntryTs);
+
+        return metadataMap;
+    }
+
+    @After
+    public void tearDown() {
+        corfuRuntime.shutdown();
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/MetadataManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/MetadataManagerTest.java
@@ -1,0 +1,179 @@
+package org.corfudb.infrastructure.logreplication;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogEntryWriter;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.corfudb.runtime.view.Address;
+import org.corfudb.util.retry.IRetry;
+import org.corfudb.util.retry.IntervalRetry;
+import org.corfudb.util.retry.RetryNeededException;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import java.util.Map;
+
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+
+@Slf4j
+@SuppressWarnings("checkstyle:magicnumber")
+public class MetadataManagerTest extends AbstractViewTest {
+
+    private CorfuRuntime corfuRuntime;
+    private LogReplicationConfig replicationConfig;
+    private boolean success;
+    private Long topologyConfigId = 5L;
+    private String localClusterId = "Test Cluster";
+    private TestUtils utils;
+
+    @Before
+    public void setUp() {
+        corfuRuntime = getDefaultRuntime();
+        replicationConfig = Mockito.mock(LogReplicationConfig.class);
+        utils = new TestUtils();
+    }
+
+    @After
+    public void tearDown() {
+        corfuRuntime.shutdown();
+    }
+
+    /**
+     * This test verifies that the timestamp of the last log entry processed during LogEntry sync is correctly
+     * updated in the metadata table on the Sink cluster
+     */
+    @Test
+    public void testMetadataAfterLogEntrySync() {
+
+        LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(corfuRuntime, topologyConfigId,
+            localClusterId);
+        LogEntryWriter writer = new LogEntryWriter(corfuRuntime, replicationConfig, metadataManager);
+
+        Long numOpaqueEntries = 3L;
+        LogReplication.LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(1, numOpaqueEntries,
+            Address.NON_ADDRESS, topologyConfigId, Address.NON_ADDRESS);
+
+        // Verify that the data was successfully applied
+        boolean success = writer.apply(lrEntryMsg);
+        Assert.assertTrue(success);
+
+        TxnContext txnContext = metadataManager.getTxnContext();
+        Map<LogReplicationMetadataManager.LogReplicationMetadataType, Long> metadataMap = metadataManager.queryMetadata(
+            txnContext,
+            LogReplicationMetadataManager.LogReplicationMetadataType.TOPOLOGY_CONFIG_ID,
+            LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED,
+            LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED);
+        txnContext.commit();
+
+        // Verify that metadata was correctly updated
+        Assert.assertEquals(topologyConfigId,
+            metadataMap.get(LogReplicationMetadataManager.LogReplicationMetadataType.TOPOLOGY_CONFIG_ID));
+        Assert.assertEquals(numOpaqueEntries,
+            metadataMap.get(LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED));
+        Assert.assertEquals(numOpaqueEntries,
+            metadataMap.get(LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED));
+    }
+
+    /**
+     * This test verifies that the initial values for last applied snapshot timestamp and last processed log entry
+     * timestamp are  Address.NON_ADDRESS.
+     * LR code relies on these initial values so any change to this expectation should be caught by this test.
+     */
+    @Test
+    public void testInitTsForSnapshotAndLogEntryProcessed() {
+
+        LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(corfuRuntime,
+            topologyConfigId, localClusterId);
+
+        long lastApppliedSnapshotTimestamp = metadataManager.getLastAppliedSnapshotTimestamp();
+        long lastProcessedLogEntryTimestamp = metadataManager.getLastProcessedLogEntryBatchTimestamp();
+
+        Assert.assertEquals(Address.NON_ADDRESS, lastApppliedSnapshotTimestamp);
+        Assert.assertEquals(Address.NON_ADDRESS, lastProcessedLogEntryTimestamp);
+    }
+
+    /**
+     * This test simulates a log entry apply and topology config update concurrently.
+     * It verifies that the topology update was successful.  Additionally, 1) if the topology update finished before all
+     * opaque entries were applied, it verifies that LAST_LOG_ENTRY_BATCH_PROCESSED was not updated (because topology
+     * config mismatch will be detected and no more entries applied) 2) if all opaque entries were applied before the
+     * topology config update, LAST_LOG_ENTRY_BATCH_PROCESSED was updated.
+     * @throws Exception
+     */
+    @Test
+    public void testConcurrentTopologyChange() throws Exception {
+
+        LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(corfuRuntime, topologyConfigId,
+            localClusterId);
+        LogEntryWriter writer = new LogEntryWriter(corfuRuntime, replicationConfig, metadataManager);
+
+        // Create a message with 50 opaque entries
+        Long numOpaqueEntries = 50L;
+        LogReplication.LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(1, numOpaqueEntries,
+            Address.NON_ADDRESS, topologyConfigId, Address.NON_ADDRESS);
+
+        // Thread 1: Log Entry apply
+        scheduleConcurrently(f -> {
+            success = writer.apply(lrEntryMsg);
+        });
+
+        // Thread 2: Topology config update
+        scheduleConcurrently(f -> {
+            try {
+                IRetry.build(IntervalRetry.class, () -> {
+                    CorfuStore corfuStore = new CorfuStore(corfuRuntime);
+                    try (TxnContext txnContext = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
+                        metadataManager.appendUpdate(txnContext,
+                            LogReplicationMetadataManager.LogReplicationMetadataType.TOPOLOGY_CONFIG_ID,
+                            topologyConfigId+1);
+                        txnContext.commit();
+                    } catch (TransactionAbortedException tae) {
+                        log.error("Transaction Aborted", tae);
+                        throw new RetryNeededException();
+                    }
+                    return null;
+                }).run();
+            } catch (Exception e) {
+                log.error("Unexpected exception caught.  Giving up", e);
+            }
+        });
+
+        executeScheduled(2, PARAMETERS.TIMEOUT_NORMAL);
+
+        TxnContext txnContext = metadataManager.getTxnContext();
+        Map<LogReplicationMetadataManager.LogReplicationMetadataType, Long> metadataMap = metadataManager.queryMetadata(
+            txnContext,
+            LogReplicationMetadataManager.LogReplicationMetadataType.TOPOLOGY_CONFIG_ID,
+            LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED,
+            LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED);
+        txnContext.commit();
+
+        // Verify that the topology was successfully updated
+        Assert.assertEquals(topologyConfigId+1,
+            (long)metadataMap.get(LogReplicationMetadataManager.LogReplicationMetadataType.TOPOLOGY_CONFIG_ID));
+
+        if (success) {
+            // Log entry apply finished before the topology changed.  Both LAST_LOG_ENTRY_PROCESSED and
+            // LAST_LOG_ENTRY_APPLIED will be updated
+            Assert.assertEquals(numOpaqueEntries,
+                metadataMap.get(LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED));
+            Assert.assertEquals(numOpaqueEntries,
+                metadataMap.get(LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED));
+        } else {
+            // Log entry was partially applied because topology change was detected.  LAST_LOG_ENTRY_PROCESSED should
+            // not have changed.
+            Assert.assertEquals(Address.NON_ADDRESS,
+                (long)metadataMap.get(LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_BATCH_PROCESSED));
+            Assert.assertTrue(
+                metadataMap.get(LogReplicationMetadataManager.LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED)
+                    < numOpaqueEntries);
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/TestUtils.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/TestUtils.java
@@ -1,0 +1,46 @@
+package org.corfudb.infrastructure.logreplication;
+
+import org.corfudb.protocols.logprotocol.OpaqueEntry;
+import org.corfudb.protocols.service.CorfuProtocolLogReplication;
+import org.corfudb.runtime.LogReplication;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static com.google.protobuf.UnsafeByteOperations.unsafeWrap;
+
+/**
+ * This class contains the common helper functions which can be used by multiple Log Replication unit tests.
+ */
+public class TestUtils {
+
+    /**
+     * Create a LogEntry message with opaque entries starting from startTs to endTs.  Each opaque entry corresponds to a
+     * transaction.  The metadata of the message is populated as per the input arguments.
+     */
+    LogReplication.LogReplicationEntryMsg generateLogEntryMsg(long startTs, long endTs, long prevTs, long topologyConfigId,
+                                                              long snapshotTs) {
+        List<OpaqueEntry> opaqueEntryList = new ArrayList<>();
+
+        for (long i = startTs; i <= endTs; i++) {
+            OpaqueEntry opaqueEntry = new OpaqueEntry(i, Collections.EMPTY_MAP);
+            opaqueEntryList.add(opaqueEntry);
+        }
+
+        // Create sample metadata
+        LogReplication.LogReplicationEntryMetadataMsg metadata = LogReplication.LogReplicationEntryMetadataMsg.newBuilder()
+            .setEntryType(LogReplication.LogReplicationEntryType.LOG_ENTRY_MESSAGE)
+            .setTimestamp(endTs)
+            .setSnapshotTimestamp(snapshotTs)
+            .setPreviousTimestamp(prevTs)
+            .setTopologyConfigID(topologyConfigId)
+            .setSnapshotSyncSeqNum(0)
+            .build();
+
+        // Generate the protobuf message to be given to LogEntryWriter
+        LogReplication.LogReplicationEntryMsg lrEntryMsg = CorfuProtocolLogReplication.getLrEntryMsg(unsafeWrap(
+            CorfuProtocolLogReplication.generatePayload(opaqueEntryList)), metadata);
+
+        return lrEntryMsg;
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -765,7 +765,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         // Verify Destination
         verifyData(dstCorfuTables, srcDataForVerification);
         expectedAckTimestamp.set(srcDataRuntime.getAddressSpaceView().getLogTail());
-        assertThat(expectedAckTimestamp.get()).isEqualTo(logReplicationMetadataManager.getLastProcessedLogEntryTimestamp());
+        assertThat(expectedAckTimestamp.get()).isEqualTo(logReplicationMetadataManager.getLastProcessedLogEntryBatchTimestamp());
         verifyPersistedSnapshotMetadata();
         verifyPersistedLogEntryMetadata();
 
@@ -1475,7 +1475,8 @@ public class LogReplicationIT extends AbstractIT implements Observer {
                     blockUntilExpectedAckType.release();
                 }
 
-                log.debug("expectedAckTs={}, logEntryTs={}", expectedAckTimestamp.get(), logReplicationEntry.getMetadata().getTimestamp());
+                log.debug("expectedAckTs={}, logEntryTs={}", expectedAckTimestamp.get(),
+                    logReplicationEntry.getMetadata().getTimestamp());
 
                 if (expectedAckTimestamp.get() == logReplicationEntry.getMetadata().getTimestamp()) {
                     blockUntilExpectedAckTs.release();
@@ -1491,7 +1492,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     }
 
     private void verifyPersistedLogEntryMetadata() {
-        long lastLogProcessed = logReplicationMetadataManager.getLastProcessedLogEntryTimestamp();
+        long lastLogProcessed = logReplicationMetadataManager.getLastProcessedLogEntryBatchTimestamp();
 
         log.debug("\nlastLogProcessed " + lastLogProcessed + " expectedTimestamp " + expectedAckTimestamp.get());
         assertThat(expectedAckTimestamp.get() == lastLogProcessed).isTrue();

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -226,7 +226,7 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
                     .setSnapshotStart(baseSnapshotTimestamp)
                     .setSnapshotTransferred(destinationLogReplicationManager.getLogReplicationMetadataManager().getLastTransferredSnapshotTimestamp())
                     .setSnapshotApplied(destinationLogReplicationManager.getLogReplicationMetadataManager().getLastAppliedSnapshotTimestamp())
-                    .setLastLogEntryTimestamp(destinationLogReplicationManager.getLogReplicationMetadataManager().getLastProcessedLogEntryTimestamp())
+                    .setLastLogEntryTimestamp(destinationLogReplicationManager.getLogReplicationMetadataManager().getLastProcessedLogEntryBatchTimestamp())
                     .build();
         }
 
@@ -301,10 +301,10 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
                 .build();
 
         assertThat(destinationLogReplicationManager.getLogReplicationMetadataManager()
-                .getLastProcessedLogEntryTimestamp())
+                .getLastProcessedLogEntryBatchTimestamp())
                 .isGreaterThanOrEqualTo(newMessage.getMetadata().getPreviousTimestamp());
         assertThat(destinationLogReplicationManager.getLogReplicationMetadataManager()
-                .getLastProcessedLogEntryTimestamp())
+                .getLastProcessedLogEntryBatchTimestamp())
                 .isLessThan(newMessage.getMetadata().getTimestamp());
 
         lastAckDropped = Long.MAX_VALUE;


### PR DESCRIPTION
## Overview
During log entry sync, multiple transactions are batched in a single message by the Sender.  Before this fix, the receiver coalesced and applied them all as a single  transaction.  This PR addresses the issue and maintains the transaction boundaries to be the same as what was received.

Why should this be merged: 
As multiple transactions are grouped in a single transaction on the receiver, the order of streaming updates is not consistent with the sender without this fix.

Tests Added
--------------

LogEntryWriterTest
---------------------
1. Verify that each opaque entry in a LogReplicationEntryMsg is applied
   in a separate transaction.
2. Verify that redundant apply of the same LogReplicationEntryMsg is not
   performed.
3. Verify that 2 LogReplicationEntryMsgs with overlapping sequence
   numbers are applied correctly
4. Simulate an exception after a LogReplicationEntryMsg is partially
   applied.  Verify that a subsequent resend of this message is correctly applied.
5. Verify that a LogReplicationEntryMsg with a mismatching 'previous
   Timestamp' is rejected.
6. Verify that a LogReplicationEntryMsg with a mismatching 'snapshot
   timestamp' (lower and higher) is not applied.
7. Verify that a LogReplicationEntryMsg with a mismatching topology id
   is rejected.

MetadataManagerTest
-------------------------
1. Verify that metadata is correctly updated after a successful LogEntry
   sync.
2. Simulate concurrent update of topology id and log entry sync.  Verify
   that the metadata is updated according to which transaction(topology
   update or log entry apply) finished first.
3. Verify that MetadataManager returns Address.NON_ADDRESS as the
   initial/default value of 'LAST_SNAPSHOT_APPLIED' and
   'LAST_LOG_ENTRY_BATCH_PROCESSED'.

CorfuStoreShimTest
-------------------------
1. Verify that for a WriteAfterWrite TX type, touch() api is needed to detect
   a conflict between a read-only and write transaction on a conflict key.
   Also verify that the conflict is not detected without the touch() api.



Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
