### PR TITLE
Minor LR Fixes Identified During Code Inspection.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -156,9 +156,11 @@ public class LogEntryWriter extends SinkWriter {
                             if (streamId.equals(REGISTRY_TABLE_ID)) {
                                 // If registry table entries are being handled, indicate the config to sync with
                                 // registry table after this transaction.
-                                registryTableUpdated.set(true);
                                 smrEntries = filterRegistryTableEntries(new ArrayList<>(smrEntries));
-                                log.info("Registry Table entries during log entry sync = {}", smrEntries.size());
+                                if (!smrEntries.isEmpty()) {
+                                    log.info("Registry Table entries during log entry sync = {}", smrEntries.size());
+                                    registryTableUpdated.set(true);
+                                }
                             }
 
                             for (SMREntry smrEntry : smrEntries) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -136,7 +136,6 @@ public class LogReplicationConfigManager {
      */
     public boolean loadRegistryTableEntries() {
         try {
-            log.info("Sync in-memory registry table entries with retry.");
             return IRetry.build(ExponentialBackoffRetry.class, () -> {
                 try {
                     StreamAddressSpace currentAddressSpace = rt.getSequencerView().getStreamAddressSpace(


### PR DESCRIPTION
Description:
This PR addresses 3 items:
- Avoid unnecessary sync with the Registry Table during Log Entry Sync
- Set correct logging level for a message to avoid it from becoming noisy
- Fix a test method which was changed in a prior PR and was not serving the intended purpose

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
