### PR TITLE
Bug fix in NO_CACHE and freeTableData for MVO use case

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuTable.java
@@ -14,6 +14,7 @@ import org.corfudb.annotations.Mutator;
 import org.corfudb.annotations.MutatorAccessor;
 import org.corfudb.annotations.PassThrough;
 import org.corfudb.annotations.TransactionalMethod;
+import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuExecutionContext;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.ICorfuVersionPolicy;
@@ -465,6 +466,12 @@ public class CorfuTable<K, V> implements ICorfuTable<K, V>, ICorfuSMR<CorfuTable
     public void clear() {
         mainMap.clear();
         secondaryIndexes.values().forEach(Map::clear);
+    }
+
+    @Override
+    @DontInstrument
+    public boolean isTableCached() {
+        return ((CorfuCompileProxy)getCorfuSMRProxy()).isObjectCached();
     }
 
     /** {@inheritDoc} */

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ICorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ICorfuTable.java
@@ -1,9 +1,6 @@
 package org.corfudb.runtime.collections;
 
-import org.corfudb.runtime.object.ICorfuSMR;
-
 import javax.annotation.Nonnull;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -51,5 +48,7 @@ public interface ICorfuTable<K, V> {
     boolean isEmpty();
 
     void clear();
+
+    boolean isTableCached();
 
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistentCorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistentCorfuTable.java
@@ -5,9 +5,9 @@ import org.corfudb.runtime.object.ICorfuExecutionContext;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.ICorfuSMRProxy;
 import org.corfudb.runtime.object.ICorfuSMRUpcallTarget;
+import org.corfudb.runtime.object.MVOCorfuCompileProxy;
 
 import javax.annotation.Nonnull;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -50,6 +50,11 @@ public class PersistentCorfuTable<K, V> implements ICorfuTable<K, V>, ICorfuSMR<
     @Override
     public void clear() {
         proxy.logUpdate("clear", false, null);
+    }
+
+    @Override
+    public boolean isTableCached() {
+        return ((MVOCorfuCompileProxy)proxy).isObjectCached();
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -209,6 +209,7 @@ public class Table<K extends Message, V extends Message, M extends Message> {
      * and make it look like the table is a newly opened one
      * This is useful for JVMs who do not wish to keep the entire table
      * around in memory.
+     * DO NOT USE THIS METHOD WITH NO_CACHE TABLES
      * @param runtime - the runtime that was used to create this table
      * @param serializer - the serializer used to materialize table data
      */
@@ -218,6 +219,9 @@ public class Table<K extends Message, V extends Message, M extends Message> {
         if (streamingMapSupplier == null) {
             // PersistentCorfuTable
             oid = new ObjectsView.ObjectID(getStreamUUID(), PersistentCorfuTable.class);
+
+            // Evict all versions of this Table from MVOCache
+            runtime.getObjectsView().getMvoCache().invalidateAllVersionsOf(getStreamUUID());
         } else {
             // Disk-backed CorfuTable
             oid = new ObjectsView.ObjectID(getStreamUUID(), CorfuTable.class);

--- a/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/Table.java
@@ -211,9 +211,13 @@ public class Table<K extends Message, V extends Message, M extends Message> {
      * around in memory.
      * DO NOT USE THIS METHOD WITH NO_CACHE TABLES
      * @param runtime - the runtime that was used to create this table
-     * @param serializer - the serializer used to materialize table data
      */
-    public void resetTableData(CorfuRuntime runtime, ISerializer serializer) {
+    public void resetTableData(CorfuRuntime runtime) {
+
+        if (!corfuTable.isTableCached()) {
+            throw new IllegalStateException("Cannot reset a table opened with NO_CACHE option.");
+        }
+
         ObjectsView.ObjectID oid;
 
         if (streamingMapSupplier == null) {

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileProxy.java
@@ -16,6 +16,7 @@ import org.corfudb.runtime.exceptions.TrimmedUpcallException;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.ObjectOpenOption;
 import org.corfudb.util.ReflectionUtils;
 import org.corfudb.util.Sleep;
 import org.corfudb.util.Utils;
@@ -103,6 +104,8 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
      */
     private final Object[] args;
 
+    private final ObjectOpenOption objectOpenOption;
+
     /**
      * Correctness Logging
      */
@@ -121,13 +124,15 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
      */
     @SuppressWarnings("checkstyle:abbreviation") // Due to deprecation
     CorfuCompileProxy(CorfuRuntime rt, UUID streamID, Class<T> type, Object[] args,
-                      ISerializer serializer, Set<UUID> streamTags, ICorfuSMR<T> wrapperObject) {
+                      ISerializer serializer, Set<UUID> streamTags, ICorfuSMR<T> wrapperObject,
+                      ObjectOpenOption objectOpenOption) {
         this.rt = rt;
         this.streamID = streamID;
         this.type = type;
         this.args = args;
         this.serializer = serializer;
         this.streamTags = streamTags;
+        this.objectOpenOption = objectOpenOption;
 
         // Since the VLO is thread safe we don't need to use a thread safe stream implementation
         // because the VLO will control access to the stream
@@ -455,5 +460,10 @@ public class CorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRProxy
     public boolean isMonotonicStreamAccess() {
         // Object version is always in sync with the stream access
         return isMonotonicObject();
+    }
+
+    @Override
+    public boolean isObjectCached() {
+        return objectOpenOption.equals(ObjectOpenOption.CACHE);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -4,6 +4,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.view.ObjectOpenOption;
 import org.corfudb.runtime.view.SMRObject;
 import org.corfudb.util.ReflectionUtils;
 import org.corfudb.util.serializer.ISerializer;
@@ -36,7 +37,8 @@ public class CorfuCompileWrapperBuilder {
     private static <T extends ICorfuSMR<T>> T getWrapper(Class<T> type, CorfuRuntime rt,
                                                          UUID streamID, Object[] args,
                                                          ISerializer serializer,
-                                                         Set<UUID> streamTags) throws Exception {
+                                                         Set<UUID> streamTags,
+                                                         ObjectOpenOption objectOpenOption) throws Exception {
 
         if (type.getName().equals(PERSISTENT_CORFU_TABLE_CLASS_NAME)) {
             // TODO: make general - This should get cleaned up
@@ -51,7 +53,7 @@ public class CorfuCompileWrapperBuilder {
 
             // Note: args are used when invoking the internal immutable data structure constructor
             wrapperObject.setProxy$CORFUSMR(new MVOCorfuCompileProxy<>(rt, streamID,
-                    immutableClass, args, serializer, streamTags, wrapperObject));
+                    immutableClass, args, serializer, streamTags, wrapperObject, objectOpenOption));
             return (T) wrapperObject;
         }
 
@@ -77,6 +79,7 @@ public class CorfuCompileWrapperBuilder {
                 smrObject.getStreamID(),
                 smrObject.getArguments(),
                 smrObject.getSerializer(),
-                smrObject.getStreamTags());
+                smrObject.getStreamTags(),
+                smrObject.getOption());
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/CorfuCompileWrapperBuilder.java
@@ -68,7 +68,7 @@ public class CorfuCompileWrapperBuilder {
         // Now we create the proxy, which actually manages
         // instances of this object. The wrapper delegates calls to the proxy.
         wrapperObject.setCorfuSMRProxy(new CorfuCompileProxy<>(rt, streamID,
-                type, args, serializer, streamTags, wrapperObject));
+                type, args, serializer, streamTags, wrapperObject, objectOpenOption));
 
         return (T) wrapperObject;
     }

--- a/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/ICorfuSMRProxyInternal.java
@@ -41,4 +41,6 @@ public interface ICorfuSMRProxyInternal<T extends ICorfuSMR<T>> extends ICorfuSM
      * @return
      */
     Set<UUID> getStreamTags();
+
+    boolean isObjectCached();
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/MVOCache.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MVOCache.java
@@ -12,8 +12,11 @@ import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.runtime.CorfuRuntime;
 
 import javax.annotation.Nonnull;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 
 /**
@@ -75,6 +78,22 @@ public class MVOCache<T extends ICorfuSMR<T>> {
         }
 
         objectCache.put(voId, object);
+    }
+
+    /**
+     * Invalidate all versioned objects with the given object ID.
+     * @param objectId
+     */
+    public void invalidateAllVersionsOf(@Nonnull UUID objectId) {
+        if (log.isTraceEnabled()) {
+            log.trace("MVOCache: performing a invalidateAllVersionsOf for {}", objectId);
+        }
+
+        List<VersionedObjectIdentifier> voIdsToInvalidate =
+                objectCache.asMap().keySet().stream()
+                        .filter(voId -> objectId.equals(voId.getObjectId()))
+                        .collect(Collectors.toList());
+        objectCache.invalidateAll(voIdsToInvalidate);
     }
 
     @VisibleForTesting

--- a/runtime/src/main/java/org/corfudb/runtime/object/MVOCache.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MVOCache.java
@@ -14,8 +14,6 @@ import org.corfudb.runtime.CorfuRuntime;
 import javax.annotation.Nonnull;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 
 
 /**
@@ -25,12 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Slf4j
 public class MVOCache<T extends ICorfuSMR<T>> {
-
-    /**
-     * A registry to keep track of all opened MVOs.
-     */
-    @Getter
-    private final ConcurrentHashMap<UUID, MultiVersionObject<T>> allMVOs = new ConcurrentHashMap<>();
 
     /**
      * A collection of strong references to all versioned objects and their state.
@@ -83,15 +75,6 @@ public class MVOCache<T extends ICorfuSMR<T>> {
         }
 
         objectCache.put(voId, object);
-    }
-
-    /**
-     * Register an MVO with this MVOCache.
-     * @param objectId The stream id of the provided MVO.
-     * @param mvo      The actual MVO being registered.
-     */
-    public void registerMVO(@Nonnull UUID objectId, @Nonnull MultiVersionObject<T> mvo) {
-        allMVOs.putIfAbsent(objectId, mvo);
     }
 
     @VisibleForTesting

--- a/runtime/src/main/java/org/corfudb/runtime/object/MVOCorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MVOCorfuCompileProxy.java
@@ -46,6 +46,8 @@ public class MVOCorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRPr
 
     private final Object[] args;
 
+    private final ObjectOpenOption objectOpenOption;
+
     public MVOCorfuCompileProxy(CorfuRuntime rt, UUID streamID, Class<T> type, Object[] args,
                                 ISerializer serializer, Set<UUID> streamTags, ICorfuSMR<T> wrapperObject,
                                 ObjectOpenOption objectOpenOption) {
@@ -55,6 +57,7 @@ public class MVOCorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRPr
         this.args = args;
         this.serializer = serializer;
         this.streamTags = streamTags;
+        this.objectOpenOption = objectOpenOption;
 
         this.underlyingMVO = new MultiVersionObject<>(
                 rt,
@@ -224,5 +227,10 @@ public class MVOCorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRPr
     @Override
     public boolean isMonotonicStreamAccess() {
         return true;
+    }
+
+    @Override
+    public boolean isObjectCached() {
+        return objectOpenOption.equals(ObjectOpenOption.CACHE);
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/object/MVOCorfuCompileProxy.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MVOCorfuCompileProxy.java
@@ -15,6 +15,7 @@ import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.Address;
+import org.corfudb.runtime.view.ObjectOpenOption;
 import org.corfudb.util.ReflectionUtils;
 import org.corfudb.util.Utils;
 import org.corfudb.util.serializer.ISerializer;
@@ -46,7 +47,8 @@ public class MVOCorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRPr
     private final Object[] args;
 
     public MVOCorfuCompileProxy(CorfuRuntime rt, UUID streamID, Class<T> type, Object[] args,
-                                ISerializer serializer, Set<UUID> streamTags, ICorfuSMR<T> wrapperObject) {
+                                ISerializer serializer, Set<UUID> streamTags, ICorfuSMR<T> wrapperObject,
+                                ObjectOpenOption objectOpenOption) {
         this.rt = rt;
         this.streamID = streamID;
         this.type = type;
@@ -58,7 +60,8 @@ public class MVOCorfuCompileProxy<T extends ICorfuSMR<T>> implements ICorfuSMRPr
                 rt,
                 this::getNewInstance,
                 new StreamViewSMRAdapter(rt, rt.getStreamsView().getUnsafe(streamID)),
-                wrapperObject);
+                wrapperObject,
+                objectOpenOption);
     }
 
     @Override

--- a/runtime/src/main/java/org/corfudb/runtime/object/MultiVersionObject.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MultiVersionObject.java
@@ -127,7 +127,6 @@ public class MultiVersionObject<T extends ICorfuSMR<T>> {
         this.currentObject = newObjectFn.get();
         this.mvoCache = corfuRuntime.getObjectsView().getMvoCache();
         this.trimRetry = corfuRuntime.getParameters().getTrimRetry();
-        this.mvoCache.registerMVO(getID(),this);
         wrapperObject.closeWrapper();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/ObjectsView.java
@@ -21,7 +21,7 @@ import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.object.CorfuCompileProxy;
 import org.corfudb.runtime.object.ICorfuSMR;
 import org.corfudb.runtime.object.MVOCache;
-import org.corfudb.runtime.object.MultiVersionObject;
+import org.corfudb.runtime.object.MVOCorfuCompileProxy;
 import org.corfudb.runtime.object.transactions.AbstractTransactionalContext;
 import org.corfudb.runtime.object.transactions.Transaction;
 import org.corfudb.runtime.object.transactions.Transaction.TransactionBuilder;
@@ -233,12 +233,12 @@ public class ObjectsView extends AbstractView {
             if (((ICorfuSMR) obj).getCorfuSMRProxy() instanceof CorfuCompileProxy) {
                 ((CorfuCompileProxy) ((ICorfuSMR) obj).
                         getCorfuSMRProxy()).getUnderlyingObject().gc(trimMark);
+            } else {
+                // MVOCorfuCompileProxy
+                ((MVOCorfuCompileProxy) ((ICorfuSMR) obj).
+                        getCorfuSMRProxy()).getUnderlyingMVO().gc(trimMark);
             }
         }
-
-        mvoCache.getAllMVOs().forEach((uuid, mvo) -> {
-            ((MultiVersionObject) mvo).gc(trimMark);
-        });
     }
 
     @Data

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -651,7 +651,7 @@ public class TableRegistry {
         if (table == null) {
             throw new NoSuchElementException("freeTableData: Did not find any table "+ fullyQualifiedTableName);
         }
-        table.resetTableData(runtime, this.protobufSerializer);
+        table.resetTableData(runtime);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/collections/PersistentCorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/PersistentCorfuTableTest.java
@@ -482,7 +482,7 @@ public class PersistentCorfuTableTest extends AbstractViewTest {
 
     /**
      * For MVO instances, the ObjectOpenOption.NO_CACHE should ensure that the instance
-     * is not saved in ObjectsView.objectCache
+     * is not saved in ObjectsView.objectCache or MVOCache.objectCache
      */
     @Test
     public void testNoCacheOption() {

--- a/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/SMRMapTest.java
@@ -202,7 +202,6 @@ public class SMRMapTest extends AbstractViewTest {
                         .setStreamID(UUID.randomUUID())
                         .setTypeToken(new TypeToken<PersistentCorfuTable<String, String>>() {
                         })
-                        .option(ObjectOpenOption.NO_CACHE)
                         .open())
                 .toArray(PersistentCorfuTable[]::new);
 
@@ -406,7 +405,6 @@ public class SMRMapTest extends AbstractViewTest {
                     .build()
                     .setStreamName("A")
                     .setSerializer(Serializers.getDefaultSerializer())
-                    .option(ObjectOpenOption.NO_CACHE)
                     .setTypeToken(new TypeToken<PersistentCorfuTable<String, String>>() {})
                     .open();
 
@@ -474,7 +472,6 @@ public class SMRMapTest extends AbstractViewTest {
                                 .setStreamID(mapStream)
                                 .setTypeToken(new TypeToken<PersistentCorfuTable<String, String>>() {
                                 })
-                                .option(ObjectOpenOption.NO_CACHE)
                                 .open())
                         .toArray(PersistentCorfuTable[]::new);
 
@@ -567,7 +564,6 @@ public class SMRMapTest extends AbstractViewTest {
         PersistentCorfuTable<String, String> testTable2 = getRuntime().getObjectsView().build()
                 .setTypeToken(new TypeToken<PersistentCorfuTable<String, String>>() {})
                 .setStreamID(stream)
-                .option(ObjectOpenOption.NO_CACHE)
                 .open();
         // Do a get to prompt the sync
         assertThat(testTable2.get(Integer.toString(0))).isEqualTo(Integer.toString(0));


### PR DESCRIPTION
Tables opened with NO_CACHE option should not be registered in MVOCache. Tables opened with CACHE option should remove all its versions in MVOCache when calling resetTableData. Without this fix, both NO_CACHE and resetTableData are broken and it causes memory leak which is a regression from VLO.

## Overview

Description:
Previously a MVO object will be registered in both ObjectsView and MVOCache. 
The latter can be removed and merged into the former. This avoids an existing
memory leak since NO_CACHE has no effect in storing objects in MVOCache.

Why should this be merged: 
Bug fix and code cleanup.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
