### PR TITLE
@docker: Package an optional YourKit Agent

### DIFF
--- a/.ci/infrastructure-docker-build.sh
+++ b/.ci/infrastructure-docker-build.sh
@@ -3,6 +3,7 @@
 set -e
 
 PROFILE=$1
+ENVIRONMENT=$2
 if [ -z "$PROFILE" ]; then
   echo "Please provide a profile name: 'docker' or 'compatibility'"
   exit 1
@@ -20,6 +21,20 @@ cp -r ./corfu_scripts ./infrastructure/target/
 cp -r ./scripts ./infrastructure/target/
 cp -r ./infrastructure/src/main/resources/logback.prod.xml ./infrastructure/target/
 
+touch ./infrastructure/target/libyjpagent.so
+
+if [ "$ENVIRONMENT" = "debug" ]; then
+  # Check for the cached version of the YourKit Agent
+  if [ ! -f .ci/lib/libyjpagent.so ]; then
+    # Download and extract the YourKit Agent and move it to the target directory
+    curl --create-dirs -LO --output-dir .ci/lib/ https://www.yourkit.com/download/docker/YourKit-JavaProfiler-2022.3-docker.zip
+    (cd .ci/lib/ && unzip YourKit-*.zip && rm YourKit-*.zip && mv */bin/linux-x86-64/libyjpagent.so .)
+  fi
+
+  cp .ci/lib/libyjpagent.so ./infrastructure/target/
+fi
+
+
 CORFU_VERSION=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
 
 cp -r ./cmdlets/target/cmdlets-"${CORFU_VERSION}"-shaded.jar ./infrastructure/target/
@@ -33,6 +48,7 @@ CMD_LINE+="--network=host "
 CMD_LINE+="--build-arg CORFU_JAR=infrastructure-${CORFU_VERSION}-shaded.jar "
 CMD_LINE+="--build-arg CMDLETS_JAR=cmdlets-${CORFU_VERSION}-shaded.jar "
 CMD_LINE+="--build-arg CORFU_TOOLS_JAR=corfudb-tools-${CORFU_VERSION}-shaded.jar "
+CMD_LINE+="--build-arg YK=libyjpagent.so "
 
 if [ "$PROFILE" = "docker" ]; then
   CMD_LINE+="-t corfudb/corfu-server:${CORFU_VERSION} -t corfudb-universe/corfu-server:${CORFU_VERSION}"

--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,6 @@ test/.jqwik-database
 .flattened-pom.xml
 /*/.flattened-pom.xml
 tags
+
+# Docker
+.ci/lib/

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -3,6 +3,7 @@ FROM openjdk:8-jdk-bullseye
 ARG CORFU_JAR
 ARG CMDLETS_JAR
 ARG CORFU_TOOLS_JAR
+ARG YK
 
 WORKDIR /app
 
@@ -11,6 +12,7 @@ RUN apt update && apt -y install iptables bash jq python3 sudo iproute2
 COPY target/${CORFU_JAR} /usr/share/corfu/lib/${CORFU_JAR}
 COPY target/${CMDLETS_JAR} /usr/share/corfu/lib/${CMDLETS_JAR}
 COPY target/${CORFU_TOOLS_JAR} /usr/share/corfu/lib/${CORFU_TOOLS_JAR}
+COPY target/${YK} /usr/share/corfu/lib/${YK}
 
 COPY target/bin /usr/share/corfu/bin
 COPY target/corfu_scripts /usr/share/corfu/corfu_scripts


### PR DESCRIPTION
When building a Docker image for the Corfu server, allow for the YourKit Agent to be packaged only if the 'debug' paramater is being used.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
