### PR TITLE
Fix runOrchestrator thread error

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -118,6 +118,7 @@ public class CompactorLeaderServices {
             syslog.error("Exception while initiating Compaction cycle {}. Stack Trace {}", e, e.getStackTrace());
             return LeaderInitStatus.FAIL;
         }
+        syslog.info("Init compaction cycle is successful");
         return LeaderInitStatus.SUCCESS;
     }
 
@@ -142,6 +143,7 @@ public class CompactorLeaderServices {
             LivenessValidator.Status statusToChange = livenessValidator.shouldChangeManagerStatus(
                     Duration.ofMillis(currentTime));
             if (statusToChange == LivenessValidator.Status.FINISH) {
+                syslog.info("Invoking finishCompactionCycle");
                 finishCompactionCycle();
                 livenessValidator.clearLivenessMap();
                 livenessValidator.clearLivenessValidator();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/InvokeCheckpointingJvm.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/InvokeCheckpointingJvm.java
@@ -72,6 +72,7 @@ public class InvokeCheckpointingJvm implements InvokeCheckpointing {
     public void shutdown() {
         if (isRunning()) {
             this.checkpointerProcess.destroy();
+            syslog.info("Shutting down existing checkpointer jvm ");
         }
         this.isInvoked = false;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LivenessValidator.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LivenessValidator.java
@@ -72,6 +72,7 @@ public class LivenessValidator {
 
     public boolean isTableCheckpointActive(TableName table, Duration currentTime) {
         livenessValidatorHelper.clear();
+        log.trace("Checking if table checkpoint is active...");
         if (validateLivenessMap.containsKey(table)) {
             LivenessMetadata previousStatus = validateLivenessMap.get(table);
             return isTailMovingForward(table, currentTime) || isHeartBeatMovingForward(table, currentTime) ||
@@ -90,6 +91,7 @@ public class LivenessValidator {
                     cpStreamTail, currentTime));
             return true;
         }
+        log.debug("Tail not moving forward for table: {}", table);
         return false;
     }
 
@@ -101,6 +103,7 @@ public class LivenessValidator {
                     previousStatus.getStreamTail(), currentTime));
             return true;
         }
+        log.debug("HeartBeat not moving forward for table: {}", table);
         return false;
     }
 
@@ -154,8 +157,9 @@ public class LivenessValidator {
                     CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload());
             txn.commit();
+            log.trace("ManagerStatus: {}", managerStatus.get().getStatus().toString());
         } catch (Exception e) {
-            log.warn("Unable to acquire Manager Status");
+            log.warn("Unable to acquire Manager Status, ", e);
         }
 
         boolean isTimedOut = currentTime.minus(livenessValidatorHelper.getPrevActiveTime()).compareTo(timeout) > 0;


### PR DESCRIPTION
When the scheduler in runOrchestrator encounters an uncaught exception, it stalls and no more tasks get added to it even though the thread seems to be alive. Hence wrapping this section of the code with a try...catch block.

Also added some logs for better debuggability

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
