### PR TITLE
Revert "Avoid passing the LR Server's Channel Context to the Client R…

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationRuntimeParameters.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogReplicationRuntimeParameters.java
@@ -5,6 +5,7 @@ import io.netty.channel.EventLoopGroup;
 import lombok.Data;
 import org.corfudb.comm.ChannelImplementation;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.transport.IChannelContext;
 
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
 import org.corfudb.runtime.RuntimeParameters;
@@ -39,6 +40,9 @@ public class LogReplicationRuntimeParameters extends RuntimeParameters {
     // Topology Configuration Identifier (configuration epoch)
     private long topologyConfigId;
 
+    // Log Replication Channel Context
+    private IChannelContext channelContext;
+
     // Max write size(in bytes) for LR's runtime
     private int maxWriteSize;
 
@@ -54,6 +58,7 @@ public class LogReplicationRuntimeParameters extends RuntimeParameters {
         private String pluginFilePath;
         private long topologyConfigId;
         private LogReplicationConfig replicationConfig;
+        private IChannelContext channelContext;
         private int maxWriteSize;
 
         private LogReplicationRuntimeParametersBuilder() {
@@ -86,6 +91,11 @@ public class LogReplicationRuntimeParameters extends RuntimeParameters {
 
         public LogReplicationRuntimeParameters.LogReplicationRuntimeParametersBuilder replicationConfig(LogReplicationConfig replicationConfig) {
             this.replicationConfig = replicationConfig;
+            return this;
+        }
+
+        public LogReplicationRuntimeParameters.LogReplicationRuntimeParametersBuilder channelContext(IChannelContext channelContext) {
+            this.channelContext = channelContext;
             return this;
         }
 
@@ -246,6 +256,7 @@ public class LogReplicationRuntimeParameters extends RuntimeParameters {
             runtimeParameters.setRemoteClusterDescriptor(remoteClusterDescriptor);
             runtimeParameters.setTopologyConfigId(topologyConfigId);
             runtimeParameters.setPluginFilePath(pluginFilePath);
+            runtimeParameters.setChannelContext(channelContext);
             runtimeParameters.setReplicationConfig(replicationConfig);
             runtimeParameters.setMaxWriteSize(maxWriteSize);
             return runtimeParameters;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -351,7 +351,10 @@ public class CorfuReplicationDiscoveryService implements Runnable, CorfuReplicat
                         .put(LogReplicationServer.class, logReplicationServerHandler)
                         .build());
 
-        replicationContext = new LogReplicationContext(logReplicationConfig, topologyDescriptor, localCorfuEndpoint);
+        // Pass server's channel context through the Log Replication Context, for shared objects between the server
+        // and the client channel (specific requirements of the transport implementation)
+        replicationContext = new LogReplicationContext(logReplicationConfig, topologyDescriptor,
+            localCorfuEndpoint, interClusterReplicationService.getRouter().getServerAdapter().getChannelContext());
 
         // Unblock server initialization & register to Log Replication Lock, to attempt lock / leadership acquisition
         serverCallback.complete(interClusterReplicationService);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -131,6 +131,7 @@ public class CorfuReplicationManager {
                             .localClusterId(localNodeDescriptor.getClusterId())
                             .replicationConfig(context.getConfig())
                             .pluginFilePath(pluginFilePath)
+                            .channelContext(context.getChannelContext())
                             .topologyConfigId(topology.getTopologyConfigId())
                             .keyStore(corfuRuntime.getParameters().getKeyStore())
                             .tlsEnabled(corfuRuntime.getParameters().isTlsEnabled())

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationContext.java
@@ -2,11 +2,13 @@ package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.Getter;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.transport.IChannelContext;
 
 /**
  * This class represents the Log Replication Context.
  *
- * It contains all abstractions required to initiate log replication either as a source cluster or as sink cluster.
+ * It contains all abstractions required to initiate log replication either as
+ * an active cluster (source) or as standby cluster (standby).
  *
  * @author amartinezman
  */
@@ -21,12 +23,17 @@ public class LogReplicationContext {
     @Getter
     private String localCorfuEndpoint;
 
+    @Getter
+    private IChannelContext channelContext;
+
     /**
      * Constructor
      **/
-    public LogReplicationContext(LogReplicationConfig config, TopologyDescriptor topology, String localCorfuEndpoint) {
+    public LogReplicationContext(LogReplicationConfig config,  TopologyDescriptor topology, String localCorfuEndpoint,
+                                 IChannelContext channelContext) {
         this.config = config;
         this.topology = topology;
         this.localCorfuEndpoint = localCorfuEndpoint;
+        this.channelContext = channelContext;
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
@@ -422,6 +422,7 @@ public class LogReplicationClientRouter implements IClientRouter {
             Class adapterType = Class.forName(config.getTransportClientClassCanonicalName(), true, child);
             channelAdapter = (IClientChannelAdapter) adapterType.getDeclaredConstructor(String.class, ClusterDescriptor.class, LogReplicationClientRouter.class)
                     .newInstance(parameters.getLocalClusterId(), remoteClusterDescriptor, this);
+            channelAdapter.setChannelContext(parameters.getChannelContext());
             log.info("Connect asynchronously to remote cluster... ");
             // When connection is established to the remote leader node, the remoteLeaderConnectionFuture will be completed.
             channelAdapter.connectAsync();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/IChannelContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/IChannelContext.java
@@ -1,0 +1,19 @@
+package org.corfudb.infrastructure.logreplication.transport;
+
+/**
+ * This interface represents the shared context of a channel.
+ *
+ * It provides common abstractions required across the Client and Server Channel Adapters.
+ *
+ * @author amartinezman
+ *
+ */
+public interface IChannelContext {
+
+    /**
+     * Return Local Node's Endpoint
+     *
+     * @return node's endpoint
+     */
+    String getEndpoint();
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure.logreplication.transport.client;
 import lombok.Getter;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientRouter;
+import org.corfudb.infrastructure.logreplication.transport.IChannelContext;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 
@@ -28,6 +29,9 @@ public abstract class IClientChannelAdapter {
 
     @Getter
     private final LogReplicationClientRouter router;
+
+    @Getter
+    private IChannelContext channelContext;
 
     /**
      * Default Constructor
@@ -58,6 +62,13 @@ public abstract class IClientChannelAdapter {
      * Stop communication across Clusters.
      */
     public void stop() {}
+
+    /**
+     * Set shared context
+     */
+    public void setChannelContext(IChannelContext channelContext) {
+        this.channelContext = channelContext;
+    }
 
     /**
      * Send a message across the channel to a specific endpoint.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/server/IServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/server/IServerChannelAdapter.java
@@ -1,8 +1,10 @@
 package org.corfudb.infrastructure.logreplication.transport.server;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
+import org.corfudb.infrastructure.logreplication.transport.IChannelContext;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 
 import java.util.concurrent.CompletableFuture;
@@ -22,6 +24,10 @@ public abstract class IServerChannelAdapter {
 
     @Getter
     private final ServerContext serverContext;
+
+    @Getter
+    @Setter
+    private IChannelContext channelContext;
 
     public IServerChannelAdapter(ServerContext serverContext, LogReplicationServerRouter adapter) {
         this.serverContext = serverContext;


### PR DESCRIPTION
Removal of serverContext is causing issues in the client transport layer on switchover when the old active leader node becomes the new standby leader node.

reverting the change as the change is more of a cleanup than "need to have". 
The cleanup will be retained as part of LR_v2
 
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
