### PR TITLE
Switch from Alpine to Debian as the default base image.

### DIFF
--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=openjdk:8-jdk-alpine3.8
+ARG BASE_IMAGE=openjdk:8-jdk-bullseye
 FROM $BASE_IMAGE
 
 ARG CORFU_JAR
@@ -7,7 +7,7 @@ ARG CORFU_TOOLS_JAR
 
 WORKDIR /app
 
-RUN apk add --update iptables bash jq python3 sudo
+RUN apt update && apt -y install iptables bash jq python3 sudo iproute2
 
 COPY target/${CORFU_JAR} /usr/share/corfu/lib/${CORFU_JAR}
 COPY target/${CMDLETS_JAR} /usr/share/corfu/lib/${CMDLETS_JAR}


### PR DESCRIPTION
Ubuntu is a more convenient image for us to use.
Also, an ubuntu-based image is used in the private Corfu version.

Also, the previous image was missing several native libraries, including ld-linux-x86-64.so.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
