### PR TITLE
@Universe: Parameterize ContainerResources

### DIFF
--- a/it/src/main/java/org/corfudb/universe/UniverseManager.java
+++ b/it/src/main/java/org/corfudb/universe/UniverseManager.java
@@ -60,7 +60,7 @@ public class UniverseManager {
         return wf;
     }
 
-    private <T extends Fixture<UniverseParams>> UniverseWorkflow<T> workflow() {
+    public <T extends Fixture<UniverseParams>> UniverseWorkflow<T> workflow() {
 
         T fixture;
         switch (universeMode) {

--- a/it/src/main/java/org/corfudb/universe/group/cluster/CorfuClusterParams.java
+++ b/it/src/main/java/org/corfudb/universe/group/cluster/CorfuClusterParams.java
@@ -13,6 +13,7 @@ import org.corfudb.universe.group.Group.GroupParams;
 import org.corfudb.universe.group.cluster.Cluster.ClusterType;
 import org.corfudb.universe.node.Node.NodeType;
 import org.corfudb.universe.node.server.CorfuServerParams;
+import org.corfudb.universe.node.server.CorfuServerParams.ContainerResources;
 
 import java.time.Duration;
 import java.util.List;
@@ -34,6 +35,11 @@ public class CorfuClusterParams<T extends CorfuServerParams> implements GroupPar
     @Default
     @Getter
     private final int numNodes = 3;
+
+    @Default
+    @Getter
+    private final ContainerResources containerResources =
+            ContainerResources.builder().build();
 
     /**
      * Corfu server version, for instance: 0.4.0-SNAPSHOT

--- a/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/CorfuServerParams.java
@@ -62,8 +62,8 @@ public class CorfuServerParams implements NodeParams {
     @EqualsAndHashCode.Exclude
     private final Duration stopTimeout = Duration.ofSeconds(1);
 
-    @Default
-    private final Optional<ContainerResources> containerResources = Optional.empty();
+    @NonNull
+    private final ContainerResources containerResources;
 
     /**
      * Corfu server version, for instance: 0.4.0-SNAPSHOT
@@ -116,6 +116,8 @@ public class CorfuServerParams implements NodeParams {
      */
     @Builder
     @ToString
+    @EqualsAndHashCode
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
     public static class ContainerResources {
 
         /**
@@ -123,6 +125,6 @@ public class CorfuServerParams implements NodeParams {
          */
         @Getter
         @Default
-        private final long memory = 1048 * 1024 * 1024;
+        private final Optional<Long> memory = Optional.of(1048L * 1024 * 1024);
     }
 }

--- a/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
+++ b/it/src/main/java/org/corfudb/universe/node/server/docker/DockerCorfuServer.java
@@ -345,8 +345,9 @@ public class DockerCorfuServer extends AbstractCorfuServer<CorfuServerParams, Un
         }
 
         HostConfig.Builder hostConfigBuilder = HostConfig.builder();
-        params.getContainerResources()
-                .ifPresent(limits -> hostConfigBuilder.memory(limits.getMemory()));
+        if (params.getContainerResources().getMemory().isPresent()) {
+            hostConfigBuilder.memory(params.getContainerResources().getMemory().get());
+        }
 
         HostConfig hostConfig = hostConfigBuilder
                 .privileged(true)

--- a/it/src/main/java/org/corfudb/universe/scenario/fixture/FixtureUtil.java
+++ b/it/src/main/java/org/corfudb/universe/scenario/fixture/FixtureUtil.java
@@ -51,7 +51,7 @@ public class FixtureUtil {
                 .map(port -> serverBuilder
                         .port(port)
                         .clusterName(cluster.getName())
-                        .containerResources(Optional.of(ContainerResources.builder().build()))
+                        .containerResources(cluster.getContainerResources())
                         .serverVersion(cluster.getServerVersion())
                         .build()
                 )

--- a/it/src/main/java/org/corfudb/universe/scenario/fixture/Fixtures.java
+++ b/it/src/main/java/org/corfudb/universe/scenario/fixture/Fixtures.java
@@ -75,6 +75,7 @@ public interface Fixtures {
 
         private final UniverseParamsBuilder universe = UniverseParams.universeBuilder();
 
+        @Getter
         private final CorfuClusterParamsBuilder<CorfuServerParams> cluster = CorfuClusterParams
                 .builder();
 

--- a/it/src/test/java/org/corfudb/universe/group/CorfuClusterParamsTest.java
+++ b/it/src/test/java/org/corfudb/universe/group/CorfuClusterParamsTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.corfudb.universe.group.cluster.CorfuClusterParams;
 import org.corfudb.universe.node.server.CorfuServerParams;
+import org.corfudb.universe.node.server.CorfuServerParams.ContainerResources;
 import org.corfudb.universe.node.server.ServerUtil;
 import org.junit.Test;
 
@@ -23,6 +24,7 @@ public class CorfuClusterParamsTest {
                 .port(port)
                 .clusterName(clusterName)
                 .serverVersion("1.0.0")
+                .containerResources(ContainerResources.builder().build())
                 .build();
 
         SortedSet<CorfuServerParams> corfuServers = new TreeSet<>(Collections.singletonList(param));

--- a/it/src/test/java/org/corfudb/universe/node/server/CorfuServerParamsTest.java
+++ b/it/src/test/java/org/corfudb/universe/node/server/CorfuServerParamsTest.java
@@ -2,6 +2,7 @@ package org.corfudb.universe.node.server;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.corfudb.universe.node.server.CorfuServerParams.ContainerResources;
 import org.junit.Test;
 import org.slf4j.event.Level;
 
@@ -22,6 +23,7 @@ public class CorfuServerParamsTest {
                 .persistence(CorfuServer.Persistence.DISK)
                 .stopTimeout(Duration.ofSeconds(123))
                 .serverVersion("1.0.0")
+                .containerResources(ContainerResources.builder().build())
                 .build();
 
         CorfuServerParams p2 = CorfuServerParams.serverParamsBuilder()
@@ -32,6 +34,7 @@ public class CorfuServerParamsTest {
                 .persistence(CorfuServer.Persistence.DISK)
                 .stopTimeout(Duration.ofSeconds(555))
                 .serverVersion("1.0.0")
+                .containerResources(ContainerResources.builder().build())
                 .build();
 
         assertThat(p1).isEqualTo(p2);


### PR DESCRIPTION
Allow the client to specify container resources when invoking the test/benchmark.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
