### PR TITLE
Revert "@docker: Change the default base image"

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-bullseye
+FROM openjdk:8-jdk-alpine3.8
 
 ARG CORFU_JAR
 ARG CMDLETS_JAR
@@ -6,7 +6,7 @@ ARG CORFU_TOOLS_JAR
 
 WORKDIR /app
 
-RUN apt update && apt -y install iptables bash jq python3 sudo iproute2
+RUN apk add --update iptables bash jq python3 sudo
 
 COPY target/${CORFU_JAR} /usr/share/corfu/lib/${CORFU_JAR}
 COPY target/${CMDLETS_JAR} /usr/share/corfu/lib/${CMDLETS_JAR}


### PR DESCRIPTION
Reverts CorfuDB/CorfuDB#3351

Reason: bootstrap fails on Kubernetes