### PR TITLE
Handle potential race condition in LivenessUpdater

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -152,13 +152,13 @@ public class CompactorLeaderServices {
 
         for (TableName table : activeCheckpointTables) {
             if (!livenessValidator.isTableCheckpointActive(table, Duration.ofMillis(currentTime)) &&
-                    hasTableCheckpointFailed(table)) {
+                    checkFailureAndFinishCompactionCycle(table)) {
                 break;
             }
         }
     }
 
-    private boolean hasTableCheckpointFailed(TableName table) {
+    private boolean checkFailureAndFinishCompactionCycle(TableName table) {
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             CheckpointingStatus tableStatus = (CheckpointingStatus) txn.getRecord(
                     CompactorMetadataTables.CHECKPOINT_STATUS_TABLE_NAME, table).getPayload();

--- a/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
@@ -43,6 +43,7 @@ public abstract class DistributedCheckpointer {
         this.corfuStore = corfuStore;
         this.compactorMetadataTables = compactorMetadataTables;
         this.livenessUpdater = new CheckpointLivenessUpdater(corfuStore);
+        this.livenessUpdater.start();
     }
 
     private boolean tryLockTableToCheckpoint(@NonNull CompactorMetadataTables compactorMetadataTables,

--- a/runtime/src/main/java/org/corfudb/runtime/LivenessUpdater.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LivenessUpdater.java
@@ -1,6 +1,8 @@
 package org.corfudb.runtime;
 
 public interface LivenessUpdater {
+    void start();
+
     void updateLiveness(CorfuStoreMetadata.TableName tableName);
 
     void notifyOnSyncComplete();

--- a/test/src/test/java/org/corfudb/integration/LivenessUpdaterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LivenessUpdaterIT.java
@@ -92,7 +92,7 @@ public class LivenessUpdaterIT extends AbstractIT {
         } catch (InterruptedException e) {
             System.out.println("Sleep interrupted: " + e);
         }
-        livenessUpdater.shutdown();
+        livenessUpdater.notifyOnSyncComplete();
 
         try (TxnContext txn = store.txn(CORFU_SYSTEM_NAMESPACE)) {
             CorfuCompactorManagement.ActiveCPStreamMsg newStatus = (CorfuCompactorManagement.ActiveCPStreamMsg)
@@ -102,6 +102,8 @@ public class LivenessUpdaterIT extends AbstractIT {
             Assert.assertEquals(1, newStatus.getSyncHeartbeat());
         } catch (Exception e) {
             Assert.fail("Transaction Failed due to " + e.getStackTrace());
+        } finally {
+            livenessUpdater.shutdown();
         }
     }
 }

--- a/test/src/test/java/org/corfudb/integration/LivenessUpdaterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LivenessUpdaterIT.java
@@ -72,6 +72,7 @@ public class LivenessUpdaterIT extends AbstractIT {
                 TableOptions.fromProtoSchema(SampleSchema.FirewallRule.class));
 
         CheckpointLivenessUpdater livenessUpdater = new CheckpointLivenessUpdater(store);
+        livenessUpdater.start();
         CorfuStoreMetadata.TableName tableNameBuilder = CorfuStoreMetadata.TableName.newBuilder().
                 setNamespace(namespace).setTableName(tableName).build();
         Duration interval = Duration.ofSeconds(15);

--- a/test/src/test/java/org/corfudb/runtime/CheckpointLivenessUpdaterUnitTest.java
+++ b/test/src/test/java/org/corfudb/runtime/CheckpointLivenessUpdaterUnitTest.java
@@ -1,8 +1,7 @@
-package org.corfudb.runtime.checkpoint;
+package org.corfudb.runtime;
 
 import com.google.protobuf.Message;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.runtime.CheckpointLivenessUpdater;
 import org.corfudb.runtime.CorfuCompactorManagement.ActiveCPStreamMsg;
 import org.corfudb.runtime.CorfuStoreMetadata.TableName;
 import org.corfudb.runtime.CorfuStoreMetadata.Timestamp;
@@ -13,8 +12,6 @@ import org.corfudb.runtime.collections.TxnContext;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.RepeatedTest;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Matchers;
 
@@ -23,7 +20,6 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -37,22 +33,19 @@ public class CheckpointLivenessUpdaterUnitTest {
             (CorfuStoreEntry<? extends Message, ? extends Message, ? extends Message>) mock(CorfuStoreEntry.class);
 
     private static final Duration INTERVAL = Duration.ofSeconds(15);
-    private static final int LONG_INTERVAL = 60;
-    private static final int NUM_REPETITIONS = 5;
     private static final TableName tableName = TableName.newBuilder().setNamespace("TestNamespace").setTableName("TestTableName").build();
 
     private CheckpointLivenessUpdater livenessUpdater;
 
-    @BeforeEach
     @Before
     public void setup() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
-        livenessUpdater = new CheckpointLivenessUpdater(corfuStore);
         when(corfuStore.openTable(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any())).thenReturn(mock(Table.class));
 
         when(corfuStore.txn(CORFU_SYSTEM_NAMESPACE)).thenReturn(txn);
         when(txn.getRecord(Matchers.anyString(), Matchers.any(Message.class))).thenReturn(corfuStoreEntry);
         doNothing().when(txn).putRecord(Matchers.any(), Matchers.any(), Matchers.any(), Matchers.any());
         when(txn.commit()).thenReturn(Timestamp.getDefaultInstance());
+        livenessUpdater = new CheckpointLivenessUpdater(corfuStore);
     }
 
     @Test
@@ -60,6 +53,7 @@ public class CheckpointLivenessUpdaterUnitTest {
         ActiveCPStreamMsg activeCPStreamMsg = ActiveCPStreamMsg.newBuilder().setSyncHeartbeat(0).build();
         when((ActiveCPStreamMsg) corfuStoreEntry.getPayload()).thenReturn(activeCPStreamMsg);
 
+        livenessUpdater.start();
         livenessUpdater.updateLiveness(tableName);
         try {
             TimeUnit.SECONDS.sleep(INTERVAL.getSeconds());
@@ -73,33 +67,40 @@ public class CheckpointLivenessUpdaterUnitTest {
         Assert.assertEquals(1, captor.getValue().getSyncHeartbeat());
     }
 
-    @RepeatedTest(NUM_REPETITIONS)
+    @Test
     public void testUpdateLivenessRaceCondition() {
         ActiveCPStreamMsg activeCPStreamMsg = ActiveCPStreamMsg.newBuilder().setSyncHeartbeat(0).build();
         when((ActiveCPStreamMsg) corfuStoreEntry.getPayload()).thenReturn(activeCPStreamMsg);
 
-        //This block helps with possibly triggering a race condition
-        long endTime = System.nanoTime() + TimeUnit.NANOSECONDS.convert(LONG_INTERVAL, TimeUnit.SECONDS);
-        boolean clear = true;
-        while (System.nanoTime() < endTime) {
-            if (clear) {
-                livenessUpdater.notifyOnSyncComplete();
-            } else {
-                livenessUpdater.updateLiveness(tableName);
-            }
-            clear = !clear;
-        }
+        livenessUpdater.updateLiveness(tableName);
+        livenessUpdater.updateHeartbeat();
+        livenessUpdater.notifyOnSyncComplete();
 
-        //ensures atLeastOnce invocation of putRecord if there were no exceptions in updateHeartbeat method
+        livenessUpdater.updateHeartbeat();
+
+        ArgumentCaptor<ActiveCPStreamMsg> captor = ArgumentCaptor.forClass(ActiveCPStreamMsg.class);
+        verify(txn).putRecord(Matchers.any(), Matchers.any(), captor.capture(), Matchers.any());
+        Assert.assertEquals(1, captor.getValue().getSyncHeartbeat());
+    }
+
+    @Test
+    public void testSchedulerOnException() {
+        ActiveCPStreamMsg activeCPStreamMsg = ActiveCPStreamMsg.newBuilder().setSyncHeartbeat(0).build();
+        when((ActiveCPStreamMsg) corfuStoreEntry.getPayload())
+                .thenReturn(null)
+                .thenReturn(activeCPStreamMsg);
+        livenessUpdater.start();
+
         livenessUpdater.updateLiveness(tableName);
         try {
-            TimeUnit.SECONDS.sleep(INTERVAL.getSeconds());
+            TimeUnit.SECONDS.sleep(INTERVAL.getSeconds()*2);
         } catch (InterruptedException e) {
             log.warn("Sleep interrupted: ", e);
         }
         livenessUpdater.notifyOnSyncComplete();
 
         ArgumentCaptor<ActiveCPStreamMsg> captor = ArgumentCaptor.forClass(ActiveCPStreamMsg.class);
-        verify(txn, atLeastOnce()).putRecord(Matchers.any(), Matchers.any(), captor.capture(), Matchers.any());
+        verify(txn).putRecord(Matchers.any(), Matchers.any(), captor.capture(), Matchers.any());
+        Assert.assertEquals(1, captor.getValue().getSyncHeartbeat());
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/MockLivenessUpdater.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/MockLivenessUpdater.java
@@ -54,6 +54,11 @@ public class MockLivenessUpdater implements LivenessUpdater {
     }
 
     @Override
+    public void start() {
+        //No action done
+    }
+
+    @Override
     public void updateLiveness(TableName tableName) {
         this.tableName = tableName;
         // update validity counter every 250ms


### PR DESCRIPTION
In liveness updater, due to different threads being able to handle the currentTable variable, there is a chance of it getting into a race condition. This change fixes it.
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
