### PR TITLE
Make corfu infrastructure base docker image customizable

### DIFF
--- a/.ci/infrastructure-docker-build.sh
+++ b/.ci/infrastructure-docker-build.sh
@@ -3,6 +3,7 @@
 set -e
 
 PROFILE=$1
+BASE_IMAGE=$2
 if [ -z "$PROFILE" ]; then
   echo "Please provide a profile name: 'docker' or 'compatibility'"
   exit 1
@@ -33,6 +34,10 @@ CMD_LINE+="--network=host "
 CMD_LINE+="--build-arg CORFU_JAR=infrastructure-${CORFU_VERSION}-shaded.jar "
 CMD_LINE+="--build-arg CMDLETS_JAR=cmdlets-${CORFU_VERSION}-shaded.jar "
 CMD_LINE+="--build-arg CORFU_TOOLS_JAR=corfudb-tools-${CORFU_VERSION}-shaded.jar "
+
+if [ -n "$BASE_IMAGE" ]; then
+  CMD_LINE+="--build-arg BASE_IMAGE=$BASE_IMAGE "
+fi
 
 if [ "$PROFILE" = "docker" ]; then
   CMD_LINE+="-t corfudb/corfu-server:${CORFU_VERSION} -t corfudb-universe/corfu-server:${CORFU_VERSION}"

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:8-jdk-alpine3.8
+ARG BASE_IMAGE=openjdk:8-jdk-alpine3.8
+FROM $BASE_IMAGE
 
 ARG CORFU_JAR
 ARG CMDLETS_JAR


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
The change allows using a different base image than used by default by passing it as an argument into the command line

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
