### PR TITLE
@vlo @monotonic Fix NoRollbackException

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -247,6 +247,12 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
         // If we aren't coming from a transactional context,
         // redirect us to a transactional context first.
         if (TransactionalContext.isInTransaction()) {
+            // Monotonic objects leverage a no-op optimistic stream,
+            // therefore, we must stub the upcall result.
+            if (underlyingObject.isMonotonicObject()) {
+                return null;
+            }
+
             try {
                 return (R) TransactionalContext.getCurrentContext()
                         .getUpcallResult(this, timestamp, conflictObject);

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/NoOpSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/NoOpSMRStream.java
@@ -1,0 +1,43 @@
+package org.corfudb.runtime.object.transactions;
+
+import org.corfudb.protocols.logprotocol.SMREntry;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * This is a no-op implementation of {@link WriteSetSMRStream}.
+ */
+public class NoOpSMRStream extends WriteSetSMRStream {
+    /**
+     * Returns a new WriteSetSMRStream containing transactional contexts and stream id.
+     *
+     * @param contexts list of transactional contexts
+     * @param id       stream id
+     */
+    public NoOpSMRStream(List<AbstractTransactionalContext> contexts, UUID id) {
+        super(contexts, id);
+    }
+
+    @Override
+    public List<SMREntry> remainingUpTo(long maxGlobal) {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<SMREntry> current() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public List<SMREntry> previous() {
+        writePos--;
+        return Collections.emptyList();
+    }
+
+    @Override
+    public long pos() {
+        return writePos;
+    }
+}

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/WriteSetSMRStream.java
@@ -73,7 +73,7 @@ public class WriteSetSMRStream implements ISMRStream {
     /**
      * Current write position in an SMREntry
      */
-    private long writePos;
+    protected long writePos;
 
     // the specific stream-id for which this SMRstream wraps the write-set
     private final UUID id;

--- a/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
@@ -47,6 +47,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
@@ -129,7 +130,7 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
                 new PojoSerializer(String.class), getRuntime());
         return getDefaultRuntime().getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
-                .setArguments(mapSupplier, ICorfuVersionPolicy.DEFAULT)
+                .setArguments(mapSupplier, ICorfuVersionPolicy.MONOTONIC)
                 .setStreamName("diskBackedMap")
                 .open();
     }
@@ -178,7 +179,7 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
                 persistedCacheLocation, options, Serializers.JSON, getRuntime());
         final CorfuTable<String, String> table = getDefaultRuntime().getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {})
-                .setArguments(mapSupplier,ICorfuVersionPolicy.DEFAULT)
+                .setArguments(mapSupplier,ICorfuVersionPolicy.MONOTONIC)
                 .setStreamName("diskBackedMap")
                 .open();
 
@@ -214,7 +215,7 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
         CorfuTable<String, Pojo>
                 table = getDefaultRuntime().getObjectsView().build()
                 .setTypeToken(new TypeToken<CorfuTable<String, Pojo>>() {})
-                .setArguments(mapSupplier, ICorfuVersionPolicy.DEFAULT)
+                .setArguments(mapSupplier, ICorfuVersionPolicy.MONOTONIC)
                 .setStreamName("diskBackedMap")
                 .open();
 


### PR DESCRIPTION
Since we are not computing undo records for monotonic objects, we need to prevent the optimistic stream from rolling back on a context switch as well. This patch effectively:

* Avoids applying updates on the optimistic streams. This avoids the issue of garbage accumulation. Since monotonic policy does not support read your own writes semantics, these updates are not even necessary.
* Avoids applying undo records on optimistic streams. This prevents NoRollbackException for being generated.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
