### PR TITLE
Update commit address computation for disk-backed tables

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/AbstractTransactionalContext.java
@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.logprotocol.MultiObjectSMREntry;
@@ -124,6 +125,13 @@ public abstract class AbstractTransactionalContext implements
     @Setter
     private TxnContext txnContext;
 
+    /**
+     * Flag used to track if this transaction has performed any accesses
+     * on monotonic objects. This is used to compute the commit address
+     * of read-only transactions.
+     */
+    protected boolean hasAccessedMonotonicObject = false;
+
     @Getter
     private final WriteSetInfo writeSetInfo = new WriteSetInfo();
 
@@ -143,15 +151,27 @@ public abstract class AbstractTransactionalContext implements
         AbstractTransactionalContext.log.trace("TXBegin[{}]", this);
     }
 
-    protected void updateKnownStreamPosition(UUID streamId, long position) {
-        Long val = knownStreamsPosition.get(streamId);
+    protected void updateKnownStreamPosition(@NonNull ICorfuSMRProxyInternal<?> proxy, long position) {
+        final boolean isMonotonicObject = proxy.getUnderlyingObject().isMonotonicObject();
+        Long val = knownStreamsPosition.get(proxy.getStreamID());
+
         if (val != null) {
-            Preconditions.checkState(val == position, "inconsistent stream positions %s and %s",
-                    val, position);
-            return;
+            if (isMonotonicObject) {
+                Preconditions.checkState(val <= position,
+                        "new stream position %s has decreased from %s", position, val);
+            } else {
+                // This precondition is not valid for monotonic objects since multiple accesses
+                // performed by a transaction may not always see the same stream position.
+                // This can occur if another thread performs accesses at a later snapshot and
+                // interleaves with this transaction.
+                Preconditions.checkState(val == position,
+                        "inconsistent stream positions %s and %s", val, position);
+                return;
+            }
         }
 
-        knownStreamsPosition.put(streamId, position);
+        hasAccessedMonotonicObject = hasAccessedMonotonicObject || isMonotonicObject;
+        knownStreamsPosition.put(proxy.getStreamID(), position);
     }
 
     /**
@@ -285,6 +305,18 @@ public abstract class AbstractTransactionalContext implements
             return Address.NON_ADDRESS;
         }
         return Collections.max(knownStreamsPosition.values());
+    }
+
+    /**
+     * Returns the min address that has been read in this transaction,
+     * or NON_ADDRESS if no such address exists.
+     */
+    protected long getMinAddressRead() {
+        if (knownStreamsPosition.isEmpty()) {
+            return Address.NON_ADDRESS;
+        }
+
+        return Collections.min(knownStreamsPosition.values());
     }
 
     /**


### PR DESCRIPTION
Since monotonic objects do not permit any rollbacks, returning the maximum address read as the commit address for read-only transactions can cause streamers to miss data if they use this address as a subscription point. Instead we return the minimum address observed while reading.  However, we note that streamers using this address as a subscription point can observe duplicate data.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
