### PR TITLE
Remove syslog based logging

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -114,7 +114,7 @@ public class CompactorLeaderServices {
             log.error("Exception while initiating Compaction cycle {}. Stack Trace {}", e, e.getStackTrace());
             return LeaderInitStatus.FAIL;
         }
-        syslog.info("Init compaction cycle is successful");
+        log.info("Init compaction cycle is successful");
         return LeaderInitStatus.SUCCESS;
     }
 
@@ -139,7 +139,7 @@ public class CompactorLeaderServices {
             LivenessValidator.Status statusToChange = livenessValidator.shouldChangeManagerStatus(
                     Duration.ofMillis(currentTime));
             if (statusToChange == LivenessValidator.Status.FINISH) {
-                syslog.info("Invoking finishCompactionCycle");
+                log.info("Invoking finishCompactionCycle");
                 finishCompactionCycle();
                 livenessValidator.clearLivenessMap();
                 livenessValidator.clearLivenessValidator();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -1,6 +1,5 @@
 package org.corfudb.infrastructure;
 
-import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.infrastructure.health.HealthMonitor;
 import org.corfudb.infrastructure.health.Issue;
@@ -15,6 +14,8 @@ import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.exceptions.AbortCause;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.proto.RpcCommon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -31,12 +32,12 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
  * 3. Set CompactoinManager's status as COMPLETED or FAILED based on the checkpointing status of all the tables. This
  * marks the end of the compaction cycle
  */
-@Slf4j
 public class CompactorLeaderServices {
     private final CorfuRuntime corfuRuntime;
     private final CorfuStore corfuStore;
     private final String nodeEndpoint;
     private final TrimLog trimLog;
+    private final Logger log;
     private final LivenessValidator livenessValidator;
     private final CompactorMetadataTables compactorMetadataTables;
 
@@ -61,6 +62,7 @@ public class CompactorLeaderServices {
         this.corfuStore = corfuStore;
         this.livenessValidator = livenessValidator;
         this.trimLog = new TrimLog(corfuRuntime, corfuStore);
+        this.log = LoggerFactory.getLogger("compactor-leader");
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -2,7 +2,6 @@ package org.corfudb.infrastructure;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import lombok.extern.slf4j.Slf4j;
 import lombok.NonNull;
 import org.corfudb.infrastructure.health.Component;
 import org.corfudb.infrastructure.health.HealthMonitor;
@@ -16,6 +15,8 @@ import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.view.Layout;
 import org.corfudb.util.LambdaUtils;
 import org.corfudb.util.concurrent.SingletonResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -30,7 +31,6 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
  * <p>
  * Created by Sundar Sridharan on 3/2/22.
  */
-@Slf4j
 public class CompactorService implements ManagementService {
 
     private final ServerContext serverContext;
@@ -42,6 +42,7 @@ public class CompactorService implements ManagementService {
     private Optional<CompactorLeaderServices> compactorLeaderServices = Optional.empty();
     private Optional<CorfuStore> corfuStore = Optional.empty();
     private TrimLog trimLog;
+    private final Logger log;
     private static final Duration LIVENESS_TIMEOUT = Duration.ofMinutes(1);
 
     CompactorService(@NonNull ServerContext serverContext,
@@ -57,6 +58,7 @@ public class CompactorService implements ManagementService {
                         .build());
         this.checkpointerJvmManager = checkpointerJvmManager;
         this.compactionTriggerPolicy = compactionTriggerPolicy;
+        this.log = LoggerFactory.getLogger("compactor-leader");
     }
 
     private CorfuRuntime getCorfuRuntime() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -70,7 +70,7 @@ public class CompactorService implements ManagementService {
      */
     @Override
     public void start(Duration interval) {
-        syslog.info("Starting Compaction service...");
+        log.info("Starting Compaction service...");
         if (getCorfuRuntime().getParameters().getCheckpointTriggerFreqMillis() <= 0) {
             return;
         }
@@ -118,7 +118,7 @@ public class CompactorService implements ManagementService {
     private void runOrchestrator() {
         try {
             boolean isLeader = isNodePrimarySequencer(updateLayoutAndGet());
-            syslog.trace("Current node isLeader: {}", isLeader);
+            log.trace("Current node isLeader: {}", isLeader);
 
             CheckpointingStatus managerStatus = null;
             try (TxnContext txn = getCorfuStore().txn(CORFU_SYSTEM_NAMESPACE)) {
@@ -126,9 +126,9 @@ public class CompactorService implements ManagementService {
                         CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
                         CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
                 txn.commit();
-                syslog.trace("ManagerStatus: {}", managerStatus.getStatus().toString());
+                log.trace("ManagerStatus: {}", managerStatus.getStatus().toString());
             } catch (Exception e) {
-                syslog.warn("Unable to acquire manager status: ", e);
+                log.warn("Unable to acquire manager status: ", e);
             }
             try {
                 if (managerStatus != null) {
@@ -151,10 +151,10 @@ public class CompactorService implements ManagementService {
                     }
                 }
             } catch (Exception ex) {
-                syslog.warn("Exception in runOrcestrator(): ", ex);
+                log.warn("Exception in runOrcestrator(): ", ex);
             }
         } catch (Throwable t) {
-            syslog.error("Encountered unexpected exception in runOrchestrator: ", t);
+            log.error("Encountered unexpected exception in runOrchestrator: ", t);
             throw t;
         }
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DynamicTriggerPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DynamicTriggerPolicy.java
@@ -1,25 +1,27 @@
 package org.corfudb.infrastructure;
 
-import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CompactorMetadataTables;
 import org.corfudb.runtime.DistributedCheckpointerHelper;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.proto.RpcCommon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
-@Slf4j
 public class DynamicTriggerPolicy implements CompactionTriggerPolicy {
     /**
      * What time did the previous cycle start
      */
     private long lastCompactionCycleStartTS;
+    private final Logger log;
 
     public DynamicTriggerPolicy() {
         this.lastCompactionCycleStartTS = System.currentTimeMillis();
+        this.log = LoggerFactory.getLogger("compactor-leader");
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/InvokeCheckpointingJvm.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/InvokeCheckpointingJvm.java
@@ -1,22 +1,24 @@
 package org.corfudb.infrastructure;
 
-import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.DistributedCheckpointer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-@Slf4j
 public class InvokeCheckpointingJvm implements InvokeCheckpointing {
 
     private static final int MAX_COMPACTION_RETRIES = 8;
     private final ServerContext serverContext;
     private volatile Process checkpointerProcess;
+    private final Logger log;
     private volatile boolean isInvoked;
 
     public InvokeCheckpointingJvm(ServerContext serverContext) {
         this.serverContext = serverContext;
+        this.log = LoggerFactory.getLogger("compactor-leader");
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/InvokeCheckpointingJvm.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/InvokeCheckpointingJvm.java
@@ -70,7 +70,7 @@ public class InvokeCheckpointingJvm implements InvokeCheckpointing {
     public void shutdown() {
         if (isRunning()) {
             this.checkpointerProcess.destroy();
-            syslog.info("Shutting down existing checkpointer jvm ");
+            log.info("Shutting down existing checkpointer jvm ");
         }
         this.isInvoked = false;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LivenessValidator.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LivenessValidator.java
@@ -3,7 +3,6 @@ package org.corfudb.infrastructure;
 import com.google.common.annotations.VisibleForTesting;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.runtime.CompactorMetadataTables;
 import org.corfudb.runtime.CorfuCompactorManagement.ActiveCPStreamMsg;
@@ -15,6 +14,8 @@ import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.view.Address;
 import org.corfudb.runtime.view.TableRegistry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -24,13 +25,13 @@ import java.util.UUID;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
-@Slf4j
 public class LivenessValidator {
     private final Map<TableName, LivenessMetadata> validateLivenessMap = new HashMap<>();
     private final CorfuRuntime corfuRuntime;
     private final CorfuStore corfuStore;
     private final Duration timeout;
     private final LivenessValidatorHelper livenessValidatorHelper;
+    private final Logger log;
 
     private static final long LIVENESS_INIT_VALUE = -1;
 
@@ -39,6 +40,7 @@ public class LivenessValidator {
         this.corfuStore = corfuStore;
         this.timeout = timeout;
         this.livenessValidatorHelper = new LivenessValidatorHelper();
+        this.log = LoggerFactory.getLogger("compactor-leader");
     }
 
     @AllArgsConstructor

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/TrimLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/TrimLog.java
@@ -1,6 +1,5 @@
 package org.corfudb.infrastructure;
 
-import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CompactorMetadataTables;
 import org.corfudb.runtime.CorfuCompactorManagement.CheckpointingStatus;
@@ -8,20 +7,23 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.proto.RpcCommon;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
-@Slf4j
 public class TrimLog {
     private final CorfuRuntime corfuRuntime;
     private final CorfuStore corfuStore;
+    private final Logger log;
 
     TrimLog(CorfuRuntime corfuRuntime, CorfuStore corfuStore) {
         this.corfuStore = corfuStore;
         this.corfuRuntime = corfuRuntime;
+        this.log = LoggerFactory.getLogger("compactor-leader");
     }
 
     private Optional<Long> getTrimAddress() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/TrimLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/TrimLog.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure;
 
+import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CompactorMetadataTables;
 import org.corfudb.runtime.CorfuCompactorManagement.CheckpointingStatus;
@@ -7,23 +8,20 @@ import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.proto.RpcCommon;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
+@Slf4j
 public class TrimLog {
     private final CorfuRuntime corfuRuntime;
     private final CorfuStore corfuStore;
-    private final Logger syslog;
 
     TrimLog(CorfuRuntime corfuRuntime, CorfuStore corfuStore) {
         this.corfuStore = corfuStore;
         this.corfuRuntime = corfuRuntime;
-        this.syslog = LoggerFactory.getLogger("syslog");
     }
 
     private Optional<Long> getTrimAddress() {
@@ -37,11 +35,11 @@ public class TrimLog {
                         CompactorMetadataTables.MIN_CHECKPOINT).getPayload();
                 trimAddress = Optional.of(trimToken.getSequence());
             } else {
-                syslog.warn("Skip trimming since last checkpointing cycle did not complete successfully");
+                log.warn("Skip trimming since last checkpointing cycle did not complete successfully");
             }
             txn.commit();
         } catch (Exception e) {
-            syslog.warn("Unable to acquire the trim token");
+            log.warn("Unable to acquire the trim token");
         }
         return trimAddress;
     }
@@ -61,7 +59,7 @@ public class TrimLog {
         corfuRuntime.getAddressSpaceView().gc();
         final long endTime = System.nanoTime();
 
-        syslog.info("Trim completed, elapsed({}s), log address up to {}.",
+        log.info("Trim completed, elapsed({}s), log address up to {}.",
                 TimeUnit.NANOSECONDS.toSeconds(endTime - startTime), trimAddress.get());
     }
 }

--- a/infrastructure/src/main/resources/compactor-logback.prod.xml
+++ b/infrastructure/src/main/resources/compactor-logback.prod.xml
@@ -27,7 +27,7 @@
             <maxIndex>10</maxIndex>
         </rollingPolicy>
         <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
-            <maxFileSize>40MB</maxFileSize>
+            <maxFileSize>50MB</maxFileSize>
         </triggeringPolicy>
         <encoder>
             <pattern>

--- a/infrastructure/src/main/resources/compactor-logback.prod.xml
+++ b/infrastructure/src/main/resources/compactor-logback.prod.xml
@@ -19,7 +19,7 @@
             </pattern>
         </encoder>
     </appender>
-    <appender name="logfile" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="compactor_file" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_DIRECTORY}/corfu-compactor-audit.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
             <fileNamePattern>${LOG_DIRECTORY}/corfu-compactor-audit.%i.log.gz</fileNamePattern>
@@ -31,13 +31,14 @@
         </triggeringPolicy>
         <encoder>
             <pattern>
-                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %msg%n%xException
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %-5level | %30.30thread | %30.30logger{30} | %msg%n%xException
             </pattern>
         </encoder>
     </appender>
+
     <!-- https://logback.qos.ch/manual/appenders.html#AsyncAppender -->
     <appender name="async_file" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="logfile" />
+        <appender-ref ref="compactor_file" />
         <queueSize>1024</queueSize>
         <maxFlushTime>5000</maxFlushTime>
     </appender>

--- a/infrastructure/src/main/resources/corfu-compactor-config.yml
+++ b/infrastructure/src/main/resources/corfu-compactor-config.yml
@@ -9,12 +9,13 @@ GCParameters:
   GCLogFileSize: 1M
 
 ConfigFiles:
-  CompactorLogPath: /usr/share/corfu/conf/compactor-logback.prod.xml
+  CompactorLogbackPath: /usr/share/corfu/conf/compactor-logback.prod.xml
   TempDir: /image/corfu-tools/temp
   ClassPath: /usr/share/corfu/lib/corfudb-tools*jar
   HeapDumpPath: /image/core/compactor_oom.hprof
 
 CorfuPaths:
+  CompactorLogfile: /var/log/corfu/corfu-compactor-audit.log
   CorfuMemLogPrefix: /dev/shm/corfu.jvm.gc.
   CorfuDiskLogDir: /var/log/corfu/jvm
 

--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -35,6 +35,22 @@
             </pattern>
         </encoder>
     </appender>
+    <appender name="compactor_leader_file" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIRECTORY}/corfu-compactor-leader.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
+            <fileNamePattern>${LOG_DIRECTORY}/corfu-compactor-leader.%i.log.gz</fileNamePattern>
+            <minIndex>1</minIndex>
+            <maxIndex>10</maxIndex>
+        </rollingPolicy>
+        <triggeringPolicy class="ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy">
+            <maxFileSize>10MB</maxFileSize>
+        </triggeringPolicy>
+        <encoder>
+            <pattern>
+                %date{yyyy-MM-dd'T'HH:mm:ss.SSSXXX, UTC} | %-5level | %30.30thread | %30.30logger{30} | %msg%n%xException
+            </pattern>
+        </encoder>
+    </appender>
 
     <!-- https://logback.qos.ch/manual/appenders.html#AsyncAppender -->
     <appender name="async_file" class="ch.qos.logback.classic.AsyncAppender">
@@ -47,12 +63,20 @@
         <queueSize>1024</queueSize>
         <maxFlushTime>5000</maxFlushTime>
     </appender>
+    <appender name="async_compactor_leader_file" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="compactor_leader_file" />
+        <queueSize>1024</queueSize>
+        <maxFlushTime>5000</maxFlushTime>
+    </appender>
 
     <logger additivity="false" level="debug" name="org.corfudb.metricsdata">
         <appender-ref ref="async_metrics_file"/>
     </logger>
     <logger name="org.corfudb.client.metricsdata" level="off" />
 
+    <logger additivity="true" name="compactor-leader" level="debug">
+	    <appender-ref ref="async_compactor_leader_file"/>
+    </logger>
     <root level="info">
         <appender-ref ref="async_file"/>
     </root>

--- a/infrastructure/src/main/resources/logback.prod.xml
+++ b/infrastructure/src/main/resources/logback.prod.xml
@@ -35,11 +35,6 @@
             </pattern>
         </encoder>
     </appender>
-    <appender name="syslog" class="ch.qos.logback.classic.net.SyslogAppender">
-        <syslogHost>localhost</syslogHost>
-        <facility>SYSLOG</facility>
-        <suffixPattern>[%thread] %-5level %msg%n%xException</suffixPattern>
-    </appender>
 
     <!-- https://logback.qos.ch/manual/appenders.html#AsyncAppender -->
     <appender name="async_file" class="ch.qos.logback.classic.AsyncAppender">
@@ -55,9 +50,6 @@
 
     <logger additivity="false" level="debug" name="org.corfudb.metricsdata">
         <appender-ref ref="async_metrics_file"/>
-    </logger>
-    <logger additivity="false" level="info" name="syslog">
-        <appender-ref ref="syslog"/>
     </logger>
     <logger name="org.corfudb.client.metricsdata" level="off" />
 

--- a/scripts/compactor_runner.py
+++ b/scripts/compactor_runner.py
@@ -19,22 +19,16 @@ import glob
 import logging
 import os
 import os.path
-import re
 import socket
 import struct
 from subprocess import check_call, check_output, STDOUT
-import sys
 import time
 import yaml
 
 CORFU_COMPACTOR_CLASS_NAME = "org.corfudb.compactor.CorfuStoreCompactorMain"
 COMPACTOR_BULK_READ_SIZE = 50
 COMPACTOR_JVM_XMX = 1024
-CORFU_COMPACTOR_LOG = "/var/log/corfu/corfu-compactor.log"
 
-logging.basicConfig(filename=CORFU_COMPACTOR_LOG,
-                    format='%(asctime)s.%(msecs)03dZ %(levelname)5s Runner - %(message)s',
-                    datefmt='%Y-%m-%dT%H:%M:%S')
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
@@ -92,7 +86,7 @@ class CommandBuilder(object):
 
         ConfigFiles = compactor_config["ConfigFiles"]
         cmd.append("-Djava.io.tmpdir=" + ConfigFiles["TempDir"])
-        cmd.append("-Dlogback.configurationFile=" + ConfigFiles["CompactorLogPath"])
+        cmd.append("-Dlogback.configurationFile=" + ConfigFiles["CompactorLogbackPath"])
         cmd.append("-XX:HeapDumpPath=" + ConfigFiles["HeapDumpPath"])
         cmd.append("-XX:OnOutOfMemoryError=\"gzip -f " + ConfigFiles["HeapDumpPath"] + "\"")
 
@@ -213,6 +207,9 @@ class Wizard(object):
         with open(self._config.configPath, "r") as config:
             compactor_config = yaml.load(config)
         corfu_paths = compactor_config["CorfuPaths"]
+        logging.basicConfig(filename=corfu_paths["CompactorLogfile"],
+                                    format='%(asctime)s.%(msecs)03dZ %(levelname)5s Runner - %(message)s',
+                                    datefmt='%Y-%m-%dT%H:%M:%S')
         # Copy mem jvm gc log files to disk
         try:
             self._rsync_log(corfu_paths["CorfuMemLogPrefix"], corfu_paths["CorfuDiskLogDir"])


### PR DESCRIPTION
Removing syslog based logging. The compactor related logs from corfu server would be logged in the server's logfile while that of the compactor jvm will be logged in another file.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
