### PR TITLE
Add Rolling Upgrade detection capability in LR

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LRRollingUpgradeHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LRRollingUpgradeHandler.java
@@ -1,0 +1,85 @@
+package org.corfudb.infrastructure.logreplication.infrastructure;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.ILogReplicationVersionAdapter;
+import org.corfudb.runtime.collections.TxnContext;
+
+/**
+ * Rolling upgrade handling means cluster must function in a mode where not all
+ * nodes are running the same codebase.
+ * Here the newer code base must function in a backward compatible mode until all
+ * the nodes have been upgraded to the same version.
+ * Once all nodes have upgraded it may atomically migrate data, clean up old code and switch
+ * completely to newer logic.
+ *
+ * To facilitate this in LR we add this module which would run once on startup as shown in the
+ * following diagram.
+ * In addition to running on startup, if cluster is in a mixed mode, all the callers who are
+ * mutating data in a new format need to check if upgrade is on and mutate data in a backward
+ * compatible manner.
+ *
+ * For anything post corfu-0.4.0.1 we consider the code base to be at "V2"
+ * Anything prior to and including corfu-0.4.0.1 is V1
+ * Any code shipped that uses Source/Sink can be thought of as "V2"
+ *                  ┌─────────────────────────────────────────────┐
+ *                  │ Start transaction to modify new format data │
+ *                  └──────────────────┬──────────────────────────┘
+ *                                     │
+ *                     ┌───────────────▼──────────┐
+ *                   ┌─┤  isRolling UpgradeON?    ├─┐
+ *         Yes ┌─────┴─┴┐  (migrate if done)     ┌┴─┴─────────────┐ No
+ *             │        └────────────────────────┘                │
+ *             │                                                  │
+ * ┌───────────▼────────────────────┐                     ┌───────▼───────────────────────┐
+ * │ Write in both old & new format │                     │ write data in new format only │
+ * └───────────┬────────────────────┘                     └───────┬───────────────────────┘
+ *             │            ┌──────────────────────┐              │
+ *             └───────────►│ end transaction      │◄─────────────┘
+ *                          └──────────────────────┘
+ */
+@Slf4j
+public class LRRollingUpgradeHandler {
+
+    private volatile boolean isClusterAllAtV2 = false;
+    ILogReplicationVersionAdapter versionAdapter;
+    public LRRollingUpgradeHandler(ILogReplicationVersionAdapter versionAdapter) {
+        this.versionAdapter = versionAdapter;
+    }
+
+    public boolean isLRUpgradeInProgress(TxnContext txnContext) {
+        if (isClusterAllAtV2) {
+            return false;
+        }
+        String nodeVersion = versionAdapter.getNodeVersion();
+        /**
+         * The ideal way to check the versions is to encapsulate the code version
+         * into Corfu's Layout information so that even when nodes are down
+         * or unresponsive it would be possible to determine if rolling upgrade
+         * is running. But since that is a bigger change we resort to the
+         * boolean check while ensuring migrateData() is idempotent and is a NO-OP
+         * when invoked on a fully upgraded cluster.
+         */
+        String pinnedClusterVersion = versionAdapter.getPinnedClusterVersion(txnContext);
+        boolean isClusterUpgradeInProgress = !nodeVersion.equals(pinnedClusterVersion);
+        if (isClusterUpgradeInProgress) {
+            return true;
+        } // else implies cluster upgrade has completed
+
+        log.info("LRRollingUpgrade upgrade completed to version {}", nodeVersion);
+        migrateData(txnContext);
+        isClusterAllAtV2 = true;
+        return false;
+    }
+
+    /**
+     * This is the primary function where data is migrated by
+     * 1. reading the old format
+     * 2. re-writing the data in new format
+     * 3. deleting the data in the old format or dropping the old tables
+     *
+     * @param txnContext All of the above must execute in the same transaction passed in.
+     */
+    public void migrateData(TxnContext txnContext) {
+        // Data migration to be added here.
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
@@ -1,8 +1,12 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.utils.CommonTypes;
 import org.corfudb.utils.LogReplicationStreams;
 
@@ -12,33 +16,148 @@ public abstract class DefaultAdapterForUpgrade implements ILogReplicationVersion
 
     public static final String NAMESPACE = "LR-Test";
 
+    public static final String PINNED_VERSION_KEY = "PINNED_VERSION_KEY";
+
+    public static final String LATEST_VERSION = "LATEST-VERSION";
+
+    /* Represents the current code's version
+     */
+    public static final String NODE_VERSION_KEY = "VERSION";
+
     String versionString = "version_latest";
+
+    String pinnedVersionString = "version_latest";
     CorfuStore corfuStore;
 
-    @Override
-    public String getVersion() {
-        if (corfuStore != null) {
-            try {
-                corfuStore.openTable(NAMESPACE, VERSION_TEST_TABLE,
-                        LogReplicationStreams.VersionString.class,
-                        LogReplicationStreams.Version.class, CommonTypes.Uuid.class,
-                        TableOptions.builder().build());
-            } catch (Exception e) {
-                // Just for wrap this up
-            }
+    public DefaultAdapterForUpgrade(CorfuRuntime runtime) {
+        this.corfuStore = new CorfuStore(runtime);
+        openVersionTable(corfuStore);
+    }
 
-            LogReplicationStreams.VersionString versionStringKey =
-                    LogReplicationStreams.VersionString.newBuilder()
-                            .setName("VERSION").build();
+    @Override
+    public String getNodeVersion() {
+        // For local testing we could be either within a transaction..
+        if (TransactionalContext.isInTransaction()) {
+            getVersion(TransactionalContext.getRootContext().getTxnContext());
+        } else { // or invoking this independently outside of a transaction..
             try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-                versionString =
-                        ((LogReplicationStreams.Version)txn.getRecord(VERSION_TEST_TABLE,
-                                versionStringKey).getPayload()).getVersion();
+                getVersion(txn);
                 txn.commit();
             } catch (Exception e) {
-                // Just for wrap this up
+                // Just to wrap this up
             }
         }
         return versionString;
+    }
+
+    private void getVersion(TxnContext txn) {
+        LogReplicationStreams.VersionString versionStringKey =
+                LogReplicationStreams.VersionString.newBuilder()
+                        .setName(NODE_VERSION_KEY).build();
+        versionString =
+                ((LogReplicationStreams.Version)txn.getRecord(VERSION_TEST_TABLE,
+                        versionStringKey).getPayload()).getVersion();
+    }
+
+    private void getPinnedVersionString(TxnContext txn) {
+        LogReplicationStreams.VersionString versionStringKey =
+                LogReplicationStreams.VersionString.newBuilder()
+                        .setName(PINNED_VERSION_KEY).build();
+        pinnedVersionString =
+                ((LogReplicationStreams.Version)txn.getRecord(VERSION_TEST_TABLE,
+                        versionStringKey).getPayload()).getVersion();
+    }
+
+    @Override
+    public String getPinnedClusterVersion(TxnContext txnContext) {
+        getPinnedVersionString(txnContext);
+        return pinnedVersionString;
+    }
+
+    /**
+     * This method should be used only for facilitating validation of the upgrade process
+     * in tests and ITs
+     *
+     * @param corfuStore - please supply the appropriate instance from the
+     *                   cluster of interest (source / sink)
+     */
+    @VisibleForTesting
+    public void startRollingUpgrade(CorfuStore corfuStore) {
+        Table<LogReplicationStreams.VersionString, LogReplicationStreams.Version, CommonTypes.Uuid>
+                versionStringVersionUuidTable = openVersionTable(corfuStore);
+
+        LogReplicationStreams.VersionString versionStringKey =
+                LogReplicationStreams.VersionString.newBuilder()
+                        .setName(NODE_VERSION_KEY).build();
+        LogReplicationStreams.Version versionPayload =
+                LogReplicationStreams.Version.newBuilder()
+                        .setVersion(LATEST_VERSION)
+                        .build();
+
+        LogReplicationStreams.VersionString pinnedVersionKey =
+                LogReplicationStreams.VersionString.newBuilder()
+                        .setName(PINNED_VERSION_KEY).build();
+        LogReplicationStreams.Version pinnedVersionPayload =
+                LogReplicationStreams.Version.newBuilder()
+                        .setVersion("OLDER-VERSION")
+                        .build();
+        try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+            txn.putRecord(versionStringVersionUuidTable, versionStringKey, versionPayload, null);
+            txn.putRecord(versionStringVersionUuidTable, pinnedVersionKey, pinnedVersionPayload, null);
+            txn.commit();
+        } catch (Exception e) {
+            // Just for wrap this up
+        }
+    }
+
+    private Table<LogReplicationStreams.VersionString, LogReplicationStreams.Version, CommonTypes.Uuid>
+    openVersionTable(CorfuStore corfuStore) {
+        Table<LogReplicationStreams.VersionString, LogReplicationStreams.Version, CommonTypes.Uuid>
+                versionStringVersionUuidTable = null;
+        try {
+            versionStringVersionUuidTable = corfuStore.openTable(NAMESPACE, VERSION_TEST_TABLE,
+                    LogReplicationStreams.VersionString.class,
+                    LogReplicationStreams.Version.class, CommonTypes.Uuid.class,
+                    TableOptions.builder().build());
+        } catch (Exception e) {
+            // Just for wrap this up
+        }
+        return versionStringVersionUuidTable;
+    }
+
+    /**
+     * This method should be used only for facilitating validation of the upgrade process
+     * in tests and ITs and it simulates end of upgrade by setting pinned version as node version
+     *
+     * @param corfuStore - please supply the appropriate instance from the
+     *                   cluster of interest (source / sink)
+     */
+    @VisibleForTesting
+    public void endRollingUpgrade(CorfuStore corfuStore) {
+        Table<LogReplicationStreams.VersionString, LogReplicationStreams.Version, CommonTypes.Uuid>
+                versionStringVersionUuidTable = openVersionTable(corfuStore);
+
+        LogReplicationStreams.VersionString versionStringKey =
+                LogReplicationStreams.VersionString.newBuilder()
+                        .setName(NODE_VERSION_KEY).build();
+        LogReplicationStreams.Version versionPayload =
+                LogReplicationStreams.Version.newBuilder()
+                        .setVersion(LATEST_VERSION)
+                        .build();
+
+        LogReplicationStreams.VersionString pinnedVersionKey =
+                LogReplicationStreams.VersionString.newBuilder()
+                        .setName(PINNED_VERSION_KEY).build();
+        LogReplicationStreams.Version pinnedVersionPayload =
+                LogReplicationStreams.Version.newBuilder()
+                        .setVersion(LATEST_VERSION)
+                        .build();
+        try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+            txn.putRecord(versionStringVersionUuidTable, versionStringKey, versionPayload, null);
+            txn.putRecord(versionStringVersionUuidTable, pinnedVersionKey, pinnedVersionPayload, null);
+            txn.commit();
+        } catch (Exception e) {
+            // Just for wrap this up
+        }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeActive.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeActive.java
@@ -9,11 +9,7 @@ import org.corfudb.runtime.collections.CorfuStore;
  */
 public class DefaultAdapterForUpgradeActive extends DefaultAdapterForUpgrade {
 
-    public DefaultAdapterForUpgradeActive() {
-        String ENDPOINT = "localhost:9000";
-        CorfuRuntime runtime =
-            CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
-                    .parseConfigurationString(ENDPOINT).connect();
-        this.corfuStore = new CorfuStore(runtime);
+    public DefaultAdapterForUpgradeActive(CorfuRuntime runtime) {
+        super(runtime);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeStandby.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeStandby.java
@@ -1,19 +1,13 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.collections.CorfuStore;
 
 /**
  * This class is created for LR rolling upgrade tests to serve as the plugin for Standby cluster to
  * get the set of streams to replicate.
  */
 public class DefaultAdapterForUpgradeStandby extends DefaultAdapterForUpgrade {
-
-    public DefaultAdapterForUpgradeStandby() {
-        String ENDPOINT = "localhost:9001";
-        CorfuRuntime runtime =
-            CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
-                    .parseConfigurationString(ENDPOINT).connect();
-        corfuStore = new CorfuStore(runtime);
+    public DefaultAdapterForUpgradeStandby(CorfuRuntime runtime) {
+        super(runtime);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -1,12 +1,28 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.TxnContext;
+
 /**
  * Default testing implementation of a Log Replication Config Provider
  */
 public class DefaultLogReplicationConfigAdapter implements ILogReplicationVersionAdapter {
 
+    private static final String latestVer = "LATEST-VERSION";
+
+    public DefaultLogReplicationConfigAdapter(CorfuRuntime runtime) {
+        if (runtime == null) {
+            throw new IllegalArgumentException("Null runtime passed in");
+        }
+    }
+
     @Override
-    public String getVersion() {
-        return "version_latest";
+    public String getNodeVersion() {
+        return latestVer;
+    }
+
+    @Override
+    public String getPinnedClusterVersion(TxnContext txnContext) {
+        return latestVer;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationVersionAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationVersionAdapter.java
@@ -1,5 +1,7 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
+import org.corfudb.runtime.collections.TxnContext;
+
 /**
  * This Interface must be implemented by any external
  * provider to give the System's version
@@ -7,9 +9,21 @@ package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 public interface ILogReplicationVersionAdapter {
 
     /**
-     * Returns a version string that indicates the version of LR.
+     * Returns a version string that indicates the version of LR
+     * As per the currently deployed codebase LR is executing under.
      *
-     * @return Version string that indicates the version of LR.
+     * @return Version string that indicates the current version of LR.
      */
-    String getVersion();
+    String getNodeVersion();
+
+    /**
+     * When cluster is in the rolling upgrade phase some nodes are
+     * running the previous code base so until all the nodes are upgraded
+     * the cluster's version is "pinned" to the prior version.
+     *
+     * @param txnContext - pass the transaction within which the determination needs to happen
+     * @return the pinned cluster version which can be compared with the
+     * getNodeVersion() to determine if rolling upgrade has completed.
+     */
+    String getPinnedClusterVersion(TxnContext txnContext);
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure.logreplication.utils;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.LRRollingUpgradeHandler;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.ILogReplicationVersionAdapter;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogEntryWriter;
@@ -71,6 +72,9 @@ public class LogReplicationConfigManager {
 
     private ILogReplicationVersionAdapter logReplicationVersionAdapter;
 
+    @Getter
+    private LRRollingUpgradeHandler lrRollingUpgradeHandler;
+
     private final String pluginConfigFilePath;
 
     private final VersionString versionString = VersionString.newBuilder().setName(VERSION_PLUGIN_KEY).build();
@@ -111,21 +115,43 @@ public class LogReplicationConfigManager {
         this.pluginConfigFilePath = pluginConfigFilePath;
         this.corfuStore = new CorfuStore(runtime);
         this.lastRegistryTableLogTail = Address.NON_ADDRESS;
-        initLogReplicationVersionPlugin();
+        initLogReplicationVersionPlugin(runtime);
+        initLogReplicationRollingUpgradeHandler(corfuStore);
         setupVersionTable();
     }
 
-    private void initLogReplicationVersionPlugin() {
+    private void initLogReplicationVersionPlugin(CorfuRuntime runtime) {
         log.info("Plugin :: {}", pluginConfigFilePath);
         LogReplicationPluginConfig config = new LogReplicationPluginConfig(pluginConfigFilePath);
         File jar = new File(config.getStreamFetcherPluginJARPath());
         try (URLClassLoader child = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader())) {
             Class plugin = Class.forName(config.getStreamFetcherClassCanonicalName(), true, child);
-            logReplicationVersionAdapter = (ILogReplicationVersionAdapter) plugin.getDeclaredConstructor()
-                    .newInstance();
+            logReplicationVersionAdapter = (ILogReplicationVersionAdapter)
+                    plugin.getDeclaredConstructor(CorfuRuntime.class).newInstance(runtime);
         } catch (Exception e) {
             log.error("Fatal error: Failed to get Log Replicatior Version Plugin", e);
             throw new UnrecoverableCorfuError(e);
+        }
+    }
+
+    /**
+     * Instantiate the LogReplicator's Rolling Upgrade Handler and invoke its
+     * check the first time, so it can cache the result in the common case
+     * where there is no rolling upgrade in progress.
+     * @param corfuStore - instance of the store to which the check is made with.
+     */
+    private void initLogReplicationRollingUpgradeHandler(CorfuStore corfuStore) {
+        this.lrRollingUpgradeHandler = new LRRollingUpgradeHandler(logReplicationVersionAdapter);
+        final int retries = 3;
+        for (int i = retries; i>=0; i--) {
+            try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
+                log.info("LRRollingUpgradeHandler: Prestart check isUpgradeOn: {}",
+                        lrRollingUpgradeHandler.isLRUpgradeInProgress(txn));
+                txn.commit();
+                break;
+            } catch (Exception ex) {
+                log.error("Fatal error: Failed to get LR upgrade status", ex);
+            }
         }
     }
 
@@ -254,7 +280,7 @@ public class LogReplicationConfigManager {
 
         try {
             if (currentVersion == null) {
-                currentVersion = logReplicationVersionAdapter.getVersion();
+                currentVersion = logReplicationVersionAdapter.getNodeVersion();
             }
 
             IRetry.build(IntervalRetry.class, () -> {


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
LR needs to adhere to a mode where not all cluster nodes are upgraded to the latest (current) version.
This PR only adds the interface to detect if we are in a version pinned phase.
Handling of the version pinning will follow.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
