### PR TITLE
Bump netty to 4.1.77 and grpc to 1.49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
 
         <!-- Dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>
-        <netty.version>4.1.80.Final</netty.version>
-        <netty.tcnative.version>2.0.54.Final</netty.tcnative.version>
+        <netty.version>4.1.77.Final</netty.version>
+        <netty.tcnative.version>2.0.53.Final</netty.tcnative.version>
         <protobuf.version>3.6.1</protobuf.version>
         <commons.io.version>2.11.0</commons.io.version>
         <lombok.version>1.18.24</lombok.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -24,7 +24,7 @@
         <annotations.api.version>6.0.53</annotations.api.version>
         <ehcahce.sizeOf.version>0.4.0</ehcahce.sizeOf.version>
 
-        <grpc.version>1.49.1</grpc.version>
+        <grpc.version>1.49.2</grpc.version>
     </properties>
 
     <build>


### PR DESCRIPTION
This reverts commit e737aafefcbab748b6e1946f56fcf16b2f0bd482.

## Overview

Description:

Why should this be merged: 
Pick a version where both netty and grpc are known to work
https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
