### PR TITLE
Fix a flaky test in PersistentCorfuTableTest

### DIFF
--- a/test/src/test/java/org/corfudb/runtime/collections/PersistentCorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/PersistentCorfuTableTest.java
@@ -397,6 +397,10 @@ public class PersistentCorfuTableTest extends AbstractViewTest {
         rt.getObjectsView().TXEnd();
     }
 
+    /**
+     * Verify that a transaction does not observe uncommitted changes by another
+     * parallel transaction.
+     */
     @Test
     public void testUncommittedChangesIsolationBetweenParallelTxns() throws Exception {
         addSingleServer(SERVERS.PORT_0);
@@ -412,7 +416,7 @@ public class PersistentCorfuTableTest extends AbstractViewTest {
         TestSchema.Uuid payload1 = TestSchema.Uuid.newBuilder().setLsb(1).setMsb(1).build();
         TestSchema.Uuid payload2 = TestSchema.Uuid.newBuilder().setLsb(2).setMsb(2).build();
         TestSchema.Uuid metadata1 = TestSchema.Uuid.newBuilder().setLsb(1).setMsb(1).build();
-        CorfuRecord value1 = new CorfuRecord(payload1, metadata1);
+        CorfuRecord<TestSchema.Uuid, TestSchema.Uuid> value1 = new CorfuRecord<>(payload1, metadata1);
 
         // put(k1, v1)
         rt.getObjectsView().TXBegin();
@@ -421,6 +425,7 @@ public class PersistentCorfuTableTest extends AbstractViewTest {
         assertThat(corfuTable.get(key1).getPayload().getLsb()).isEqualTo(payload1.getLsb());
 
         CountDownLatch readLatch = new CountDownLatch(1);
+        CountDownLatch writeLatch = new CountDownLatch(1);
         AtomicLong readerResult = new AtomicLong();
         AtomicLong writerResult = new AtomicLong();
 
@@ -432,20 +437,32 @@ public class PersistentCorfuTableTest extends AbstractViewTest {
             } catch (InterruptedException e) {
                 e.printStackTrace();
             }
+
             // Changes made by writeThread should be isolated.
             readerResult.set(corfuTable.get(key1).getPayload().getLsb());
+
+            // Read is done. Signal the writerThread to commit
+            writeLatch.countDown();
             rt.getObjectsView().TXEnd();
         });
 
         // put(k1, v2) to overwrite the previous put, but do not commit
         Thread writerThread = new Thread(() -> {
             rt.getObjectsView().TXBegin();
-            CorfuRecord value2 = new CorfuRecord(payload2, metadata1);
+            CorfuRecord<TestSchema.Uuid, TestSchema.Uuid> value2 = new CorfuRecord<>(payload2, metadata1);
             corfuTable.insert(key1, value2);
             writerResult.set(corfuTable.get(key1).getPayload().getLsb());
 
             // Signals the readerThread to read
             readLatch.countDown();
+
+            try {
+                // Unblocked until the readThread has read the table.
+                // Without this, the readThread might read this change as a committed transaction.
+                writeLatch.await();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
             rt.getObjectsView().TXEnd();
         });
 


### PR DESCRIPTION
## Overview

Description:

In the testUncommittedChangesIsolationBetweenParallelTxns, when write transaction is committed before the read transaction starts, the reader result assertion fails. This fix adds a writeLatch to prevent this.


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
