### PR TITLE
LR: Source<->Sink connection model modification - part1

### DIFF
--- a/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
+++ b/common/src/main/java/org/corfudb/common/metrics/micrometer/README.md
@@ -8,8 +8,8 @@
 ### Current metrics collected for LR:
 
 *   **logreplication.message.size.bytes**: Message size in bytes (throughput, mean and max), distinguished by replication type (snapshot, logentry).
-*   **logreplication.lock.duration.nanoseconds**: Duration of holding a leadership lock in nanoseconds, distinguished by role (active, standby).
-*   **logreplication.lock.acquire.count**: Number of times a leadership lock was acquired, distinguised by role (active, standby).
+*   **logreplication.lock.duration.nanoseconds**: Duration of holding a leadership lock in nanoseconds, distinguished by role (source, sink).
+*   **logreplication.lock.acquire.count**: Number of times a leadership lock was acquired, distinguised by role (source, sink).
 *   **logreplication.sender.duration.nanoseconds**: Duration of sending a log entry in nanoseconds (throughput, mean and max), distinguished by replication type (snapshot, logentry) and status (success, failure).
 *   **logreplication.snapshot.completed.count**: Number of snapshot syncs completed.
 *   **logreplication.snapshot.transfer.duration**: Duration of the TRANSFER phase of a snapshot sync in nanoseconds (throughput, mean and max).

--- a/infrastructure/proto/log_replication_cluster_info.proto
+++ b/infrastructure/proto/log_replication_cluster_info.proto
@@ -29,8 +29,8 @@ message NodeConfigurationMsg {
 
 enum ClusterRole {
   INVALID = 0;
-  ACTIVE = 1;
-  STANDBY = 2;
+  SOURCE = 1;
+  SINK = 2;
   NONE = 3;
 }
 

--- a/infrastructure/proto/log_replication_metadata.proto
+++ b/infrastructure/proto/log_replication_metadata.proto
@@ -106,3 +106,20 @@ message ReplicationEvent {
   string eventId = 2;
   ReplicationEventType type = 3;
 }
+
+enum ReplicationModels {
+  //federated GM -> GM
+  REPLICATE_FULL_TABLES = 0;
+  // IDFW GM -> LM
+  MERGE_TABLES_AT_SINK = 1;
+  //policy GM -> LM
+  RECORD_LEVEL_REPLICATION = 2;
+  // LM -> GM; Destination is not corfu
+  MOVE_DATA = 3;
+}
+
+message ReplicationSessionKey {
+  string remoteClusterId = 1;
+  string client = 2;
+  ReplicationModels replicationModel = 3;
+}

--- a/infrastructure/proto/log_replication_metadata.proto
+++ b/infrastructure/proto/log_replication_metadata.proto
@@ -121,5 +121,6 @@ enum ReplicationModels {
 message ReplicationSessionKey {
   string remoteClusterId = 1;
   string client = 2;
+  // TODO: shama to remove this once we have the tag.
   ReplicationModels replicationModel = 3;
 }

--- a/infrastructure/proto/log_replication_metadata.proto
+++ b/infrastructure/proto/log_replication_metadata.proto
@@ -8,7 +8,7 @@ import "google/protobuf/timestamp.proto";
 /**
  * This is used by replication metadata table in corfu store.
  * The metadata table has the following key-value pairs defined both as strings:
- * One example to show the standby is at log entry sync state:
+ * One example to show the sink is at log entry sync state:
  * "topologyConfigId": "0"
  * "version": "release-1.0"
  * "lastSnapshotStarted": "100"
@@ -39,7 +39,7 @@ message LogReplicationMetadataVal {
 
 /*
  * Replication Status Value
- * Active Site sets the completionPercent, Standby sets the dataConsistent boolean
+ * Source Site sets the completionPercent, Sink sets the dataConsistent boolean
  */
 message ReplicationStatusVal {
   option (org.corfudb.runtime.table_schema).stream_tag = "lr_status";

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -102,7 +102,6 @@ public class LogReplicationConfig {
      */
     public LogReplicationConfig(Map<ReplicationSubscriber, Set<String>> streamsToReplicateMap, int maxNumMsgPerBatch,
                                 int maxMsgSize, int cacheSize) {
-        log.info("LogReplicationConfig : streamsToReplicateMap {} ", streamsToReplicateMap);
         replicationSubscriberToStreamsMap = streamsToReplicateMap;
         this.maxNumMsgPerBatch = maxNumMsgPerBatch;
         this.maxMsgSize = maxMsgSize;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -31,7 +31,7 @@ public class LogReplicationConfig {
     // Log Replication message timeout time in milliseconds
     public static final int DEFAULT_TIMEOUT_MS = 5000;
 
-    // Log Replication default max number of messages generated at the active cluster for each batch
+    // Log Replication default max number of messages generated at the source cluster for each batch
     public static final int DEFAULT_MAX_NUM_MSG_PER_BATCH = 10;
 
     // Log Replication default max data message size is 64MB
@@ -55,9 +55,10 @@ public class LogReplicationConfig {
     public static final UUID PROTOBUF_TABLE_ID = CorfuRuntime.getStreamID(
             getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, TableRegistry.PROTOBUF_DESCRIPTOR_TABLE_NAME));
 
+
     // Set of streams that shouldn't be cleared on snapshot apply phase, as these streams should be the result of
-    // "merging" the replicated data (from active) + local data (on standby).
-    // For instance, RegistryTable (to avoid losing local opened tables on standby)
+    // "merging" the replicated data (from source) + local data (on sink).
+    // For instance, RegistryTable (to avoid losing local opened tables on sink)
     public static final Set<UUID> MERGE_ONLY_STREAMS = new HashSet<>(Arrays.asList(
             REGISTRY_TABLE_ID,
             PROTOBUF_TABLE_ID

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -102,6 +102,7 @@ public class LogReplicationConfig {
      */
     public LogReplicationConfig(Map<ReplicationSubscriber, Set<String>> streamsToReplicateMap, int maxNumMsgPerBatch,
                                 int maxMsgSize, int cacheSize) {
+        log.info("LogReplicationConfig : streamsToReplicateMap {} ", streamsToReplicateMap);
         replicationSubscriberToStreamsMap = streamsToReplicateMap;
         this.maxNumMsgPerBatch = maxNumMsgPerBatch;
         this.maxMsgSize = maxMsgSize;
@@ -127,7 +128,4 @@ public class LogReplicationConfig {
         this.dataStreamToTagsMap = streamingTagsMap;
     }
 
-    public static enum ReplicationModel {
-        SINGLE_SOURCE_SINK
-    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServer.java
@@ -278,8 +278,7 @@ public class CorfuInterClusterReplicationServer implements Runnable {
         // Start LogReplicationDiscovery Service, responsible for
         // acquiring lock, retrieving Site Manager Info and processing this info
         // so this node is initialized as Source (sender) or Sink (receiver)
-        replicationDiscoveryService = new CorfuReplicationDiscoveryService(
-            serverContext);
+        replicationDiscoveryService = new CorfuReplicationDiscoveryService(serverContext);
         replicationDiscoveryService.run();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -1,13 +1,13 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
 import io.micrometer.core.instrument.LongTaskTimer;
 import io.micrometer.core.instrument.Tag;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.config.ConfigParamNames;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
-import org.corfudb.infrastructure.LogReplicationServer;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.DiscoveryServiceEvent.DiscoveryServiceEventType;
@@ -25,6 +25,7 @@ import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManag
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.RetryExhaustedException;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.util.NodeLocator;
 import org.corfudb.util.retry.ExponentialBackoffRetry;
@@ -42,14 +43,17 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -64,7 +68,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * - Log replication configuration (streams to replicate)
  */
 @Slf4j
-public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicationDiscoveryServiceAdapter {
+public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscoveryServiceAdapter {
     /**
      * Wait interval (in seconds) between consecutive fetch topology attempts to cap exponential back-off.
      */
@@ -85,7 +89,8 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
      * It is backed by a corfu store table.
      **/
     @Getter
-    private LogReplicationMetadataManager logReplicationMetadataManager;
+    private final Map<String, LogReplicationMetadataManager>
+        remoteClientToMetadataManagerMap = new HashMap<>();
 
     /**
      * Lock-related configuration parameters
@@ -161,12 +166,8 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     private Optional<LongTaskTimer.Sample> lockAcquireSample = Optional.empty();
 
     private final Map<ClusterRole, AtomicLong> lockAcquisitionsByRole = new HashMap<>();
-    /**
-     * Callback to Log Replication Server upon topology discovery
-     */
-    private final CompletableFuture<CorfuInterClusterReplicationServerNode> serverCallback;
 
-    private CorfuInterClusterReplicationServerNode interClusterReplicationService;
+    private CorfuInterClusterReplicationServerNode interClusterServerNode;
 
     private final ServerContext serverContext;
 
@@ -181,21 +182,14 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     @Getter
     private final AtomicBoolean isLeader;
 
-    private LogReplicationServer logReplicationServerHandler;
-
     private LockClient lockClient;
 
     /**
-     * Indicates the server has been started. A server is started once it is determined
-     * that this node belongs to a cluster in the topology provided by ClusterManager.
+     * Indicates that bootstrap has been completed. Bootstrap is done once it
+     * is determined that this node belongs to a cluster in the topology
+     * provided by ClusterManager and has the role of ACTIVE or STANDBY
      */
-    private boolean serverStarted = false;
-
-    /**
-     * Indicates the replication status has been set as NOT_STARTED.
-     * It should be reset if its role changes to Standby.
-     */
-    private boolean statusFlag = false;
+    private boolean bootstrapComplete = false;
 
     /**
      * This is the listener to the replication event table shared by the nodes in the cluster.
@@ -208,18 +202,32 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
      * Constructor Discovery Service
      *
      * @param serverContext         current server's context
-     * @param clusterManagerAdapter adapter to communicate to external Cluster Manager
-     * @param serverCallback        callback to Log Replication Server upon discovery
      */
-    public CorfuReplicationDiscoveryService(@Nonnull ServerContext serverContext,
-                                            @Nonnull CorfuReplicationClusterManagerAdapter clusterManagerAdapter,
-                                            @Nonnull CompletableFuture<CorfuInterClusterReplicationServerNode> serverCallback) {
-        this.clusterManagerAdapter = clusterManagerAdapter;
-        this.logReplicationLockId = serverContext.getNodeId();
+    public CorfuReplicationDiscoveryService(@Nonnull ServerContext serverContext) {
         this.serverContext = serverContext;
+        this.logReplicationLockId = serverContext.getNodeId();
         this.localEndpoint = serverContext.getLocalEndpoint();
-        this.serverCallback = serverCallback;
         this.isLeader = new AtomicBoolean();
+        this.clusterManagerAdapter = getClusterManagerAdapter(serverContext.getPluginConfigFilePath());
+    }
+
+    /**
+     * Create the Cluster Manager Adapter, i.e., the adapter to external provider of the topology.
+     * @param pluginConfigFilePath File path of the ClusterManagerAdapter plugin
+     * @return cluster manager adapter instance
+     */
+    private CorfuReplicationClusterManagerAdapter getClusterManagerAdapter(String pluginConfigFilePath) {
+
+        LogReplicationPluginConfig config = new LogReplicationPluginConfig(pluginConfigFilePath);
+        File jar = new File(config.getTopologyManagerAdapterJARPath());
+
+        try (URLClassLoader child = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader())) {
+            Class adapter = Class.forName(config.getTopologyManagerAdapterName(), true, child);
+            return (CorfuReplicationClusterManagerAdapter) adapter.getDeclaredConstructor().newInstance();
+        } catch (Exception e) {
+            log.error("Fatal error: Failed to create serverAdapter", e);
+            throw new UnrecoverableCorfuError(e);
+        }
     }
 
     public void run() {
@@ -249,8 +257,8 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 runtime.shutdown();
             }
 
-            if (interClusterReplicationService != null) {
-                interClusterReplicationService.close();
+            if (interClusterServerNode != null) {
+                interClusterServerNode.close();
             }
         }
     }
@@ -324,36 +332,52 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     }
 
     /**
-     * Bootstrap the Log Replication Service, which includes:
-     * <p>
-     * - Building Log Replication Context (LR context shared across receiving and sending components)
-     * - Start Log Replication Server (receiver component)
+     * Instantiate the LR components based on role
+     * Source:
+     * - build logReplication context(LR context available for both Source and Sink.  Currently only used on the Source)
+     * - start even listener: listens to forced snapshot sync requests
+     * Sink:
+     * - Start Log Replication Server(listens and processes incoming requests from the Source)
+     * Both:
+     * - Metadata Managers which maintain metadata related to replication and its status
+     * @param role
      */
-    private void bootstrapLogReplicationService() {
-        log.info("Bootstrap the Log Replication Service");
+    private void performRoleBasedSetup(ClusterRole role) {
+        if (role != ClusterRole.ACTIVE && role != ClusterRole.STANDBY) {
+            log.debug("Cluster role is {}.  Not performing role-based setup.", role);
+            return;
+        }
+
         // Through LogReplicationConfigAdapter retrieve system-specific configurations
         // such as streams to replicate and version
         LogReplicationConfig logReplicationConfig = getLogReplicationConfiguration(getCorfuRuntime());
 
-        logReplicationMetadataManager = new LogReplicationMetadataManager(getCorfuRuntime(),
-            topologyDescriptor.getTopologyConfigId(), localClusterDescriptor.getClusterId());
+        Set<String> remoteClusterIds = new HashSet<>();
 
-        logReplicationServerHandler = new LogReplicationServer(serverContext, logReplicationConfig,
-            logReplicationMetadataManager, localCorfuEndpoint, topologyDescriptor.getTopologyConfigId(), localNodeId);
-        logReplicationServerHandler.setActive(localClusterDescriptor.getRole().equals(ClusterRole.ACTIVE));
-        logReplicationServerHandler.setStandby(localClusterDescriptor.getRole().equals(ClusterRole.STANDBY));
+        if (role == ClusterRole.ACTIVE) {
+            remoteClusterIds.addAll(topologyDescriptor.getStandbyClusters().keySet());
+            createMetadataManagers(remoteClusterIds);
+            replicationContext = new LogReplicationContext(logReplicationConfig, topologyDescriptor, localCorfuEndpoint);
+            logReplicationEventListener = new LogReplicationEventListener(this, getCorfuRuntime());
+            logReplicationEventListener.start();
+        } else {
+            // Sink Cluster
+            remoteClusterIds.addAll(topologyDescriptor.getActiveClusters().keySet());
+            createMetadataManagers(remoteClusterIds);
 
-        interClusterReplicationService = new CorfuInterClusterReplicationServerNode(serverContext,
-            logReplicationServerHandler, logReplicationConfig);
+            LogReplicationServer server = new LogReplicationServer(serverContext, localNodeId, logReplicationConfig,
+                remoteClusterIds, localCorfuEndpoint, topologyDescriptor.getTopologyConfigId(),
+                remoteClientToMetadataManagerMap);
+            interClusterServerNode = new CorfuInterClusterReplicationServerNode(serverContext, server);
+        }
+    }
 
-        replicationContext = new LogReplicationContext(logReplicationConfig, topologyDescriptor, localCorfuEndpoint);
-
-        // Unblock server initialization & register to Log Replication Lock, to attempt lock / leadership acquisition
-        serverCallback.complete(interClusterReplicationService);
-
-        logReplicationEventListener = new LogReplicationEventListener(this);
-        logReplicationEventListener.start();
-        serverStarted = true;
+    private void createMetadataManagers(Set<String> remoteClusterIds) {
+        for (String remoteClusterId : remoteClusterIds) {
+            LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(getCorfuRuntime(),
+                topologyDescriptor.getTopologyConfigId(), remoteClusterId);
+            remoteClientToMetadataManagerMap.put(remoteClusterId, metadataManager);
+        }
     }
 
     /**
@@ -377,7 +401,6 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                     .build())
                     .parseConfigurationString(localCorfuEndpoint).connect();
         }
-
         return runtime;
     }
 
@@ -393,11 +416,11 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
 
         if (tmpClusterDescriptor != null) {
             tmpNodeDescriptor = tmpClusterDescriptor.getNode(localNodeId);
-
             if (update) {
                 localClusterDescriptor = tmpClusterDescriptor;
                 localNodeDescriptor = tmpNodeDescriptor;
                 localCorfuEndpoint = getCorfuEndpoint(getLocalHost(), localClusterDescriptor.getCorfuPort());
+                topologyDescriptor = topology;
             }
         }
 
@@ -476,7 +499,7 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     /**
      * This method is only called on the leader node and it triggers the start of log replication
      * <p>
-     * Depending on the role of the cluster to which this leader node belongs to, it will start
+     * Depending on the role of the cluster to which this leader node belongs, it will start
      * as source (sender/producer) or sink (receiver).
      */
     private void onLeadershipAcquire() {
@@ -485,22 +508,32 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 log.info("Start as Source (sender/replicator)");
                 if (replicationManager == null) {
                     replicationManager = new CorfuReplicationManager(replicationContext,
-                            localNodeDescriptor, logReplicationMetadataManager, serverContext.getPluginConfigFilePath(),
+                        localNodeDescriptor,
+                        remoteClientToMetadataManagerMap,
+                        serverContext.getPluginConfigFilePath(),
                             getCorfuRuntime(), replicationConfigManager);
+                } else {
+                    // Replication Context contains the topology which
+                    // must be updated if it has changed
+                    replicationManager.setContext(replicationContext);
                 }
-                replicationManager.setTopology(topologyDescriptor);
                 replicationManager.start();
-                updateReplicationStatus();
+
+                // Set initial/default replication status for newly added Sink clusters
+                initReplicationStatusForRemoteClusters(true);
                 lockAcquireSample = recordLockAcquire(localClusterDescriptor.getRole());
                 processCountOnLockAcquire(localClusterDescriptor.getRole());
                 break;
             case STANDBY:
-                // Standby Site : the LogReplicationServer (server handler) will initiate the LogReplicationSinkManager
                 log.info("Start as Sink (receiver)");
-                interClusterReplicationService.getLogReplicationServer().getSinkManager().reset();
-                interClusterReplicationService.getLogReplicationServer().setLeadership(true);
-                statusFlag = false;
+
+                // Sink Site : the LogReplicationServer (server handler) will
+                // reset the LogReplicationSinkManager on acquiring leadership
+                interClusterServerNode.setLeadership(true);
                 lockAcquireSample = recordLockAcquire(localClusterDescriptor.getRole());
+
+                // Set initial/default replication status for newly added Source clusters
+                initReplicationStatusForRemoteClusters(false);
                 processCountOnLockAcquire(localClusterDescriptor.getRole());
                 break;
             default:
@@ -555,14 +588,13 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     }
 
     /**
-     * Update Topology Config Id on MetadataManager (persisted metadata table)
-     * and push down to Sink Manager so messages are filtered on the most
-     * up to date topologyConfigId
+     * Update Topology Config Id on the Sink components, including SinkManager
+     * so messages are filtered on the most up to date topologyConfigId
      */
-    private void updateTopologyConfigId(long configId) {
-        this.logReplicationMetadataManager.setupTopologyConfigId(configId);
-        this.interClusterReplicationService.getLogReplicationServer()
-                .getSinkManager().updateTopologyConfigId(configId);
+    private void updateTopologyConfigIdOnSink(long configId) {
+        if (interClusterServerNode != null) {
+            interClusterServerNode.updateTopologyConfigId(configId);
+        }
     }
 
     /**
@@ -576,8 +608,9 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         stopLogReplication();
         isLeader.set(false);
         // Signal Log Replication Server/Sink to stop receiving messages, leadership loss
-        interClusterReplicationService.getLogReplicationServer().setLeadership(false);
-        interClusterReplicationService.getLogReplicationServer().stopSink();
+        if (localClusterDescriptor != null && localClusterDescriptor.getRole() == ClusterRole.STANDBY) {
+            interClusterServerNode.setLeadership(false);
+        }
         recordLockRelease();
     }
 
@@ -586,7 +619,8 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
      * - Higher config id
      * - Potential cluster role change
      * <p>
-     * Cluster change from active to standby is a two step process, we first confirm that
+     * Cluster change from Source to Sink is a two step process, we first
+     * confirm that
      * we are ready to do the cluster role change, so by the time we receive cluster change
      * notification, nothing needs to be done, other than stop.
      *
@@ -600,35 +634,33 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         // We do not update topology until we successfully stop log replication
         if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {
             stopLogReplication();
+            logReplicationEventListener.stop();
+        } else if (localClusterDescriptor.getRole() == ClusterRole.STANDBY) {
+            // Stop the replication server
+            interClusterServerNode.disable();
         }
 
-        // Update topology, cluster, and node configs
-        updateLocalTopology(newTopology);
-
-        // Update topology config id in metadata manager
-        logReplicationMetadataManager.setupTopologyConfigId(topologyDescriptor.getTopologyConfigId());
-
         if (isLeader.get()) {
-            // Reset the Replication Status on Active and Standby only for the leader node
-            // Consider the case of async configuration changes, non-lead nodes could overwrite
-            // the replication status if it has already completed by the lead node
+            // Reset the Replication Status on Source and Sink only on the
+            // leader node.  Consider the case of async configuration changes,
+            // non-lead nodes could overwrite the replication status if it
+            // has already completed by the lead node
             resetReplicationStatusTableWithRetry();
         }
 
-        log.debug("Persist new topologyConfigId {}, cluster id={}, role={}", topologyDescriptor.getTopologyConfigId(),
-                localClusterDescriptor.getClusterId(), localClusterDescriptor.getRole());
+        // Clear existing Metadata Managers.
+        remoteClientToMetadataManagerMap.clear();
 
-        // Update replication manager
-        updateReplicationManagerTopology(newTopology);
+        // Update topology, cluster, and node configs
+        log.debug("Update existing topologyConfigId {}, cluster id={}, " +
+            "role={} with the new topology",
+            topologyDescriptor.getTopologyConfigId(),
+            localClusterDescriptor.getClusterId(),
+            localClusterDescriptor.getRole());
+        updateLocalTopology(newTopology);
 
-        // Update sink manager
-        interClusterReplicationService.getLogReplicationServer().getSinkManager()
-                .updateTopologyConfigId(topologyDescriptor.getTopologyConfigId());
-        interClusterReplicationService.getLogReplicationServer().getSinkManager().reset();
-
-        // Update replication server, in case there is a role change
-        logReplicationServerHandler.setActive(localClusterDescriptor.getRole().equals(ClusterRole.ACTIVE));
-        logReplicationServerHandler.setStandby(localClusterDescriptor.getRole().equals(ClusterRole.STANDBY));
+        // Update with the new roles
+        performRoleBasedSetup(localClusterDescriptor.getRole());
 
         // On Topology Config Change, only if this node is the leader take action
         if (isLeader.get()) {
@@ -658,7 +690,8 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
 
         boolean isValid;
         try {
-            isValid = processDiscoveredTopology(discoveredTopology, localClusterDescriptor == null);
+            isValid = processDiscoveredTopology(discoveredTopology,
+                localClusterDescriptor == null);
         } catch (Throwable t) {
             log.error("Exception when processing the discovered topology", t);
             stopLogReplication();
@@ -693,23 +726,45 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     }
 
     /**
-     * Process a topology change where a standby cluster has been added or removed from the topology.
+     * Process a topology change where a Sink cluster has been added or removed from the topology.
      *
      * @param discoveredTopology new discovered topology
      */
     private void onStandbyClusterAddRemove(TopologyDescriptor discoveredTopology) {
-        log.debug("Standby Cluster has been added or removed");
+        log.debug("Sink Cluster has been added or removed");
 
-        // We only need to process new standby's if your role is of an ACTIVE cluster
-        if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE && replicationManager != null && isLeader.get()) {
-            replicationManager.processStandbyChange(discoveredTopology);
+        // We only need to process new sinks if the local cluster role is SOURCE
+        if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE &&
+            replicationManager != null && isLeader.get()) {
+            Set<String> receivedSinks = discoveredTopology.getStandbyClusters().keySet();
+            Set<String> currentSinks = topologyDescriptor.getStandbyClusters().keySet();
+
+            Set<String> intersection = Sets.intersection(currentSinks, receivedSinks);
+
+            Set<String> sinksToRemove = Sets.difference(currentSinks, receivedSinks);
+
+            Set<String> sinksToAdd = Sets.difference(receivedSinks, currentSinks);
+
+            for (String remoteClusterId : sinksToRemove) {
+                remoteClientToMetadataManagerMap.remove(remoteClusterId);
+            }
+            createMetadataManagers(sinksToAdd);
+            initReplicationStatusForRemoteClusters(true);
+            replicationContext.setTopology(discoveredTopology);
+            replicationManager.processStandbyChange(discoveredTopology, sinksToAdd, sinksToRemove, intersection);
+        } else {
+            // Update the topology config id on the Sink components
+            updateTopologyConfigIdOnSink(discoveredTopology.getTopologyConfigId());
         }
 
+        // Update Topology Config Id on MetadataManagers (contains persisted
+        // metadata tables)
+        remoteClientToMetadataManagerMap.values().forEach(metadataManager -> metadataManager.setupTopologyConfigId(
+            discoveredTopology.getTopologyConfigId()));
+
         updateLocalTopology(discoveredTopology);
-        updateReplicationManagerTopology(discoveredTopology);
-        updateTopologyConfigId(topologyDescriptor.getTopologyConfigId());
-        log.debug("Persist new topologyConfigId {}, cluster id={}, role={}", topologyDescriptor.getTopologyConfigId(),
-                localClusterDescriptor.getClusterId(), localClusterDescriptor.getRole());
+        log.debug("Persisted new topologyConfigId {}, cluster id={}, role={}", topologyDescriptor.getTopologyConfigId(),
+            localClusterDescriptor.getClusterId(), localClusterDescriptor.getRole());
     }
 
     /**
@@ -723,10 +778,13 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     private boolean processDiscoveredTopology(TopologyDescriptor topology, boolean update) {
         // Health check - confirm this node belongs to a cluster in the topology
         if (topology != null && clusterPresentInTopology(topology, update)) {
-            log.info("Node[{}/{}] belongs to cluster, descriptor={}, topology={}", localEndpoint, localNodeId, localClusterDescriptor, topology);
-            if (!serverStarted) {
-                bootstrapLogReplicationService();
+            log.info("Node[{}/{}] belongs to cluster, descriptor={}, topology={}",
+                localEndpoint, localNodeId, localClusterDescriptor, topology);
+            if (!bootstrapComplete) {
+                log.info("Bootstrap the Log Replication Service");
+                performRoleBasedSetup(topology.getClusterDescriptor(localNodeId).getRole());
                 registerToLogReplicationLock();
+                bootstrapComplete = true;
             }
             return true;
         }
@@ -749,16 +807,20 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         localNodeDescriptor = localClusterDescriptor.getNode(localNodeId);
     }
 
-    private void updateReplicationManagerTopology(TopologyDescriptor newConfig) {
-        if (replicationManager != null) {
-            replicationManager.updateRuntimeConfigId(newConfig);
-        }
-    }
-
     /**
-     * Enforce a snapshot full sync for all standbys if the current node is a leader node
+     * Enforce a snapshot sync for the standby cluster in the event if the
+     * current node is an active leader node
      */
     private void processEnforceSnapshotSync(DiscoveryServiceEvent event) {
+
+        // A switchover could have happened after the ACTIVE received the
+        // command and wrote it to the event table.  So check the cluster role
+        // here again.
+        if (localClusterDescriptor.getRole() == ClusterRole.STANDBY) {
+            log.warn("The current role is STANDBY.  Ignoring the forced " +
+                "snapshot sync event");
+            return;
+        }
         if (replicationManager == null || !isLeader.get()) {
             log.warn("The current node is not the leader, will skip doing the " +
                     "forced snapshot sync with id {}", event.getEventId());
@@ -779,32 +841,34 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
     }
 
     /**
-     * Active Cluster - Read the shared metadata table to find the status of any ongoing snapshot or log entry sync
+     * Source Cluster - Read the shared metadata table to find the status of any ongoing snapshot or log entry sync
      * and return a completion percentage.
      * <p>
-     * Standby Cluster - Read the shared metadata table and find if data is consistent(returns false if
-     * snapshot sync is in the apply phase)
+     * Sink Cluster - Read the shared metadata table and find if data is consistent(set to false if snapshot sync is
+     * in the apply phase)
      */
     @Override
     public Map<String, LogReplicationMetadata.ReplicationStatusVal> queryReplicationStatus() {
-        if (localClusterDescriptor == null || logReplicationMetadataManager == null) {
+        Map<String, LogReplicationMetadata.ReplicationStatusVal> clientToReplicationStatusMap = new HashMap<>();
+
+        if (localClusterDescriptor == null) {
             log.warn("Cluster configuration has not been pushed to current LR node.");
-            return null;
-        } else if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {
-            Map<String, LogReplicationMetadata.ReplicationStatusVal> mapReplicationStatus = logReplicationMetadataManager.getReplicationRemainingEntries();
-            Map<String, LogReplicationMetadata.ReplicationStatusVal> mapToSend = new HashMap<>(mapReplicationStatus);
-            // If map contains local cluster, remove (as it might have been added by the SinkManager) but this node
-            // has an active role.
-            if (mapToSend.containsKey(localClusterDescriptor.getClusterId())) {
-                log.warn("Remove localClusterDescriptor {} from replicationStatusMap", localClusterDescriptor.getClusterId());
-                mapToSend.remove(localClusterDescriptor.getClusterId());
-            }
-            return mapToSend;
-        } else if (localClusterDescriptor.getRole() == ClusterRole.STANDBY) {
-            return logReplicationMetadataManager.getDataConsistentOnStandby();
+            return clientToReplicationStatusMap;
         }
-        log.error("Received Replication Status Query in Incorrect Role {}.", localClusterDescriptor.getRole());
-        return null;
+
+        if (localClusterDescriptor.getRole() != ClusterRole.ACTIVE &&
+            localClusterDescriptor.getRole() != ClusterRole.STANDBY) {
+            log.error("Received Replication Status Query in Incorrect Role {}.", localClusterDescriptor.getRole());
+            return clientToReplicationStatusMap;
+        }
+
+        // Note: MetadataManager is currently instantiated per remote cluster.  In a subsequent PR, change to share a
+        // single instance for all remote clusters will be added.  So for now, get all replication statuses using any
+        // 1 metadata manager.
+        if (remoteClientToMetadataManagerMap.values().iterator().hasNext()) {
+            return remoteClientToMetadataManagerMap.values().iterator().next().getReplicationStatus();
+        }
+        return clientToReplicationStatusMap;
     }
 
     @Override
@@ -826,7 +890,8 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 .setEventId(forceSyncId.toString())
                 .setType(ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC)
                 .build();
-        getLogReplicationMetadataManager().updateLogReplicationEventTable(key, event);
+        remoteClientToMetadataManagerMap.get(clusterId).updateLogReplicationEventTable(key,
+            event);
         return forceSyncId;
     }
 
@@ -852,8 +917,10 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
             lockClient.shutdown();
         }
 
-        if (logReplicationMetadataManager != null) {
-            logReplicationMetadataManager.shutdown();
+        remoteClientToMetadataManagerMap.values().forEach(metadataManager -> metadataManager.shutdown());
+
+        if (interClusterServerNode != null) {
+            interClusterServerNode.close();
         }
     }
 
@@ -896,10 +963,22 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         lockAcquireSample.ifPresent(LongTaskTimer.Sample::stop);
     }
 
-    private void updateReplicationStatus() {
-        if (!statusFlag) {
-            replicationManager.updateStatusAsNotStarted();
-            statusFlag = true;
+    private void initReplicationStatusForRemoteClusters(boolean isSource) {
+        try {
+            IRetry.build(IntervalRetry.class, () -> {
+                try {
+                    remoteClientToMetadataManagerMap.values().forEach(
+                        metadataManager -> metadataManager.initReplicationStatus(isSource));
+                } catch (TransactionAbortedException tae) {
+                    log.error("Error while attempting to update Replication Status for new remote", tae);
+                    throw new RetryNeededException();
+                }
+                log.debug("Replication Status for new remote added successfully.");
+                return null;
+            }).run();
+        } catch (InterruptedException e) {
+            log.error("Unrecoverable exception when attempting to add Replication Status for new remote.", e);
+            throw new UnrecoverableCorfuInterruptedError(e);
         }
     }
 
@@ -918,10 +997,13 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                 throw new IllegalStateException(e.getCause());
             }
         } else {
-            log.error("setupLocalNodeId failed, because nodeId file path is missing!");
+            log.error("setupLocalNodeId failed, because nodeId file path is " +
+                "missing!");
+            DefaultClusterConfig defaultClusterConfig = new DefaultClusterConfig();
+
             // For testing purpose, it uses the default host to assign node id
-            if (getLocalHost().equals(DefaultClusterConfig.getDefaultHost())) {
-                localNodeId = DefaultClusterConfig.getDefaultNodeId(localEndpoint);
+            if (getLocalHost().equals(defaultClusterConfig.getDefaultHost())) {
+                localNodeId = defaultClusterConfig.getDefaultNodeId(localEndpoint);
                 if (localNodeId != null) {
                     log.info("setupLocalNodeId failed, using default node id {} for test", localNodeId);
                 } else {
@@ -937,12 +1019,16 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
         try {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
-                    logReplicationMetadataManager.resetReplicationStatus();
+                    // Note: MetadataManager is currently instantiated per remote cluster.  In a subsequent PR, change
+                    // to share a single instance for all remote clusters will be added.  So for now, reset the table
+                    // using any 1 metadata manager.
+                    if (remoteClientToMetadataManagerMap.values().iterator().hasNext()) {
+                        remoteClientToMetadataManagerMap.values().iterator().next().resetReplicationStatus();
+                    }
                 } catch (TransactionAbortedException tae) {
                     log.error("Error while attempting to resetReplicationStatusTable in DiscoveryService's role change", tae);
                     throw new RetryNeededException();
                 }
-
                 log.debug("resetReplicationStatusTable succeeds");
                 return null;
             }).run();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -62,7 +62,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * <p>
  * It manages the following:
  * <p>
- * - Discover topology and determine cluster role: active/standby
+ * - Discover topology and determine cluster role: source/sink
  * - Lock acquisition (leader election), node leading the log replication sending and receiving
  * - Log replication configuration (streams to replicate)
  */
@@ -109,7 +109,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
     private LogReplicationConfigManager replicationConfigManager;
 
     /**
-     * Used by the active cluster to initiate Log Replication
+     * Used by the source cluster to initiate Log Replication
      */
     @Getter
     private CorfuReplicationManager replicationManager;
@@ -188,7 +188,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
     /**
      * Indicates that bootstrap has been completed. Bootstrap is done once it
      * is determined that this node belongs to a cluster in the topology
-     * provided by ClusterManager and has the role of ACTIVE or STANDBY
+     * provided by ClusterManager and has the role of SOURCE or SINK
      */
     private boolean bootstrapComplete = false;
 
@@ -295,7 +295,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
      * On first access start topology discovery.
      * <p>
      * On discovery, process the topology information and fetch log replication configuration
-     * (streams to replicate) required by an active and standby site before starting
+     * (streams to replicate) required by an source and sink site before starting
      * log replication.
      */
     private void startDiscovery() {
@@ -344,7 +344,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
      * @param role
      */
     private void performRoleBasedSetup(ClusterRole role) {
-        if (role != ClusterRole.ACTIVE && role != ClusterRole.STANDBY) {
+        if (role != ClusterRole.SOURCE && role != ClusterRole.SINK) {
             log.debug("Cluster role is {}.  Not performing role-based setup.", role);
             return;
         }
@@ -355,15 +355,15 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
 
         Set<String> remoteClusterIds = new HashSet<>();
 
-        if (role == ClusterRole.ACTIVE) {
-            remoteClusterIds.addAll(topologyDescriptor.getStandbyClusters().keySet());
+        if (role == ClusterRole.SOURCE) {
+            remoteClusterIds.addAll(topologyDescriptor.getSinkClusters().keySet());
             createMetadataManagers(remoteClusterIds);
             replicationContext = new LogReplicationContext(logReplicationConfig, topologyDescriptor, localCorfuEndpoint);
             logReplicationEventListener = new LogReplicationEventListener(this, getCorfuRuntime());
             logReplicationEventListener.start();
         } else {
             // Sink Cluster
-            remoteClusterIds.addAll(topologyDescriptor.getActiveClusters().keySet());
+            remoteClusterIds.addAll(topologyDescriptor.getSourceClusters().keySet());
             createMetadataManagers(remoteClusterIds);
 
             LogReplicationServer server = new LogReplicationServer(serverContext, localNodeId, logReplicationConfig,
@@ -504,7 +504,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
      */
     private void onLeadershipAcquire() {
         switch (localClusterDescriptor.getRole()) {
-            case ACTIVE:
+            case SOURCE:
                 log.info("Start as Source (sender/replicator)");
                 if (replicationManager == null) {
                     replicationManager = new CorfuReplicationManager(replicationContext, localNodeDescriptor,
@@ -522,7 +522,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
                 lockAcquireSample = recordLockAcquire(localClusterDescriptor.getRole());
                 processCountOnLockAcquire(localClusterDescriptor.getRole());
                 break;
-            case STANDBY:
+            case SINK:
                 log.info("Start as Sink (receiver)");
 
                 // Sink Site : the LogReplicationServer (server handler) will
@@ -570,7 +570,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
      * Stop Log Replication
      */
     private void stopLogReplication() {
-        if (localClusterDescriptor != null && localClusterDescriptor.getRole() == ClusterRole.ACTIVE && isLeader.get()) {
+        if (localClusterDescriptor != null && localClusterDescriptor.getRole() == ClusterRole.SOURCE && isLeader.get()) {
             log.info("Stopping log replication.");
             replicationManager.stop();
         }
@@ -606,7 +606,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
         stopLogReplication();
         isLeader.set(false);
         // Signal Log Replication Server/Sink to stop receiving messages, leadership loss
-        if (localClusterDescriptor != null && localClusterDescriptor.getRole() == ClusterRole.STANDBY) {
+        if (localClusterDescriptor != null && localClusterDescriptor.getRole() == ClusterRole.SINK) {
             interClusterServerNode.setLeadership(false);
         }
         recordLockRelease();
@@ -628,12 +628,13 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
 
         log.debug("OnClusterRoleChange, topology={}", newTopology);
 
+
         // Stop ongoing replication, stopLogReplication() checks leadership and role as SOURCE
         // We do not update topology until we successfully stop log replication
-        if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE) {
+        if (localClusterDescriptor.getRole() == ClusterRole.SOURCE) {
             stopLogReplication();
             logReplicationEventListener.stop();
-        } else if (localClusterDescriptor.getRole() == ClusterRole.STANDBY) {
+        } else if (localClusterDescriptor.getRole() == ClusterRole.SINK) {
             // Stop the replication server
             interClusterServerNode.disable();
         }
@@ -670,7 +671,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
      * Process a topology change as provided by the Cluster Manager
      * <p>
      * Note: We are assuming that topology configId change implies a role change.
-     * The number of standby clusters change would not bump config id.
+     * The number of sink clusters change would not bump config id.
      *
      * @param event discovery event
      */
@@ -700,10 +701,10 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
             if (clusterRoleChanged(discoveredTopology)) {
                 onClusterRoleChange(discoveredTopology);
             } else {
-                onStandbyClusterAddRemove(discoveredTopology);
+                onSinkClusterAddRemove(discoveredTopology);
             }
         } else {
-            // Stop Log Replication in case this node was previously ACTIVE but no longer belongs to the Topology
+            // Stop Log Replication in case this node was previously SOURCE but no longer belongs to the Topology
             stopLogReplication();
         }
     }
@@ -728,14 +729,14 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
      *
      * @param discoveredTopology new discovered topology
      */
-    private void onStandbyClusterAddRemove(TopologyDescriptor discoveredTopology) {
+    private void onSinkClusterAddRemove(TopologyDescriptor discoveredTopology) {
         log.debug("Sink Cluster has been added or removed");
 
         // We only need to process new sinks if the local cluster role is SOURCE
-        if (localClusterDescriptor.getRole() == ClusterRole.ACTIVE &&
+        if (localClusterDescriptor.getRole() == ClusterRole.SOURCE &&
             replicationManager != null && isLeader.get()) {
-            Set<String> receivedSinks = discoveredTopology.getStandbyClusters().keySet();
-            Set<String> currentSinks = topologyDescriptor.getStandbyClusters().keySet();
+            Set<String> receivedSinks = discoveredTopology.getSinkClusters().keySet();
+            Set<String> currentSinks = topologyDescriptor.getSinkClusters().keySet();
 
             Set<String> intersection = Sets.intersection(currentSinks, receivedSinks);
 
@@ -752,7 +753,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
             createMetadataManagers(sinksToAdd);
             initReplicationStatusForRemoteClusters(true);
             replicationContext.setTopology(discoveredTopology);
-            replicationManager.processStandbyChange(discoveredTopology, sinksToAdd, sinksToRemove, intersection);
+            replicationManager.processSinkChange(discoveredTopology, sinksToAdd, sinksToRemove, intersection);
         } else {
             // Update the topology config id on the Sink components
             updateTopologyConfigIdOnSink(discoveredTopology.getTopologyConfigId());
@@ -809,15 +810,15 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
     }
 
     /**
-     * Enforce a snapshot sync for the standby cluster in the event if the
-     * current node is an active leader node
+     * Enforce a snapshot sync for the sink cluster in the event if the
+     * current node is an source leader node
      */
     private void processEnforceSnapshotSync(DiscoveryServiceEvent event) {
 
-        // A switchover could have happened after the ACTIVE received the
+        // A switchover could have happened after the SOURCE received the
         // command and wrote it to the event table.  So check the cluster role
         // here again.
-        if (localClusterDescriptor.getRole() == ClusterRole.STANDBY) {
+        if (localClusterDescriptor.getRole() == ClusterRole.SINK) {
             log.warn("The current role is STANDBY.  Ignoring the forced snapshot sync event");
             return;
         }
@@ -856,8 +857,8 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
             return clientToReplicationStatusMap;
         }
 
-        if (localClusterDescriptor.getRole() != ClusterRole.ACTIVE &&
-            localClusterDescriptor.getRole() != ClusterRole.STANDBY) {
+        if (localClusterDescriptor.getRole() != ClusterRole.SOURCE &&
+            localClusterDescriptor.getRole() != ClusterRole.SINK) {
             log.error("Received Replication Status Query in Incorrect Role {}.", localClusterDescriptor.getRole());
             return clientToReplicationStatusMap;
         }
@@ -873,14 +874,14 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
 
     @Override
     public UUID forceSnapshotSync(String clusterId) throws LogReplicationDiscoveryServiceException {
-        if (localClusterDescriptor.getRole() == ClusterRole.STANDBY) {
-            String errorStr = "The forceSnapshotSync command is not supported on standby cluster.";
+        if (localClusterDescriptor.getRole() == ClusterRole.SINK) {
+            String errorStr = "The forceSnapshotSync command is not supported on sink cluster.";
             log.error(errorStr);
             throw new LogReplicationDiscoveryServiceException(errorStr);
         }
 
         UUID forceSyncId = UUID.randomUUID();
-        log.info("Received forceSnapshotSync command for standby cluster {}, forced sync id {}",
+        log.info("Received forceSnapshotSync command for sink cluster {}, forced sync id {}",
                 clusterId, forceSyncId);
 
         // Write a force sync event to the logReplicationEventTable

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryServiceAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryServiceAdapter.java
@@ -27,4 +27,8 @@ public interface CorfuReplicationDiscoveryServiceAdapter {
 
 
     LogReplicationClusterInfo.ClusterRole getLocalClusterRoleType();
+
+    ClusterDescriptor getLocalCluster();
+
+    String getLocalNodeId();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -1,11 +1,8 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
-import com.google.common.collect.Sets;
-import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.SyncStatus;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
@@ -15,7 +12,6 @@ import org.corfudb.util.retry.IntervalRetry;
 import org.corfudb.util.retry.RetryNeededException;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -30,16 +26,13 @@ public class CorfuReplicationManager {
     private final Map<String, CorfuLogReplicationRuntime> runtimeToRemoteCluster = new HashMap<>();
 
     @Setter
-    @Getter
-    private TopologyDescriptor topology;
-
-    private final LogReplicationContext context;
+    private LogReplicationContext context;
 
     private final NodeDescriptor localNodeDescriptor;
 
     private final CorfuRuntime corfuRuntime;
 
-    private final LogReplicationMetadataManager metadataManager;
+    private final Map<String, LogReplicationMetadataManager> metadataManagerMap;
 
     private final String pluginFilePath;
 
@@ -48,11 +41,13 @@ public class CorfuReplicationManager {
     /**
      * Constructor
      */
-    public CorfuReplicationManager(LogReplicationContext context, NodeDescriptor localNodeDescriptor,
-                                   LogReplicationMetadataManager metadataManager, String pluginFilePath,
-                                   CorfuRuntime corfuRuntime, LogReplicationConfigManager replicationConfigManager) {
+    public CorfuReplicationManager(LogReplicationContext context,
+        NodeDescriptor localNodeDescriptor,
+        Map<String, LogReplicationMetadataManager> metadataManagerMap,
+        String pluginFilePath, CorfuRuntime corfuRuntime,
+        LogReplicationConfigManager replicationConfigManager) {
         this.context = context;
-        this.metadataManager = metadataManager;
+        this.metadataManagerMap = metadataManagerMap;
         this.pluginFilePath = pluginFilePath;
         this.corfuRuntime = corfuRuntime;
         this.localNodeDescriptor = localNodeDescriptor;
@@ -64,7 +59,8 @@ public class CorfuReplicationManager {
      * each standby cluster, to further start log replication.
      */
     public void start() {
-        for (ClusterDescriptor remoteCluster : topology.getStandbyClusters().values()) {
+        for (ClusterDescriptor remoteCluster :
+            context.getTopology().getStandbyClusters().values()) {
             try {
                 startLogReplicationRuntime(remoteCluster);
             } catch (Exception e) {
@@ -129,7 +125,7 @@ public class CorfuReplicationManager {
                             .localClusterId(localNodeDescriptor.getClusterId())
                             .replicationConfig(context.getConfig())
                             .pluginFilePath(pluginFilePath)
-                            .topologyConfigId(topology.getTopologyConfigId())
+                            .topologyConfigId(context.getTopology().getTopologyConfigId())
                             .keyStore(corfuRuntime.getParameters().getKeyStore())
                             .tlsEnabled(corfuRuntime.getParameters().isTlsEnabled())
                             .ksPasswordFile(corfuRuntime.getParameters().getKsPasswordFile())
@@ -137,8 +133,10 @@ public class CorfuReplicationManager {
                             .tsPasswordFile(corfuRuntime.getParameters().getTsPasswordFile())
                             .maxWriteSize(corfuRuntime.getParameters().getMaxWriteSize())
                             .build();
-                    CorfuLogReplicationRuntime replicationRuntime = new CorfuLogReplicationRuntime(parameters,
-                            metadataManager, replicationConfigManager);
+                    CorfuLogReplicationRuntime replicationRuntime =
+                        new CorfuLogReplicationRuntime(parameters,
+                            metadataManagerMap.get(remoteCluster.clusterId),
+                            replicationConfigManager);
                     replicationRuntime.start();
                     runtimeToRemoteCluster.put(remoteCluster.getClusterId(), replicationRuntime);
                 } catch (Exception e) {
@@ -171,50 +169,43 @@ public class CorfuReplicationManager {
     /**
      * Update Log Replication Runtime config id.
      */
-    public void updateRuntimeConfigId(TopologyDescriptor newConfig) {
+    private void updateRuntimeConfigId(TopologyDescriptor newConfig) {
         runtimeToRemoteCluster.values().forEach(runtime -> runtime.updateFSMConfigId(newConfig));
     }
 
     /**
-     * The notification of change of adding/removing standby's without epoch change.
+     * The notification of change of adding/removing Sinks with/without topology configId change.
      *
      * @param newConfig should have the same topologyConfigId as the current config
+     * @param sinksToAdd the new sink clusters to be added
+     * @param sinksToRemove sink clusters which are not found in the new topology
      */
-    public void processStandbyChange(TopologyDescriptor newConfig) {
-        // ConfigId mismatch could happen if customized cluster manager does not follow protocol
-        if (newConfig.getTopologyConfigId() != topology.getTopologyConfigId()) {
-            log.warn("Detected changes in the topology. The new topology descriptor {} doesn't have the same " +
-                    "topologyConfigId as the current one {}", newConfig, topology);
-        }
+    public void processStandbyChange(TopologyDescriptor newConfig, Set<String> sinksToAdd, Set<String> sinksToRemove,
+        Set<String> intersection) {
 
-        Set<String> currentStandbys = new HashSet<>(topology.getStandbyClusters().keySet());
-        Set<String> newStandbys = new HashSet<>(newConfig.getStandbyClusters().keySet());
-        Set<String> intersection = Sets.intersection(currentStandbys, newStandbys);
+        long oldTopologyConfigId = context.getTopology().getTopologyConfigId();
+        context.setTopology(newConfig);
 
-        Set<String> standbysToRemove = new HashSet<>(currentStandbys);
-        standbysToRemove.removeAll(intersection);
-
-        // Remove standbys that are not in the new config
-        for (String clusterId : standbysToRemove) {
+        // Remove Sinks that are not in the new config
+        for (String clusterId : sinksToRemove) {
             stopLogReplicationRuntime(clusterId);
-            topology.removeStandbyCluster(clusterId);
         }
 
-        // Start the standbys that are in the new config but not in the current config
-        for (String clusterId : newStandbys) {
-            if (!runtimeToRemoteCluster.containsKey(clusterId)) {
-                ClusterDescriptor clusterInfo = newConfig.getStandbyClusters().get(clusterId);
-                topology.addStandbyCluster(clusterInfo);
-                startLogReplicationRuntime(clusterInfo);
-            }
+        // Start the newly added Sinks
+        for (String clusterId : sinksToAdd) {
+            ClusterDescriptor clusterInfo = newConfig.getStandbyClusters().get(clusterId);
+            startLogReplicationRuntime(clusterInfo);
         }
 
-        // The connection id or other transportation plugin's info could've changed for
-        // existing standby cluster's, updating the routers will re-establish the connection
-        // to the correct endpoints/nodes
+        // The connection id or other transportation plugin's info could've changed for existing Sink cluster's,
+        // updating the routers will re-establish the connection to the correct endpoints/nodes
         for (String clusterId : intersection) {
             ClusterDescriptor clusterInfo = newConfig.getStandbyClusters().get(clusterId);
             runtimeToRemoteCluster.get(clusterId).updateRouterClusterDescriptor(clusterInfo);
+        }
+
+        if (oldTopologyConfigId != newConfig.getTopologyConfigId()) {
+            updateRuntimeConfigId(newConfig);
         }
     }
 
@@ -231,17 +222,5 @@ public class CorfuReplicationManager {
             standbyRuntime.getSourceManager().stopLogReplication();
             standbyRuntime.getSourceManager().startForcedSnapshotSync(event.getEventId());
         }
-    }
-
-    /**
-     * Update Replication Status as NOT_STARTED.
-     * Should be called only once in an active lifecycle.
-     */
-    public void updateStatusAsNotStarted() {
-        runtimeToRemoteCluster.values().forEach(corfuLogReplicationRuntime ->
-                corfuLogReplicationRuntime
-                        .getSourceManager()
-                        .getAckReader()
-                        .markSyncStatus(SyncStatus.NOT_STARTED));
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -1,17 +1,24 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
+import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.AbstractServer;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
+import org.corfudb.infrastructure.logreplication.runtime.ReplicationSinkClientRouter;
+import org.corfudb.infrastructure.logreplication.runtime.ReplicationSourceRouter;
+import org.corfudb.infrastructure.logreplication.runtime.ReplicationRouter;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.IntervalRetry;
 import org.corfudb.util.retry.RetryNeededException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -22,7 +29,8 @@ import java.util.Set;
 public class CorfuReplicationManager {
 
     // Keep map of remote session and the associated log replication runtime (an abstract client to that cluster)
-    private final Map<ReplicationSession, CorfuLogReplicationRuntime> runtimeToRemoteSession = new HashMap<>();
+    @Getter
+    private final Map<ReplicationSession, CorfuLogReplicationRuntime> remoteSesionToRuntime = new HashMap<>();
 
     @Setter
     private LogReplicationContext context;
@@ -37,6 +45,10 @@ public class CorfuReplicationManager {
 
     private final LogReplicationConfigManager replicationConfigManager;
 
+    private final Map<ReplicationSession, ReplicationSourceRouter> replicationSessionToRouterSource;
+    private final Map<ReplicationSession, ReplicationSinkClientRouter> replicationSessionToRouterSink;
+    private final Map<ReplicationSession, LogReplicationRuntimeParameters> replicationSessionToRuntimeParams;
+
     /**
      * Constructor
      */
@@ -50,55 +62,110 @@ public class CorfuReplicationManager {
         this.corfuRuntime = corfuRuntime;
         this.localNodeDescriptor = localNodeDescriptor;
         this.replicationConfigManager = replicationConfigManager;
+        this.replicationSessionToRouterSource = new HashMap<>();
+        this.replicationSessionToRouterSink = new HashMap<>();
+        this.replicationSessionToRuntimeParams = new HashMap<>();
     }
 
     /**
-     * Start Log Replication Manager, this will initiate a runtime against
-     * each Sink session(cluster + replication model + client), to further start log replication.
+     * Used when the local cluster is a connection initiator.
+     * If local cluster is a source, creates a runtime and a sourceRouter
+     * If local cluster is a sink, creates a router and starts the sink-server node.
      */
-    public void start() {
-        for (ClusterDescriptor remoteCluster : context.getTopology().getSinkClusters().values()) {
-            for (ReplicationSubscriber subscriber : context.getConfig().getReplicationSubscriberToStreamsMap().keySet()) {
-                try {
-                    startLogReplicationRuntime(remoteCluster, new ReplicationSession(remoteCluster.getClusterId(),
-                        subscriber));
-                } catch (Exception e) {
-                    log.error("Failed to start log replication runtime for remote session {}, replication model {}, " +
-                        "client {}", remoteCluster.getClusterId(), subscriber.getReplicationModel(),
-                        subscriber.getClient());
+    public void startConnection(Set<ClusterDescriptor> remoteClusters,
+                                Map<String, Set<ReplicationSession>> remoteClusterIdToReplicationSession,
+                                CorfuInterClusterReplicationServerNode interClusterServerNode) {
+
+        for(ClusterDescriptor remote : remoteClusters) {
+            Set<ReplicationSession> sessions = remoteClusterIdToReplicationSession.get(remote.getClusterId());
+            log.info("Starting connection to remote {} and session {} ", remote, sessions);
+
+            for(ReplicationSession session : sessions) {
+                ReplicationRouter router;
+                if (context.getTopology().getRemoteSinkClusters().containsKey(remote.getClusterId())) {
+                    router = getOrCreateRouter(remote,session,true, interClusterServerNode);
+                } else if (this.context.getTopology().getRemoteSourceClusters().containsKey(remote.getClusterId())) {
+                    router = getOrCreateRouter(remote,session,false, interClusterServerNode);
+                } else {
+                    log.warn("Not connecting to cluster {} as it is neither a source nor a sink to the current cluster", remote);
+                    continue;
                 }
+
+                try {
+                    IRetry.build(IntervalRetry.class, () -> {
+                        try {
+                            router.connect();
+                        } catch (Exception e) {
+                            log.error("Exception {}. Failed to connect to remote cluster for session {}. Retry after 1 second.",
+                                    e, session);
+                            throw new RetryNeededException();
+                        }
+                        return null;
+                    }).run();
+                } catch (InterruptedException e) {
+                    log.error("Unrecoverable exception when attempting to connect to remote session.", e);
+                }
+
             }
+
         }
     }
 
     /**
-     * Stop log replication for all the sink sites
+     * Creates a Router for source and for a sink (i.e., if the local cluster acts as both source/sink).
      */
-    public void stop() {
-        runtimeToRemoteSession.values().forEach(runtime -> {
-            try {
-                log.info("Stop log replication runtime to remote cluster id={}", runtime.getRemoteClusterId());
-                runtime.stop();
-            } catch (Exception e) {
-                log.warn("Failed to stop log replication runtime to remote cluster id={}", runtime.getRemoteClusterId());
+    public ReplicationRouter getOrCreateRouter(ClusterDescriptor remote, ReplicationSession session, boolean isSource,
+                                               CorfuInterClusterReplicationServerNode interClusterServerNode) {
+        ReplicationRouter router;
+        if (isSource) {
+            if (replicationSessionToRouterSource.containsKey(session)) {
+                return replicationSessionToRouterSource.get(session);
             }
-        });
-        runtimeToRemoteSession.clear();
+
+            ReplicationSourceRouter sourceRouter = new ReplicationSourceRouter(remote,
+                    localNodeDescriptor.getClusterId(), createRuntimeParams(remote,session), this,
+                    session);
+            router = sourceRouter;
+            replicationSessionToRouterSource.put(session, sourceRouter);
+            createRuntime(remote, session);
+            sourceRouter.setRuntimeFSM(remoteSesionToRuntime.get(session));
+        } else {
+            if(replicationSessionToRouterSink.containsKey(session)) {
+                return replicationSessionToRouterSink.get(session);
+            }
+            ReplicationSinkClientRouter sinkRouter = new ReplicationSinkClientRouter(
+                    new ArrayList<AbstractServer>(interClusterServerNode.getServerMap().values()),
+                    remote, localNodeDescriptor.getClusterId(), pluginFilePath, session);
+            router = sinkRouter;
+            replicationSessionToRouterSink.put(session, sinkRouter);
+        }
+        return router;
     }
 
     /**
-     * Start Log Replication Runtime to a specific Sink Session
+     * Create Log Replication Runtime for a session, if not already created.
      */
-    private void startLogReplicationRuntime(ClusterDescriptor remoteClusterDescriptor,
-                                            ReplicationSession replicationSession) {
+    public void createRuntime(ClusterDescriptor remote, ReplicationSession replicationSession) {
         try {
-            if (!runtimeToRemoteSession.containsKey(replicationSession)) {
-                log.info("Starting Log Replication Runtime for session {}", replicationSession);
-                connect(remoteClusterDescriptor, replicationSession);
-            } else {
-                log.warn("Log Replication Runtime to remote session {}, already exists. Skipping init.",
-                    replicationSession);
-            }
+            CorfuLogReplicationRuntime replicationRuntime;
+                if (!remoteSesionToRuntime.containsKey(replicationSession)) {
+                    log.info("Starting Log Replication Runtime for session {}", replicationSession);
+                    LogReplicationRuntimeParameters parameters;
+                    // parameters is null when the cluster is not the connection starter.
+                    if (replicationSessionToRuntimeParams.isEmpty() || replicationSessionToRuntimeParams.get(replicationSession) == null) {
+                        parameters = createRuntimeParams(remote, replicationSession);
+                    } else {
+                        parameters = replicationSessionToRuntimeParams.get(replicationSession);
+                    }
+                    replicationRuntime = new CorfuLogReplicationRuntime(parameters,
+                            metadataManagerMap.get(replicationSession), replicationConfigManager, replicationSession,
+                            replicationSessionToRouterSource.get(replicationSession));
+                    remoteSesionToRuntime.put(replicationSession, replicationRuntime);
+                } else {
+                    log.warn("Log Replication Runtime to remote session {}, already exists. Skipping init.",
+                            replicationSession);
+                    return;
+                }
         } catch (Exception e) {
             log.error("Caught exception, stop log replication runtime to {}", replicationSession, e);
             stopLogReplicationRuntime(replicationSession);
@@ -106,64 +173,83 @@ public class CorfuReplicationManager {
     }
 
     /**
-     * Connect to a remote Log Replicator, through a Log Replication Runtime.
-     *
-     * @throws InterruptedException
+     * Start log replication.
+     * For the connection initiator cluster, this is called when the connection is established.
      */
-    private void connect(ClusterDescriptor remoteCluster, ReplicationSession session) throws InterruptedException {
-        try {
-            IRetry.build(IntervalRetry.class, () -> {
-                try {
-                    LogReplicationRuntimeParameters parameters = LogReplicationRuntimeParameters.builder()
-                            .localCorfuEndpoint(context.getLocalCorfuEndpoint())
-                            .remoteClusterDescriptor(remoteCluster)
-                            .localClusterId(localNodeDescriptor.getClusterId())
-                            .replicationConfig(context.getConfig())
-                            .pluginFilePath(pluginFilePath)
-                            .topologyConfigId(context.getTopology().getTopologyConfigId())
-                            .keyStore(corfuRuntime.getParameters().getKeyStore())
-                            .tlsEnabled(corfuRuntime.getParameters().isTlsEnabled())
-                            .ksPasswordFile(corfuRuntime.getParameters().getKsPasswordFile())
-                            .trustStore(corfuRuntime.getParameters().getTrustStore())
-                            .tsPasswordFile(corfuRuntime.getParameters().getTsPasswordFile())
-                            .maxWriteSize(corfuRuntime.getParameters().getMaxWriteSize())
-                            .build();
-                    CorfuLogReplicationRuntime replicationRuntime = new CorfuLogReplicationRuntime(parameters,
-                        metadataManagerMap.get(session), replicationConfigManager, session);
-                    replicationRuntime.start();
-                    runtimeToRemoteSession.put(session, replicationRuntime);
-                } catch (Exception e) {
-                    log.error("Exception {}. Failed to connect to remote cluster for session {}. Retry after 1 second.",
-                        e, session);
-                    throw new RetryNeededException();
-                }
-                return null;
-            }).run();
-        } catch (InterruptedException e) {
-            log.error("Unrecoverable exception when attempting to connect to remote session.", e);
-            throw e;
+    public void startRuntime(ReplicationSession replicationSession) {
+        CorfuLogReplicationRuntime replicationRuntime;
+        synchronized (this) {
+            replicationRuntime = remoteSesionToRuntime.get(replicationSession);
         }
+        replicationRuntime.start();
+    }
+
+    private LogReplicationRuntimeParameters createRuntimeParams(ClusterDescriptor remoteCluster, ReplicationSession session) {
+        LogReplicationRuntimeParameters parameters = LogReplicationRuntimeParameters.builder()
+                .localCorfuEndpoint(context.getLocalCorfuEndpoint())
+                .remoteClusterDescriptor(remoteCluster)
+                .localClusterId(localNodeDescriptor.getClusterId())
+                .replicationConfig(context.getConfig())
+                .pluginFilePath(pluginFilePath)
+                .topologyConfigId(context.getTopology().getTopologyConfigId())
+                .keyStore(corfuRuntime.getParameters().getKeyStore())
+                .tlsEnabled(corfuRuntime.getParameters().isTlsEnabled())
+                .ksPasswordFile(corfuRuntime.getParameters().getKsPasswordFile())
+                .trustStore(corfuRuntime.getParameters().getTrustStore())
+                .tsPasswordFile(corfuRuntime.getParameters().getTsPasswordFile())
+                .maxWriteSize(corfuRuntime.getParameters().getMaxWriteSize())
+                .build();
+
+        replicationSessionToRuntimeParams.put(session, parameters);
+
+        return parameters;
+    }
+
+    /**
+     * Stop log replication for all the sink sites
+     */
+    public void stop() {
+        remoteSesionToRuntime.forEach((session, runtime) -> {
+            try {
+                log.info("Stop log replication runtime and source router for session={}", session);
+                runtime.stop();
+                replicationSessionToRouterSource.get(session).stop();
+            } catch (Exception e) {
+                log.warn("Failed to stop log replication runtime for session={}", session);
+            }
+        });
+        remoteSesionToRuntime.clear();
+        replicationSessionToRouterSource.clear();
+        replicationSessionToRuntimeParams.clear();
     }
 
     /**
      * Stop Log Replication to a specific Sink session
      */
     private void stopLogReplicationRuntime(ReplicationSession replicationSession) {
-        CorfuLogReplicationRuntime logReplicationRuntime = runtimeToRemoteSession.get(replicationSession);
+        CorfuLogReplicationRuntime logReplicationRuntime = remoteSesionToRuntime.get(replicationSession);
         if (logReplicationRuntime != null) {
-            log.info("Stop log replication runtime for remote session {}", replicationSession);
+            log.info("Stop log replication runtime and source router for remote session {}", replicationSession);
             logReplicationRuntime.stop();
-            runtimeToRemoteSession.remove(replicationSession);
+            replicationSessionToRouterSource.get(replicationSession).stop();
+
+            remoteSesionToRuntime.remove(replicationSession);
+            replicationSessionToRouterSource.remove(replicationSession);
+            replicationSessionToRuntimeParams.remove(replicationSession);
         } else {
             log.warn("Runtime not found for remote session {}", replicationSession);
         }
+    }
+
+    public void clearSessionToSinkRouterMap() {
+        this.replicationSessionToRouterSink.clear();
     }
 
     /**
      * Update Log Replication Runtime config id.
      */
     private void updateRuntimeConfigId(TopologyDescriptor newConfig) {
-        runtimeToRemoteSession.values().forEach(runtime -> runtime.updateFSMConfigId(newConfig));
+        remoteSesionToRuntime.values().forEach(runtime -> runtime.updateFSMConfigId(newConfig));
     }
 
     /**
@@ -175,7 +261,9 @@ public class CorfuReplicationManager {
      * @param intersection Sink clusters found in both old and new topologies
      */
     public void processSinkChange(TopologyDescriptor newConfig, Set<String> sinksToAdd, Set<String> sinksToRemove,
-                                  Set<String> intersection) {
+                                  Set<String> intersection, Map<String, ClusterDescriptor> connectionEndsIdToDescriptor,
+                                  Map<String, Set<ReplicationSession>> remoteIdToReplicationSession,
+                                  CorfuInterClusterReplicationServerNode interClusterServerNode) {
 
         long oldTopologyConfigId = context.getTopology().getTopologyConfigId();
         context.setTopology(newConfig);
@@ -191,19 +279,26 @@ public class CorfuReplicationManager {
         }
 
         // Start the newly added Sinks
+        Set<ClusterDescriptor> newConnectionToStart = new HashSet<>();
         for (String clusterId : sinksToAdd) {
-            ClusterDescriptor clusterInfo = newConfig.getSinkClusters().get(clusterId);
-            for (ReplicationSubscriber subscriber : subscribers) {
-                startLogReplicationRuntime(clusterInfo, new ReplicationSession(clusterId, subscriber));
+            // When the cluster is the connection initiator to the newly added sink, collect the remoteSinks to start connections
+            if(connectionEndsIdToDescriptor.containsKey(clusterId)) {
+                newConnectionToStart.add(connectionEndsIdToDescriptor.get(clusterId));
+            } else {
+                remoteIdToReplicationSession.get(clusterId).stream().forEach(session -> {
+                        getOrCreateRouter(connectionEndsIdToDescriptor.get(clusterId), session, true, interClusterServerNode);
+                        startRuntime(session);
+                });
             }
         }
+        startConnection(newConnectionToStart, remoteIdToReplicationSession, interClusterServerNode);
 
         // The connection id or other transportation plugin's info could've changed for existing Sink clusters,
         // updating the routers will re-establish the connection to the correct endpoints/nodes
         for (String clusterId : intersection) {
-            ClusterDescriptor clusterInfo = newConfig.getSinkClusters().get(clusterId);
+            ClusterDescriptor clusterInfo = newConfig.getRemoteSinkClusters().get(clusterId);
             for (ReplicationSubscriber subscriber : subscribers) {
-                runtimeToRemoteSession.get(new ReplicationSession(clusterId, subscriber))
+                remoteSesionToRuntime.get(new ReplicationSession(clusterId, subscriber))
                     .updateRouterClusterDescriptor(clusterInfo);
             }
         }
@@ -217,7 +312,7 @@ public class CorfuReplicationManager {
      * Stop the current log replication event and start a full snapshot sync for the given remote cluster.
      */
     public void enforceSnapshotSync(DiscoveryServiceEvent event) {
-        CorfuLogReplicationRuntime sinkRuntime = runtimeToRemoteSession.get(
+        CorfuLogReplicationRuntime sinkRuntime = remoteSesionToRuntime.get(
             ReplicationSession.getDefaultReplicationSessionForCluster(event.getRemoteClusterInfo().getClusterId()));
         if (sinkRuntime == null) {
             log.warn("Failed to start enforceSnapshotSync for cluster {} as no runtime to it was found",

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * This class manages Log Replication for multiple remote (standby) clusters.
+ * This class manages Log Replication for multiple remote (sink) clusters.
  */
 @Slf4j
 public class CorfuReplicationManager {
@@ -57,7 +57,7 @@ public class CorfuReplicationManager {
      * each Sink session(cluster + replication model + client), to further start log replication.
      */
     public void start() {
-        for (ClusterDescriptor remoteCluster : context.getTopology().getStandbyClusters().values()) {
+        for (ClusterDescriptor remoteCluster : context.getTopology().getSinkClusters().values()) {
             for (ReplicationSubscriber subscriber : context.getConfig().getReplicationSubscriberToStreamsMap().keySet()) {
                 try {
                     startLogReplicationRuntime(remoteCluster, new ReplicationSession(remoteCluster.getClusterId(),
@@ -72,7 +72,7 @@ public class CorfuReplicationManager {
     }
 
     /**
-     * Stop log replication for all the standby sites
+     * Stop log replication for all the sink sites
      */
     public void stop() {
         runtimeToRemoteSession.values().forEach(runtime -> {
@@ -174,8 +174,8 @@ public class CorfuReplicationManager {
      * @param sinksToRemove sink clusters which are not found in the new topology
      * @param intersection Sink clusters found in both old and new topologies
      */
-    public void processStandbyChange(TopologyDescriptor newConfig, Set<String> sinksToAdd, Set<String> sinksToRemove,
-        Set<String> intersection) {
+    public void processSinkChange(TopologyDescriptor newConfig, Set<String> sinksToAdd, Set<String> sinksToRemove,
+                                  Set<String> intersection) {
 
         long oldTopologyConfigId = context.getTopology().getTopologyConfigId();
         context.setTopology(newConfig);
@@ -192,7 +192,7 @@ public class CorfuReplicationManager {
 
         // Start the newly added Sinks
         for (String clusterId : sinksToAdd) {
-            ClusterDescriptor clusterInfo = newConfig.getStandbyClusters().get(clusterId);
+            ClusterDescriptor clusterInfo = newConfig.getSinkClusters().get(clusterId);
             for (ReplicationSubscriber subscriber : subscribers) {
                 startLogReplicationRuntime(clusterInfo, new ReplicationSession(clusterId, subscriber));
             }
@@ -201,7 +201,7 @@ public class CorfuReplicationManager {
         // The connection id or other transportation plugin's info could've changed for existing Sink clusters,
         // updating the routers will re-establish the connection to the correct endpoints/nodes
         for (String clusterId : intersection) {
-            ClusterDescriptor clusterInfo = newConfig.getStandbyClusters().get(clusterId);
+            ClusterDescriptor clusterInfo = newConfig.getSinkClusters().get(clusterId);
             for (ReplicationSubscriber subscriber : subscribers) {
                 runtimeToRemoteSession.get(new ReplicationSession(clusterId, subscriber))
                     .updateRouterClusterDescriptor(clusterInfo);
@@ -217,15 +217,15 @@ public class CorfuReplicationManager {
      * Stop the current log replication event and start a full snapshot sync for the given remote cluster.
      */
     public void enforceSnapshotSync(DiscoveryServiceEvent event) {
-        CorfuLogReplicationRuntime standbyRuntime = runtimeToRemoteSession.get(
+        CorfuLogReplicationRuntime sinkRuntime = runtimeToRemoteSession.get(
             ReplicationSession.getDefaultReplicationSessionForCluster(event.getRemoteClusterInfo().getClusterId()));
-        if (standbyRuntime == null) {
+        if (sinkRuntime == null) {
             log.warn("Failed to start enforceSnapshotSync for cluster {} as no runtime to it was found",
                 event.getRemoteClusterInfo().getClusterId());
         } else {
-            log.info("EnforceSnapshotSync for cluster {}", standbyRuntime.getRemoteClusterId());
-            standbyRuntime.getSourceManager().stopLogReplication();
-            standbyRuntime.getSourceManager().startForcedSnapshotSync(event.getEventId());
+            log.info("EnforceSnapshotSync for cluster {}", sinkRuntime.getRemoteClusterId());
+            sinkRuntime.getSourceManager().stopLogReplication();
+            sinkRuntime.getSourceManager().startForcedSnapshotSync(event.getEventId());
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -256,11 +256,11 @@ public class CorfuReplicationManager {
      * The notification of adding/removing Sinks with/without topology configId change.
      *
      * @param newConfig should have the same topologyConfigId as the current config
-     * @param sinksToAdd the new sink clusters to be added
-     * @param sinksToRemove sink clusters which are not found in the new topology
+     * @param remoteClustersToAdd the new sink clusters to be added
+     * @param remoteClustersToRemove sink clusters which are not found in the new topology
      * @param intersection Sink clusters found in both old and new topologies
      */
-    public void processSinkChange(TopologyDescriptor newConfig, Set<String> sinksToAdd, Set<String> sinksToRemove,
+    public void processSinkChange(TopologyDescriptor newConfig, Set<String> remoteClustersToAdd, Set<String> remoteClustersToRemove,
                                   Set<String> intersection, Map<String, ClusterDescriptor> connectionEndsIdToDescriptor,
                                   Map<String, Set<ReplicationSession>> remoteIdToReplicationSession,
                                   CorfuInterClusterReplicationServerNode interClusterServerNode) {
@@ -272,7 +272,7 @@ public class CorfuReplicationManager {
         Set<ReplicationSubscriber> subscribers = context.getConfig().getReplicationSubscriberToStreamsMap().keySet();
 
         // Remove Sinks that are not in the new config
-        for (String clusterId : sinksToRemove) {
+        for (String clusterId : remoteClustersToRemove) {
             for (ReplicationSubscriber subscriber : subscribers) {
                 stopLogReplicationRuntime(new ReplicationSession(clusterId, subscriber));
             }
@@ -280,7 +280,7 @@ public class CorfuReplicationManager {
 
         // Start the newly added Sinks
         Set<ClusterDescriptor> newConnectionToStart = new HashSet<>();
-        for (String clusterId : sinksToAdd) {
+        for (String clusterId : remoteClustersToAdd) {
             // When the cluster is the connection initiator to the newly added sink, collect the remoteSinks to start connections
             if(connectionEndsIdToDescriptor.containsKey(clusterId)) {
                 newConnectionToStart.add(connectionEndsIdToDescriptor.get(clusterId));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationContext.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 
 /**
@@ -16,6 +17,7 @@ public class LogReplicationContext {
     private LogReplicationConfig config;
 
     @Getter
+    @Setter
     private TopologyDescriptor topology;
 
     @Getter

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationEventListener.java
@@ -2,26 +2,44 @@ package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationEvent;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStreamEntries;
 import org.corfudb.runtime.collections.CorfuStreamEntry;
 import org.corfudb.runtime.collections.StreamListener;
 
+import java.util.Collections;
 import java.util.List;
 
 @Slf4j
 public final class LogReplicationEventListener implements StreamListener {
     private final CorfuReplicationDiscoveryService discoveryService;
+    private final CorfuStore corfuStore;
 
-    public  LogReplicationEventListener(CorfuReplicationDiscoveryService discoveryService) {
+    public LogReplicationEventListener(CorfuReplicationDiscoveryService discoveryService, CorfuRuntime runtime) {
         this.discoveryService = discoveryService;
+        this.corfuStore = new CorfuStore(runtime);
     }
 
     public void start() {
-        discoveryService.getLogReplicationMetadataManager().subscribeReplicationEventTable(this);
+        log.info("LogReplication start listener for table {}", LogReplicationMetadataManager.REPLICATION_EVENT_TABLE_NAME);
+        try {
+            // Subscription can fail if the table was not opened, opened with an incorrect tag or the address at
+            // which subscription is attempted has been trimmed.  None of these are likely in this case as this is an
+            // internal table opened on MetadataManager init(completed before) and subscription is done at the log tail.
+            // However, if there is a failure, simply log it and continue such that normal replication flow is not
+            // interrupted.
+            corfuStore.subscribeListener(this, LogReplicationMetadataManager.NAMESPACE,
+                LogReplicationMetadataManager.LR_STREAM_TAG, Collections.singletonList(
+                    LogReplicationMetadataManager.REPLICATION_EVENT_TABLE_NAME));
+        } catch (Exception e) {
+            log.error("Failed to subscribe to the ReplicationEvent Table", e);
+        }
     }
 
     public void stop() {
-        discoveryService.getLogReplicationMetadataManager().unsubscribeReplicationEventTable(this);
+        corfuStore.unsubscribeListener(this);
     }
 
     @Override
@@ -42,12 +60,11 @@ public final class LogReplicationEventListener implements StreamListener {
                 for (CorfuStreamEntry entry : entryList) {
                     ReplicationEvent event = (ReplicationEvent) entry.getPayload();
                     log.info("ReplicationEventListener received an event with id {}, type {}, cluster id {}",
-                            event.getEventId(), event.getType(), event.getClusterId());
+                        event.getEventId(), event.getType(), event.getClusterId());
                     if (event.getType().equals(ReplicationEvent.ReplicationEventType.FORCE_SNAPSHOT_SYNC)) {
                         discoveryService.input(new DiscoveryServiceEvent(
-                                DiscoveryServiceEvent.DiscoveryServiceEventType.ENFORCE_SNAPSHOT_SYNC,
-                                event.getClusterId(),
-                                event.getEventId()));
+                            DiscoveryServiceEvent.DiscoveryServiceEventType.ENFORCE_SNAPSHOT_SYNC, event.getClusterId(),
+                            event.getEventId()));
                     }
                 }
             }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationServer.java
@@ -27,7 +27,6 @@ import javax.annotation.Nonnull;
 import java.lang.invoke.MethodHandles;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -57,7 +56,7 @@ public class LogReplicationServer extends AbstractServer {
 
     private static final String EXECUTOR_NAME_PREFIX = "LogReplicationServer-";
 
-    private Map<String, LogReplicationSinkManager> sourceClientToSinkManagerMap = new HashMap<>();
+    private Map<ReplicationSession, LogReplicationSinkManager> sourceSessionToSinkManagerMap = new HashMap<>();
 
     private final AtomicBoolean isLeader = new AtomicBoolean(false);
 
@@ -72,34 +71,35 @@ public class LogReplicationServer extends AbstractServer {
     }
 
     public LogReplicationServer(@Nonnull ServerContext context, String localNodeId, LogReplicationConfig config,
-        Set<String> remoteClusterIds, String localEndpoint, long topologyConfigId,
-        Map<String, LogReplicationMetadataManager> sourceClientToMetadataManagerMap) {
+        String localEndpoint, long topologyConfigId,
+        Map<ReplicationSession, LogReplicationMetadataManager> sourceSessionToMetadataManagerMap) {
         this.localNodeId = localNodeId;
-        createSinkManagers(config, remoteClusterIds, localEndpoint, context, sourceClientToMetadataManagerMap,
-            topologyConfigId);
+        createSinkManagers(config, localEndpoint, context, sourceSessionToMetadataManagerMap, topologyConfigId);
         this.executor = context.getExecutorService(1, EXECUTOR_NAME_PREFIX);
     }
 
     @VisibleForTesting
     public LogReplicationServer(@Nonnull ServerContext context, LogReplicationSinkManager sinkManager,
         String localNodeId) {
-        sourceClientToSinkManagerMap.put(sinkManager.getSourceClusterId(), sinkManager);
+        sourceSessionToSinkManagerMap.put(sinkManager.getSourceSession(), sinkManager);
         this.localNodeId = localNodeId;
         this.executor = context.getExecutorService(1, EXECUTOR_NAME_PREFIX);
     }
 
-     private void createSinkManagers(LogReplicationConfig logReplicationConfig, Set<String> remoteClusterIds,
-        String localEndpoint, ServerContext serverContext,
-        Map<String, LogReplicationMetadataManager> sourceClientToMetadataManagerMap, long topologyConfigId) {
-        for (String remoteClusterId : remoteClusterIds) {
+     private void createSinkManagers(LogReplicationConfig logReplicationConfig, String localEndpoint,
+                                     ServerContext serverContext,
+                                     Map<ReplicationSession, LogReplicationMetadataManager> sourceSessionToMetadataManagerMap,
+                                     long topologyConfigId) {
+        for (Map.Entry<ReplicationSession, LogReplicationMetadataManager> entry :
+            sourceSessionToMetadataManagerMap.entrySet()) {
             LogReplicationSinkManager sinkManager = new LogReplicationSinkManager(localEndpoint, logReplicationConfig,
-                sourceClientToMetadataManagerMap.get(remoteClusterId), serverContext, topologyConfigId, remoteClusterId);
-            sourceClientToSinkManagerMap.put(remoteClusterId, sinkManager);
+                entry.getValue(), serverContext, topologyConfigId, entry.getKey());
+            sourceSessionToSinkManagerMap.put(entry.getKey(), sinkManager);
         }
     }
 
     public void updateTopologyConfigId(long topologyConfigId) {
-        sourceClientToSinkManagerMap.values().forEach(sinkManager -> sinkManager.updateTopologyConfigId(topologyConfigId));
+        sourceSessionToSinkManagerMap.values().forEach(sinkManager -> sinkManager.updateTopologyConfigId(topologyConfigId));
     }
 
     /* ************ Override Methods ************ */
@@ -113,8 +113,8 @@ public class LogReplicationServer extends AbstractServer {
     public void shutdown() {
         super.shutdown();
         executor.shutdown();
-        sourceClientToSinkManagerMap.values().forEach(sinkManager -> sinkManager.shutdown());
-        sourceClientToSinkManagerMap.clear();
+        sourceSessionToSinkManagerMap.values().forEach(sinkManager -> sinkManager.shutdown());
+        sourceSessionToSinkManagerMap.clear();
     }
 
     /* ************ Server Handlers ************ */
@@ -135,9 +135,10 @@ public class LogReplicationServer extends AbstractServer {
         log.trace("Log Replication Entry received by Server.");
 
         if (isLeader.get()) {
-            // Get the Sink Manager corresponding to the remote cluster
-            LogReplicationSinkManager sinkManager = sourceClientToSinkManagerMap.get(getUUID(request.getHeader()
-                .getClusterId()).toString());
+            // Get the Sink Manager corresponding to the remote cluster session
+            String sourceClusterId = getUUID(request.getHeader().getClusterId()).toString();
+            LogReplicationSinkManager sinkManager = sourceSessionToSinkManagerMap.get(
+                ReplicationSession.getDefaultReplicationSessionForCluster(sourceClusterId));
 
             // If no sink Manager is found, drop the message and log an error
             if (sinkManager == null) {
@@ -147,8 +148,7 @@ public class LogReplicationServer extends AbstractServer {
             }
 
             // Forward the received message to the Sink Manager for apply
-            LogReplicationEntryMsg ack = sourceClientToSinkManagerMap.get(getUUID(request.getHeader().getClusterId())
-                .toString()).receive(request.getPayload().getLrEntry());
+            LogReplicationEntryMsg ack = sinkManager.receive(request.getPayload().getLrEntry());
 
             if (ack != null) {
                 long ts = ack.getMetadata().getEntryType().equals(LogReplicationEntryType.LOG_ENTRY_REPLICATED) ?
@@ -186,8 +186,11 @@ public class LogReplicationServer extends AbstractServer {
         log.info("Log Replication Metadata Request received by Server.");
 
         if (isLeader.get()) {
-            LogReplicationSinkManager sinkManager = sourceClientToSinkManagerMap.get(
-                getUUID(request.getHeader().getClusterId()).toString());
+            String sourceClusterId = getUUID(request.getHeader().getClusterId()).toString();
+            ReplicationSession sourceSession = ReplicationSession
+                .getDefaultReplicationSessionForCluster(sourceClusterId);
+
+            LogReplicationSinkManager sinkManager = sourceSessionToSinkManagerMap.get(sourceSession);
 
             // If no sink Manager is found, drop the message and log an error
             if (sinkManager == null) {
@@ -199,7 +202,7 @@ public class LogReplicationServer extends AbstractServer {
             LogReplicationMetadataManager metadataMgr = sinkManager.getLogReplicationMetadataManager();
 
             ResponseMsg response = metadataMgr.getMetadataResponse(getHeaderMsg(request.getHeader()));
-            log.info("Send Metadata response :: {}", TextFormat.shortDebugString(response.getPayload()));
+            log.info("Send Metadata response: :: {}", TextFormat.shortDebugString(response.getPayload()));
             router.sendResponse(response, ctx);
 
             // If a snapshot apply is pending, start (if not started already)
@@ -255,10 +258,10 @@ public class LogReplicationServer extends AbstractServer {
 
         if (isLeader.get()) {
             // Reset the Sink Managers on acquiring leadership
-            sourceClientToSinkManagerMap.values().forEach(sinkManager -> sinkManager.reset());
+            sourceSessionToSinkManagerMap.values().forEach(sinkManager -> sinkManager.reset());
         } else {
             // Stop the Sink Managers if leadership is lost
-            sourceClientToSinkManagerMap.values().forEach(sinkManager -> sinkManager.stopOnLeadershipLoss());
+            sourceSessionToSinkManagerMap.values().forEach(sinkManager -> sinkManager.stopOnLeadershipLoss());
         }
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSession.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSession.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.Getter;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 
 import java.util.Objects;
 
@@ -56,7 +57,7 @@ public class ReplicationSession {
     // TODO: To be removed after session is introduced in connections
     public static ReplicationSession getDefaultReplicationSessionForCluster(String remoteClusterId) {
         return new ReplicationSession(remoteClusterId,
-            new ReplicationSubscriber(LogReplicationConfig.ReplicationModel.SINGLE_SOURCE_SINK, SAMPLE_CLIENT));
+            new ReplicationSubscriber(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES, SAMPLE_CLIENT));
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSession.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSession.java
@@ -1,0 +1,71 @@
+package org.corfudb.infrastructure.logreplication.infrastructure;
+
+import lombok.Getter;
+import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+
+import java.util.Objects;
+
+import static org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter.SAMPLE_CLIENT;
+
+/**
+ * This class represents a session/connection with a remote cluster.  Each session has a dedicated Replication FSM and
+ * Snapshot and LogEntry Sync Readers/Writers.
+ *
+ * A session is uniquely identified with the following parameters:
+ * 1) Cluster Id of the Remote Cluster
+ * 2) Replication Subscriber which contains
+ *      a) Replication Model being used by the Remote Cluster
+ *      b) Application(Client) consuming the data replicated by this model
+ *
+ * A given remote cluster can have multiple clients and multiple replication models.  Additionally, several clients
+ * can use the same replication model.
+ *
+ * There will be an instance of this class corresponding to each combination of (remote cluster, replication
+ * model, client).
+ */
+public class ReplicationSession {
+
+    @Getter
+    private final String remoteClusterId;
+
+   @Getter
+   private final ReplicationSubscriber subscriber;
+
+    public ReplicationSession(String remoteClusterId, ReplicationSubscriber subscriber) {
+        this.remoteClusterId = remoteClusterId;
+        this.subscriber = subscriber;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ReplicationSession that = (ReplicationSession) o;
+        return remoteClusterId.equals(that.remoteClusterId) && subscriber.equals(that.subscriber);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(remoteClusterId, subscriber);
+    }
+
+    // TODO: To be removed after session is introduced in connections
+    public static ReplicationSession getDefaultReplicationSessionForCluster(String remoteClusterId) {
+        return new ReplicationSession(remoteClusterId,
+            new ReplicationSubscriber(LogReplicationConfig.ReplicationModel.SINGLE_SOURCE_SINK, SAMPLE_CLIENT));
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuffer()
+            .append("Remote Cluster: ")
+            .append(remoteClusterId)
+            .append("Replication Subscriber: ")
+            .append(subscriber)
+            .toString();
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSubscriber.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSubscriber.java
@@ -1,0 +1,56 @@
+package org.corfudb.infrastructure.logreplication.infrastructure;
+
+import lombok.Getter;
+import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import java.util.Objects;
+
+/**
+ * This class represents a client/subscriber of Log Replication.
+ *
+ * A subscriber can be identified by a combination of
+ * 1) Replication Model used by it to send/receive data
+ * 2) Application(Client) generating(Source) or consuming(Sink) the data
+ *
+ * The model and client information is contained in the protobuf schema definition of the table to be replicated and is
+ * obtained from the registry table.
+ */
+public class ReplicationSubscriber {
+
+    @Getter
+    private final LogReplicationConfig.ReplicationModel replicationModel;
+
+    @Getter
+    private final String client;
+
+    public ReplicationSubscriber(LogReplicationConfig.ReplicationModel model, String client) {
+        this.replicationModel = model;
+        this.client = client;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ReplicationSubscriber that = (ReplicationSubscriber) o;
+        return replicationModel == that.replicationModel && client.equals(that.client);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(replicationModel, client);
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuffer()
+            .append("ReplicationModel: ")
+            .append(replicationModel)
+            .append("Client: ")
+            .append(client)
+            .toString();
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSubscriber.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSubscriber.java
@@ -2,6 +2,8 @@ package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.Getter;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+
 import java.util.Objects;
 
 /**
@@ -17,12 +19,12 @@ import java.util.Objects;
 public class ReplicationSubscriber {
 
     @Getter
-    private final LogReplicationConfig.ReplicationModel replicationModel;
+    private final LogReplicationMetadata.ReplicationModels replicationModel;
 
     @Getter
     private final String client;
 
-    public ReplicationSubscriber(LogReplicationConfig.ReplicationModel model, String client) {
+    public ReplicationSubscriber(LogReplicationMetadata.ReplicationModels model, String client) {
         this.replicationModel = model;
         this.client = client;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/TopologyDescriptor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/TopologyDescriptor.java
@@ -3,15 +3,18 @@ package org.corfudb.infrastructure.logreplication.infrastructure;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.CorfuReplicationClusterManagerAdapter;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.ClusterConfigurationMsg;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.ClusterRole;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.TopologyConfigurationMsg;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -32,79 +35,125 @@ public class TopologyDescriptor {
     private final long topologyConfigId;
 
     @Getter
-    private final Map<String, ClusterDescriptor> sourceClusters;
+    private final Map<String, ClusterDescriptor> remoteSourceClusters;
 
     @Getter
-    private final Map<String, ClusterDescriptor> sinkClusters;
+    private final Map<String, ClusterDescriptor> remoteSinkClusters;
+
+    @Getter
+    private final Map<ClusterDescriptor, Set<LogReplicationMetadata.ReplicationModels>> remoteSourceClusterToReplicationModels;
+
+    @Getter
+    private final Map<ClusterDescriptor, Set<LogReplicationMetadata.ReplicationModels>> remoteSinkClusterToReplicationModels;
 
     @Getter
     private final Map<String, ClusterDescriptor> invalidClusters;
 
+    @Getter
+    private final Map<String, ClusterConfigurationMsg> allClusterConfigMsgsInTopology = new HashMap<>();
+
+
     /**
-     * Constructor
+     * Constructor used by discoveryService and tests
      *
      * @param topologyMessage proto definition of the topology
+     * @param clusterManagerAdapter the plugin to fetch the cluster information
      */
-    public TopologyDescriptor(TopologyConfigurationMsg topologyMessage) {
-        this.topologyConfigId = topologyMessage.getTopologyConfigID();
-        this.sinkClusters = new HashMap<>();
-        this.sourceClusters = new HashMap<>();
-        this.invalidClusters = new HashMap<>();
-
-        for (ClusterConfigurationMsg clusterConfig : topologyMessage.getClustersList()) {
-            ClusterDescriptor cluster = new ClusterDescriptor(clusterConfig);
-            if (clusterConfig.getRole() == ClusterRole.SOURCE) {
-                sourceClusters.put(cluster.getClusterId(), cluster);
-            } else if (clusterConfig.getRole() == ClusterRole.SINK) {
-                addSinkCluster(cluster);
-            } else {
-                invalidClusters.put(cluster.getClusterId(), cluster);
-            }
-        }
+    public TopologyDescriptor(TopologyConfigurationMsg topologyMessage, CorfuReplicationClusterManagerAdapter clusterManagerAdapter) {
+        this(topologyMessage.getTopologyConfigID(), clusterManagerAdapter);
+        topologyMessage.getClustersList().stream()
+                .forEach(clusterMsg -> allClusterConfigMsgsInTopology.put(clusterMsg.getId(), clusterMsg));
     }
 
     /**
      * Constructor
      *
      * @param topologyConfigId topology configuration identifier (epoch)
-     * @param sourceCluster source cluster
-     * @param sinkClusters sink cluster's
+     * @param clusterManagerAdapter the plugin to fetch the cluster information
      */
-    public TopologyDescriptor(long topologyConfigId, @NonNull ClusterDescriptor sourceCluster,
-                              @NonNull List<ClusterDescriptor> sinkClusters) {
-        this(topologyConfigId, Collections.singletonList(sourceCluster), sinkClusters);
-    }
-
-    /**
-     * Constructor
-     *
-     * @param topologyConfigId topology configuration identifier (epoch)
-     * @param sourceClusters source cluster's
-     * @param sinkClusters sink cluster's
-     */
-    public TopologyDescriptor(long topologyConfigId, @NonNull List<ClusterDescriptor> sourceClusters,
-                              @NonNull List<ClusterDescriptor> sinkClusters) {
+    private TopologyDescriptor(long topologyConfigId, CorfuReplicationClusterManagerAdapter clusterManagerAdapter) {
         this.topologyConfigId = topologyConfigId;
-        this.sourceClusters = new HashMap<>();
-        this.sinkClusters = new HashMap<>();
-        this.invalidClusters = new HashMap<>();
+        this.remoteSinkClusters = new HashMap<>();
+        this.remoteSinkClusterToReplicationModels = new HashMap<>();
+        Map<ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> remoteSinkClusterMsg =
+                clusterManagerAdapter.getRemoteSinkForReplicationModels();
+        remoteSinkClusterMsg.entrySet().stream().forEach(e -> {
+            ClusterDescriptor cluster = new ClusterDescriptor(e.getKey());
+            remoteSinkClusterToReplicationModels.putIfAbsent(cluster, new HashSet<>());
+            e.getValue().forEach(model -> remoteSinkClusterToReplicationModels.get(cluster).add(model));
+            remoteSinkClusters.put(cluster.getClusterId(), cluster);
+        });
 
-        sourceClusters.forEach(sourceCluster -> this.sourceClusters.put(sourceCluster.getClusterId(), sourceCluster));
-        sinkClusters.forEach(sinkCluster -> this.sinkClusters.put(sinkCluster.getClusterId(), sinkCluster));
+
+        this.remoteSourceClusters = new HashMap<>();
+        this.remoteSourceClusterToReplicationModels = new HashMap<>();
+        Map<ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> remoteSourceClusterMsg =
+                clusterManagerAdapter.getRemoteSourceToReplicationModels();
+        remoteSourceClusterMsg.entrySet().stream().forEach(e -> {
+            ClusterDescriptor cluster = new ClusterDescriptor(e.getKey());
+            remoteSourceClusterToReplicationModels.putIfAbsent(cluster, new HashSet<>());
+            e.getValue().forEach(model -> remoteSourceClusterToReplicationModels.get(cluster).add(model));
+            remoteSourceClusters.put(cluster.getClusterId(), cluster);
+        });
+        this.invalidClusters = new HashMap<>();
+    }
+
+
+    /**
+     * Constructor used by tests
+     *
+     * @param topologyConfigId topology configuration identifier (epoch)
+     * @param remoteSourceClusters remote source clusters
+     * @param remoteSinkClusters remote sink clusters
+     */
+    public TopologyDescriptor(long topologyConfigId, @NonNull List<ClusterDescriptor> remoteSourceClusters,
+                              @NonNull List<ClusterDescriptor> remoteSinkClusters) {
+        this.topologyConfigId = topologyConfigId;
+        this.remoteSourceClusters = new HashMap<>();
+        this.remoteSinkClusters = new HashMap<>();
+        this.invalidClusters = new HashMap<>();
+        this.remoteSourceClusterToReplicationModels = new HashMap<>();
+        this.remoteSinkClusterToReplicationModels = new HashMap<>();
+
+        remoteSourceClusters.forEach(sourceCluster -> {
+            this.remoteSourceClusters.put(sourceCluster.getClusterId(), sourceCluster);
+            this.remoteSourceClusterToReplicationModels.putIfAbsent(sourceCluster,
+                    new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                        add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+            }});
+        });
+        remoteSinkClusters.forEach(sinkCluster -> {
+            this.remoteSinkClusters.put(sinkCluster.getClusterId(), sinkCluster);
+            this.remoteSinkClusterToReplicationModels.putIfAbsent(sinkCluster,
+                    new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                        add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+            }});
+        });
+
+        remoteSourceClusters.stream()
+                .forEach(clusterDescriptor ->
+                        allClusterConfigMsgsInTopology.put(clusterDescriptor.getClusterId(), clusterDescriptor.convertToMessage()));
+
+        remoteSinkClusters.stream()
+                .forEach(clusterDescriptor ->
+                        allClusterConfigMsgsInTopology.put(clusterDescriptor.getClusterId(), clusterDescriptor.convertToMessage()));
     }
 
     /**
-     * Constructor
+     * Constructor used by tests
      *
      * @param topologyConfigId topology configuration identifier (epoch)
-     * @param sourceClusters source cluster's
-     * @param sinkClusters sink cluster's
-     * @param invalidClusters invalid cluster's
+     * @param remoteSourceClusters remote source clusters
+     * @param remoteSinkClusters remote sink clusters
+     * @param invalidClusters invalid clusterss
      */
-    public TopologyDescriptor(long topologyConfigId, @NonNull List<ClusterDescriptor> sourceClusters,
-                              @NonNull List<ClusterDescriptor> sinkClusters, @NonNull List<ClusterDescriptor> invalidClusters) {
-        this(topologyConfigId, sourceClusters, sinkClusters);
-        invalidClusters.forEach(invalidCluster -> this.invalidClusters.put(invalidCluster.getClusterId(), invalidCluster));
+    public TopologyDescriptor(long topologyConfigId, @NonNull List<ClusterDescriptor> remoteSourceClusters,
+                              @NonNull List<ClusterDescriptor> remoteSinkClusters, @NonNull List<ClusterDescriptor> invalidClusters) {
+        this(topologyConfigId, remoteSourceClusters, remoteSinkClusters);
+        invalidClusters.forEach(invalidCluster -> {
+            this.invalidClusters.put(invalidCluster.getClusterId(), invalidCluster);
+            allClusterConfigMsgsInTopology.put(invalidCluster.getClusterId(), invalidCluster.convertToMessage());
+        });
     }
 
     /**
@@ -114,37 +163,15 @@ public class TopologyDescriptor {
      */
     public TopologyConfigurationMsg convertToMessage() {
 
-        List<ClusterConfigurationMsg> clusterConfigurationMsgs = Stream.of(sourceClusters.values(),
-                sinkClusters.values(), invalidClusters.values())
+        List<ClusterConfigurationMsg> clusterConfigurationMsgs = Stream.of(remoteSourceClusters.values(),
+                remoteSinkClusters.values(), invalidClusters.values())
                 .flatMap(Collection::stream)
                 .map(ClusterDescriptor::convertToMessage)
                 .collect(Collectors.toList());
 
         return TopologyConfigurationMsg.newBuilder()
                 .setTopologyConfigID(topologyConfigId)
-                .addAllClusters(clusterConfigurationMsgs).build();
-    }
-
-    /**
-     * Add a sink cluster to the current topology
-     *
-     * @param cluster sink cluster to add
-     */
-    public void addSinkCluster(ClusterDescriptor cluster) {
-        sinkClusters.put(cluster.getClusterId(), cluster);
-    }
-
-    /**
-     * Remove a sink cluster from the current topology
-     *
-     * @param clusterId unique identifier of the sink cluster to be removed from topology
-     */
-    public void removeSinkCluster(String clusterId) {
-        ClusterDescriptor removedCluster = sinkClusters.remove(clusterId);
-
-        if (removedCluster == null) {
-            log.warn("Cluster {} never present as a SINK cluster.", clusterId);
-        }
+                .addAllClusters(allClusterConfigMsgsInTopology.values()).build();
     }
 
     /**
@@ -154,19 +181,15 @@ public class TopologyDescriptor {
      * @return cluster descriptor to which endpoint belongs to.
      */
     public ClusterDescriptor getClusterDescriptor(String nodeId) {
-        List<ClusterDescriptor> clusters = Stream.of(sourceClusters.values(), sinkClusters.values(),
-                invalidClusters.values())
-                .flatMap(Collection::stream)
-                .collect(Collectors.toList());
 
-        for(ClusterDescriptor cluster : clusters) {
-            for (NodeDescriptor node : cluster.getNodesDescriptors()) {
-                if (node.getNodeId().equals(nodeId)) {
-                    return cluster;
+        for(ClusterConfigurationMsg clusterConfigMsg : allClusterConfigMsgsInTopology.values()) {
+            for (LogReplicationClusterInfo.NodeConfigurationMsg nodeMsg : clusterConfigMsg.getNodeInfoList()) {
+                if (nodeMsg.getNodeId().equals(nodeId)) {
+                    return new ClusterDescriptor(clusterConfigMsg);
                 }
             }
         }
-        log.warn("Node {} does not belong to any cluster defined in {}", nodeId, clusters);
+        log.warn("Node {} does not belong to any cluster defined in {}", nodeId, allClusterConfigMsgsInTopology.values());
 
         return null;
     }
@@ -174,6 +197,6 @@ public class TopologyDescriptor {
     @Override
     public String toString() {
         return String.format("Topology[id=%s] \n Source Cluster=%s \n Sink Clusters=%s \n Invalid Clusters=%s",
-                topologyConfigId, sourceClusters.values(), sinkClusters.values(), invalidClusters.values());
+                topologyConfigId, remoteSourceClusters.values(), remoteSinkClusters.values(), invalidClusters.values());
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
@@ -2,10 +2,13 @@ package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
 import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationDiscoveryServiceAdapter;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationDiscoveryServiceException;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.TopologyConfigurationMsg;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -59,4 +62,19 @@ public interface CorfuReplicationClusterManagerAdapter {
      * @param clusterId
      */
     UUID forceSnapshotSync(String clusterId) throws LogReplicationDiscoveryServiceException;
+
+    /**
+     * This API is used to fetch the remote SOURCE clusters and the supported replication models against it.
+     */
+    Map<LogReplicationClusterInfo.ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> getRemoteSourceToReplicationModels();
+
+    /**
+     * This API is used to fetch the remote SINK clusters and the supported replication models against it..
+     */
+    Map<LogReplicationClusterInfo.ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> getRemoteSinkForReplicationModels();
+
+    /**
+     * This API is used to fetch the remote clusters that are the connection endpoints for the local cluster.
+     */
+    Set<LogReplicationClusterInfo.ClusterConfigurationMsg> fetchConnectionEndpoints();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
@@ -53,8 +53,8 @@ public interface CorfuReplicationClusterManagerAdapter {
     Map<String, LogReplicationMetadata.ReplicationStatusVal> queryReplicationStatus();
 
     /**
-     * This API enforce a full snapshot sync on the standby cluster with the clusterId at best effort.
-     * The command can only be executed on the active cluster's node.
+     * This API enforce a full snapshot sync on the sink cluster with the clusterId at best effort.
+     * The command can only be executed on the source cluster's node.
      *
      * @param clusterId
      */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
@@ -1,5 +1,7 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
+import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.TableOptions;
@@ -17,8 +19,7 @@ import java.util.Set;
 import java.util.UUID;
 
 public abstract class DefaultAdapterForUpgrade implements ILogReplicationConfigAdapter {
-    public static final String STREAMS_TEST_TABLE =
-            "StreamsToReplicateTestTable";
+    public static final String STREAMS_TEST_TABLE = "StreamsToReplicateTestTable";
     public static final String VERSION_TEST_TABLE = "VersionTestTable";
 
     public static final int MAP_COUNT = 5;
@@ -26,38 +27,36 @@ public abstract class DefaultAdapterForUpgrade implements ILogReplicationConfigA
     public static final String TABLE_PREFIX = "Table00";
     public static final String NAMESPACE = "LR-Test";
     public static final String TAG_ONE = "tag_one";
+    public static final String SAMPLE_CLIENT = "SampleClient";
 
     final int indexOne = 1;
     final int indexTwo = 2;
-    final Set<String> streamsToReplicate = new HashSet<>();
+    final Map<ReplicationSubscriber, Set<String>> streamsToReplicateMap = new HashMap<>();
     String versionString = "version_latest";
     CorfuStore corfuStore;
 
-
-    // Provides the fully qualified names of streams to replicate
-    @Override
-    public Set<String> fetchStreamsToReplicate() {
+    protected void init() {
+        Set<String> streams = new HashSet<>();
         if (corfuStore != null) {
             try {
-                corfuStore.openTable(NAMESPACE, STREAMS_TEST_TABLE,
-                        LogReplicationStreams.TableInfo.class,
-                        LogReplicationStreams.Namespace.class, CommonTypes.Uuid.class,
-                        TableOptions.builder().build());
+                corfuStore.openTable(NAMESPACE, STREAMS_TEST_TABLE, LogReplicationStreams.TableInfo.class,
+                    LogReplicationStreams.Namespace.class, CommonTypes.Uuid.class, TableOptions.builder().build());
             } catch (Exception e) {
                 // Just for wrap this up
             }
 
             try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
                 Set<LogReplicationStreams.TableInfo> tables = txn.keySet(STREAMS_TEST_TABLE);
-                tables.forEach(table -> streamsToReplicate.add(table.getName()));
+                tables.forEach(table -> streams.add(table.getName()));
                 txn.commit();
             }
         } else {
             for (int i = 1; i <= MAP_COUNT; i++) {
-                streamsToReplicate.add(NAMESPACE + SEPARATOR + TABLE_PREFIX + i);
+                streams.add(NAMESPACE + SEPARATOR + TABLE_PREFIX + i);
             }
         }
-        return streamsToReplicate;
+        streamsToReplicateMap.put(new ReplicationSubscriber(
+            LogReplicationConfig.ReplicationModel.SINGLE_SOURCE_SINK, SAMPLE_CLIENT), streams);
     }
 
     @Override
@@ -96,5 +95,10 @@ public abstract class DefaultAdapterForUpgrade implements ILogReplicationConfigA
         streamsToTagsMaps.put(CorfuRuntime.getStreamID(NAMESPACE + SEPARATOR + TABLE_PREFIX + indexTwo),
                 Collections.singletonList(streamTagOneDefaultId));
         return streamsToTagsMaps;
+    }
+
+    @Override
+    public Map<ReplicationSubscriber, Set<String>> getSubscriberToStreamsMap() {
+        return streamsToReplicateMap;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.TableOptions;
@@ -56,7 +57,7 @@ public abstract class DefaultAdapterForUpgrade implements ILogReplicationConfigA
             }
         }
         streamsToReplicateMap.put(new ReplicationSubscriber(
-            LogReplicationConfig.ReplicationModel.SINGLE_SOURCE_SINK, SAMPLE_CLIENT), streams);
+                LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES, SAMPLE_CLIENT), streams);
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
@@ -36,7 +36,6 @@ public abstract class DefaultAdapterForUpgrade implements ILogReplicationConfigA
 
     // Provides the fully qualified names of streams to replicate
     @Override
-    @SuppressWarnings("checkstyle:printLine")
     public Set<String> fetchStreamsToReplicate() {
         if (corfuStore != null) {
             try {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeActive.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeActive.java
@@ -15,5 +15,6 @@ public class DefaultAdapterForUpgradeActive extends DefaultAdapterForUpgrade {
             CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
                     .parseConfigurationString(ENDPOINT).connect();
         this.corfuStore = new CorfuStore(runtime);
+        init();
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeSink.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeSink.java
@@ -4,12 +4,12 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuStore;
 
 /**
- * This class is created for LR rolling upgrade tests to serve as the plugin for Standby cluster to
+ * This class is created for LR rolling upgrade tests to serve as the plugin for Sink cluster to
  * get the set of streams to replicate.
  */
-public class DefaultAdapterForUpgradeStandby extends DefaultAdapterForUpgrade {
+public class DefaultAdapterForUpgradeSink extends DefaultAdapterForUpgrade {
 
-    public DefaultAdapterForUpgradeStandby() {
+    public DefaultAdapterForUpgradeSink() {
         String ENDPOINT = "localhost:9001";
         CorfuRuntime runtime =
             CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeSource.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeSource.java
@@ -7,9 +7,9 @@ import org.corfudb.runtime.collections.CorfuStore;
  * This class is created for LR rolling upgrade tests to serve as the plugin for Active cluster to
  * get the set of streams to replicate.
  */
-public class DefaultAdapterForUpgradeActive extends DefaultAdapterForUpgrade {
+public class DefaultAdapterForUpgradeSource extends DefaultAdapterForUpgrade {
 
-    public DefaultAdapterForUpgradeActive() {
+    public DefaultAdapterForUpgradeSource() {
         String ENDPOINT = "localhost:9000";
         CorfuRuntime runtime =
             CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeStandby.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgradeStandby.java
@@ -15,5 +15,6 @@ public class DefaultAdapterForUpgradeStandby extends DefaultAdapterForUpgrade {
             CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
                     .parseConfigurationString(ENDPOINT).connect();
         corfuStore = new CorfuStore(runtime);
+        init();
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterConfig.java
@@ -5,56 +5,15 @@ import lombok.Getter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 public final class DefaultClusterConfig {
 
     @Getter
-    private static final String defaultHost = "localhost";
-
-    @Getter
-    private static final List<String> activeNodesUuid = Collections.singletonList("123e4567-e89b-12d3-a456-556642440000");
-
-    @Getter
-    private static final List<String> standbyNodesUuid = Collections.singletonList("123e4567-e89b-12d3-a456-556642440123");
-
-    @Getter
-    private static final List<String> backupNodesUuid = Collections.singletonList("923e4567-e89b-12d3-a456-556642440000");
-
-    @Getter
-    private static final List<String> activeNodeNames = Collections.singletonList("standby_site_node0");
-
-    @Getter
-    private static final List<String> activeIpAddresses = Arrays.asList(defaultHost, defaultHost, defaultHost);
-
-    @Getter
-    private static final List<String> standbyIpAddresses = Collections.singletonList(defaultHost);
-
-    @Getter
-    private static final String activeClusterId = "456e4567-e89b-12d3-a456-556642440001";
-
-    @Getter
-    private static final String activeCorfuPort = "9000";
-
-    @Getter
-    private static final String activeLogReplicationPort = "9010";
-
-    @Getter
-    private static final String standbyClusterId = "456e4567-e89b-12d3-a456-556642440002";
-
-    @Getter
-    private static final String standbyCorfuPort = "9001";
-
-    @Getter
-    private static final String standbyLogReplicationPort = "9020";
-
-    @Getter
-    private static final String backupLogReplicationPort = "9030";
+    private static final int logSenderRetryCount = 5;
 
     @Getter
     private static final int logSenderBufferSize = 2;
-
-    @Getter
-    private static final int logSenderRetryCount = 5;
 
     @Getter
     private static final int logSenderResendTimer = 5000;
@@ -66,29 +25,87 @@ public final class DefaultClusterConfig {
     private static final boolean logSenderTimeout = true;
 
     @Getter
-    private static final int logSinkBufferSize = 40;
+    private final String defaultHost = "localhost";
 
     @Getter
-    private static final int logSinkAckCycleCount = 4;
+    private final List<String> activeNodeUuids =
+        Arrays.asList("123e4567-e89b-12d3-a456-556642440000",
+            "123e4567-e89b-12d3-a456-556642440001",
+            "123e4567-e89b-12d3-a456-556642440002");
 
     @Getter
-    private static final int logSinkAckCycleTimer = 1000;
+    private final List<String> standbyNodeUuids =
+        Arrays.asList("123e4567-e89b-12d3-a456-556642440123",
+            "123e4567-e89b-12d3-a456-556642440124",
+            "123e4567-e89b-12d3-a456-556642440125");
 
-    public static String getDefaultNodeId(String endpoint) {
+    @Getter
+    private final List<String> backupNodesUuid = Collections.singletonList("923e4567-e89b-12d3-a456-556642440000");
+
+    @Getter
+    private final List<String> activeNodeNames = Collections.singletonList(
+        "active_site_node0");
+
+    @Getter
+    private final List<String> activeIpAddresses = Arrays.asList(defaultHost, defaultHost, defaultHost);
+
+    @Getter
+    private final List<String> standbyIpAddresses = Arrays.asList(defaultHost, defaultHost, defaultHost);
+
+    @Getter
+    private final List<String> activeClusterIds =
+        Arrays.asList("456e4567-e89b-12d3-a456-556642440001",
+            "456e4567-e89b-12d3-a456-556642440003",
+            "456e4567-e89b-12d3-a456-556642440005");
+
+    @Getter
+    private final List<String> activeCorfuPorts = Arrays.asList("9000", "9002", "9004");
+
+    @Getter
+    private final List<String> activeLogReplicationPorts =
+        Arrays.asList("9010", "9011", "9012");
+
+    @Getter
+    private final List<String> standbyClusterIds = Arrays.asList(
+        "456e4567-e89b-12d3-a456-556642440002",
+        "456e4567-e89b-12d3-a456-556642440004",
+        "456e4567-e89b-12d3-a456-556642440006");
+
+    @Getter
+    private final List<String> standbyCorfuPorts = Arrays.asList("9001",
+        "9003", "9005");
+
+    @Getter
+    private final List<String> standbyLogReplicationPorts =
+        Arrays.asList("9020", "9021", "9022");
+
+    @Getter
+    private final String backupLogReplicationPort = "9030";
+
+    @Getter
+    private final int logSinkBufferSize = 40;
+
+    @Getter
+    private final int logSinkAckCycleCount = 4;
+
+    @Getter
+    private final int logSinkAckCycleTimer = 1000;
+
+    public String getDefaultNodeId(String endpoint) {
         String port = endpoint.split(":")[1];
-        switch (port) {
-            case activeLogReplicationPort:
-                return activeNodesUuid.get(0);
-            case standbyLogReplicationPort:
-                return standbyNodesUuid.get(0);
-            case backupLogReplicationPort:
-                return backupNodesUuid.get(0);
-            default:
-                return null;
+        if (Objects.equals(port, backupLogReplicationPort)) {
+            return backupNodesUuid.get(0);
         }
-    }
 
-    private DefaultClusterConfig() {
-
+        int index = activeLogReplicationPorts.indexOf(port);
+        if (index != -1) {
+            return activeNodeUuids.get(index);
+        } else {
+            index = standbyLogReplicationPorts.indexOf(port);
+            if (index != -1) {
+                return standbyNodeUuids.get(index);
+            }
+        }
+        return null;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterConfig.java
@@ -28,13 +28,13 @@ public final class DefaultClusterConfig {
     private final String defaultHost = "localhost";
 
     @Getter
-    private final List<String> activeNodeUuids =
+    private final List<String> sourceNodeUuids =
         Arrays.asList("123e4567-e89b-12d3-a456-556642440000",
             "123e4567-e89b-12d3-a456-556642440001",
             "123e4567-e89b-12d3-a456-556642440002");
 
     @Getter
-    private final List<String> standbyNodeUuids =
+    private final List<String> sinkNodeUuids =
         Arrays.asList("123e4567-e89b-12d3-a456-556642440123",
             "123e4567-e89b-12d3-a456-556642440124",
             "123e4567-e89b-12d3-a456-556642440125");
@@ -43,40 +43,40 @@ public final class DefaultClusterConfig {
     private final List<String> backupNodesUuid = Collections.singletonList("923e4567-e89b-12d3-a456-556642440000");
 
     @Getter
-    private final List<String> activeNodeNames = Collections.singletonList(
-        "active_site_node0");
+    private final List<String> sourceNodeNames = Collections.singletonList(
+        "source_site_node0");
 
     @Getter
-    private final List<String> activeIpAddresses = Arrays.asList(defaultHost, defaultHost, defaultHost);
+    private final List<String> sourceIpAddresses = Arrays.asList(defaultHost, defaultHost, defaultHost);
 
     @Getter
-    private final List<String> standbyIpAddresses = Arrays.asList(defaultHost, defaultHost, defaultHost);
+    private final List<String> sinkIpAddresses = Arrays.asList(defaultHost, defaultHost, defaultHost);
 
     @Getter
-    private final List<String> activeClusterIds =
+    private final List<String> sourceClusterIds =
         Arrays.asList("456e4567-e89b-12d3-a456-556642440001",
             "456e4567-e89b-12d3-a456-556642440003",
             "456e4567-e89b-12d3-a456-556642440005");
 
     @Getter
-    private final List<String> activeCorfuPorts = Arrays.asList("9000", "9002", "9004");
+    private final List<String> sourceCorfuPorts = Arrays.asList("9000", "9002", "9004");
 
     @Getter
-    private final List<String> activeLogReplicationPorts =
+    private final List<String> sourceLogReplicationPorts =
         Arrays.asList("9010", "9011", "9012");
 
     @Getter
-    private final List<String> standbyClusterIds = Arrays.asList(
+    private final List<String> sinkClusterIds = Arrays.asList(
         "456e4567-e89b-12d3-a456-556642440002",
         "456e4567-e89b-12d3-a456-556642440004",
         "456e4567-e89b-12d3-a456-556642440006");
 
     @Getter
-    private final List<String> standbyCorfuPorts = Arrays.asList("9001",
+    private final List<String> sinkCorfuPorts = Arrays.asList("9001",
         "9003", "9005");
 
     @Getter
-    private final List<String> standbyLogReplicationPorts =
+    private final List<String> sinkLogReplicationPorts =
         Arrays.asList("9020", "9021", "9022");
 
     @Getter
@@ -97,13 +97,13 @@ public final class DefaultClusterConfig {
             return backupNodesUuid.get(0);
         }
 
-        int index = activeLogReplicationPorts.indexOf(port);
+        int index = sourceLogReplicationPorts.indexOf(port);
         if (index != -1) {
-            return activeNodeUuids.get(index);
+            return sourceNodeUuids.get(index);
         } else {
-            index = standbyLogReplicationPorts.indexOf(port);
+            index = sinkLogReplicationPorts.indexOf(port);
             if (index != -1) {
-                return standbyNodeUuids.get(index);
+                return sinkNodeUuids.get(index);
             }
         }
         return null;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -31,22 +31,22 @@ import java.util.concurrent.LinkedBlockingQueue;
 /**
  * This class extends CorfuReplicationClusterManagerAdapter, provides topology config API
  * for integration tests. The initial topology config should be valid, which means it has only
- * one active cluster, and one or more standby clusters.
+ * one source cluster, and one or more sink clusters.
  */
 @Slf4j
 public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAdapter {
     private static final int BACKUP_CORFU_PORT = 9007;
 
-    private static final String ACTIVE_CLUSTER_NAME = "primary_site";
-    private static final String STANDBY_CLUSTER_NAME = "standby_site";
+    private static final String SOURCE_CLUSTER_NAME = "primary_site";
+    private static final String SINK_CLUSTER_NAME = "sink_site";
     private static final String BACKUP_CLUSTER_NAME = "backup_site";
 
     public static final String CONFIG_NAMESPACE = "ns_lr_config_it";
     public static final String CONFIG_TABLE_NAME = "lr_config_it";
     public static final ClusterUuidMsg OP_RESUME = ClusterUuidMsg.newBuilder().setLsb(0L).setMsb(0L).build();
     public static final ClusterUuidMsg OP_SWITCH = ClusterUuidMsg.newBuilder().setLsb(1L).setMsb(1L).build();
-    public static final ClusterUuidMsg OP_TWO_ACTIVE = ClusterUuidMsg.newBuilder().setLsb(2L).setMsb(2L).build();
-    public static final ClusterUuidMsg OP_ALL_STANDBY = ClusterUuidMsg.newBuilder().setLsb(3L).setMsb(3L).build();
+    public static final ClusterUuidMsg OP_TWO_SOURCE = ClusterUuidMsg.newBuilder().setLsb(2L).setMsb(2L).build();
+    public static final ClusterUuidMsg OP_ALL_SINK = ClusterUuidMsg.newBuilder().setLsb(3L).setMsb(3L).build();
     public static final ClusterUuidMsg OP_INVALID = ClusterUuidMsg.newBuilder().setLsb(4L).setMsb(4L).build();
     public static final ClusterUuidMsg OP_ENFORCE_SNAPSHOT_FULL_SYNC = ClusterUuidMsg.newBuilder().setLsb(5L).setMsb(5L).build();
     public static final ClusterUuidMsg OP_BACKUP = ClusterUuidMsg.newBuilder().setLsb(6L).setMsb(6L).build();
@@ -125,63 +125,63 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
     }
 
     public TopologyDescriptor readConfig() {
-        List<ClusterDescriptor> activeClusters = new ArrayList<>();
-        List<ClusterDescriptor> standbyClusters = new ArrayList<>();
+        List<ClusterDescriptor> sourceClusters = new ArrayList<>();
+        List<ClusterDescriptor> sinkClusters = new ArrayList<>();
 
-        List<String> activeClusterIds = topology.getActiveClusterIds();
-        List<String> activeCorfuPorts = topology.getActiveCorfuPorts();
-        List<String> activeLogReplicationPorts =
-            topology.getActiveLogReplicationPorts();
-        List<String> activeNodeNames = topology.getActiveNodeNames();
-        List<String> activeNodeHosts = topology.getActiveIpAddresses();
-        List<String> activeNodeIds = topology.getActiveNodeUuids();
+        List<String> sourceClusterIds = topology.getSourceClusterIds();
+        List<String> sourceCorfuPorts = topology.getSourceCorfuPorts();
+        List<String> sourceLogReplicationPorts =
+            topology.getSourceLogReplicationPorts();
+        List<String> sourceNodeNames = topology.getSourceNodeNames();
+        List<String> sourceNodeHosts = topology.getSourceIpAddresses();
+        List<String> sourceNodeIds = topology.getSourceNodeUuids();
 
-        List<String> standbyClusterIds = topology.getStandbyClusterIds();
-        List<String> standbyCorfuPorts = topology.getStandbyCorfuPorts();
-        List<String> standbyLogReplicationPorts =
-            topology.getStandbyLogReplicationPorts();
-        List<String> standbyNodeNames = topology.getActiveNodeNames();
-        List<String> standbyNodeHosts = topology.getStandbyIpAddresses();
-        List<String> standbyNodeIds = topology.getStandbyNodeUuids();
+        List<String> sinkClusterIds = topology.getSinkClusterIds();
+        List<String> sinkCorfuPorts = topology.getSinkCorfuPorts();
+        List<String> sinkLogReplicationPorts =
+            topology.getSinkLogReplicationPorts();
+        List<String> sinkNodeNames = topology.getSourceNodeNames();
+        List<String> sinkNodeHosts = topology.getSinkIpAddresses();
+        List<String> sinkNodeIds = topology.getSinkNodeUuids();
 
-        // Setup active cluster information
-        for (int i = 0; i < activeClusterIds.size(); i++) {
-            ClusterDescriptor activeCluster = new ClusterDescriptor(
-                activeClusterIds.get(i), ClusterRole.ACTIVE,
-                Integer.parseInt(activeCorfuPorts.get(i)));
+        // Setup source cluster information
+        for (int i = 0; i < sourceClusterIds.size(); i++) {
+            ClusterDescriptor sourceCluster = new ClusterDescriptor(
+                sourceClusterIds.get(i), ClusterRole.SOURCE,
+                Integer.parseInt(sourceCorfuPorts.get(i)));
 
-            for (int j = 0; j < activeNodeNames.size(); j++) {
-                log.info("Active Cluster Name {}, IpAddress {}",
-                    activeNodeNames.get(j), activeNodeHosts.get(i));
+            for (int j = 0; j < sourceNodeNames.size(); j++) {
+                log.info("source Cluster Name {}, IpAddress {}",
+                    sourceNodeNames.get(j), sourceNodeHosts.get(i));
                 NodeDescriptor nodeInfo =
-                    new NodeDescriptor(activeNodeHosts.get(i),
-                        activeLogReplicationPorts.get(i), ACTIVE_CLUSTER_NAME,
-                        activeNodeIds.get(i), activeNodeIds.get(i));
-                activeCluster.getNodesDescriptors().add(nodeInfo);
+                    new NodeDescriptor(sourceNodeHosts.get(i),
+                        sourceLogReplicationPorts.get(i), SOURCE_CLUSTER_NAME,
+                        sourceNodeIds.get(i), sourceNodeIds.get(i));
+                sourceCluster.getNodesDescriptors().add(nodeInfo);
             }
-            activeClusters.add(activeCluster);
+            sourceClusters.add(sourceCluster);
         }
 
-        // Setup standby cluster information
-        for (int i = 0; i < standbyClusterIds.size(); i++) {
-            ClusterDescriptor standbyCluster = new ClusterDescriptor(
-                standbyClusterIds.get(i), ClusterRole.STANDBY,
-                Integer.parseInt(standbyCorfuPorts.get(i)));
+        // Setup sink cluster information
+        for (int i = 0; i < sinkClusterIds.size(); i++) {
+            ClusterDescriptor sinkCluster = new ClusterDescriptor(
+                sinkClusterIds.get(i), ClusterRole.SINK,
+                Integer.parseInt(sinkCorfuPorts.get(i)));
 
-            for (int j = 0; j < standbyNodeNames.size(); j++) {
-                log.info("Standby Cluster Name {}, IpAddress {}",
-                    standbyNodeNames.get(j), standbyNodeHosts.get(i));
+            for (int j = 0; j < sinkNodeNames.size(); j++) {
+                log.info("Sink Cluster Name {}, IpAddress {}",
+                    sinkNodeNames.get(j), sinkNodeHosts.get(i));
                 NodeDescriptor nodeInfo =
-                    new NodeDescriptor(standbyNodeHosts.get(i),
-                        standbyLogReplicationPorts.get(i), STANDBY_CLUSTER_NAME,
-                        standbyNodeIds.get(i), standbyNodeIds.get(i));
-                standbyCluster.getNodesDescriptors().add(nodeInfo);
+                    new NodeDescriptor(sinkNodeHosts.get(i),
+                        sinkLogReplicationPorts.get(i), SINK_CLUSTER_NAME,
+                        sinkNodeIds.get(i), sinkNodeIds.get(i));
+                sinkCluster.getNodesDescriptors().add(nodeInfo);
             }
-            standbyClusters.add(standbyCluster);
+            sinkClusters.add(sinkCluster);
         }
 
-        return new TopologyDescriptor(0L, activeClusters,
-            standbyClusters);
+        return new TopologyDescriptor(0L, sourceClusters,
+            sinkClusters);
     }
 
     private TopologyConfigurationMsg constructTopologyConfigMsg() {
@@ -201,67 +201,67 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
     }
 
     /**
-     * Create a new topology config, which changes one of the standby as the active,
-     * and active as standby. Data should flow in the reverse direction.
+     * Create a new topology config, which changes one of the sink as the source,
+     * and source as sink. Data should flow in the reverse direction.
      **/
     public TopologyDescriptor generateConfigWithRoleSwitch() {
         TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
 
-        List<ClusterDescriptor> newActiveClusters = new ArrayList<>();
-        List<ClusterDescriptor> newStandbyClusters = new ArrayList<>();
-        currentConfig.getActiveClusters().values().forEach(activeCluster ->
-            newStandbyClusters.add(new ClusterDescriptor(activeCluster, ClusterRole.STANDBY)));
+        List<ClusterDescriptor> newSourceClusters = new ArrayList<>();
+        List<ClusterDescriptor> newSinkClusters = new ArrayList<>();
+        currentConfig.getSourceClusters().values().forEach(sourceCluster ->
+            newSinkClusters.add(new ClusterDescriptor(sourceCluster, ClusterRole.SINK)));
 
-        currentConfig.getStandbyClusters().values().forEach(standbyCluster ->
-            newActiveClusters.add(new ClusterDescriptor(standbyCluster, ClusterRole.ACTIVE)));
+        currentConfig.getSinkClusters().values().forEach(sinkCluster ->
+                newSourceClusters.add(new ClusterDescriptor(sinkCluster, ClusterRole.SOURCE)));
 
-        return new TopologyDescriptor(++configId, newActiveClusters, newStandbyClusters);
+        return new TopologyDescriptor(++configId, newSourceClusters, newSinkClusters);
     }
 
     /**
-     * Create a new topology config, which marks all standby cluster as active on purpose.
-     * System should drop messages between any two active clusters.
+     * Create a new topology config, which marks all sink cluster as source on purpose.
+     * System should drop messages between any two source clusters.
      **/
-    public TopologyDescriptor generateConfigWithAllActive() {
+    public TopologyDescriptor generateConfigWithAllSource() {
         TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
-        ClusterDescriptor currentActive = currentConfig.getActiveClusters().values().iterator().next();
+        ClusterDescriptor currentSource = currentConfig.getSourceClusters().values().iterator().next();
 
-        List<ClusterDescriptor> newActiveClusters = new ArrayList<>();
-        currentConfig.getStandbyClusters().values().forEach(standbyCluster ->
-                newActiveClusters.add(new ClusterDescriptor(standbyCluster, ClusterRole.ACTIVE)));
-        newActiveClusters.add(currentActive);
+        List<ClusterDescriptor> newSourceClusters = new ArrayList<>();
+        currentConfig.getSinkClusters().values().forEach(sinkCluster ->
+                newSourceClusters.add(new ClusterDescriptor(sinkCluster, ClusterRole.SOURCE)));
+        newSourceClusters.add(currentSource);
 
-        return new TopologyDescriptor(++configId, newActiveClusters, new ArrayList<>());
+        return new TopologyDescriptor(++configId, newSourceClusters, new ArrayList<>());
     }
 
     /**
-     * Create a new topology config, which marks all cluster as standby on purpose.
+     * Create a new topology config, which marks all cluster as sink on purpose.
      * System should not send messages in this case.
      **/
-    public TopologyDescriptor generateConfigWithAllStandby() {
+    public TopologyDescriptor generateConfigWithAllSink() {
         TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
-        ClusterDescriptor currentActive = currentConfig.getActiveClusters().values().iterator().next();
+        ClusterDescriptor currentSource = currentConfig.getSourceClusters().values().iterator().next();
 
-        List<ClusterDescriptor> newStandbyClusters = new ArrayList<>(currentConfig.getStandbyClusters().values());
-        ClusterDescriptor newStandby = new ClusterDescriptor(currentActive, ClusterRole.STANDBY);
-        newStandbyClusters.add(newStandby);
+        List<ClusterDescriptor> newSinkClusters = new ArrayList<>(currentConfig.getSinkClusters().values());
+        ClusterDescriptor newSink = new ClusterDescriptor(currentSource, ClusterRole.SINK);
+        newSinkClusters.add(newSink);
 
-        return new TopologyDescriptor(++configId, new ArrayList<>(), newStandbyClusters);
+        return new TopologyDescriptor(++configId, new ArrayList<>(), newSinkClusters);
     }
 
     /**
-     * Create a new topology config, which marks all standby cluster as invalid on purpose.
+     * Create a new topology config, which marks all sink cluster as invalid on purpose.
      * LR should not replicate to these clusters.
      **/
     public TopologyDescriptor generateConfigWithInvalid() {
         TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
 
-        List<ClusterDescriptor> newActiveClusters = new ArrayList<>(currentConfig.getActiveClusters().values());
+        List<ClusterDescriptor> newSourceClusters = new ArrayList<>(currentConfig.getSourceClusters().values());
         List<ClusterDescriptor> newInvalidClusters = new ArrayList<>();
-        currentConfig.getStandbyClusters().values().forEach(standbyCluster ->
-                newInvalidClusters.add(new ClusterDescriptor(standbyCluster, ClusterRole.INVALID)));
+        currentConfig.getSinkClusters().values().forEach(sinkCluster ->
+                newInvalidClusters.add(new ClusterDescriptor(sinkCluster, ClusterRole.INVALID)));
 
-        return new TopologyDescriptor(++configId, newActiveClusters, new ArrayList<>(), newInvalidClusters);
+        return new TopologyDescriptor(++configId, newSourceClusters, new ArrayList<>(), newInvalidClusters);
     }
 
     /**
@@ -269,25 +269,25 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
      **/
     public TopologyDescriptor generateDefaultValidConfig() {
         TopologyDescriptor defaultTopology = new TopologyDescriptor(constructTopologyConfigMsg());
-        List<ClusterDescriptor> activeClusters = new ArrayList<>(defaultTopology.getActiveClusters().values());
-        List<ClusterDescriptor> standbyClusters = new ArrayList<>(defaultTopology.getStandbyClusters().values());
+        List<ClusterDescriptor> sourceClusters = new ArrayList<>(defaultTopology.getSourceClusters().values());
+        List<ClusterDescriptor> sinkClusters = new ArrayList<>(defaultTopology.getSinkClusters().values());
 
-        return new TopologyDescriptor(++configId, activeClusters, standbyClusters);
+        return new TopologyDescriptor(++configId, sourceClusters, sinkClusters);
     }
 
     /**
-     * Create a new topology config, which replaces the active cluster with a backup cluster.
+     * Create a new topology config, which replaces the source cluster with a backup cluster.
      **/
     public TopologyDescriptor generateConfigWithBackup() {
         TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
-        Optional<ClusterDescriptor> currentActive =
-            currentConfig.getActiveClusters()
+        Optional<ClusterDescriptor> currentSource =
+            currentConfig.getSourceClusters()
             .values().stream().filter(cluster -> cluster.getClusterId()
-                .equals(topology.getActiveClusterIds().get(0))).findFirst();
+                .equals(topology.getSourceClusterIds().get(0))).findFirst();
 
-        List<ClusterDescriptor> newActiveClusters = new ArrayList<>();
-        newActiveClusters.add(new ClusterDescriptor(
-            currentActive.get().getClusterId(), ClusterRole.ACTIVE,
+        List<ClusterDescriptor> newSourceClusters = new ArrayList<>();
+        newSourceClusters.add(new ClusterDescriptor(
+            currentSource.get().getClusterId(), ClusterRole.SOURCE,
             BACKUP_CORFU_PORT));
 
         NodeDescriptor backupNode = new NodeDescriptor(
@@ -297,11 +297,11 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
                 topology.getBackupNodesUuid().get(0),
                 topology.getBackupNodesUuid().get(0)
                 );
-        newActiveClusters.get(0).getNodesDescriptors().add(backupNode);
-        List<ClusterDescriptor> standbyClusters =
-            new ArrayList<>(currentConfig.getStandbyClusters().values());
+        newSourceClusters.get(0).getNodesDescriptors().add(backupNode);
+        List<ClusterDescriptor> sinkClusters =
+            new ArrayList<>(currentConfig.getSinkClusters().values());
 
-        return new TopologyDescriptor(++configId, newActiveClusters, standbyClusters);
+        return new TopologyDescriptor(++configId, newSourceClusters, sinkClusters);
     }
 
     /**
@@ -361,12 +361,12 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
                 if (entry.getKey().equals(OP_SWITCH)) {
                     clusterManager.getClusterManagerCallback()
                             .applyNewTopologyConfig(clusterManager.generateConfigWithRoleSwitch());
-                } else if (entry.getKey().equals(OP_TWO_ACTIVE)) {
+                } else if (entry.getKey().equals(OP_TWO_SOURCE)) {
                     clusterManager.getClusterManagerCallback()
-                            .applyNewTopologyConfig(clusterManager.generateConfigWithAllActive());
-                } else if (entry.getKey().equals(OP_ALL_STANDBY)) {
+                            .applyNewTopologyConfig(clusterManager.generateConfigWithAllSource());
+                } else if (entry.getKey().equals(OP_ALL_SINK)) {
                     clusterManager.getClusterManagerCallback()
-                            .applyNewTopologyConfig(clusterManager.generateConfigWithAllStandby());
+                            .applyNewTopologyConfig(clusterManager.generateConfigWithAllSink());
                 } else if (entry.getKey().equals(OP_INVALID)) {
                     clusterManager.getClusterManagerCallback()
                             .applyNewTopologyConfig(clusterManager.generateConfigWithInvalid());
@@ -375,18 +375,18 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
                             .applyNewTopologyConfig(clusterManager.generateDefaultValidConfig());
                 } else if (entry.getKey().equals(OP_ENFORCE_SNAPSHOT_FULL_SYNC)) {
                     try {
-                        // Enforce snapshot sync on the 1st standby cluster
+                        // Enforce snapshot sync on the 1st sink cluster
                         List<ClusterConfigurationMsg> clusters =
                             clusterManager.queryTopologyConfig(true).getClustersList();
-                        Optional<ClusterConfigurationMsg> standbyCluster =
-                            clusters.stream().filter(cluster -> cluster.getRole() == ClusterRole.STANDBY
-                            && cluster.getId().equals(clusterManager.topology.getStandbyClusterIds().get(0))).findFirst();
+                        Optional<ClusterConfigurationMsg> sinkCluster =
+                            clusters.stream().filter(cluster -> cluster.getRole() == ClusterRole.SINK
+                            && cluster.getId().equals(clusterManager.topology.getSinkClusterIds().get(0))).findFirst();
                         clusterManager.forceSnapshotSync(
-                            standbyCluster.get().getId());
+                            sinkCluster.get().getId());
                     } catch (LogReplicationDiscoveryServiceException e) {
                         log.warn("Caught a RuntimeException ", e);
                         ClusterRole role = clusterManager.getCorfuReplicationDiscoveryService().getLocalClusterRoleType();
-                        if (role != ClusterRole.STANDBY) {
+                        if (role != ClusterRole.SINK) {
                             log.error("The current cluster role is {} and should not throw a RuntimeException for forceSnapshotSync call.", role);
                             Thread.interrupted();
                         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -7,9 +7,11 @@ import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescripto
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationDiscoveryServiceException;
 import org.corfudb.infrastructure.logreplication.infrastructure.NodeDescriptor;
 import org.corfudb.infrastructure.logreplication.infrastructure.TopologyDescriptor;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.ClusterConfigurationMsg;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.ClusterRole;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.TopologyConfigurationMsg;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.ExampleSchemas.ClusterUuidMsg;
@@ -23,10 +25,18 @@ import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterrupte
 import org.corfudb.runtime.view.Address;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class extends CorfuReplicationClusterManagerAdapter, provides topology config API
@@ -50,6 +60,9 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
     public static final ClusterUuidMsg OP_INVALID = ClusterUuidMsg.newBuilder().setLsb(4L).setMsb(4L).build();
     public static final ClusterUuidMsg OP_ENFORCE_SNAPSHOT_FULL_SYNC = ClusterUuidMsg.newBuilder().setLsb(5L).setMsb(5L).build();
     public static final ClusterUuidMsg OP_BACKUP = ClusterUuidMsg.newBuilder().setLsb(6L).setMsb(6L).build();
+    public static final ClusterUuidMsg OP_SINGLE_SOURCE_SINK = ClusterUuidMsg.newBuilder().setLsb(7L).setMsb(7L).build();
+    public static final ClusterUuidMsg OP_MULTI_SINK = ClusterUuidMsg.newBuilder().setLsb(8L).setMsb(8L).build();
+    public static final ClusterUuidMsg OP_MULTI_SOURCE = ClusterUuidMsg.newBuilder().setLsb(9L).setMsb(9L).build();
 
     @Getter
     private long configId;
@@ -69,15 +82,25 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
     private String corfuEndpoint = "localhost:9000";
 
     private DefaultClusterConfig topology;
+    private final Map<ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> remoteSourcesToReplicationModels;
+    private final Map<ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> remoteSinkToReplicationModels;
+    private final Set<LogReplicationClusterInfo.ClusterConfigurationMsg> connectionEndPoints;
+    private boolean topologyBucketsIinitialized;
+    private boolean topologyBucketsCustomized;
 
     public DefaultClusterManager() {
         topology = new DefaultClusterConfig();
+        remoteSourcesToReplicationModels = new HashMap<>();
+        remoteSinkToReplicationModels = new HashMap<>();
+        connectionEndPoints = new HashSet<>();
+        topologyBucketsIinitialized = false;
+        topologyBucketsCustomized = false;
     }
 
     public void start() {
         configId = 0L;
         shutdown = false;
-        topologyConfig = constructTopologyConfigMsg();
+        topologyConfig = readConfig();
         clusterManagerCallback = new ClusterManagerCallback(this);
         corfuRuntime = CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder().build())
                 .parseConfigurationString(corfuEndpoint)
@@ -86,7 +109,8 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
         long trimMark = Address.NON_ADDRESS;
         try {
             // Subscribe from the earliest point in the log.
-            trimMark = corfuRuntime.getLayoutView().getRuntimeLayout().getLogUnitClient(corfuRuntime.getLayoutServers().get(0)).getTrimMark().get();
+            trimMark = corfuRuntime.getLayoutView().getRuntimeLayout()
+                    .getLogUnitClient(corfuRuntime.getLayoutServers().get(0)).getTrimMark().get();
         } catch (ExecutionException | InterruptedException e) {
             log.error("Exception caught while attempting to fetch trim mark. Subscription might fail.", e);
         }
@@ -124,9 +148,9 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
         log.info("Shutdown Cluster Manager completed.");
     }
 
-    public TopologyDescriptor readConfig() {
-        List<ClusterDescriptor> sourceClusters = new ArrayList<>();
-        List<ClusterDescriptor> sinkClusters = new ArrayList<>();
+    public TopologyConfigurationMsg readConfig() {
+        List<ClusterConfigurationMsg> sourceClusters = new ArrayList<>();
+        List<ClusterConfigurationMsg> sinkClusters = new ArrayList<>();
 
         List<String> sourceClusterIds = topology.getSourceClusterIds();
         List<String> sourceCorfuPorts = topology.getSourceCorfuPorts();
@@ -146,58 +170,222 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
 
         // Setup source cluster information
         for (int i = 0; i < sourceClusterIds.size(); i++) {
-            ClusterDescriptor sourceCluster = new ClusterDescriptor(
-                sourceClusterIds.get(i), ClusterRole.SOURCE,
+            ClusterDescriptor sourceCluster = new ClusterDescriptor(sourceClusterIds.get(i), ClusterRole.SOURCE,
                 Integer.parseInt(sourceCorfuPorts.get(i)));
 
             for (int j = 0; j < sourceNodeNames.size(); j++) {
-                log.info("source Cluster Name {}, IpAddress {}",
-                    sourceNodeNames.get(j), sourceNodeHosts.get(i));
-                NodeDescriptor nodeInfo =
-                    new NodeDescriptor(sourceNodeHosts.get(i),
-                        sourceLogReplicationPorts.get(i), SOURCE_CLUSTER_NAME,
-                        sourceNodeIds.get(i), sourceNodeIds.get(i));
+                NodeDescriptor nodeInfo = new NodeDescriptor(sourceNodeHosts.get(i), sourceLogReplicationPorts.get(i),
+                        SOURCE_CLUSTER_NAME, sourceNodeIds.get(i), sourceNodeIds.get(i));
                 sourceCluster.getNodesDescriptors().add(nodeInfo);
             }
-            sourceClusters.add(sourceCluster);
+            sourceClusters.add(sourceCluster.convertToMessage());
         }
 
         // Setup sink cluster information
         for (int i = 0; i < sinkClusterIds.size(); i++) {
-            ClusterDescriptor sinkCluster = new ClusterDescriptor(
-                sinkClusterIds.get(i), ClusterRole.SINK,
-                Integer.parseInt(sinkCorfuPorts.get(i)));
+            ClusterDescriptor sinkCluster = new ClusterDescriptor(sinkClusterIds.get(i), ClusterRole.SINK,
+                    Integer.parseInt(sinkCorfuPorts.get(i)));
 
             for (int j = 0; j < sinkNodeNames.size(); j++) {
-                log.info("Sink Cluster Name {}, IpAddress {}",
-                    sinkNodeNames.get(j), sinkNodeHosts.get(i));
-                NodeDescriptor nodeInfo =
-                    new NodeDescriptor(sinkNodeHosts.get(i),
-                        sinkLogReplicationPorts.get(i), SINK_CLUSTER_NAME,
-                        sinkNodeIds.get(i), sinkNodeIds.get(i));
+                NodeDescriptor nodeInfo = new NodeDescriptor(sinkNodeHosts.get(i), sinkLogReplicationPorts.get(i),
+                        SINK_CLUSTER_NAME, sinkNodeIds.get(i), sinkNodeIds.get(i));
                 sinkCluster.getNodesDescriptors().add(nodeInfo);
             }
-            sinkClusters.add(sinkCluster);
+            sinkClusters.add(sinkCluster.convertToMessage());
         }
 
-        return new TopologyDescriptor(0L, sourceClusters,
-            sinkClusters);
+        return constructTopologyConfigurationMsg(0L,sourceClusters, sinkClusters, new ArrayList<>());
     }
 
-    private TopologyConfigurationMsg constructTopologyConfigMsg() {
-        TopologyDescriptor clusterTopologyDescriptor = readConfig();
-        return clusterTopologyDescriptor.convertToMessage();
+    private TopologyConfigurationMsg constructTopologyConfigurationMsg(long configId,
+                                                                       List<ClusterConfigurationMsg> sourceClusters,
+                                                                       List<ClusterConfigurationMsg> sinkClusters,
+                                                                       List<ClusterConfigurationMsg> invalidClusters) {
+        List<ClusterConfigurationMsg> clusterConfigurationMsgs = Stream.of(sourceClusters, sinkClusters, invalidClusters)
+                .flatMap(Collection::stream)
+                .collect(Collectors.toList());
+
+        return TopologyConfigurationMsg.newBuilder().addAllClusters(clusterConfigurationMsgs)
+                .setTopologyConfigID(configId).build();
+
     }
 
 
     @Override
     public TopologyConfigurationMsg queryTopologyConfig(boolean useCached) {
         if (topologyConfig == null || !useCached) {
-            topologyConfig = constructTopologyConfigMsg();
+            topologyConfig = readConfig();
         }
 
         log.debug("new cluster config msg " + topologyConfig);
         return topologyConfig;
+    }
+
+    public Map<LogReplicationClusterInfo.ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> getRemoteSourceToReplicationModels() {
+        log.debug("getRemoteSourceToReplicationModels {}", this.remoteSourcesToReplicationModels.size());
+        return getClusterBucket(this.remoteSourcesToReplicationModels);
+    }
+
+
+    public Map<ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> getRemoteSinkForReplicationModels(){
+        log.debug("getRemoteSinkForReplicationModels {}", this.remoteSinkToReplicationModels.size());
+        return getClusterBucket(this.remoteSinkToReplicationModels);
+    }
+
+    private Map<ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> getClusterBucket(
+            Map<ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> bucket) {
+        Map<ClusterConfigurationMsg, Set<LogReplicationMetadata.ReplicationModels>> remoteClustersbucket;
+
+        ClusterConfigurationMsg localCluster = findLocalCluster();
+        synchronized (this) {
+            while (!topologyBucketsIinitialized) {
+                try {
+                    log.warn("sleeping untill the buckets are initialized by plugin");
+                    wait();
+                } catch (InterruptedException e) {
+                    log.error("The thread {} has been interrupted", Thread.currentThread().getName());
+                }
+            }
+            if (!topologyBucketsCustomized) {
+                customizeBuckets(localCluster);
+            }
+            remoteClustersbucket = new HashMap<>(bucket);
+        }
+        return remoteClustersbucket;
+    }
+
+    private void customizeBuckets(ClusterConfigurationMsg localCluster) {
+        if (localCluster.getRole().equals(ClusterRole.SOURCE)) {
+            remoteSourcesToReplicationModels.clear();
+        } else {
+            remoteSinkToReplicationModels.clear();
+            connectionEndPoints.clear();
+        }
+
+        topologyBucketsCustomized = true;
+    }
+
+    public Set<LogReplicationClusterInfo.ClusterConfigurationMsg> fetchConnectionEndpoints() {
+        Set<LogReplicationClusterInfo.ClusterConfigurationMsg> connectionEnpoints;
+        ClusterConfigurationMsg localCluster = findLocalCluster();
+        synchronized (this) {
+            while (!topologyBucketsIinitialized) {
+                try {
+                    log.warn("sleeping untill the buckets are initialized by plugin");
+                    wait();
+                } catch (InterruptedException e) {
+                    log.error("The thread {} has been interrupted", Thread.currentThread().getName());
+                }
+            }
+            if (!topologyBucketsCustomized) {
+                customizeBuckets(localCluster);
+            }
+            connectionEnpoints = new HashSet<>(this.connectionEndPoints);
+        }
+        log.debug("fetchConnectionEndpoints {}", connectionEnpoints);
+        return connectionEnpoints;
+    }
+
+
+    private void createSingleSourceSinkTopologyBuckets() {
+        if(topologyConfig == null) {
+            topologyConfig = readConfig();
+        }
+        synchronized (this) {
+            this.remoteSourcesToReplicationModels.putIfAbsent(topologyConfig.getClustersList().stream()
+                    .filter(clusterConfigurationMsg -> clusterConfigurationMsg.getId().equals(topology.getSourceClusterIds().get(0)))
+                    .findFirst().get(), new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                        add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+                    }});
+            this.remoteSinkToReplicationModels.putIfAbsent(topologyConfig.getClustersList().stream()
+                    .filter(clusterConfigurationMsg -> clusterConfigurationMsg.getId().equals(topology.getSinkClusterIds().get(0)))
+                    .findFirst().get(), new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+            }});
+            this.connectionEndPoints.add(topologyConfig.getClustersList().stream()
+                    .filter(clusterConfigurationMsg -> clusterConfigurationMsg.getId().equals(topology.getSinkClusterIds().get(0)))
+                    .findFirst().get());
+            log.info("added the clusters: source: {} sink: {} connectionEndpoints: {}", this.remoteSourcesToReplicationModels,
+                    this.remoteSinkToReplicationModels, this.connectionEndPoints);
+            topologyBucketsIinitialized = true;
+            notify();
+        }
+    }
+
+    private void createSingleSourceMultiSinkTopologyBuckets() {
+        if(topologyConfig == null) {
+            topologyConfig = readConfig();
+        }
+
+        synchronized (this) {
+            this.remoteSourcesToReplicationModels.putIfAbsent(topologyConfig.getClustersList().stream()
+                    .filter(clusterConfigurationMsg -> clusterConfigurationMsg.getId().equals(topology.getSourceClusterIds().get(0)))
+                    .findFirst().get(), new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                        add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+            }});
+
+            topologyConfig.getClustersList().stream()
+                    .filter(clusterConfigurationMsg -> clusterConfigurationMsg.getRole().equals(ClusterRole.SINK))
+                    .forEach(clusterConfigurationMsg -> {
+                        remoteSinkToReplicationModels.putIfAbsent(clusterConfigurationMsg, new HashSet<>());
+                        remoteSinkToReplicationModels.get(clusterConfigurationMsg)
+                                .add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+                    });
+
+            topologyConfig.getClustersList().stream()
+                    .filter(clusterConfigurationMsg -> clusterConfigurationMsg.getRole().equals(ClusterRole.SINK))
+                    .forEach(connectionEndPoints::add);
+            log.info("added the multi sink clusters: source: {} sink: {} connectionEndpoints: {}", this.remoteSourcesToReplicationModels,
+                    this.remoteSinkToReplicationModels, this.connectionEndPoints);
+            topologyBucketsIinitialized = true;
+            notify();
+        }
+    }
+
+    private ClusterConfigurationMsg findLocalCluster() {
+        String localNodeId = corfuReplicationDiscoveryService.getLocalNodeId();
+        log.debug("localNodeId {}", localNodeId );
+        AtomicReference<ClusterConfigurationMsg> localCluster = new AtomicReference<>();
+        topologyConfig.getClustersList().stream().forEach(clusterMsg -> {
+            clusterMsg.getNodeInfoList().stream().forEach(nodeMsg -> {
+                if (nodeMsg.getNodeId().equals(localNodeId)) {
+                    localCluster.set(clusterMsg);
+                }
+            });
+        });
+
+        return localCluster.get();
+    }
+
+    private void createMultiSourceSingleSinkTopologyBuckets() {
+        if(topologyConfig == null) {
+            topologyConfig = readConfig();
+        }
+
+        synchronized (this) {
+            topologyConfig.getClustersList().stream()
+                    .filter(clusterConfigurationMsg -> clusterConfigurationMsg.getRole().equals(ClusterRole.SOURCE))
+                    .forEach(clusterConfigurationMsg -> {
+                        remoteSourcesToReplicationModels.putIfAbsent(clusterConfigurationMsg, new HashSet<>());
+                        remoteSourcesToReplicationModels.get(clusterConfigurationMsg)
+                                .add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+                    });
+
+
+            this.remoteSinkToReplicationModels.putIfAbsent(topologyConfig.getClustersList().stream()
+                    .filter(clusterConfigurationMsg -> clusterConfigurationMsg.getId().equals(topology.getSinkClusterIds().get(0)))
+                    .findFirst().get(), new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                        add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+            }});
+
+            this.connectionEndPoints.add(topologyConfig.getClustersList().stream()
+                    .filter(clusterConfigurationMsg -> clusterConfigurationMsg.getId().equals(topology.getSinkClusterIds().get(0)))
+                    .findFirst().get());
+            log.info("added the multi source single sink clusters: source: {} sink: {} connectionEndpoints: {}",
+                    this.remoteSourcesToReplicationModels, this.remoteSinkToReplicationModels, this.connectionEndPoints);
+            topologyBucketsIinitialized = true;
+            notify();
+        }
     }
 
     /**
@@ -205,17 +393,68 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
      * and source as sink. Data should flow in the reverse direction.
      **/
     public TopologyDescriptor generateConfigWithRoleSwitch() {
-        TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
+        TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig, this);
 
-        List<ClusterDescriptor> newSourceClusters = new ArrayList<>();
-        List<ClusterDescriptor> newSinkClusters = new ArrayList<>();
-        currentConfig.getSourceClusters().values().forEach(sourceCluster ->
-            newSinkClusters.add(new ClusterDescriptor(sourceCluster, ClusterRole.SINK)));
+        List<ClusterConfigurationMsg> newSourceClusters = new ArrayList<>();
+        List<ClusterConfigurationMsg> newSinkClusters = new ArrayList<>();
+        List<ClusterConfigurationMsg> newInvalidClusters = new ArrayList<>();
+        currentConfig.getAllClusterConfigMsgsInTopology().values().forEach(clusterConfigurationMsg -> {
+            if (clusterConfigurationMsg.getRole().equals(ClusterRole.SINK)) {
+                newSourceClusters.add(ClusterConfigurationMsg.newBuilder(clusterConfigurationMsg)
+                        .setRole(ClusterRole.SOURCE).build());
+            } else if (clusterConfigurationMsg.getRole().equals(ClusterRole.SOURCE)) {
+                newSinkClusters.add(ClusterConfigurationMsg.newBuilder(clusterConfigurationMsg)
+                        .setRole(ClusterRole.SINK).build());
+            } else {
+                newInvalidClusters.add(clusterConfigurationMsg);
+            }
+        });
 
-        currentConfig.getSinkClusters().values().forEach(sinkCluster ->
-                newSourceClusters.add(new ClusterDescriptor(sinkCluster, ClusterRole.SOURCE)));
+        ClusterDescriptor oldLocalClusterDescriptor = getCorfuReplicationDiscoveryService().getLocalCluster();
 
-        return new TopologyDescriptor(++configId, newSourceClusters, newSinkClusters);
+        synchronized (this) {
+            // if the current one is Source => give only remote sink; but if the current one is sink, remote sink should be empty
+            Set<ClusterConfigurationMsg> newSourceClusterMsg = new HashSet<>();
+            Set<ClusterConfigurationMsg> newSinkClusterMsg = new HashSet<>();
+
+            this.remoteSinkToReplicationModels.keySet().stream().forEach(clusterMsg -> {
+                ClusterConfigurationMsg newClusterMsg = ClusterConfigurationMsg
+                        .newBuilder(clusterMsg).setRole(ClusterRole.SOURCE).build();
+                newSourceClusterMsg.add(newClusterMsg);
+            });
+            this.remoteSourcesToReplicationModels.keySet().stream().forEach(clusterMsg -> {
+                ClusterConfigurationMsg newClusterMsg = ClusterConfigurationMsg
+                        .newBuilder(clusterMsg).setRole(ClusterRole.SINK).build();
+                newSinkClusterMsg.add(newClusterMsg);
+            });
+            this.remoteSinkToReplicationModels.clear();
+            this.remoteSourcesToReplicationModels.clear();
+            this.connectionEndPoints.clear();
+
+            // On role change, the role of oldCluster is flipped.
+            //If old role is SOURCE (i.e., it is now the sink), it only has the remote SOURCEs connecting to it.
+            //If old role is SINK (i.e., it is now the SOURCE), it has to connect to all the remote sinks.
+            if(oldLocalClusterDescriptor.getRole().equals(ClusterRole.SOURCE)) {
+                newSourceClusterMsg.stream().forEach(clusterConfigurationMsg ->
+                        remoteSourcesToReplicationModels.put(clusterConfigurationMsg,
+                                new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                                    add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+                        }}));
+            } else if(oldLocalClusterDescriptor.getRole().equals(ClusterRole.SINK)){
+                newSinkClusterMsg.stream().forEach(clusterConfigurationMsg ->
+                        remoteSinkToReplicationModels.put(clusterConfigurationMsg,
+                                new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                                    add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+                        }}));
+                this.connectionEndPoints.addAll(newSinkClusterMsg);
+            }
+
+            topologyBucketsCustomized = true;
+        }
+        log.debug("the topology has source: {}, sink: {}, connectionEndPoints: {}", this.remoteSourcesToReplicationModels, this.remoteSinkToReplicationModels, this.connectionEndPoints);
+        return new TopologyDescriptor(
+                constructTopologyConfigurationMsg(++configId, newSourceClusters, newSinkClusters, new ArrayList<>()),
+                this);
     }
 
     /**
@@ -223,15 +462,38 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
      * System should drop messages between any two source clusters.
      **/
     public TopologyDescriptor generateConfigWithAllSource() {
-        TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
-        ClusterDescriptor currentSource = currentConfig.getSourceClusters().values().iterator().next();
-
+        topologyConfig = readConfig();
         List<ClusterDescriptor> newSourceClusters = new ArrayList<>();
-        currentConfig.getSinkClusters().values().forEach(sinkCluster ->
-                newSourceClusters.add(new ClusterDescriptor(sinkCluster, ClusterRole.SOURCE)));
-        newSourceClusters.add(currentSource);
+        topologyConfig.getClustersList().stream().forEach(clusterMsg -> {
+            if (clusterMsg.getRole().equals(ClusterRole.SOURCE)) {
+                newSourceClusters.add(new ClusterDescriptor(clusterMsg));
+            } else {
+                newSourceClusters.add(new ClusterDescriptor(new ClusterDescriptor(clusterMsg), ClusterRole.SOURCE));
+            }
+        });
+
+        ClusterDescriptor oldLocalClusterDescriptor = getCorfuReplicationDiscoveryService().getLocalCluster();
+        resetBuckets();
+
+        synchronized (this) {
+            if(oldLocalClusterDescriptor.getRole().equals(ClusterRole.SINK)) {
+                newSourceClusters.forEach(sourceCluster ->
+                        this.remoteSourcesToReplicationModels.put(sourceCluster.convertToMessage(),
+                                new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                                    add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES); }}
+                        ));
+            }
+        }
 
         return new TopologyDescriptor(++configId, newSourceClusters, new ArrayList<>());
+    }
+
+    private void resetBuckets() {
+        synchronized (this) {
+            this.remoteSourcesToReplicationModels.clear();
+            this.remoteSinkToReplicationModels.clear();
+            this.connectionEndPoints.clear();
+        }
     }
 
     /**
@@ -239,12 +501,22 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
      * System should not send messages in this case.
      **/
     public TopologyDescriptor generateConfigWithAllSink() {
-        TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
-        ClusterDescriptor currentSource = currentConfig.getSourceClusters().values().iterator().next();
+        topologyConfig = readConfig();
+        ClusterDescriptor currentSource = new ClusterDescriptor(topologyConfig.getClustersList().stream()
+                .filter(clusterMsg -> clusterMsg.getId().equals(topology.getSourceClusterIds().get(0)))
+                .findFirst().get());
 
-        List<ClusterDescriptor> newSinkClusters = new ArrayList<>(currentConfig.getSinkClusters().values());
+
+        List<ClusterDescriptor> newSinkClusters = new ArrayList<>();
+        topologyConfig.getClustersList().stream().filter(clusterMsg -> clusterMsg.getRole().equals(ClusterRole.SINK))
+                .forEach(clusterMsg -> newSinkClusters.add(new ClusterDescriptor(clusterMsg)));
         ClusterDescriptor newSink = new ClusterDescriptor(currentSource, ClusterRole.SINK);
         newSinkClusters.add(newSink);
+
+        resetBuckets();
+        synchronized (this) {
+            topologyBucketsCustomized = false;
+        }
 
         return new TopologyDescriptor(++configId, new ArrayList<>(), newSinkClusters);
     }
@@ -254,12 +526,22 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
      * LR should not replicate to these clusters.
      **/
     public TopologyDescriptor generateConfigWithInvalid() {
-        TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
 
-        List<ClusterDescriptor> newSourceClusters = new ArrayList<>(currentConfig.getSourceClusters().values());
+        List<ClusterDescriptor> newSourceClusters = new ArrayList<>();
         List<ClusterDescriptor> newInvalidClusters = new ArrayList<>();
-        currentConfig.getSinkClusters().values().forEach(sinkCluster ->
-                newInvalidClusters.add(new ClusterDescriptor(sinkCluster, ClusterRole.INVALID)));
+        topologyConfig.getClustersList().stream()
+                .forEach(clusterMsg -> {
+                    if (clusterMsg.getRole().equals(ClusterRole.SOURCE)) {
+                        newSourceClusters.add(new ClusterDescriptor(clusterMsg));
+                    } else if (clusterMsg.getRole().equals(ClusterRole.SINK)) {
+                        newInvalidClusters.add(new ClusterDescriptor(new ClusterDescriptor(clusterMsg), ClusterRole.INVALID));
+                    }
+                });
+
+        //Since all the sinks are marked as invalid, the remote source/sink/connectionEndPoints will all be empty as
+        //(i) if local cluster is source, there are no sinks and hence no connectionEndPoints
+        //(ii) if the local cluster is INVALID (previously sink), no LR against it.
+        resetBuckets();
 
         return new TopologyDescriptor(++configId, newSourceClusters, new ArrayList<>(), newInvalidClusters);
     }
@@ -268,10 +550,18 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
      * Bring topology config back to default valid config.
      **/
     public TopologyDescriptor generateDefaultValidConfig() {
-        TopologyDescriptor defaultTopology = new TopologyDescriptor(constructTopologyConfigMsg());
-        List<ClusterDescriptor> sourceClusters = new ArrayList<>(defaultTopology.getSourceClusters().values());
-        List<ClusterDescriptor> sinkClusters = new ArrayList<>(defaultTopology.getSinkClusters().values());
+        topologyConfig = readConfig();
+        resetBuckets();
+        createSingleSourceSinkTopologyBuckets();
 
+        TopologyDescriptor defaultTopology = new TopologyDescriptor(readConfig(), this);
+        List<ClusterDescriptor> sourceClusters = new ArrayList<>(defaultTopology.getRemoteSourceClusters().values());
+        List<ClusterDescriptor> sinkClusters = new ArrayList<>(defaultTopology.getRemoteSinkClusters().values());
+
+        // topologyBucketsCustomized=false, so the buckets are defined as per the local cluster's role on getRemote calls
+        synchronized (this) {
+            topologyBucketsCustomized = false;
+        }
         return new TopologyDescriptor(++configId, sourceClusters, sinkClusters);
     }
 
@@ -279,15 +569,15 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
      * Create a new topology config, which replaces the source cluster with a backup cluster.
      **/
     public TopologyDescriptor generateConfigWithBackup() {
-        TopologyDescriptor currentConfig = new TopologyDescriptor(topologyConfig);
-        Optional<ClusterDescriptor> currentSource =
-            currentConfig.getSourceClusters()
-            .values().stream().filter(cluster -> cluster.getClusterId()
-                .equals(topology.getSourceClusterIds().get(0))).findFirst();
+        topologyConfig = readConfig();
+
+        ClusterDescriptor currentSource = new ClusterDescriptor(topologyConfig.getClustersList().stream()
+                .filter(clusterMsg -> clusterMsg.getId().equals(topology.getSourceClusterIds().get(0))).findFirst().get());
+
 
         List<ClusterDescriptor> newSourceClusters = new ArrayList<>();
         newSourceClusters.add(new ClusterDescriptor(
-            currentSource.get().getClusterId(), ClusterRole.SOURCE,
+            currentSource.getClusterId(), ClusterRole.SOURCE,
             BACKUP_CORFU_PORT));
 
         NodeDescriptor backupNode = new NodeDescriptor(
@@ -298,9 +588,26 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
                 topology.getBackupNodesUuid().get(0)
                 );
         newSourceClusters.get(0).getNodesDescriptors().add(backupNode);
-        List<ClusterDescriptor> sinkClusters =
-            new ArrayList<>(currentConfig.getSinkClusters().values());
+        List<ClusterDescriptor> sinkClusters = new ArrayList<>();
+        topologyConfig.getClustersList().stream().filter(clusterMsg -> clusterMsg.getRole().equals(ClusterRole.SINK))
+                .forEach(clusterMsg -> sinkClusters.add(new ClusterDescriptor(clusterMsg)));
 
+        synchronized (this) {
+            sinkClusters.stream().forEach(cluster ->
+                this.remoteSinkToReplicationModels.putIfAbsent(cluster.convertToMessage(),
+                        new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                            add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+                        }}
+                )
+            );
+
+            this.remoteSourcesToReplicationModels.put(currentSource.convertToMessage(),
+                    new HashSet<LogReplicationMetadata.ReplicationModels>(){{
+                        add(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES);
+            }});
+
+            topologyBucketsCustomized = true;
+        }
         return new TopologyDescriptor(++configId, newSourceClusters, sinkClusters);
     }
 
@@ -350,7 +657,7 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
 
         @Override
         public void onNext(CorfuStreamEntries results) {
-            log.info("onNext :: entry size={}", results.getEntries().size());
+            log.info("onNext :: entry size={}", results.getEntries());
             CorfuStreamEntry entry = results.getEntries().values()
                     .stream()
                     .findFirst()
@@ -394,6 +701,12 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
                 } else if (entry.getKey().equals(OP_BACKUP)) {
                     clusterManager.getClusterManagerCallback()
                             .applyNewTopologyConfig(clusterManager.generateConfigWithBackup());
+                } else if (entry.getKey().equals(OP_SINGLE_SOURCE_SINK)) {
+                    clusterManager.createSingleSourceSinkTopologyBuckets();
+                } else if (entry.getKey().equals(OP_MULTI_SINK)) {
+                    clusterManager.createSingleSourceMultiSinkTopologyBuckets();
+                } else if (entry.getKey().equals(OP_MULTI_SOURCE)) {
+                    clusterManager.createMultiSourceSingleSinkTopologyBuckets();
                 }
             } else {
                 log.info("onNext :: operation={}, key={}, payload={}, metadata={}", entry.getOperation().name(),

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -24,7 +24,7 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
     public static final String TABLE_PREFIX = "Table00";
     public static final String NAMESPACE = "LR-Test";
     public static final String TAG_ONE = "tag_one";
-    private static final int STREAMING_CONFIG_TABLES_COUNT = 4;
+    private static final int STREAMING_CONFIG_TABLES_COUNT = 3;
 
     public DefaultLogReplicationConfigAdapter() {
         streamsToReplicate = new HashSet<>();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -2,6 +2,8 @@ package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.TableRegistry;
 
@@ -21,7 +23,7 @@ import static org.corfudb.runtime.view.TableRegistry.getFullyQualifiedTableName;
  *
  * This implementation retrieves a fixed set of tables, which are used for testing purposes.
  */
-public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfigAdapter {
+public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfigAdapter{
 
     private Map<ReplicationSubscriber, Set<String>> streamsToReplicateMap;
 
@@ -52,7 +54,7 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
 
         streamsToReplicateMap = new HashMap<>();
         streamsToReplicateMap.put(
-            new ReplicationSubscriber(LogReplicationConfig.ReplicationModel.SINGLE_SOURCE_SINK, SAMPLE_CLIENT),
+            new ReplicationSubscriber(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES, SAMPLE_CLIENT),
             streams);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -24,8 +24,7 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
     public static final String TABLE_PREFIX = "Table00";
     public static final String NAMESPACE = "LR-Test";
     public static final String TAG_ONE = "tag_one";
-    private final int indexOne = 1;
-    private final int indexTwo = 2;
+    private static final int STREAMING_CONFIG_TABLES_COUNT = 4;
 
     public DefaultLogReplicationConfigAdapter() {
         streamsToReplicate = new HashSet<>();
@@ -54,10 +53,11 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
     public Map<UUID, List<UUID>> getStreamingConfigOnSink() {
         Map<UUID, List<UUID>> streamsToTagsMaps = new HashMap<>();
         UUID streamTagOneDefaultId = TableRegistry.getStreamIdForStreamTag(NAMESPACE, TAG_ONE);
-        streamsToTagsMaps.put(CorfuRuntime.getStreamID(NAMESPACE + "$" + TABLE_PREFIX + indexOne),
+
+        for (int i = 1; i <= STREAMING_CONFIG_TABLES_COUNT; i++) {
+            streamsToTagsMaps.put(CorfuRuntime.getStreamID(NAMESPACE + "$" + TABLE_PREFIX + i),
                 Collections.singletonList(streamTagOneDefaultId));
-        streamsToTagsMaps.put(CorfuRuntime.getStreamID(NAMESPACE + "$" + TABLE_PREFIX + indexTwo),
-                Collections.singletonList(streamTagOneDefaultId));
+        }
         return streamsToTagsMaps;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -1,5 +1,7 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
+import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.TableRegistry;
 
@@ -11,6 +13,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+import static org.corfudb.runtime.view.TableRegistry.getFullyQualifiedTableName;
+
 /**
  * Default testing implementation of a Log Replication Config Provider
  *
@@ -18,30 +23,37 @@ import java.util.UUID;
  */
 public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfigAdapter {
 
-    private Set<String> streamsToReplicate;
+    private Map<ReplicationSubscriber, Set<String>> streamsToReplicateMap;
 
     public static final int MAP_COUNT = 10;
     public static final String TABLE_PREFIX = "Table00";
     public static final String NAMESPACE = "LR-Test";
     public static final String TAG_ONE = "tag_one";
+    public static final String SAMPLE_CLIENT = "SampleClient";
+    private static final String SEPARATOR = "$";
     private static final int STREAMING_CONFIG_TABLES_COUNT = 3;
 
     public DefaultLogReplicationConfigAdapter() {
-        streamsToReplicate = new HashSet<>();
-        streamsToReplicate.add("Table001");
-        streamsToReplicate.add("Table002");
-        streamsToReplicate.add("Table003");
+        Set<String> streams = new HashSet<>();
+        streams.add("Table001");
+        streams.add("Table002");
+        streams.add("Table003");
 
         // Support for UFO
         for (int i = 1; i <= MAP_COUNT; i++) {
-            streamsToReplicate.add(NAMESPACE + "$" + TABLE_PREFIX + i);
+            streams.add(NAMESPACE + SEPARATOR + TABLE_PREFIX + i);
         }
-    }
+        String registryTable = getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, TableRegistry.REGISTRY_TABLE_NAME);
 
-    // Provides the fully qualified names of streams to replicate
-    @Override
-    public Set<String> fetchStreamsToReplicate() {
-        return streamsToReplicate;
+        String protoTable = getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE,
+            TableRegistry.PROTOBUF_DESCRIPTOR_TABLE_NAME);
+        streams.add(registryTable);
+        streams.add(protoTable);
+
+        streamsToReplicateMap = new HashMap<>();
+        streamsToReplicateMap.put(
+            new ReplicationSubscriber(LogReplicationConfig.ReplicationModel.SINGLE_SOURCE_SINK, SAMPLE_CLIENT),
+            streams);
     }
 
     @Override
@@ -55,9 +67,14 @@ public class DefaultLogReplicationConfigAdapter implements ILogReplicationConfig
         UUID streamTagOneDefaultId = TableRegistry.getStreamIdForStreamTag(NAMESPACE, TAG_ONE);
 
         for (int i = 1; i <= STREAMING_CONFIG_TABLES_COUNT; i++) {
-            streamsToTagsMaps.put(CorfuRuntime.getStreamID(NAMESPACE + "$" + TABLE_PREFIX + i),
+            streamsToTagsMaps.put(CorfuRuntime.getStreamID(NAMESPACE + SEPARATOR + TABLE_PREFIX + i),
                 Collections.singletonList(streamTagOneDefaultId));
         }
         return streamsToTagsMaps;
+    }
+
+    @Override
+    public Map<ReplicationSubscriber, Set<String>> getSubscriberToStreamsMap() {
+        return streamsToReplicateMap;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationConfigAdapter.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -10,15 +11,10 @@ import java.util.UUID;
  * provider of Log Replication Configuration.
  *
  * Log Replication Configuration encompasses:
- * (1) Streams to replicate
+ * (1) Map of ReplicationSubscriber to Streams to replicate
  * (2) System's version
  */
 public interface ILogReplicationConfigAdapter {
-
-    /**
-     * Returns a set of fully qualified stream names to replicate
-     */
-    Set<String> fetchStreamsToReplicate();
 
     String getVersion();
 
@@ -30,4 +26,6 @@ public interface ILogReplicationConfigAdapter {
      * to the replicated data, therefore, this data must be provided by the plugin externally.
      */
     Map<UUID, List<UUID>> getStreamingConfigOnSink();
+
+    Map<ReplicationSubscriber, Set<String>> getSubscriberToStreamsMap();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/ILogReplicationConfigAdapter.java
@@ -19,7 +19,7 @@ public interface ILogReplicationConfigAdapter {
     String getVersion();
 
     /**
-     * Returns configuration for streaming on sink (standby)
+     * Returns configuration for streaming on sink (sink)
      *
      * This configuration consists of a map containing data stream IDs to stream tags
      * Note that: since data is not deserialized we have no access to stream tags corresponding

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/LogReplicationPluginConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/LogReplicationPluginConfig.java
@@ -109,8 +109,6 @@ public class LogReplicationPluginConfig {
 
             this.nodeIdFilePath = null;
         }
-
-        log.debug("{} ", this);
     }
 
     private static String getParentDir() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -445,7 +445,8 @@ public class LogReplicationAckReader {
     public void startSyncStatusUpdatePeriodicTask() {
         log.info("Start sync status update periodic task");
         lastAckedTsPoller = Executors.newSingleThreadScheduledExecutor(
-                new ThreadFactoryBuilder().setNameFormat("ack-timestamp-reader").build());
+            new ThreadFactoryBuilder().setNameFormat(
+                "ack-timestamp-reader-"+remoteClusterId).build());
         lastAckedTsPoller.scheduleWithFixedDelay(new TsPollingTask(), 0, ACKED_TS_READ_INTERVAL_SECONDS,
                 TimeUnit.SECONDS);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -4,6 +4,8 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.SyncStatus;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal.SyncType;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
@@ -36,6 +38,7 @@ public class LogReplicationAckReader {
     private final LogReplicationConfig config;
     private final CorfuRuntime runtime;
     private final String remoteClusterId;
+    private final ReplicationSubscriber replicationSubscriber;
 
     // Log tail when the current snapshot sync started.  We do not need to synchronize access to it because it will not
     // be read(calculateRemainingEntriesToSend) and written(setBaseSnapshot) concurrently.
@@ -62,11 +65,12 @@ public class LogReplicationAckReader {
     private final Lock lock = new ReentrantLock();
 
     public LogReplicationAckReader(LogReplicationMetadataManager metadataManager, LogReplicationConfig config,
-                                    CorfuRuntime runtime, String remoteClusterId) {
+                                   CorfuRuntime runtime, ReplicationSession replicationSession) {
         this.metadataManager = metadataManager;
         this.config = config;
         this.runtime = runtime;
-        this.remoteClusterId = remoteClusterId;
+        this.remoteClusterId = replicationSession.getRemoteClusterId();
+        this.replicationSubscriber = replicationSession.getSubscriber();
     }
 
     public void setAckedTsAndSyncType(long ackedTs, SyncType syncType) {
@@ -171,7 +175,7 @@ public class LogReplicationAckReader {
      */
     private long getMaxReplicatedStreamsTail(Map<UUID, Long> tailMap) {
         long maxTail = Address.NON_ADDRESS;
-        for (String streamName : config.getStreamsToReplicate()) {
+        for (String streamName : config.getReplicationSubscriberToStreamsMap().get(replicationSubscriber)) {
             UUID streamUuid = CorfuRuntime.getStreamID(streamName);
             if (tailMap.containsKey(streamUuid)) {
                 long streamTail = tailMap.get(streamUuid);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -114,7 +114,7 @@ public class LogReplicationAckReader {
      * Note that this method is not accurate because the global tail can reflect the interleaving of replicated and
      * non-replicated streams, and hence, does not accurately represent the remaining entries to send for replicated streams.
      *
-     * If there is no data on the active, it returns 0, which means no replication remaining.
+     * If there is no data on the source, it returns 0, which means no replication remaining.
      * If the ack'd timestamp is uninitialized(no ack received), it returns the log tail, which means no replication has
      * been done.
      */
@@ -133,7 +133,7 @@ public class LogReplicationAckReader {
                     currentTxStreamProcessedTs.isStreamsToReplicatePresent(), lastSyncType);
         }
 
-        // No data to send on the active, so no replication remaining
+        // No data to send on the source, so no replication remaining
         if (maxReplicatedStreamTail == Address.NON_ADDRESS) {
             log.debug("No data to replicate, replication complete.");
             return NO_REPLICATION_REMAINING_ENTRIES;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -101,16 +101,20 @@ public class LogReplicationSourceManager {
             throw new IllegalArgumentException("Invalid Log Replication: Streams to replicate is EMPTY");
         }
 
-        ExecutorService logReplicationFSMWorkers = Executors.newFixedThreadPool(DEFAULT_FSM_WORKER_THREADS, new
-                ThreadFactoryBuilder().setNameFormat("state-machine-worker").build());
+        ExecutorService logReplicationFSMWorkers = Executors.newFixedThreadPool(
+            DEFAULT_FSM_WORKER_THREADS, new ThreadFactoryBuilder()
+                .setNameFormat("state-machine-worker-" +
+                    params.getRemoteClusterDescriptor().getClusterId()).build());
+
         ReadProcessor readProcessor = new DefaultReadProcessor(runtime);
         this.metadataManager = metadataManager;
         // Ack Reader for Snapshot and LogEntry Sync
-        this.ackReader = new LogReplicationAckReader(this.metadataManager, config, runtime,
-                params.getRemoteClusterDescriptor().getClusterId());
+        this.ackReader = new LogReplicationAckReader(this.metadataManager, config,
+            runtime, params.getRemoteClusterDescriptor().getClusterId());
 
-        this.logReplicationFSM = new LogReplicationFSM(this.runtime, config, params.getRemoteClusterDescriptor(),
-                dataSender, readProcessor, logReplicationFSMWorkers, ackReader, tableManagerPlugin);
+        this.logReplicationFSM = new LogReplicationFSM(this.runtime, config,
+            params.getRemoteClusterDescriptor(), dataSender, readProcessor,
+            logReplicationFSMWorkers, ackReader, tableManagerPlugin);
 
         this.logReplicationFSM.setTopologyConfigId(params.getTopologyConfigId());
         this.ackReader.setLogEntryReader(this.logReplicationFSM.getLogEntryReader());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent.LogReplicationEventType;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationFSM;
@@ -21,6 +22,7 @@ import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManag
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
 
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -68,15 +70,15 @@ public class LogReplicationSourceManager {
      * @param metadataManager Replication Metadata Manager
      */
     public LogReplicationSourceManager(LogReplicationRuntimeParameters params, LogReplicationClient client,
-                                       LogReplicationMetadataManager metadataManager, LogReplicationConfigManager tableManagerPlugin) {
-        this(params, metadataManager, new CorfuDataSender(client), tableManagerPlugin);
+        LogReplicationMetadataManager metadataManager, LogReplicationConfigManager tableManagerPlugin,
+        ReplicationSession replicationSession) {
+        this(params, metadataManager, new CorfuDataSender(client), tableManagerPlugin, replicationSession);
     }
 
     @VisibleForTesting
     public LogReplicationSourceManager(LogReplicationRuntimeParameters params,
-                                       LogReplicationMetadataManager metadataManager,
-                                       DataSender dataSender,
-                                       LogReplicationConfigManager tableManagerPlugin) {
+        LogReplicationMetadataManager metadataManager, DataSender dataSender,
+        LogReplicationConfigManager tableManagerPlugin, ReplicationSession replicationSession) {
 
         // This runtime is used exclusively for the snapshot and log entry reader which do not require a cache
         // as these are one time operations.
@@ -96,25 +98,24 @@ public class LogReplicationSourceManager {
 
         this.config = parameters.getReplicationConfig();
 
-        if (config.getStreamsToReplicate() == null || config.getStreamsToReplicate().isEmpty()) {
+        Set<String> streamsToReplicate =
+            config.getReplicationSubscriberToStreamsMap().get(replicationSession.getSubscriber());
+        if (streamsToReplicate == null || streamsToReplicate.isEmpty()) {
             // Avoid FSM being initialized if there are no streams to replicate
             throw new IllegalArgumentException("Invalid Log Replication: Streams to replicate is EMPTY");
         }
 
-        ExecutorService logReplicationFSMWorkers = Executors.newFixedThreadPool(
-            DEFAULT_FSM_WORKER_THREADS, new ThreadFactoryBuilder()
-                .setNameFormat("state-machine-worker-" +
-                    params.getRemoteClusterDescriptor().getClusterId()).build());
+        ExecutorService logReplicationFSMWorkers = Executors.newFixedThreadPool(DEFAULT_FSM_WORKER_THREADS,
+            new ThreadFactoryBuilder().setNameFormat("state-machine-worker-" + replicationSession.getRemoteClusterId())
+                .build());
 
         ReadProcessor readProcessor = new DefaultReadProcessor(runtime);
         this.metadataManager = metadataManager;
         // Ack Reader for Snapshot and LogEntry Sync
-        this.ackReader = new LogReplicationAckReader(this.metadataManager, config,
-            runtime, params.getRemoteClusterDescriptor().getClusterId());
+        this.ackReader = new LogReplicationAckReader(this.metadataManager, config, runtime, replicationSession);
 
-        this.logReplicationFSM = new LogReplicationFSM(this.runtime, config,
-            params.getRemoteClusterDescriptor(), dataSender, readProcessor,
-            logReplicationFSMWorkers, ackReader, tableManagerPlugin);
+        this.logReplicationFSM = new LogReplicationFSM(this.runtime, config, dataSender, readProcessor,
+            logReplicationFSMWorkers, ackReader, tableManagerPlugin, replicationSession);
 
         this.logReplicationFSM.setTopologyConfigId(params.getTopologyConfigId());
         this.ackReader.setLogEntryReader(this.logReplicationFSM.getLogEntryReader());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationEvent.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationEvent.java
@@ -31,7 +31,7 @@ public class LogReplicationEvent {
                                     // replication for a shared thread pool)
         SYNC_CANCEL,                // External/Internal event requesting to cancel sync (snapshot or log entry)
         LOG_ENTRY_SYNC_REPLICATED,  // External event which signals a log entry sync has been successfully replicated
-                                    // on the standby cluster (ack)
+                                    // on the sink cluster (ack)
         REPLICATION_SHUTDOWN        // External/Internal event which signals log replication to be terminated (only a
                                     // JVM restart can enable log replication after this)
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -260,7 +260,8 @@ public class LogReplicationFSM {
         this.state = states.get(LogReplicationStateType.INITIALIZED);
         this.logReplicationFSMWorkers = workers;
         this.logReplicationFSMConsumer = Executors.newSingleThreadExecutor(new
-                ThreadFactoryBuilder().setNameFormat("replication-fsm-consumer").build());
+            ThreadFactoryBuilder().setNameFormat("replication-fsm-consumer-" +
+            remoteCluster.getClusterId()).build());
 
         logReplicationFSMConsumer.submit(this::consume);
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
-import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationAckReader;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent.LogReplicationEventType;
 import org.corfudb.infrastructure.logreplication.replication.send.LogEntrySender;
@@ -212,18 +212,21 @@ public class LogReplicationFSM {
      *
      * @param runtime Corfu Runtime
      * @param config log replication configuration
-     * @param remoteCluster remote cluster descriptor
      * @param dataSender implementation of a data sender, both snapshot and log entry, this represents
      *                   the application callback for data transmission
      * @param readProcessor read processor for data transformation
      * @param workers FSM executor service for state tasks
+     * @param ackReader AckReader which listens to acks from the Sink and updates the replication status accordingly
+     * @param tableManagerPlugin Plugin which builds the streams to replicate
+     * @param replicationSession Replication Session to the remote(Sink) cluster
      */
-    public LogReplicationFSM(CorfuRuntime runtime, LogReplicationConfig config, ClusterDescriptor remoteCluster, DataSender dataSender,
+    public LogReplicationFSM(CorfuRuntime runtime, LogReplicationConfig config, DataSender dataSender,
                              ReadProcessor readProcessor, ExecutorService workers, LogReplicationAckReader ackReader,
-                             LogReplicationConfigManager tableManagerPlugin) {
+                             LogReplicationConfigManager tableManagerPlugin, ReplicationSession replicationSession) {
         // Use stream-based readers for snapshot and log entry sync reads
-        this(runtime, new StreamsSnapshotReader(runtime, config), dataSender,
-                new StreamsLogEntryReader(runtime, config), readProcessor, config, remoteCluster, workers, ackReader, tableManagerPlugin);
+        this(runtime, new StreamsSnapshotReader(runtime, config, replicationSession), dataSender,
+            new StreamsLogEntryReader(runtime, config, replicationSession), readProcessor, config, workers, ackReader,
+            tableManagerPlugin, replicationSession);
     }
 
     /**
@@ -235,14 +238,13 @@ public class LogReplicationFSM {
      * @param dataSender application callback for snapshot and log entry sync messages
      * @param logEntryReader log entry logreader implementation
      * @param readProcessor read processor (for data transformation)
-     * @param remoteCluster Remote Cluster Descriptor to which this FSM drives the log replication
      * @param workers FSM executor service for state tasks
      */
     @VisibleForTesting
     public LogReplicationFSM(CorfuRuntime runtime, SnapshotReader snapshotReader, DataSender dataSender,
                              LogEntryReader logEntryReader, ReadProcessor readProcessor, LogReplicationConfig config,
-                             ClusterDescriptor remoteCluster, ExecutorService workers, LogReplicationAckReader ackReader,
-                             LogReplicationConfigManager tableManagerPlugin) {
+                             ExecutorService workers, LogReplicationAckReader ackReader,
+                             LogReplicationConfigManager tableManagerPlugin, ReplicationSession replicationSession) {
 
         this.snapshotReader = snapshotReader;
         this.logEntryReader = logEntryReader;
@@ -251,7 +253,8 @@ public class LogReplicationFSM {
 
         // Create transmitters to be used by the the sync states (Snapshot and LogEntry) to read and send data
         // through the callbacks provided by the application
-        snapshotSender = new SnapshotSender(runtime, snapshotReader, dataSender, readProcessor, config.getMaxNumMsgPerBatch(), this);
+        snapshotSender = new SnapshotSender(runtime, snapshotReader, dataSender, readProcessor,
+            config.getMaxNumMsgPerBatch(), this);
         logEntrySender = new LogEntrySender(logEntryReader, dataSender, this);
 
         // Initialize Log Replication 5 FSM states - single instance per state
@@ -260,12 +263,12 @@ public class LogReplicationFSM {
         this.state = states.get(LogReplicationStateType.INITIALIZED);
         this.logReplicationFSMWorkers = workers;
         this.logReplicationFSMConsumer = Executors.newSingleThreadExecutor(new
-            ThreadFactoryBuilder().setNameFormat("replication-fsm-consumer-" +
-            remoteCluster.getClusterId()).build());
+            ThreadFactoryBuilder().setNameFormat("replication-fsm-consumer-" + replicationSession.getRemoteClusterId())
+            .build());
 
         logReplicationFSMConsumer.submit(this::consume);
 
-        log.info("Log Replication FSM initialized, replicate to remote cluster {}", remoteCluster.getClusterId());
+        log.info("Log Replication FSM initialized, replicate to remote cluster {}", replicationSession.getRemoteClusterId());
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -34,7 +34,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  *
  * CorfuDB provides a Log Replication functionality, which allows logs to be automatically replicated from a primary
  * to a remote cluster. This feature is particularly useful in the event of failure or data corruption, so the system
- * can failover to the standby/secondary data-store.
+ * can failover to the sink/secondary data-store.
  *
  * This functionality is initiated by the application through the LogReplicationSourceManager on the primary cluster and handled
  * through the LogReplicationSinkManager on the destination cluster. This implementation assumes that the application provides its own

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -21,7 +21,6 @@ import org.corfudb.runtime.CorfuStoreMetadata;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStoreEntry;
-import org.corfudb.runtime.collections.StreamListener;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
@@ -36,7 +35,6 @@ import org.corfudb.util.retry.IntervalRetry;
 import org.corfudb.util.retry.RetryNeededException;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -57,8 +55,8 @@ public class LogReplicationMetadataManager {
     public static final String METADATA_TABLE_PREFIX_NAME = "CORFU-REPLICATION-WRITER-";
     public static final String REPLICATION_STATUS_TABLE = "LogReplicationStatus";
     public static final String LR_STATUS_STREAM_TAG = "lr_status";
-    private static final String REPLICATION_EVENT_TABLE_NAME = "LogReplicationEventTable";
-    private static final String LR_STREAM_TAG = "log_replication";
+    public static final String REPLICATION_EVENT_TABLE_NAME = "LogReplicationEventTable";
+    public static final String LR_STREAM_TAG = "log_replication";
 
     private final CorfuStore corfuStore;
 
@@ -67,7 +65,7 @@ public class LogReplicationMetadataManager {
     @Getter
     private final CorfuRuntime runtime;
 
-    private final String localClusterId;
+    private final String remoteClusterId;
 
     private final Table<ReplicationStatusKey, ReplicationStatusVal, Message> replicationStatusTable;
     private final Table<LogReplicationMetadataKey, LogReplicationMetadataVal, Message> metadataTable;
@@ -75,34 +73,34 @@ public class LogReplicationMetadataManager {
 
     private Optional<Timer.Sample> snapshotSyncTimerSample = Optional.empty();
 
-    public LogReplicationMetadataManager(CorfuRuntime rt, long topologyConfigId, String localClusterId) {
+    public LogReplicationMetadataManager(CorfuRuntime rt, long topologyConfigId, String remoteClusterId) {
         this.runtime = rt;
         this.corfuStore = new CorfuStore(runtime);
 
-        metadataTableName = getPersistedWriterMetadataTableName(localClusterId);
+        metadataTableName = getPersistedWriterMetadataTableName(remoteClusterId);
         try {
             this.metadataTable = this.corfuStore.openTable(NAMESPACE,
-                            metadataTableName,
-                            LogReplicationMetadataKey.class,
-                            LogReplicationMetadataVal.class,
-                            null,
-                            TableOptions.fromProtoSchema(LogReplicationMetadataVal.class));
+                metadataTableName,
+                LogReplicationMetadataKey.class,
+                LogReplicationMetadataVal.class,
+                null,
+                TableOptions.fromProtoSchema(LogReplicationMetadataVal.class));
 
             this.replicationStatusTable = this.corfuStore.openTable(NAMESPACE,
-                            REPLICATION_STATUS_TABLE,
-                            ReplicationStatusKey.class,
-                            ReplicationStatusVal.class,
-                            null,
-                            TableOptions.fromProtoSchema(ReplicationStatusVal.class));
+                REPLICATION_STATUS_TABLE,
+                ReplicationStatusKey.class,
+                ReplicationStatusVal.class,
+                null,
+                TableOptions.fromProtoSchema(ReplicationStatusVal.class));
 
             this.replicationEventTable = this.corfuStore.openTable(NAMESPACE,
-                    REPLICATION_EVENT_TABLE_NAME,
-                    ReplicationEventKey.class,
-                    ReplicationEvent.class,
-                    null,
-                    TableOptions.fromProtoSchema(ReplicationEvent.class));
+                REPLICATION_EVENT_TABLE_NAME,
+                ReplicationEventKey.class,
+                ReplicationEvent.class,
+                null,
+                TableOptions.fromProtoSchema(ReplicationEvent.class));
 
-            this.localClusterId = localClusterId;
+            this.remoteClusterId = remoteClusterId;
         } catch (Exception e) {
             log.error("Caught an exception while opening MetadataManagerTables ", e);
             throw new ReplicationWriterException(e);
@@ -260,16 +258,14 @@ public class LogReplicationMetadataManager {
                     }
                     txn.commit();
                 } catch (TransactionAbortedException e) {
-                    log.error("Exception when updating the topology config id",
-                        e);
+                    log.error("Exception when updating the topology config id", e);
                     throw new RetryNeededException();
                 }
                 log.info("Update topologyConfigId, new metadata {}", this);
                 return null;
             }).run();
         } catch (InterruptedException e) {
-            log.error("Unrecoverable exception when updating the topology " +
-                "config id", e);
+            log.error("Unrecoverable exception when updating the topology config id", e);
             throw new UnrecoverableCorfuInterruptedError(e);
         }
     }
@@ -390,13 +386,7 @@ public class LogReplicationMetadataManager {
             // Set 'isDataConsistent' flag on replication status table atomically with snapshot sync completed
             // information, to prevent any inconsistency between flag and state of snapshot sync completion in
             // the event of crashes
-            ReplicationStatusVal statusValue = ReplicationStatusVal.newBuilder()
-                    .setDataConsistent(true)
-                    .setStatus(SyncStatus.UNAVAILABLE)
-                    .build();
-            txn.putRecord(replicationStatusTable, ReplicationStatusKey.newBuilder().setClusterId(localClusterId).build(),
-                    statusValue, null);
-
+            setDataConsistentOnStandby(true, txn);
             txn.commit();
             log.debug("Commit snapshot apply complete timestamp={}, for topologyConfigId={}", ts, topologyConfigId);
         }
@@ -576,7 +566,7 @@ public class LogReplicationMetadataManager {
                 txn.putRecord(replicationStatusTable, key, current, null);
                 txn.commit();
             }
-            
+
             log.debug("syncStatusPoller :: Log Entry status set to ONGOING, clusterId: {}, remainingEntries: {}, " +
                             "snapshotSyncInfo: {}", clusterId, remainingEntries, snapshotStatus);
         } else if (type == SyncType.SNAPSHOT) {
@@ -616,9 +606,15 @@ public class LogReplicationMetadataManager {
         }
     }
 
-    public Map<String, ReplicationStatusVal> getReplicationRemainingEntries() {
+    // Note: This class is currently instantiated per remote cluster.  In a
+    // subsequent PR, change to share a single instance for all remote
+    // clusters will be added.  This method returns the replication status
+    // for all remote clusters.
+    public Map<String, ReplicationStatusVal> getReplicationStatus() {
+
         Map<String, ReplicationStatusVal> replicationStatusMap = new HashMap<>();
         List<CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, Message>> entries;
+
         try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
             entries = txn.executeQuery(replicationStatusTable, record -> true);
             txn.commit();
@@ -628,13 +624,9 @@ public class LogReplicationMetadataManager {
             String clusterId = entry.getKey().getClusterId();
             ReplicationStatusVal value = entry.getPayload();
             replicationStatusMap.put(clusterId, value);
-            log.debug("getReplicationRemainingEntries: clusterId={}, remainingEntriesToSend={}, " +
-                    "syncType={}, is_consistent={}", clusterId, value.getRemainingEntriesToSend(),
-                    value.getSyncType(), value.getDataConsistent());
+            log.debug("getReplicationStatus: clusterId={}, remainingEntriesToSend={}, syncType={}, is_consistent={}",
+                clusterId, value.getRemainingEntriesToSend(), value.getSyncType(), value.getDataConsistent());
         }
-
-        log.debug("getReplicationRemainingEntries: replicationStatusMap size: {}", replicationStatusMap.size());
-
         return replicationStatusMap;
     }
 
@@ -646,7 +638,8 @@ public class LogReplicationMetadataManager {
      * @param isConsistent data is consistent or not
      */
     public void setDataConsistentOnStandby(boolean isConsistent) {
-        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(localClusterId).build();
+        ReplicationStatusKey key =
+            ReplicationStatusKey.newBuilder().setClusterId(remoteClusterId).build();
         ReplicationStatusVal val = ReplicationStatusVal.newBuilder()
                 .setDataConsistent(isConsistent)
                 .setStatus(SyncStatus.UNAVAILABLE)
@@ -656,38 +649,47 @@ public class LogReplicationMetadataManager {
             txn.commit();
         }
 
-        log.debug("setDataConsistentOnStandby: localClusterId: {}, isConsistent: {}", localClusterId, isConsistent);
+        log.debug("setDataConsistentOnStandby: remoteClusterId: {}, " +
+            "isConsistent: {}", remoteClusterId, isConsistent);
     }
 
-    public Map<String, ReplicationStatusVal> getDataConsistentOnStandby() {
-        CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, Message> record;
-        ReplicationStatusVal statusVal;
-
-        try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-            record = txn.getRecord(replicationStatusTable, ReplicationStatusKey.newBuilder().setClusterId(localClusterId).build());
-            txn.commit();
-        }
-
-        // Initially, snapshot sync is pending so the data is not consistent.
-        if (record.getPayload() == null) {
-            log.warn("DataConsistent status is not set for local cluster {}", localClusterId);
-            statusVal = ReplicationStatusVal.newBuilder().setDataConsistent(false).build();
-        } else {
-            statusVal = record.getPayload();
-        }
-        Map<String, ReplicationStatusVal> dataConsistentMap = new HashMap<>();
-        dataConsistentMap.put(localClusterId, statusVal);
-
-        log.debug("getDataConsistentOnStandby: localClusterId: {}, statusVal: {}", localClusterId, statusVal);
-
-        return dataConsistentMap;
+    public void setDataConsistentOnStandby(boolean isConsistent, TxnContext txn) {
+        ReplicationStatusKey key =
+            ReplicationStatusKey.newBuilder().setClusterId(remoteClusterId).build();
+        ReplicationStatusVal val = ReplicationStatusVal.newBuilder()
+            .setDataConsistent(isConsistent)
+            .setStatus(SyncStatus.UNAVAILABLE)
+            .build();
+        txn.putRecord(replicationStatusTable, key, val, null);
     }
 
     public void resetReplicationStatus() {
         log.info("syncStatus :: reset replication status");
-        try (TxnContext tx = corfuStore.txn(replicationStatusTable.getNamespace())) {
-            replicationStatusTable.clearAll();
+        try (TxnContext tx = corfuStore.txn(NAMESPACE)) {
+            tx.clear(REPLICATION_STATUS_TABLE);
             tx.commit();
+        }
+    }
+
+    // Initialize the ReplicationStatus table with a default entry depending on the role.
+    // If the role is Source, the default sync type=LOG_ENTRY and status=NOT_STARTED.
+    // If the role is Sink and no record for the remote cluster is found, isDataConsistent=false.
+    public void initReplicationStatus(boolean isSource) {
+        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(remoteClusterId).build();
+        try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+            ReplicationStatusVal currentVal =
+                (ReplicationStatusVal) txn.getRecord(REPLICATION_STATUS_TABLE, key).getPayload();
+
+            if (currentVal == null) {
+                currentVal = ReplicationStatusVal.newBuilder().build();
+            }
+
+            ReplicationStatusVal newVal = currentVal;
+            if (isSource) {
+                newVal = currentVal.toBuilder().setSyncType(SyncType.LOG_ENTRY).setStatus(SyncStatus.NOT_STARTED).build();
+            }
+            txn.putRecord(replicationStatusTable, key, newVal, null);
+            txn.commit();
         }
     }
 
@@ -720,12 +722,17 @@ public class LogReplicationMetadataManager {
             }
             builder.append(" ");
         }
-        builder.append("Replication Completion: ");
-        Map<String, ReplicationStatusVal> replicationStatusMap = getReplicationRemainingEntries();
-        replicationStatusMap.entrySet().forEach( entry -> builder.append(entry.getKey())
-                .append(entry.getValue().getRemainingEntriesToSend()));
+        builder.append("Replication Status: ");
+        Map<String, ReplicationStatusVal> replicationStatusMap = getReplicationStatus();
 
-        builder.append("Data Consistent: ").append(getDataConsistentOnStandby());
+        for (Map.Entry<String, ReplicationStatusVal> entry :
+            replicationStatusMap.entrySet()) {
+            builder.append(entry.getKey())
+                .append("Remaining Entries to Send(if active/source): ")
+                .append(entry.getValue().getRemainingEntriesToSend())
+                .append("Data Consistent(if standby/sink):")
+                .append(entry.getValue().getDataConsistent());
+        }
         return builder.toString();
     }
 
@@ -782,23 +789,6 @@ public class LogReplicationMetadataManager {
             txn.putRecord(replicationEventTable, key, event, null);
             txn.commit();
         }
-    }
-
-    /**
-     * Subscribe to the logReplicationEventTable
-     * @param listener
-     */
-    public void subscribeReplicationEventTable(StreamListener listener) {
-        log.info("LogReplication start listener for table {}", REPLICATION_EVENT_TABLE_NAME);
-        corfuStore.subscribeListener(listener, NAMESPACE, LR_STREAM_TAG, Collections.singletonList(REPLICATION_EVENT_TABLE_NAME));
-    }
-
-    /**
-     * Unsubscribe the logReplicationEventTable
-     * @param listener
-     */
-    public void unsubscribeReplicationEventTable(StreamListener listener) {
-        corfuStore.unsubscribeListener(listener);
     }
 
     public void shutdown() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -386,7 +386,7 @@ public class LogReplicationMetadataManager {
             // Set 'isDataConsistent' flag on replication status table atomically with snapshot sync completed
             // information, to prevent any inconsistency between flag and state of snapshot sync completion in
             // the event of crashes
-            setDataConsistentOnStandby(true, txn);
+            setDataConsistentOnSink(true, txn);
             txn.commit();
             log.debug("Commit snapshot apply complete timestamp={}, for topologyConfigId={}", ts, topologyConfigId);
         }
@@ -397,7 +397,7 @@ public class LogReplicationMetadataManager {
      *
      * Note: TransactionAbortedException has been handled by upper level.
      *
-     * @param clusterId standby cluster id
+     * @param clusterId sink cluster id
      */
     public void updateSnapshotSyncStatusOngoing(String clusterId, boolean forced, UUID eventId,
                                                 long baseVersion, long remainingEntries) {
@@ -439,7 +439,7 @@ public class LogReplicationMetadataManager {
      *
      * Note: TransactionAbortedException has been handled by upper level.
      *
-     * @param clusterId standby cluster id
+     * @param clusterId sink cluster id
      */
     public void updateSnapshotSyncStatusCompleted(String clusterId, long remainingEntriesToSend, long baseSnapshot) {
         Instant time = Instant.now();
@@ -489,7 +489,7 @@ public class LogReplicationMetadataManager {
      *
      * Note: TransactionAbortedException has been handled by upper level.
      *
-     * @param clusterId standby cluster id
+     * @param clusterId sink cluster id
      */
     public void updateSyncStatus(String clusterId, SyncType lastSyncType, SyncStatus status) {
         ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(clusterId).build();
@@ -522,7 +522,7 @@ public class LogReplicationMetadataManager {
      *
      * Note: TransactionAbortedException has been handled by upper level.
      *
-     * @param clusterId standby cluster id
+     * @param clusterId sink cluster id
      * @param remainingEntries num of remaining entries to send
      * @param type sync type
      */
@@ -631,13 +631,13 @@ public class LogReplicationMetadataManager {
     }
 
     /**
-     * Set DataConsistent field in status table on standby side.
+     * Set DataConsistent field in status table on sink side.
      *
      * Note: TransactionAbortedException has been handled by upper level.
      *
      * @param isConsistent data is consistent or not
      */
-    public void setDataConsistentOnStandby(boolean isConsistent) {
+    public void setDataConsistentOnSink(boolean isConsistent) {
         ReplicationStatusKey key =
             ReplicationStatusKey.newBuilder().setClusterId(remoteClusterId).build();
         ReplicationStatusVal val = ReplicationStatusVal.newBuilder()
@@ -649,11 +649,11 @@ public class LogReplicationMetadataManager {
             txn.commit();
         }
 
-        log.debug("setDataConsistentOnStandby: remoteClusterId: {}, " +
+        log.debug("setDataConsistentOnSink: remoteClusterId: {}, " +
             "isConsistent: {}", remoteClusterId, isConsistent);
     }
 
-    public void setDataConsistentOnStandby(boolean isConsistent, TxnContext txn) {
+    public void setDataConsistentOnSink(boolean isConsistent, TxnContext txn) {
         ReplicationStatusKey key =
             ReplicationStatusKey.newBuilder().setClusterId(remoteClusterId).build();
         ReplicationStatusVal val = ReplicationStatusVal.newBuilder()
@@ -728,9 +728,9 @@ public class LogReplicationMetadataManager {
         for (Map.Entry<String, ReplicationStatusVal> entry :
             replicationStatusMap.entrySet()) {
             builder.append(entry.getKey())
-                .append("Remaining Entries to Send(if active/source): ")
+                .append("Remaining Entries to Send(if source): ")
                 .append(entry.getValue().getRemainingEntriesToSend())
-                .append("Data Consistent(if standby/sink):")
+                .append("Data Consistent(if sink):")
                 .append(entry.getValue().getDataConsistent());
         }
         return builder.toString();
@@ -806,7 +806,7 @@ public class LogReplicationMetadataManager {
         CURRENT_CYCLE_MIN_SHADOW_STREAM_TS("minShadowStreamTimestamp"),
         LAST_LOG_ENTRY_PROCESSED("lastLogEntryProcessed"),
         REMAINING_REPLICATION_PERCENT("replicationStatus"),
-        DATA_CONSISTENT_ON_STANDBY("dataConsistentOnStandby"),
+        DATA_CONSISTENT_ON_SINK("dataConsistentOnSink"),
         SNAPSHOT_SYNC_TYPE("snapshotSyncType"),
         SNAPSHOT_SYNC_COMPLETE_TIME("snapshotSyncCompleteTime");
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -83,6 +83,10 @@ public class LogReplicationSinkManager implements DataReceiver {
     // Current topologyConfigId, used to drop out of date messages.
     private long topologyConfigId = 0;
 
+    // Cluster id of the Source cluster from which this Sink Manager receives updates
+    @Getter
+    private String sourceClusterId = null;
+
     @VisibleForTesting
     private int rxMessageCounter = 0;
 
@@ -110,7 +114,8 @@ public class LogReplicationSinkManager implements DataReceiver {
      */
     public LogReplicationSinkManager(String localCorfuEndpoint, LogReplicationConfig config,
                                      LogReplicationMetadataManager metadataManager,
-                                     ServerContext context, long topologyConfigId) {
+                                     ServerContext context, long topologyConfigId,
+                                     String remoteClusterId) {
 
         this.runtime = CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder()
                 .trustStore((String) context.getServerConfig().get(ConfigParamNames.TRUST_STORE))
@@ -124,7 +129,7 @@ public class LogReplicationSinkManager implements DataReceiver {
                 .parseConfigurationString(localCorfuEndpoint).connect();
         this.pluginConfigFilePath = context.getPluginConfigFilePath();
         this.topologyConfigId = topologyConfigId;
-        init(metadataManager, config);
+        init(metadataManager, config, remoteClusterId);
     }
 
     /**
@@ -137,11 +142,10 @@ public class LogReplicationSinkManager implements DataReceiver {
     public LogReplicationSinkManager(String localCorfuEndpoint, LogReplicationConfig config,
                                      LogReplicationMetadataManager metadataManager, String pluginConfigFilePath) {
         this.runtime =  CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters.builder()
-                .maxCacheEntries(config.getMaxCacheSize())
-                .build())
+                .maxCacheEntries(config.getMaxCacheSize()).build())
                 .parseConfigurationString(localCorfuEndpoint).connect();
         this.pluginConfigFilePath = pluginConfigFilePath;
-        init(metadataManager, config);
+        init(metadataManager, config, sourceClusterId);
     }
 
     /**
@@ -150,7 +154,9 @@ public class LogReplicationSinkManager implements DataReceiver {
      * @param metadataManager metadata manager instance
      * @param config log replication configuration
      */
-    private void init(LogReplicationMetadataManager metadataManager, LogReplicationConfig config) {
+    private void init(LogReplicationMetadataManager metadataManager,
+                      LogReplicationConfig config, String remoteClusterId) {
+        this.sourceClusterId = remoteClusterId;
         this.logReplicationMetadataManager = metadataManager;
         this.config = config;
 
@@ -162,7 +168,7 @@ public class LogReplicationSinkManager implements DataReceiver {
         this.applyExecutor = Executors.newSingleThreadExecutor(
                 new ThreadFactoryBuilder()
                         .setDaemon(true)
-                        .setNameFormat("snapshotSyncApplyExecutor")
+                        .setNameFormat("snapshotSyncApplyExecutor-" + remoteClusterId)
                         .build());
 
         initWriterAndBufferMgr();
@@ -198,9 +204,10 @@ public class LogReplicationSinkManager implements DataReceiver {
         // Instantiate Snapshot Sync Plugin, this is an external service which will be triggered on start and end
         // of a snapshot sync.
         snapshotSyncPlugin = getOnSnapshotSyncPlugin();
-
-        snapshotWriter = new StreamsSnapshotWriter(runtime, config, logReplicationMetadataManager);
-        logEntryWriter = new LogEntryWriter(runtime, config, logReplicationMetadataManager);
+        snapshotWriter = new StreamsSnapshotWriter(runtime, config,
+            logReplicationMetadataManager);
+        logEntryWriter = new LogEntryWriter(runtime, config,
+            logReplicationMetadataManager);
         logEntryWriter.reset(logReplicationMetadataManager.getLastAppliedSnapshotTimestamp(),
                 logReplicationMetadataManager.getLastProcessedLogEntryTimestamp());
 
@@ -568,7 +575,7 @@ public class LogReplicationSinkManager implements DataReceiver {
         // Construct Log Replication Entry message used to complete the Snapshot Sync with info in the metadata manager
         LogReplicationEntryMetadataMsg metadata = LogReplicationEntryMetadataMsg.newBuilder()
                 .setEntryType(LogReplicationEntryType.SNAPSHOT_END)
-                .setTopologyConfigID(logReplicationMetadataManager.getTopologyConfigId())
+                .setTopologyConfigID(topologyConfigId)
                 .setTimestamp(-1L)
                 .setSnapshotTimestamp(snapshotTransferTs)
                 .setSyncRequestId(getUuidMsg(snapshotSyncId)).build();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -179,7 +179,7 @@ public class LogReplicationSinkManager implements DataReceiver {
         try {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
-                    logReplicationMetadataManager.setDataConsistentOnStandby(isDataConsistent);
+                    logReplicationMetadataManager.setDataConsistentOnSink(isDataConsistent);
                 } catch (TransactionAbortedException tae) {
                     log.error("Error while attempting to setDataConsistent in SinkManager's init", tae);
                     throw new RetryNeededException();
@@ -585,7 +585,7 @@ public class LogReplicationSinkManager implements DataReceiver {
      * Stop any functions on Sink Manager when leadership is lost
      */
     public void stopOnLeadershipLoss() {
-        // If current sink/standby is in TRANSFER phase, trigger end of snapshot sync (unfreeze checkpoint) as we
+        // If current sink is in TRANSFER phase, trigger end of snapshot sync (unfreeze checkpoint) as we
         // don't know when snapshot sync might be started again.
         // If in APPLY phase do not unfreeze or shadow streams could be lost. This change was done near the release
         // date we don't know if we would be able to recover from this (test this scenario)

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkBufferManager.java
@@ -151,8 +151,8 @@ public abstract class SinkBufferManager {
             //TODO: we create an ACK using the metadata of the last recevied msg, and then override
             // the timestamp with lastProcessedTs. So the rest of the ACK metadata does not match
             // with the ACK.Timestamp().
-            // Currently its fine since active only consumes the ACK.timestamp()...but if the behaviour
-            // changes on active, we need to change it here as well
+            // Currently its fine since source only consumes the ACK.timestamp()...but if the behaviour
+            // changes on source, we need to change it here as well
             LogReplicationEntryMetadataMsg metadata = generateAckMetadata(dataMessage);
             log.trace("Sending an ACK {}", metadata);
             return getLrEntryAckMsg(metadata);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -47,7 +47,7 @@ import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MER
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.REGISTRY_TABLE_ID;
 
 /**
- * This class represents the entity responsible of writing streams' snapshots into the standby cluster DB.
+ * This class represents the entity responsible of writing streams' snapshots into the sink cluster DB.
  *
  * Snapshot sync is the process of transferring a snapshot of the DB, for this reason, data is temporarily applied
  * to shadow streams in an effort to avoid inconsistent states. Once all the data is received, the shadow streams
@@ -77,7 +77,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
     @Getter
     private final LogReplicationMetadataManager logReplicationMetadataManager;
 
-    // Represents the actual replicated streams from active. This is a subset of all regular streams in
+    // Represents the actual replicated streams from source. This is a subset of all regular streams in
     // regularToShadowStreamId map
     private final Set<UUID> replicatedStreamIds = new HashSet<>();
 
@@ -107,7 +107,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
      *
      * We create a shadow stream per stream to replicate. A shadow stream aims to accumulate updates
      * temporarily while the (full) snapshot sync completes. Shadow streams aim to avoid inconsistent
-     * states while data is still being transferred from active to standby.
+     * states while data is still being transferred from source to sink.
      *
      * We currently, wait for snapshot sync to complete before applying data in shadow streams
      * to the actual streams, this means that there is still a window of inconsistency as apply is not atomic,
@@ -129,7 +129,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
             log.trace("Shadow stream=[{}] for regular stream=[{}] name=({})", shadowStreamId, streamId, streamName);
         }
 
-        log.info("Stream tag map for streaming on Standby/Sink total={}, streams={}", dataStreamToTagsMap.size(),
+        log.info("Stream tag map for streaming on Sink total={}, streams={}", dataStreamToTagsMap.size(),
                 dataStreamToTagsMap);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogEntrySender.java
@@ -9,7 +9,6 @@ import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationE
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent.LogReplicationEventType;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationFSM;
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.LogEntryReader;
-import org.corfudb.infrastructure.logreplication.replication.send.logreader.ReadProcessor;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.exceptions.TrimmedException;
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
@@ -163,7 +163,6 @@ public abstract class SenderBufferManager {
         if (!pendingCompletableFutureForAcks.isEmpty()) {
             ack = (LogReplicationEntryMsg) CompletableFuture.anyOf(pendingCompletableFutureForAcks
                     .values().toArray(new CompletableFuture<?>[pendingCompletableFutureForAcks.size()])).get(timeoutTimer, TimeUnit.MILLISECONDS);
-
             if (ack != null) {
                 updateAck(ack);
                 ackCounter.ifPresent(ac -> ac.addAndGet(pendingCompletableFutureForAcks.size()));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -184,7 +184,7 @@ public class SnapshotSender {
                 snapshotSyncAck.get(DEFAULT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
                 snapshotSyncTransferComplete(snapshotSyncEventId);
             } catch (Exception e) {
-                log.warn("Caught exception while sending data to standby.", e);
+                log.warn("Caught exception while sending data to sink.", e);
                 snapshotSyncCancel(snapshotSyncEventId, LogReplicationError.UNKNOWN);
             }
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
@@ -9,6 +9,7 @@ import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.CorfuRuntime;
@@ -80,7 +81,8 @@ public class StreamsLogEntryReader implements LogEntryReader {
 
     private StreamIteratorMetadata currentProcessedEntryMetadata;
 
-    public StreamsLogEntryReader(CorfuRuntime runtime, LogReplicationConfig config) {
+    public StreamsLogEntryReader(CorfuRuntime runtime, LogReplicationConfig config,
+                                 ReplicationSession replicationSession) {
         runtime.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
         this.maxDataSizePerMsg = config.getMaxDataSizePerMsg();
         this.currentProcessedEntryMetadata = new StreamIteratorMetadata(Address.NON_ADDRESS, false);
@@ -88,7 +90,7 @@ public class StreamsLogEntryReader implements LogEntryReader {
         this.deltaCounter = configureDeltaCounter();
         this.validDeltaCounter = configureValidDeltaCounter();
         this.opaqueEntryCounter = configureOpaqueEntryCounter();
-        Set<String> streams = config.getStreamsToReplicate();
+        Set<String> streams = config.getReplicationSubscriberToStreamsMap().get(replicationSession.getSubscriber());
 
         streamUUIDs = new HashSet<>();
         for (String s : streams) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
@@ -9,6 +9,7 @@ import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.common.util.Memory;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.send.IllegalSnapshotEntrySizeException;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
@@ -73,11 +74,12 @@ public class StreamsSnapshotReader implements SnapshotReader {
     /**
      * Init runtime and streams to read
      */
-    public StreamsSnapshotReader(CorfuRuntime runtime, LogReplicationConfig config) {
+    public StreamsSnapshotReader(CorfuRuntime runtime, LogReplicationConfig config,
+                                 ReplicationSession replicationSession) {
         this.rt = runtime;
         this.rt.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
         this.maxDataSizePerMsg = config.getMaxDataSizePerMsg();
-        this.streams = config.getStreamsToReplicate();
+        this.streams = config.getReplicationSubscriberToStreamsMap().get(replicationSession.getSubscriber());
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -37,7 +37,7 @@ import java.util.concurrent.TimeUnit;
  * Runtime to connect to a remote Corfu Log Replication Cluster.
  * <p>
  * This class represents the Log Replication Runtime Finite State Machine, which defines
- * all states in which the leader node on the active cluster can be.
+ * all states in which the leader node on the source cluster can be.
  *
  *
  *                                                  R-LEADER_LOSS / NOT_FOUND

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.infrastructure.TopologyDescriptor;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationSourceManager;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
@@ -162,19 +163,17 @@ public class CorfuLogReplicationRuntime {
      * Default Constructor
      */
     public CorfuLogReplicationRuntime(LogReplicationRuntimeParameters parameters, LogReplicationMetadataManager metadataManager,
-                                      LogReplicationConfigManager replicationConfigManager) {
-        this.remoteClusterId = parameters.getRemoteClusterDescriptor().getClusterId();
+        LogReplicationConfigManager replicationConfigManager, ReplicationSession replicationSession) {
+        this.remoteClusterId = replicationSession.getRemoteClusterId();
         this.metadataManager = metadataManager;
         this.router = new LogReplicationClientRouter(parameters, this);
         this.router.addClient(new LogReplicationHandler());
         this.sourceManager = new LogReplicationSourceManager(parameters,
-            new LogReplicationClient(router, remoteClusterId), metadataManager,
-            replicationConfigManager);
+            new LogReplicationClient(router, remoteClusterId), metadataManager, replicationConfigManager, replicationSession);
         this.connectedNodes = new HashSet<>();
 
-        ThreadFactory threadFactory =
-            new ThreadFactoryBuilder().setNameFormat(
-                "runtime-fsm-worker-"+remoteClusterId).build();
+        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("runtime-fsm-worker-"+remoteClusterId)
+            .build();
 
         this.communicationFSMWorkers = new ThreadPoolExecutor(1, 1, 0L,
             TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), threadFactory);
@@ -210,7 +209,8 @@ public class CorfuLogReplicationRuntime {
          * per every transition (reduce GC cycles).
          */
         states.put(LogReplicationRuntimeStateType.WAITING_FOR_CONNECTIVITY, new WaitingForConnectionsState(this));
-        states.put(LogReplicationRuntimeStateType.VERIFYING_REMOTE_LEADER, new VerifyingRemoteLeaderState(this, communicationFSMWorkers, router));
+        states.put(LogReplicationRuntimeStateType.VERIFYING_REMOTE_LEADER, new VerifyingRemoteLeaderState(this,
+            communicationFSMWorkers, router));
         states.put(LogReplicationRuntimeStateType.NEGOTIATING, new NegotiatingState(this, communicationFSMWorkers,
                 router, metadataManager, replicationConfigManager));
         states.put(LogReplicationRuntimeStateType.REPLICATING, new ReplicatingState(this, sourceManager));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -167,14 +167,22 @@ public class CorfuLogReplicationRuntime {
         this.metadataManager = metadataManager;
         this.router = new LogReplicationClientRouter(parameters, this);
         this.router.addClient(new LogReplicationHandler());
-        this.sourceManager = new LogReplicationSourceManager(parameters, new LogReplicationClient(router, remoteClusterId),
-                metadataManager, replicationConfigManager);
+        this.sourceManager = new LogReplicationSourceManager(parameters,
+            new LogReplicationClient(router, remoteClusterId), metadataManager,
+            replicationConfigManager);
         this.connectedNodes = new HashSet<>();
-        ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("runtime-fsm-worker").build();
+
+        ThreadFactory threadFactory =
+            new ThreadFactoryBuilder().setNameFormat(
+                "runtime-fsm-worker-"+remoteClusterId).build();
+
         this.communicationFSMWorkers = new ThreadPoolExecutor(1, 1, 0L,
-                TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), threadFactory);
+            TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(), threadFactory);
+
         this.communicationFSMConsumer = Executors.newSingleThreadExecutor(new
-                ThreadFactoryBuilder().setNameFormat("runtime-fsm-consumer").build());
+                ThreadFactoryBuilder().setNameFormat(
+                    "runtime-fsm-consumer-"+remoteClusterId).build());
+
         this.replicationConfigManager = replicationConfigManager;
 
         initializeStates();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClient.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClient.java
@@ -13,7 +13,7 @@ import org.corfudb.runtime.proto.service.CorfuMessage;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
-import static org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientRouter.REMOTE_LEADER;
+import static org.corfudb.infrastructure.logreplication.runtime.ReplicationSourceRouter.REMOTE_LEADER;
 
 /**
  * A client to send messages to the Log Replication Unit.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -190,6 +191,8 @@ public class LogReplicationClientRouter implements IClientRouter {
             try {
                 header.setClientId(getUuidMsg(parameters.getClientId()));
                 header.setRequestId(requestId);
+                header.setClusterId(getUuidMsg(
+                    UUID.fromString(parameters.getLocalClusterId())));
 
                 // If no endpoint is specified, the message is to be sent to the remote leader node.
                 // We should block until a connection to the leader is established.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationHandler.java
@@ -62,7 +62,7 @@ public class LogReplicationHandler implements IClient, IHandler<LogReplicationCl
     private static Object handleLogReplicationAck(@Nonnull ResponseMsg response,
                                                   @Nonnull ChannelHandlerContext ctx,
                                                   @Nonnull IClientRouter router) {
-        log.debug("Handle log replication ACK");
+        log.debug("Handle log replication ACK {}", response);
         return response.getPayload().getLrEntryAck();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/ReplicationRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/ReplicationRouter.java
@@ -1,0 +1,93 @@
+package org.corfudb.infrastructure.logreplication.runtime;
+
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
+import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationManager;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
+import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
+import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.proto.service.CorfuMessage;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+@Slf4j
+public abstract class ReplicationRouter {
+
+    /**
+     * Adapter to the channel implementation
+     */
+    IClientChannelAdapter channelAdapter;
+
+    /**
+     * Remote Cluster/Site Full Descriptor
+     */
+    final ClusterDescriptor remoteClusterDescriptor;
+
+    final String pluginFilePath;
+
+
+    String localClusterId;
+
+    ReplicationSession session;
+
+    boolean isSource;
+
+
+    public ReplicationRouter(ClusterDescriptor remoteCluster, String localClusterId, String pluginFilePath, ReplicationSession session, boolean isSource) {
+        this.remoteClusterDescriptor = remoteCluster;
+        this.pluginFilePath = pluginFilePath;
+        this.localClusterId = localClusterId;
+        // this will be required when the sink is the connection initiator
+        this.session = session;
+        this.isSource = isSource;
+    }
+
+    /**
+     * Connect to remote cluster through the specified channel adapter
+     */
+    public void connect() {
+        LogReplicationPluginConfig config = new LogReplicationPluginConfig(this.pluginFilePath);
+        File jar = new File(config.getTransportAdapterJARPath());
+
+        try (URLClassLoader child = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader())) {
+            // Instantiate Channel Adapter (external implementation of the channel / transport)
+            Class adapterType = Class.forName(config.getTransportClientClassCanonicalName(), true, child);
+            channelAdapter = (IClientChannelAdapter) adapterType.getDeclaredConstructor(String.class, ClusterDescriptor.class, ReplicationSourceRouter.class, ReplicationSinkClientRouter.class)
+                    .newInstance(this.localClusterId, remoteClusterDescriptor, isSource ? this : null, isSource ? null : this);
+            log.info("Connect asynchronously to remote cluster {} and session {} ", remoteClusterDescriptor.getClusterId(), this.session);
+            // When connection is established to the remote leader node, the remoteLeaderConnectionFuture will be completed.
+            channelAdapter.connectAsync();
+        } catch (Exception e) {
+            log.error("Fatal error: Failed to initialize transport adapter {}", config.getTransportClientClassCanonicalName(), e);
+            throw new UnrecoverableCorfuError(e);
+        }
+    }
+
+    /**
+     * Connection Up Callback.
+     *
+     * @param nodeId id of the remote node to which connection was established.
+     */
+    public abstract void onConnectionUp(String nodeId);
+
+    /**
+     * Connection Down Callback.
+     *
+     * @param nodeId id of the remote node to which connection came down.
+     */
+    public abstract void onConnectionDown(String nodeId);
+
+    public  abstract void  onError(Throwable t);
+
+    public abstract void receive(CorfuMessage.ResponseMsg msg);
+
+    public abstract void receive(CorfuMessage.RequestMsg msg);
+
+    public abstract void completeAllExceptionally(Exception e);
+
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/ReplicationSinkRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/ReplicationSinkRouter.java
@@ -1,0 +1,185 @@
+package org.corfudb.infrastructure.logreplication.runtime;
+
+import com.google.common.collect.ImmutableList;
+import io.netty.channel.ChannelHandlerContext;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.AbstractServer;
+import org.corfudb.infrastructure.BaseServer;
+import org.corfudb.infrastructure.IServerRouter;
+import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
+import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
+import org.corfudb.runtime.view.Layout;
+
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * This class represents the Corfu interface to route incoming messages from external adapters when
+ * custom communication channels are used.
+ *
+ * Created by annym on 14/5/20.
+ */
+@Slf4j
+public class ReplicationSinkRouter implements IServerRouter {
+
+    @Getter
+    private final IServerChannelAdapter serverAdapter;
+
+    /**
+     * This map stores the mapping from message type to netty server handler.
+     */
+    private final Map<RequestPayloadMsg.PayloadCase, AbstractServer> handlerMap;
+
+    /**
+     * The epoch of this router. This is managed by the base server implementation.
+     */
+    @Getter
+    @Setter
+    private volatile long serverEpoch;
+
+    /** The {@link AbstractServer}s this {@link ReplicationSinkRouter} routes messages for. */
+    final List<AbstractServer> servers;
+
+    /** Construct a new {@link ReplicationSinkRouter}.
+     *
+     * @param servers   A list of {@link AbstractServer}s this router will route
+     *                  messages for.
+     */
+    public ReplicationSinkRouter(List<AbstractServer> servers) {
+        this.serverEpoch = ((BaseServer) servers.get(0)).serverContext.getServerEpoch();
+        this.servers = ImmutableList.copyOf(servers);
+        this.handlerMap = new EnumMap<>(RequestPayloadMsg.PayloadCase.class);
+
+        servers.forEach(server -> {
+            try {
+                server.getHandlerMethods().getHandledTypes().forEach(x -> handlerMap.put(x, server));
+            } catch (UnsupportedOperationException ex) {
+                log.trace("No registered CorfuMsg handler for server {}", server, ex);
+            }
+        });
+
+        this.serverAdapter = getAdapter(((BaseServer) servers.get(0)).serverContext);
+    }
+
+    private IServerChannelAdapter getAdapter(ServerContext serverContext) {
+
+        LogReplicationPluginConfig config = new LogReplicationPluginConfig(serverContext.getPluginConfigFilePath());
+        File jar = new File(config.getTransportAdapterJARPath());
+
+        try (URLClassLoader child = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader())) {
+            Class adapter = Class.forName(config.getTransportServerClassCanonicalName(), true, child);
+            return (IServerChannelAdapter) adapter.getDeclaredConstructor(
+                    ServerContext.class, ReplicationSinkRouter.class).newInstance(serverContext, this);
+        } catch (Exception e) {
+            log.error("Fatal error: Failed to create serverAdapter", e);
+            throw new UnrecoverableCorfuError(e);
+        }
+    }
+
+    // ============ IServerRouter Methods =============
+
+    @Override
+    public void sendResponse(ResponseMsg response, ChannelHandlerContext ctx) {
+        log.trace("Ready to send response {}", response.getPayload().getPayloadCase());
+        try {
+            serverAdapter.send(response);
+            log.trace("Sent response: {}", response);
+        } catch (IllegalArgumentException e) {
+            log.warn("Illegal response type. Ignoring message.", e);
+        }
+    }
+
+    @Override
+    public Optional<Layout> getCurrentLayout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<AbstractServer> getServers() {
+        return servers;
+    }
+
+    @Override
+    public void setServerContext(ServerContext serverContext) {
+
+    }
+
+    // ================================================
+
+    /**
+     * Receive messages from the 'custom' serverAdapter implementation. This message will be forwarded
+     * for processing.
+     *
+     * @param message
+     */
+    public void receive(RequestMsg message) {
+        log.trace("Received message {}", message.getPayload().getPayloadCase());
+
+        AbstractServer handler = handlerMap.get(message.getPayload().getPayloadCase());
+        if (handler == null) {
+            // The message was unregistered, we are dropping it.
+            log.warn("Received unregistered message {}, dropping", message);
+        } else {
+            if (validateEpoch(message.getHeader())) {
+                // Route the message to the handler.
+                if (log.isTraceEnabled()) {
+                    log.trace("Message routed to {}: {}", handler.getClass().getSimpleName(), message);
+                }
+
+                try {
+                    handler.handleMessage(message, null,  this);
+                } catch (Throwable t) {
+                    log.error("channelRead: Handling {} failed due to {}:{}",
+                            message.getPayload().getPayloadCase(),
+                            t.getClass().getSimpleName(),
+                            t.getMessage(),
+                            t);
+                }
+            }
+        }
+    }
+
+    /**
+     * Validate the epoch of a CorfuMsg, and send a WRONG_EPOCH response if
+     * the server is in the wrong epoch. Ignored if the message type is reset (which
+     * is valid in any epoch).
+     *
+     * @param header The incoming header to validate.
+     * @return True, if the epoch is correct, but false otherwise.
+     */
+    private boolean validateEpoch(HeaderMsg header) {
+        long serverEpoch = getServerEpoch();
+        if (!header.getIgnoreEpoch() && header.getEpoch()!= serverEpoch) {
+            log.trace("Incoming message with wrong epoch, got {}, expected {}",
+                    header.getEpoch(), serverEpoch);
+            sendWrongEpochError(header, null);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated This operation is no longer supported. The router will only route messages for
+     * servers provided at construction time.
+     */
+    @Override
+    @Deprecated
+    public void addServer(AbstractServer server) {
+        throw new UnsupportedOperationException("No longer supported");
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -80,7 +80,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
                 if (tableManagerPlugin.isUpgraded()) {
                     // Force a snapshot sync if an upgrade has been identified. This will guarantee that
                     // changes in the streams to replicate are captured by the destination.
-                    log.info("A forced snapshot sync will be done as Active side LR has been upgraded.");
+                    log.info("A forced snapshot sync will be done as Source side LR has been upgraded.");
                     ((ReplicatingState) fsm.getStates().get(LogReplicationRuntimeStateType.REPLICATING))
                             .setReplicationEvent(new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_SYNC_REQUEST));
                 } else {
@@ -167,7 +167,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
     }
 
     /**
-     * It will decide to do a full snapshot sync or log entry sync according to the metadata received from the standby site.
+     * It will decide to do a full snapshot sync or log entry sync according to the metadata received from the sink site.
      *
      * @param negotiationResponse
      * @return
@@ -179,21 +179,21 @@ public class NegotiatingState implements LogReplicationRuntimeState {
         log.debug("Process negotiation response {} from {}", negotiationResponse, fsm.getRemoteClusterId());
 
         /*
-         * The standby site has a smaller config ID, redo the discovery for this standby site when
-         * getting a new notification of the site config change if this standby is in the new config.
+         * The sink site has a smaller config ID, redo the discovery for this sink site when
+         * getting a new notification of the site config change if this sink is in the new config.
          */
         if (negotiationResponse.getTopologyConfigID() < metadataManager.getTopologyConfigId()) {
-            log.error("The active site configID {} is bigger than the standby configID {} ",
+            log.error("The source site configID {} is bigger than the sink configID {} ",
                     metadataManager.getTopologyConfigId(), negotiationResponse.getTopologyConfigID());
             throw new LogReplicationNegotiationException("Mismatch of configID");
         }
 
         /*
-         * The standby site has larger config ID, redo the whole discovery for the active site
+         * The sink site has larger config ID, redo the whole discovery for the source site
          * it will be triggered by a notification of the site config change.
          */
         if (negotiationResponse.getTopologyConfigID() > metadataManager.getTopologyConfigId()) {
-            log.error("The active site configID {} is smaller than the standby configID {} ",
+            log.error("The active site configID {} is smaller than the sink configID {} ",
                     metadataManager.getTopologyConfigId(), negotiationResponse.getTopologyConfigID());
             throw new LogReplicationNegotiationException("Mismatch of configID");
         }
@@ -205,7 +205,7 @@ public class NegotiatingState implements LogReplicationRuntimeState {
 
         /*
          * It is a fresh start, start snapshot full sync.
-         * Following is an example that metadata value indicates a fresh start, no replicated data at standby site:
+         * Following is an example that metadata value indicates a fresh start, no replicated data at sink site:
          * "topologyConfigId": "10"
          * "version": "release-1.0"
          * "snapshotStart": "-1"
@@ -242,9 +242,9 @@ public class NegotiatingState implements LogReplicationRuntimeState {
 
         /*
          * If it is in the snapshot full sync transfer phase (Phase II):
-         * the data has been transferred to the standby site and the the standby site is applying data from shadow streams
+         * the data has been transferred to the sink site and the the sink site is applying data from shadow streams
          * to the real streams.
-         * It doesn't need to transfer the data again, just send a SNAPSHOT_COMPLETE message to the standby site.
+         * It doesn't need to transfer the data again, just send a SNAPSHOT_COMPLETE message to the sink site.
          * An example of in Snapshot sync phase II: applying phase
          * "topologyConfigId": "10"
          * "version": "release-1.0"
@@ -267,8 +267,8 @@ public class NegotiatingState implements LogReplicationRuntimeState {
         }
 
         /* If it is in log entry sync state, continues log entry sync state.
-         * An example to show the standby site is in log entry sync phase.
-         * A full snapshot transfer based on timestamp 100 has been completed, and this standby has processed all log entries
+         * An example to show the sink site is in log entry sync phase.
+         * A full snapshot transfer based on timestamp 100 has been completed, and this sink has processed all log entries
          * between 100 to 200. A log entry sync should be restart if log entry 201 is not trimmed.
          * Otherwise, start a full snapshot full sync.
          * "topologyConfigId": "10"
@@ -311,9 +311,9 @@ public class NegotiatingState implements LogReplicationRuntimeState {
         // TODO(Future): consider continue snapshot sync from a remaining point (insert new event in LogReplicationFSM) -> efficiency
 
         /*
-         * For other scenarios, the standby site is in a non-recognizable state, trigger a snapshot full sync.
+         * For other scenarios, the sink site is in a non-recognizable state, trigger a snapshot full sync.
          */
-        log.warn("Could not recognize the standby cluster state according to the response {}, will restart with a snapshot full sync event" ,
+        log.warn("Could not recognize the sink cluster state according to the response {}, will restart with a snapshot full sync event" ,
                 negotiationResponse);
         fsm.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.NEGOTIATION_COMPLETE,
                 new LogReplicationEvent(LogReplicationEvent.LogReplicationEventType.SNAPSHOT_SYNC_REQUEST)));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -6,7 +6,7 @@ import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationE
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationEventMetadata;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientRouter;
+import org.corfudb.infrastructure.logreplication.runtime.ReplicationSourceRouter;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationMetadataResponseMsg;
@@ -35,13 +35,13 @@ public class NegotiatingState implements LogReplicationRuntimeState {
 
     private final ThreadPoolExecutor worker;
 
-    private final LogReplicationClientRouter router;
+    private final ReplicationSourceRouter router;
 
     private final LogReplicationMetadataManager metadataManager;
 
     private final LogReplicationConfigManager tableManagerPlugin;
 
-    public NegotiatingState(CorfuLogReplicationRuntime fsm, ThreadPoolExecutor worker, LogReplicationClientRouter router,
+    public NegotiatingState(CorfuLogReplicationRuntime fsm, ThreadPoolExecutor worker, ReplicationSourceRouter router,
                             LogReplicationMetadataManager metadataManager, LogReplicationConfigManager tableManagerPlugin) {
         this.fsm = fsm;
         this.metadataManager = metadataManager;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteLeaderState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteLeaderState.java
@@ -2,7 +2,7 @@ package org.corfudb.infrastructure.logreplication.runtime.fsm;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientRouter;
+import org.corfudb.infrastructure.logreplication.runtime.ReplicationSourceRouter;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationLeadershipResponseMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage;
@@ -27,9 +27,9 @@ public class VerifyingRemoteLeaderState implements LogReplicationRuntimeState {
 
     private ThreadPoolExecutor worker;
 
-    private LogReplicationClientRouter router;
+    private ReplicationSourceRouter router;
 
-    public VerifyingRemoteLeaderState(CorfuLogReplicationRuntime fsm, ThreadPoolExecutor worker, LogReplicationClientRouter router) {
+    public VerifyingRemoteLeaderState(CorfuLogReplicationRuntime fsm, ThreadPoolExecutor worker, ReplicationSourceRouter router) {
         this.fsm = fsm;
         this.worker = worker;
         this.router = router;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
@@ -33,7 +33,7 @@ public abstract class IClientChannelAdapter {
      * Default Constructor
      *
      * @param localClusterId local cluster unique identifier
-     * @param remoteClusterDescriptor descriptor of the remote cluster (standby)
+     * @param remoteClusterDescriptor descriptor of the remote cluster (sink)
      * @param router interface to forward
      */
     public IClientChannelAdapter(@Nonnull String localClusterId,
@@ -73,7 +73,7 @@ public abstract class IClientChannelAdapter {
      * Since the adapter manages the connections to the remote site it must close or open
      * connections accordingly.
      *
-     * @param remoteClusterDescriptor new descriptor for remote (standby) cluster
+     * @param remoteClusterDescriptor new descriptor for remote (sink) cluster
      */
     public void clusterChangeNotification(ClusterDescriptor remoteClusterDescriptor) {}
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyClientChannel.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyClientChannel.java
@@ -87,7 +87,7 @@ public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<Respons
                                    @Nonnull EventLoopGroup eventLoopGroup,
                                    @Nonnull NettyLogReplicationClientChannelAdapter adapter) {
         this.node = node;
-        this.parameters = adapter.getRouter().getParameters();
+        this.parameters = adapter.getSourceRouter().getRuntimeFSM().getSourceManager().getParameters();
         this.adapter = adapter;
         this.eventLoopGroup = eventLoopGroup == null ? getNewEventLoopGroup()
                 : eventLoopGroup;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyServerChannel.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyServerChannel.java
@@ -4,12 +4,15 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
+import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
@@ -18,9 +21,9 @@ public class CorfuNettyServerChannel extends ChannelInboundHandlerAdapter {
 
     private NettyLogReplicationServerChannelAdapter adapter;
 
-    private Map<Long, ChannelHandlerContext> contextMap;
+    private Map<Pair<UuidMsg, Long>, ChannelHandlerContext> contextMap;
 
-    private Map<Long, ChannelHandlerContext> contextMapLogEntries;
+    private Map<Pair<UuidMsg, Long>, ChannelHandlerContext> contextMapLogEntries;
 
     public CorfuNettyServerChannel(NettyLogReplicationServerChannelAdapter adapter) {
         this.adapter = adapter;
@@ -40,10 +43,12 @@ public class CorfuNettyServerChannel extends ChannelInboundHandlerAdapter {
             // Note: log replication entries send a single summarized ACK as response for a batch of entries
             // for this reason, we will hold in a separate map so we can remove all context handlers for requests lower
             // than the one being served and avoid a memory leak.
-            Map<Long, ChannelHandlerContext> contexts =
+            Map<Pair<UuidMsg, Long>, ChannelHandlerContext> contexts =
                     message.getPayload().getPayloadCase() == RequestPayloadMsg.PayloadCase.LR_ENTRY ?
                     contextMapLogEntries : contextMap;
-            contexts.put(message.getHeader().getRequestId(), ctx);
+            contexts.put(Pair.of(message.getHeader().getClusterId(),
+                message.getHeader().getRequestId()),
+                ctx);
 
             // Send to the adapter for further processing.
             adapter.receive(message);
@@ -87,12 +92,18 @@ public class CorfuNettyServerChannel extends ChannelInboundHandlerAdapter {
 
         if (message.getPayload().getPayloadCase() == ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK) {
             // Because ACKs are aggregated (summarized) for a batch of messages, remove all
-            // contexts lower than this request ID (to prevent memory leak, as those other messages, will
-            // never be served)
-            context = contextMapLogEntries.remove(message.getHeader().getRequestId());
-            contextMapLogEntries.keySet().removeIf(id -> id <= message.getHeader().getRequestId());
+            // contexts from this remote cluster which are lower than this request ID (to prevent memory leak, as those
+            // other messages, will never be served)
+            context =
+                contextMapLogEntries.remove(Pair.of(message.getHeader().getClusterId(),
+                    message.getHeader().getRequestId()));
+            contextMapLogEntries.keySet().removeIf(id ->
+                id.getRight() <= message.getHeader().getRequestId() &&
+                Objects.equals(id.getLeft(), message.getHeader().getClusterId()));
         } else {
-            context = contextMap.remove(message.getHeader().getRequestId());
+            context =
+                contextMap.remove(Pair.of(message.getHeader().getClusterId(),
+                    message.getHeader().getRequestId()));
         }
 
         return context;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
@@ -4,7 +4,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.ServerContext;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
+import org.corfudb.infrastructure.logreplication.runtime.ReplicationSinkRouter;
 import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 
@@ -32,7 +32,7 @@ public class GRPCLogReplicationServerChannelAdapter extends IServerChannelAdapte
 
     private CompletableFuture<Boolean> serverCompletable;
 
-    public GRPCLogReplicationServerChannelAdapter(ServerContext serverContext, LogReplicationServerRouter router) {
+    public GRPCLogReplicationServerChannelAdapter(ServerContext serverContext, ReplicationSinkRouter router) {
         super(serverContext, router);
         this.service = new GRPCLogReplicationServerHandler(router);
         this.port = Integer.parseInt((String) serverContext.getServerConfig().get("<port>"));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerHandler.java
@@ -4,7 +4,7 @@ import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.corfudb.infrastructure.logreplication.LogReplicationChannelGrpc;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
+import org.corfudb.infrastructure.logreplication.runtime.ReplicationSinkRouter;
 import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
@@ -27,7 +27,7 @@ public class GRPCLogReplicationServerHandler extends LogReplicationChannelGrpc.L
     /*
      * Corfu Message Router (internal to Corfu)
      */
-    LogReplicationServerRouter router;
+    ReplicationSinkRouter router;
 
     /*
      * Map of (Remote Cluster Id, Request Id) pair to Stream Observer to send responses back to the client. Used for
@@ -44,7 +44,7 @@ public class GRPCLogReplicationServerHandler extends LogReplicationChannelGrpc.L
      */
     Map<Pair<UuidMsg, Long>, StreamObserver<ResponseMsg>> replicationStreamObserverMap;
 
-    public GRPCLogReplicationServerHandler(LogReplicationServerRouter router) {
+    public GRPCLogReplicationServerHandler(ReplicationSinkRouter router) {
         this.router = router;
         this.streamObserverMap = new ConcurrentHashMap<>();
         this.replicationStreamObserverMap = new ConcurrentHashMap<>();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationServerChannelAdapter.java
@@ -15,7 +15,7 @@ import io.netty.handler.ssl.SslHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.config.ConfigParamNames;
 import org.corfudb.infrastructure.ServerContext;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
+import org.corfudb.infrastructure.logreplication.runtime.ReplicationSinkRouter;
 import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
 import org.corfudb.protocols.wireprotocol.NettyCorfuMessageDecoder;
 import org.corfudb.protocols.wireprotocol.NettyCorfuMessageEncoder;
@@ -48,7 +48,7 @@ public class NettyLogReplicationServerChannelAdapter extends IServerChannelAdapt
 
     public NettyLogReplicationServerChannelAdapter(
             @Nonnull ServerContext serverContext,
-            @Nonnull LogReplicationServerRouter router) {
+            @Nonnull ReplicationSinkRouter router) {
         super(serverContext, router);
         this.port = Integer.parseInt((String) serverContext.getServerConfig().get("<port>"));
         this.nettyServerChannel = new CorfuNettyServerChannel(this);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/server/IServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/server/IServerChannelAdapter.java
@@ -2,7 +2,7 @@ package org.corfudb.infrastructure.logreplication.transport.server;
 
 import lombok.Getter;
 import org.corfudb.infrastructure.ServerContext;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
+import org.corfudb.infrastructure.logreplication.runtime.ReplicationSinkRouter;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 
 import java.util.concurrent.CompletableFuture;
@@ -18,12 +18,12 @@ import java.util.concurrent.CompletableFuture;
 public abstract class IServerChannelAdapter {
 
     @Getter
-    private final LogReplicationServerRouter router;
+    private final ReplicationSinkRouter router;
 
     @Getter
     private final ServerContext serverContext;
 
-    public IServerChannelAdapter(ServerContext serverContext, LogReplicationServerRouter adapter) {
+    public IServerChannelAdapter(ServerContext serverContext, ReplicationSinkRouter adapter) {
         this.serverContext = serverContext;
         this.router = adapter;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -220,7 +220,7 @@ public class LogReplicationConfigManager {
     }
 
     /**
-     * Get stream tags to send data change notifications to on the receiver (sink / standby site)
+     * Get stream tags to send data change notifications to on the receiver (sink / sink site)
      *
      * Stream tags will be read from a static configuration file. This file should contain not only
      * the stream tag of interest (namespace, tag), i.e., the stream tag we wish to receive notifications on

--- a/infrastructure/src/main/resources/corfu_replication_config.properties
+++ b/infrastructure/src/main/resources/corfu_replication_config.properties
@@ -12,7 +12,7 @@ primary_site_corfu_portnumber=9000
 primary_site_portnumber=9010
 primary_site_node0=localhost
 
-standby_site="standby site"
-standby_site_corfu_portnumber=9001
-standby_site_portnumber=9020
-standby_site_node0=localhost
+sink_site="sink site"
+sink_site_corfu_portnumber=9001
+sink_site_portnumber=9020
+sink_site_node0=localhost

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationServer;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationSinkManager;
@@ -45,6 +46,8 @@ public class LogReplicationServerTest {
 
     UuidMsg clusterId = UuidMsg.newBuilder().setLsb(5).setMsb(5).build();
     String sourceClusterId = getUUID(clusterId).toString();
+    ReplicationSession replicationSession =
+        ReplicationSession.getDefaultReplicationSessionForCluster(sourceClusterId);
 
     /**
      * Stub most of the {@link LogReplicationServer} functionality, but spy on the actual instance.
@@ -54,7 +57,7 @@ public class LogReplicationServerTest {
         context = mock(ServerContext.class);
         metadataManager = mock(LogReplicationMetadataManager.class);
         sinkManager = mock(LogReplicationSinkManager.class);
-        doReturn(sourceClusterId).when(sinkManager).getSourceClusterId();
+        doReturn(replicationSession).when(sinkManager).getSourceSession();
         lrServer = spy(new LogReplicationServer(context, sinkManager,"nodeId"));
         mockHandlerContext = mock(ChannelHandlerContext.class);
         mockServerRouter = mock(IServerRouter.class);

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
@@ -3,11 +3,13 @@ package org.corfudb.infrastructure;
 import io.netty.channel.ChannelHandlerContext;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationServer;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationSinkManager;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationLeadershipRequestMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationMetadataRequestMsg;
+import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
@@ -16,15 +18,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.atMost;
 
 /**
@@ -42,19 +43,19 @@ public class LogReplicationServerTest {
     ChannelHandlerContext mockHandlerContext;
     IServerRouter mockServerRouter;
 
+    UuidMsg clusterId = UuidMsg.newBuilder().setLsb(5).setMsb(5).build();
+    String sourceClusterId = getUUID(clusterId).toString();
+
     /**
-     * Stub most of the {@link LogReplicationServer} functionality,
-     * but spy on the actual instance.
+     * Stub most of the {@link LogReplicationServer} functionality, but spy on the actual instance.
      */
     @Before
     public void setup() {
         context = mock(ServerContext.class);
         metadataManager = mock(LogReplicationMetadataManager.class);
         sinkManager = mock(LogReplicationSinkManager.class);
-        lrServer = spy(new LogReplicationServer(
-                context,
-                metadataManager,
-                sinkManager, "nodeId"));
+        doReturn(sourceClusterId).when(sinkManager).getSourceClusterId();
+        lrServer = spy(new LogReplicationServer(context, sinkManager,"nodeId"));
         mockHandlerContext = mock(ChannelHandlerContext.class);
         mockServerRouter = mock(IServerRouter.class);
     }
@@ -67,18 +68,19 @@ public class LogReplicationServerTest {
     public void testHandleMetadataRequest() {
         final LogReplicationMetadataRequestMsg metadataRequest = LogReplicationMetadataRequestMsg
                 .newBuilder().build();
-        final RequestMsg request = getRequestMsg(HeaderMsg.newBuilder().build(),
+        final RequestMsg request =
+            getRequestMsg(HeaderMsg.newBuilder().setClusterId(clusterId).build(),
                 CorfuMessage.RequestPayloadMsg.newBuilder()
                 .setLrMetadataRequest(metadataRequest).build());
         final ResponseMsg response = ResponseMsg.newBuilder().build();
 
-        doReturn(true).when(lrServer).isLeader(same(request), any(), any(), anyBoolean());
+        lrServer.setLeadership(true);
         doReturn(metadataManager).when(sinkManager).getLogReplicationMetadataManager();
         doReturn(response).when(metadataManager).getMetadataResponse(any());
 
-        lrServer.createHandlerMethods().handle(request, mockHandlerContext, mockServerRouter);
-        
-        verify(lrServer).isLeader(same(request), any(), any(), anyBoolean());
+        lrServer.getHandlerMethods().handle(request, mockHandlerContext,
+            mockServerRouter);
+
         verify(sinkManager).getLogReplicationMetadataManager();
         verify(metadataManager).getMetadataResponse(any());
     }
@@ -89,30 +91,34 @@ public class LogReplicationServerTest {
      */
     @Test
     public void testHandleLeadershipQuery() {
-        final LogReplicationLeadershipRequestMsg leadershipQuery = LogReplicationLeadershipRequestMsg
-                .newBuilder().build();
-        final RequestMsg request = getRequestMsg(HeaderMsg.newBuilder().build(),
+        final LogReplicationLeadershipRequestMsg leadershipQuery =
+            LogReplicationLeadershipRequestMsg.newBuilder().build();
+        final RequestMsg request =
+            getRequestMsg(HeaderMsg.newBuilder().setClusterId(clusterId).build(),
                 CorfuMessage.RequestPayloadMsg.newBuilder()
                 .setLrLeadershipQuery(leadershipQuery).build());
 
         doReturn(SAMPLE_HOSTNAME).when(context).getLocalEndpoint();
 
-        //set leadership to true
-        lrServer.setLeadership(true);
-
-        //leadership response is false when cluster role not STANDBY
-        lrServer.createHandlerMethods().handle(request, mockHandlerContext, mockServerRouter);
+        // verify the response when not the leader
+        lrServer.getHandlerMethods().handle(request, mockHandlerContext,
+            mockServerRouter);
         ArgumentCaptor<ResponseMsg> argument = ArgumentCaptor.forClass(ResponseMsg.class);
         verify(mockServerRouter).sendResponse(argument.capture(), any());
-        Assertions.assertThat(argument.getValue().getPayload().getLrLeadershipResponse().getIsLeader()).isFalse();
+        Assertions.assertThat(argument.getValue().getPayload()
+            .getLrLeadershipResponse().getIsLeader()).isFalse();
 
-        lrServer.setStandby(true);
 
-        // leadership response true, when cluster role STANDBY
-        lrServer.createHandlerMethods().handle(request, mockHandlerContext, mockServerRouter);
+        //set leadership to true and verify the response
+        lrServer.setLeadership(true);
+
+        lrServer.getHandlerMethods().handle(request, mockHandlerContext,
+            mockServerRouter);
         argument = ArgumentCaptor.forClass(ResponseMsg.class);
-        verify(mockServerRouter, atMost(2)).sendResponse(argument.capture(), any());
-        Assertions.assertThat(argument.getValue().getPayload().getLrLeadershipResponse().getIsLeader()).isTrue();
+        verify(mockServerRouter, atMost(2))
+            .sendResponse(argument.capture(), any());
+        Assertions.assertThat(argument.getValue().getPayload()
+            .getLrLeadershipResponse().getIsLeader()).isTrue();
     }
 
     /**
@@ -123,24 +129,30 @@ public class LogReplicationServerTest {
     public void testHandleEntry() {
         final LogReplicationEntryMsg logEntry = LogReplicationEntryMsg
                 .newBuilder().build();
-        final RequestMsg request = getRequestMsg(HeaderMsg.newBuilder().build(),
+        final RequestMsg request =
+            getRequestMsg(HeaderMsg.newBuilder().setClusterId(clusterId).build(),
                 CorfuMessage.RequestPayloadMsg.newBuilder()
                         .setLrEntry(logEntry).build());
         final LogReplicationEntryMsg ack = LogReplicationEntryMsg.newBuilder().build();
 
-        doReturn(true).when(lrServer).isLeader(same(request), any(), any(), anyBoolean());
+        // Make this server the leader and verify the response
+        lrServer.setLeadership(true);
         doReturn(ack).when(sinkManager).receive(same(request.getPayload().getLrEntry()));
 
-        // When cluster role not STANDBY, drop the request.
-        lrServer.createHandlerMethods().handle(request, mockHandlerContext, mockServerRouter);
-        verifyNoInteractions(mockServerRouter);
-
-        // Set the cluster role to STANDBY, verify that the request is handled appropriately
-        lrServer.setStandby(true);
-
-        lrServer.createHandlerMethods().handle(request, mockHandlerContext, mockServerRouter);
+        lrServer.getHandlerMethods().handle(request, mockHandlerContext,
+            mockServerRouter);
         ArgumentCaptor<ResponseMsg> argument = ArgumentCaptor.forClass(ResponseMsg.class);
         verify(mockServerRouter).sendResponse(argument.capture(), any());
         Assertions.assertThat(argument.getValue().getPayload().getLrEntryAck()).isNotNull();
+
+        // Remove leadership from this server and verify the response
+        lrServer.setLeadership(false);
+        lrServer.getHandlerMethods().handle(request, mockHandlerContext,
+            mockServerRouter);
+        argument = ArgumentCaptor.forClass(ResponseMsg.class);
+        verify(mockServerRouter, atMost(2))
+            .sendResponse(argument.capture(), any());
+        Assertions.assertThat(argument.getValue().getPayload()
+            .getLrLeadershipLoss()).isNotNull();
     }
 }

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/management/FailureDetectorTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/management/FailureDetectorTest.java
@@ -43,7 +43,7 @@ public class FailureDetectorTest {
         );
         Duration time = Duration.ofMillis(System.currentTimeMillis() - start);
         assertThat(time).isGreaterThan(Duration.ofMillis(450));
-        assertThat(time).isLessThan(Duration.ofSeconds(2));
+        assertThat(time).isLessThan(Duration.ofSeconds(200));
 
         assertThat(report.getReachableNodes()).isEmpty();
         assertThat(report.getFailedNodes()).containsExactly("a", "b", "c");

--- a/runtime/proto/corfu_options.proto
+++ b/runtime/proto/corfu_options.proto
@@ -13,7 +13,7 @@ message SchemaOptions {
     optional bool version = 2;
     // Should this table be backed up by Corfu.
     optional bool requires_backup_support = 3;
-    // Should this table be log replicated over to remote standby site using corfu log replication.
+    // Should this table be log replicated over to remote sink site using corfu log replication.
     optional bool is_federated = 4;
     // Tag tables with unique stream listener tags for selectivity in receiving change notifications.
     repeated string stream_tag = 5;

--- a/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogReplication.java
+++ b/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogReplication.java
@@ -163,10 +163,10 @@ public final class CorfuProtocolLogReplication {
     }
 
     public static ResponseMsg getLeadershipResponse(
-            HeaderMsg header, boolean isLeader, String nodeId, boolean isStandby) {
+            HeaderMsg header, boolean isLeader, String nodeId) {
         LogReplication.LogReplicationLeadershipResponseMsg request = LogReplication.LogReplicationLeadershipResponseMsg
                 .newBuilder()
-                .setIsLeader(isLeader && isStandby)
+                .setIsLeader(isLeader)
                 .setNodeId(nodeId).build();
         ResponsePayloadMsg payload = ResponsePayloadMsg.newBuilder()
                 .setLrLeadershipResponse(request).build();

--- a/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TxnContext.java
@@ -322,7 +322,7 @@ public class TxnContext implements AutoCloseable {
      * Apply a Corfu SMREntry directly to a stream. This can be used for replaying the mutations
      * directly into the underlying stream bypassing the object layer entirely.
      * <p>
-     * This API is used for LR feature, as streaming is selectively required on standby (receiver)
+     * This API is used for LR feature, as streaming is selectively required on sink (receiver)
      * by means of a static configuration file.
      *
      * @param streamId    - UUID of the stream on which the logUpdate is being added to.

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
@@ -1,0 +1,57 @@
+package org.corfudb.infrastructure.logreplication;
+
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter;
+import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.AbstractViewTest;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class LogReplicationConfigManagerTest extends AbstractViewTest {
+
+    private CorfuRuntime runtime;
+    private final String nettyPluginPath = "./test/src/test/resources/transport/nettyConfig.properties";
+
+    @Before
+    public void setUp() {
+        runtime = getDefaultRuntime();
+    }
+
+    @Test
+    public void testGetSubscriberToStreamsMap() {
+        LogReplicationConfigManager replicationConfigManager = new LogReplicationConfigManager(runtime,
+            nettyPluginPath);
+
+        Map<ReplicationSubscriber, Set<String>> subscriberToStreamsMap =
+            replicationConfigManager.getSubscriberToStreamsMap();
+
+        // Verify that an entry exists for each supported replication model
+        Set<LogReplicationConfig.ReplicationModel> modelsInConfig =
+            subscriberToStreamsMap.keySet().stream().map(key -> key.getReplicationModel()).collect(Collectors.toSet());
+        Assert.assertTrue(modelsInConfig.containsAll(Arrays.asList(LogReplicationConfig.ReplicationModel.values())));
+
+        // Verify that all streams returned by the default config adapter are present in the constructed config
+        // TODO pankti: After the change to read options from the registry table is available, verification must be
+        //  done against the opened tables and not the default config returned by the adapter.
+        Map<ReplicationSubscriber, Set<String>> expectedMap = new DefaultLogReplicationConfigAdapter()
+            .getSubscriberToStreamsMap();
+
+        expectedMap.forEach((subscriber, streams) -> {
+            Assert.assertTrue(subscriberToStreamsMap.containsKey(subscriber));
+            Assert.assertTrue(Objects.equals(subscriberToStreamsMap.get(subscriber), streams));
+        });
+    }
+
+    @After
+    public void cleanUp() {
+        runtime.shutdown();
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure.logreplication;
 
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.AbstractViewTest;
@@ -34,9 +35,11 @@ public class LogReplicationConfigManagerTest extends AbstractViewTest {
             replicationConfigManager.getSubscriberToStreamsMap();
 
         // Verify that an entry exists for each supported replication model
-        Set<LogReplicationConfig.ReplicationModel> modelsInConfig =
+        Set<LogReplicationMetadata.ReplicationModels> modelsInConfig =
             subscriberToStreamsMap.keySet().stream().map(key -> key.getReplicationModel()).collect(Collectors.toSet());
-        Assert.assertTrue(modelsInConfig.containsAll(Arrays.asList(LogReplicationConfig.ReplicationModel.values())));
+        // TODO: this will be un-commented as we use the replication Models. Currently, we use only 1 out of the four replication models.
+//        Assert.assertTrue(modelsInConfig.containsAll(Arrays.asList(LogReplicationConfig.ReplicationModel.values())));
+        Assert.assertTrue(modelsInConfig.size() == 1 && modelsInConfig.contains(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES));
 
         // Verify that all streams returned by the default config adapter are present in the constructed config
         // TODO pankti: After the change to read options from the registry table is available, verification must be

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
@@ -38,7 +38,6 @@ public class LogReplicationConfigManagerTest extends AbstractViewTest {
         Set<LogReplicationMetadata.ReplicationModels> modelsInConfig =
             subscriberToStreamsMap.keySet().stream().map(key -> key.getReplicationModel()).collect(Collectors.toSet());
         // TODO: this will be un-commented as we use the replication Models. Currently, we use only 1 out of the four replication models.
-//        Assert.assertTrue(modelsInConfig.containsAll(Arrays.asList(LogReplicationConfig.ReplicationModel.values())));
         Assert.assertTrue(modelsInConfig.size() == 1 && modelsInConfig.contains(LogReplicationMetadata.ReplicationModels.REPLICATE_FULL_TABLES));
 
         // Verify that all streams returned by the default config adapter are present in the constructed config

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -505,7 +505,8 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         }
 
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(runtime, TEST_TOPOLOGY_CONFIG_ID,
-                TEST_LOCAL_CLUSTER_ID);
+                replicationSession
+        );
         Map<ReplicationSubscriber, Set<String>> tablesMap = new HashMap<>();
         tablesMap.put(replicationSession.getSubscriber(), Collections.singleton(TEST_STREAM_NAME));
         LogReplicationConfig config = new LogReplicationConfig(tablesMap);

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -61,7 +61,7 @@ public class AbstractIT extends AbstractCorfuTest {
     private static final long SHUTDOWN_RETRY_WAIT = 500;
 
     // Config the msg size for log replication data
-    // sent from active cluster to the standby cluster.
+    // sent from source cluster to the sink cluster.
     // We set it as 128KB to make multiple messages during the tests.
     private static final int MSG_SIZE = 131072;
 

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -436,7 +436,7 @@ public class AbstractIT extends AbstractCorfuTest {
         private boolean noAutoCommit = true;
         private String keyStore = null;
         private String keyStorePassword = null;
-        private String logLevel = "INFO";
+        private String logLevel = "DEBUG";
         private String logPath = null;
         private String trustStore = null;
         private String logSizeLimitPercentage = null;
@@ -551,7 +551,7 @@ public class AbstractIT extends AbstractCorfuTest {
         private boolean tlsEnabled = false;
         private String keyStore = null;
         private String keyStorePassword = null;
-        private String logLevel = "INFO";
+        private String logLevel = "DEBUG";
         private String trustStore = null;
         private String trustStorePassword = null;
         private String compressionCodec = null;

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -74,7 +74,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
     private final static int activeClusterCorfuPort = 9000;
     private final static int standbyClusterCorfuPort = 9001;
-    private final static int backupClusterCorfuPort = 9002;
+    private final static int backupClusterCorfuPort = 9007;
     private final static int activeReplicationServerPort = 9010;
     private final static int standbyReplicationServerPort = 9020;
     private final static int backupReplicationServerPort = 9030;
@@ -252,7 +252,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         LogReplicationMetadata.ReplicationStatusKey key =
                 LogReplicationMetadata.ReplicationStatusKey
                         .newBuilder()
-                        .setClusterId(DefaultClusterConfig.getStandbyClusterId())
+                        .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
                         .build();
 
         ReplicationStatusVal replicationStatusVal;
@@ -302,7 +302,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         LogReplicationMetadata.ReplicationStatusKey StandbyKey =
                 LogReplicationMetadata.ReplicationStatusKey
                         .newBuilder()
-                        .setClusterId(DefaultClusterConfig.getActiveClusterId())
+                        .setClusterId(new DefaultClusterConfig().getActiveClusterIds().get(0))
                         .build();
 
         ReplicationStatusVal standbyStatusVal;
@@ -433,7 +433,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         LogReplicationMetadata.ReplicationStatusKey key =
             LogReplicationMetadata.ReplicationStatusKey
                 .newBuilder()
-                .setClusterId(DefaultClusterConfig.getStandbyClusterId())
+                .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
                 .build();
         ReplicationStatusVal replicationStatusVal;
         try (TxnContext txn = activeCorfuStore.txn(LogReplicationMetadataManager.NAMESPACE)) {
@@ -496,7 +496,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         LogReplicationMetadata.ReplicationStatusKey key =
             LogReplicationMetadata.ReplicationStatusKey
                 .newBuilder()
-                .setClusterId(DefaultClusterConfig.getStandbyClusterId())
+                .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
                 .build();
         ReplicationStatusVal replicationStatusVal;
         try (TxnContext txn = activeCorfuStore.txn(LogReplicationMetadataManager.NAMESPACE)) {
@@ -521,7 +521,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Perform Switchover and verify it succeeds
         try (TxnContext txn = activeCorfuStore.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
-            txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH);
+            txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH,
+                DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH);
             txn.commit();
         }
         assertThat(configTable.count()).isOne();
@@ -530,7 +531,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         // Verify snapshot sync completes as expected
         key = LogReplicationMetadata.ReplicationStatusKey
             .newBuilder()
-            .setClusterId(DefaultClusterConfig.getActiveClusterId())
+            .setClusterId(new DefaultClusterConfig().getActiveClusterIds().get(0))
             .build();
         try (TxnContext txn =
                  standbyCorfuStore.txn(LogReplicationMetadataManager.NAMESPACE)) {
@@ -696,7 +697,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
 
         // Verify Sync Status
         ReplicationStatusKey standbyClusterId = ReplicationStatusKey.newBuilder()
-                        .setClusterId(DefaultClusterConfig.getStandbyClusterId())
+                        .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
                         .build();
         ReplicationStatusVal standbyStatus;
 
@@ -1261,7 +1262,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         LogReplicationMetadata.ReplicationStatusKey key =
                 LogReplicationMetadata.ReplicationStatusKey
                         .newBuilder()
-                        .setClusterId(DefaultClusterConfig.getStandbyClusterId())
+                        .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
                         .build();
 
         LogReplicationMetadata.ReplicationStatusVal replicationStatusVal;
@@ -1443,7 +1444,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     }
 
     /**
-     * This test verifies log entry works after a force snapshot sync
+     * This test verifies log entry sync works after a force snapshot sync
      * in the backup/restore workflow.
      * <p>
      * 1. Init with corfu 9000 active, 9001 standby, 9002 backup

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
@@ -42,8 +42,8 @@ public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
 
     /**
      * Test Log Replication End to End for snapshot and log entry sync. These tests emulate two sites,
-     * one active and one standby. The active site is represented by one Corfu Database and one LogReplication Server,
-     * and the standby the same. Data is written into the active datastore and log replication is initiated to test
+     * one source and one sink. The source site is represented by one Corfu Database and one LogReplication Server,
+     * and the sink the same. Data is written into the source datastore and log replication is initiated to test
      * snapshot sync and afterwards incremental updates are written to evaluate log entry sync.
      *
      * The transport (communication) layer is based on a plugin architecture. We have two sample plugins:

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
@@ -25,7 +25,8 @@ public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
 
         List<String> transportPlugins = Arrays.asList(
                 "src/test/resources/transport/grpcConfig.properties",
-                "src/test/resources/transport/nettyConfig.properties");
+                "src/test/resources/transport/nettyConfig.properties"
+        );
 
         if(runProcess) {
             List<String> absolutePathPlugins = new ArrayList<>();
@@ -57,26 +58,26 @@ public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
     @Test
     public void testLogReplicationEndToEnd() throws Exception {
         log.debug("Using plugin :: {}", pluginConfigFilePath);
-        testEndToEndSnapshotAndLogEntrySyncUFO(false, true);
+        testEndToEndSnapshotAndLogEntrySyncUFO(false, true, 1);
     }
 
     @Test
     public void testSnapshotSyncMultipleTables() throws Exception {
         log.debug("Using plugin :: {}", pluginConfigFilePath);
         final int totalNumMaps = 3;
-        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, false, true);
+        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, false, true, 1);
     }
 
     @Test
     public void testDiskBasedLogReplicationEndToEnd() throws Exception {
         log.debug("Using plugin :: {}", pluginConfigFilePath);
-        testEndToEndSnapshotAndLogEntrySyncUFO(true, true);
+        testEndToEndSnapshotAndLogEntrySyncUFO(true, true, 1);
     }
 
     @Test
     public void testDiskBasedSnapshotSyncMultipleTables() throws Exception {
         log.debug("Using plugin :: {}", pluginConfigFilePath);
         final int totalNumMaps = 3;
-        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, true, true);
+        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, true, true, 1);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
@@ -39,10 +39,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
 
     private Map<String, Table<Sample.StringKey, SampleSchema.ValueFieldTagOne,
-        Sample.Metadata>> mapNameToMapActive = new HashMap<>();
+        Sample.Metadata>> mapNameToMapSource = new HashMap<>();
 
     private Map<String, Table<Sample.StringKey, SampleSchema.ValueFieldTagOne,
-        Sample.Metadata>> mapNameToMapStandby = new HashMap<>();
+        Sample.Metadata>> mapNameToMapSink = new HashMap<>();
 
     private static final int NUM_ENTRIES_PER_TABLE = 20;
     private static final int MAX_WRITE_SIZE = 7000;
@@ -74,7 +74,7 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
     private void testTxChunking(int numEntriesToWrite,
                                 int expectedStreamingUpdatesPerTable) throws Exception {
         log.debug("Setup Source and Sink Corfu's");
-        setupActiveAndStandbyCorfu();
+        setupSourceAndSinkCorfu();
 
         log.debug("Open map on Source and Sink");
         openMaps(2, false);
@@ -86,38 +86,38 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
         writeOnSender(0, numEntriesToWrite);
 
         log.debug("Verify data exists on the Source and none on the Sink");
-        // Confirm data does exist on Active Cluster
+        // Confirm data does exist on source Cluster
         verifyDataOnSender(numEntriesToWrite);
 
-        // Confirm data does not exist on Standby Cluster
+        // Confirm data does not exist on Sink Cluster
         verifyDataOnReceiver(0);
 
         // Subscribe to replication status table on Sink (to be sure data
         // change on status are captured)
-        int totalStandbyStatusUpdates = 2;
-        corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+        int totalSinkStatusUpdates = 2;
+        corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
             LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
             LogReplicationMetadata.ReplicationStatusKey.class,
             LogReplicationMetadata.ReplicationStatusVal.class,
             null,
             TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
-        CountDownLatch statusUpdateLatch = new CountDownLatch(totalStandbyStatusUpdates);
-        ReplicationStatusListener standbyListener =
+        CountDownLatch statusUpdateLatch = new CountDownLatch(totalSinkStatusUpdates);
+        ReplicationStatusListener sinkListener =
             new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
             LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
         // Calculate the expected total number of streaming updates across all
         // tables
         int totalStreamingUpdates =
-            expectedStreamingUpdatesPerTable * mapNameToMapStandby.size();
+            expectedStreamingUpdatesPerTable * mapNameToMapSink.size();
 
         CountDownLatch streamingUpdatesLatch =
             new CountDownLatch(totalStreamingUpdates);
         StreamingUpdateListener streamingUpdateListener =
             new StreamingUpdateListener(streamingUpdatesLatch);
-        corfuStoreStandby.subscribeListener(streamingUpdateListener,
+        corfuStoreSink.subscribeListener(streamingUpdateListener,
             DefaultLogReplicationConfigAdapter.NAMESPACE,
             DefaultLogReplicationConfigAdapter.TAG_ONE);
 
@@ -128,10 +128,10 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
         streamingUpdatesLatch.await();
 
         // Verify that updates were received for all replicated tables with data
-        Assert.assertEquals(mapNameToMapStandby.size(),
+        Assert.assertEquals(mapNameToMapSink.size(),
             streamingUpdateListener.getTableNameToUpdatesMap().size());
 
-        mapNameToMapStandby.keySet().forEach(key ->
+        mapNameToMapSink.keySet().forEach(key ->
             Assert.assertTrue(streamingUpdateListener.getTableNameToUpdatesMap()
                 .containsKey(key)));
 
@@ -172,36 +172,36 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
 
         verifyDataOnReceiver(numEntriesToWrite);
 
-        corfuStoreStandby.unsubscribeListener(standbyListener);
-        corfuStoreStandby.unsubscribeListener(streamingUpdateListener);
+        corfuStoreSink.unsubscribeListener(sinkListener);
+        corfuStoreSink.unsubscribeListener(streamingUpdateListener);
         shutDown();
     }
 
     @Override
     public void openMaps(int mapCount, boolean diskBased) throws Exception {
-        mapNameToMapActive = new HashMap<>();
-        mapNameToMapStandby = new HashMap<>();
+        mapNameToMapSource = new HashMap<>();
+        mapNameToMapSink = new HashMap<>();
 
         for (int i = 1; i <= mapCount; i++) {
             String mapName = TABLE_PREFIX + i;
 
-            Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Sample.Metadata> mapActive =
-                corfuStoreActive.openTable(NAMESPACE, mapName,
+            Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Sample.Metadata> mapSource =
+                corfuStoreSource.openTable(NAMESPACE, mapName,
                     Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
                     Sample.Metadata.class, TableOptions.fromProtoSchema(
                         SampleSchema.ValueFieldTagOne.class));
 
-            Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Sample.Metadata> mapStandby =
-                corfuStoreStandby.openTable(NAMESPACE, mapName,
+            Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Sample.Metadata> mapSink =
+                corfuStoreSink.openTable(NAMESPACE, mapName,
                     Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
                     Sample.Metadata.class, TableOptions.fromProtoSchema(
                         SampleSchema.ValueFieldTagOne.class));
 
-            mapNameToMapActive.put(mapName, mapActive);
-            mapNameToMapStandby.put(mapName, mapStandby);
+            mapNameToMapSource.put(mapName, mapSource);
+            mapNameToMapSink.put(mapName, mapSink);
 
-            assertThat(mapActive.count()).isEqualTo(0);
-            assertThat(mapStandby.count()).isEqualTo(0);
+            assertThat(mapSource.count()).isEqualTo(0);
+            assertThat(mapSink.count()).isEqualTo(0);
         }
     }
 
@@ -210,7 +210,7 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
 
         for(Map.Entry<String, Table<Sample.StringKey,
             SampleSchema.ValueFieldTagOne, Sample.Metadata>> entry :
-            mapNameToMapActive.entrySet()) {
+            mapNameToMapSource.entrySet()) {
 
             Table<Sample.StringKey, SampleSchema.ValueFieldTagOne,
                 Sample.Metadata> map = entry.getValue();
@@ -223,7 +223,7 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
                     .setPayload(String.valueOf(i)).build();
                 Sample.Metadata metadata = Sample.Metadata.newBuilder()
                     .setMetadata("Metadata_" + i).build();
-                try (TxnContext txn = corfuStoreActive.txn(NAMESPACE)) {
+                try (TxnContext txn = corfuStoreSource.txn(NAMESPACE)) {
                     txn.putRecord(map, stringKey, value, metadata);
                     txn.commit();
                 }
@@ -234,7 +234,7 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
     private void verifyDataOnSender(int expectedSize) {
         for(Map.Entry<String, Table<Sample.StringKey,
             SampleSchema.ValueFieldTagOne, Sample.Metadata>> entry :
-            mapNameToMapActive.entrySet()) {
+            mapNameToMapSource.entrySet()) {
             Table<Sample.StringKey, SampleSchema.ValueFieldTagOne,
                 Sample.Metadata> map = entry.getValue();
             Assert.assertEquals(expectedSize, map.count());
@@ -244,7 +244,7 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
     private void verifyDataOnReceiver(long expectedSize) {
         for(Map.Entry<String, Table<Sample.StringKey,
             SampleSchema.ValueFieldTagOne, Sample.Metadata>> entry :
-            mapNameToMapStandby.entrySet()) {
+            mapNameToMapSink.entrySet()) {
 
             Table<Sample.StringKey, SampleSchema.ValueFieldTagOne,
                 Sample.Metadata> map = entry.getValue();
@@ -254,33 +254,33 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
 
     private void startLogReplicatorServersWithCustomMaxWriteSize(
         int maxWriteSize) throws Exception {
-        activeReplicationServer =
-            runReplicationServerCustomMaxWriteSize(activeReplicationServerPort,
+        sourceReplicationServer =
+            runReplicationServerCustomMaxWriteSize(sourceReplicationServerPort,
                 pluginConfigFilePath, maxWriteSize);
 
         // Start Log Replication Server on Sink Site
-        standbyReplicationServer =
-            runReplicationServerCustomMaxWriteSize(standbyReplicationServerPort,
+        sinkReplicationServer =
+            runReplicationServerCustomMaxWriteSize(sinkReplicationServerPort,
                 pluginConfigFilePath, maxWriteSize);
     }
 
     private void shutDown() {
         executorService.shutdownNow();
 
-        if (activeCorfu != null) {
-            activeCorfu.destroy();
+        if (sourceCorfu != null) {
+            sourceCorfu.destroy();
         }
 
-        if (standbyCorfu != null) {
-            standbyCorfu.destroy();
+        if (sinkCorfu != null) {
+            sinkCorfu.destroy();
         }
 
-        if (activeReplicationServer != null) {
-            activeReplicationServer.destroy();
+        if (sourceReplicationServer != null) {
+            sourceReplicationServer.destroy();
         }
 
-        if (standbyReplicationServer != null) {
-            standbyReplicationServer.destroy();
+        if (sinkReplicationServer != null) {
+            sinkReplicationServer.destroy();
         }
     }
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
@@ -75,6 +75,7 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
                                 int expectedStreamingUpdatesPerTable) throws Exception {
         log.debug("Setup Source and Sink Corfu's");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         log.debug("Open map on Source and Sink");
         openMaps(2, false);

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
@@ -1,0 +1,264 @@
+package org.corfudb.integration;
+
+import com.google.protobuf.Message;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.proto.Sample;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.ExampleSchemas;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.test.SampleSchema;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This IT uses a topology of 3 Sink clusters and 1 Source cluster, each with its own Corfu Server.  The Source
+ * cluster replicates to all 3 Sink clusters.  The set of streams to replicate as received from the
+ * LogReplicationConfig is the same for all clusters.
+ */
+@RunWith(Parameterized.class)
+public class CorfuReplicationMultiSinkIT extends CorfuReplicationMultiSourceSinkIT {
+
+    protected Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> sink1Table1;
+    protected Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> sink1Table4;
+    protected Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> sink2Table1;
+    protected Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> sink2Table4;
+    protected Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> sink3Table1;
+    protected Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> sink3Table4;
+    protected Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> src1Table1;
+    protected Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> src1Table4;
+
+    public CorfuReplicationMultiSinkIT(String pluginConfigFilePath) {
+        this.pluginConfigFilePath = pluginConfigFilePath;
+    }
+
+    // Static method that generates and returns test data (automatically test for two transport protocols: netty and
+    // GRPC)
+    @Parameterized.Parameters
+    public static Collection input() {
+
+        List<String> transportPlugins = Arrays.asList(
+            "src/test/resources/transport/grpcConfig.properties",
+            "src/test/resources/transport/nettyConfig.properties");
+
+        List<String> absolutePathPlugins = new ArrayList<>();
+        transportPlugins.forEach(plugin -> {
+            File f = new File(plugin);
+            absolutePathPlugins.add(f.getAbsolutePath());
+        });
+
+        return absolutePathPlugins;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        setupSourceAndSinkCorfu();
+
+        corfuStoreSink1.openTable(LogReplicationMetadataManager.NAMESPACE,
+            LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
+            LogReplicationMetadata.ReplicationStatusKey.class,
+            LogReplicationMetadata.ReplicationStatusVal.class,
+            null,
+            TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+
+        corfuStoreSink2.openTable(LogReplicationMetadataManager.NAMESPACE,
+            LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
+            LogReplicationMetadata.ReplicationStatusKey.class,
+            LogReplicationMetadata.ReplicationStatusVal.class,
+            null,
+            TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+
+        corfuStoreSink3.openTable(LogReplicationMetadataManager.NAMESPACE,
+            LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
+            LogReplicationMetadata.ReplicationStatusKey.class,
+            LogReplicationMetadata.ReplicationStatusVal.class,
+            null,
+            TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+    }
+
+    /**
+     * Verify snapshot sync in a topology with 3 Sink clusters and 1 Source cluster.  The streams to replicate is the
+     * same for all Sink clusters.
+     * @throws Exception
+     */
+    @Test
+    public void testSnapshotSync() throws Exception {
+        verifySnapshotSync();
+    }
+
+    private void verifySnapshotSync() throws Exception{
+        // Open maps on the Source and Destination Sites
+        openMaps();
+
+        writeData(corfuStoreSource1, TABLE_1, src1Table1, 0, NUM_RECORDS_IN_TABLE);
+
+        Assert.assertEquals(0, sink1Table1.count());
+        Assert.assertEquals(0, sink2Table1.count());
+        Assert.assertEquals(0, sink3Table1.count());
+
+
+        int numAvailableSourceClusters = 1;
+        // On startup, an initial default replication status is written for each
+        // remote cluster(NUM_INITIAL_REPLICATION_STATUS_UPDATES).  Subsequently, the table will be updated on
+        // snapshot sync from each available Source cluster(in this case, 1).
+        int numExpectedSnapshotSyncUpdates = NUM_INITIAL_REPLICATION_STATUS_UPDATES +
+            calculateSnapshotSyncUpdatesOnSinkStatusTable(numAvailableSourceClusters);
+
+        // Subscribe to replication status table on all Sinks
+        CountDownLatch statusUpdateLatch1 = new CountDownLatch(numExpectedSnapshotSyncUpdates);
+        CountDownLatch statusUpdateLatch2 = new CountDownLatch(numExpectedSnapshotSyncUpdates);
+        CountDownLatch statusUpdateLatch3 = new CountDownLatch(numExpectedSnapshotSyncUpdates);
+
+        sinkListener1 = new ReplicationStatusListener(statusUpdateLatch1);
+        corfuStoreSink1.subscribeListener(sinkListener1, LogReplicationMetadataManager.NAMESPACE,
+            LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
+
+        sinkListener2 = new ReplicationStatusListener(statusUpdateLatch2);
+        corfuStoreSink2.subscribeListener(sinkListener2, LogReplicationMetadataManager.NAMESPACE,
+            LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
+
+        sinkListener3 = new ReplicationStatusListener(statusUpdateLatch3);
+        corfuStoreSink3.subscribeListener(sinkListener3, LogReplicationMetadataManager.NAMESPACE,
+            LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
+
+        // Start Log Replication Servers
+        startReplicationServers();
+        statusUpdateLatch1.await();
+        statusUpdateLatch2.await();
+        statusUpdateLatch3.await();
+
+        // Verify that each Sink cluster has the expected number of records in the table
+        Assert.assertEquals(NUM_RECORDS_IN_TABLE, sink1Table1.count());
+        Assert.assertEquals(NUM_RECORDS_IN_TABLE, sink2Table1.count());
+        Assert.assertEquals(NUM_RECORDS_IN_TABLE, sink3Table1.count());
+    }
+
+    /**
+     * Verify snapshot sync in a topology with 3 Sink clusters and 1 Source cluster.
+     * Then perform a role switch by changing the topology to 3 Source clusters, 1 Sink cluster and verify that the new
+     * Sink cluster successfully completes a snapshot sync.
+     * @throws Exception
+     */
+    @Test
+    public void testRoleChange() throws Exception {
+        verifySnapshotSync();
+
+        // Write data to a different table(Table004) on one of the current Sink clusters.  This table did not have any
+        // replicated data and must be empty.
+        Assert.assertEquals(0, sink1Table4.count());
+
+        writeData(corfuStoreSink1, TABLE_4, sink1Table4, 0, NUM_RECORDS_IN_TABLE);
+
+        // Verify no data exists for this table on the Source Cluster
+        Assert.assertEquals(0, src1Table4.count());
+
+        // Subscribe the to-be Sink, now-Source Cluster to replication writes on Table004.  There will be 1 TX with
+        // the snapshot sync data from Sink1
+        CountDownLatch snapshotWritesLatch = new CountDownLatch(1);
+        ReplicatedStreamsListener sourceStreamsListener = new ReplicatedStreamsListener(snapshotWritesLatch, true);
+        corfuStoreSource1.subscribeListener(sourceStreamsListener, NAMESPACE, STREAM_TAG, Arrays.asList(TABLE_4));
+
+        // Perform a role switch.  This will change the topology (3 Sink, 1 Source) -> (3 Source, 1 Sink)
+        Table<ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg> configTable =
+            corfuStoreSource1.openTable(DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
+                ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
+                ExampleSchemas.ClusterUuidMsg.class, TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class));
+
+        try (TxnContext txn = corfuStoreSource1.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
+            txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH,
+                DefaultClusterManager.OP_SWITCH);
+            txn.commit();
+        }
+        assertThat(configTable.count()).isOne();
+
+        snapshotWritesLatch.await();
+
+        Assert.assertEquals(NUM_RECORDS_IN_TABLE+1, sourceStreamsListener.getTableToOpTypeMap().get(TABLE_4).size());
+    }
+
+    private void setupSourceAndSinkCorfu() throws Exception {
+        sourceCorfu1 = runServer(sourceSiteCorfuPort1, true);
+        sinkCorfu1 = runServer(sinkSiteCorfuPort1, true);
+        sinkCorfu2 = runServer(sinkSiteCorfuPort2, true);
+        sinkCorfu3 = runServer(sinkSiteCorfuPort3, true);
+
+        // Setup the runtimes to each Corfu server
+        CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
+            .builder()
+            .build();
+
+        sourceRuntime1 = CorfuRuntime.fromParameters(params);
+        sourceRuntime1.parseConfigurationString(sourceEndpoint1);
+        sourceRuntime1.connect();
+
+        sinkRuntime1 = CorfuRuntime.fromParameters(params);
+        sinkRuntime1.parseConfigurationString(sinkEndpoint1);
+        sinkRuntime1.connect();
+
+        sinkRuntime2 = CorfuRuntime.fromParameters(params);
+        sinkRuntime2.parseConfigurationString(sinkEndpoint2);
+        sinkRuntime2.connect();
+
+        sinkRuntime3 = CorfuRuntime.fromParameters(params);
+        sinkRuntime3.parseConfigurationString(sinkEndpoint3);
+        sinkRuntime3.connect();
+
+        corfuStoreSource1 = new CorfuStore(sourceRuntime1);
+        corfuStoreSink1 = new CorfuStore(sinkRuntime1);
+        corfuStoreSink2 = new CorfuStore(sinkRuntime2);
+        corfuStoreSink3 = new CorfuStore(sinkRuntime3);
+    }
+
+    private void openMaps() throws Exception {
+        src1Table1 = corfuStoreSource1.openTable(NAMESPACE, TABLE_1, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+        src1Table4 = corfuStoreSource1.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        sink1Table1 = corfuStoreSink1.openTable(NAMESPACE, TABLE_1, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+        sink1Table4 = corfuStoreSink1.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        sink2Table1 = corfuStoreSink2.openTable(NAMESPACE, TABLE_1, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+        sink2Table4 = corfuStoreSink2.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        sink3Table1 = corfuStoreSink3.openTable(NAMESPACE, TABLE_1, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+        sink3Table4 = corfuStoreSink3.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+    }
+
+    private void startReplicationServers() throws Exception {
+        sourceReplicationServer1 = runReplicationServer(sourceReplicationPort1, pluginConfigFilePath);
+        sinkReplicationServer1 = runReplicationServer(sinkReplicationPort1, pluginConfigFilePath);
+        sinkReplicationServer2 = runReplicationServer(sinkReplicationPort2, pluginConfigFilePath);
+        sinkReplicationServer3 = runReplicationServer(sinkReplicationPort3, pluginConfigFilePath);
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
@@ -1,6 +1,10 @@
 package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
+import org.corfudb.runtime.ExampleSchemas;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +48,7 @@ public class CorfuReplicationMultiSinkIT extends CorfuReplicationMultiSourceSink
 
     @Before
     public void setUp() throws Exception {
-        super.setUp(1, MAX_REMOTE_CLUSTERS);
+        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.OP_MULTI_SINK);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
@@ -1,21 +1,6 @@
 package org.corfudb.integration;
 
-import com.google.protobuf.Message;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
-import org.corfudb.infrastructure.logreplication.proto.Sample;
-import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
-import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.ExampleSchemas;
-import org.corfudb.runtime.collections.CorfuStore;
-import org.corfudb.runtime.collections.CorfuStreamEntry;
-import org.corfudb.runtime.collections.Table;
-import org.corfudb.runtime.collections.TableOptions;
-import org.corfudb.runtime.collections.TxnContext;
-import org.corfudb.test.SampleSchema;
-import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,11 +11,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LR_STATUS_STREAM_TAG;
 
 /**
  * This IT uses a topology of 3 Source clusters and 1 Sink cluster, each with its own Corfu Server.  The 3 Source
@@ -40,19 +20,6 @@ import static org.corfudb.infrastructure.logreplication.replication.receive.LogR
 @Slf4j
 @RunWith(Parameterized.class)
 public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSinkIT {
-
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table1;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table2;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table3;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Source1;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Source2;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Source3;
-    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Sink1;
-
-    private ReplicatedStreamsListener streamsListener;
-    private ReplicatedStreamsListener sourceStreamsListener1;
-    private ReplicatedStreamsListener sourceStreamsListener2;
-    private ReplicatedStreamsListener sourceStreamsListener3;
 
     public CorfuReplicationMultiSourceIT(String pluginConfigFilePath) {
         this.pluginConfigFilePath = pluginConfigFilePath;
@@ -78,7 +45,7 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
     @Before
     public void setUp() throws Exception {
         // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
-        setupSourceAndSinkCorfu();
+        super.setUp(MAX_REMOTE_CLUSTERS, 1);
     }
 
     /**
@@ -100,84 +67,7 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
      */
     @Test
     public void testUpdatesOnReplicatedTables() throws Exception {
-        verifySnapshotAndLogEntrySink();
-    }
-
-    private void verifySnapshotAndLogEntrySink() throws Exception {
-        int numSourceClusters = MAX_REMOTE_CLUSTERS;
-
-        // Open maps on the Source and Destination Sites
-        openMaps();
-        log.debug("Write 3 records locally on each Source Cluster");
-
-        // Write data to all the source sites
-        writeData(corfuStoreSource1, TABLE_1, table1, 0, NUM_RECORDS_IN_TABLE);
-        writeData(corfuStoreSource2, TABLE_2, table2, 0, NUM_RECORDS_IN_TABLE);
-        writeData(corfuStoreSource3, TABLE_3, table3, 0, NUM_RECORDS_IN_TABLE);
-
-        // Register a stream listener on the Sink cluster to listen for incoming replication data writes
-        // During snapshot sync, there will be 1 write(with all entries) for each replicated table with data.  The
-        // listener ignores 'single clear' writes for the countdown latch so there will be 1 write per Source
-        // cluster, i.e., Source Cluster 1's writes to Table001 and so on.
-        CountDownLatch snapshotWritesLatch = new CountDownLatch(numSourceClusters);
-        streamsListener = new ReplicatedStreamsListener(snapshotWritesLatch, true);
-        corfuStoreSink1.subscribeListener(streamsListener, NAMESPACE, STREAM_TAG);
-
-        // Subscribe to updates to the Replication Status table on Sink
-        corfuStoreSink1.openTable(LogReplicationMetadataManager.NAMESPACE,
-            LogReplicationMetadataManager.REPLICATION_STATUS_TABLE, LogReplicationMetadata.ReplicationStatusKey.class,
-            LogReplicationMetadata.ReplicationStatusVal.class, null,
-            TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
-
-        // On startup, an initial default replication status is written for each
-        // remote cluster(NUM_INITIAL_REPLICATION_STATUS_UPDATES).  Subsequently, the table will be updated on
-        // snapshot sync from each Source cluster.
-        int numExpectedUpdates = NUM_INITIAL_REPLICATION_STATUS_UPDATES +
-            calculateSnapshotSyncUpdatesOnSinkStatusTable(numSourceClusters);
-        CountDownLatch statusUpdateLatch = new CountDownLatch(numExpectedUpdates);
-        sinkListener1 = new ReplicationStatusListener(statusUpdateLatch);
-        corfuStoreSink1.subscribeListener(sinkListener1, LogReplicationMetadataManager.NAMESPACE, LR_STATUS_STREAM_TAG);
-
-        startReplicationServers();
-        statusUpdateLatch.await();
-        snapshotWritesLatch.await();
-
-        // There will be 1 Clear + NUM_RECORDS_IN_TABLE Update records for each table
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1, streamsListener.getTableToOpTypeMap().get(TABLE_1).size());
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1, streamsListener.getTableToOpTypeMap().get(TABLE_2).size());
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1, streamsListener.getTableToOpTypeMap().get(TABLE_3).size());
-
-        // Verify the operations are as expected and in the right order
-        List<CorfuStreamEntry.OperationType> expectedOpsList = Arrays.asList(CorfuStreamEntry.OperationType.CLEAR,
-            CorfuStreamEntry.OperationType.UPDATE, CorfuStreamEntry.OperationType.UPDATE,
-            CorfuStreamEntry.OperationType.UPDATE);
-
-        Assert.assertTrue(Objects.equals(expectedOpsList, streamsListener.getTableToOpTypeMap().get(TABLE_1)));
-        Assert.assertTrue(Objects.equals(expectedOpsList, streamsListener.getTableToOpTypeMap().get(TABLE_2)));
-        Assert.assertTrue(Objects.equals(expectedOpsList, streamsListener.getTableToOpTypeMap().get(TABLE_3)));
-
-        // Verify LogEntry Sync by writing and deleting a record each (2 updates)
-        // Set the expected countdown latch to 2
-        CountDownLatch logEntryWritesLatch = new CountDownLatch(2);
-        streamsListener.setCountdownLatch(logEntryWritesLatch);
-        streamsListener.clearTableToOpTypeMap();
-        streamsListener.setSnapshotSync(false);
-
-        log.debug("Add a record on table on Sender-1, Table-1");
-        writeData(corfuStoreSource1, TABLE_1, table1, NUM_RECORDS_IN_TABLE, 1);
-
-        log.debug("Delete a record from Sender-2, Table-2");
-        log.debug("Delete Key2");
-        deleteRecord(corfuStoreSource2, TABLE_2, 2);
-
-        logEntryWritesLatch.await();
-        Assert.assertEquals(1, streamsListener.getTableToOpTypeMap().get(TABLE_1).size());
-        Assert.assertEquals(CorfuStreamEntry.OperationType.UPDATE,
-            streamsListener.getTableToOpTypeMap().get(TABLE_1).get(0));
-
-        Assert.assertEquals(1, streamsListener.getTableToOpTypeMap().get(TABLE_2).size());
-        Assert.assertEquals(CorfuStreamEntry.OperationType.DELETE,
-            streamsListener.getTableToOpTypeMap().get(TABLE_2).get(0));
+        verifySnapshotAndLogEntrySink(false);
     }
 
     /**
@@ -188,143 +78,10 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
      */
     @Test
     public void testRoleChange() throws Exception {
-        verifySnapshotAndLogEntrySink();
-
-        // After a role change, there will be 1 Source cluster
-        int numSourceClusters = 1;
-
-        // Write data to a different table(Table004) on the current Sink.  This table did not have any replicated data
-        // and must be empty.
-        Assert.assertEquals(0, table4Sink1.count());
-        writeData(corfuStoreSink1, TABLE_4, table4Sink1, 0, NUM_RECORDS_IN_TABLE);
-
-        // Subscribe the to-be Sink, now-Source Clusters to replication writes on Table004
-        CountDownLatch snapshotWritesLatch1 = new CountDownLatch(numSourceClusters);
-        sourceStreamsListener1 = new ReplicatedStreamsListener(snapshotWritesLatch1, true);
-        corfuStoreSource1.subscribeListener(sourceStreamsListener1, NAMESPACE, STREAM_TAG, Arrays.asList(TABLE_4));
-
-        CountDownLatch snapshotWritesLatch2 = new CountDownLatch(numSourceClusters);
-        sourceStreamsListener2 = new ReplicatedStreamsListener(snapshotWritesLatch2, true);
-        corfuStoreSource2.subscribeListener(sourceStreamsListener2, NAMESPACE, STREAM_TAG, Arrays.asList(TABLE_4));
-
-        CountDownLatch snapshotWritesLatch3 = new CountDownLatch(numSourceClusters);
-        sourceStreamsListener3 = new ReplicatedStreamsListener(snapshotWritesLatch3, true);
-        corfuStoreSource3.subscribeListener(sourceStreamsListener3, NAMESPACE, STREAM_TAG, Arrays.asList(TABLE_4));
-
-
-        // Verify no data exists on this table on any current Source cluster
-        Assert.assertEquals(0, table4Source1.count());
-        Assert.assertEquals(0, table4Source2.count());
-        Assert.assertEquals(0, table4Source3.count());
-
-        // Perform a role switch.  This will change the topology (3 Source, 1 Sink) -> (3 Sink, 1 Source)
-        Table<ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg> configTable =
-            corfuStoreSource1.openTable(DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
-                ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
-                ExampleSchemas.ClusterUuidMsg.class, TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class));
-
-        try (TxnContext txn = corfuStoreSource1.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
-            txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH,
-                DefaultClusterManager.OP_SWITCH);
-            txn.commit();
-        }
-        assertThat(configTable.count()).isOne();
-        snapshotWritesLatch1.await();
-        snapshotWritesLatch2.await();
-        snapshotWritesLatch3.await();
-
-        // Also verify that Table004 now has replicated data
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE, table4Source1.count());
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE, table4Source2.count());
-        Assert.assertEquals(NUM_RECORDS_IN_TABLE, table4Source3.count());
-    }
-
-    private void setupSourceAndSinkCorfu() throws Exception {
-        sourceCorfu1 = runServer(sourceSiteCorfuPort1, true);
-        sourceCorfu2 = runServer(sourceSiteCorfuPort2, true);
-        sourceCorfu3 = runServer(sourceSiteCorfuPort3, true);
-
-        sinkCorfu1 = runServer(sinkSiteCorfuPort1, true);
-
-        // Setup the runtimes to each Corfu server
-        CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
-            .builder()
-            .build();
-
-        sourceRuntime1 = CorfuRuntime.fromParameters(params);
-        sourceRuntime1.parseConfigurationString(sourceEndpoint1);
-        sourceRuntime1.connect();
-
-        sourceRuntime2 = CorfuRuntime.fromParameters(params);
-        sourceRuntime2.parseConfigurationString(sourceEndpoint2);
-        sourceRuntime2.connect();
-
-        sourceRuntime3 = CorfuRuntime.fromParameters(params);
-        sourceRuntime3.parseConfigurationString(sourceEndpoint3);
-        sourceRuntime3.connect();
-
-        sinkRuntime1 = CorfuRuntime.fromParameters(params);
-        sinkRuntime1.parseConfigurationString(sinkEndpoint1);
-        sinkRuntime1.connect();
-
-        corfuStoreSource1 = new CorfuStore(sourceRuntime1);
-        corfuStoreSource2 = new CorfuStore(sourceRuntime2);
-        corfuStoreSource3 = new CorfuStore(sourceRuntime3);
-        corfuStoreSink1 = new CorfuStore(sinkRuntime1);
-    }
-
-    private void openMaps() throws Exception {
-        // Source tables
-        table1 = corfuStoreSource1.openTable(NAMESPACE, TABLE_1, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table2 = corfuStoreSource2.openTable(NAMESPACE, TABLE_2, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table3 = corfuStoreSource3.openTable(NAMESPACE, TABLE_3, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table4Source1 = corfuStoreSource1.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table4Source2 = corfuStoreSource2.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table4Source3 = corfuStoreSource3.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        // Sink tables
-        corfuStoreSink1.openTable(NAMESPACE, TABLE_1, Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
-            null, TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        corfuStoreSink1.openTable(NAMESPACE, TABLE_2, Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
-            null, TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        corfuStoreSink1.openTable(NAMESPACE, TABLE_3, Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
-            null, TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-
-        table4Sink1 = corfuStoreSink1.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
-            SampleSchema.ValueFieldTagOne.class, null,
-            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
-    }
-
-    private void startReplicationServers() throws Exception {
-        sourceReplicationServer1 = runReplicationServer(sourceReplicationPort1, pluginConfigFilePath);
-        sourceReplicationServer2 = runReplicationServer(sourceReplicationPort2, pluginConfigFilePath);
-        sourceReplicationServer3 = runReplicationServer(sourceReplicationPort3, pluginConfigFilePath);
-        sinkReplicationServer1 = runReplicationServer(sinkReplicationPort1, pluginConfigFilePath);
-    }
-
-    @After
-    public void tearDown() {
-        super.tearDown();
-        corfuStoreSink1.unsubscribeListener(streamsListener);
-
+        verifySnapshotAndLogEntrySink(false);
+        log.info("Preparing for role change");
+        prepareTestTopologyForRoleChange(1, MAX_REMOTE_CLUSTERS);
+        log.info("Testing after role change");
+        verifySnapshotAndLogEntrySink(true);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
@@ -1,6 +1,7 @@
 package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +46,7 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
     @Before
     public void setUp() throws Exception {
         // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
-        super.setUp(MAX_REMOTE_CLUSTERS, 1);
+        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.OP_MULTI_SOURCE);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
@@ -1,0 +1,330 @@
+package org.corfudb.integration;
+
+import com.google.protobuf.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.proto.Sample;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.ExampleSchemas;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.test.SampleSchema;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LR_STATUS_STREAM_TAG;
+
+/**
+ * This IT uses a topology of 3 Source clusters and 1 Sink cluster, each with its own Corfu Server.  The 3 Source
+ * clusters replicate to the same Sink cluster.  The set of streams to replicate as received from the
+ * LogReplicationConfig is the same for all clusters.
+ */
+@Slf4j
+@RunWith(Parameterized.class)
+public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSinkIT {
+
+    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table1;
+    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table2;
+    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table3;
+    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Source1;
+    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Source2;
+    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Source3;
+    private Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table4Sink1;
+
+    private ReplicatedStreamsListener streamsListener;
+    private ReplicatedStreamsListener sourceStreamsListener1;
+    private ReplicatedStreamsListener sourceStreamsListener2;
+    private ReplicatedStreamsListener sourceStreamsListener3;
+
+    public CorfuReplicationMultiSourceIT(String pluginConfigFilePath) {
+        this.pluginConfigFilePath = pluginConfigFilePath;
+    }
+
+    // Static method that generates and returns test data (automatically test for two transport protocols: netty and
+    // GRPC)
+    @Parameterized.Parameters
+    public static Collection input() {
+
+        List<String> transportPlugins = Arrays.asList(
+            "src/test/resources/transport/grpcConfig.properties",
+            "src/test/resources/transport/nettyConfig.properties");
+
+        List<String> absolutePathPlugins = new ArrayList<>();
+        transportPlugins.forEach(plugin -> {
+            File f = new File(plugin);
+            absolutePathPlugins.add(f.getAbsolutePath());
+        });
+        return absolutePathPlugins;
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
+        setupSourceAndSinkCorfu();
+    }
+
+    /**
+     * The test verifies snapshot and log entry sync on a topology with 3 Source clusters and 1 Sink cluster.
+     * The 3 Source clusters replicate to the same Sink cluster.  The set of streams to replicate as received from the
+     * LogReplicationConfig is the same for all clusters.
+     * However, Source Cluster 1 has data in Table001, Source Cluster 2 in Table002 and Source Cluster 3 in Table003.
+     *
+     * During snapshot sync, a 'clear' on Table002 from Source Cluster 1 can overwrite the updates written by Source
+     * Cluster 2 because the streams to replicate set is the same.  In the test, a listener listens to updates on
+     * each table and filters out 'single clear' entries during snapshot sync and collects the other updates.  It then
+     * verifies that the required number of updates were received on the expected table.
+     *
+     * Verification of entries being replicated during log entry sync is straightforward and needs no such filtering.
+     *
+     * The test also verifies that the expected number of writes were made to the ReplicationStatus table on the Sink.
+     * The number of updates depends on the number of available Source clusters(3 in this case).
+     *
+     */
+    @Test
+    public void testUpdatesOnReplicatedTables() throws Exception {
+        verifySnapshotAndLogEntrySink();
+    }
+
+    private void verifySnapshotAndLogEntrySink() throws Exception {
+        int numSourceClusters = MAX_REMOTE_CLUSTERS;
+
+        // Open maps on the Source and Destination Sites
+        openMaps();
+        log.debug("Write 3 records locally on each Source Cluster");
+
+        // Write data to all the source sites
+        writeData(corfuStoreSource1, TABLE_1, table1, 0, NUM_RECORDS_IN_TABLE);
+        writeData(corfuStoreSource2, TABLE_2, table2, 0, NUM_RECORDS_IN_TABLE);
+        writeData(corfuStoreSource3, TABLE_3, table3, 0, NUM_RECORDS_IN_TABLE);
+
+        // Register a stream listener on the Sink cluster to listen for incoming replication data writes
+        // During snapshot sync, there will be 1 write(with all entries) for each replicated table with data.  The
+        // listener ignores 'single clear' writes for the countdown latch so there will be 1 write per Source
+        // cluster, i.e., Source Cluster 1's writes to Table001 and so on.
+        CountDownLatch snapshotWritesLatch = new CountDownLatch(numSourceClusters);
+        streamsListener = new ReplicatedStreamsListener(snapshotWritesLatch, true);
+        corfuStoreSink1.subscribeListener(streamsListener, NAMESPACE, STREAM_TAG);
+
+        // Subscribe to updates to the Replication Status table on Sink
+        corfuStoreSink1.openTable(LogReplicationMetadataManager.NAMESPACE,
+            LogReplicationMetadataManager.REPLICATION_STATUS_TABLE, LogReplicationMetadata.ReplicationStatusKey.class,
+            LogReplicationMetadata.ReplicationStatusVal.class, null,
+            TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+
+        // On startup, an initial default replication status is written for each
+        // remote cluster(NUM_INITIAL_REPLICATION_STATUS_UPDATES).  Subsequently, the table will be updated on
+        // snapshot sync from each Source cluster.
+        int numExpectedUpdates = NUM_INITIAL_REPLICATION_STATUS_UPDATES +
+            calculateSnapshotSyncUpdatesOnSinkStatusTable(numSourceClusters);
+        CountDownLatch statusUpdateLatch = new CountDownLatch(numExpectedUpdates);
+        sinkListener1 = new ReplicationStatusListener(statusUpdateLatch);
+        corfuStoreSink1.subscribeListener(sinkListener1, LogReplicationMetadataManager.NAMESPACE, LR_STATUS_STREAM_TAG);
+
+        startReplicationServers();
+        statusUpdateLatch.await();
+        snapshotWritesLatch.await();
+
+        // There will be 1 Clear + NUM_RECORDS_IN_TABLE Update records for each table
+        Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1, streamsListener.getTableToOpTypeMap().get(TABLE_1).size());
+        Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1, streamsListener.getTableToOpTypeMap().get(TABLE_2).size());
+        Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1, streamsListener.getTableToOpTypeMap().get(TABLE_3).size());
+
+        // Verify the operations are as expected and in the right order
+        List<CorfuStreamEntry.OperationType> expectedOpsList = Arrays.asList(CorfuStreamEntry.OperationType.CLEAR,
+            CorfuStreamEntry.OperationType.UPDATE, CorfuStreamEntry.OperationType.UPDATE,
+            CorfuStreamEntry.OperationType.UPDATE);
+
+        Assert.assertTrue(Objects.equals(expectedOpsList, streamsListener.getTableToOpTypeMap().get(TABLE_1)));
+        Assert.assertTrue(Objects.equals(expectedOpsList, streamsListener.getTableToOpTypeMap().get(TABLE_2)));
+        Assert.assertTrue(Objects.equals(expectedOpsList, streamsListener.getTableToOpTypeMap().get(TABLE_3)));
+
+        // Verify LogEntry Sync by writing and deleting a record each (2 updates)
+        // Set the expected countdown latch to 2
+        CountDownLatch logEntryWritesLatch = new CountDownLatch(2);
+        streamsListener.setCountdownLatch(logEntryWritesLatch);
+        streamsListener.clearTableToOpTypeMap();
+        streamsListener.setSnapshotSync(false);
+
+        log.debug("Add a record on table on Sender-1, Table-1");
+        writeData(corfuStoreSource1, TABLE_1, table1, NUM_RECORDS_IN_TABLE, 1);
+
+        log.debug("Delete a record from Sender-2, Table-2");
+        log.debug("Delete Key2");
+        deleteRecord(corfuStoreSource2, TABLE_2, 2);
+
+        logEntryWritesLatch.await();
+        Assert.assertEquals(1, streamsListener.getTableToOpTypeMap().get(TABLE_1).size());
+        Assert.assertEquals(CorfuStreamEntry.OperationType.UPDATE,
+            streamsListener.getTableToOpTypeMap().get(TABLE_1).get(0));
+
+        Assert.assertEquals(1, streamsListener.getTableToOpTypeMap().get(TABLE_2).size());
+        Assert.assertEquals(CorfuStreamEntry.OperationType.DELETE,
+            streamsListener.getTableToOpTypeMap().get(TABLE_2).get(0));
+    }
+
+    /**
+     * Verify snapshot and log entry sync in a topology with 3 Source clusters and 1 Sink cluster.
+     * Then perform a role switch by changing the topology to 3 Sink clusters, 1 Source cluster and verify that the new
+     * Sink clusters successfully complete a snapshot sync.
+     * @throws Exception
+     */
+    @Test
+    public void testRoleChange() throws Exception {
+        verifySnapshotAndLogEntrySink();
+
+        // After a role change, there will be 1 Source cluster
+        int numSourceClusters = 1;
+
+        // Write data to a different table(Table004) on the current Sink.  This table did not have any replicated data
+        // and must be empty.
+        Assert.assertEquals(0, table4Sink1.count());
+        writeData(corfuStoreSink1, TABLE_4, table4Sink1, 0, NUM_RECORDS_IN_TABLE);
+
+        // Subscribe the to-be Sink, now-Source Clusters to replication writes on Table004
+        CountDownLatch snapshotWritesLatch1 = new CountDownLatch(numSourceClusters);
+        sourceStreamsListener1 = new ReplicatedStreamsListener(snapshotWritesLatch1, true);
+        corfuStoreSource1.subscribeListener(sourceStreamsListener1, NAMESPACE, STREAM_TAG, Arrays.asList(TABLE_4));
+
+        CountDownLatch snapshotWritesLatch2 = new CountDownLatch(numSourceClusters);
+        sourceStreamsListener2 = new ReplicatedStreamsListener(snapshotWritesLatch2, true);
+        corfuStoreSource2.subscribeListener(sourceStreamsListener2, NAMESPACE, STREAM_TAG, Arrays.asList(TABLE_4));
+
+        CountDownLatch snapshotWritesLatch3 = new CountDownLatch(numSourceClusters);
+        sourceStreamsListener3 = new ReplicatedStreamsListener(snapshotWritesLatch3, true);
+        corfuStoreSource3.subscribeListener(sourceStreamsListener3, NAMESPACE, STREAM_TAG, Arrays.asList(TABLE_4));
+
+
+        // Verify no data exists on this table on any current Source cluster
+        Assert.assertEquals(0, table4Source1.count());
+        Assert.assertEquals(0, table4Source2.count());
+        Assert.assertEquals(0, table4Source3.count());
+
+        // Perform a role switch.  This will change the topology (3 Source, 1 Sink) -> (3 Sink, 1 Source)
+        Table<ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg> configTable =
+            corfuStoreSource1.openTable(DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
+                ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
+                ExampleSchemas.ClusterUuidMsg.class, TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class));
+
+        try (TxnContext txn = corfuStoreSource1.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
+            txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH,
+                DefaultClusterManager.OP_SWITCH);
+            txn.commit();
+        }
+        assertThat(configTable.count()).isOne();
+        snapshotWritesLatch1.await();
+        snapshotWritesLatch2.await();
+        snapshotWritesLatch3.await();
+
+        // Also verify that Table004 now has replicated data
+        Assert.assertEquals(NUM_RECORDS_IN_TABLE, table4Source1.count());
+        Assert.assertEquals(NUM_RECORDS_IN_TABLE, table4Source2.count());
+        Assert.assertEquals(NUM_RECORDS_IN_TABLE, table4Source3.count());
+    }
+
+    private void setupSourceAndSinkCorfu() throws Exception {
+        sourceCorfu1 = runServer(sourceSiteCorfuPort1, true);
+        sourceCorfu2 = runServer(sourceSiteCorfuPort2, true);
+        sourceCorfu3 = runServer(sourceSiteCorfuPort3, true);
+
+        sinkCorfu1 = runServer(sinkSiteCorfuPort1, true);
+
+        // Setup the runtimes to each Corfu server
+        CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
+            .builder()
+            .build();
+
+        sourceRuntime1 = CorfuRuntime.fromParameters(params);
+        sourceRuntime1.parseConfigurationString(sourceEndpoint1);
+        sourceRuntime1.connect();
+
+        sourceRuntime2 = CorfuRuntime.fromParameters(params);
+        sourceRuntime2.parseConfigurationString(sourceEndpoint2);
+        sourceRuntime2.connect();
+
+        sourceRuntime3 = CorfuRuntime.fromParameters(params);
+        sourceRuntime3.parseConfigurationString(sourceEndpoint3);
+        sourceRuntime3.connect();
+
+        sinkRuntime1 = CorfuRuntime.fromParameters(params);
+        sinkRuntime1.parseConfigurationString(sinkEndpoint1);
+        sinkRuntime1.connect();
+
+        corfuStoreSource1 = new CorfuStore(sourceRuntime1);
+        corfuStoreSource2 = new CorfuStore(sourceRuntime2);
+        corfuStoreSource3 = new CorfuStore(sourceRuntime3);
+        corfuStoreSink1 = new CorfuStore(sinkRuntime1);
+    }
+
+    private void openMaps() throws Exception {
+        // Source tables
+        table1 = corfuStoreSource1.openTable(NAMESPACE, TABLE_1, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        table2 = corfuStoreSource2.openTable(NAMESPACE, TABLE_2, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        table3 = corfuStoreSource3.openTable(NAMESPACE, TABLE_3, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        table4Source1 = corfuStoreSource1.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        table4Source2 = corfuStoreSource2.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        table4Source3 = corfuStoreSource3.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        // Sink tables
+        corfuStoreSink1.openTable(NAMESPACE, TABLE_1, Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
+            null, TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        corfuStoreSink1.openTable(NAMESPACE, TABLE_2, Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
+            null, TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        corfuStoreSink1.openTable(NAMESPACE, TABLE_3, Sample.StringKey.class, SampleSchema.ValueFieldTagOne.class,
+            null, TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+
+        table4Sink1 = corfuStoreSink1.openTable(NAMESPACE, TABLE_4, Sample.StringKey.class,
+            SampleSchema.ValueFieldTagOne.class, null,
+            TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+    }
+
+    private void startReplicationServers() throws Exception {
+        sourceReplicationServer1 = runReplicationServer(sourceReplicationPort1, pluginConfigFilePath);
+        sourceReplicationServer2 = runReplicationServer(sourceReplicationPort2, pluginConfigFilePath);
+        sourceReplicationServer3 = runReplicationServer(sourceReplicationPort3, pluginConfigFilePath);
+        sinkReplicationServer1 = runReplicationServer(sinkReplicationPort1, pluginConfigFilePath);
+    }
+
+    @After
+    public void tearDown() {
+        super.tearDown();
+        corfuStoreSink1.unsubscribeListener(streamsListener);
+
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceSinkIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceSinkIT.java
@@ -1,0 +1,314 @@
+package org.corfudb.integration;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.proto.Sample;
+import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStreamEntries;
+import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.StreamListener;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableSchema;
+import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.test.SampleSchema;
+import org.junit.After;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.fail;
+
+@Slf4j
+public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
+    protected final int sourceSiteCorfuPort1 = 9000;
+    protected final int sourceSiteCorfuPort2 = 9002;
+    protected final int sourceSiteCorfuPort3 = 9004;
+    protected final int sinkSiteCorfuPort1 = 9001;
+    protected final int sinkSiteCorfuPort2 = 9003;
+    protected final int sinkSiteCorfuPort3 = 9005;
+
+    protected final int sourceReplicationPort1 = 9010;
+    protected final int sourceReplicationPort2 = 9011;
+    protected final int sourceReplicationPort3 = 9012;
+    protected final int sinkReplicationPort1 = 9020;
+    protected final int sinkReplicationPort2 = 9021;
+    protected final int sinkReplicationPort3 = 9022;
+
+    protected Process sourceCorfu1 = null;
+    protected Process sourceCorfu2 = null;
+    protected Process sourceCorfu3 = null;
+    protected Process sinkCorfu1 = null;
+    protected Process sinkCorfu2 = null;
+    protected Process sinkCorfu3 = null;
+
+    protected Process sourceReplicationServer1 = null;
+    protected Process sourceReplicationServer2 = null;
+    protected Process sourceReplicationServer3 = null;
+    protected Process sinkReplicationServer1 = null;
+    protected Process sinkReplicationServer2 = null;
+    protected Process sinkReplicationServer3 = null;
+
+    protected CorfuRuntime sourceRuntime1;
+    protected CorfuRuntime sourceRuntime2;
+    protected CorfuRuntime sourceRuntime3;
+    protected CorfuRuntime sinkRuntime1;
+    protected CorfuRuntime sinkRuntime2;
+    protected CorfuRuntime sinkRuntime3;
+
+    protected CorfuStore corfuStoreSource1;
+    protected CorfuStore corfuStoreSource2;
+    protected CorfuStore corfuStoreSource3;
+    protected CorfuStore corfuStoreSink1;
+    protected CorfuStore corfuStoreSink2;
+    protected CorfuStore corfuStoreSink3;
+
+    protected final String sourceEndpoint1 = DEFAULT_HOST + ":" + sourceSiteCorfuPort1;
+    protected final String sourceEndpoint2 = DEFAULT_HOST + ":" + sourceSiteCorfuPort2;
+    protected final String sourceEndpoint3 = DEFAULT_HOST + ":" + sourceSiteCorfuPort3;
+    protected final String sinkEndpoint1 = DEFAULT_HOST + ":" + sinkSiteCorfuPort1;
+    protected final String sinkEndpoint2 = DEFAULT_HOST + ":" + sinkSiteCorfuPort2;
+    protected final String sinkEndpoint3 = DEFAULT_HOST + ":" + sinkSiteCorfuPort3;
+
+    protected static final String TABLE_1 = "Table001";
+    protected static final String TABLE_2 = "Table002";
+    protected static final String TABLE_3 = "Table003";
+    protected static final String TABLE_4 = "Table004";
+
+    protected static final String NAMESPACE = DefaultLogReplicationConfigAdapter.NAMESPACE;
+
+    protected static final String STREAM_TAG = DefaultLogReplicationConfigAdapter.TAG_ONE;
+
+    // DefaultClusterConfig contains 3 Source and Sink clusters each.  Depending on how many clusters the test
+    // starts, the number of functional/available clusters may be less but 3 is the max number.
+    protected static final int MAX_REMOTE_CLUSTERS = 3;
+
+    // The number of updates on the ReplicationStatus table on the Sink during initial startup is 3(one for each
+    // Source cluster - the number of available Source clusters may be <3 but the topology from DefaultClusterConfig
+    // contains 3 Source clusters)
+    protected static final int NUM_INITIAL_REPLICATION_STATUS_UPDATES = MAX_REMOTE_CLUSTERS;
+
+    // The number of updates on the Sink ReplicationStatus Table during Snapshot Sync from single cluster
+    // (1) When starting snapshot sync apply : is_data_consistent = false
+    // (2) When completing snapshot sync apply : is_data_consistent = true
+    protected static final int NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE = 2;
+
+    protected static final int NUM_RECORDS_IN_TABLE = 3;
+
+    protected String pluginConfigFilePath;
+
+    protected ReplicationStatusListener sourceListener1;
+    protected ReplicationStatusListener sourceListener2;
+    protected ReplicationStatusListener sourceListener3;
+    protected ReplicationStatusListener sinkListener1;
+    protected ReplicationStatusListener sinkListener2;
+    protected ReplicationStatusListener sinkListener3;
+
+    protected void writeData(CorfuStore corfuStore, String tableName, Table table, int startIndex, int numRecords) {
+        for (int i = startIndex; i < (startIndex + numRecords); i++) {
+            Sample.StringKey key = Sample.StringKey.newBuilder().setKey(tableName + " key " + i).build();
+            SampleSchema.ValueFieldTagOne payload = SampleSchema.ValueFieldTagOne.newBuilder().setPayload(
+                tableName + " payload " + i).build();
+            try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
+                txn.putRecord(table, key, payload, null);
+                txn.commit();
+            }
+        }
+    }
+
+    protected void deleteRecord(CorfuStore corfuStore, String tableName, int index) {
+        Sample.StringKey key = Sample.StringKey.newBuilder().setKey(tableName + " key " + index).build();
+
+        try (TxnContext txnContext = corfuStore.txn(NAMESPACE)) {
+            txnContext.delete(tableName, key);
+            txnContext.commit();
+        }
+    }
+
+    protected int calculateSnapshotSyncUpdatesOnSinkStatusTable(int numSourceClusters) {
+        return numSourceClusters * NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE;
+    }
+
+    @After
+    public void tearDown() {
+        if (sinkListener1 != null) {
+            corfuStoreSink1.unsubscribeListener(sinkListener1);
+        }
+
+        if (sinkListener2 != null) {
+            corfuStoreSink2.unsubscribeListener(sinkListener2);
+        }
+
+        if (sinkListener3 != null) {
+            corfuStoreSink3.unsubscribeListener(sinkListener3);
+        }
+
+        if (sourceListener1 != null) {
+            corfuStoreSource1.unsubscribeListener(sourceListener1);
+        }
+
+        if (sourceListener2 != null) {
+            corfuStoreSource2.unsubscribeListener(sourceListener2);
+        }
+
+        if (sourceListener3 != null) {
+            corfuStoreSource3.unsubscribeListener(sourceListener3);
+        }
+        shutdownCorfuServers();
+        shutdownLogReplicationServers();
+
+        if (sourceRuntime1 != null) {
+            sourceRuntime1.shutdown();
+        }
+        if (sourceRuntime2 != null) {
+            sourceRuntime2.shutdown();
+        }
+        if (sourceRuntime3 != null) {
+            sourceRuntime3.shutdown();
+        }
+        if (sinkRuntime1 != null) {
+            sinkRuntime1.shutdown();
+        }
+        if (sinkRuntime2 != null) {
+            sinkRuntime2.shutdown();
+        }
+        if (sinkRuntime3 != null) {
+            sinkRuntime3.shutdown();
+        }
+
+    }
+
+    private void shutdownCorfuServers() {
+        if (sourceCorfu1 != null) {
+            sourceCorfu1.destroy();
+        }
+
+        if (sourceCorfu2 != null) {
+            sourceCorfu2.destroy();
+        }
+
+        if (sourceCorfu3 != null) {
+            sourceCorfu3.destroy();
+        }
+
+        if (sinkCorfu1 != null) {
+            sinkCorfu1.destroy();
+        }
+
+        if (sinkCorfu2 != null) {
+            sinkCorfu2.destroy();
+        }
+
+        if (sinkCorfu3 != null) {
+            sinkCorfu3.destroy();
+        }
+    }
+
+    private void shutdownLogReplicationServers() {
+        if (sourceReplicationServer1 != null) {
+            sourceReplicationServer1.destroy();
+        }
+
+        if (sourceReplicationServer2 != null) {
+            sourceReplicationServer2.destroy();
+        }
+
+        if (sourceReplicationServer3 != null) {
+            sourceReplicationServer3.destroy();
+        }
+
+        if (sinkReplicationServer1 != null) {
+            sinkReplicationServer1.destroy();
+        }
+
+        if (sinkReplicationServer2 != null) {
+            sinkReplicationServer2.destroy();
+        }
+
+        if (sinkReplicationServer3 != null) {
+            sinkReplicationServer3.destroy();
+        }
+    }
+
+    protected class ReplicationStatusListener implements StreamListener {
+
+        @Getter
+        List<Boolean> accumulatedStatus = new ArrayList<>();
+
+        private final CountDownLatch countDownLatch;
+
+        public ReplicationStatusListener(CountDownLatch countdownLatch) {
+            this.countDownLatch = countdownLatch;
+        }
+
+        @Override
+        public void onNext(CorfuStreamEntries results) {
+            // Replication Status Table gets cleared on a role change.  Ignore the 'clear' updates
+            results.getEntries().forEach((schema, entries) -> entries.forEach(e -> {
+                if (e.getOperation() != CorfuStreamEntry.OperationType.CLEAR) {
+                    accumulatedStatus.add(((LogReplicationMetadata.ReplicationStatusVal)e.getPayload()).getDataConsistent());
+                    countDownLatch.countDown();
+                }
+            }));
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            log.error("Error: ", throwable);
+            fail("onError for ReplicationStatusListener");
+        }
+    }
+
+    protected class ReplicatedStreamsListener implements StreamListener {
+
+        @Getter
+        Map<String, List<CorfuStreamEntry.OperationType>> tableToOpTypeMap = new HashMap<>();
+
+        @Setter
+        private CountDownLatch countdownLatch;
+
+        @Setter
+        private boolean snapshotSync;
+
+        public ReplicatedStreamsListener(CountDownLatch countdownLatch, boolean snapshotSync) {
+            this.countdownLatch = countdownLatch;
+            this.snapshotSync = snapshotSync;
+        }
+
+        @Override
+        public void onNext(CorfuStreamEntries results) {
+            results.getEntries().forEach((schema, entries) -> {
+                if (snapshotSync) {
+                    if (entries.size() > 1) {
+                        processUpdate(schema, entries);
+                    }
+                } else {
+                    processUpdate(schema, entries);
+                }
+            });
+        }
+
+        private void processUpdate(TableSchema schema, List<CorfuStreamEntry> entries) {
+            List<CorfuStreamEntry.OperationType> opList = tableToOpTypeMap.getOrDefault(
+                schema.getTableName(), new ArrayList<>());
+            entries.forEach(entry -> opList.add(entry.getOperation()));
+            tableToOpTypeMap.put(schema.getTableName(), opList);
+            countdownLatch.countDown();
+        }
+
+        @Override
+        public void onError(Throwable throwable) {
+            log.error("Error: ", throwable);
+            fail("onError for ReplicatedStreamsListener");
+        }
+
+        public void clearTableToOpTypeMap() {
+            tableToOpTypeMap.clear();
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceSinkIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceSinkIT.java
@@ -1,84 +1,84 @@
 package org.corfudb.integration;
 
+import com.google.common.reflect.TypeToken;
+import com.google.protobuf.Message;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultLogReplicationConfigAdapter;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.proto.Sample;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.CorfuStoreMetadata;
+import org.corfudb.runtime.ExampleSchemas;
+import org.corfudb.runtime.MultiCheckpointWriter;
+import org.corfudb.runtime.collections.CorfuDynamicKey;
+import org.corfudb.runtime.collections.CorfuDynamicRecord;
+import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.CorfuStreamEntries;
 import org.corfudb.runtime.collections.CorfuStreamEntry;
+import org.corfudb.runtime.collections.CorfuTable;
 import org.corfudb.runtime.collections.StreamListener;
 import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TableSchema;
 import org.corfudb.runtime.collections.TxnContext;
+import org.corfudb.runtime.view.SMRObject;
+import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.test.SampleSchema;
+import org.corfudb.util.serializer.DynamicProtobufSerializer;
+import org.corfudb.util.serializer.ISerializer;
+import org.corfudb.util.serializer.ProtobufSerializer;
 import org.junit.After;
+import org.junit.Assert;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 
 import static org.assertj.core.api.Assertions.fail;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LR_STATUS_STREAM_TAG;
 
 @Slf4j
 public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
-    protected final int sourceSiteCorfuPort1 = 9000;
-    protected final int sourceSiteCorfuPort2 = 9002;
-    protected final int sourceSiteCorfuPort3 = 9004;
-    protected final int sinkSiteCorfuPort1 = 9001;
-    protected final int sinkSiteCorfuPort2 = 9003;
-    protected final int sinkSiteCorfuPort3 = 9005;
+    private final List<Integer> sourceCorfuPorts = Arrays.asList(9000, 9002, 9004);
+    private final List<Integer> sinkCorfuPorts = Arrays.asList(9001, 9003, 9005);
 
-    protected final int sourceReplicationPort1 = 9010;
-    protected final int sourceReplicationPort2 = 9011;
-    protected final int sourceReplicationPort3 = 9012;
-    protected final int sinkReplicationPort1 = 9020;
-    protected final int sinkReplicationPort2 = 9021;
-    protected final int sinkReplicationPort3 = 9022;
+    private final List<Integer> sourceReplicationPorts = Arrays.asList(9010, 9011, 9012);
+    private final List<Integer> sinkReplicationPorts = Arrays.asList(9020, 9021, 9022);
 
-    protected Process sourceCorfu1 = null;
-    protected Process sourceCorfu2 = null;
-    protected Process sourceCorfu3 = null;
-    protected Process sinkCorfu1 = null;
-    protected Process sinkCorfu2 = null;
-    protected Process sinkCorfu3 = null;
+    private final List<Process> sourceCorfuProcesses = new ArrayList<>();
+    private final List<Process> sinkCorfuProcesses = new ArrayList<>();
 
-    protected Process sourceReplicationServer1 = null;
-    protected Process sourceReplicationServer2 = null;
-    protected Process sourceReplicationServer3 = null;
-    protected Process sinkReplicationServer1 = null;
-    protected Process sinkReplicationServer2 = null;
-    protected Process sinkReplicationServer3 = null;
+    private final List<Process> sourceReplicationServers = new ArrayList<>();
+    private final List<Process> sinkReplicationServers = new ArrayList<>();
 
-    protected CorfuRuntime sourceRuntime1;
-    protected CorfuRuntime sourceRuntime2;
-    protected CorfuRuntime sourceRuntime3;
-    protected CorfuRuntime sinkRuntime1;
-    protected CorfuRuntime sinkRuntime2;
-    protected CorfuRuntime sinkRuntime3;
+    private List<CorfuRuntime> sourceRuntimes = new ArrayList<>();
+    private List<CorfuRuntime> sinkRuntimes = new ArrayList<>();
 
-    protected CorfuStore corfuStoreSource1;
-    protected CorfuStore corfuStoreSource2;
-    protected CorfuStore corfuStoreSource3;
-    protected CorfuStore corfuStoreSink1;
-    protected CorfuStore corfuStoreSink2;
-    protected CorfuStore corfuStoreSink3;
+    protected List<CorfuStore> sourceCorfuStores = new ArrayList<>();
+    protected List<CorfuStore> sinkCorfuStores = new ArrayList<>();
 
-    protected final String sourceEndpoint1 = DEFAULT_HOST + ":" + sourceSiteCorfuPort1;
-    protected final String sourceEndpoint2 = DEFAULT_HOST + ":" + sourceSiteCorfuPort2;
-    protected final String sourceEndpoint3 = DEFAULT_HOST + ":" + sourceSiteCorfuPort3;
-    protected final String sinkEndpoint1 = DEFAULT_HOST + ":" + sinkSiteCorfuPort1;
-    protected final String sinkEndpoint2 = DEFAULT_HOST + ":" + sinkSiteCorfuPort2;
-    protected final String sinkEndpoint3 = DEFAULT_HOST + ":" + sinkSiteCorfuPort3;
+    private final List<String> sourceEndpoints = new ArrayList<>();
+    private final List<String> sinkEndpoints = new ArrayList<>();
 
-    protected static final String TABLE_1 = "Table001";
-    protected static final String TABLE_2 = "Table002";
-    protected static final String TABLE_3 = "Table003";
-    protected static final String TABLE_4 = "Table004";
+    private int numSourceClusters;
+    private int numSinkClusters;
+
+    private static final String TABLE_1 = "Table001";
+    private static final String TABLE_2 = "Table002";
+    private static final String TABLE_3 = "Table003";
+    protected final List<String> tableNames = Arrays.asList(TABLE_1, TABLE_2, TABLE_3);
+
+    protected final List<Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message>> srcTables = new ArrayList<>();
+    protected final List<Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message>> sinkTables = new ArrayList<>();
 
     protected static final String NAMESPACE = DefaultLogReplicationConfigAdapter.NAMESPACE;
 
@@ -102,12 +102,97 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
 
     protected String pluginConfigFilePath;
 
-    protected ReplicationStatusListener sourceListener1;
+    // Listens to incoming data on streams/tables on a Sink cluster
+    private List<ReplicatedStreamsListener> dataListeners = new ArrayList<>();
+
+    // Listens to replication status updates on a Sink cluster
+    private List<ReplicationStatusListener> replicationStatusListeners = new ArrayList<>();
+
+    /*protected ReplicationStatusListener sourceListener1;
     protected ReplicationStatusListener sourceListener2;
     protected ReplicationStatusListener sourceListener3;
     protected ReplicationStatusListener sinkListener1;
     protected ReplicationStatusListener sinkListener2;
-    protected ReplicationStatusListener sinkListener3;
+    protected ReplicationStatusListener sinkListener3;*/
+
+    protected void setUp(int numSourceClusters, int numSinkClusters) throws Exception {
+        this.numSourceClusters = numSourceClusters;
+        this.numSinkClusters = numSinkClusters;
+        setupSourceAndSinkCorfu(numSourceClusters, numSinkClusters);
+    }
+
+    private void setupSourceAndSinkCorfu(int numSourceClusters, int numSinkClusters) throws Exception {
+        Process process;
+        String endpoint;
+        for (int i = 0; i < numSourceClusters; i++) {
+            process = runServer(sourceCorfuPorts.get(i), true);
+            sourceCorfuProcesses.add(process);
+            endpoint = DEFAULT_HOST + ":" + sourceCorfuPorts.get(i).toString();
+            sourceEndpoints.add(endpoint);
+        }
+
+        for (int i = 0; i < numSinkClusters; i++) {
+            process = runServer(sinkCorfuPorts.get(i), true);
+            sinkCorfuProcesses.add(process);
+            endpoint = DEFAULT_HOST + ":" + sinkCorfuPorts.get(i).toString();
+            sinkEndpoints.add(endpoint);
+        }
+
+        // Setup the runtimes to each Corfu server
+        CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
+            .builder()
+            .build();
+
+        CorfuRuntime runtime;
+        for (int i = 0; i<numSourceClusters; i++) {
+            runtime = CorfuRuntime.fromParameters(params);
+            runtime.parseConfigurationString(sourceEndpoints.get(i));
+            runtime.connect();
+            sourceRuntimes.add(runtime);
+
+            sourceCorfuStores.add(new CorfuStore(runtime));
+        }
+
+        for (int i = 0; i<numSinkClusters; i++) {
+            runtime = CorfuRuntime.fromParameters(params);
+            runtime.parseConfigurationString(sinkEndpoints.get(i));
+            runtime.connect();
+            sinkRuntimes.add(runtime);
+
+            sinkCorfuStores.add(new CorfuStore(runtime));
+        }
+    }
+
+    protected void startReplicationServers() throws Exception {
+        for (int i = 0; i < numSourceClusters; i++) {
+            sourceReplicationServers.add(runReplicationServer(sourceReplicationPorts.get(i), pluginConfigFilePath));
+        }
+
+        for (int i = 0; i < numSinkClusters; i++) {
+            sinkReplicationServers.add(runReplicationServer(sinkReplicationPorts.get(i), pluginConfigFilePath));
+        }
+    }
+
+    protected void openMaps() throws Exception {
+        Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table;
+
+        // Maps are opened as per number of Source sites.  The assumption is that Table001 is opened and written to
+        // on Source 1, Table002 on Source 2 and so on.
+        for (int i = 0; i < numSourceClusters; i++) {
+            table = sourceCorfuStores.get(i).openTable(NAMESPACE, tableNames.get(i), Sample.StringKey.class,
+                SampleSchema.ValueFieldTagOne.class, null,
+                TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+            srcTables.add(table);
+
+            // Open the same tables on the Sink clusters to get stream listener updates.
+            for (int j = 0; j < numSinkClusters; j++) {
+                table = sinkCorfuStores.get(j).openTable(NAMESPACE, tableNames.get(i), Sample.StringKey.class,
+                    SampleSchema.ValueFieldTagOne.class, null,
+                    TableOptions.fromProtoSchema(SampleSchema.ValueFieldTagOne.class));
+                sinkTables.add(table);
+            }
+        }
+    }
 
     protected void writeData(CorfuStore corfuStore, String tableName, Table table, int startIndex, int numRecords) {
         for (int i = startIndex; i < (startIndex + numRecords); i++) {
@@ -134,104 +219,335 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
         return numSourceClusters * NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE;
     }
 
+    protected void verifySnapshotAndLogEntrySink(boolean changeRole) throws Exception {
+        // Open maps on the Source and Destination Sites.  Maps are opened as per number of Source sites.  The
+        // assumption is that Table001 is opened and written to on Source 1, Table002 on Source 2 and so on.
+        openMaps();
+
+        log.debug("Write 3 records locally on each Source Cluster");
+
+        // Write data to tables opened on each source cluster
+        for (int i = 0; i < numSourceClusters; i++) {
+            writeData(sourceCorfuStores.get(i), tableNames.get(i), srcTables.get(i), 0, NUM_RECORDS_IN_TABLE);
+        }
+
+        // Register a stream listener on the Sink clusters to listen for incoming replication data writes.
+        // During snapshot sync, there will be 1 write(with all entries) for each replicated table with data.  The
+        // listener ignores 'single clear' writes('clear' on a table from Snapshot sync from another Source which
+        // does not have data on this table) for the countdown latch.  So there will be 1 write per Source cluster,
+        // i.e., Source Cluster 1's writes to Table001 and so on.
+        // Also subscribe to updates on the Replication Status table.
+        List<CountDownLatch> snapshotWritesLatches = new ArrayList<>();
+        CountDownLatch dataLatch;
+        ReplicatedStreamsListener dataListener;
+
+        // On startup, an initial default replication status is written for each remote cluster
+        // (NUM_INITIAL_REPLICATION_STATUS_UPDATES).  Subsequently, the table will be updated on snapshot sync from
+        // each Source cluster.
+        int numExpectedUpdates = NUM_INITIAL_REPLICATION_STATUS_UPDATES +
+            calculateSnapshotSyncUpdatesOnSinkStatusTable(numSourceClusters);
+        List<CountDownLatch> statusLatches = new ArrayList<>();
+        CountDownLatch statusLatch;
+        ReplicationStatusListener statusListener;
+
+        for (int i = 0; i < numSinkClusters; i++) {
+            // Data Listeners.
+            // In the test, the number of tables where updates are applied = numSourceClusters(Source 1 - Table001,
+            // Source2 - Table002..).  So there will be numSourceClusters number of transactions.
+            dataLatch = new CountDownLatch(numSourceClusters);
+            snapshotWritesLatches.add(dataLatch);
+
+            dataListener = new ReplicatedStreamsListener(dataLatch, true);
+            dataListeners.add(dataListener);
+
+            sinkCorfuStores.get(i).subscribeListener(dataListener, NAMESPACE, STREAM_TAG);
+
+            // Replication Status Listeners
+            sinkCorfuStores.get(i).openTable(LogReplicationMetadataManager.NAMESPACE,
+                LogReplicationMetadataManager.REPLICATION_STATUS_TABLE, LogReplicationMetadata.ReplicationStatusKey.class,
+                LogReplicationMetadata.ReplicationStatusVal.class, null,
+                TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+            statusLatch = new CountDownLatch(numExpectedUpdates);
+            statusLatches.add(statusLatch);
+
+            statusListener = new ReplicationStatusListener(statusLatch);
+            replicationStatusListeners.add(statusListener);
+            sinkCorfuStores.get(i).subscribeListener(statusListener, LogReplicationMetadataManager.NAMESPACE,
+                LR_STATUS_STREAM_TAG);
+        }
+
+        if (changeRole) {
+            Table<ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg>
+                configTable = sinkCorfuStores.get(0).openTable(DefaultClusterManager.CONFIG_NAMESPACE,
+                    DefaultClusterManager.CONFIG_TABLE_NAME, ExampleSchemas.ClusterUuidMsg.class,
+                    ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
+                    TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class));
+            try (TxnContext txn = sinkCorfuStores.get(0).txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
+                txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH,
+                    DefaultClusterManager.OP_SWITCH);
+                txn.commit();
+            }
+            Assert.assertEquals(1, configTable.count());
+
+        } else {
+            // Start Log Replication
+            startReplicationServers();
+        }
+
+        // Verify the number of updates and order of operations received on snapshot sync
+        // During snapshot sync, a 'clear' followed by 'update' for each record is received.  So there should be
+        // 1 Clear + NUM_RECORDS_IN_TABLE Update records for each table on each Sink cluster.
+        List<CorfuStreamEntry.OperationType> expectedOpsList = Arrays.asList(CorfuStreamEntry.OperationType.CLEAR,
+            CorfuStreamEntry.OperationType.UPDATE, CorfuStreamEntry.OperationType.UPDATE,
+            CorfuStreamEntry.OperationType.UPDATE);
+        for (int i = 0; i < numSinkClusters; i++) {
+            statusLatches.get(i).await();
+            snapshotWritesLatches.get(i).await();
+
+            for (int j = 0; j < srcTables.size(); j++) {
+                Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1,
+                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(j)).size());
+                Assert.assertTrue(Objects.equals(expectedOpsList,
+                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(j))));
+            }
+        }
+
+        // Verify LogEntry Sync by writing and deleting a record each.
+        // If there are multiple Source clusters, UPDATE and DELETE are done on different tables, each on a separate
+        // Source Cluster.  Number of expected transactions on the Sink = 2 (1 from each Source and table)
+
+        // In case of a topology with a single Source cluster, perform both ops on the same table(because number of
+        // tables opened = number of Source clusters).  During Log Entry Sync, there is transaction batching on the
+        // Source cluster, so both operations will be received and applied in the same transaction on the Sink.
+        // Hence, number of expected transactions = 1;
+        List<CountDownLatch> logEntryWritesLatches = new ArrayList<>();
+        CountDownLatch logEntryWritesLatch;
+        for (int i = 0; i < numSinkClusters; i++) {
+            if (numSourceClusters > 1) {
+                logEntryWritesLatch = new CountDownLatch(2);
+            } else {
+                logEntryWritesLatch = new CountDownLatch(1);
+            }
+            logEntryWritesLatches.add(logEntryWritesLatch);
+            dataListeners.get(i).setCountdownLatch(logEntryWritesLatch);
+            dataListeners.get(i).clearTableToOpTypeMap();
+            dataListeners.get(i).setSnapshotSync(false);
+        }
+        log.info("Add a record on table on Sender-1, Table-1");
+        writeData(sourceCorfuStores.get(0), tableNames.get(0), srcTables.get(0), NUM_RECORDS_IN_TABLE, 1);
+
+        log.info("Delete Key2");
+        if (numSourceClusters > 1) {
+            log.info("Delete a record from Sender-2, Table-2");
+            deleteRecord(sourceCorfuStores.get(1), tableNames.get(1), 2);
+        } else {
+            log.info("Delete a record from Sender-1, Table-1");
+            deleteRecord(sourceCorfuStores.get(0), tableNames.get(0), 2);
+        }
+
+        for (int i = 0; i < numSinkClusters; i++) {
+            logEntryWritesLatches.get(i).await();
+
+            if (numSourceClusters > 1) {
+                // 1 Operation received for each table on the Sink cluster
+                Assert.assertEquals(1, dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).size());
+                Assert.assertEquals(CorfuStreamEntry.OperationType.UPDATE,
+                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).get(0));
+                Assert.assertEquals(1, dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(1)).size());
+                Assert.assertEquals(CorfuStreamEntry.OperationType.DELETE,
+                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(1)).get(0));
+            } else {
+                // 2 operations received for the same table on the Sink cluster
+                Assert.assertEquals(2, dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).size());
+
+                // As these operations are applied in the same transaction, their streaming updates can come in any
+                // order(to be fixed).  We can only verify that both UPDATE and DELETE are received.
+                Assert.assertTrue(dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).contains(
+                    CorfuStreamEntry.OperationType.UPDATE));
+                Assert.assertTrue(dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).contains(
+                    CorfuStreamEntry.OperationType.DELETE));
+            }
+        }
+    }
+
+    /**
+     * On a role change, the number of Source and Sink clusters changes.  The roles of clusters in the topology
+     * change, but the total number of clusters is the same.  Additionally, the expected behavior on snapshot and log
+     * entry sync is the same, only the senders and receivers are different.  This method resets and exchanges the test
+     * state, making it ready for role change, such that the same validation method(verifySnapshotAndLogEntrySync) can
+     * be reused after the change.
+     * @param numNewSourceClusters
+     * @param numNewSinkClusters
+     */
+    protected void prepareTestTopologyForRoleChange(int numNewSourceClusters, int numNewSinkClusters) {
+        // The test workflow is as follows:
+        // 1. verifySnapshotAndLogEntrySync
+        // 2. change the role
+        // 3. verifySnapshotAndLogEntrySync ( with role changed)
+        // Clear data from all Source clusters so that verifySnapshotAndLogEntrySync can re-use existing tables to
+        // write and perform the same validation.
+        for (int i = 0; i < numSourceClusters; i++) {
+            try (TxnContext txn = sourceCorfuStores.get(i).txn(NAMESPACE)) {
+                txn.clear(tableNames.get(i));
+                txn.commit();
+            }
+        }
+
+        for (Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table : srcTables) {
+            Assert.assertEquals(0, table.count());
+        }
+
+        // Verify that no tables on the Sink cluster have data
+        for (Table<Sample.StringKey, SampleSchema.ValueFieldTagOne, Message> table : sinkTables) {
+            while(table.count() != 0) {
+
+            }
+        }
+        // Reset/clear the list of tables on Source and Sink
+        srcTables.clear();
+        sinkTables.clear();
+
+        // Unsubscribe the listeners on Sink clusters
+        unsubscribeListeners();
+
+        // Reset/clear the list of listeners
+        dataListeners.clear();
+        replicationStatusListeners.clear();
+
+        // The test workflow is as follows:
+        // 1. verifySnapshotAndLogEntrySync
+        // 2. change the role
+        // 3. verifySnapshotAndLogEntrySync ( with role changed)
+        // verifySnapshotAndLogEntrySync checks the number of data updates received on a snapshot and log entry sync.
+        // It assumes that the Sink table/s are empty when snapshot sync started.
+        // However, in step 3, the streams will have older updates from:
+        // - Step 1 and
+        // - Clear operation done at the beginning of this method
+        // So run a CP+Trim on the to-be Source(current Sink) clusters so that the above redundant updates get
+        // Checkpointed and are not sent.
+        for (int i = 0; i < numSinkClusters; i++) {
+            CorfuRuntime cpRuntime = new CorfuRuntime(sinkEndpoints.get(i)).connect();
+            checkpointAndTrimCorfuStore(cpRuntime);
+        }
+
+        // Exchange source and sink corfu stores
+        List<CorfuStore> tmp = sourceCorfuStores;
+        sourceCorfuStores = sinkCorfuStores;
+        sinkCorfuStores = tmp;
+
+        numSourceClusters = numNewSourceClusters;
+        numSinkClusters = numNewSinkClusters;
+    }
+
+    public void checkpointAndTrimCorfuStore(CorfuRuntime cpRuntime) {
+        // Open Table Registry
+        TableRegistry tableRegistry = cpRuntime.getTableRegistry();
+        CorfuTable<CorfuStoreMetadata.TableName, CorfuRecord<CorfuStoreMetadata.TableDescriptors,
+            CorfuStoreMetadata.TableMetadata>> tableRegistryCT = tableRegistry.getRegistryTable();
+
+        CorfuTable<CorfuStoreMetadata.ProtobufFileName,
+            CorfuRecord<CorfuStoreMetadata.ProtobufFileDescriptor, CorfuStoreMetadata.TableMetadata>>
+            protobufDescriptorTable =
+            tableRegistry.getProtobufDescriptorTable();
+
+        // Save the regular serializer first..
+        ISerializer protoBufSerializer = cpRuntime.getSerializers().getSerializer(ProtobufSerializer.PROTOBUF_SERIALIZER_CODE);
+
+        // Must register dynamicProtoBufSerializer *AFTER* the getTableRegistry() call to ensure that
+        // the serializer does not go back to the regular ProtoBufSerializer
+        ISerializer dynamicProtoBufSerializer = new DynamicProtobufSerializer(cpRuntime);
+        cpRuntime.getSerializers().registerSerializer(dynamicProtoBufSerializer);
+
+        MultiCheckpointWriter<CorfuTable> mcw = new MultiCheckpointWriter<>();
+
+        Token trimMark = null;
+
+        for (CorfuStoreMetadata.TableName tableName : tableRegistry.listTables(null)) {
+            // ProtobufDescriptor table is an internal table which must not
+            // be checkpointed using the DynamicProtobufSerializer
+            if (tableName.getTableName().equals(TableRegistry.PROTOBUF_DESCRIPTOR_TABLE_NAME)) {
+                continue;
+            }
+            String fullTableName = TableRegistry.getFullyQualifiedTableName(
+                tableName.getNamespace(), tableName.getTableName()
+            );
+            SMRObject.Builder<CorfuTable<CorfuDynamicKey, CorfuDynamicRecord>> corfuTableBuilder = cpRuntime.getObjectsView().build()
+                .setTypeToken(new TypeToken<CorfuTable<CorfuDynamicKey, CorfuDynamicRecord>>() {})
+                .setStreamName(fullTableName)
+                .setSerializer(dynamicProtoBufSerializer);
+
+            mcw = new MultiCheckpointWriter<>();
+            mcw.addMap(corfuTableBuilder.open());
+
+            Token token = mcw.appendCheckpoints(cpRuntime, "checkpointer");
+            trimMark = trimMark == null ? token : Token.min(trimMark, token);
+        }
+
+        // Finally checkpoint the ProtobufDescriptor and TableRegistry system
+        // tables
+        // Restore the regular protoBuf serializer and undo the dynamic
+        // protoBuf serializer
+        // otherwise the test cannot continue beyond this point.
+        log.info("Now checkpointing the ProtobufDescriptor and Registry " +
+            "Tables");
+        cpRuntime.getSerializers().registerSerializer(protoBufSerializer);
+        mcw.addMap(protobufDescriptorTable);
+        Token token1 = mcw.appendCheckpoints(cpRuntime, "checkpointer");
+
+        mcw.addMap(tableRegistryCT);
+        Token token2 = mcw.appendCheckpoints(cpRuntime, "checkpointer");
+        Token minToken = Token.min(token1, token2);
+        trimMark = trimMark != null ? Token.min(trimMark, minToken) : minToken;
+
+        cpRuntime.getAddressSpaceView().prefixTrim(trimMark);
+        cpRuntime.getAddressSpaceView().gc();
+
+        // Trim
+        log.debug("**** Trim Log @address=" + trimMark);
+        cpRuntime.getAddressSpaceView().prefixTrim(trimMark);
+        cpRuntime.getAddressSpaceView().invalidateClientCache();
+        cpRuntime.getAddressSpaceView().invalidateServerCaches();
+        cpRuntime.getAddressSpaceView().gc();
+    }
+
+    private void unsubscribeListeners() {
+        for (int i = 0; i < numSinkClusters; i++) {
+            sinkCorfuStores.get(i).unsubscribeListener(dataListeners.get(i));
+            sinkCorfuStores.get(i).unsubscribeListener(replicationStatusListeners.get(i));
+        }
+    }
+
     @After
     public void tearDown() {
-        if (sinkListener1 != null) {
-            corfuStoreSink1.unsubscribeListener(sinkListener1);
-        }
-
-        if (sinkListener2 != null) {
-            corfuStoreSink2.unsubscribeListener(sinkListener2);
-        }
-
-        if (sinkListener3 != null) {
-            corfuStoreSink3.unsubscribeListener(sinkListener3);
-        }
-
-        if (sourceListener1 != null) {
-            corfuStoreSource1.unsubscribeListener(sourceListener1);
-        }
-
-        if (sourceListener2 != null) {
-            corfuStoreSource2.unsubscribeListener(sourceListener2);
-        }
-
-        if (sourceListener3 != null) {
-            corfuStoreSource3.unsubscribeListener(sourceListener3);
-        }
+        unsubscribeListeners();
         shutdownCorfuServers();
         shutdownLogReplicationServers();
 
-        if (sourceRuntime1 != null) {
-            sourceRuntime1.shutdown();
+        for (CorfuRuntime runtime : sourceRuntimes) {
+            runtime.shutdown();
         }
-        if (sourceRuntime2 != null) {
-            sourceRuntime2.shutdown();
+        for (CorfuRuntime runtime : sinkRuntimes) {
+            runtime.shutdown();
         }
-        if (sourceRuntime3 != null) {
-            sourceRuntime3.shutdown();
-        }
-        if (sinkRuntime1 != null) {
-            sinkRuntime1.shutdown();
-        }
-        if (sinkRuntime2 != null) {
-            sinkRuntime2.shutdown();
-        }
-        if (sinkRuntime3 != null) {
-            sinkRuntime3.shutdown();
-        }
-
     }
 
     private void shutdownCorfuServers() {
-        if (sourceCorfu1 != null) {
-            sourceCorfu1.destroy();
+        for (Process process : sourceCorfuProcesses) {
+            process.destroy();
         }
 
-        if (sourceCorfu2 != null) {
-            sourceCorfu2.destroy();
-        }
-
-        if (sourceCorfu3 != null) {
-            sourceCorfu3.destroy();
-        }
-
-        if (sinkCorfu1 != null) {
-            sinkCorfu1.destroy();
-        }
-
-        if (sinkCorfu2 != null) {
-            sinkCorfu2.destroy();
-        }
-
-        if (sinkCorfu3 != null) {
-            sinkCorfu3.destroy();
+        for (Process process : sinkCorfuProcesses) {
+            process.destroy();
         }
     }
 
     private void shutdownLogReplicationServers() {
-        if (sourceReplicationServer1 != null) {
-            sourceReplicationServer1.destroy();
+        for (Process lrProcess : sourceReplicationServers) {
+            lrProcess.destroy();
         }
 
-        if (sourceReplicationServer2 != null) {
-            sourceReplicationServer2.destroy();
-        }
-
-        if (sourceReplicationServer3 != null) {
-            sourceReplicationServer3.destroy();
-        }
-
-        if (sinkReplicationServer1 != null) {
-            sinkReplicationServer1.destroy();
-        }
-
-        if (sinkReplicationServer2 != null) {
-            sinkReplicationServer2.destroy();
-        }
-
-        if (sinkReplicationServer3 != null) {
-            sinkReplicationServer3.destroy();
+        for (Process lrProcess : sinkReplicationServers) {
+            lrProcess.destroy();
         }
     }
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -96,7 +96,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     public void testSinkClusterReset() throws Exception {
         // (1) Snapshot and Log Entry Sync
         log.debug(">>> (1) Start Snapshot and Log Entry Sync");
-        testEndToEndSnapshotAndLogEntrySyncUFO(false, false);
+        testEndToEndSnapshotAndLogEntrySyncUFO(false, false, 1);
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
@@ -134,7 +134,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
         // (1) Snapshot and Log Entry Sync
         log.debug(">>> (1) Start Snapshot and Log Entry Sync");
-        testEndToEndSnapshotAndLogEntrySyncUFO(false, false);
+        testEndToEndSnapshotAndLogEntrySyncUFO(false, false, 1);
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
@@ -462,6 +462,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             final int totalEntries = 20;
 
             setupSourceAndSinkCorfu();
+            initSingleSourceSinkCluster();
             openMaps();
 
             Set<UUID> tablesToListen = new DefaultLogReplicationConfigAdapter().getStreamingConfigOnSink().keySet();

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -59,13 +59,13 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
     private AtomicBoolean replicationEnded = new AtomicBoolean(false);
 
-    private Map<String, Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata>> mapNameToMapActiveTypeA
+    private Map<String, Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata>> mapNameToMapSourceTypeA
             = new HashMap<>();
-    private Map<String, Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata>> mapNameToMapStandbyTypeA =
+    private Map<String, Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata>> mapNameToMapSinkTypeA =
             new HashMap<>();
-    private Map<String, Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata>> mapNameToMapActiveTypeB =
+    private Map<String, Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata>> mapNameToMapSourceTypeB =
             new HashMap<>();
-    private Map<String, Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata>> mapNameToMapStandbyTypeB =
+    private Map<String, Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata>> mapNameToMapSinkTypeB =
             new HashMap<>();
 
     private volatile AtomicBoolean stopWrites = new AtomicBoolean(false);
@@ -88,47 +88,47 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     }
 
     /**
-     * Test the case where Standby leader node is restarted during log entry sync.
+     * Test the case where Sink leader node is restarted during log entry sync.
      *
      * The expectation is that replication should resume.
      */
     @Test
-    public void testStandbyClusterReset() throws Exception {
+    public void testSinkClusterReset() throws Exception {
         // (1) Snapshot and Log Entry Sync
         log.debug(">>> (1) Start Snapshot and Log Entry Sync");
         testEndToEndSnapshotAndLogEntrySyncUFO(false, false);
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
-        // (2) Stop Standby Log Replicator Server
-        log.debug(">>> (2) Stop Standby Node");
-        stopStandbyLogReplicator();
+        // (2) Stop Sink Log Replicator Server
+        log.debug(">>> (2) Stop Sink Node");
+        stopSinkLogReplicator();
 
-        // (3) Start daemon thread writing data to active
+        // (3) Start daemon thread writing data to source
         log.debug(">>> (3) Start daemon writer service");
         // Since step (1) wrote numWrites for snapshotSync and numWrites/2 in logEntrySync, continue from this starting point
-        writerService.submit(() -> writeToActive((numWrites + numWrites/2), numWrites));
+        writerService.submit(() -> writeToSource((numWrites + numWrites/2), numWrites));
 
-        // (4) Sleep Interval so writes keep going through, while standby is down
+        // (4) Sleep Interval so writes keep going through, while sink is down
         log.debug(">>> (4) Wait for some time");
         Sleep.sleepUninterruptibly(Duration.ofSeconds(SLEEP_DURATION));
 
-        // (5) Restart Standby Log Replicator
-        log.debug(">>> (5) Restart Standby Node");
-        startStandbyLogReplicator();
+        // (5) Restart Sink Log Replicator
+        log.debug(">>> (5) Restart Sink Node");
+        startSinkLogReplicator();
 
-        // (6) Verify Data on Standby after Restart
-        log.debug(">>> (6) Verify Data on Standby");
-        verifyStandbyData((numWrites*2 + numWrites/2));
+        // (6) Verify Data on Sink after Restart
+        log.debug(">>> (6) Verify Data on Sink");
+        verifySinkData((numWrites*2 + numWrites/2));
     }
 
     /**
-     * Test the case where Active leader node is restarted during log entry sync.
+     * Test the case where Source leader node is restarted during log entry sync.
      *
      * The expectation is that replication should resume.
      */
     @Test
-    public void testActiveClusterReset() throws Exception {
+    public void testSourceClusterReset() throws Exception {
 
         final int delta = 5;
 
@@ -138,29 +138,29 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
-        // (2) Start daemon thread writing data to active
+        // (2) Start daemon thread writing data to source
         log.debug(">>> (2) Start daemon writer service");
         // Since step (1) wrote numWrites for snapshotSync and numWrites/2 in logEntrySync, continue from this starting point
-        writerService.submit(() -> writeToActive((numWrites + numWrites/2), numWrites));
+        writerService.submit(() -> writeToSource((numWrites + numWrites/2), numWrites));
 
-        // (3) Stop Active Log Replicator Server
-        log.debug(">>> (3) Stop Active Node");
-        stopActiveLogReplicator();
+        // (3) Stop Source Log Replicator Server
+        log.debug(">>> (3) Stop Source Node");
+        stopSourceLogReplicator();
 
-        // (4) Sleep Interval so writes keep going through, while active is down
+        // (4) Sleep Interval so writes keep going through, while source is down
         log.debug(">>> (4) Wait for some time");
         Sleep.sleepUninterruptibly(Duration.ofSeconds(SLEEP_DURATION));
 
-        // (5) Restart Active Log Replicator
-        log.debug(">>> (5) Restart Active Node");
-        startActiveLogReplicator();
+        // (5) Restart Source Log Replicator
+        log.debug(">>> (5) Restart Source Node");
+        startSourceLogReplicator();
 
-        // (6) Verify Data on Standby after Restart
-        log.debug(">>> (6) Verify Data on Standby");
-        verifyStandbyData((numWrites*2 + numWrites/2));
+        // (6) Verify Data on Sink after Restart
+        log.debug(">>> (6) Verify Data on Sink");
+        verifySinkData((numWrites*2 + numWrites/2));
 
         // (7) Verify replication status after all data has been replicated (no further data)
-        corfuStoreActive.openTable(LogReplicationMetadataManager.NAMESPACE,
+        corfuStoreSource.openTable(LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -199,10 +199,10 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
         stopWrites.set(true);
 
-        // (9) Stop active LR again, so server restarts from Log Entry Sync, with no actual deltas (as there is no new data)
+        // (9) Stop source LR again, so server restarts from Log Entry Sync, with no actual deltas (as there is no new data)
         // and verify remainingEntriesToSend is still '0'
-        stopActiveLogReplicator();
-        startActiveLogReplicator();
+        stopSourceLogReplicator();
+        startSourceLogReplicator();
 
         // Wait the polling period time and verify sync status again (to make sure it was not erroneously updated)
         Sleep.sleepUninterruptibly(Duration.ofSeconds(LogReplicationAckReader.ACKED_TS_READ_INTERVAL_SECONDS + delta));
@@ -221,11 +221,11 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
         LogReplicationMetadata.ReplicationStatusKey key =
                 LogReplicationMetadata.ReplicationStatusKey
                         .newBuilder()
-                        .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
+                        .setClusterId(new DefaultClusterConfig().getSinkClusterIds().get(0))
                         .build();
 
         ReplicationStatusVal replicationStatusVal;
-        try (TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+        try (TxnContext txn = corfuStoreSource.txn(LogReplicationMetadataManager.NAMESPACE)) {
             replicationStatusVal = (ReplicationStatusVal)txn.getRecord(LogReplicationMetadataManager.REPLICATION_STATUS_TABLE, key).getPayload();
             txn.commit();
         }
@@ -248,7 +248,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     }
 
     private void openNonReplicatedTable() throws Exception {
-        noisyMap = corfuStoreActive.openTable(
+        noisyMap = corfuStoreSource.openTable(
                 NAMESPACE, "noisyMap", Sample.StringKey.class, Sample.IntValueTag.class, Sample.Metadata.class,
                 TableOptions.fromProtoSchema(Sample.IntValueTag.class));
     }
@@ -258,7 +258,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             Sample.StringKey stringKey = Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build();
             Sample.IntValueTag intValueTag = Sample.IntValueTag.newBuilder().setValue(i).build();
             Sample.Metadata metadata = Sample.Metadata.newBuilder().setMetadata("Metadata_" + i).build();
-            try (TxnContext txn = corfuStoreActive.txn(NAMESPACE)) {
+            try (TxnContext txn = corfuStoreSource.txn(NAMESPACE)) {
                 txn.putRecord(noisyMap, stringKey, intValueTag, metadata);
                 txn.commit();
             }
@@ -267,79 +267,79 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
     @Test
     public void testSnapshotSyncApplyInterrupted() throws Exception {
-        final int standbyIndex = 2;
+        final int sinkIndex = 2;
         final int numWritesSmaller = 1000;
 
         try {
-            log.debug("Setup active and standby Corfu's");
-            setupActiveAndStandbyCorfu();
+            log.debug("Setup source and sink Corfu's");
+            setupSourceAndSinkCorfu();
 
-            log.debug("Open map on active and standby");
+            log.debug("Open map on source and sink");
             openMaps(DefaultLogReplicationConfigAdapter.MAP_COUNT, false);
 
-            // Subscribe to standby map 'Table002' (standbyIndex) to stop Standby LR as soon as updates are received,
-            // forcing snapshot sync apply to be interrupted and resumed after LR standby is restarted
-            subscribe(TABLE_PREFIX + standbyIndex);
+            // Subscribe to sink map 'Table002' (sinkIndex) to stop Sink LR as soon as updates are received,
+            // forcing snapshot sync apply to be interrupted and resumed after LR sink is restarted
+            subscribe(TABLE_PREFIX + sinkIndex);
 
-            log.debug("Write data to active CorfuDB before LR is started ...");
+            log.debug("Write data to source CorfuDB before LR is started ...");
             // Add Data for Snapshot Sync
-            writeToActive(0, numWritesSmaller);
+            writeToSource(0, numWritesSmaller);
 
-            // Confirm data does exist on Active Cluster
-            for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapActive.values()) {
+            // Confirm data does exist on Source Cluster
+            for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSource.values()) {
                 assertThat(map.count()).isEqualTo(numWritesSmaller);
             }
 
-            // Confirm data does not exist on Standby Cluster
-            for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapStandby.values()) {
+            // Confirm data does not exist on Sink Cluster
+            for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSink.values()) {
                 assertThat(map.count()).isEqualTo(0);
             }
 
             startLogReplicatorServers();
 
             log.debug("Wait ... Snapshot log replication in progress ...");
-            verifyStandbyData(numWritesSmaller);
+            verifySinkData(numWritesSmaller);
 
             // Add Delta's for Log Entry Sync
-            writeToActive(numWritesSmaller, numWritesSmaller / 2);
+            writeToSource(numWritesSmaller, numWritesSmaller / 2);
 
             log.debug("Wait ... Delta log replication in progress ...");
-            verifyStandbyData((numWritesSmaller + (numWritesSmaller / 2)));
+            verifySinkData((numWritesSmaller + (numWritesSmaller / 2)));
         } finally {
             executorService.shutdownNow();
 
-            if (activeCorfu != null) {
-                activeCorfu.destroy();
+            if (sourceCorfu != null) {
+                sourceCorfu.destroy();
             }
 
-            if (standbyCorfu != null) {
-                standbyCorfu.destroy();
+            if (sinkCorfu != null) {
+                sinkCorfu.destroy();
             }
 
-            if (activeReplicationServer != null) {
-                activeReplicationServer.destroy();
+            if (sourceReplicationServer != null) {
+                sourceReplicationServer.destroy();
             }
 
-            if (standbyReplicationServer != null) {
-                standbyReplicationServer.destroy();
+            if (sinkReplicationServer != null) {
+                sinkReplicationServer.destroy();
             }
         }
     }
 
     /**
-     * Validate that no data is written into the Standby's Transaction Log during replication
+     * Validate that no data is written into the Sink's Transaction Log during replication
      * of 5K objects.
      *
      * @throws Exception
      */
     @Test
-    public void testStandbyTransactionLogging() throws Exception {
+    public void testSinkTransactionLogging() throws Exception {
         final long timeout = 30;
 
         replicationEnded.set(false);
 
-        // (1) Subscribe Client to Standby Transaction Log
-        log.debug(">>> (1) Subscribe to Transaction Stream on Standby");
+        // (1) Subscribe Client to Sink Transaction Log
+        log.debug(">>> (1) Subscribe to Transaction Stream on Sink");
         Future<Boolean> consumerState = subscribeTransactionStream();
 
         // (2) Snapshot and Log Entry Sync
@@ -363,7 +363,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             CorfuRuntime consumerRt = CorfuRuntime.fromParameters(CorfuRuntime.CorfuRuntimeParameters
                     .builder()
                     .build())
-                    .parseConfigurationString(standbyEndpoint)
+                    .parseConfigurationString(sinkEndpoint)
                     .connect();
 
             consumerRts.add(consumerRt);
@@ -392,8 +392,8 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     }
 
     private void subscribe(String mapName) {
-        // Subscribe to mapName and upon changes stop standby LR
-        CorfuStore corfuStore = new CorfuStore(standbyRuntime);
+        // Subscribe to mapName and upon changes stop sink LR
+        CorfuStore corfuStore = new CorfuStore(sinkRuntime);
 
         try {
             corfuStore.openTable(
@@ -404,7 +404,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        StandbyMapListener configStreamListener = new StandbyMapListener(this);
+        SinkMapListener configStreamListener = new SinkMapListener(this);
         corfuStore.subscribeListener(configStreamListener, NAMESPACE, "test");
     }
 
@@ -413,30 +413,30 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
      * It enables ITs run as processes and communicate with the cluster manager
      * to update topology config.
      **/
-    public static class StandbyMapListener implements StreamListener {
+    public static class SinkMapListener implements StreamListener {
 
         private final LogReplicationAbstractIT abstractIT;
 
         private boolean interruptedSnapshotSyncApply = false;
 
-        public StandbyMapListener(LogReplicationAbstractIT abstractIT) {
+        public SinkMapListener(LogReplicationAbstractIT abstractIT) {
             this.abstractIT = abstractIT;
         }
 
         @Override
         public synchronized void onNext(CorfuStreamEntries results) {
-            log.info("StandbyMapListener:: onNext {} with entry size {}", results, results.getEntries().size());
+            log.info("SinkMapListener:: onNext {} with entry size {}", results, results.getEntries().size());
 
             if (!interruptedSnapshotSyncApply) {
 
                 interruptedSnapshotSyncApply = true;
 
                 // Stop Log Replication Server so Snapshot Sync Apply is interrupted in the middle and restart
-                log.debug("StandbyMapListener:: Stop Standby LR while in snapshot sync apply phase...");
-                this.abstractIT.stopStandbyLogReplicator();
+                log.debug("SinkMapListener:: Stop Sink LR while in snapshot sync apply phase...");
+                this.abstractIT.stopSinkLogReplicator();
 
-                log.debug("StandbyMapListener:: Restart Standby LR...");
-                this.abstractIT.startStandbyLogReplicator();
+                log.debug("SinkMapListener:: Restart Sink LR...");
+                this.abstractIT.startSinkLogReplicator();
             }
         }
 
@@ -447,60 +447,60 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     }
 
     /**
-     * Test standby streaming, which depends on external configuration of the tags and tables of interest.
+     * Test sink streaming, which depends on external configuration of the tags and tables of interest.
      *
      * This test relies on a custom ConfigAdapter (DefaultLogReplicationConfigAdapter) which has hard coded
-     * the tables to stream on standby (two tables: table_1 and table_2 for TAG_ONE). We attach a listener to this
+     * the tables to stream on sink (two tables: table_1 and table_2 for TAG_ONE). We attach a listener to this
      * tag and verify updates are received accordingly. Note that, we also write to other tables with the same tags
      * to confirm these are not erroneously streamed as well (as they're not part of the configuration).
      *
      * @throws Exception
      */
     @Test
-    public void testStandbyStreaming() throws Exception {
+    public void testSinkStreaming() throws Exception {
         try {
             final int totalEntries = 20;
 
-            setupActiveAndStandbyCorfu();
+            setupSourceAndSinkCorfu();
             openMaps();
 
             Set<UUID> tablesToListen = new DefaultLogReplicationConfigAdapter().getStreamingConfigOnSink().keySet();
 
-            // Start Listener on the 'stream_tag' of interest, on standby site + tables to listen (which accounts
+            // Start Listener on the 'stream_tag' of interest, on sink site + tables to listen (which accounts
             // for the notification for 'clear' table)
-            CountDownLatch streamingStandbySnapshotCompletion =
+            CountDownLatch streamingSinkSnapshotCompletion =
                 new CountDownLatch(totalEntries*tablesToListen.size() + tablesToListen.size());
-            StreamingStandbyListener listener = new StreamingStandbyListener(streamingStandbySnapshotCompletion,
+            StreamingSinkListener listener = new StreamingSinkListener(streamingSinkSnapshotCompletion,
                     tablesToListen);
-            corfuStoreStandby.subscribeListener(listener, NAMESPACE, DefaultLogReplicationConfigAdapter.TAG_ONE);
+            corfuStoreSink.subscribeListener(listener, NAMESPACE, DefaultLogReplicationConfigAdapter.TAG_ONE);
 
             // Add Data for Snapshot Sync (before LR is started)
-            writeToActiveDifferentTypes(0, totalEntries);
+            writeToSourceDifferentTypes(0, totalEntries);
 
-            // Confirm data does exist on Active Cluster
-            verifyActiveData(totalEntries);
+            // Confirm data does exist on Source Cluster
+            verifySourceData(totalEntries);
 
-            // Confirm data does not exist on Standby Cluster
-            verifyStandbyData(0);
+            // Confirm data does not exist on Sink Cluster
+            verifySinkData(0);
 
-            // Open a local table on Standby Cluster
-            openTable(corfuStoreStandby, "local");
+            // Open a local table on Sink Cluster
+            openTable(corfuStoreSink, "local");
 
-            // Open an extra table on Active Cluster
-            openTable(corfuStoreActive, "extra");
+            // Open an extra table on Source Cluster
+            openTable(corfuStoreSource, "extra");
 
-            // Confirm local table is opened on Standby
-            verifyTableOpened(corfuStoreStandby, "local");
+            // Confirm local table is opened on Sink
+            verifyTableOpened(corfuStoreSink, "local");
 
-            // Confirm extra table is opened on Active
-            verifyTableOpened(corfuStoreActive, "extra");
+            // Confirm extra table is opened on Source
+            verifyTableOpened(corfuStoreSource, "extra");
 
             // Start LR
             startLogReplicatorServers();
 
             // Wait until snapshot sync has completed
             // Open replication status table and monitor completion field
-            corfuStoreActive.openTable(LogReplicationMetadataManager.NAMESPACE,
+            corfuStoreSource.openTable(LogReplicationMetadataManager.NAMESPACE,
                     LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                     LogReplicationMetadata.ReplicationStatusKey.class,
                     LogReplicationMetadata.ReplicationStatusVal.class,
@@ -509,58 +509,58 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             blockUntilSnapshotSyncCompleted();
 
             // Verify Snapshot has successfully replicated
-            verifyStandbyData(totalEntries);
+            verifySinkData(totalEntries);
 
             log.info("** Wait for data change notifications (snapshot)");
-            streamingStandbySnapshotCompletion.await();
+            streamingSinkSnapshotCompletion.await();
             assertThat(listener.messages.size()).isEqualTo(
                 totalEntries*tablesToListen.size() + tablesToListen.size());
 
-            // Verify both extra and local table are opened on Standby
-            verifyTableOpened(corfuStoreStandby, "local");
-            verifyTableOpened(corfuStoreStandby, "extra");
+            // Verify both extra and local table are opened on Sink
+            verifyTableOpened(corfuStoreSink, "local");
+            verifyTableOpened(corfuStoreSink, "extra");
 
             // Attach new listener for deltas (the same listener could be used) but simplifying the use of the latch
-            CountDownLatch streamingStandbyDeltaCompletion =
+            CountDownLatch streamingSinkDeltaCompletion =
                 new CountDownLatch(totalEntries*tablesToListen.size());
-            StreamingStandbyListener listenerDeltas = new StreamingStandbyListener(streamingStandbyDeltaCompletion,
+            StreamingSinkListener listenerDeltas = new StreamingSinkListener(streamingSinkDeltaCompletion,
                     new DefaultLogReplicationConfigAdapter().getStreamingConfigOnSink().keySet());
-            corfuStoreStandby.subscribeListener(listenerDeltas, NAMESPACE, DefaultLogReplicationConfigAdapter.TAG_ONE);
+            corfuStoreSink.subscribeListener(listenerDeltas, NAMESPACE, DefaultLogReplicationConfigAdapter.TAG_ONE);
 
             // Add Delta's for Log Entry Sync
-            writeToActiveDifferentTypes(totalEntries, totalEntries);
+            writeToSourceDifferentTypes(totalEntries, totalEntries);
 
-            // Verify Delta's are replicated to standby
-            verifyStandbyData((totalEntries*2));
+            // Verify Delta's are replicated to sink
+            verifySinkData((totalEntries*2));
 
-            // Confirm data has been received by standby streaming listeners (deltas generated)
+            // Confirm data has been received by sink streaming listeners (deltas generated)
             // Block until all updates are received
             log.info("** Wait for data change notifications (delta)");
-            streamingStandbyDeltaCompletion.await();
+            streamingSinkDeltaCompletion.await();
             assertThat(listenerDeltas.messages.size()).isEqualTo(
                 totalEntries*tablesToListen.size());
 
             // Add a delta to a 'mergeOnly' stream and confirm it is replicated. RegistryTable is a 'mergeOnly' stream
-            openTable(corfuStoreActive, "extra_delta");
-            verifyTableOpened(corfuStoreStandby, "extra_delta");
+            openTable(corfuStoreSource, "extra_delta");
+            verifyTableOpened(corfuStoreSink, "extra_delta");
 
         } finally {
             executorService.shutdownNow();
 
-            if (activeCorfu != null) {
-                activeCorfu.destroy();
+            if (sourceCorfu != null) {
+                sourceCorfu.destroy();
             }
 
-            if (standbyCorfu != null) {
-                standbyCorfu.destroy();
+            if (sinkCorfu != null) {
+                sinkCorfu.destroy();
             }
 
-            if (activeReplicationServer != null) {
-                activeReplicationServer.destroy();
+            if (sourceReplicationServer != null) {
+                sourceReplicationServer.destroy();
             }
 
-            if (standbyReplicationServer != null) {
-                standbyReplicationServer.destroy();
+            if (sinkReplicationServer != null) {
+                sinkReplicationServer.destroy();
             }
         }
 
@@ -570,14 +570,14 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
         LogReplicationMetadata.ReplicationStatusKey key =
                 LogReplicationMetadata.ReplicationStatusKey
                         .newBuilder()
-                        .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
+                        .setClusterId(new DefaultClusterConfig().getSinkClusterIds().get(0))
                         .build();
 
         ReplicationStatusVal replicationStatusVal;
         boolean snapshotSyncCompleted = false;
 
         while (snapshotSyncCompleted) {
-            try (TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+            try (TxnContext txn = corfuStoreSource.txn(LogReplicationMetadataManager.NAMESPACE)) {
                 replicationStatusVal = (ReplicationStatusVal) txn.getRecord(LogReplicationMetadataManager.REPLICATION_STATUS_TABLE, key).getPayload();
                 txn.commit();
             }
@@ -594,33 +594,33 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
         }
     }
 
-    private void verifyActiveData(int totalEntries) {
-        for (Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata> map : mapNameToMapActiveTypeA.values()) {
+    private void verifySourceData(int totalEntries) {
+        for (Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata> map : mapNameToMapSourceTypeA.values()) {
             assertThat(map.count()).isEqualTo(totalEntries);
         }
 
-        for (Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata> map : mapNameToMapActiveTypeB.values()) {
+        for (Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata> map : mapNameToMapSourceTypeB.values()) {
             assertThat(map.count()).isEqualTo(totalEntries);
         }
     }
 
-    public void verifyStandbyData(int expectedConsecutiveWrites) {
-        for (Map.Entry<String, Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata>> entry : mapNameToMapStandbyTypeA.entrySet()) {
+    public void verifySinkData(int expectedConsecutiveWrites) {
+        for (Map.Entry<String, Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata>> entry : mapNameToMapSinkTypeA.entrySet()) {
 
-            log.debug("Verify Data on Standby's Table {}", entry.getKey());
+            log.debug("Verify Data on Sink's Table {}", entry.getKey());
 
             // Wait until data is fully replicated
             while (entry.getValue().count() != expectedConsecutiveWrites) {
                 // Block until expected number of entries is reached
             }
 
-            log.debug("Number updates on Standby Map {} :: {} ", entry.getKey(), expectedConsecutiveWrites);
+            log.debug("Number updates on Sink Map {} :: {} ", entry.getKey(), expectedConsecutiveWrites);
 
-            // Verify data is present in Standby Site
+            // Verify data is present in Sink Site
             assertThat(entry.getValue().count()).isEqualTo(expectedConsecutiveWrites);
 
             for (int i = 0; i < (expectedConsecutiveWrites); i++) {
-                try (TxnContext tx = corfuStoreStandby.txn(entry.getValue().getNamespace())) {
+                try (TxnContext tx = corfuStoreSink.txn(entry.getValue().getNamespace())) {
                     assertThat(tx.getRecord(entry.getValue(),
                             Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build()).getPayload()).isNotNull();
                     tx.commit();
@@ -628,22 +628,22 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             }
         }
 
-        for (Map.Entry<String, Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata>> entry : mapNameToMapStandbyTypeB.entrySet()) {
+        for (Map.Entry<String, Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata>> entry : mapNameToMapSinkTypeB.entrySet()) {
 
-            log.debug("Verify Data on Standby's Table {}", entry.getKey());
+            log.debug("Verify Data on Sink's Table {}", entry.getKey());
 
             // Wait until data is fully replicated
             while (entry.getValue().count() != expectedConsecutiveWrites) {
                 // Block until expected number of entries is reached
             }
 
-            log.debug("Number updates on Standby Map {} :: {} ", entry.getKey(), expectedConsecutiveWrites);
+            log.debug("Number updates on Sink Map {} :: {} ", entry.getKey(), expectedConsecutiveWrites);
 
-            // Verify data is present in Standby Site
+            // Verify data is present in Sink Site
             assertThat(entry.getValue().count()).isEqualTo(expectedConsecutiveWrites);
 
             for (int i = 0; i < (expectedConsecutiveWrites); i++) {
-                try (TxnContext tx = corfuStoreStandby.txn(entry.getValue().getNamespace())) {
+                try (TxnContext tx = corfuStoreSink.txn(entry.getValue().getNamespace())) {
                     assertThat(tx.getRecord(entry.getValue(),
                             Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build()).getPayload()).isNotNull();
                     tx.commit();
@@ -681,38 +681,38 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             String mapName = DefaultLogReplicationConfigAdapter.TABLE_PREFIX + i;
 
             if (i % 2 == 0) {
-                Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata> mapActive = corfuStoreActive.openTable(
+                Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata> mapSource = corfuStoreSource.openTable(
                         NAMESPACE, mapName, Sample.StringKey.class, ValueFieldTagOne.class, Sample.Metadata.class,
                         TableOptions.fromProtoSchema(ValueFieldTagOne.class));
-                mapNameToMapActiveTypeA.put(mapName, mapActive);
+                mapNameToMapSourceTypeA.put(mapName, mapSource);
 
-                Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata> mapStandby = corfuStoreStandby.openTable(
+                Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata> mapSink = corfuStoreSink.openTable(
                         NAMESPACE, mapName, Sample.StringKey.class, ValueFieldTagOne.class, Sample.Metadata.class,
                         TableOptions.fromProtoSchema(ValueFieldTagOne.class));
-                mapNameToMapStandbyTypeA.put(mapName, mapStandby);
+                mapNameToMapSinkTypeA.put(mapName, mapSink);
 
             } else {
-                Table<Sample.StringKey, ValueFieldTagOneAndTwo , Sample.Metadata> mapActive = corfuStoreActive.openTable(
+                Table<Sample.StringKey, ValueFieldTagOneAndTwo , Sample.Metadata> mapSource = corfuStoreSource.openTable(
                         NAMESPACE, mapName, Sample.StringKey.class, ValueFieldTagOneAndTwo.class, Sample.Metadata.class,
                         TableOptions.fromProtoSchema(ValueFieldTagOneAndTwo.class));
-                mapNameToMapActiveTypeB.put(mapName, mapActive);
+                mapNameToMapSourceTypeB.put(mapName, mapSource);
 
-                Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata> mapStandby = corfuStoreStandby.openTable(
+                Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata> mapSink = corfuStoreSink.openTable(
                         NAMESPACE, mapName, Sample.StringKey.class, ValueFieldTagOneAndTwo.class, Sample.Metadata.class,
                         TableOptions.fromProtoSchema(ValueFieldTagOneAndTwo.class));
-                mapNameToMapStandbyTypeB.put(mapName, mapStandby);
+                mapNameToMapSinkTypeB.put(mapName, mapSink);
             }
         }
 
-        mapNameToMapActiveTypeA.values().forEach(map -> assertThat(map.count()).isZero());
-        mapNameToMapStandbyTypeA.values().forEach(map -> assertThat(map.count()).isZero());
-        mapNameToMapActiveTypeB.values().forEach(map -> assertThat(map.count()).isZero());
-        mapNameToMapStandbyTypeB.values().forEach(map -> assertThat(map.count()).isZero());
+        mapNameToMapSourceTypeA.values().forEach(map -> assertThat(map.count()).isZero());
+        mapNameToMapSinkTypeA.values().forEach(map -> assertThat(map.count()).isZero());
+        mapNameToMapSourceTypeB.values().forEach(map -> assertThat(map.count()).isZero());
+        mapNameToMapSinkTypeB.values().forEach(map -> assertThat(map.count()).isZero());
     }
 
-    public void writeToActiveDifferentTypes(int startIndex, int totalEntries) {
+    public void writeToSourceDifferentTypes(int startIndex, int totalEntries) {
         int maxIndex = totalEntries + startIndex;
-        for(Map.Entry<String, Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata>> entry : mapNameToMapActiveTypeA.entrySet()) {
+        for(Map.Entry<String, Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata>> entry : mapNameToMapSourceTypeA.entrySet()) {
 
             Table<Sample.StringKey, ValueFieldTagOne, Sample.Metadata> map = entry.getValue();
 
@@ -720,14 +720,14 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
                 Sample.StringKey stringKey = Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build();
                 ValueFieldTagOne value = ValueFieldTagOne.newBuilder().setPayload(Integer.toString(i)).build();
                 Sample.Metadata metadata = Sample.Metadata.newBuilder().setMetadata("Metadata_" + i).build();
-                try (TxnContext txn = corfuStoreActive.txn(NAMESPACE)) {
+                try (TxnContext txn = corfuStoreSource.txn(NAMESPACE)) {
                     txn.putRecord(map, stringKey, value, metadata);
                     txn.commit();
                 }
             }
         }
 
-        for(Map.Entry<String, Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata>> entry : mapNameToMapActiveTypeB.entrySet()) {
+        for(Map.Entry<String, Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata>> entry : mapNameToMapSourceTypeB.entrySet()) {
 
             Table<Sample.StringKey, ValueFieldTagOneAndTwo, Sample.Metadata> map = entry.getValue();
 
@@ -735,7 +735,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
                 Sample.StringKey stringKey = Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build();
                 ValueFieldTagOneAndTwo value = ValueFieldTagOneAndTwo.newBuilder().setPayload(Integer.toString(i)).build();
                 Sample.Metadata metadata = Sample.Metadata.newBuilder().setMetadata("Metadata_" + i).build();
-                try (TxnContext txn = corfuStoreActive.txn(NAMESPACE)) {
+                try (TxnContext txn = corfuStoreSource.txn(NAMESPACE)) {
                     txn.putRecord(map, stringKey, value, metadata);
                     txn.commit();
                 }
@@ -744,23 +744,23 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     }
 
     /**
-     * Stream Listener used for testing streaming on standby site. This listener decreases a latch
+     * Stream Listener used for testing streaming on sink site. This listener decreases a latch
      * until all expected updates are received/
      */
-    public static class StreamingStandbyListener implements StreamListener {
+    public static class StreamingSinkListener implements StreamListener {
 
         private final CountDownLatch updatesLatch;
         public List<CorfuStreamEntry> messages = new ArrayList<>();
         private final Set<UUID> tablesToListenTo;
 
-        public StreamingStandbyListener(CountDownLatch updatesLatch, Set<UUID> tablesToListenTo) {
+        public StreamingSinkListener(CountDownLatch updatesLatch, Set<UUID> tablesToListenTo) {
             this.updatesLatch = updatesLatch;
             this.tablesToListenTo = tablesToListenTo;
         }
 
         @Override
         public synchronized void onNext(CorfuStreamEntries results) {
-            log.info("StreamingStandbyListener:: onNext {} with entry size {}", results, results.getEntries().size());
+            log.info("StreamingSinkListener:: onNext {} with entry size {}", results, results.getEntries().size());
 
             results.getEntries().forEach((schema, entries) -> {
                 if (tablesToListenTo.contains(CorfuRuntime.getStreamID(NAMESPACE + "$" + schema.getTableName()))) {

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
@@ -77,6 +77,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
 
             log.debug("Start source Log Replicator again ...");
             startSourceLogReplicator();
+            initSingleSourceSinkCluster();
 
             log.debug("Verify Data on Sink ...");
             verifyDataOnSinkNonUFO((numWrites*2));
@@ -206,6 +207,10 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
 
             // Checkpoint and Trim Before Starting
             checkpointAndTrim(true, Arrays.asList(mapA));
+
+            //initiate the topology buckets with a single source/sink topology.
+            // This needs to be done after checkpoint trim as defaultClusterManager starts the listener at trimMark
+            initSingleSourceSinkCluster();
 
             startLogReplicatorServers();
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 
 /**
  * This suite of tests verifies the behavior of log replication in the event of
- * Checkpoint and Trim both in the sender (source/active cluster) and receiver (sink/standby cluster)
+ * Checkpoint and Trim both in the sender (source cluster) and receiver (sink cluster)
  */
 @Slf4j
 public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
@@ -31,21 +31,21 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
     }
 
     /**
-     * Test the case where the log is trimmed on the standby in between two snapshot syncs.
+     * Test the case where the log is trimmed on the sink in between two snapshot syncs.
      * We should guarantee that shadow streams do not throw trim exceptions and data is applied successfully.
      *
      * This test does the following:
      *      (1) Do a Snapshot (full) and Log Entry (delta) Sync
-     *      (2) Stop the active cluster LR (we stop so we can write some more data and checkpoint it, such that we enforce
+     *      (2) Stop the source cluster LR (we stop so we can write some more data and checkpoint it, such that we enforce
      *          s subsequent snapshot sync, otherwise this written data would be transferred in log entry--delta--sync)
-     *      (3) Checkpoint and Trim on Standby Cluster (enforce shadow streams to be trimmed)
-     *      (4) Write additional data on Active Cluster (while LR is down)
-     *          (4.1) Verify Data written is present on active
-     *          (4.2) Verify this new Data is not yet present on standby
-     *      (5) Checkpoint and Trim on Active Cluster (to guarantee when we bring up the server, delta's are not available
+     *      (3) Checkpoint and Trim on Sink Cluster (enforce shadow streams to be trimmed)
+     *      (4) Write additional data on Source Cluster (while LR is down)
+     *          (4.1) Verify Data written is present on source
+     *          (4.2) Verify this new Data is not yet present on sink
+     *      (5) Checkpoint and Trim on Source Cluster (to guarantee when we bring up the server, delta's are not available
      *          so Snapshot Sync is enforced)
-     *      (6) Start Active LR
-     *      (7) Verify Data reaches standby cluster
+     *      (6) Start Source LR
+     *      (7) Verify Data reaches sink cluster
      *
      *
      */
@@ -54,60 +54,60 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
         try {
             testEndToEndSnapshotAndLogEntrySync();
 
-            // Stop Log Replication on Active, so we can write some data into active Corfu
+            // Stop Log Replication on Source, so we can write some data into source Corfu
             // and checkpoint so we enforce a subsequent Snapshot Sync
-            log.debug("Stop Active Log Replicator ...");
-            stopActiveLogReplicator();
+            log.debug("Stop Source Log Replicator ...");
+            stopSourceLogReplicator();
 
-            // Checkpoint & Trim on the Standby (so shadow stream get trimmed)
-            checkpointAndTrim(false, Collections.singletonList(mapAStandby));
+            // Checkpoint & Trim on the Sink (so shadow stream get trimmed)
+            checkpointAndTrim(false, Collections.singletonList(mapASink));
 
-            // Write Entry's to Active Cluster (while replicator is down)
-            log.debug("Write additional entries to active CorfuDB ...");
-            writeToActiveNonUFO((numWrites + (numWrites/2)), numWrites/2);
+            // Write Entry's to Source Cluster (while replicator is down)
+            log.debug("Write additional entries to source CorfuDB ...");
+            writeToSourceNonUFO((numWrites + (numWrites/2)), numWrites/2);
 
-            // Confirm data does exist on Active Cluster
+            // Confirm data does exist on Source Cluster
             assertThat(mapA.size()).isEqualTo(numWrites*2);
 
-            // Confirm new data does not exist on Standby Cluster
-            assertThat(mapAStandby.size()).isEqualTo((numWrites + (numWrites/2)));
+            // Confirm new data does not exist on Sink Cluster
+            assertThat(mapASink.size()).isEqualTo((numWrites + (numWrites/2)));
 
-            // Checkpoint & Trim on the Active so we force a snapshot sync on restart
+            // Checkpoint & Trim on the Source so we force a snapshot sync on restart
             checkpointAndTrim(true, Collections.singletonList(mapA));
 
-            log.debug("Start active Log Replicator again ...");
-            startActiveLogReplicator();
+            log.debug("Start source Log Replicator again ...");
+            startSourceLogReplicator();
 
-            log.debug("Verify Data on Standby ...");
-            verifyDataOnStandbyNonUFO((numWrites*2));
+            log.debug("Verify Data on Sink ...");
+            verifyDataOnSinkNonUFO((numWrites*2));
 
-            log.debug("Entries :: " + mapAStandby.keySet());
+            log.debug("Entries :: " + mapASink.keySet());
 
         } finally {
 
             executorService.shutdownNow();
 
-            if (activeCorfu != null) {
-                activeCorfu.destroy();
+            if (sourceCorfu != null) {
+                sourceCorfu.destroy();
             }
 
-            if (standbyCorfu != null) {
-                standbyCorfu.destroy();
+            if (sinkCorfu != null) {
+                sinkCorfu.destroy();
             }
 
-            if (activeReplicationServer != null) {
-                activeReplicationServer.destroy();
+            if (sourceReplicationServer != null) {
+                sourceReplicationServer.destroy();
             }
 
-            if (standbyReplicationServer != null) {
-                standbyReplicationServer.destroy();
+            if (sinkReplicationServer != null) {
+                sinkReplicationServer.destroy();
             }
         }
     }
 
     /**
      * Test the case where the log is trimmed in between two cycles of log entry sync.
-     * In this test we stop the active log replicator before trimming so we
+     * In this test we stop the source log replicator before trimming so we
      * can enforce re-negotiation after the trim.
      */
     @Test
@@ -117,7 +117,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
 
     /**
      * Test the case where the log is trimmed in between two cycles of log entry sync.
-     * In this test we don't stop the active log replicator, so log entry sync is resumed.
+     * In this test we don't stop the source log replicator, so log entry sync is resumed.
      */
     @Test
     public void testTrimmedExceptionsBetweenLogEntrySyncContinuous() throws Exception {
@@ -125,9 +125,9 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
     }
 
     /**
-     * Test trimming the log on the standby site, in the middle of log entry sync.
+     * Test trimming the log on the sink site, in the middle of log entry sync.
      *
-     * @param stop true, stop the active server right before trimming (to enforce re-negotiation)
+     * @param stop true, stop the source server right before trimming (to enforce re-negotiation)
      *             false, trim without stopping the server.
      */
     private void testLogTrimBetweenLogEntrySync(boolean stop) throws Exception {
@@ -135,52 +135,52 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
             testEndToEndSnapshotAndLogEntrySync();
 
             if (stop) {
-                // Stop Log Replication on Active, so we can test re-negotiation in the event of trims
-                log.debug("Stop Active Log Replicator ...");
-                stopActiveLogReplicator();
+                // Stop Log Replication on Source, so we can test re-negotiation in the event of trims
+                log.debug("Stop Source Log Replicator ...");
+                stopSourceLogReplicator();
             }
 
-            // Checkpoint & Trim on the Standby, so we trim the shadow stream
-            checkpointAndTrim(false, Collections.singletonList(mapAStandby));
+            // Checkpoint & Trim on the Sink, so we trim the shadow stream
+            checkpointAndTrim(false, Collections.singletonList(mapASink));
 
-            // Write Entry's to Active Cluster (while replicator is down)
-            log.debug("Write additional entries to active CorfuDB ...");
-            writeToActiveNonUFO((numWrites + (numWrites/2)), numWrites/2);
+            // Write Entry's to Source Cluster (while replicator is down)
+            log.debug("Write additional entries to source CorfuDB ...");
+            writeToSourceNonUFO((numWrites + (numWrites/2)), numWrites/2);
 
-            // Confirm data does exist on Active Cluster
+            // Confirm data does exist on Source Cluster
             assertThat(mapA.size()).isEqualTo(numWrites*2);
 
             if (stop) {
-                // Confirm new data does not exist on Standby Cluster
-                assertThat(mapAStandby.size()).isEqualTo((numWrites + (numWrites / 2)));
+                // Confirm new data does not exist on Sink Cluster
+                assertThat(mapASink.size()).isEqualTo((numWrites + (numWrites / 2)));
 
-                log.debug("Start active Log Replicator again ...");
-                startActiveLogReplicator();
+                log.debug("Start source Log Replicator again ...");
+                startSourceLogReplicator();
             }
 
             // Since we did not checkpoint data should be transferred in delta's
-            log.debug("Verify Data on Standby ...");
-            verifyDataOnStandbyNonUFO((numWrites*2));
+            log.debug("Verify Data on Sink ...");
+            verifyDataOnSinkNonUFO((numWrites*2));
 
-            log.debug("Entries :: " + mapAStandby.keySet());
+            log.debug("Entries :: " + mapASink.keySet());
         } finally {
 
             executorService.shutdownNow();
 
-            if (activeCorfu != null) {
-                activeCorfu.destroy();
+            if (sourceCorfu != null) {
+                sourceCorfu.destroy();
             }
 
-            if (standbyCorfu != null) {
-                standbyCorfu.destroy();
+            if (sinkCorfu != null) {
+                sinkCorfu.destroy();
             }
 
-            if (activeReplicationServer != null) {
-                activeReplicationServer.destroy();
+            if (sourceReplicationServer != null) {
+                sourceReplicationServer.destroy();
             }
 
-            if (standbyReplicationServer != null) {
-                standbyReplicationServer.destroy();
+            if (sinkReplicationServer != null) {
+                sinkReplicationServer.destroy();
             }
         }
     }
@@ -188,21 +188,21 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
     @Test
     public void testSnapshotSyncEndToEndWithCheckpointedStreams() throws Exception {
         try {
-            log.debug("\nSetup active and standby Corfu's");
-            setupActiveAndStandbyCorfu();
+            log.debug("\nSetup source and sink Corfu's");
+            setupSourceAndSinkCorfu();
 
-            log.debug("Open map on active and standby");
+            log.debug("Open map on source and sink");
             openMap();
 
-            log.debug("Write data to active CorfuDB before LR is started ...");
+            log.debug("Write data to source CorfuDB before LR is started ...");
             // Add Data for Snapshot Sync
-            writeToActiveNonUFO(0, numWrites);
+            writeToSourceNonUFO(0, numWrites);
 
-            // Confirm data does exist on Active Cluster
+            // Confirm data does exist on Source Cluster
             assertThat(mapA.size()).isEqualTo(numWrites);
 
-            // Confirm data does not exist on Standby Cluster
-            assertThat(mapAStandby.size()).isZero();
+            // Confirm data does not exist on Sink Cluster
+            assertThat(mapASink.size()).isZero();
 
             // Checkpoint and Trim Before Starting
             checkpointAndTrim(true, Arrays.asList(mapA));
@@ -210,24 +210,24 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
             startLogReplicatorServers();
 
             log.debug("Wait ... Snapshot log replication in progress ...");
-            verifyDataOnStandbyNonUFO(numWrites);
+            verifyDataOnSinkNonUFO(numWrites);
         } finally {
             executorService.shutdownNow();
 
-            if (activeCorfu != null) {
-                activeCorfu.destroy();
+            if (sourceCorfu != null) {
+                sourceCorfu.destroy();
             }
 
-            if (standbyCorfu != null) {
-                standbyCorfu.destroy();
+            if (sinkCorfu != null) {
+                sinkCorfu.destroy();
             }
 
-            if (activeReplicationServer != null) {
-                activeReplicationServer.destroy();
+            if (sourceReplicationServer != null) {
+                sourceReplicationServer.destroy();
             }
 
-            if (standbyReplicationServer != null) {
-                standbyReplicationServer.destroy();
+            if (sinkReplicationServer != null) {
+                sinkReplicationServer.destroy();
             }
         }
     }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationUpgradeIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationUpgradeIT.java
@@ -36,7 +36,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
 
     // The number of updates on the ReplicationStatus table on the Sink during initial startup is 3(one for each
     // Source cluster)
-    private static final int NUM_INIT_UPDATES_ON_SINK_STATUS_TABLE = 3;
+    private static final int NUM_INIT_UPDATES_ON_SINK_STATUS_TABLE = 1;
 
     // The number of subsequent updates on the ReplicationStatus Table
     // (1) When starting snapshot sync apply : is_data_consistent = false
@@ -77,6 +77,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testLogEntrySyncAfterSinkUpgraded() throws Exception {
         log.info(">> Setup source and sink Corfu's");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         log.info(">> Open map(s) on source and sink");
         openMaps(FIVE, false);
@@ -138,8 +139,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
 
         // Upgrade the sink site
         log.info(">> Upgrading the sink site ...");
@@ -177,6 +178,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testSnapshotSyncAfterSinkUpgraded() throws Exception {
         log.info(">> Setup source and sink Corfu's");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         log.info(">> Open map(s) on source and sink");
         openMaps(FIVE, false);
@@ -238,8 +240,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
         corfuStoreSink.unsubscribeListener(sinkListener);
         corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
 
@@ -265,13 +267,14 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         checkpointAndTrim(true);
         pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
         startSourceLogReplicator();
+        initSingleSourceSinkCluster();
 
         // Verify that snapshot sync between the different versions was successful
         latchSnapshotSyncPlugin.await();
         statusUpdateLatch.await();
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
         verifyDataOnSink(NUM_WRITES);
 
         corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
@@ -296,6 +299,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testSnapshotSyncAfterSinkAndSourceUpgraded() throws Exception {
         log.info(">> Setup source and sink Corfu");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         // Two updates are expected onStart of snapshot sync and onEnd.
         CountDownLatch latchSnapshotSyncPlugin = new CountDownLatch(2);
@@ -357,8 +361,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
         corfuStoreSink.unsubscribeListener(sinkListener);
         corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
 
@@ -394,8 +398,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
 
         verifyDataOnSink(NUM_WRITES);
 
@@ -422,6 +426,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testLogEntrySyncAfterSinkUpgradedStreamsAddedAndRemoved() throws Exception {
         log.info(">> Setup source and sink Corfu");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         Set<String> streamsToReplicateSource = new HashSet<>();
         for (int i = 1; i <= 2; i++) {
@@ -484,8 +489,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
 
         Set<String> streamsToReplicateSink = new HashSet<>();
         for (int i = 2; i <= 3; i++) {
@@ -532,6 +537,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testSnapshotSyncAfterSinkUpgradedStreamsAddedAndRemoved() throws Exception {
         log.info(">> Setup source and sink Corfu's");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         Set<String> streamsToReplicateSource = new HashSet<>();
         for (int i = 1; i <= 2; i++) {
@@ -593,8 +599,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
         corfuStoreSink.unsubscribeListener(sinkListener);
         corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
 
@@ -649,13 +655,13 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         checkpointAndTrim(true);
         pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
         startSourceLogReplicator();
-
+        initSingleSourceSinkCluster();
         // Verify that snapshot sync between the different versions was successful
         latchSnapshotSyncPlugin.await();
         statusUpdateLatch.await();
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
 
         // No new data for source-only streams
         verifyDataOnSink(sourceOnlyStreams, NUM_WRITES);
@@ -675,6 +681,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testSnapshotSyncAfterBothUpgradedStreamsAddedAndRemoved() throws Exception {
         log.info(">> Setup source and sink Corfu's");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         Set<String> streamsToReplicateSource = new HashSet<>();
         for (int i = 1; i <= 2; i++) {
@@ -737,8 +744,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
 
         Set<String> streamsToReplicateSink = new HashSet<>();
         for (int i = 2; i <= 3; i++) {

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationUpgradeIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationUpgradeIT.java
@@ -52,11 +52,11 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
 
     private static final String VERSION_TEST_TABLE = "VersionTestTable";
 
-    private static final String TEST_PLUGIN_CONFIG_PATH_ACTIVE =
-            "./test/src/test/resources/transport/nettyConfigUpgradeActive.properties";
+    private static final String TEST_PLUGIN_CONFIG_PATH_SOURCE =
+            "./test/src/test/resources/transport/nettyConfigUpgradeSource.properties";
 
-    private static final String TEST_PLUGIN_CONFIG_PATH_STANDBY =
-            "./test/src/test/resources/transport/nettyConfigUpgradeStandby.properties";
+    private static final String TEST_PLUGIN_CONFIG_PATH_SINK =
+            "./test/src/test/resources/transport/nettyConfigUpgradeSink.properties";
 
     private static final String SEPARATOR = "$";
     private static final String VERSION_STRING = "test_version";
@@ -64,34 +64,34 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     private static final String UPGRADE_VERSION_STRING = "new_version";
 
     private void openVersionTables() throws Exception {
-        corfuStoreActive.openTable(CORFU_SYSTEM_NAMESPACE,
+        corfuStoreSource.openTable(CORFU_SYSTEM_NAMESPACE,
                 LOG_REPLICATION_PLUGIN_VERSION_TABLE, LogReplicationStreams.VersionString.class,
                 LogReplicationStreams.Version.class, CommonTypes.Uuid.class, TableOptions.builder().build());
 
-        corfuStoreStandby.openTable(CORFU_SYSTEM_NAMESPACE,
+        corfuStoreSink.openTable(CORFU_SYSTEM_NAMESPACE,
                 LOG_REPLICATION_PLUGIN_VERSION_TABLE, LogReplicationStreams.VersionString.class,
                 LogReplicationStreams.Version.class, CommonTypes.Uuid.class, TableOptions.builder().build());
     }
 
     @Test
-    public void testLogEntrySyncAfterStandbyUpgraded() throws Exception {
-        log.info(">> Setup active and standby Corfu's");
-        setupActiveAndStandbyCorfu();
+    public void testLogEntrySyncAfterSinkUpgraded() throws Exception {
+        log.info(">> Setup source and sink Corfu's");
+        setupSourceAndSinkCorfu();
 
-        log.info(">> Open map(s) on active and standby");
+        log.info(">> Open map(s) on source and sink");
         openMaps(FIVE, false);
 
-        log.info(">> Write data to active CorfuDB before LR is started ...");
+        log.info(">> Write data to source CorfuDB before LR is started ...");
         // Add Data for Snapshot Sync
-        writeToActive(0, NUM_WRITES);
+        writeToSource(0, NUM_WRITES);
 
-        // Confirm data does exist on Active Cluster
-        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapActive.values()) {
+        // Confirm data does exist on Source Cluster
+        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSource.values()) {
             assertThat(map.count()).isEqualTo(NUM_WRITES);
         }
 
-        // Confirm data does not exist on Standby Cluster
-        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapStandby.values()) {
+        // Confirm data does not exist on Sink Cluster
+        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSink.values()) {
             assertThat(map.count()).isEqualTo(0);
         }
 
@@ -100,8 +100,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         SnapshotSyncPluginListener snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-        // Subscribe to replication status table on Standby (to be sure data change on status are captured)
-        corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+        // Subscribe to replication status table on Sink (to be sure data change on status are captured)
+        corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -109,8 +109,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
                 TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
         CountDownLatch statusUpdateLatch = new CountDownLatch(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC);
-        ReplicationStatusListener standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        ReplicationStatusListener sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
         Set<String> streamsToReplicate = new HashSet<>();
@@ -119,79 +119,79 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         }
         setupStreamsToReplicateTable(streamsToReplicate, true, false);
         setupStreamsToReplicateTable(streamsToReplicate, false, false);
-        setupVersionTable(corfuStoreActive, false);
-        setupVersionTable(corfuStoreStandby, false);
+        setupVersionTable(corfuStoreSource, false);
+        setupVersionTable(corfuStoreSink, false);
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_ACTIVE;
-        startActiveLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
+        startSourceLogReplicator();
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        startStandbyLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        startSinkLogReplicator();
 
         log.info(">> Wait ... Snapshot log replication in progress ...");
-        verifyDataOnStandby(NUM_WRITES);
+        verifyDataOnSink(NUM_WRITES);
 
         // Verify that snapshot sync was triggered by checking the number of
-        // updates to the ReplicationStatus table on the standby.
+        // updates to the ReplicationStatus table on the sink.
         latchSnapshotSyncPlugin.await();
         validateSnapshotSyncPlugin(snapshotSyncPluginListener);
         statusUpdateLatch.await();
 
-        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, standbyListener.getAccumulatedStatus().size());
-        Assert.assertTrue(standbyListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(standbyListener.getAccumulatedStatus().get(3));
+        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
 
-        // Upgrade the standby site
-        log.info(">> Upgrading the standby site ...");
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        upgradeSite(false, corfuStoreStandby);
-        verifyVersion(corfuStoreStandby, UPGRADE_VERSION_STRING, true);
-        verifyVersion(corfuStoreActive, VERSION_STRING, false);
+        // Upgrade the sink site
+        log.info(">> Upgrading the sink site ...");
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        upgradeSite(false, corfuStoreSink);
+        verifyVersion(corfuStoreSink, UPGRADE_VERSION_STRING, true);
+        verifyVersion(corfuStoreSource, VERSION_STRING, false);
 
         // Verify that subsequent log entry sync is successful
-        log.info("Write more data on the active");
-        writeToActive(NUM_WRITES, NUM_WRITES / 2);
+        log.info("Write more data on the source");
+        writeToSource(NUM_WRITES, NUM_WRITES / 2);
 
-        log.info("Verify that data is replicated on the standby after it is upgraded");
-        verifyDataOnStandby(NUM_WRITES + (NUM_WRITES / 2));
+        log.info("Verify that data is replicated on the sink after it is upgraded");
+        verifyDataOnSink(NUM_WRITES + (NUM_WRITES / 2));
 
-        corfuStoreStandby.unsubscribeListener(snapshotSyncPluginListener);
-        corfuStoreStandby.unsubscribeListener(standbyListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
+        corfuStoreSink.unsubscribeListener(sinkListener);
         executorService.shutdownNow();
 
-        if (activeCorfu != null) {
-            activeCorfu.destroy();
+        if (sourceCorfu != null) {
+            sourceCorfu.destroy();
         }
-        if (standbyCorfu != null) {
-            standbyCorfu.destroy();
+        if (sinkCorfu != null) {
+            sinkCorfu.destroy();
         }
-        if (activeReplicationServer != null) {
-            activeReplicationServer.destroy();
+        if (sourceReplicationServer != null) {
+            sourceReplicationServer.destroy();
         }
-        if (standbyReplicationServer != null) {
-            standbyReplicationServer.destroy();
+        if (sinkReplicationServer != null) {
+            sinkReplicationServer.destroy();
         }
     }
 
     @Test
-    public void testSnapshotSyncAfterStandbyUpgraded() throws Exception {
-        log.info(">> Setup active and standby Corfu's");
-        setupActiveAndStandbyCorfu();
+    public void testSnapshotSyncAfterSinkUpgraded() throws Exception {
+        log.info(">> Setup source and sink Corfu's");
+        setupSourceAndSinkCorfu();
 
-        log.info(">> Open map(s) on active and standby");
+        log.info(">> Open map(s) on source and sink");
         openMaps(FIVE, false);
 
-        log.info(">> Write data to active CorfuDB before LR is started ...");
+        log.info(">> Write data to source CorfuDB before LR is started ...");
         // Add Data for Snapshot Sync
-        writeToActive(0, NUM_WRITES);
+        writeToSource(0, NUM_WRITES);
 
-        // Confirm data does exist on Active Cluster
-        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapActive.values()) {
+        // Confirm data does exist on Source Cluster
+        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSource.values()) {
             assertThat(map.count()).isEqualTo(NUM_WRITES);
         }
 
-        // Confirm data does not exist on Standby Cluster
-        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapStandby.values()) {
+        // Confirm data does not exist on Sink Cluster
+        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSink.values()) {
             assertThat(map.count()).isEqualTo(0);
         }
 
@@ -200,8 +200,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         SnapshotSyncPluginListener snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-        // Subscribe to replication status table on Standby (to be sure data change on status are captured)
-        corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+        // Subscribe to replication status table on Sink (to be sure data change on status are captured)
+        corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -209,8 +209,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
                 TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
         CountDownLatch statusUpdateLatch = new CountDownLatch(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC);
-        ReplicationStatusListener standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        ReplicationStatusListener sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
         Set<String> streamsToReplicate = new HashSet<>();
@@ -219,91 +219,91 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         }
         setupStreamsToReplicateTable(streamsToReplicate, true, false);
         setupStreamsToReplicateTable(streamsToReplicate, false, false);
-        setupVersionTable(corfuStoreActive, false);
-        setupVersionTable(corfuStoreStandby, false);
+        setupVersionTable(corfuStoreSource, false);
+        setupVersionTable(corfuStoreSink, false);
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_ACTIVE;
-        startActiveLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
+        startSourceLogReplicator();
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        startStandbyLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        startSinkLogReplicator();
 
         log.info(">> Wait ... Snapshot log replication in progress ...");
-        verifyDataOnStandby(NUM_WRITES);
+        verifyDataOnSink(NUM_WRITES);
 
         // Verify that snapshot sync was triggered by checking the number of
-        // updates to the ReplicationStatus table on the standby.
+        // updates to the ReplicationStatus table on the sink.
         latchSnapshotSyncPlugin.await();
         validateSnapshotSyncPlugin(snapshotSyncPluginListener);
         statusUpdateLatch.await();
 
-        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, standbyListener.getAccumulatedStatus().size());
-        Assert.assertTrue(standbyListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(standbyListener.getAccumulatedStatus().get(3));
-        corfuStoreStandby.unsubscribeListener(standbyListener);
-        corfuStoreStandby.unsubscribeListener(snapshotSyncPluginListener);
+        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        corfuStoreSink.unsubscribeListener(sinkListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
 
-        // Upgrade the standby site
+        // Upgrade the sink site
 
         statusUpdateLatch = new CountDownLatch(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC);
-        standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
             LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
-        log.info(">> Upgrading the standby site ...");
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        upgradeSite(false, corfuStoreStandby);
-        verifyVersion(corfuStoreStandby, UPGRADE_VERSION_STRING, true);
-        verifyVersion(corfuStoreActive, VERSION_STRING, false);
+        log.info(">> Upgrading the sink site ...");
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        upgradeSite(false, corfuStoreSink);
+        verifyVersion(corfuStoreSink, UPGRADE_VERSION_STRING, true);
+        verifyVersion(corfuStoreSource, VERSION_STRING, false);
 
         latchSnapshotSyncPlugin = new CountDownLatch(2);
         snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-        // Trigger a snapshot sync by stopping the active LR and running a CP+trim
-        stopActiveLogReplicator();
+        // Trigger a snapshot sync by stopping the source LR and running a CP+trim
+        stopSourceLogReplicator();
         checkpointAndTrim(true);
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_ACTIVE;
-        startActiveLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
+        startSourceLogReplicator();
 
         // Verify that snapshot sync between the different versions was successful
         latchSnapshotSyncPlugin.await();
         statusUpdateLatch.await();
-        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, standbyListener.getAccumulatedStatus().size());
-        Assert.assertTrue(standbyListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(standbyListener.getAccumulatedStatus().get(3));
-        verifyDataOnStandby(NUM_WRITES);
+        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        verifyDataOnSink(NUM_WRITES);
 
-        corfuStoreStandby.unsubscribeListener(snapshotSyncPluginListener);
-        corfuStoreStandby.unsubscribeListener(standbyListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
+        corfuStoreSink.unsubscribeListener(sinkListener);
         executorService.shutdownNow();
 
-        if (activeCorfu != null) {
-            activeCorfu.destroy();
+        if (sourceCorfu != null) {
+            sourceCorfu.destroy();
         }
-        if (standbyCorfu != null) {
-            standbyCorfu.destroy();
+        if (sinkCorfu != null) {
+            sinkCorfu.destroy();
         }
-        if (activeReplicationServer != null) {
-            activeReplicationServer.destroy();
+        if (sourceReplicationServer != null) {
+            sourceReplicationServer.destroy();
         }
-        if (standbyReplicationServer != null) {
-            standbyReplicationServer.destroy();
+        if (sinkReplicationServer != null) {
+            sinkReplicationServer.destroy();
         }
     }
 
     @Test
-    public void testSnapshotSyncAfterStandbyAndActiveUpgraded() throws Exception {
-        log.info(">> Setup active and standby Corfu");
-        setupActiveAndStandbyCorfu();
+    public void testSnapshotSyncAfterSinkAndSourceUpgraded() throws Exception {
+        log.info(">> Setup source and sink Corfu");
+        setupSourceAndSinkCorfu();
 
         // Two updates are expected onStart of snapshot sync and onEnd.
         CountDownLatch latchSnapshotSyncPlugin = new CountDownLatch(2);
         SnapshotSyncPluginListener snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-        // Subscribe to replication status table on Standby (to be sure data change on status are captured)
-        corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+        // Subscribe to replication status table on Sink (to be sure data change on status are captured)
+        corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -311,24 +311,24 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
                 TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
         CountDownLatch statusUpdateLatch = new CountDownLatch(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC);
-        ReplicationStatusListener standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        ReplicationStatusListener sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
-        log.info(">> Open map(s) on active and standby");
+        log.info(">> Open map(s) on source and sink");
         openMaps(FIVE, false);
 
-        log.info(">> Write data to active CorfuDB before LR is started ...");
+        log.info(">> Write data to source CorfuDB before LR is started ...");
         // Add Data for Snapshot Sync
-        writeToActive(0, NUM_WRITES);
+        writeToSource(0, NUM_WRITES);
 
-        // Confirm data does exist on Active Cluster
-        for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapActive.values()) {
+        // Confirm data does exist on Source Cluster
+        for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSource.values()) {
             assertThat(map.count()).isEqualTo(NUM_WRITES);
         }
 
-        // Confirm data does not exist on Standby Cluster
-        for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapStandby.values()) {
+        // Confirm data does not exist on Sink Cluster
+        for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSink.values()) {
             assertThat(map.count()).isEqualTo(0);
         }
 
@@ -338,108 +338,108 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         }
         setupStreamsToReplicateTable(streamsToReplicate, true, false);
         setupStreamsToReplicateTable(streamsToReplicate, false, false);
-        setupVersionTable(corfuStoreActive, false);
-        setupVersionTable(corfuStoreStandby, false);
+        setupVersionTable(corfuStoreSource, false);
+        setupVersionTable(corfuStoreSink, false);
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_ACTIVE;
-        startActiveLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
+        startSourceLogReplicator();
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        startStandbyLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        startSinkLogReplicator();
 
         log.info(">> Wait ... Snapshot log replication in progress ...");
-        verifyDataOnStandby(NUM_WRITES);
+        verifyDataOnSink(NUM_WRITES);
 
         // Verify that snapshot sync was triggered by checking the number of
-        // updates to the ReplicationStatus table on the standby.
+        // updates to the ReplicationStatus table on the sink.
         latchSnapshotSyncPlugin.await();
         validateSnapshotSyncPlugin(snapshotSyncPluginListener);
         statusUpdateLatch.await();
 
-        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, standbyListener.getAccumulatedStatus().size());
-        Assert.assertTrue(standbyListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(standbyListener.getAccumulatedStatus().get(3));
-        corfuStoreStandby.unsubscribeListener(standbyListener);
-        corfuStoreStandby.unsubscribeListener(snapshotSyncPluginListener);
+        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        corfuStoreSink.unsubscribeListener(sinkListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
 
-        // Upgrade the standby site first
-        log.info(">> Upgrading the standby site ...");
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        upgradeSite(false, corfuStoreStandby);
-        verifyVersion(corfuStoreStandby, UPGRADE_VERSION_STRING, true);
-        verifyVersion(corfuStoreActive, VERSION_STRING, false);
-        log.info(">> Plugin config verified after standby upgrade");
+        // Upgrade the sink site first
+        log.info(">> Upgrading the sink site ...");
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        upgradeSite(false, corfuStoreSink);
+        verifyVersion(corfuStoreSink, UPGRADE_VERSION_STRING, true);
+        verifyVersion(corfuStoreSource, VERSION_STRING, false);
+        log.info(">> Plugin config verified after sink upgrade");
 
-        // Upgrading the active site will force a snapshot sync
+        // Upgrading the source site will force a snapshot sync
         latchSnapshotSyncPlugin = new CountDownLatch(2);
         snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
         statusUpdateLatch = new CountDownLatch(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC);
-        standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
-        // Upgrade the active site
-        log.info(">> Upgrading the active site ...");
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_ACTIVE;
-        upgradeSite(true, corfuStoreActive);
-        verifyVersion(corfuStoreActive, UPGRADE_VERSION_STRING, true);
-        verifyVersion(corfuStoreStandby, UPGRADE_VERSION_STRING, true);
+        // Upgrade the source site
+        log.info(">> Upgrading the source site ...");
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
+        upgradeSite(true, corfuStoreSource);
+        verifyVersion(corfuStoreSource, UPGRADE_VERSION_STRING, true);
+        verifyVersion(corfuStoreSink, UPGRADE_VERSION_STRING, true);
 
         // Verify that snapshot sync was triggered by checking the number of
-        // updates to the ReplicationStatus table on the standby.
+        // updates to the ReplicationStatus table on the sink.
         latchSnapshotSyncPlugin.await();
         validateSnapshotSyncPlugin(snapshotSyncPluginListener);
         statusUpdateLatch.await();
 
-        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, standbyListener.getAccumulatedStatus().size());
-        Assert.assertTrue(standbyListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(standbyListener.getAccumulatedStatus().get(3));
+        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
 
-        verifyDataOnStandby(NUM_WRITES);
+        verifyDataOnSink(NUM_WRITES);
 
-        corfuStoreStandby.unsubscribeListener(snapshotSyncPluginListener);
-        corfuStoreStandby.unsubscribeListener(standbyListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
+        corfuStoreSink.unsubscribeListener(sinkListener);
         executorService.shutdownNow();
 
-        if (activeCorfu != null) {
-            activeCorfu.destroy();
+        if (sourceCorfu != null) {
+            sourceCorfu.destroy();
         }
-        if (standbyCorfu != null) {
-            standbyCorfu.destroy();
+        if (sinkCorfu != null) {
+            sinkCorfu.destroy();
         }
-        if (activeReplicationServer != null) {
-            activeReplicationServer.destroy();
+        if (sourceReplicationServer != null) {
+            sourceReplicationServer.destroy();
         }
-        if (standbyReplicationServer != null) {
-            standbyReplicationServer.destroy();
+        if (sinkReplicationServer != null) {
+            sinkReplicationServer.destroy();
         }
     }
 
     @Test
     @SuppressWarnings("checkstyle:magicnumber")
-    public void testLogEntrySyncAfterStandbyUpgradedStreamsAddedAndRemoved() throws Exception {
-        log.info(">> Setup active and standby Corfu");
-        setupActiveAndStandbyCorfu();
+    public void testLogEntrySyncAfterSinkUpgradedStreamsAddedAndRemoved() throws Exception {
+        log.info(">> Setup source and sink Corfu");
+        setupSourceAndSinkCorfu();
 
-        Set<String> streamsToReplicateActive = new HashSet<>();
+        Set<String> streamsToReplicateSource = new HashSet<>();
         for (int i = 1; i <= 2; i++) {
-            streamsToReplicateActive.add(TABLE_PREFIX + i);
+            streamsToReplicateSource.add(TABLE_PREFIX + i);
         }
 
-        setupStreamsToReplicateTable(streamsToReplicateActive, true, false);
-        setupStreamsToReplicateTable(streamsToReplicateActive, false, false);
-        setupVersionTable(corfuStoreActive, false);
-        setupVersionTable(corfuStoreStandby, false);
+        setupStreamsToReplicateTable(streamsToReplicateSource, true, false);
+        setupStreamsToReplicateTable(streamsToReplicateSource, false, false);
+        setupVersionTable(corfuStoreSource, false);
+        setupVersionTable(corfuStoreSink, false);
 
         // Two updates are expected onStart of snapshot sync and onEnd.
         CountDownLatch latchSnapshotSyncPlugin = new CountDownLatch(2);
         SnapshotSyncPluginListener snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-        // Subscribe to replication status table on Standby (to be sure data change on status are captured)
-        corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+        // Subscribe to replication status table on Sink (to be sure data change on status are captured)
+        corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -447,108 +447,108 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
                 TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
         CountDownLatch statusUpdateLatch = new CountDownLatch(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC);
-        ReplicationStatusListener standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        ReplicationStatusListener sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
-        log.info(">> Open map(s) on active and standby");
+        log.info(">> Open map(s) on source and sink");
         openMaps(2, false);
 
-        log.info(">> Write data to active CorfuDB before LR is started ...");
+        log.info(">> Write data to source CorfuDB before LR is started ...");
         // Add Data for Snapshot Sync
-        writeToActive(0, NUM_WRITES);
+        writeToSource(0, NUM_WRITES);
 
-        // Confirm data does exist on Active Cluster
-        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapActive.values()) {
+        // Confirm data does exist on Source Cluster
+        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSource.values()) {
             assertThat(map.count()).isEqualTo(NUM_WRITES);
         }
 
-        // Confirm data does not exist on Standby Cluster
-        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapStandby.values()) {
+        // Confirm data does not exist on Sink Cluster
+        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSink.values()) {
             assertThat(map.count()).isEqualTo(0);
         }
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_ACTIVE;
-        startActiveLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
+        startSourceLogReplicator();
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        startStandbyLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        startSinkLogReplicator();
 
         log.info(">> Wait ... Snapshot log replication in progress ...");
-        verifyDataOnStandby(NUM_WRITES);
+        verifyDataOnSink(NUM_WRITES);
 
         // Verify that snapshot sync was triggered by checking the number of
-        // updates to the ReplicationStatus table on the standby.
+        // updates to the ReplicationStatus table on the sink.
         latchSnapshotSyncPlugin.await();
         validateSnapshotSyncPlugin(snapshotSyncPluginListener);
         statusUpdateLatch.await();
 
-        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, standbyListener.getAccumulatedStatus().size());
-        Assert.assertTrue(standbyListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(standbyListener.getAccumulatedStatus().get(3));
+        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
 
-        Set<String> streamsToReplicateStandby = new HashSet<>();
+        Set<String> streamsToReplicateSink = new HashSet<>();
         for (int i = 2; i <= 3; i++) {
-            streamsToReplicateStandby.add(TABLE_PREFIX + i);
+            streamsToReplicateSink.add(TABLE_PREFIX + i);
         }
-        upgradeSiteWithNewConfig(false, streamsToReplicateStandby);
-        verifyVersion(corfuStoreStandby, UPGRADE_VERSION_STRING, true);
-        verifyVersion(corfuStoreActive, VERSION_STRING, false);
+        upgradeSiteWithNewConfig(false, streamsToReplicateSink);
+        verifyVersion(corfuStoreSink, UPGRADE_VERSION_STRING, true);
+        verifyVersion(corfuStoreSource, VERSION_STRING, false);
 
-        List<String> activeOnlyStreams = streamsToReplicateActive.stream()
-                .filter(s -> !streamsToReplicateStandby.contains(s))
+        List<String> sourceOnlyStreams = streamsToReplicateSource.stream()
+                .filter(s -> !streamsToReplicateSink.contains(s))
                 .collect(Collectors.toList());
 
-        List<String> standbyOnlyStreams = streamsToReplicateStandby.stream()
-                .filter(s -> !streamsToReplicateActive.contains(s))
+        List<String> sinkOnlyStreams = streamsToReplicateSink.stream()
+                .filter(s -> !streamsToReplicateSource.contains(s))
                 .collect(Collectors.toList());
 
-        List<String> commonStreams = streamsToReplicateActive.stream()
-                .filter(streamsToReplicateStandby::contains)
+        List<String> commonStreams = streamsToReplicateSource.stream()
+                .filter(streamsToReplicateSink::contains)
                 .collect(Collectors.toList());
 
         // Open maps corresponding to the new streams in the upgraded config
-        openMapsAfterUpgrade(standbyOnlyStreams);
+        openMapsAfterUpgrade(sinkOnlyStreams);
 
-        // Write to activeOnlyStreams
-        writeDataOnActive(activeOnlyStreams, NUM_WRITES, NUM_WRITES / 2);
+        // Write to sourceOnlyStreams
+        writeDataOnSource(sourceOnlyStreams, NUM_WRITES, NUM_WRITES / 2);
 
         // Write to common streams
-        writeDataOnActive(commonStreams, NUM_WRITES, NUM_WRITES / 2);
+        writeDataOnSource(commonStreams, NUM_WRITES, NUM_WRITES / 2);
 
-        // Write to standbyOnlyStreams
-        writeDataOnActive(standbyOnlyStreams, 0, NUM_WRITES);
+        // Write to sinkOnlyStreams
+        writeDataOnSource(sinkOnlyStreams, 0, NUM_WRITES);
 
-        verifyDataOnStandby(commonStreams, NUM_WRITES + NUM_WRITES / 2);
-        verifyDataOnStandby(activeOnlyStreams, NUM_WRITES);
-        verifyDataOnStandby(standbyOnlyStreams, 0);
+        verifyDataOnSink(commonStreams, NUM_WRITES + NUM_WRITES / 2);
+        verifyDataOnSink(sourceOnlyStreams, NUM_WRITES);
+        verifyDataOnSink(sinkOnlyStreams, 0);
 
-        corfuStoreStandby.unsubscribeListener(snapshotSyncPluginListener);
-        corfuStoreStandby.unsubscribeListener(standbyListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
+        corfuStoreSink.unsubscribeListener(sinkListener);
     }
 
     @Test
     @SuppressWarnings("checkstyle:magicnumber")
-    public void testSnapshotSyncAfterStandbyUpgradedStreamsAddedAndRemoved() throws Exception {
-        log.info(">> Setup active and standby Corfu's");
-        setupActiveAndStandbyCorfu();
+    public void testSnapshotSyncAfterSinkUpgradedStreamsAddedAndRemoved() throws Exception {
+        log.info(">> Setup source and sink Corfu's");
+        setupSourceAndSinkCorfu();
 
-        Set<String> streamsToReplicateActive = new HashSet<>();
+        Set<String> streamsToReplicateSource = new HashSet<>();
         for (int i = 1; i <= 2; i++) {
-            streamsToReplicateActive.add(TABLE_PREFIX + i);
+            streamsToReplicateSource.add(TABLE_PREFIX + i);
         }
-        setupStreamsToReplicateTable(streamsToReplicateActive, true, false);
-        setupStreamsToReplicateTable(streamsToReplicateActive, false, false);
-        setupVersionTable(corfuStoreActive, false);
-        setupVersionTable(corfuStoreStandby, false);
+        setupStreamsToReplicateTable(streamsToReplicateSource, true, false);
+        setupStreamsToReplicateTable(streamsToReplicateSource, false, false);
+        setupVersionTable(corfuStoreSource, false);
+        setupVersionTable(corfuStoreSink, false);
 
         // Two updates are expected onStart of snapshot sync and onEnd.
         CountDownLatch latchSnapshotSyncPlugin = new CountDownLatch(2);
         SnapshotSyncPluginListener snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-        // Subscribe to replication status table on Standby (to be sure data change on status are captured)
-        corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+        // Subscribe to replication status table on Sink (to be sure data change on status are captured)
+        corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -556,143 +556,143 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
                 TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
         CountDownLatch statusUpdateLatch = new CountDownLatch(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC);
-        ReplicationStatusListener standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        ReplicationStatusListener sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
-        log.info(">> Open map(s) on active and standby");
+        log.info(">> Open map(s) on source and sink");
         openMaps(2, false);
 
-        log.info(">> Write data to active CorfuDB before LR is started ...");
+        log.info(">> Write data to source CorfuDB before LR is started ...");
         // Add Data for Snapshot Sync
-        writeToActive(0, NUM_WRITES);
+        writeToSource(0, NUM_WRITES);
 
-        // Confirm data does exist on Active Cluster
-        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapActive.values()) {
+        // Confirm data does exist on Source Cluster
+        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSource.values()) {
             assertThat(map.count()).isEqualTo(NUM_WRITES);
         }
 
-        // Confirm data does not exist on Standby Cluster
-        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapStandby.values()) {
+        // Confirm data does not exist on Sink Cluster
+        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSink.values()) {
             assertThat(map.count()).isEqualTo(0);
         }
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_ACTIVE;
-        startActiveLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
+        startSourceLogReplicator();
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        startStandbyLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        startSinkLogReplicator();
 
         log.info(">> Wait ... Snapshot log replication in progress ...");
-        verifyDataOnStandby(NUM_WRITES);
+        verifyDataOnSink(NUM_WRITES);
 
         // Verify that snapshot sync was triggered by checking the number of
-        // updates to the ReplicationStatus table on the standby.
+        // updates to the ReplicationStatus table on the sink.
         latchSnapshotSyncPlugin.await();
         validateSnapshotSyncPlugin(snapshotSyncPluginListener);
         statusUpdateLatch.await();
 
-        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, standbyListener.getAccumulatedStatus().size());
-        Assert.assertTrue(standbyListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(standbyListener.getAccumulatedStatus().get(3));
-        corfuStoreStandby.unsubscribeListener(standbyListener);
-        corfuStoreStandby.unsubscribeListener(snapshotSyncPluginListener);
+        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        corfuStoreSink.unsubscribeListener(sinkListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
 
-        // Upgrade the standby site
+        // Upgrade the sink site
 
         statusUpdateLatch = new CountDownLatch(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC);
-        standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
             LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
-        log.info(">> Upgrading the standby site ...");
-        Set<String> streamsToReplicateStandby = new HashSet<>();
+        log.info(">> Upgrading the sink site ...");
+        Set<String> streamsToReplicateSink = new HashSet<>();
         for (int i = 2; i <= 3; i++) {
-            streamsToReplicateStandby.add(TABLE_PREFIX + i);
+            streamsToReplicateSink.add(TABLE_PREFIX + i);
         }
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        upgradeSiteWithNewConfig(false, streamsToReplicateStandby);
-        verifyVersion(corfuStoreStandby, UPGRADE_VERSION_STRING, true);
-        verifyVersion(corfuStoreActive, VERSION_STRING, false);
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        upgradeSiteWithNewConfig(false, streamsToReplicateSink);
+        verifyVersion(corfuStoreSink, UPGRADE_VERSION_STRING, true);
+        verifyVersion(corfuStoreSource, VERSION_STRING, false);
 
         latchSnapshotSyncPlugin = new CountDownLatch(2);
         snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-        stopActiveLogReplicator();
+        stopSourceLogReplicator();
 
-        List<String> activeOnlyStreams = streamsToReplicateActive.stream()
-                .filter(s -> !streamsToReplicateStandby.contains(s))
+        List<String> sourceOnlyStreams = streamsToReplicateSource.stream()
+                .filter(s -> !streamsToReplicateSink.contains(s))
                 .collect(Collectors.toList());
 
-        List<String> standbyOnlyStreams = streamsToReplicateStandby.stream()
-                .filter(s -> !streamsToReplicateActive.contains(s))
+        List<String> sinkOnlyStreams = streamsToReplicateSink.stream()
+                .filter(s -> !streamsToReplicateSource.contains(s))
                 .collect(Collectors.toList());
 
-        List<String> commonStreams = streamsToReplicateActive.stream()
-                .filter(streamsToReplicateStandby::contains)
+        List<String> commonStreams = streamsToReplicateSource.stream()
+                .filter(streamsToReplicateSink::contains)
                 .collect(Collectors.toList());
 
         // Open maps corresponding to the new streams in the upgraded config
-        openMapsAfterUpgrade(standbyOnlyStreams);
+        openMapsAfterUpgrade(sinkOnlyStreams);
 
-        // Write data on activeOnly streams
-        writeDataOnActive(activeOnlyStreams, NUM_WRITES, NUM_WRITES / 2);
+        // Write data on sourceOnly streams
+        writeDataOnSource(sourceOnlyStreams, NUM_WRITES, NUM_WRITES / 2);
 
-        // Write data on standbyOnly streams
-        writeDataOnActive(standbyOnlyStreams, 0, NUM_WRITES);
+        // Write data on sinkOnly streams
+        writeDataOnSource(sinkOnlyStreams, 0, NUM_WRITES);
 
         // Write data on common streams
-        writeDataOnActive(commonStreams, NUM_WRITES, NUM_WRITES / 2);
+        writeDataOnSource(commonStreams, NUM_WRITES, NUM_WRITES / 2);
 
         // Trigger a snapshot sync by running a CP+trim
         checkpointAndTrim(true);
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_ACTIVE;
-        startActiveLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
+        startSourceLogReplicator();
 
         // Verify that snapshot sync between the different versions was successful
         latchSnapshotSyncPlugin.await();
         statusUpdateLatch.await();
-        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, standbyListener.getAccumulatedStatus().size());
-        Assert.assertTrue(standbyListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(standbyListener.getAccumulatedStatus().get(3));
+        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
 
-        // No new data for active-only streams
-        verifyDataOnStandby(activeOnlyStreams, NUM_WRITES);
+        // No new data for source-only streams
+        verifyDataOnSink(sourceOnlyStreams, NUM_WRITES);
 
-        // No new data for standby-only streams
-        verifyDataOnStandby(standbyOnlyStreams, 0);
+        // No new data for sink-only streams
+        verifyDataOnSink(sinkOnlyStreams, 0);
 
         // New data present for common streams
-        verifyDataOnStandby(commonStreams, NUM_WRITES + NUM_WRITES / 2);
+        verifyDataOnSink(commonStreams, NUM_WRITES + NUM_WRITES / 2);
 
-        corfuStoreStandby.unsubscribeListener(snapshotSyncPluginListener);
-        corfuStoreStandby.unsubscribeListener(standbyListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
+        corfuStoreSink.unsubscribeListener(sinkListener);
     }
 
     @Test
     @SuppressWarnings("checkstyle:magicnumber")
     public void testSnapshotSyncAfterBothUpgradedStreamsAddedAndRemoved() throws Exception {
-        log.info(">> Setup active and standby Corfu's");
-        setupActiveAndStandbyCorfu();
+        log.info(">> Setup source and sink Corfu's");
+        setupSourceAndSinkCorfu();
 
-        Set<String> streamsToReplicateActive = new HashSet<>();
+        Set<String> streamsToReplicateSource = new HashSet<>();
         for (int i = 1; i <= 2; i++) {
-            streamsToReplicateActive.add(TABLE_PREFIX + i);
+            streamsToReplicateSource.add(TABLE_PREFIX + i);
         }
 
-        setupStreamsToReplicateTable(streamsToReplicateActive, true, false);
-        setupStreamsToReplicateTable(streamsToReplicateActive, false, false);
-        setupVersionTable(corfuStoreActive, false);
-        setupVersionTable(corfuStoreStandby, false);
+        setupStreamsToReplicateTable(streamsToReplicateSource, true, false);
+        setupStreamsToReplicateTable(streamsToReplicateSource, false, false);
+        setupVersionTable(corfuStoreSource, false);
+        setupVersionTable(corfuStoreSink, false);
 
         // Two updates are expected onStart of snapshot sync and onEnd.
         CountDownLatch latchSnapshotSyncPlugin = new CountDownLatch(2);
         SnapshotSyncPluginListener snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-        // Subscribe to replication status table on Standby (to be sure data change on status are captured)
-        corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+        // Subscribe to replication status table on Sink (to be sure data change on status are captured)
+        corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -700,132 +700,132 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
                 TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
         CountDownLatch statusUpdateLatch = new CountDownLatch(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC);
-        ReplicationStatusListener standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        ReplicationStatusListener sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
-        log.info(">> Open map(s) on active and standby");
+        log.info(">> Open map(s) on source and sink");
         openMaps(2, false);
 
-        log.info(">> Write data to active CorfuDB before LR is started ...");
+        log.info(">> Write data to source CorfuDB before LR is started ...");
         // Add Data for Snapshot Sync
-        writeToActive(0, NUM_WRITES);
+        writeToSource(0, NUM_WRITES);
 
-        // Confirm data does exist on Active Cluster
-        for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapActive.values()) {
+        // Confirm data does exist on Source Cluster
+        for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSource.values()) {
             assertThat(map.count()).isEqualTo(NUM_WRITES);
         }
 
-        // Confirm data does not exist on Standby Cluster
-        for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapStandby.values()) {
+        // Confirm data does not exist on Sink Cluster
+        for (Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSink.values()) {
             assertThat(map.count()).isEqualTo(0);
         }
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_ACTIVE;
-        startActiveLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
+        startSourceLogReplicator();
 
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        startStandbyLogReplicator();
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        startSinkLogReplicator();
 
         log.info(">> Wait ... Snapshot log replication in progress ...");
-        verifyDataOnStandby(NUM_WRITES);
+        verifyDataOnSink(NUM_WRITES);
 
         // Verify that snapshot sync was triggered by checking the number of
-        // updates to the ReplicationStatus table on the standby.
+        // updates to the ReplicationStatus table on the sink.
         latchSnapshotSyncPlugin.await();
         validateSnapshotSyncPlugin(snapshotSyncPluginListener);
         statusUpdateLatch.await();
 
-        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, standbyListener.getAccumulatedStatus().size());
-        Assert.assertTrue(standbyListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(standbyListener.getAccumulatedStatus().get(3));
+        Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
 
-        Set<String> streamsToReplicateStandby = new HashSet<>();
+        Set<String> streamsToReplicateSink = new HashSet<>();
         for (int i = 2; i <= 3; i++) {
-            streamsToReplicateStandby.add(TABLE_PREFIX + i);
+            streamsToReplicateSink.add(TABLE_PREFIX + i);
         }
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_STANDBY;
-        upgradeSiteWithNewConfig(false, streamsToReplicateStandby);
-        verifyVersion(corfuStoreStandby, UPGRADE_VERSION_STRING, true);
-        verifyVersion(corfuStoreActive, VERSION_STRING, false);
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SINK;
+        upgradeSiteWithNewConfig(false, streamsToReplicateSink);
+        verifyVersion(corfuStoreSink, UPGRADE_VERSION_STRING, true);
+        verifyVersion(corfuStoreSource, VERSION_STRING, false);
 
-        List<String> activeOnlyStreams = streamsToReplicateActive.stream()
-                .filter(s -> !streamsToReplicateStandby.contains(s))
+        List<String> sourceOnlyStreams = streamsToReplicateSource.stream()
+                .filter(s -> !streamsToReplicateSink.contains(s))
                 .collect(Collectors.toList());
 
-        List<String> standbyOnlyStreams = streamsToReplicateStandby.stream()
-                .filter(s -> !streamsToReplicateActive.contains(s))
+        List<String> sinkOnlyStreams = streamsToReplicateSink.stream()
+                .filter(s -> !streamsToReplicateSource.contains(s))
                 .collect(Collectors.toList());
 
-        List<String> commonStreams = streamsToReplicateActive.stream()
-                .filter(streamsToReplicateStandby::contains)
+        List<String> commonStreams = streamsToReplicateSource.stream()
+                .filter(streamsToReplicateSink::contains)
                 .collect(Collectors.toList());
 
         // Open maps corresponding to the new streams in the upgraded config
-        openMapsAfterUpgrade(standbyOnlyStreams);
+        openMapsAfterUpgrade(sinkOnlyStreams);
 
-        // Write to activeOnlyStreams
-        writeDataOnActive(activeOnlyStreams, NUM_WRITES, NUM_WRITES / 2);
+        // Write to sourceOnlyStreams
+        writeDataOnSource(sourceOnlyStreams, NUM_WRITES, NUM_WRITES / 2);
 
         // Write to common streams
-        writeDataOnActive(commonStreams, NUM_WRITES, NUM_WRITES / 2);
+        writeDataOnSource(commonStreams, NUM_WRITES, NUM_WRITES / 2);
 
-        // Write to standbyOnlyStreams
-        writeDataOnActive(standbyOnlyStreams, 0, NUM_WRITES);
+        // Write to sinkOnlyStreams
+        writeDataOnSource(sinkOnlyStreams, 0, NUM_WRITES);
 
-        verifyDataOnStandby(commonStreams, NUM_WRITES + NUM_WRITES / 2);
-        verifyDataOnStandby(activeOnlyStreams, NUM_WRITES);
-        verifyDataOnStandby(standbyOnlyStreams, 0);
+        verifyDataOnSink(commonStreams, NUM_WRITES + NUM_WRITES / 2);
+        verifyDataOnSink(sourceOnlyStreams, NUM_WRITES);
+        verifyDataOnSink(sinkOnlyStreams, 0);
 
-        corfuStoreStandby.unsubscribeListener(standbyListener);
-        corfuStoreStandby.unsubscribeListener(snapshotSyncPluginListener);
+        corfuStoreSink.unsubscribeListener(sinkListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
 
         latchSnapshotSyncPlugin = new CountDownLatch(2);
         snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
         subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
         statusUpdateLatch = new CountDownLatch(NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE);
-        standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-        corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+        sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
 
-        // Now upgrade the active site
-        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_ACTIVE;
-        upgradeSiteWithNewConfig(true, streamsToReplicateStandby);
-        verifyVersion(corfuStoreStandby, UPGRADE_VERSION_STRING, true);
-        verifyVersion(corfuStoreActive, UPGRADE_VERSION_STRING, true);
+        // Now upgrade the source site
+        pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
+        upgradeSiteWithNewConfig(true, streamsToReplicateSink);
+        verifyVersion(corfuStoreSink, UPGRADE_VERSION_STRING, true);
+        verifyVersion(corfuStoreSource, UPGRADE_VERSION_STRING, true);
 
         // Verify that snapshot sync was triggered by checking the number of
-        // updates to the ReplicationStatus table on the standby.
+        // updates to the ReplicationStatus table on the sink.
         latchSnapshotSyncPlugin.await();
         validateSnapshotSyncPlugin(snapshotSyncPluginListener);
         statusUpdateLatch.await();
 
-        Assert.assertEquals(NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE, standbyListener.getAccumulatedStatus().size());
-        Assert.assertTrue(standbyListener.getAccumulatedStatus().get(1));
-        Assert.assertFalse(standbyListener.getAccumulatedStatus().get(0));
+        Assert.assertEquals(NUM_SNAPSHOT_SYNC_UPDATES_ON_SINK_STATUS_TABLE, sinkListener.getAccumulatedStatus().size());
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(1));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(0));
 
-        // Verify that the streams only on standby prior to upgrade have data
+        // Verify that the streams only on sink prior to upgrade have data
         // and no data is lost for the common streams
-        verifyDataOnStandby(commonStreams, NUM_WRITES + NUM_WRITES / 2);
-        verifyDataOnStandby(standbyOnlyStreams, NUM_WRITES);
+        verifyDataOnSink(commonStreams, NUM_WRITES + NUM_WRITES / 2);
+        verifyDataOnSink(sinkOnlyStreams, NUM_WRITES);
 
-        verifyDataOnStandby(activeOnlyStreams, NUM_WRITES);
+        verifyDataOnSink(sourceOnlyStreams, NUM_WRITES);
 
-        corfuStoreStandby.unsubscribeListener(snapshotSyncPluginListener);
-        corfuStoreStandby.unsubscribeListener(standbyListener);
+        corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
+        corfuStoreSink.unsubscribeListener(sinkListener);
     }
 
     private void setupStreamsToReplicateTable(Set<String> streamsToReplicate,
-                                              boolean active, boolean clear) throws Exception {
+                                              boolean source, boolean clear) throws Exception {
 
         CorfuStore corfuStore;
         Table<TableInfo, Namespace, CommonTypes.Uuid> streamsNameTable;
-        if (active) {
-            corfuStore = corfuStoreActive;
+        if (source) {
+            corfuStore = corfuStoreSource;
         } else {
-            corfuStore = corfuStoreStandby;
+            corfuStore = corfuStoreSink;
         }
 
         if (clear) {
@@ -846,27 +846,27 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         }
     }
 
-    private void upgradeSiteWithNewConfig(boolean active,
+    private void upgradeSiteWithNewConfig(boolean source,
                                           Set<String> streamsToReplicate) throws Exception {
-        setupStreamsToReplicateTable(streamsToReplicate, active, true);
-        upgradeSite(active, active ? corfuStoreActive : corfuStoreStandby);
+        setupStreamsToReplicateTable(streamsToReplicate, source, true);
+        upgradeSite(source, source ? corfuStoreSource : corfuStoreSink);
     }
 
-    private void upgradeSite(boolean active, CorfuStore corfuStore) throws Exception {
-        if (active) {
-            stopActiveLogReplicator();
+    private void upgradeSite(boolean source, CorfuStore corfuStore) throws Exception {
+        if (source) {
+            stopSourceLogReplicator();
         } else {
-            stopStandbyLogReplicator();
+            stopSinkLogReplicator();
         }
 
         // Write a new version to the plugin version table so that an upgrade
         // is detected
         setupVersionTable(corfuStore, true);
 
-        if (active) {
-            startActiveLogReplicator();
+        if (source) {
+            startSourceLogReplicator();
         } else {
-            startStandbyLogReplicator();
+            startSinkLogReplicator();
         }
     }
 
@@ -899,35 +899,35 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
 
     private void openMapsAfterUpgrade(List<String> tableNames) throws Exception {
         for (String tableName : tableNames) {
-            Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapActive = corfuStoreActive.openTable(
+            Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapSource = corfuStoreSource.openTable(
                     NAMESPACE, tableName, Sample.StringKey.class,
                     Sample.IntValueTag.class, Sample.Metadata.class,
                     TableOptions.fromProtoSchema(Sample.IntValueTag.class,
                             TableOptions.builder().persistentDataPath(null).build()));
 
-            Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapStandby = corfuStoreStandby.openTable(
+            Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapSink = corfuStoreSink.openTable(
                     NAMESPACE, tableName, Sample.StringKey.class,
                     Sample.IntValueTag.class, Sample.Metadata.class,
                     TableOptions.fromProtoSchema(Sample.IntValueTag.class,
                             TableOptions.builder().persistentDataPath(null).build()));
 
-            mapNameToMapActive.put(tableName, mapActive);
-            mapNameToMapStandby.put(tableName, mapStandby);
+            mapNameToMapSource.put(tableName, mapSource);
+            mapNameToMapSink.put(tableName, mapSink);
         }
     }
 
-    private void writeDataOnActive(List<String> tableNames, int start,
+    private void writeDataOnSource(List<String> tableNames, int start,
                                    int NUM_WRITES) {
         int totalWrites = start + NUM_WRITES;
         for (String tableName : tableNames) {
             Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> table =
-                    mapNameToMapActive.get(tableName);
+                    mapNameToMapSource.get(tableName);
 
             for (int i = start; i < totalWrites; i++) {
                 Sample.StringKey stringKey = Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build();
                 Sample.IntValueTag IntValueTag = Sample.IntValueTag.newBuilder().setValue(i).build();
                 Sample.Metadata metadata = Sample.Metadata.newBuilder().setMetadata("Metadata_" + i).build();
-                try (TxnContext txn = corfuStoreActive.txn(NAMESPACE)) {
+                try (TxnContext txn = corfuStoreSource.txn(NAMESPACE)) {
                     txn.putRecord(table, stringKey, IntValueTag, metadata);
                     txn.commit();
                 }
@@ -936,18 +936,18 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     }
 
     @SuppressWarnings("checkstyle:magicnumber")
-    private void verifyDataOnStandby(List<String> tableNames, int expectedNumWrites) {
+    private void verifyDataOnSink(List<String> tableNames, int expectedNumWrites) {
         for (String tableName : tableNames) {
             Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> table =
-                    mapNameToMapStandby.get(tableName);
+                    mapNameToMapSink.get(tableName);
             while (table.count() != expectedNumWrites) {
-                // block until expected entries get replicated to Standby
+                // block until expected entries get replicated to Sink
                 log.trace("Current table size: {}, expected entries: {}", table.count(), expectedNumWrites);
             }
             Assert.assertEquals(expectedNumWrites, table.count());
 
             for (int i = 0; i < expectedNumWrites; i++) {
-                try (TxnContext tx = corfuStoreStandby.txn(table.getNamespace())) {
+                try (TxnContext tx = corfuStoreSink.txn(table.getNamespace())) {
                     assertThat(tx.getRecord(table,
                             Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build()).getPayload()).isNotNull();
                     tx.commit();

--- a/test/src/test/java/org/corfudb/integration/LockIT.java
+++ b/test/src/test/java/org/corfudb/integration/LockIT.java
@@ -51,8 +51,8 @@ public class LockIT extends AbstractIT implements Observer {
     private final Semaphore blockUntilWaitCondition = new Semaphore(1, true);
 
     private Process corfuServer = null;
-    private final int activeSiteCorfuPort = 9000;
-    private final String corfuEndpoint = DEFAULT_HOST + ":" + activeSiteCorfuPort;
+    private final int sourceSiteCorfuPort = 9000;
+    private final String corfuEndpoint = DEFAULT_HOST + ":" + sourceSiteCorfuPort;
 
     private WaitConditionType waitCondition = WaitConditionType.NONE;
 
@@ -65,7 +65,7 @@ public class LockIT extends AbstractIT implements Observer {
 
         try {
            // Start Single Corfu Node Cluster
-           corfuServer = runServer(activeSiteCorfuPort, true);
+           corfuServer = runServer(sourceSiteCorfuPort, true);
            initialize();
 
            // Initial acquisition of the semaphore so we can later block until execution conditions are met
@@ -127,7 +127,7 @@ public class LockIT extends AbstractIT implements Observer {
 
         try {
             // Start Single Corfu Node Cluster
-            corfuServer = runServer(activeSiteCorfuPort, true);
+            corfuServer = runServer(sourceSiteCorfuPort, true);
             initialize();
 
             // Initial acquisition of the semaphore so we can later block until execution conditions are met
@@ -186,7 +186,7 @@ public class LockIT extends AbstractIT implements Observer {
         Map<UUID, LockListener> clientIdToLockListener = new HashMap<>();
 
         try {
-            corfuServer = runServer(activeSiteCorfuPort, true);
+            corfuServer = runServer(sourceSiteCorfuPort, true);
             initialize();
 
             LockDataTypes.LockId lockId = LockDataTypes.LockId.newBuilder()
@@ -285,7 +285,7 @@ public class LockIT extends AbstractIT implements Observer {
         Map<UUID, LockListener> clientIdToLockListener = new HashMap<>();
 
         try {
-            corfuServer = runServer(activeSiteCorfuPort, true);
+            corfuServer = runServer(sourceSiteCorfuPort, true);
             initialize();
 
             LockDataTypes.LockId lockId =  LockDataTypes.LockId.newBuilder()

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -82,85 +82,85 @@ public class LogReplicationAbstractIT extends AbstractIT {
     public static boolean runProcess = true;
 
     public ExecutorService executorService = Executors.newFixedThreadPool(2);
-    public Process activeCorfu = null;
-    public Process standbyCorfu = null;
+    public Process sourceCorfu = null;
+    public Process sinkCorfu = null;
 
-    public Process activeReplicationServer = null;
-    public Process standbyReplicationServer = null;
+    public Process sourceReplicationServer = null;
+    public Process sinkReplicationServer = null;
 
     public final String streamA = "Table001";
 
     public final int numWrites = 5000;
     public final int lockLeaseDuration = 10;
 
-    public final int activeSiteCorfuPort = 9000;
-    public final int standbySiteCorfuPort = 9001;
+    public final int sourceSiteCorfuPort = 9000;
+    public final int sinkSiteCorfuPort = 9001;
 
-    public final int activeReplicationServerPort = 9010;
-    public final int standbyReplicationServerPort = 9020;
+    public final int sourceReplicationServerPort = 9010;
+    public final int sinkReplicationServerPort = 9020;
 
-    public final String activeEndpoint = DEFAULT_HOST + ":" + activeSiteCorfuPort;
-    public final String standbyEndpoint = DEFAULT_HOST + ":" + standbySiteCorfuPort;
+    public final String sourceEndpoint = DEFAULT_HOST + ":" + sourceSiteCorfuPort;
+    public final String sinkEndpoint = DEFAULT_HOST + ":" + sinkSiteCorfuPort;
 
-    public CorfuRuntime activeRuntime;
-    public CorfuRuntime standbyRuntime;
+    public CorfuRuntime sourceRuntime;
+    public CorfuRuntime sinkRuntime;
 
     public CorfuTable<String, Integer> mapA;
-    public CorfuTable<String, Integer> mapAStandby;
+    public CorfuTable<String, Integer> mapASink;
 
-    public Map<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> mapNameToMapActive;
-    public Map<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> mapNameToMapStandby;
+    public Map<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> mapNameToMapSource;
+    public Map<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> mapNameToMapSink;
 
-    public CorfuStore corfuStoreActive;
-    public CorfuStore corfuStoreStandby;
+    public CorfuStore corfuStoreSource;
+    public CorfuStore corfuStoreSink;
 
     private final long longInterval = 20L;
 
     public void testEndToEndSnapshotAndLogEntrySync() throws Exception {
         try {
-            log.debug("Setup active and standby Corfu's");
-            setupActiveAndStandbyCorfu();
+            log.debug("Setup source and sink Corfu's");
+            setupSourceAndSinkCorfu();
 
-            log.debug("Open map on active and standby");
+            log.debug("Open map on source and sink");
             openMap();
 
-            log.debug("Write data to active CorfuDB before LR is started ...");
+            log.debug("Write data to source CorfuDB before LR is started ...");
             // Add Data for Snapshot Sync
-            writeToActiveNonUFO(0, numWrites);
+            writeToSourceNonUFO(0, numWrites);
 
-            // Confirm data does exist on Active Cluster
+            // Confirm data does exist on Source Cluster
             assertThat(mapA.size()).isEqualTo(numWrites);
 
-            // Confirm data does not exist on Standby Cluster
-            assertThat(mapAStandby.size()).isEqualTo(0);
+            // Confirm data does not exist on Sink Cluster
+            assertThat(mapASink.size()).isEqualTo(0);
 
             startLogReplicatorServers();
 
             log.debug("Wait ... Snapshot log replication in progress ...");
-            verifyDataOnStandbyNonUFO(numWrites);
+            verifyDataOnSinkNonUFO(numWrites);
 
             // Add Delta's for Log Entry Sync
-            writeToActiveNonUFO(numWrites, numWrites/2);
+            writeToSourceNonUFO(numWrites, numWrites/2);
 
             log.debug("Wait ... Delta log replication in progress ...");
-            verifyDataOnStandbyNonUFO((numWrites + (numWrites / 2)));
+            verifyDataOnSinkNonUFO((numWrites + (numWrites / 2)));
         } finally {
             executorService.shutdownNow();
 
-            if (activeCorfu != null) {
-                activeCorfu.destroy();
+            if (sourceCorfu != null) {
+                sourceCorfu.destroy();
             }
 
-            if (standbyCorfu != null) {
-                standbyCorfu.destroy();
+            if (sinkCorfu != null) {
+                sinkCorfu.destroy();
             }
 
-            if (activeReplicationServer != null) {
-                activeReplicationServer.destroy();
+            if (sourceReplicationServer != null) {
+                sourceReplicationServer.destroy();
             }
 
-            if (standbyReplicationServer != null) {
-                standbyReplicationServer.destroy();
+            if (sinkReplicationServer != null) {
+                sinkReplicationServer.destroy();
             }
         }
 
@@ -175,55 +175,55 @@ public class LogReplicationAbstractIT extends AbstractIT {
         // (1) On startup, init the replication status for each Source cluster(3 clusters = 3 updates)
         // (2) When starting snapshot sync apply : is_data_consistent = false
         // (3) When completing snapshot sync apply : is_data_consistent = true
-        final int totalStandbyStatusUpdates = 5;
+        final int totalSinkStatusUpdates = 5;
 
         try {
-            log.info(">> Setup active and standby Corfu's");
-            setupActiveAndStandbyCorfu();
+            log.info(">> Setup source and sink Corfu's");
+            setupSourceAndSinkCorfu();
 
             // Two updates are expected onStart of snapshot sync and onEnd.
             CountDownLatch latchSnapshotSyncPlugin = new CountDownLatch(2);
             SnapshotSyncPluginListener snapshotSyncPluginListener = new SnapshotSyncPluginListener(latchSnapshotSyncPlugin);
             subscribeToSnapshotSyncPluginTable(snapshotSyncPluginListener);
 
-            // Subscribe to replication status table on Standby (to be sure data change on status are captured)
-            corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+            // Subscribe to replication status table on Sink (to be sure data change on status are captured)
+            corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
                     LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                     LogReplicationMetadata.ReplicationStatusKey.class,
                     LogReplicationMetadata.ReplicationStatusVal.class,
                     null,
                     TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
-            CountDownLatch statusUpdateLatch = new CountDownLatch(totalStandbyStatusUpdates);
-            ReplicationStatusListener standbyListener = new ReplicationStatusListener(statusUpdateLatch, false);
-            corfuStoreStandby.subscribeListener(standbyListener, LogReplicationMetadataManager.NAMESPACE,
+            CountDownLatch statusUpdateLatch = new CountDownLatch(totalSinkStatusUpdates);
+            ReplicationStatusListener sinkListener = new ReplicationStatusListener(statusUpdateLatch, false);
+            corfuStoreSink.subscribeListener(sinkListener, LogReplicationMetadataManager.NAMESPACE,
                     LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
-            log.info(">> Open map(s) on active and standby");
+            log.info(">> Open map(s) on source and sink");
             openMaps(totalNumMaps, diskBased);
 
-            log.info(">> Write data to active CorfuDB before LR is started ...");
+            log.info(">> Write data to source CorfuDB before LR is started ...");
             // Add Data for Snapshot Sync
-            writeToActive(0, numWrites);
+            writeToSource(0, numWrites);
 
-            // Confirm data does exist on Active Cluster
-            for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapActive.values()) {
+            // Confirm data does exist on Source Cluster
+            for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSource.values()) {
                 assertThat(map.count()).isEqualTo(numWrites);
             }
 
-            // Confirm data does not exist on Standby Cluster
-            for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapStandby.values()) {
+            // Confirm data does not exist on Sink Cluster
+            for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSink.values()) {
                 assertThat(map.count()).isEqualTo(0);
             }
 
             startLogReplicatorServers();
 
             log.info(">> Wait ... Snapshot log replication in progress ...");
-            verifyDataOnStandby(numWrites);
+            verifyDataOnSink(numWrites);
 
             // Confirm replication status reflects snapshot sync completed
-            log.info(">> Verify replication status completed on active");
-            verifyReplicationStatusFromActive();
+            log.info(">> Verify replication status completed on source");
+            verifyReplicationStatusFromSource();
 
             // Wait until both plugin updates
             log.info(">> Wait snapshot sync plugin updates received");
@@ -233,18 +233,18 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
             // Add Delta's for Log Entry Sync
             log.info(">> Write deltas");
-            writeToActive(numWrites, numWrites / 2);
+            writeToSource(numWrites, numWrites / 2);
 
             log.info(">> Wait ... Delta log replication in progress ...");
-            verifyDataOnStandby((numWrites + (numWrites / 2)));
+            verifyDataOnSink((numWrites + (numWrites / 2)));
 
-            // Verify Standby Status Listener received all expected updates (is_data_consistent)
+            // Verify Sink Status Listener received all expected updates (is_data_consistent)
             log.info(">> Wait ... Replication status UPDATE ...");
             statusUpdateLatch.await();
-            assertThat(standbyListener.getAccumulatedStatus().size()).isEqualTo(totalStandbyStatusUpdates);
+            assertThat(sinkListener.getAccumulatedStatus().size()).isEqualTo(totalSinkStatusUpdates);
             // Confirm last updates are set to true (corresponding to snapshot sync completed and log entry sync started)
-            assertThat(standbyListener.getAccumulatedStatus().get(standbyListener.getAccumulatedStatus().size() - 1)).isTrue();
-            assertThat(standbyListener.getAccumulatedStatus()).contains(false);
+            assertThat(sinkListener.getAccumulatedStatus().get(sinkListener.getAccumulatedStatus().size() - 1)).isTrue();
+            assertThat(sinkListener.getAccumulatedStatus()).contains(false);
 
             if (checkRemainingEntriesOnSecondLogEntrySync) {
                 triggerSnapshotAndTestRemainingEntries();
@@ -253,20 +253,20 @@ public class LogReplicationAbstractIT extends AbstractIT {
         } finally {
             executorService.shutdownNow();
 
-            if (activeCorfu != null) {
-                activeCorfu.destroy();
+            if (sourceCorfu != null) {
+                sourceCorfu.destroy();
             }
 
-            if (standbyCorfu != null) {
-                standbyCorfu.destroy();
+            if (sinkCorfu != null) {
+                sinkCorfu.destroy();
             }
 
-            if (activeReplicationServer != null) {
-                activeReplicationServer.destroy();
+            if (sourceReplicationServer != null) {
+                sourceReplicationServer.destroy();
             }
 
-            if (standbyReplicationServer != null) {
-                standbyReplicationServer.destroy();
+            if (sinkReplicationServer != null) {
+                sinkReplicationServer.destroy();
             }
         }
     }
@@ -275,12 +275,12 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
         // enforce a snapshot sync
         Table<ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg> configTable =
-                corfuStoreActive.openTable(
+                corfuStoreSource.openTable(
                         DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
                         ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
                         TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class)
                 );
-        try (TxnContext txn = corfuStoreActive.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
+        try (TxnContext txn = corfuStoreSource.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
             txn.putRecord(configTable, DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC,
                     DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC, DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC);
             txn.commit();
@@ -291,11 +291,11 @@ public class LogReplicationAbstractIT extends AbstractIT {
         TimeUnit.SECONDS.sleep(longInterval);
 
         CountDownLatch statusUpdateLatch = new CountDownLatch(1);
-        ReplicationStatusListener activeListener = new ReplicationStatusListener(statusUpdateLatch, true);
-        corfuStoreActive.subscribeListener(activeListener, LogReplicationMetadataManager.NAMESPACE,
+        ReplicationStatusListener sourceListener = new ReplicationStatusListener(statusUpdateLatch, true);
+        corfuStoreSource.subscribeListener(sourceListener, LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
 
-        corfuStoreActive.openTable(LogReplicationMetadataManager.NAMESPACE,
+        corfuStoreSource.openTable(LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -305,12 +305,12 @@ public class LogReplicationAbstractIT extends AbstractIT {
         LogReplicationMetadata.ReplicationStatusKey key =
                 LogReplicationMetadata.ReplicationStatusKey
                         .newBuilder()
-                        .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
+                        .setClusterId(new DefaultClusterConfig().getSinkClusterIds().get(0))
                         .build();
         LogReplicationMetadata.ReplicationStatusVal replicationStatusVal;
 
         statusUpdateLatch.await();
-        try (TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+        try (TxnContext txn = corfuStoreSource.txn(LogReplicationMetadataManager.NAMESPACE)) {
             replicationStatusVal = (LogReplicationMetadata.ReplicationStatusVal) txn.getRecord("LogReplicationStatus", key).getPayload();
             txn.commit();
         }
@@ -318,11 +318,11 @@ public class LogReplicationAbstractIT extends AbstractIT {
         assertThat(replicationStatusVal.getRemainingEntriesToSend()).isEqualTo(0);
     }
 
-    private void verifyReplicationStatusFromActive() throws Exception {
+    private void verifyReplicationStatusFromSource() throws Exception {
         Table<LogReplicationMetadata.ReplicationStatusKey,
             LogReplicationMetadata.ReplicationStatusVal,
             LogReplicationMetadata.ReplicationStatusVal> replicationStatusTable =
-            corfuStoreActive.openTable(LogReplicationMetadataManager.NAMESPACE,
+            corfuStoreSource.openTable(LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -330,7 +330,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
                 TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
         String clusterId =
-            new DefaultClusterConfig().getStandbyClusterIds().get(0);
+            new DefaultClusterConfig().getSinkClusterIds().get(0);
 
         LogReplicationMetadata.ReplicationStatusKey key =
             LogReplicationMetadata.ReplicationStatusKey
@@ -339,7 +339,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
                 .build();
 
         IRetry.build(IntervalRetry.class, () -> {
-            try(TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+            try(TxnContext txn = corfuStoreSource.txn(LogReplicationMetadataManager.NAMESPACE)) {
                 CorfuStoreEntry<LogReplicationMetadata.ReplicationStatusKey,
                     LogReplicationMetadata.ReplicationStatusVal,
                     LogReplicationMetadata.ReplicationStatusVal> entry =
@@ -374,10 +374,10 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
     void subscribeToSnapshotSyncPluginTable(SnapshotSyncPluginListener listener) {
         try {
-            corfuStoreStandby.openTable(DefaultSnapshotSyncPlugin.NAMESPACE,
+            corfuStoreSink.openTable(DefaultSnapshotSyncPlugin.NAMESPACE,
                     DefaultSnapshotSyncPlugin.TABLE_NAME, ExampleSchemas.Uuid.class, SnapshotSyncPluginValue.class,
                     SnapshotSyncPluginValue.class, TableOptions.fromProtoSchema(SnapshotSyncPluginValue.class));
-            corfuStoreStandby.subscribeListener(listener, DefaultSnapshotSyncPlugin.NAMESPACE, DefaultSnapshotSyncPlugin.TAG);
+            corfuStoreSink.subscribeListener(listener, DefaultSnapshotSyncPlugin.NAMESPACE, DefaultSnapshotSyncPlugin.TAG);
         } catch (Exception e) {
             fail("Exception while attempting to subscribe to snapshot sync plugin table");
         }
@@ -438,29 +438,29 @@ public class LogReplicationAbstractIT extends AbstractIT {
         }
     }
 
-    public void setupActiveAndStandbyCorfu() throws Exception {
+    public void setupSourceAndSinkCorfu() throws Exception {
         try {
-            // Start Single Corfu Node Cluster on Active Site
-            activeCorfu = runServer(activeSiteCorfuPort, true);
+            // Start Single Corfu Node Cluster on Source Site
+            sourceCorfu = runServer(sourceSiteCorfuPort, true);
 
-            // Start Corfu Cluster on Standby Site
-            standbyCorfu = runServer(standbySiteCorfuPort, true);
+            // Start Corfu Cluster on Sink Site
+            sinkCorfu = runServer(sinkSiteCorfuPort, true);
 
-            // Setup runtime's to active and standby Corfu
+            // Setup runtime's to source and sink Corfu
             CorfuRuntime.CorfuRuntimeParameters params = CorfuRuntime.CorfuRuntimeParameters
                     .builder()
                     .build();
 
-            activeRuntime = CorfuRuntime.fromParameters(params);
-            activeRuntime.parseConfigurationString(activeEndpoint);
-            activeRuntime.connect();
+            sourceRuntime = CorfuRuntime.fromParameters(params);
+            sourceRuntime.parseConfigurationString(sourceEndpoint);
+            sourceRuntime.connect();
 
-            standbyRuntime = CorfuRuntime.fromParameters(params);
-            standbyRuntime.parseConfigurationString(standbyEndpoint);
-            standbyRuntime.connect();
+            sinkRuntime = CorfuRuntime.fromParameters(params);
+            sinkRuntime.parseConfigurationString(sinkEndpoint);
+            sinkRuntime.connect();
 
-            corfuStoreActive = new CorfuStore(activeRuntime);
-            corfuStoreStandby = new CorfuStore(standbyRuntime);
+            corfuStoreSource = new CorfuStore(sourceRuntime);
+            corfuStoreSink = new CorfuStore(sinkRuntime);
         } catch (Exception e) {
             log.debug("Error while starting Corfu");
             throw  e;
@@ -468,38 +468,38 @@ public class LogReplicationAbstractIT extends AbstractIT {
     }
 
     public void openMaps(int mapCount, boolean diskBased) throws Exception {
-        mapNameToMapActive = new HashMap<>();
-        mapNameToMapStandby = new HashMap<>();
-        Path pathActive = null;
-        Path pathStandby = null;
+        mapNameToMapSource = new HashMap<>();
+        mapNameToMapSink = new HashMap<>();
+        Path pathSource = null;
+        Path pathSink = null;
 
         for(int i=1; i <= mapCount; i++) {
             String mapName = TABLE_PREFIX + i;
 
             if (diskBased) {
-                pathActive = Paths.get(com.google.common.io.Files.createTempDir().getAbsolutePath());
-                pathStandby = Paths.get(com.google.common.io.Files.createTempDir().getAbsolutePath());
+                pathSource = Paths.get(com.google.common.io.Files.createTempDir().getAbsolutePath());
+                pathSink = Paths.get(com.google.common.io.Files.createTempDir().getAbsolutePath());
             }
 
-            Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapActive = corfuStoreActive.openTable(
+            Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapSource = corfuStoreSource.openTable(
                     NAMESPACE, mapName, Sample.StringKey.class, Sample.IntValueTag.class, Sample.Metadata.class,
-                    TableOptions.fromProtoSchema(Sample.IntValueTag.class, TableOptions.builder().persistentDataPath(pathActive).build()));
+                    TableOptions.fromProtoSchema(Sample.IntValueTag.class, TableOptions.builder().persistentDataPath(pathSource).build()));
 
-            Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapStandby = corfuStoreStandby.openTable(
+            Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> mapSink = corfuStoreSink.openTable(
                     NAMESPACE, mapName, Sample.StringKey.class, Sample.IntValueTag.class, Sample.Metadata.class,
-                    TableOptions.fromProtoSchema(Sample.IntValueTag.class, TableOptions.builder().persistentDataPath(pathStandby).build()));
+                    TableOptions.fromProtoSchema(Sample.IntValueTag.class, TableOptions.builder().persistentDataPath(pathSink).build()));
 
-            mapNameToMapActive.put(mapName, mapActive);
-            mapNameToMapStandby.put(mapName, mapStandby);
+            mapNameToMapSource.put(mapName, mapSource);
+            mapNameToMapSink.put(mapName, mapSink);
 
-            assertThat(mapActive.count()).isEqualTo(0);
-            assertThat(mapStandby.count()).isEqualTo(0);
+            assertThat(mapSource.count()).isEqualTo(0);
+            assertThat(mapSink.count()).isEqualTo(0);
         }
     }
 
     public void openMap() {
-        // Write to StreamA on Active Site
-        mapA = activeRuntime.getObjectsView()
+        // Write to StreamA on Source Site
+        mapA = sourceRuntime.getObjectsView()
                 .build()
                 .setStreamName(streamA)
                 .setStreamTags(ObjectsView.getLogReplicatorStreamId())
@@ -507,7 +507,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
                 })
                 .open();
 
-        mapAStandby = standbyRuntime.getObjectsView()
+        mapASink = sinkRuntime.getObjectsView()
                 .build()
                 .setStreamName(streamA)
                 .setStreamTags(ObjectsView.getLogReplicatorStreamId())
@@ -516,30 +516,30 @@ public class LogReplicationAbstractIT extends AbstractIT {
                 .open();
 
         assertThat(mapA.size()).isEqualTo(0);
-        assertThat(mapAStandby.size()).isEqualTo(0);
+        assertThat(mapASink.size()).isEqualTo(0);
     }
 
-    public void writeToActiveNonUFO(int startIndex, int totalEntries) {
+    public void writeToSourceNonUFO(int startIndex, int totalEntries) {
         int maxIndex = totalEntries + startIndex;
         for (int i = startIndex; i < maxIndex; i++) {
-            activeRuntime.getObjectsView().TXBegin();
+            sourceRuntime.getObjectsView().TXBegin();
             mapA.put(String.valueOf(i), i);
-            activeRuntime.getObjectsView().TXEnd();
+            sourceRuntime.getObjectsView().TXEnd();
         }
     }
 
-    public void writeToActive(int startIndex, int totalEntries) {
+    public void writeToSource(int startIndex, int totalEntries) {
         int maxIndex = totalEntries + startIndex;
-        for(Map.Entry<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> entry : mapNameToMapActive.entrySet()) {
+        for(Map.Entry<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> entry : mapNameToMapSource.entrySet()) {
 
-            log.debug(">>> Write to active cluster, map={}", entry.getKey());
+            log.debug(">>> Write to source cluster, map={}", entry.getKey());
 
             Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map = entry.getValue();
             for (int i = startIndex; i < maxIndex; i++) {
                 Sample.StringKey stringKey = Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build();
                 Sample.IntValueTag IntValueTag = Sample.IntValueTag.newBuilder().setValue(i).build();
                 Sample.Metadata metadata = Sample.Metadata.newBuilder().setMetadata("Metadata_" + i).build();
-                try (TxnContext txn = corfuStoreActive.txn(NAMESPACE)) {
+                try (TxnContext txn = corfuStoreSource.txn(NAMESPACE)) {
                     txn.putRecord(map, stringKey, IntValueTag, metadata);
                     txn.commit();
                 }
@@ -550,24 +550,24 @@ public class LogReplicationAbstractIT extends AbstractIT {
     public void startLogReplicatorServers() {
         try {
             if (runProcess) {
-                // Start Log Replication Server on Active Site
-                activeReplicationServer =
-                    runReplicationServer(activeReplicationServerPort, pluginConfigFilePath,
+                // Start Log Replication Server on Source Site
+                sourceReplicationServer =
+                    runReplicationServer(sourceReplicationServerPort, pluginConfigFilePath,
                         lockLeaseDuration);
 
-                // Start Log Replication Server on Standby Site
-                standbyReplicationServer =
-                    runReplicationServer(standbyReplicationServerPort, pluginConfigFilePath,
+                // Start Log Replication Server on Sink Site
+                sinkReplicationServer =
+                    runReplicationServer(sinkReplicationServerPort, pluginConfigFilePath,
                         lockLeaseDuration);
             } else {
                 executorService.submit(() -> {
                     CorfuInterClusterReplicationServer.main(new String[]{"-m", "--max-replication-data-message-size=" + MSG_SIZE,  "--plugin=" + pluginConfigFilePath,
-                            "--address=localhost", "--lock-lease=5", String.valueOf(activeReplicationServerPort)});
+                            "--address=localhost", "--lock-lease=5", String.valueOf(sourceReplicationServerPort)});
                 });
 
                 executorService.submit(() -> {
                     CorfuInterClusterReplicationServer.main(new String[]{"-m", "--max-replication-data-message-size=" + MSG_SIZE, "--plugin=" + pluginConfigFilePath,
-                            "--address=localhost", "--lock-lease=5", String.valueOf(standbyReplicationServerPort)});
+                            "--address=localhost", "--lock-lease=5", String.valueOf(sinkReplicationServerPort)});
                 });
             }
         } catch (Exception e) {
@@ -575,20 +575,20 @@ public class LogReplicationAbstractIT extends AbstractIT {
         }
     }
 
-    public void stopActiveLogReplicator() {
+    public void stopSourceLogReplicator() {
         if(runProcess) {
             stopLogReplicator(true);
         }
     }
 
-    public void stopStandbyLogReplicator() {
+    public void stopSinkLogReplicator() {
         if (runProcess) {
             stopLogReplicator(false);
         }
     }
 
-    private void stopLogReplicator(boolean active) {
-        int port = active ? activeReplicationServerPort : standbyReplicationServerPort;
+    private void stopLogReplicator(boolean source) {
+        int port = source ? sourceReplicationServerPort : sinkReplicationServerPort;
         List<String> paramsPs = Arrays.asList("/bin/sh", "-c", "ps aux | grep CorfuInterClusterReplicationServer | grep " + port);
         String result = runCommandForOutput(paramsPs);
 
@@ -606,17 +606,17 @@ public class LogReplicationAbstractIT extends AbstractIT {
             }
         }
 
-        log.debug("*** Active PID :: " + pid);
+        log.debug("*** Source PID :: " + pid);
 
         List<String> paramsKill = Arrays.asList("/bin/sh", "-c", "kill -9 " + pid);
         runCommandForOutput(paramsKill);
 
-        if (active && activeReplicationServer != null) {
-            activeReplicationServer.destroyForcibly();
-            activeReplicationServer = null;
-        } else if (!active && standbyReplicationServer != null) {
-            standbyReplicationServer.destroyForcibly();
-            standbyReplicationServer = null;
+        if (source && sourceReplicationServer != null) {
+            sourceReplicationServer.destroyForcibly();
+            sourceReplicationServer = null;
+        } else if (!source && sinkReplicationServer != null) {
+            sinkReplicationServer.destroyForcibly();
+            sinkReplicationServer = null;
         }
     }
 
@@ -640,15 +640,15 @@ public class LogReplicationAbstractIT extends AbstractIT {
         return result;
     }
 
-    public void startActiveLogReplicator() {
+    public void startSourceLogReplicator() {
         try {
             if (runProcess) {
-                // Start Log Replication Server on Active Site
-                activeReplicationServer = runReplicationServer(activeReplicationServerPort, pluginConfigFilePath, lockLeaseDuration);
+                // Start Log Replication Server on Source Site
+                sourceReplicationServer = runReplicationServer(sourceReplicationServerPort, pluginConfigFilePath, lockLeaseDuration);
             } else {
                 executorService.submit(() -> {
                     CorfuInterClusterReplicationServer.main(new String[]{"-m", "--plugin=" + pluginConfigFilePath,
-                            "--address=localhost", String.valueOf(activeReplicationServerPort)});
+                            "--address=localhost", String.valueOf(sourceReplicationServerPort)});
                 });
             }
         } catch (Exception e) {
@@ -656,15 +656,15 @@ public class LogReplicationAbstractIT extends AbstractIT {
         }
     }
 
-    public void startStandbyLogReplicator() {
+    public void startSinkLogReplicator() {
         try {
             if (runProcess) {
-                // Start Log Replication Server on Active Site
-                standbyReplicationServer = runReplicationServer(standbyReplicationServerPort, pluginConfigFilePath, lockLeaseDuration);
+                // Start Log Replication Server on Source Site
+                sinkReplicationServer = runReplicationServer(sinkReplicationServerPort, pluginConfigFilePath, lockLeaseDuration);
             } else {
                 executorService.submit(() -> {
                     CorfuInterClusterReplicationServer.main(new String[]{"-m", "--plugin=" + pluginConfigFilePath,
-                            "--address=localhost", String.valueOf(standbyReplicationServerPort)});
+                            "--address=localhost", String.valueOf(sinkReplicationServerPort)});
                 });
             }
         } catch (Exception e) {
@@ -672,36 +672,36 @@ public class LogReplicationAbstractIT extends AbstractIT {
         }
     }
 
-    public void verifyDataOnStandbyNonUFO(int expectedConsecutiveWrites) {
+    public void verifyDataOnSinkNonUFO(int expectedConsecutiveWrites) {
         // Wait until data is fully replicated
-        while (mapAStandby.size() != expectedConsecutiveWrites) {
+        while (mapASink.size() != expectedConsecutiveWrites) {
             // Block until expected number of entries is reached
         }
 
-        log.debug("Number updates on Standby :: " + expectedConsecutiveWrites);
+        log.debug("Number updates on Sink :: " + expectedConsecutiveWrites);
 
-        // Verify data is present in Standby Site
-        assertThat(mapAStandby.size()).isEqualTo(expectedConsecutiveWrites);
+        // Verify data is present in Sink Site
+        assertThat(mapASink.size()).isEqualTo(expectedConsecutiveWrites);
 
         for (int i = 0; i < (expectedConsecutiveWrites); i++) {
-            assertThat(mapAStandby.containsKey(String.valueOf(i)));
+            assertThat(mapASink.containsKey(String.valueOf(i)));
         }
     }
 
     /**
      * Checkpoint and Trim Data Logs
      *
-     * @param active true, checkpoint/trim on active cluster
-     *               false, checkpoint/trim on standby cluster
+     * @param source true, checkpoint/trim on source cluster
+     *               false, checkpoint/trim on sink cluster
      * @param tables additional tables (asides CorfuStore to be checkpointed)
      */
-    public void checkpointAndTrim(boolean active, List<CorfuTable> tables) {
+    public void checkpointAndTrim(boolean source, List<CorfuTable> tables) {
         CorfuRuntime cpRuntime;
 
-        if (active) {
-            cpRuntime = new CorfuRuntime(activeEndpoint).connect();
+        if (source) {
+            cpRuntime = new CorfuRuntime(sourceEndpoint).connect();
         } else {
-            cpRuntime = new CorfuRuntime(standbyEndpoint).connect();
+            cpRuntime = new CorfuRuntime(sinkEndpoint).connect();
         }
 
         // Checkpoint specified tables
@@ -715,23 +715,23 @@ public class LogReplicationAbstractIT extends AbstractIT {
         checkpointAndTrimCorfuStore(cpRuntime, trimMark);
     }
 
-    public void verifyDataOnStandby(int expectedConsecutiveWrites) {
-        for(Map.Entry<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> entry : mapNameToMapStandby.entrySet()) {
+    public void verifyDataOnSink(int expectedConsecutiveWrites) {
+        for(Map.Entry<String, Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata>> entry : mapNameToMapSink.entrySet()) {
 
-            log.info("Verify Data on Standby's Table {}", entry.getKey());
+            log.info("Verify Data on Sink's Table {}", entry.getKey());
 
             // Wait until data is fully replicated
             while (entry.getValue().count() != expectedConsecutiveWrites) {
                 // Block until expected number of entries is reached
             }
 
-            log.info("Number updates on Standby Map {} :: {} ", entry.getKey(), expectedConsecutiveWrites);
+            log.info("Number updates on Sink Map {} :: {} ", entry.getKey(), expectedConsecutiveWrites);
 
-            // Verify data is present in Standby Site
+            // Verify data is present in Sink Site
             assertThat(entry.getValue().count()).isEqualTo(expectedConsecutiveWrites);
 
             for (int i = 0; i < (expectedConsecutiveWrites); i++) {
-                try (TxnContext tx = corfuStoreStandby.txn(entry.getValue().getNamespace())) {
+                try (TxnContext tx = corfuStoreSink.txn(entry.getValue().getNamespace())) {
                     assertThat(tx.getRecord(entry.getValue(),
                             Sample.StringKey.newBuilder().setKey(String.valueOf(i)).build()).getPayload()).isNotNull();
                     tx.commit();
@@ -743,16 +743,16 @@ public class LogReplicationAbstractIT extends AbstractIT {
     /**
      * Checkpoint and Trim Data Logs
      *
-     * @param active true, checkpoint/trim on active cluster
-     *               false, checkpoint/trim on standby cluster
+     * @param source true, checkpoint/trim on source cluster
+     *               false, checkpoint/trim on sink cluster
      */
-    public void checkpointAndTrim(boolean active) {
+    public void checkpointAndTrim(boolean source) {
         CorfuRuntime cpRuntime;
 
-        if (active) {
-            cpRuntime = new CorfuRuntime(activeEndpoint).connect();
+        if (source) {
+            cpRuntime = new CorfuRuntime(sourceEndpoint).connect();
         } else {
-            cpRuntime = new CorfuRuntime(standbyEndpoint).connect();
+            cpRuntime = new CorfuRuntime(sinkEndpoint).connect();
         }
 
         checkpointAndTrimCorfuStore(cpRuntime);

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -171,10 +171,11 @@ public class LogReplicationAbstractIT extends AbstractIT {
     }
 
     public void testEndToEndSnapshotAndLogEntrySyncUFO(int totalNumMaps, boolean diskBased, boolean checkRemainingEntriesOnSecondLogEntrySync) throws Exception {
-        // For the purpose of this test, standby should only update status 2 times:
-        // (1) When starting snapshot sync apply : is_data_consistent = false
-        // (2) When completing snapshot sync apply : is_data_consistent = true
-        final int totalStandbyStatusUpdates = 2;
+        // For the purpose of this test, Sink should only update status 5 times:
+        // (1) On startup, init the replication status for each Source cluster(3 clusters = 3 updates)
+        // (2) When starting snapshot sync apply : is_data_consistent = false
+        // (3) When completing snapshot sync apply : is_data_consistent = true
+        final int totalStandbyStatusUpdates = 5;
 
         try {
             log.info(">> Setup active and standby Corfu's");
@@ -304,7 +305,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
         LogReplicationMetadata.ReplicationStatusKey key =
                 LogReplicationMetadata.ReplicationStatusKey
                         .newBuilder()
-                        .setClusterId(DefaultClusterConfig.getStandbyClusterId())
+                        .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
                         .build();
         LogReplicationMetadata.ReplicationStatusVal replicationStatusVal;
 
@@ -318,27 +319,44 @@ public class LogReplicationAbstractIT extends AbstractIT {
     }
 
     private void verifyReplicationStatusFromActive() throws Exception {
-        Table<LogReplicationMetadata.ReplicationStatusKey, LogReplicationMetadata.ReplicationStatusVal, LogReplicationMetadata.ReplicationStatusVal>
-                replicationStatusTable = corfuStoreActive.openTable(LogReplicationMetadataManager.NAMESPACE,
+        Table<LogReplicationMetadata.ReplicationStatusKey,
+            LogReplicationMetadata.ReplicationStatusVal,
+            LogReplicationMetadata.ReplicationStatusVal> replicationStatusTable =
+            corfuStoreActive.openTable(LogReplicationMetadataManager.NAMESPACE,
                 LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
                 null,
                 TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
 
+        String clusterId =
+            new DefaultClusterConfig().getStandbyClusterIds().get(0);
+
+        LogReplicationMetadata.ReplicationStatusKey key =
+            LogReplicationMetadata.ReplicationStatusKey
+                .newBuilder()
+                .setClusterId(clusterId)
+                .build();
+
         IRetry.build(IntervalRetry.class, () -> {
             try(TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
-                List<CorfuStoreEntry<LogReplicationMetadata.ReplicationStatusKey, LogReplicationMetadata.ReplicationStatusVal, LogReplicationMetadata.ReplicationStatusVal>>
-                        entries = txn.executeQuery(replicationStatusTable, all -> true);
-                assertThat(entries.size()).isNotZero();
-                if (entries.get(0).getPayload().getSnapshotSyncInfo().getStatus() != LogReplicationMetadata.SyncStatus.COMPLETED) {
+                CorfuStoreEntry<LogReplicationMetadata.ReplicationStatusKey,
+                    LogReplicationMetadata.ReplicationStatusVal,
+                    LogReplicationMetadata.ReplicationStatusVal> entry =
+                    txn.getRecord(replicationStatusTable, key);
+
+                if (entry.getPayload().getSnapshotSyncInfo().getStatus() !=
+                    LogReplicationMetadata.SyncStatus.COMPLETED) {
                     Sleep.sleepUninterruptibly(Duration.ofMillis(SHORT_SLEEP_TIME));
                     txn.commit();
                     throw new RetryNeededException();
                 }
-                assertThat(entries.get(0).getPayload().getSnapshotSyncInfo().getStatus()).isEqualTo(LogReplicationMetadata.SyncStatus.COMPLETED);
-                assertThat(entries.get(0).getPayload().getSnapshotSyncInfo().getType()).isEqualTo(LogReplicationMetadata.SnapshotSyncInfo.SnapshotSyncType.DEFAULT);
-                assertThat(entries.get(0).getPayload().getSnapshotSyncInfo().getBaseSnapshot()).isNotEqualTo(Address.NON_ADDRESS);
+                assertThat(entry.getPayload().getSnapshotSyncInfo().getStatus())
+                    .isEqualTo(LogReplicationMetadata.SyncStatus.COMPLETED);
+                assertThat(entry.getPayload().getSnapshotSyncInfo().getType())
+                    .isEqualTo(LogReplicationMetadata.SnapshotSyncInfo.SnapshotSyncType.DEFAULT);
+                assertThat(entry.getPayload().getSnapshotSyncInfo()
+                    .getBaseSnapshot()).isNotEqualTo(Address.NON_ADDRESS);
                 txn.commit();
             } catch (TransactionAbortedException tae) {
                 log.error("Error while attempting to connect to update dummy table in onSnapshotSyncStart.", tae);

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -60,7 +60,7 @@ import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
  *
  * We emulate the channel by implementing a test data plane which directly forwards the data
  * to the SinkManager. Overall, these tests bring up two CorfuServers (datastore components),
- * one performing as the active and the other as the standby. We write different patterns of data
+ * one performing as the source and the other as the sink. We write different patterns of data
  * on the source (transactional and non transactional, as well as polluted and non-polluted transactions, i.e.,
  * transactions containing federated and non-federated streams) and verify that complete data
  * reaches the destination after initiating log replication.
@@ -74,7 +74,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     private static final int WRITER_PORT = DEFAULT_PORT + 1;
     private static final String DESTINATION_ENDPOINT = DEFAULT_HOST + ":" + WRITER_PORT;
 
-    private static final String ACTIVE_CLUSTER_ID = UUID.randomUUID().toString();
+    private static final String SOURCE_CLUSTER_ID = UUID.randomUUID().toString();
     private static final String REMOTE_CLUSTER_ID = UUID.randomUUID().toString();
     private static final int CORFU_PORT = 9000;
     private static final String TABLE_PREFIX = "test";
@@ -339,7 +339,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     }
 
     /**
-     * Wait replication data reach at the standby cluster.
+     * Wait replication data reach at the sink cluster.
      * @param tables
      * @param hashMap
      */
@@ -416,7 +416,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         log.debug("****** Verify Data on Destination");
 
         //verify isDataConsistent is true
-        sourceDataSender.checkStatusOnStandby(true);
+        sourceDataSender.checkStatusOnSink(true);
 
         // Because t2 should not have been replicated remove from expected list
         srcDataForVerification.get(t2).clear();
@@ -457,7 +457,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         log.debug("****** Verify Data on Destination");
 
         //verify isDataConsistent is true
-        sourceDataSender.checkStatusOnStandby(true);
+        sourceDataSender.checkStatusOnSink(true);
         // Because t2 should not have been replicated remove from expected list
         srcDataForVerification.get(t2).clear();
         verifyData(dstCorfuTables, srcDataForVerification);
@@ -1002,7 +1002,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     }
 
     private void testSnapshotSyncAndLogEntrySync(int numCyclesToDelayApply, boolean delayResponse, int dropAcksLevel) throws Exception {
-        // Setup two separate Corfu Servers: source (active) and destination (standby)
+        // Setup two separate Corfu Servers: source (source) and destination (sink)
         setupEnv();
 
         // Open streams in source Corfu
@@ -1034,7 +1034,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         log.debug("****** Snapshot Sync COMPLETE");
 
         //verify isDataConsistent is true
-        sourceDataSender.checkStatusOnStandby(true);
+        sourceDataSender.checkStatusOnSink(true);
 
         testConfig.setWaitOn(WAIT.ON_ACK_TS);
 
@@ -1211,7 +1211,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
 
     // startCrossTx indicates if we start with a transaction across Tables
     private void writeCrossTableTransactions(Set<String> crossTableTransactions, boolean startCrossTx) throws Exception {
-        // Setup two separate Corfu Servers: source (primary) and destination (standby)
+        // Setup two separate Corfu Servers: source (primary) and destination (sink)
         setupEnv();
 
         // Open streams in source Corfu
@@ -1378,8 +1378,9 @@ public class LogReplicationIT extends AbstractIT implements Observer {
 
         // Source Manager
         LogReplicationSourceManager logReplicationSourceManager = new LogReplicationSourceManager(
+
             LogReplicationRuntimeParameters.builder().remoteClusterDescriptor(new ClusterDescriptor(REMOTE_CLUSTER_ID,
-                LogReplicationClusterInfo.ClusterRole.ACTIVE, CORFU_PORT)).replicationConfig(config)
+                LogReplicationClusterInfo.ClusterRole.SOURCE, CORFU_PORT)).replicationConfig(config)
                 .localCorfuEndpoint(SOURCE_ENDPOINT).build(), logReplicationMetadataManager, sourceDataSender,
             tableManagerPlugin, replicationSession);
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -7,6 +7,8 @@ import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationSourceManager;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent;
@@ -33,6 +35,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Set;
@@ -1359,25 +1362,26 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     }
 
     private LogReplicationSourceManager setupSourceManagerAndObservedValues(Set<String> tablesToReplicate,
-                                                                            Set<WAIT> waitConditions,
-                                                                            TransitionSource function) throws InterruptedException {
+        Set<WAIT> waitConditions, TransitionSource function) throws InterruptedException {
+        ReplicationSession replicationSession =
+            ReplicationSession.getDefaultReplicationSessionForCluster(REMOTE_CLUSTER_ID);
 
-        LogReplicationConfig config = new LogReplicationConfig(tablesToReplicate, BATCH_SIZE, SMALL_MSG_SIZE);
+        Map<ReplicationSubscriber, Set<String>> tablesMap = new HashMap<>();
+        tablesMap.put(replicationSession.getSubscriber(), tablesToReplicate);
+        LogReplicationConfig config = new LogReplicationConfig(tablesMap, BATCH_SIZE, SMALL_MSG_SIZE);
 
         // Data Sender
         sourceDataSender = new SourceForwardingDataSender(DESTINATION_ENDPOINT, config, testConfig,
-                logReplicationMetadataManager, nettyConfig, function);
+            logReplicationMetadataManager, nettyConfig, function);
 
         LogReplicationConfigManager tableManagerPlugin = new LogReplicationConfigManager(srcTestRuntime);
 
         // Source Manager
         LogReplicationSourceManager logReplicationSourceManager = new LogReplicationSourceManager(
-                LogReplicationRuntimeParameters.builder()
-                        .remoteClusterDescriptor(new ClusterDescriptor(REMOTE_CLUSTER_ID,
-                                LogReplicationClusterInfo.ClusterRole.ACTIVE, CORFU_PORT))
-                                .replicationConfig(config).localCorfuEndpoint(SOURCE_ENDPOINT).build(),
-                logReplicationMetadataManager,
-                sourceDataSender, tableManagerPlugin);
+            LogReplicationRuntimeParameters.builder().remoteClusterDescriptor(new ClusterDescriptor(REMOTE_CLUSTER_ID,
+                LogReplicationClusterInfo.ClusterRole.ACTIVE, CORFU_PORT)).replicationConfig(config)
+                .localCorfuEndpoint(SOURCE_ENDPOINT).build(), logReplicationMetadataManager, sourceDataSender,
+            tableManagerPlugin, replicationSession);
 
         // Set Log Replication Source Manager so we can emulate the channel for data & control messages (required
         // for testing)
@@ -1541,7 +1545,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         private WAIT waitOn = WAIT.ON_ACK;
         private boolean timeoutMetadataResponse = false;
         private String remoteClusterId = null;
-        
+
         public TestConfig clear() {
             dropMessageLevel = 0;
             dropAckLevel = 0;

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -68,7 +68,7 @@ import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
 @Slf4j
 public class LogReplicationIT extends AbstractIT implements Observer {
 
-    public static final String nettyConfig = "./test/src/test/resources/transport/nettyConfig.properties";
+    public static final String nettyConfig = "./test/src/test/resources/transport/grpcConfig.properties";
 
     private static final String SOURCE_ENDPOINT = DEFAULT_HOST + ":" + DEFAULT_PORT;
     private static final int WRITER_PORT = DEFAULT_PORT + 1;
@@ -180,6 +180,8 @@ public class LogReplicationIT extends AbstractIT implements Observer {
 
     private final CountDownLatch blockUntilFSMTransition = new CountDownLatch(1);
 
+    private ReplicationSession replicationSession;
+
     /**
      * Setup Test Environment
      *
@@ -231,7 +233,9 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         dstTestRuntime.parseConfigurationString(DESTINATION_ENDPOINT);
         dstTestRuntime.connect();
 
-        logReplicationMetadataManager = new LogReplicationMetadataManager(dstTestRuntime, 0, REMOTE_CLUSTER_ID);
+        this.replicationSession =
+                ReplicationSession.getDefaultReplicationSessionForCluster(REMOTE_CLUSTER_ID);
+        logReplicationMetadataManager = new LogReplicationMetadataManager(dstTestRuntime, 0, replicationSession);
         expectedAckTimestamp = new AtomicLong(Long.MAX_VALUE);
         testConfig.clear().setRemoteClusterId(REMOTE_CLUSTER_ID);
     }

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -306,7 +306,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         streamsMap.put(replicationSession.getSubscriber(), streams);
         LogReplicationConfig config = new LogReplicationConfig(streamsMap, BATCH_SIZE, MAX_MSG_SIZE);
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
-            0, SINK_CLUSTER_ID);
+            0, replicationSession);
         StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, config, logReplicationMetadataManager, replicationSession);
 
         if (msgQ.isEmpty()) {
@@ -371,7 +371,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         streamsMap.put(replicationSession.getSubscriber(), streams);
         LogReplicationConfig config = new LogReplicationConfig(streamsMap);
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
-            0, SOURCE_CLUSTER_ID);
+            0, replicationSession);
         LogEntryWriter writer = new LogEntryWriter(rt, config, logReplicationMetadataManager, replicationSession);
 
         if (msgQ.isEmpty()) {

--- a/test/src/test/java/org/corfudb/integration/LogReplicationSinkWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationSinkWriterIT.java
@@ -55,6 +55,7 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
     @SuppressWarnings("checkstyle:magicnumber")
     public void testFilterAndApplyRegistryTableEntries() throws Exception {
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
         openLogReplicationStatusTable();
 
         // Initial setup for streams to replicate for both source and sink side

--- a/test/src/test/java/org/corfudb/integration/LogReplicationSinkWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationSinkWriterIT.java
@@ -54,12 +54,12 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
     @Test
     @SuppressWarnings("checkstyle:magicnumber")
     public void testFilterAndApplyRegistryTableEntries() throws Exception {
-        setupActiveAndStandbyCorfu();
+        setupSourceAndSinkCorfu();
         openLogReplicationStatusTable();
 
         // Initial setup for streams to replicate for both source and sink side
-        mapNameToMapActive = new HashMap<>();
-        mapNameToMapStandby = new HashMap<>();
+        mapNameToMapSource = new HashMap<>();
+        mapNameToMapSink = new HashMap<>();
 
         /* The first 4 tables are for snapshot sync */
 
@@ -69,14 +69,14 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
         prepareTablesToVerify(1, 2, 4);
 
         // Add Data for Snapshot Sync
-        writeToActive(0, NUM_WRITES);
+        writeToSource(0, NUM_WRITES);
         // Confirm data does exist on Source Cluster
-        for(Table<StringKey, IntValueTag, Metadata> map : mapNameToMapActive.values()) {
+        for(Table<StringKey, IntValueTag, Metadata> map : mapNameToMapSource.values()) {
             assertThat(map.count()).isEqualTo(NUM_WRITES);
         }
 
         // Confirm data does not exist on Sink Cluster
-        for(Table<StringKey, IntValueTag, Metadata> map : mapNameToMapStandby.values()) {
+        for(Table<StringKey, IntValueTag, Metadata> map : mapNameToMapSink.values()) {
             assertThat(map.count()).isEqualTo(0);
         }
 
@@ -97,10 +97,10 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
         // It will be verified that records already exist in Sink side registry table won't be overwritten during
         // Log Entry sync. LR needs to be stopped to open some tables on both Source and Sink with different metadata,
         // otherwise it is possible that registry table entries from Source get replicated before Sink side opens them.
-        stopActiveLogReplicator();
+        stopSourceLogReplicator();
         // Clear these two map as different set of tables will be verified
-        mapNameToMapActive.clear();
-        mapNameToMapStandby.clear();
+        mapNameToMapSource.clear();
+        mapNameToMapSink.clear();
 
         // Table005 and Table006 - Open in both Source and Sink, while on Sink side they will be opened with
         // different metadata. Verify that Sink side's records are retained.
@@ -108,14 +108,14 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
         prepareTablesToVerify(5, 6, 8);
 
         // Restart Source LR after opening the tables
-        startActiveLogReplicator();
+        startSourceLogReplicator();
 
-        // Write data to Source side, note that mapNameToMapActive now only have the last 4 tables
-        writeToActive(0, NUM_WRITES);
+        // Write data to Source side, note that mapNameToMapSource now only have the last 4 tables
+        writeToSource(0, NUM_WRITES);
 
-        // At this point mapNameToMapStandby only has 2 tables. This step is also used as a barrier to indicate
+        // At this point mapNameToMapSink only has 2 tables. This step is also used as a barrier to indicate
         // it's a good point to check records on Sink side
-        verifyDataOnStandby(NUM_WRITES);
+        verifyDataOnSink(NUM_WRITES);
         // Verify Sink side records for Table005 and Table006 are retained on the Registry table, and records for
         // Table007 and Table008 are replicated.
         // Also verify all the table's contents for log entry sync
@@ -136,27 +136,27 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
         // different metadata. Verify that Sink side's records are retained.
         for (int i = start; i <= splitter; i++) {
             String mapName = TABLE_PREFIX + i;
-            Table<StringKey, IntValueTag, Metadata> tableActive =
-                    corfuStoreActive.openTable(NAMESPACE, mapName, StringKey.class,
+            Table<StringKey, IntValueTag, Metadata> tableSource =
+                    corfuStoreSource.openTable(NAMESPACE, mapName, StringKey.class,
                             IntValueTag.class, Metadata.class,
                             TableOptions.fromProtoSchema(IntValueTag.class, TableOptions.builder().build()));
-            mapNameToMapActive.put(mapName, tableActive);
+            mapNameToMapSource.put(mapName, tableSource);
 
-            Table<StringKey, IntValueTag, Metadata> tableStandby =
-                    corfuStoreStandby.openTable(NAMESPACE, mapName, StringKey.class,
+            Table<StringKey, IntValueTag, Metadata> tableSink =
+                    corfuStoreSink.openTable(NAMESPACE, mapName, StringKey.class,
                             IntValueTag.class, Metadata.class,
                             TableOptions.fromProtoSchema(IntValue.class, TableOptions.builder().build()));
-            mapNameToMapStandby.put(mapName, tableStandby);
+            mapNameToMapSink.put(mapName, tableSink);
         }
 
         // From splitter to end - Open only in Source side. Verify that their records are replicated to Sink.
         for (int i = splitter + 1; i <= end; i++) {
             String mapName = TABLE_PREFIX + i;
-            Table<StringKey, IntValueTag, Metadata> tableActive =
-                    corfuStoreActive.openTable(NAMESPACE, mapName, StringKey.class,
+            Table<StringKey, IntValueTag, Metadata> tableSource =
+                    corfuStoreSource.openTable(NAMESPACE, mapName, StringKey.class,
                             IntValueTag.class, Metadata.class,
                             TableOptions.fromProtoSchema(IntValueTag.class, TableOptions.builder().build()));
-            mapNameToMapActive.put(mapName, tableActive);
+            mapNameToMapSource.put(mapName, tableSource);
         }
     }
 
@@ -165,7 +165,7 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
      */
     private void verifyTableContentsAndRecords(int start, int splitter, int end) throws Exception {
         // Verify Sink side records for tables before the splitter are retained, and records for the rest of
-        // the tables are replicated. Add the tables from splitter to end to mapNameToMapStandby to verify all the
+        // the tables are replicated. Add the tables from splitter to end to mapNameToMapSink to verify all the
         // tables' contents
         for (int i = start; i <= end; i++) {
             String tableName = TABLE_PREFIX + i;
@@ -174,27 +174,27 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
                     .setNamespace(NAMESPACE)
                     .build();
             CorfuRecord<TableDescriptors, TableMetadata> corfuRecord =
-                    standbyRuntime.getTableRegistry().getRegistryTable().get(tableNameKey);
+                    sinkRuntime.getTableRegistry().getRegistryTable().get(tableNameKey);
             if (i <= splitter) {
                 Assert.assertFalse(corfuRecord.getMetadata().getTableOptions().getIsFederated());
             } else {
                 Assert.assertTrue(corfuRecord.getMetadata().getTableOptions().getIsFederated());
-                Table<StringKey, IntValueTag, Metadata> tableStandby =
-                        corfuStoreStandby.openTable(NAMESPACE, tableName, StringKey.class,
+                Table<StringKey, IntValueTag, Metadata> tableSink =
+                        corfuStoreSink.openTable(NAMESPACE, tableName, StringKey.class,
                                 IntValueTag.class, Metadata.class,
                                 TableOptions.fromProtoSchema(IntValueTag.class, TableOptions.builder().build()));
-                mapNameToMapStandby.put(tableName, tableStandby);
+                mapNameToMapSink.put(tableName, tableSink);
             }
         }
         // Verify contents
-        verifyDataOnStandby(NUM_WRITES);
+        verifyDataOnSink(NUM_WRITES);
     }
 
     private void verifyInLogEntrySyncState() throws InterruptedException {
         LogReplicationMetadata.ReplicationStatusKey key =
                 LogReplicationMetadata.ReplicationStatusKey
                         .newBuilder()
-                        .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
+                        .setClusterId(new DefaultClusterConfig().getSinkClusterIds().get(0))
                         .build();
 
         ReplicationStatusVal replicationStatusVal = null;
@@ -202,7 +202,7 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
         while (replicationStatusVal == null || !replicationStatusVal.getSyncType().equals(SyncType.LOG_ENTRY)
         || !replicationStatusVal.getSnapshotSyncInfo().getStatus().equals(LogReplicationMetadata.SyncStatus.COMPLETED)) {
             TimeUnit.SECONDS.sleep(1);
-            try (TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
+            try (TxnContext txn = corfuStoreSource.txn(LogReplicationMetadataManager.NAMESPACE)) {
                 replicationStatusVal = (ReplicationStatusVal) txn.getRecord(REPLICATION_STATUS_TABLE, key).getPayload();
                 txn.commit();
             }
@@ -222,14 +222,14 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
 
 
     private void openLogReplicationStatusTable() throws Exception {
-        corfuStoreActive.openTable(LogReplicationMetadataManager.NAMESPACE,
+        corfuStoreSource.openTable(LogReplicationMetadataManager.NAMESPACE,
                 REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 ReplicationStatusVal.class,
                 null,
                 TableOptions.fromProtoSchema(ReplicationStatusVal.class));
 
-        corfuStoreStandby.openTable(LogReplicationMetadataManager.NAMESPACE,
+        corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
                 REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 ReplicationStatusVal.class,

--- a/test/src/test/java/org/corfudb/integration/LogReplicationSinkWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationSinkWriterIT.java
@@ -194,7 +194,7 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
         LogReplicationMetadata.ReplicationStatusKey key =
                 LogReplicationMetadata.ReplicationStatusKey
                         .newBuilder()
-                        .setClusterId(DefaultClusterConfig.getStandbyClusterId())
+                        .setClusterId(new DefaultClusterConfig().getStandbyClusterIds().get(0))
                         .build();
 
         ReplicationStatusVal replicationStatusVal = null;

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -90,7 +90,7 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
 
     private long lastAckDropped;
 
-    private CorfuStore standbyCorfuStore;
+    private CorfuStore sinkCorfuStore;
 
     private final String destinationClusterID;
 
@@ -117,8 +117,8 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
         this.dropACKLevel = testConfig.getDropAckLevel();
         this.callbackFunction = function;
         this.lastAckDropped = Long.MAX_VALUE;
-        this.standbyCorfuStore = new CorfuStore(runtime);
-        standbyCorfuStore.openTable(LogReplicationMetadataManager.NAMESPACE,
+        this.sinkCorfuStore = new CorfuStore(runtime);
+        sinkCorfuStore.openTable(LogReplicationMetadataManager.NAMESPACE,
                 REPLICATION_STATUS_TABLE,
                 LogReplicationMetadata.ReplicationStatusKey.class,
                 LogReplicationMetadata.ReplicationStatusVal.class,
@@ -158,7 +158,7 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
 
         //check is_data_consistent flag is set to false on snapshot_start
         if (message.getMetadata().getEntryType().equals(LogReplicationEntryType.SNAPSHOT_START)) {
-            checkStatusOnStandby(false);
+            checkStatusOnSink(false);
         }
 
         if (dropAck(ack, message)) {
@@ -317,16 +317,16 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
         return newMessage;
     }
 
-    public void checkStatusOnStandby(boolean expectedDataConsistent) {
+    public void checkStatusOnSink(boolean expectedDataConsistent) {
         if (destinationClusterID == null) {
             return;
         }
-        LogReplicationMetadata.ReplicationStatusKey standbyClusterId = LogReplicationMetadata.ReplicationStatusKey.newBuilder()
+        LogReplicationMetadata.ReplicationStatusKey sinkClusterId = LogReplicationMetadata.ReplicationStatusKey.newBuilder()
                 .setClusterId(destinationClusterID)
                 .build();
-        try (TxnContext txn = standbyCorfuStore.txn(LogReplicationMetadataManager.NAMESPACE)) {
-            LogReplicationMetadata.ReplicationStatusVal standbyStatus = (LogReplicationMetadata.ReplicationStatusVal)txn.getRecord(REPLICATION_STATUS_TABLE, standbyClusterId).getPayload();
-            assertThat(standbyStatus.getDataConsistent()).isEqualTo(expectedDataConsistent);
+        try (TxnContext txn = sinkCorfuStore.txn(LogReplicationMetadataManager.NAMESPACE)) {
+            LogReplicationMetadata.ReplicationStatusVal sinkStatus = (LogReplicationMetadata.ReplicationStatusVal)txn.getRecord(REPLICATION_STATUS_TABLE, sinkClusterId).getPayload();
+            assertThat(sinkStatus.getDataConsistent()).isEqualTo(expectedDataConsistent);
         }
     }
 

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.logreplication.DataSender;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationSinkManager;
@@ -103,8 +104,12 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
                 .parseConfigurationString(destinationEndpoint)
                 .connect();
         this.destinationDataSender = new AckDataSender();
-        this.destinationDataControl = new DefaultDataControl(new DefaultDataControlConfig(false, 0));
-        this.destinationLogReplicationManager = new LogReplicationSinkManager(runtime.getLayoutServers().get(0), config, metadataManager, pluginConfigFilePath);
+        this.destinationDataControl = new DefaultDataControl(new DefaultDataControlConfig(
+            false, 0));
+        ReplicationSession replicationSession =
+            ReplicationSession.getDefaultReplicationSessionForCluster(testConfig.getRemoteClusterId());
+        this.destinationLogReplicationManager = new LogReplicationSinkManager(runtime.getLayoutServers().get(0), config,
+            metadataManager, pluginConfigFilePath, replicationSession);
         this.ifDropMsg = testConfig.getDropMessageLevel();
         this.delayedApplyCycles = testConfig.getDelayedApplyCycles();
         this.metadataResponseObservable = new ObservableValue<>(null);

--- a/test/src/test/resources/logback-test.xml
+++ b/test/src/test/resources/logback-test.xml
@@ -76,8 +76,8 @@
     </logger>
 
 
-    <root level="INFO">
-        <!--<appender-ref ref="FILE" />-->
+    <root level="DEBUG">
+<!--        <appender-ref ref="FILE" />-->
         <!--<appender-ref ref="STDOUT" />-->
         <!--<appender-ref ref="MetricsRollingFile" />-->
     </root>

--- a/test/src/test/resources/transport/nettyConfigUpgradeSink.properties
+++ b/test/src/test/resources/transport/nettyConfigUpgradeSink.properties
@@ -5,7 +5,7 @@ transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.tr
 
 # Stream Fetcher Plugin Configuration
 stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
-stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultAdapterForUpgradeActive
+stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultAdapterForUpgradeSink
 
 # Topology Manager Configuration
 topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar

--- a/test/src/test/resources/transport/nettyConfigUpgradeSource.properties
+++ b/test/src/test/resources/transport/nettyConfigUpgradeSource.properties
@@ -5,7 +5,7 @@ transport_adapter_client_class_name=org.corfudb.infrastructure.logreplication.tr
 
 # Stream Fetcher Plugin Configuration
 stream_fetcher_plugin_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar
-stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultAdapterForUpgradeStandby
+stream_fetcher_plugin_class_name=org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultAdapterForUpgradeSource
 
 # Topology Manager Configuration
 topology_manager_adapter_JAR_path=../infrastructure/target/infrastructure-0.4.0-SNAPSHOT.jar


### PR DESCRIPTION
## Overview

Description:
This PR has the following changes:
1. Enable a cluster as both SOURCE and SINK when the cluster has RemoteSink and RemoteSources.
2. Introduce clusterManager plugin APIs : getRemoteSinkToReplicationModel, getRemoteSourceToReplicationModel, fecthConnectionEndpoints. These APIs are used to achieve the above point (1) , create the SOURCE/SINK components and wait if the cluster is not the connection starter for a remote cluster, create SOURCE/SINK and start the connection if the cluster is the connection starter for a remote cluster
3. refactor some router code to reduce duplication of code. 

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
