### PR TITLE
fix(sec): upgrade commons-io:commons-io to 2.7

### DIFF
--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.7</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-io:commons-io 2.4
- [CVE-2021-29425](https://www.oscs1024.com/hd/CVE-2021-29425)


### What did I do？
Upgrade commons-io:commons-io from 2.4 to 2.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS