### PR TITLE
MVCC Special Handling For Tables Without Updates

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
@@ -6,7 +6,6 @@ import java.util.NavigableSet;
 import java.util.TreeSet;
 import java.util.UUID;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.ILogData;
@@ -133,13 +132,6 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
         if (entry != null) {
             // Update the pointer.
             updatePointer(entry);
-
-            // We added hole to StreamView layer, in order to enable VLO sync to a hole
-            // and in this way, we can avoid unnecessary sync that call sequencer every time.
-            // It can expose a hole to sv consumer, so check if entry is a hole.
-            if (entry.isHole()) {
-                return nextUpTo(maxGlobal);
-            }
         }
 
         // Return the entry.

--- a/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/stream/AbstractContextStreamView.java
@@ -132,6 +132,14 @@ public abstract class AbstractContextStreamView<T extends AbstractStreamContext>
         if (entry != null) {
             // Update the pointer.
             updatePointer(entry);
+
+            // If we see a hole that doesn't have a backpointer that belongs to this
+            // stream then it can be skipped. Otherwise, holes that do belong to this
+            // stream (i.e., written by the checkpointer) will be returned and not skipped.
+            // Higher layers can interpret this hole as a no-op
+            if (entry.isHole() && entry.getBackpointerMap().isEmpty()) {
+                return nextUpTo(maxGlobal);
+            }
         }
 
         // Return the entry.

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.BiConsumer;
@@ -40,11 +41,11 @@ import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.exceptions.WriteSizeException;
+import org.corfudb.runtime.object.VersionedObjectIdentifier;
 import org.corfudb.runtime.object.transactions.TransactionType;
 import org.corfudb.runtime.object.transactions.TransactionalContext;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.corfudb.runtime.view.ObjectOpenOption;
-import org.corfudb.runtime.view.SMRObject;
 import org.corfudb.runtime.view.StreamOptions;
 import org.corfudb.runtime.view.TableRegistry;
 import org.corfudb.runtime.view.stream.AddressMapStreamView;
@@ -71,6 +72,53 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         // This module *really* needs separate & independent runtimes.
         r = getDefaultRuntime().connect(); // side-effect of using AbstractViewTest::getRouterFunction
         r = getNewRuntime(getDefaultNode()).setCacheDisabled(true).connect();
+    }
+
+    /**
+     * This test validates that object versions corresponding to checkpoints
+     * are populated into the MVOCache.
+     */
+    @Test
+    public void testEmptyCheckpointCache() {
+        final String tableName = "table1";
+        final String table2Name = "table2";
+
+        PersistentCorfuTable<String, Long> tableFirstRuntime = instantiateTable(tableName, getRuntime());
+        PersistentCorfuTable<String, Long> tableSecondRuntime = instantiateTable(tableName, r);
+
+        PersistentCorfuTable<String, Long> table2FirstRuntime = instantiateTable(table2Name, getRuntime());
+        PersistentCorfuTable<String, Long> table2SecondRuntime = instantiateTable(table2Name, r);
+
+        /// [Write-T2:0]
+        getRuntime().getObjectsView().TXBegin();
+        table2FirstRuntime.insert("foo", 1L);
+        getRuntime().getObjectsView().TXEnd();
+
+        getRuntime().getObjectsView().TXBegin();
+        tableFirstRuntime.size();
+        getRuntime().getObjectsView().TXEnd();
+
+        /// [Hole-T:1, Start-T:2, End-T:3, Hole-T2:4, Start-T2:5, Cont-T2:6, End-T2:7]
+        MultiCheckpointWriter<PersistentCorfuTable<?, ?>> mcw = new MultiCheckpointWriter<>();
+        mcw.addMap(tableSecondRuntime);
+        mcw.addMap(table2SecondRuntime);
+        mcw.appendCheckpoints(r, "Author");
+
+        // [Write-T:8]
+        getRuntime().getObjectsView().TXBegin();
+        tableFirstRuntime.insert("bar", 2L);
+        getRuntime().getObjectsView().TXEnd();
+
+        getRuntime().getObjectsView().TXBegin();
+        tableFirstRuntime.size();
+        getRuntime().getObjectsView().TXEnd();
+
+        // Only [:-1] and [:1] are present in the cache.
+        Set<VersionedObjectIdentifier> cache = getRuntime().getObjectsView().getMvoCache().keySet();
+        assertThat(cache).containsExactlyInAnyOrder(
+                new VersionedObjectIdentifier(tableFirstRuntime.getCorfuStreamID(), -1L),
+                new VersionedObjectIdentifier(tableFirstRuntime.getCorfuStreamID(), 1L)
+        );
     }
 
     @Test
@@ -892,6 +940,16 @@ public class CheckpointSmokeTest extends AbstractViewTest {
     private PersistentCorfuTable<String, Long> instantiateTable(String streamName) {
         r.getSerializers().registerSerializer(serializer);
         return r.getObjectsView()
+                .build()
+                .setStreamName(streamName)
+                .setTypeToken(new TypeToken<PersistentCorfuTable<String, Long>>() {})
+                .setSerializer(serializer)
+                .open();
+    }
+
+    private PersistentCorfuTable<String, Long> instantiateTable(String streamName, CorfuRuntime rt) {
+        rt.getSerializers().registerSerializer(serializer);
+        return rt.getObjectsView()
                 .build()
                 .setStreamName(streamName)
                 .setTypeToken(new TypeToken<PersistentCorfuTable<String, Long>>() {})

--- a/test/src/test/java/org/corfudb/runtime/collections/PersistentCorfuTableTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/PersistentCorfuTableTest.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.collections;
 
+import com.google.common.reflect.TypeToken;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import lombok.SneakyThrows;
@@ -39,6 +40,7 @@ import java.util.stream.LongStream;
 import java.util.stream.StreamSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 @SuppressWarnings("checkstyle:magicnumber")
 public class PersistentCorfuTableTest extends AbstractViewTest {
@@ -50,7 +52,7 @@ public class PersistentCorfuTableTest extends AbstractViewTest {
     private static final long MEDIUM_CACHE_SIZE = 100;
     private static final long LARGE_CACHE_SIZE = 50_000;
 
-    private static final long MVO_AUTO_SYNC_PERIOD_SECONDS = 1;
+    private static final String INTERRUPTED_ERROR_MSG = "Unexpected InterruptedException";
 
     private static final String someNamespace = "some-namespace";
     private static final String someTable = "some-table";
@@ -334,8 +336,8 @@ public class PersistentCorfuTableTest extends AbstractViewTest {
         // Verify the MVOCache has exactly 2 versions
         Set<VersionedObjectIdentifier> voIds = rt.getObjectsView().getMvoCache().keySet();
         assertThat(voIds).containsExactlyInAnyOrder(
-                new VersionedObjectIdentifier(corfuTable.getCorfuStreamID(), 0),
-                new VersionedObjectIdentifier(corfuTable.getCorfuStreamID(), 1));
+                new VersionedObjectIdentifier(corfuTable.getCorfuStreamID(), -1L),
+                new VersionedObjectIdentifier(corfuTable.getCorfuStreamID(), 0L));
     }
 
     @Test
@@ -1262,5 +1264,83 @@ public class PersistentCorfuTableTest extends AbstractViewTest {
         entries = toList(table.getByIndex(() -> "exercises", null));
         assertThat(entries.size()).isEqualTo(2);
         rt.getObjectsView().TXEnd();
+    }
+
+    /**
+     * Test that a table without any updates can be served when a concurrent
+     * transaction syncs the stream forward before this first transaction has
+     * a chance to request a snapshot proxy.
+     */
+    @Test
+    public void testTableNoUpdateInterleave() {
+        PersistentCorfuTable<String, String>
+                table1 = getDefaultRuntime().getObjectsView().build()
+                .setTypeToken(new TypeToken<PersistentCorfuTable<String, String>>() {})
+                .setStreamName("t1")
+                .open();
+
+        PersistentCorfuTable<String, String>
+                table2 = getDefaultRuntime().getObjectsView().build()
+                .setTypeToken(new TypeToken<PersistentCorfuTable<String, String>>() {})
+                .setStreamName("t2")
+                .open();
+
+        // Perform some writes to a second table in order to move the global tail.
+        final int smallNum = 5;
+        for (int i = 0; i < smallNum; i++) {
+            getDefaultRuntime().getObjectsView().TXBegin();
+            table2.insert(Integer.toString(i), Integer.toString(i));
+            getDefaultRuntime().getObjectsView().TXEnd();
+        }
+
+        CountDownLatch latch1 = new CountDownLatch(1);
+        CountDownLatch latch2 = new CountDownLatch(1);
+
+        Thread t2 = new Thread(() -> {
+            // Wait until the main thread has acquired a transaction timestamp.
+            try {
+                latch2.await();
+            } catch (InterruptedException ex) {
+                fail(INTERRUPTED_ERROR_MSG, ex);
+            }
+
+            // Move the stream tail for this object.
+            getDefaultRuntime().getObjectsView().TXBegin();
+            table1.insert("foo", "bar");
+            getDefaultRuntime().getObjectsView().TXEnd();
+
+            // Perform an access to sync the underlying MVO to the update from above.
+            getDefaultRuntime().getObjectsView().TXBegin();
+            assertThat(table1.size()).isNotZero();
+            getDefaultRuntime().getObjectsView().TXEnd();
+
+            // Notify the main thread so that it can request a snapshot proxy. The main
+            // thread should not see the update above, and should not get a TrimmedException.
+            latch1.countDown();
+        });
+
+        t2.start();
+
+        getDefaultRuntime().getObjectsView().TXBegin();
+
+        // Acquire a transaction timestamp and wait until the second thread has
+        // finished moving the object forward in time.
+        assertThat(table2.size()).isNotZero();
+        latch2.countDown();
+        try {
+            latch1.await();
+        } catch (InterruptedException ex) {
+            fail(INTERRUPTED_ERROR_MSG, ex);
+        }
+
+        // Validate that we do not see any updates. A TrimmedException should not be thrown either.
+        assertThat(table1.size()).isZero();
+        getDefaultRuntime().getObjectsView().TXEnd();
+
+        try {
+            t2.join();
+        } catch (InterruptedException ex) {
+            fail(INTERRUPTED_ERROR_MSG, ex);
+        }
     }
 }


### PR DESCRIPTION
This patch introduces an optimization for MVCC to better handle corner cases involving tables without updates under certain multi-threaded interleaving access patterns.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
