### PR TITLE
@docker: Change the default base image

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine3.8
+FROM openjdk:8-jdk-bullseye
 
 ARG CORFU_JAR
 ARG CMDLETS_JAR
@@ -6,7 +6,7 @@ ARG CORFU_TOOLS_JAR
 
 WORKDIR /app
 
-RUN apk add --update iptables bash jq python3 sudo
+RUN apt update && apt -y install iptables bash jq python3 sudo iproute2
 
 COPY target/${CORFU_JAR} /usr/share/corfu/lib/${CORFU_JAR}
 COPY target/${CMDLETS_JAR} /usr/share/corfu/lib/${CMDLETS_JAR}


### PR DESCRIPTION
Switch from Alpine to Debian as the default base image. The previous image was missing several native libraries, including ld-linux-x86-64.so.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
