### PR TITLE
Revert "Update CorfuTable getByIndex API"

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -21,6 +21,7 @@ import org.corfudb.util.ImmutableListSetWrapper;
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -227,13 +228,13 @@ public class CorfuTable<K, V> implements ICorfuTable<K, V>, ICorfuSMR<CorfuTable
      *
      * @param indexName Name of the the secondary index to query.
      * @param indexKey  The index key used to query the secondary index
-     * @return A stream of {@code Map.Entry<K, V>}
+     * @return A collection of Map.Entry<K, V>
      */
     @SuppressWarnings("unchecked")
     @Accessor
     public @Nonnull
     <I>
-    Stream<Entry<K, V>> getByIndex(@Nonnull Index.Name indexName, I indexKey) {
+    Collection<Entry<K, V>> getByIndex(@Nonnull Index.Name indexName, I indexKey) {
         String secondaryIndex = indexName.get();
         Map<Object, Map<K, V>> secondaryMap;
         if ((secondaryIndexes.containsKey(secondaryIndex) &&
@@ -243,8 +244,8 @@ public class CorfuTable<K, V> implements ICorfuTable<K, V>, ICorfuSMR<CorfuTable
             Map<K, V> res = secondaryMap.get(indexKey);
 
             return res == null ?
-                    Stream.empty() :
-                    res.entrySet().stream();
+                    Collections.emptySet() :
+                    new HashSet<>(res.entrySet());
         }
 
         // If index is not specified, the lookup by index API must fail.
@@ -257,8 +258,8 @@ public class CorfuTable<K, V> implements ICorfuTable<K, V>, ICorfuSMR<CorfuTable
      *
      * @param indexName      Name of the the secondary index to query.
      * @param entryPredicate The predicate to scan and filter with.
-     * @param indexKey       The index key used to query the secondary index
-     * @return A collection of {@code Map.Entry<K, V>}
+     * @param indexKey       A collection of Map.Entry<K, V>
+     * @return
      */
     @Accessor
     public @Nonnull

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -441,7 +441,7 @@ public class Table<K extends Message, V extends Message, M extends Message> {
     <I>
     List<CorfuStoreEntry<K, V, M>> getByIndex(@Nonnull final String indexName,
                                               @Nonnull final I indexKey) {
-        return corfuTable.getByIndex(() -> indexName, indexKey)
+        return corfuTable.getByIndex(() -> indexName, indexKey).stream()
                 .map(entry -> new CorfuStoreEntry<K, V, M>(entry.getKey(),
                         entry.getValue().getPayload(),
                         entry.getValue().getMetadata()))

--- a/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
+++ b/test/src/test/java/org/corfudb/integration/ServerRestartIT.java
@@ -2,6 +2,7 @@ package org.corfudb.integration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+
 import com.google.common.reflect.TypeToken;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -26,8 +27,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
-
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CheckpointWriter;
@@ -543,16 +542,14 @@ public class ServerRestartIT extends AbstractIT {
             corfuTable1.put(Integer.toString(i), Integer.toString(i));
         }
 
-        final String indexKeyQuery = "9";
-
         // Checkpoint and trim the log.
         MultiCheckpointWriter mcw = new MultiCheckpointWriter();
         mcw.addMap(corfuTable1);
         Token trimMark = mcw.appendCheckpoints(runtime1, "author");
         Collection<Map.Entry<String, String>> c1a =
-                corfuTable1.getByIndex(StringIndexer.BY_FIRST_LETTER, indexKeyQuery).collect(Collectors.toList());
+                corfuTable1.getByIndex(StringIndexer.BY_FIRST_LETTER, "9");
         Collection<Map.Entry<String, String>> c1b =
-                corfuTable1.getByIndex(StringIndexer.BY_VALUE, indexKeyQuery).collect(Collectors.toList());
+                corfuTable1.getByIndex(StringIndexer.BY_VALUE, "9");
         runtime1.getAddressSpaceView().prefixTrim(trimMark);
         runtime1.getAddressSpaceView().invalidateClientCache();
         runtime1.getAddressSpaceView().invalidateServerCaches();
@@ -566,7 +563,7 @@ public class ServerRestartIT extends AbstractIT {
         CorfuRuntime runtime2 = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
         CorfuTable<String, String> corfuTable2 = createTable(runtime2, new StringIndexer());
         Collection<Map.Entry<String, String>> c2 =
-                corfuTable2.getByIndex(StringIndexer.BY_FIRST_LETTER, indexKeyQuery).collect(Collectors.toList());
+                corfuTable2.getByIndex(StringIndexer.BY_FIRST_LETTER, "9");
         assertThat(c1a.size()).isEqualTo(c2.size());
         assertThat(c1a.containsAll(c2)).isTrue();
 
@@ -576,7 +573,7 @@ public class ServerRestartIT extends AbstractIT {
                 .connect();
         CorfuTable<String, String> corfuTable3 = createTable(runtime3, new StringIndexer());
         Collection<Map.Entry<String, String>> c3 =
-                corfuTable3.getByIndex(StringIndexer.BY_VALUE, indexKeyQuery).collect(Collectors.toList());
+                corfuTable3.getByIndex(StringIndexer.BY_VALUE, "9");
         assertThat(c1b.size()).isEqualTo(c3.size());
         assertThat(c1b.containsAll(c3)).isTrue();
 
@@ -620,14 +617,12 @@ public class ServerRestartIT extends AbstractIT {
             corfuTable1.put(key, value.toString());
         }
 
-        final String indexKeyQuery = "tag666";
-
         // Checkpoint and trim
         MultiCheckpointWriter multiCheckpointWriter = new MultiCheckpointWriter();
         multiCheckpointWriter.addMap(corfuTable1);
         Token trimMark = multiCheckpointWriter.appendCheckpoints(runtime1, "Sam.Behnam");
         Collection<Map.Entry<String, String>> resultInitial =
-                corfuTable1.getByIndex(StringMultiIndexer.BY_EACH_WORD, indexKeyQuery).collect(Collectors.toList());
+                corfuTable1.getByIndex(StringMultiIndexer.BY_EACH_WORD, "tag666");
         runtime1.getAddressSpaceView().prefixTrim(trimMark);
         runtime1.getAddressSpaceView().invalidateClientCache();
         runtime1.getAddressSpaceView().invalidateServerCaches();
@@ -641,7 +636,7 @@ public class ServerRestartIT extends AbstractIT {
         CorfuRuntime runtime2 = new CorfuRuntime(DEFAULT_ENDPOINT).connect();
         CorfuTable<String, String> corfuTable2 = createTable(runtime2, new StringMultiIndexer());
         Collection<Map.Entry<String, String>> resultAfterRestart =
-                corfuTable2.getByIndex(StringMultiIndexer.BY_EACH_WORD, indexKeyQuery).collect(Collectors.toList());
+                corfuTable2.getByIndex(StringMultiIndexer.BY_EACH_WORD, "tag666");
         assertThat(resultAfterRestart.size()).isEqualTo(resultInitial.size());
         assertThat(resultAfterRestart.containsAll(resultInitial)).isTrue();
 
@@ -651,7 +646,7 @@ public class ServerRestartIT extends AbstractIT {
                 .connect();
         CorfuTable<String, String> corfuTable3 = createTable(runtime3, new StringMultiIndexer());
         Collection<Map.Entry<String, String>> resultDisabledCacheAndFasLoader =
-                corfuTable3.getByIndex(StringMultiIndexer.BY_EACH_WORD, indexKeyQuery).collect(Collectors.toList());
+                corfuTable3.getByIndex(StringMultiIndexer.BY_EACH_WORD, "tag666");
         assertThat(resultDisabledCacheAndFasLoader.size()).isEqualTo(resultInitial.size());
         assertThat(resultDisabledCacheAndFasLoader.containsAll(resultInitial)).isTrue();
 

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuTableTest.java
@@ -33,8 +33,8 @@ public class CorfuTableTest extends AbstractViewTest {
 
     private static final int ITERATIONS = 20;
 
-    Collection<String> project(Stream<Map.Entry<String, String>> entries) {
-        return entries.map(Map.Entry::getValue).collect(Collectors.toCollection(ArrayList::new));
+    Collection<String> project(Collection<Map.Entry<String, String>> entries) {
+        return entries.stream().map(entry -> entry.getValue()).collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Test
@@ -100,10 +100,10 @@ public class CorfuTableTest extends AbstractViewTest {
         corfuTable.put("k3", "b");
 
         assertThat(project(corfuTable.getByIndex(StringIndexer.BY_FIRST_LETTER, "a")))
-                .containsExactlyInAnyOrder("ab", "a");
+                .containsExactly("ab", "a");
 
         assertThat(project(corfuTable.getByIndex(StringIndexer.BY_VALUE, "ab")))
-                .containsExactlyInAnyOrder("ab");
+                .containsExactly("ab");
     }
 
     /**
@@ -195,8 +195,9 @@ public class CorfuTableTest extends AbstractViewTest {
         corfuTable.put("k2", "dog bat");
         corfuTable.put("k3", "fox");
 
-        assertThat(project(corfuTable.getByIndex(StringMultiIndexer.BY_EACH_WORD, "fox")))
-                .containsExactlyInAnyOrder("dog fox cat", "fox");
+        final Collection<Map.Entry<String, String>> result =
+                corfuTable.getByIndex(StringMultiIndexer.BY_EACH_WORD, "fox");
+        assertThat(project(result)).containsExactlyInAnyOrder("dog fox cat", "fox");
     }
 
     @Test
@@ -210,10 +211,10 @@ public class CorfuTableTest extends AbstractViewTest {
                 .open();
 
 
-        assertThat(project(corfuTable.getByIndex(StringIndexer.BY_FIRST_LETTER, "a")))
+        assertThat(corfuTable.getByIndex(StringIndexer.BY_FIRST_LETTER, "a"))
                 .isEmpty();
 
-        assertThat(project(corfuTable.getByIndex(StringIndexer.BY_VALUE, "ab")))
+        assertThat(corfuTable.getByIndex(StringIndexer.BY_VALUE, "ab"))
                 .isEmpty();
     }
 


### PR DESCRIPTION
Reverts CorfuDB/CorfuDB#3340 - Creates a regression with respect to concurrency, where the VLO can modify the entry set backing the map, and hence the content of the stream, before they are collected.