### PR TITLE
Change The Default Garbage Collector

### DIFF
--- a/scripts/corfu_server.sh
+++ b/scripts/corfu_server.sh
@@ -42,6 +42,6 @@ fi
 
 # default heap for corfudb
 CORFUDB_HEAP="${CORFUDB_HEAP:-2000}"
-export JVMFLAGS="-Xmx${CORFUDB_HEAP}m $SERVER_JVMFLAGS"
+export JVMFLAGS="-XX:+UseG1GC -Xmx${CORFUDB_HEAP}m $SERVER_JVMFLAGS"
 
 $JAVA -cp "$CLASSPATH" $JVMFLAGS org.corfudb.infrastructure.CorfuServer $*


### PR DESCRIPTION
## Overview

Added -XX:+UseG1GC to the server launcher script.

Why should this be merged: Brings the server defaults closer to what what is being tested

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
