### PR TITLE
Fix Publish Corfu Artifacts Action

### DIFF
--- a/.github/workflows/publish-corfu.yml
+++ b/.github/workflows/publish-corfu.yml
@@ -42,7 +42,9 @@ jobs:
         continue-on-error: true
 
       - name: Prepare Corfu
-        run: .ci/infrastructure-docker-build.sh docker
+        run: |
+          .ci/infrastructure-docker-build.sh docker
+          .ci/generator-docker-build.sh
         shell: bash
 
       - name: Publish corfu artifacts


### PR DESCRIPTION
Build the missing generator image before the docker push.

## Overview

Description:

Why should this be merged: Fixes CI/CD.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
