### PR TITLE
Changing the string of LR checkpointer freeze-token

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CompactorMetadataTables.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CompactorMetadataTables.java
@@ -29,7 +29,7 @@ public class CompactorMetadataTables {
 
     public static final StringKey COMPACTION_MANAGER_KEY = StringKey.newBuilder().setKey("CompactionManagerKey").build();
     public static final StringKey MIN_CHECKPOINT = StringKey.newBuilder().setKey("MinCheckpointToken").build();
-    public static final StringKey FREEZE_TOKEN = StringKey.newBuilder().setKey("freezeTokenNS").build();
+    public static final StringKey FREEZE_TOKEN = StringKey.newBuilder().setKey("freezeCheckpointNS").build();
     public static final StringKey INSTANT_TIGGER = StringKey.newBuilder().setKey("InstantTrigger").build();
     public static final StringKey INSTANT_TIGGER_WITH_TRIM = StringKey.newBuilder().setKey("InstantTriggerTrim").build();
 


### PR DESCRIPTION
## Overview

Description:
Changing the freeze-token name to what was used in compactor V1.

Why should this be merged: 
Checkpointer doesn't get frozen as LR uses "freezeCheckpointNS" and checkpointer currently checks for "freezeTokenNS"

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
