### PR TITLE
@queue: Fix a bug in entryList() API

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuQueue.java
@@ -315,8 +315,9 @@ public class CorfuQueue {
         Comparator<Map.Entry<CorfuRecordId, ByteString>> recordIdComparator = Comparator.comparing(Map.Entry::getKey);
         for (Map.Entry<CorfuRecordId, ByteString> entry : corfuTable.entryStream()
                 .filter(e -> e.getKey().compareTo(entriesAfter) > 0)
+                .sorted(recordIdComparator)
                 .limit(maxEntries)
-                .sorted(recordIdComparator).collect(Collectors.toList())) {
+                .collect(Collectors.toList())) {
             copy.add(new CorfuQueueRecord(entry.getKey(), entry.getValue()));
         }
         return copy;


### PR DESCRIPTION
The filter() and sort() sequence of operations performed on the entryStream() needs to be reversed.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
