### PR TITLE
Fix incorrect runtime passed to CheckpointWriter

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/compactor/CorfuStoreCompactorConfig.java
+++ b/corfudb-tools/src/main/java/org/corfudb/compactor/CorfuStoreCompactorConfig.java
@@ -91,7 +91,10 @@ public class CorfuStoreCompactorConfig {
         builder.systemDownHandlerTriggerLimit(SYSTEM_DOWN_HANDLER_TRIGGER_LIMIT)
                 .systemDownHandler(defaultSystemDownHandler);
 
-        params = builder.priorityLevel(PriorityLevel.HIGH).build();
+        params = builder
+                .priorityLevel(PriorityLevel.HIGH)
+                .cacheDisabled(true)
+                .build();
     }
 
     private Map<String, Object> parseOpts(String[] args) {

--- a/runtime/src/main/java/org/corfudb/runtime/ServerTriggeredCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/ServerTriggeredCheckpointer.java
@@ -57,7 +57,7 @@ public class ServerTriggeredCheckpointer extends DistributedCheckpointer {
         CorfuTable<CorfuDynamicKey, OpaqueCorfuDynamicRecord> corfuTable = openTable(tableName, keyDynamicProtobufSerializer,
                 checkpointerBuilder.cpRuntime.get());
         CheckpointWriter<ICorfuTable<?,?>> cpw =
-                new CheckpointWriter(checkpointerBuilder.corfuRuntime, streamId, "ServerCheckpointer", corfuTable);
+                new CheckpointWriter(checkpointerBuilder.cpRuntime.get(), streamId, "ServerCheckpointer", corfuTable);
         ISerializer serializer = ((CorfuCompileProxy) corfuTable.getCorfuSMRProxy())
                 .getSerializer();
         cpw.setSerializer(serializer);

--- a/test/src/test/java/org/corfudb/CorfuStoreCompactorConfigUnitTest.java
+++ b/test/src/test/java/org/corfudb/CorfuStoreCompactorConfigUnitTest.java
@@ -36,6 +36,7 @@ public class CorfuStoreCompactorConfigUnitTest {
                 .systemDownHandlerTriggerLimit(CorfuStoreCompactorConfig.SYSTEM_DOWN_HANDLER_TRIGGER_LIMIT)
                 .systemDownHandler(corfuStoreCompactorConfig.getDefaultSystemDownHandler())
                 .clientName(hostname)
+                .cacheDisabled(true)
                 .build();
 
         Assert.assertEquals(Optional.empty(), corfuStoreCompactorConfig.getPersistedCacheRoot());


### PR DESCRIPTION
Error found in the checkpoint invocation where two different runtimes are used while opening the table and checkpointing.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
