### PR TITLE
MultiVersionObject: Clear Stream Address Space on Reset

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/MultiVersionObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MultiVersionObject.java
@@ -48,7 +48,7 @@ public class MultiVersionObject<T extends ICorfuSMR<T>> {
     /**
      * Metadata on object versions generated.
      */
-    private final StreamAddressSpace addressSpace;
+    private StreamAddressSpace addressSpace;
 
     /**
      * Current state of the underlying object. We maintain a reference here explicitly
@@ -358,6 +358,7 @@ public class MultiVersionObject<T extends ICorfuSMR<T>> {
         currentObject.close();
         currentObject = newObjectFn.get();
         currentObjectVersion = Address.NON_EXIST;
+        addressSpace = new StreamAddressSpace();
         smrStream.reset();
     }
 


### PR DESCRIPTION
## Overview

This patch will create a new StreamAddressSpace on reset so that subsequent floor queries cannot query the state before the reset.

Why should this be merged: Fixes reset bug

## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
