### PR TITLE
Fix the flakiness in CorfuReplicationE2EIT.

### DIFF
--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -316,7 +316,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
 
         statusUpdateLatch.await();
         try (TxnContext txn = corfuStoreActive.txn(LogReplicationMetadataManager.NAMESPACE)) {
-            replicationStatusVal = (LogReplicationMetadata.ReplicationStatusVal) txn.getRecord("LogReplicationStatus", key).getPayload();
+            replicationStatusVal = (LogReplicationMetadata.ReplicationStatusVal) txn.getRecord(REPLICATION_STATUS_TABLE, key).getPayload();
             txn.commit();
         }
 
@@ -417,7 +417,10 @@ public class LogReplicationAbstractIT extends AbstractIT {
                         countDownLatch.countDown();
                     }
             }));
-            countDownLatch.countDown();
+
+            if (!this.waitSnapshotStatusComplete) {
+                countDownLatch.countDown();
+            }
         }
 
         @Override
@@ -813,7 +816,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
         cpRuntime.getSerializers().registerSerializer(protoBufSerializer);
         mcw.addMap(protobufDescriptorTable);
         Token token1 = mcw.appendCheckpoints(cpRuntime, "checkpointer");
-        
+
         mcw.addMap(tableRegistryCT);
         Token token2 = mcw.appendCheckpoints(cpRuntime, "checkpointer");
         Token minToken = Token.min(token1, token2);


### PR DESCRIPTION
Why should this be merged: Addresses the flakiness in a LogReplication IT

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
