### PR TITLE
@universe: Release resources on shutdown

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/ServerContext.java
@@ -230,6 +230,16 @@ public class ServerContext implements AutoCloseable {
     }
 
     /**
+     * Get a new ExecutorService backed by a cached thread pool.
+     * @param threadPrefix  The naming prefix
+     * @return The newly created ExecutorService
+     */
+    public static ExecutorService getCachedExecutorService(@Nonnull String threadPrefix) {
+        return Executors.newCachedThreadPool(
+                new ServerThreadFactory(threadPrefix, new ServerThreadFactory.ExceptionHandler()));
+    }
+
+    /**
      * Get the max number of messages can be sent over per batch.
      * @return
      */

--- a/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCluster.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/AbstractCluster.java
@@ -3,7 +3,9 @@ package org.corfudb.universe.group.cluster;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.concurrent.BasicThreadFactory;
 import org.corfudb.common.util.ClassUtils;
+import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.universe.group.Group;
 import org.corfudb.universe.group.Group.GroupParams;
 import org.corfudb.universe.node.Node;
@@ -35,7 +37,7 @@ public abstract class AbstractCluster<
     protected AbstractCluster(P params, U universeParams) {
         this.params = params;
         this.universeParams = universeParams;
-        this.executor = Executors.newCachedThreadPool();
+        this.executor = ServerContext.getCachedExecutorService("abstract-cluster");
     }
 
     protected CompletableFuture<Node> deployAsync(Node server) {
@@ -87,6 +89,8 @@ public abstract class AbstractCluster<
                 log.warn("Can't destroy node: {} in group: {}", node.getParams().getName(), getParams().getName(), e);
             }
         });
+
+        executor.shutdownNow();
     }
 
     @Override

--- a/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
@@ -102,7 +102,7 @@ public class CorfuServerParams implements NodeParams {
     }
 
     public String getDockerImageNameFullName() {
-        return dockerImage + ":" + serverVersion;
+        return (dockerImage + ":" + serverVersion).trim();
     }
 
     public Path getInfrastructureJar() {

--- a/it/src/main/java/org/corfudb/universe/universe/docker/DockerUniverse.java
+++ b/it/src/main/java/org/corfudb/universe/universe/docker/DockerUniverse.java
@@ -81,13 +81,14 @@ public class DockerUniverse extends AbstractUniverse<NodeParams, UniverseParams>
         }
 
         shutdownGroups();
-
         // Remove docker network
         try {
             network.shutdown();
         } catch (UniverseException e) {
             log.debug("Can't remove docker network: {}", universeParams.getNetworkName());
         }
+
+        docker.close();
     }
 
     @Override


### PR DESCRIPTION
Release all resources during the shutdown of the AbstractCluster and the DockerUniverse.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
