### PR TITLE
Disable Caching and Add Support For Floor Queries

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -754,7 +754,7 @@ public class SequencerServer extends AbstractServer {
             // (to keep track of all updates to this stream)
             streamsAddressMap.compute(uuid, (streamId, addressMap) -> {
                 if (addressMap == null) {
-                    addressMap = new StreamAddressSpace();
+                    addressMap = new StreamAddressSpace(true);
                 }
 
                 for (long i = globalLogTail; i < newTail; i++) {

--- a/runtime/src/test/java/org/corfudb/runtime/clients/SequencerHandlerTest.java
+++ b/runtime/src/test/java/org/corfudb/runtime/clients/SequencerHandlerTest.java
@@ -95,7 +95,7 @@ public class SequencerHandlerTest {
         Map<UUID, StreamAddressSpace> defaultMap = new HashMap<>();
         int numIter = 10;
         for (int i = 0; i < numIter; i++) {
-            defaultMap.put(UUID.randomUUID(), new StreamAddressSpace());
+            defaultMap.put(UUID.randomUUID(), new StreamAddressSpace(true));
         }
         return defaultMap;
     }

--- a/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
+++ b/test/src/test/java/org/corfudb/runtime/utils/UtilsTest.java
@@ -249,7 +249,7 @@ public class UtilsTest {
   }
 
   private StreamAddressSpace getRandomStreamSpace(long max) {
-    StreamAddressSpace streamA = new StreamAddressSpace();
+    StreamAddressSpace streamA = new StreamAddressSpace(true);
     LongStream.range(0, max)
             .forEach(address -> streamA.addAddress(((address & 0x1) == 1) ? 0 : address));
     return streamA;


### PR DESCRIPTION
This patch exposes a new floor API for StreamAddressSpace. This core
operation will allow MVCC to efficiently determine the latest version that
is visible from a particular timestamp.  This patch also disables caching
within the Roaring64NavigableMap backing the address space in order
to allow for concurrent optimistic read operations on the data structure.

## Overview

Description:

Why should this be merged: Adds support for core operation used in MVCC.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
