### PR TITLE
WIP: New connection Model for LR 

### DIFF
--- a/infrastructure/proto/log_replication_metadata.proto
+++ b/infrastructure/proto/log_replication_metadata.proto
@@ -107,6 +107,7 @@ message ReplicationEvent {
   ReplicationEventType type = 3;
 }
 
+
 enum ReplicationModel {
   FULL_TABLE = 0;                 // Full table replication (Single Source to Single Sink = 1:1)
   ROUTING_QUEUES = 1;             // Routing queue replication (used for entry-level replication) (1:1)

--- a/infrastructure/proto/log_replication_transport.proto
+++ b/infrastructure/proto/log_replication_transport.proto
@@ -19,4 +19,8 @@ service LogReplicationChannel {
     // again using a provided stream. Once the client has finished writing the messages, it waits for the server
     // to read them all and return its response (ack).
     rpc replicate(stream org.corfudb.runtime.RequestMsg) returns (org.corfudb.runtime.ResponseMsg) {}
+
+    // Used when the SINK is the connection initiator. This RPC creates a long living stream, on which the source and
+    // sink exchange negotiation-msg/replication-msg/ACKs
+    rpc subscribeAndStartreplication(stream org.corfudb.runtime.ResponseMsg) returns (stream org.corfudb.runtime.RequestMsg) {}
 }

--- a/infrastructure/proto/log_replication_transport.proto
+++ b/infrastructure/proto/log_replication_transport.proto
@@ -7,7 +7,7 @@ import "google/protobuf/any.proto";
 import "service/corfu_message.proto";
 
 
-service LogReplicationChannel {
+service LogReplicationChannel{
 
     // Client sends Negotiation Request
     rpc negotiate(org.corfudb.runtime.RequestMsg) returns (org.corfudb.runtime.ResponseMsg) {}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
 import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
+import org.corfudb.runtime.clients.IClientRouter;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/AbstractServer.java
@@ -5,7 +5,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
 import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
-import org.corfudb.runtime.clients.IClientRouter;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/RequestHandlerMethods.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/RequestHandlerMethods.java
@@ -6,7 +6,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
 import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
-import org.corfudb.runtime.clients.IClientRouter;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/RequestHandlerMethods.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/RequestHandlerMethods.java
@@ -6,6 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
 import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
+import org.corfudb.runtime.clients.IClientRouter;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
 import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ClusterDescriptor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ClusterDescriptor.java
@@ -7,7 +7,8 @@ import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class describes a Cluster ore Site in terms of its Log Replication Nodes
@@ -91,6 +92,23 @@ public class ClusterDescriptor {
     @Override
     public String toString() {
         return String.format("Cluster[%s]:: role=%s, CorfuPort=%s, Nodes[%s]:  %s", getClusterId(), role, corfuPort, nodesDescriptors.size(), listToString(nodesDescriptors));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ClusterDescriptor that = (ClusterDescriptor) o;
+        return clusterId.equals(that.clusterId) && role.equals(that.role) && nodesDescriptors.equals(that.nodesDescriptors);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterId, role, nodesDescriptors);
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ClusterDescriptor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ClusterDescriptor.java
@@ -8,7 +8,6 @@ import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * This class describes a Cluster ore Site in terms of its Log Replication Nodes

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServerNode.java
@@ -1,11 +1,9 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.AbstractServer;
-import org.corfudb.infrastructure.BaseServer;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.ServerThreadFactory;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
@@ -13,8 +11,6 @@ import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkServe
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceServerRouter;
 
 import javax.annotation.Nonnull;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -30,9 +26,6 @@ public class CorfuInterClusterReplicationServerNode implements AutoCloseable {
 
     @Getter
     private final Map<Class, AbstractServer> serverMap;
-
-    @Getter
-    private Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToRouterMap = new HashMap<>();
 
     // This flag makes the closing of the CorfuServer idempotent.
     private final AtomicBoolean close;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServerNode.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuInterClusterReplicationServerNode.java
@@ -9,9 +9,12 @@ import org.corfudb.infrastructure.BaseServer;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.ServerThreadFactory;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkServerRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceServerRouter;
 
 import javax.annotation.Nonnull;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -29,7 +32,7 @@ public class CorfuInterClusterReplicationServerNode implements AutoCloseable {
     private final Map<Class, AbstractServer> serverMap;
 
     @Getter
-    private final LogReplicationServerRouter router;
+    private Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToRouterMap = new HashMap<>();
 
     // This flag makes the closing of the CorfuServer idempotent.
     private final AtomicBoolean close;
@@ -41,33 +44,36 @@ public class CorfuInterClusterReplicationServerNode implements AutoCloseable {
     // Error code required to detect an ungraceful shutdown.
     private static final int EXIT_ERROR_CODE = 100;
 
+    LogReplicationServerRouter router;
+
     /**
-     * Corfu Server initialization.
+     * Log Replication Server initialization.
      *
      * @param serverContext Initialized Server Context
-     * @param logReplicationServer Replication Server which processes incoming requests
+     * @param serverMap Servers which help process/validate incoming requests
      */
     public CorfuInterClusterReplicationServerNode(@Nonnull ServerContext serverContext,
-        LogReplicationServer logReplicationServer) {
+                                                  Map<Class, AbstractServer> serverMap) {
 
         this.serverContext = serverContext;
 
-        this.logReplicationServer = logReplicationServer;
+        this.logReplicationServer = (LogReplicationServer) serverMap.get(LogReplicationServer.class);
 
-        this.serverMap = ImmutableMap.<Class, AbstractServer>builder()
-            .put(BaseServer.class, new BaseServer(serverContext))
-            .put(LogReplicationServer.class, logReplicationServer)
-            .build();
+        this.serverMap = serverMap;
 
         this.close = new AtomicBoolean(false);
-        this.router = new LogReplicationServerRouter(new ArrayList<>(serverMap.values()));
-        this.serverContext.setServerRouter(router);
 
         logReplicationServerRunner = Executors.newSingleThreadScheduledExecutor(new ThreadFactoryBuilder()
             .setNameFormat("replication-server-runner").build());
+    }
 
+    public void setRouterAndStartServer(Map<ReplicationSession, LogReplicationSourceServerRouter> sessionToSourceServer,
+                                        Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServer) {
+
+        this.router = new LogReplicationServerRouter(serverMap, this.serverContext, sessionToSourceServer, sessionToSinkServer);
+        this.serverContext.setServerRouter(router);
         // Start and listen to the server
-        logReplicationServerRunner.submit(this::startAndListen);
+        logReplicationServerRunner.submit(() -> this.startAndListen());
     }
 
     /**
@@ -75,8 +81,8 @@ public class CorfuInterClusterReplicationServerNode implements AutoCloseable {
      */
     private void startAndListen() {
         try {
-            log.info("Starting server transport adapter...");
-            router.getServerAdapter().start().get();
+            log.info("Starting server transport adapter ...");
+            this.router.getServerAdapter().start().get();
         } catch (InterruptedException e) {
             // The server can be interrupted and stopped on a role switch.
             // It should not be treated as fatal
@@ -121,7 +127,6 @@ public class CorfuInterClusterReplicationServerNode implements AutoCloseable {
         }
         log.info("close: Shutting down Log Replication server and cleaning resources");
         serverContext.close();
-        cleanupResources();
     }
 
     private void cleanupResources() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryServiceAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryServiceAdapter.java
@@ -27,4 +27,8 @@ public interface CorfuReplicationDiscoveryServiceAdapter {
 
 
     LogReplicationClusterInfo.ClusterRole getLocalClusterRoleType();
+
+    ClusterDescriptor getLocalCluster();
+
+    String getLocalNodeId();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -140,15 +140,13 @@ public class CorfuReplicationManager {
         }
         LogReplicationSourceRouterHelper router;
         if (isConnectionStarter) {
-            LogReplicationSourceClientRouter sourceClientRouter = new LogReplicationSourceClientRouter(remote,
+            router = new LogReplicationSourceClientRouter(remote,
                     localNodeDescriptor.getClusterId(), createRuntimeParams(remote, session), this,
-                    session);
-            router = sourceClientRouter;
+                    session);;
         } else {
-            LogReplicationSourceServerRouter sourceServerRouter = new LogReplicationSourceServerRouter(remote,
+            router = new LogReplicationSourceServerRouter(remote,
                     localNodeDescriptor.getClusterId(), createRuntimeParams(remote, session), this,
-                    session, serverMap);
-            router = sourceServerRouter;
+                    session, serverMap);;
         }
         replicationSessionToRouterSource.put(session, router);
         createRuntime(remote, session);
@@ -248,6 +246,7 @@ public class CorfuReplicationManager {
      * Stop log replication for all the sink sites
      */
     public void stop() {
+        //Stop the source component
         remoteSesionToRuntime.forEach((session, runtime) -> {
             try {
                 log.info("Stop log replication runtime and source router for session={}", session);
@@ -260,6 +259,9 @@ public class CorfuReplicationManager {
         remoteSesionToRuntime.clear();
         replicationSessionToRouterSource.clear();
         replicationSessionToRuntimeParams.clear();
+
+        //Stop the sink component
+        replicationSessionToRouterSink.values().stream().forEach(router -> ((LogReplicationSinkClientRouter)router).stop());
     }
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -1,19 +1,26 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
+import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.AbstractServer;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationHandler;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkClientRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkServerRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceClientRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceRouterHelper;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceServerRouter;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.IntervalRetry;
 import org.corfudb.util.retry.RetryNeededException;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -24,7 +31,8 @@ import java.util.Set;
 public class CorfuReplicationManager {
 
     // Keep map of remote session and the associated log replication runtime (an abstract client to that cluster)
-    private final Map<ReplicationSession, CorfuLogReplicationRuntime> runtimeToRemoteSession = new HashMap<>();
+    @Getter
+    private final Map<ReplicationSession, CorfuLogReplicationRuntime> remoteSesionToRuntime = new HashMap<>();
 
     @Setter
     private LogReplicationContext context;
@@ -39,6 +47,10 @@ public class CorfuReplicationManager {
 
     private final LogReplicationConfigManager replicationConfigManager;
 
+    private final Map<ReplicationSession, LogReplicationSourceRouterHelper> replicationSessionToRouterSource;
+    private final Map<ReplicationSession, LogReplicationSinkServerRouter> replicationSessionToRouterSink;
+    private final Map<ReplicationSession, LogReplicationRuntimeParameters> replicationSessionToRuntimeParams;
+
     /**
      * Constructor
      */
@@ -52,55 +64,148 @@ public class CorfuReplicationManager {
         this.corfuRuntime = corfuRuntime;
         this.localNodeDescriptor = localNodeDescriptor;
         this.replicationConfigManager = replicationConfigManager;
+        this.replicationSessionToRouterSource = new HashMap<>();
+        this.replicationSessionToRouterSink = new HashMap<>();
+        this.replicationSessionToRuntimeParams = new HashMap<>();
     }
 
     /**
-     * Start Log Replication Manager, this will initiate a runtime against
-     * each Sink session(cluster + replication model + client), to further start log replication.
+     * Used when the local cluster is a connection initiator.
+     * If local cluster is a source, creates a runtime and a sourceRouter
+     * If local cluster is a sink, creates a router and starts the sink-server node.
      */
-    public void start() {
-        for (ClusterDescriptor remoteCluster : context.getTopology().getSinkClusters().values()) {
-            for (ReplicationSubscriber subscriber : context.getConfig().getReplicationSubscriberToStreamsMap().keySet()) {
-                try {
-                    startLogReplicationRuntime(remoteCluster, new ReplicationSession(remoteCluster.getClusterId(),
-                        subscriber));
-                } catch (Exception e) {
-                    log.error("Failed to start log replication runtime for remote session {}, replication model {}, " +
-                        "client {}", remoteCluster.getClusterId(), subscriber.getReplicationModel(),
-                        subscriber.getClient());
+    public void startConnection(Set<ClusterDescriptor> remoteClusters,
+                                Map<String, Set<ReplicationSession>> remoteClusterIdToReplicationSession,
+                                Map<Class, AbstractServer> serverMap) {
+
+        for(ClusterDescriptor remote : remoteClusters) {
+            Set<ReplicationSession> sessions = remoteClusterIdToReplicationSession.get(remote.getClusterId());
+            log.info("Starting connection to remote {} and session {} ", remote, sessions);
+
+            for(ReplicationSession session : sessions) {
+                if (!context.getTopology().getRemoteSinkClusters().isEmpty() &&
+                        context.getTopology().getRemoteSinkClusters().containsKey(remote.getClusterId())) {
+                    LogReplicationSourceRouterHelper router = getOrCreateSourceRouter(remote,session, serverMap, true);
+                    try {
+                        IRetry.build(IntervalRetry.class, () -> {
+                            try {
+                                if(router instanceof LogReplicationSourceClientRouter) {
+                                    ((LogReplicationSourceClientRouter) router).connect();
+                                }
+                            } catch (Exception e) {
+                                log.error("Exception {}. Failed to connect to remote cluster for session {}. Retry after 1 second.",
+                                        e, session);
+                                throw new RetryNeededException();
+                            }
+                            return null;
+                        }).run();
+                    } catch (InterruptedException e) {
+                        log.error("Unrecoverable exception when attempting to connect to remote session.", e);
+                    }
+                } else if (!this.context.getTopology().getRemoteSourceClusters().isEmpty() &&
+                        this.context.getTopology().getRemoteSourceClusters().containsKey(remote.getClusterId())) {
+                    LogReplicationSinkServerRouter router = getOrCreateSinkRouter(remote,session, serverMap, true);
+                    try {
+                        IRetry.build(IntervalRetry.class, () -> {
+                            try {
+                                if(router instanceof LogReplicationSinkClientRouter) {
+                                    ((LogReplicationSinkClientRouter) router).connect();
+                                }
+                            } catch (Exception e) {
+                                log.error("Exception {}. Failed to connect to remote cluster for session {}. Retry after 1 second.",
+                                        e, session);
+                                throw new RetryNeededException();
+                            }
+                            return null;
+                        }).run();
+                    } catch (InterruptedException e) {
+                        log.error("Unrecoverable exception when attempting to connect to remote session.", e);
+                    }
+                } else {
+                    log.warn("Not connecting to cluster {} as it is neither a source nor a sink to the current cluster", remote);
+                    continue;
                 }
             }
+
         }
     }
 
     /**
-     * Stop log replication for all the sink sites
+     * Creates a source router if not already created,
+     * A source-client router if cluster is connection starter else a source-server router
      */
-    public void stop() {
-        runtimeToRemoteSession.values().forEach(runtime -> {
-            try {
-                log.info("Stop log replication runtime to remote cluster id={}", runtime.getRemoteClusterId());
-                runtime.stop();
-            } catch (Exception e) {
-                log.warn("Failed to stop log replication runtime to remote cluster id={}", runtime.getRemoteClusterId());
-            }
-        });
-        runtimeToRemoteSession.clear();
+    public LogReplicationSourceRouterHelper getOrCreateSourceRouter(ClusterDescriptor remote, ReplicationSession session,
+                                                                    Map<Class, AbstractServer> serverMap, boolean isConnectionStarter) {
+        if (replicationSessionToRouterSource.containsKey(session)) {
+            return replicationSessionToRouterSource.get(session);
+        }
+        LogReplicationSourceRouterHelper router;
+        if (isConnectionStarter) {
+            LogReplicationSourceClientRouter sourceClientRouter = new LogReplicationSourceClientRouter(remote,
+                    localNodeDescriptor.getClusterId(), createRuntimeParams(remote, session), this,
+                    session);
+            router = sourceClientRouter;
+        } else {
+            LogReplicationSourceServerRouter sourceServerRouter = new LogReplicationSourceServerRouter(remote,
+                    localNodeDescriptor.getClusterId(), createRuntimeParams(remote, session), this,
+                    session, serverMap);
+            router = sourceServerRouter;
+        }
+        replicationSessionToRouterSource.put(session, router);
+        createRuntime(remote, session);
+        router.setRuntimeFSM(remoteSesionToRuntime.get(session));
+
+        return router;
     }
 
     /**
-     * Start Log Replication Runtime to a specific Sink Session
+     * Creates a sink router if not already created,
+     * A sink-client router if cluster is connection starter else a sink-server router
      */
-    private void startLogReplicationRuntime(ClusterDescriptor remoteClusterDescriptor,
-                                            ReplicationSession replicationSession) {
+    public LogReplicationSinkServerRouter getOrCreateSinkRouter(ClusterDescriptor remote, ReplicationSession session,
+                                                                Map<Class, AbstractServer> serverMap, boolean isConnectionStarter) {
+        if (replicationSessionToRouterSink.containsKey(session)) {
+            return replicationSessionToRouterSink.get(session);
+        }
+        LogReplicationSinkServerRouter router;
+        if(isConnectionStarter) {
+            LogReplicationSinkClientRouter sinkClientRouter = new LogReplicationSinkClientRouter(remote,
+                    localNodeDescriptor.getClusterId(), pluginFilePath, corfuRuntime.getParameters()
+                    .getRequestTimeout().toMillis(), session, serverMap);
+            sinkClientRouter.addClient(new LogReplicationHandler(session));
+            router = sinkClientRouter;
+        } else {
+            LogReplicationSinkServerRouter sinkServerRouter = new LogReplicationSinkServerRouter(serverMap, false);
+            router = sinkServerRouter;
+        }
+        replicationSessionToRouterSink.put(session, router);
+        return router;
+    }
+
+    /**
+     * Create Log Replication Runtime for a session, if not already created.
+     */
+    public void createRuntime(ClusterDescriptor remote, ReplicationSession replicationSession) {
         try {
-            if (!runtimeToRemoteSession.containsKey(replicationSession)) {
-                log.info("Starting Log Replication Runtime for session {}", replicationSession);
-                connect(remoteClusterDescriptor, replicationSession);
-            } else {
-                log.warn("Log Replication Runtime to remote session {}, already exists. Skipping init.",
-                    replicationSession);
-            }
+            CorfuLogReplicationRuntime replicationRuntime;
+                if (!remoteSesionToRuntime.containsKey(replicationSession)) {
+                    log.info("Starting Log Replication Runtime for session {}", replicationSession);
+                    LogReplicationRuntimeParameters parameters;
+                    // parameters is null when the cluster is not the connection starter.
+                    if (replicationSessionToRuntimeParams.isEmpty() || replicationSessionToRuntimeParams.get(replicationSession) == null) {
+                        parameters = createRuntimeParams(remote, replicationSession);
+                    } else {
+                        parameters = replicationSessionToRuntimeParams.get(replicationSession);
+                    }
+                    replicationRuntime = new CorfuLogReplicationRuntime(parameters,
+                            metadataManagerMap.get(replicationSession), replicationConfigManager, replicationSession,
+                            replicationSessionToRouterSource.get(replicationSession));
+                    remoteSesionToRuntime.put(replicationSession, replicationRuntime);
+                } else {
+                    log.warn("Log Replication Runtime to remote session {}, already exists. Skipping init.",
+                            replicationSession);
+                    return;
+                }
         } catch (Exception e) {
             log.error("Caught exception, stop log replication runtime to {}", replicationSession, e);
             stopLogReplicationRuntime(replicationSession);
@@ -108,76 +213,98 @@ public class CorfuReplicationManager {
     }
 
     /**
-     * Connect to a remote Log Replicator, through a Log Replication Runtime.
-     *
-     * @throws InterruptedException
+     * Start log replication.
+     * For the connection initiator cluster, this is called when the connection is established.
      */
-    private void connect(ClusterDescriptor remoteCluster, ReplicationSession session) throws InterruptedException {
-        try {
-            IRetry.build(IntervalRetry.class, () -> {
-                try {
-                    LogReplicationRuntimeParameters parameters = LogReplicationRuntimeParameters.builder()
-                            .localCorfuEndpoint(context.getLocalCorfuEndpoint())
-                            .remoteClusterDescriptor(remoteCluster)
-                            .localClusterId(localNodeDescriptor.getClusterId())
-                            .replicationConfig(context.getConfig())
-                            .pluginFilePath(pluginFilePath)
-                            .topologyConfigId(context.getTopology().getTopologyConfigId())
-                            .keyStore(corfuRuntime.getParameters().getKeyStore())
-                            .tlsEnabled(corfuRuntime.getParameters().isTlsEnabled())
-                            .ksPasswordFile(corfuRuntime.getParameters().getKsPasswordFile())
-                            .trustStore(corfuRuntime.getParameters().getTrustStore())
-                            .tsPasswordFile(corfuRuntime.getParameters().getTsPasswordFile())
-                            .maxWriteSize(corfuRuntime.getParameters().getMaxWriteSize())
-                            .build();
-                    CorfuLogReplicationRuntime replicationRuntime = new CorfuLogReplicationRuntime(parameters,
-                        metadataManagerMap.get(session), replicationConfigManager, session);
-                    replicationRuntime.start();
-                    runtimeToRemoteSession.put(session, replicationRuntime);
-                } catch (Exception e) {
-                    log.error("Exception {}. Failed to connect to remote cluster for session {}. Retry after 1 second.",
-                        e, session);
-                    throw new RetryNeededException();
-                }
-                return null;
-            }).run();
-        } catch (InterruptedException e) {
-            log.error("Unrecoverable exception when attempting to connect to remote session.", e);
-            throw e;
+    public void startRuntime(ReplicationSession replicationSession) {
+        CorfuLogReplicationRuntime replicationRuntime;
+        synchronized (this) {
+            replicationRuntime = remoteSesionToRuntime.get(replicationSession);
         }
+        replicationRuntime.start();
+    }
+
+    private LogReplicationRuntimeParameters createRuntimeParams(ClusterDescriptor remoteCluster, ReplicationSession session) {
+        LogReplicationRuntimeParameters parameters = LogReplicationRuntimeParameters.builder()
+                .localCorfuEndpoint(context.getLocalCorfuEndpoint())
+                .remoteClusterDescriptor(remoteCluster)
+                .localClusterId(localNodeDescriptor.getClusterId())
+                .replicationConfig(context.getConfig())
+                .pluginFilePath(pluginFilePath)
+                .topologyConfigId(context.getTopology().getTopologyConfigId())
+                .keyStore(corfuRuntime.getParameters().getKeyStore())
+                .tlsEnabled(corfuRuntime.getParameters().isTlsEnabled())
+                .ksPasswordFile(corfuRuntime.getParameters().getKsPasswordFile())
+                .trustStore(corfuRuntime.getParameters().getTrustStore())
+                .tsPasswordFile(corfuRuntime.getParameters().getTsPasswordFile())
+                .maxWriteSize(corfuRuntime.getParameters().getMaxWriteSize())
+                .build();
+
+        replicationSessionToRuntimeParams.put(session, parameters);
+
+        return parameters;
+    }
+
+    /**
+     * Stop log replication for all the sink sites
+     */
+    public void stop() {
+        remoteSesionToRuntime.forEach((session, runtime) -> {
+            try {
+                log.info("Stop log replication runtime and source router for session={}", session);
+                runtime.stop();
+                replicationSessionToRouterSource.get(session).stop();
+            } catch (Exception e) {
+                log.warn("Failed to stop log replication runtime for session={}", session);
+            }
+        });
+        remoteSesionToRuntime.clear();
+        replicationSessionToRouterSource.clear();
+        replicationSessionToRuntimeParams.clear();
     }
 
     /**
      * Stop Log Replication to a specific Sink session
      */
     private void stopLogReplicationRuntime(ReplicationSession replicationSession) {
-        CorfuLogReplicationRuntime logReplicationRuntime = runtimeToRemoteSession.get(replicationSession);
+        CorfuLogReplicationRuntime logReplicationRuntime = remoteSesionToRuntime.get(replicationSession);
         if (logReplicationRuntime != null) {
-            log.info("Stop log replication runtime for remote session {}", replicationSession);
+            log.info("Stop log replication runtime and source router for remote session {}", replicationSession);
             logReplicationRuntime.stop();
-            runtimeToRemoteSession.remove(replicationSession);
+            replicationSessionToRouterSource.get(replicationSession).stop();
+
+            remoteSesionToRuntime.remove(replicationSession);
+            replicationSessionToRouterSource.remove(replicationSession);
+            replicationSessionToRuntimeParams.remove(replicationSession);
         } else {
             log.warn("Runtime not found for remote session {}", replicationSession);
         }
+    }
+
+    public void clearSessionToSinkRouterMap() {
+        this.replicationSessionToRouterSink.clear();
     }
 
     /**
      * Update Log Replication Runtime config id.
      */
     private void updateRuntimeConfigId(TopologyDescriptor newConfig) {
-        runtimeToRemoteSession.values().forEach(runtime -> runtime.updateFSMConfigId(newConfig));
+        remoteSesionToRuntime.values().forEach(runtime -> runtime.updateFSMConfigId(newConfig));
     }
 
     /**
      * The notification of adding/removing Sinks with/without topology configId change.
      *
      * @param newConfig should have the same topologyConfigId as the current config
-     * @param sinksToAdd the new sink clusters to be added
-     * @param sinksToRemove sink clusters which are not found in the new topology
+     * @param remoteSinkClustersToAdd the new sink clusters to be added
+     * @param remoteSourceClusterToAdd the new source clusters to be added
+     * @param remoteClustersToRemove sink clusters which are not found in the new topology
      * @param intersection Sink clusters found in both old and new topologies
      */
-    public void processSinkChange(TopologyDescriptor newConfig, Set<String> sinksToAdd, Set<String> sinksToRemove,
-                                  Set<String> intersection) {
+    public void processSinkChange(TopologyDescriptor newConfig, Set<String> remoteSinkClustersToAdd, Set<String> remoteSourceClusterToAdd,
+                                  Set<String> remoteClustersToRemove, Set<String> intersection, Map<String, ClusterDescriptor> connectionEndsIdToDescriptor,
+                                  Map<String, Set<ReplicationSession>> remoteIdToReplicationSession,
+                                  CorfuInterClusterReplicationServerNode interClusterServerNode, Map<Class, AbstractServer> serverMap) {
 
         long oldTopologyConfigId = context.getTopology().getTopologyConfigId();
         context.setTopology(newConfig);
@@ -186,26 +313,43 @@ public class CorfuReplicationManager {
         Set<ReplicationSubscriber> subscribers = context.getConfig().getReplicationSubscriberToStreamsMap().keySet();
 
         // Remove Sinks that are not in the new config
-        for (String clusterId : sinksToRemove) {
+        for (String clusterId : remoteClustersToRemove) {
             for (ReplicationSubscriber subscriber : subscribers) {
-                stopLogReplicationRuntime(new ReplicationSession(clusterId, subscriber));
+                stopLogReplicationRuntime(new ReplicationSession(clusterId, localNodeDescriptor.getClusterId(), subscriber));
             }
         }
 
         // Start the newly added Sinks
-        for (String clusterId : sinksToAdd) {
-            ClusterDescriptor clusterInfo = newConfig.getSinkClusters().get(clusterId);
-            for (ReplicationSubscriber subscriber : subscribers) {
-                startLogReplicationRuntime(clusterInfo, new ReplicationSession(clusterId, subscriber));
+        Set<ClusterDescriptor> newConnectionToStart = new HashSet<>();
+        Set<String> remoteClustersToAdd = new HashSet<>();
+        remoteClustersToAdd.addAll(remoteSinkClustersToAdd);
+        remoteClustersToAdd.addAll(remoteSourceClusterToAdd);
+
+        for (String clusterId : remoteClustersToAdd) {
+            // When the local cluster is the connection initiator to the newly added sink, collect the remoteSinks to start connections
+            if(connectionEndsIdToDescriptor.containsKey(clusterId)) {
+                newConnectionToStart.add(connectionEndsIdToDescriptor.get(clusterId));
+            } else {
+                if (remoteSinkClustersToAdd.contains(clusterId)) {
+                    remoteIdToReplicationSession.get(clusterId).stream().forEach(session -> {
+                        getOrCreateSourceRouter(connectionEndsIdToDescriptor.get(clusterId), session, serverMap, false);
+                        startRuntime(session);
+                    });
+                } else {
+                    remoteIdToReplicationSession.get(clusterId).stream().forEach(session -> {
+                        getOrCreateSinkRouter(connectionEndsIdToDescriptor.get(clusterId), session, serverMap, false);
+                    });
+                }
             }
         }
+        startConnection(newConnectionToStart, remoteIdToReplicationSession, serverMap);
 
         // The connection id or other transportation plugin's info could've changed for existing Sink clusters,
         // updating the routers will re-establish the connection to the correct endpoints/nodes
         for (String clusterId : intersection) {
-            ClusterDescriptor clusterInfo = newConfig.getSinkClusters().get(clusterId);
+            ClusterDescriptor clusterInfo = newConfig.getRemoteSinkClusters().get(clusterId);
             for (ReplicationSubscriber subscriber : subscribers) {
-                runtimeToRemoteSession.get(new ReplicationSession(clusterId, subscriber))
+                remoteSesionToRuntime.get(new ReplicationSession(clusterId, localNodeDescriptor.getClusterId(), subscriber))
                     .updateRouterClusterDescriptor(clusterInfo);
             }
         }
@@ -219,8 +363,8 @@ public class CorfuReplicationManager {
      * Stop the current log replication event and start a full snapshot sync for the given remote cluster.
      */
     public void enforceSnapshotSync(DiscoveryServiceEvent event) {
-        CorfuLogReplicationRuntime sinkRuntime = runtimeToRemoteSession.get(
-            ReplicationSession.getDefaultReplicationSessionForCluster(event.getRemoteClusterInfo().getClusterId()));
+        CorfuLogReplicationRuntime sinkRuntime = remoteSesionToRuntime.get(
+            ReplicationSession.getDefaultReplicationSessionForCluster(event.getRemoteClusterInfo().getClusterId(), localNodeDescriptor.getClusterId()));
         if (sinkRuntime == null) {
             log.warn("Failed to start enforceSnapshotSync for cluster {} as no runtime to it was found",
                 event.getRemoteClusterInfo().getClusterId());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -81,6 +81,9 @@ public class CorfuReplicationManager {
         for(ClusterDescriptor remote : remoteClusters) {
             Set<ReplicationSession> sessions = remoteClusterIdToReplicationSession.get(remote.getClusterId());
             log.info("Starting connection to remote {} and session {} ", remote, sessions);
+            if(sessions.isEmpty()) {
+                continue;
+            }
 
             for(ReplicationSession session : sessions) {
                 if (!context.getTopology().getRemoteSinkClusters().isEmpty() &&
@@ -293,7 +296,7 @@ public class CorfuReplicationManager {
     }
 
     /**
-     * The notification of adding/removing Sinks with/without topology configId change.
+     * The notification of adding/removing remote clusters with/without topology configId change.
      *
      * @param newConfig should have the same topologyConfigId as the current config
      * @param remoteSinkClustersToAdd the new sink clusters to be added
@@ -301,10 +304,10 @@ public class CorfuReplicationManager {
      * @param remoteClustersToRemove sink clusters which are not found in the new topology
      * @param intersection Sink clusters found in both old and new topologies
      */
-    public void processSinkChange(TopologyDescriptor newConfig, Set<String> remoteSinkClustersToAdd, Set<String> remoteSourceClusterToAdd,
-                                  Set<String> remoteClustersToRemove, Set<String> intersection, Map<String, ClusterDescriptor> connectionEndsIdToDescriptor,
-                                  Map<String, Set<ReplicationSession>> remoteIdToReplicationSession,
-                                  CorfuInterClusterReplicationServerNode interClusterServerNode, Map<Class, AbstractServer> serverMap) {
+    public void processRemoteClusterChange(TopologyDescriptor newConfig, Set<String> remoteSinkClustersToAdd, Set<String> remoteSourceClusterToAdd,
+                                           Set<String> remoteClustersToRemove, Set<String> intersection, Map<String, ClusterDescriptor> connectionEndsIdToDescriptor,
+                                           Map<String, Set<ReplicationSession>> remoteIdToReplicationSession,
+                                           CorfuInterClusterReplicationServerNode interClusterServerNode, Map<Class, AbstractServer> serverMap) {
 
         long oldTopologyConfigId = context.getTopology().getTopologyConfigId();
         context.setTopology(newConfig);
@@ -319,7 +322,7 @@ public class CorfuReplicationManager {
             }
         }
 
-        // Start the newly added Sinks
+        // Add the new clusters
         Set<ClusterDescriptor> newConnectionToStart = new HashSet<>();
         Set<String> remoteClustersToAdd = new HashSet<>();
         remoteClustersToAdd.addAll(remoteSinkClustersToAdd);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationServer.java
@@ -259,7 +259,7 @@ public class LogReplicationServer extends AbstractServer {
      * @param ctx Channel context
      * @param router Client router for sending the NACK
      */
-    private void sendLeadershipLoss(@Nonnull RequestMsg request,
+    public void sendLeadershipLoss(@Nonnull RequestMsg request,
         @Nonnull ChannelHandlerContext ctx, @Nonnull IServerRouter router) {
         HeaderMsg responseHeader = getHeaderMsg(request.getHeader());
         ResponseMsg response = getLeadershipLoss(responseHeader, localNodeId);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationServer.java
@@ -53,8 +53,6 @@ public class LogReplicationServer extends AbstractServer {
     // node id should be the only identifier for a node in the topology
     private String localNodeId;
 
-    private String localClusterId;
-
     private final ExecutorService executor;
 
     private static final String EXECUTOR_NAME_PREFIX = "LogReplicationServer-";
@@ -76,10 +74,8 @@ public class LogReplicationServer extends AbstractServer {
     public LogReplicationServer(@Nonnull ServerContext context, String localNodeId,
                                 LogReplicationConfigManager configManager,
                                 String localEndpoint, long topologyConfigId,
-                                Map<ReplicationSession, LogReplicationMetadataManager> sourceSessionToMetadataManagerMap,
-                                String localClusterId) {
+                                Map<ReplicationSession, LogReplicationMetadataManager> sourceSessionToMetadataManagerMap) {
         this.localNodeId = localNodeId;
-        this.localClusterId = localClusterId;
         createSinkManagers(configManager, localEndpoint, context, sourceSessionToMetadataManagerMap, topologyConfigId);
         this.executor = context.getExecutorService(1, EXECUTOR_NAME_PREFIX);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/NodeDescriptor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/NodeDescriptor.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.NodeConfigurationMsg;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
@@ -51,6 +52,24 @@ public class NodeDescriptor {
     @Override
     public String toString() {
         return String.format("Node: %s, %s", nodeId, getEndpoint());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        NodeDescriptor that = (NodeDescriptor) o;
+        return clusterId.equals(that.clusterId) && connectionId.equals(that.connectionId) && host.equals(that.host) &&
+                nodeId.equals(that.nodeId) && port.equals(that.port);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(clusterId, connectionId, host, nodeId, port);
     }
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/NodeDescriptor.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/NodeDescriptor.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.NodeConfigurationMsg;
 
 import java.util.Objects;
-import java.util.UUID;
 
 /**
  * This class represents a Log Replication Node

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSession.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSession.java
@@ -1,8 +1,11 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.Getter;
+import org.corfudb.runtime.LogReplication;
 
 import java.util.Objects;
+
+import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.SAMPLE_CLIENT;
 
 
 /**
@@ -26,11 +29,15 @@ public class ReplicationSession {
     @Getter
     private final String remoteClusterId;
 
+    @Getter
+    private final String localClusterId;
+
    @Getter
    private final ReplicationSubscriber subscriber;
 
-    public ReplicationSession(String remoteClusterId, ReplicationSubscriber subscriber) {
+    public ReplicationSession(String remoteClusterId, String localClusterId, ReplicationSubscriber subscriber) {
         this.remoteClusterId = remoteClusterId;
+        this.localClusterId = localClusterId;
         this.subscriber = subscriber;
     }
 
@@ -43,17 +50,19 @@ public class ReplicationSession {
             return false;
         }
         ReplicationSession that = (ReplicationSession) o;
-        return remoteClusterId.equals(that.remoteClusterId) && subscriber.equals(that.subscriber);
+        return remoteClusterId.equals(that.remoteClusterId) && localClusterId.equals(that.localClusterId)
+                && subscriber.equals(that.subscriber);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(remoteClusterId, subscriber);
+        return Objects.hash(remoteClusterId, localClusterId, subscriber);
     }
 
     // TODO: To be removed after session is introduced in connections
-    public static ReplicationSession getDefaultReplicationSessionForCluster(String remoteClusterId) {
-        return new ReplicationSession(remoteClusterId, ReplicationSubscriber.getDefaultReplicationSubscriber());
+    public static ReplicationSession getDefaultReplicationSessionForCluster(String remoteClusterId, String localClusterId) {
+        return new ReplicationSession(remoteClusterId, localClusterId,
+            new ReplicationSubscriber(LogReplication.ReplicationModel.FULL_TABLE, SAMPLE_CLIENT));
     }
 
     @Override
@@ -61,7 +70,9 @@ public class ReplicationSession {
         return new StringBuffer()
             .append("Remote Cluster: ")
             .append(remoteClusterId)
-            .append(" Replication Subscriber: ")
+            .append("Local Cluster: ")
+            .append(localClusterId)
+            .append("Replication Subscriber: ")
             .append(subscriber)
             .toString();
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSubscriber.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSubscriber.java
@@ -1,7 +1,8 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.Getter;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationModel;
+import org.corfudb.runtime.LogReplication;
+
 import java.util.Objects;
 
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.SAMPLE_CLIENT;
@@ -19,12 +20,13 @@ import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.SAM
 public class ReplicationSubscriber {
 
     @Getter
-    private final ReplicationModel replicationModel;
+    private final LogReplication.ReplicationModel replicationModel;
 
     @Getter
     private final String client;
 
-    public ReplicationSubscriber(ReplicationModel model, String client) {
+
+    public ReplicationSubscriber(LogReplication.ReplicationModel model, String client) {
         this.replicationModel = model;
         this.client = client;
     }
@@ -42,7 +44,11 @@ public class ReplicationSubscriber {
             return false;
         }
         ReplicationSubscriber that = (ReplicationSubscriber) o;
-        return replicationModel == that.getReplicationModel() && client.equals(that.getClient());
+        return replicationModel == that.replicationModel && client.equals(that.client);
+    }
+
+    public static ReplicationSubscriber getDefaultReplicationSubscriber() {
+        return new ReplicationSubscriber(LogReplication.ReplicationModel.FULL_TABLE, SAMPLE_CLIENT);
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSubscriber.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSubscriber.java
@@ -30,10 +30,7 @@ public class ReplicationSubscriber {
         this.replicationModel = model;
         this.client = client;
     }
-
-    public static ReplicationSubscriber getDefaultReplicationSubscriber() {
-        return new ReplicationSubscriber(ReplicationModel.FULL_TABLE, SAMPLE_CLIENT);
-    }
+    
 
     @Override
     public boolean equals(Object o) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
@@ -2,10 +2,14 @@ package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
 import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationDiscoveryServiceAdapter;
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationDiscoveryServiceException;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo.TopologyConfigurationMsg;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.runtime.LogReplication;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -59,4 +63,19 @@ public interface CorfuReplicationClusterManagerAdapter {
      * @param clusterId
      */
     UUID forceSnapshotSync(String clusterId) throws LogReplicationDiscoveryServiceException;
+
+    /**
+     * This API is used to fetch the remote SOURCE clusters and the supported replication models against it.
+     */
+    Map<LogReplicationClusterInfo.ClusterConfigurationMsg, Set<LogReplication.ReplicationModel>> getRemoteSourceToReplicationModels();
+
+    /**
+     * This API is used to fetch the remote SINK clusters and the supported replication models against it..
+     */
+    Map<LogReplicationClusterInfo.ClusterConfigurationMsg, Set<LogReplication.ReplicationModel>> getRemoteSinkForReplicationModels();
+
+    /**
+     * This API is used to fetch the remote clusters that are the connection endpoints for the local cluster.
+     */
+    Set<LogReplicationClusterInfo.ClusterConfigurationMsg> fetchConnectionEndpoints();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
@@ -7,7 +7,6 @@ import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.runtime.LogReplication;
 
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -65,17 +64,23 @@ public interface CorfuReplicationClusterManagerAdapter {
     UUID forceSnapshotSync(String clusterId) throws LogReplicationDiscoveryServiceException;
 
     /**
-     * This API is used to fetch the remote SOURCE clusters and the supported replication models against it.
+     * This API is used to fetch the remote SOURCE clusters (w.r.t local cluster) and the supported replication models against it.
+     *
+     * @return Map of remote cluster that acts as SOURCE for a corresponding replication model.
      */
     Map<LogReplicationClusterInfo.ClusterConfigurationMsg, Set<LogReplication.ReplicationModel>> getRemoteSourceToReplicationModels();
 
     /**
-     * This API is used to fetch the remote SINK clusters and the supported replication models against it..
+     * This API is used to fetch the remote SINK clusters (w.r.t local cluster) and the supported replication models against it.
+     *
+     * @return Map of remote cluster that acts as SINK for a corresponding replication model.
      */
     Map<LogReplicationClusterInfo.ClusterConfigurationMsg, Set<LogReplication.ReplicationModel>> getRemoteSinkForReplicationModels();
 
     /**
      * This API is used to fetch the remote clusters that are the connection endpoints for the local cluster.
+     *
+     * @return ClusterConfigurationMsg
      */
     Set<LogReplicationClusterInfo.ClusterConfigurationMsg> fetchConnectionEndpoints();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/CorfuReplicationClusterManagerAdapter.java
@@ -75,7 +75,7 @@ public interface CorfuReplicationClusterManagerAdapter {
      *
      * @return Map of remote cluster that acts as SINK for a corresponding replication model.
      */
-    Map<LogReplicationClusterInfo.ClusterConfigurationMsg, Set<LogReplication.ReplicationModel>> getRemoteSinkForReplicationModels();
+    Map<LogReplicationClusterInfo.ClusterConfigurationMsg, Set<LogReplication.ReplicationModel>> getRemoteSinkToReplicationModels();
 
     /**
      * This API is used to fetch the remote clusters that are the connection endpoints for the local cluster.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultAdapterForUpgrade.java
@@ -2,7 +2,6 @@ package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.TxnContext;
 
+
 /**
  * Default testing implementation of a Log Replication Config Provider
  */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultLogReplicationConfigAdapter.java
@@ -3,7 +3,6 @@ package org.corfudb.infrastructure.logreplication.infrastructure.plugins;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.TxnContext;
 
-
 /**
  * Default testing implementation of a Log Replication Config Provider
  */

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/LogReplicationPluginConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/LogReplicationPluginConfig.java
@@ -27,8 +27,14 @@ public class LogReplicationPluginConfig {
 
     // Transport Plugin
     public static final String DEFAULT_JAR_PATH = "/infrastructure/target/infrastructure-0.3.1-SNAPSHOT.jar";
-    public static final String DEFAULT_SERVER_CLASSNAME = "org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationServerChannelAdapter";
-    public static final String DEFAULT_CLIENT_CLASSNAME = "org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationClientChannelAdapter";
+
+    // Since the change is focused on GRPC.
+    // TODO: Shama to remove uncomment/remove the default transport, once the change for netty is in
+//    public static final String DEFAULT_SERVER_CLASSNAME = "org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationServerChannelAdapter";
+//    public static final String DEFAULT_CLIENT_CLASSNAME = "org.corfudb.infrastructure.logreplication.transport.sample.NettyLogReplicationClientChannelAdapter";
+
+    public static final String DEFAULT_SERVER_CLASSNAME = "org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationServerChannelAdapter";
+    public static final String DEFAULT_CLIENT_CLASSNAME = "org.corfudb.infrastructure.logreplication.transport.sample.GRPCLogReplicationClientChannelAdapter";
 
     // Stream Fetcher Plugin
     public static final String DEFAULT_STREAM_FETCHER_JAR_PATH = "/target/infrastructure-0.3.1-SNAPSHOT.jar";
@@ -109,8 +115,6 @@ public class LogReplicationPluginConfig {
 
             this.nodeIdFilePath = null;
         }
-
-        log.debug("{} ", this);
     }
 
     private static String getParentDir() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/LogReplicationPluginConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/LogReplicationPluginConfig.java
@@ -115,6 +115,8 @@ public class LogReplicationPluginConfig {
 
             this.nodeIdFilePath = null;
         }
+
+        log.debug("{} ", this);
     }
 
     private static String getParentDir() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -65,7 +65,6 @@ public class LogReplicationAckReader {
 
     private final Lock lock = new ReentrantLock();
 
-
     public LogReplicationAckReader(LogReplicationMetadataManager metadataManager, LogReplicationConfigManager configManager,
                                    CorfuRuntime runtime, ReplicationSession replicationSession) {
         this.metadataManager = metadataManager;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -65,6 +65,7 @@ public class LogReplicationAckReader {
 
     private final Lock lock = new ReentrantLock();
 
+
     public LogReplicationAckReader(LogReplicationMetadataManager metadataManager, LogReplicationConfigManager configManager,
                                    CorfuRuntime runtime, ReplicationSession replicationSession) {
         this.metadataManager = metadataManager;
@@ -355,7 +356,7 @@ public class LogReplicationAckReader {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
                     lock.lock();
-                    metadataManager.updateSnapshotSyncStatusCompleted(remoteClusterId,
+                    metadataManager.updateSnapshotSyncStatusCompleted(replicationSession,
                             calculateRemainingEntriesToSend(baseSnapshotTimestamp), baseSnapshotTimestamp);
                 } catch (TransactionAbortedException tae) {
                     log.error("Error while attempting to markSnapshotSyncInfoCompleted for remote cluster {}.", remoteClusterId, tae);
@@ -381,7 +382,7 @@ public class LogReplicationAckReader {
                 try {
                     lock.lock();
                     long remainingEntriesToSend = calculateRemainingEntriesToSend(lastAckedTimestamp);
-                    metadataManager.updateSnapshotSyncStatusOngoing(remoteClusterId, forced, eventId,
+                    metadataManager.updateSnapshotSyncStatusOngoing(replicationSession, forced, eventId,
                             baseSnapshotTimestamp, remainingEntriesToSend);
                 } catch (TransactionAbortedException tae) {
                     log.error("Error while attempting to markSnapshotSyncInfoOngoing for event {}.", eventId, tae);
@@ -406,7 +407,7 @@ public class LogReplicationAckReader {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
                     lock.lock();
-                    metadataManager.updateSyncStatus(remoteClusterId, SyncType.SNAPSHOT, SyncStatus.ONGOING);
+                    metadataManager.updateSyncStatus(replicationSession, SyncType.SNAPSHOT, SyncStatus.ONGOING);
                 } catch (TransactionAbortedException tae) {
                     log.error("Error while attempting to markSnapshotSyncInfoOngoing for cluster {}.", remoteClusterId, tae);
                     throw new RetryNeededException();
@@ -427,7 +428,7 @@ public class LogReplicationAckReader {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
                     lock.lock();
-                    metadataManager.updateSyncStatus(remoteClusterId, lastSyncType, status);
+                    metadataManager.updateSyncStatus(replicationSession, lastSyncType, status);
                 } catch (TransactionAbortedException tae) {
                     log.error("Error while attempting to markSyncStatus as {}.", status, tae);
                     throw new RetryNeededException();
@@ -479,7 +480,7 @@ public class LogReplicationAckReader {
                     try {
                         lock.lock();
                         long entriesToSend = calculateRemainingEntriesToSend(lastAckedTimestamp);
-                        metadataManager.setReplicationStatusTable(remoteClusterId, entriesToSend, lastSyncType);
+                        metadataManager.setReplicationStatusTable(replicationSession, entriesToSend, lastSyncType);
                     } catch (TransactionAbortedException tae) {
                         log.error("Error while attempting to set replication status for " +
                                         "remote cluster {} with lastSyncType {}.",

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -210,6 +210,9 @@ public class LogReplicationFSM {
     @Getter
     private final LogReplicationAckReader ackReader;
 
+    @Getter
+    private final ReplicationSession replicationSession;
+
     /**
      * Constructor for LogReplicationFSM, custom read processor for data transformation.
      *
@@ -238,7 +241,7 @@ public class LogReplicationFSM {
         this.logReplicationFSMConsumer = Executors.newSingleThreadExecutor(new
                 ThreadFactoryBuilder().setNameFormat("replication-fsm-consumer-" + session.getRemoteClusterId())
                 .build());
-
+        this.replicationSession = session;
         init(dataSender, session);
     }
 
@@ -271,6 +274,7 @@ public class LogReplicationFSM {
         this.logReplicationFSMConsumer = Executors.newSingleThreadExecutor(new
                 ThreadFactoryBuilder().setNameFormat("replication-fsm-consumer-" + session.getRemoteClusterId())
                 .build());
+        this.replicationSession = session;
 
         init(dataSender, session);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/TestSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/TestSnapshotReader.java
@@ -1,9 +1,11 @@
 package org.corfudb.infrastructure.logreplication.replication.fsm;
 
 import com.google.protobuf.ByteString;
-import org.corfudb.infrastructure.logreplication.replication.send.logreader.SnapshotReader;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.SnapshotReadMessage;
+import org.corfudb.infrastructure.logreplication.replication.send.logreader.SnapshotReader;
 import org.corfudb.runtime.CorfuRuntime;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMetadataMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryType;
@@ -42,8 +44,11 @@ public class TestSnapshotReader extends SnapshotReader {
 
     private List<Long> seqNumsToRead;
 
-    public TestSnapshotReader(TestReaderConfiguration config) {
+    private final ReplicationSession replicationSession;
+
+    public TestSnapshotReader(TestReaderConfiguration config, ReplicationSession replicationSession) {
         this.config = config;
+        this.replicationSession = replicationSession;
         this.baseSnapshot = config.getNumEntries() + offset;
         this.runtime = new CorfuRuntime(config.getEndpoint()).connect();
     }
@@ -52,7 +57,6 @@ public class TestSnapshotReader extends SnapshotReader {
     public SnapshotReadMessage read(UUID snapshotRequestId) {
         // Connect to endpoint
         List<LogReplicationEntryMsg> messages = new ArrayList<>();
-
         for (long i : seqNumsToRead) {
             Object data = runtime.getAddressSpaceView().read(i).getPayload(runtime);
             LogReplicationEntryMetadataMsg metadata = LogReplicationEntryMetadataMsg.newBuilder()
@@ -61,6 +65,12 @@ public class TestSnapshotReader extends SnapshotReader {
                     .setTimestamp(i)
                     .setSnapshotTimestamp(baseSnapshot)
                     .setSyncRequestId(getUuidMsg(snapshotRequestId))
+                    .setSessionInfo(LogReplication.ReplicationSessionMsg.newBuilder()
+                            .setRemoteClusterId(this.replicationSession.getRemoteClusterId())
+                            .setLocalClusterId(this.replicationSession.getLocalClusterId())
+                            .setClient(this.replicationSession.getSubscriber().getClient())
+                            .setReplicationModel(this.replicationSession.getSubscriber().getReplicationModel())
+                            .build())
                     .build();
 
             messages.add(getLrEntryMsg(ByteString.copyFrom((byte[]) data), metadata));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.Timer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.LogReplicationMetadataKey;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.LogReplicationMetadataVal;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationEvent;
@@ -65,7 +66,7 @@ public class LogReplicationMetadataManager {
     @Getter
     private final CorfuRuntime runtime;
 
-    private final String remoteClusterId;
+    private final ReplicationSession replicationSession;
 
     private final Table<ReplicationStatusKey, ReplicationStatusVal, Message> replicationStatusTable;
     private final Table<LogReplicationMetadataKey, LogReplicationMetadataVal, Message> metadataTable;
@@ -73,11 +74,11 @@ public class LogReplicationMetadataManager {
 
     private Optional<Timer.Sample> snapshotSyncTimerSample = Optional.empty();
 
-    public LogReplicationMetadataManager(CorfuRuntime rt, long topologyConfigId, String remoteClusterId) {
+    public LogReplicationMetadataManager(CorfuRuntime rt, long topologyConfigId, ReplicationSession replicationSession) {
         this.runtime = rt;
         this.corfuStore = new CorfuStore(runtime);
 
-        metadataTableName = getPersistedWriterMetadataTableName(remoteClusterId);
+        metadataTableName = getPersistedWriterMetadataTableName(replicationSession.getRemoteClusterId());
         try {
             this.metadataTable = this.corfuStore.openTable(NAMESPACE,
                 metadataTableName,
@@ -100,7 +101,7 @@ public class LogReplicationMetadataManager {
                 null,
                 TableOptions.fromProtoSchema(ReplicationEvent.class));
 
-            this.remoteClusterId = remoteClusterId;
+            this.replicationSession = replicationSession;
         } catch (Exception e) {
             log.error("Caught an exception while opening MetadataManagerTables ", e);
             throw new ReplicationWriterException(e);
@@ -204,7 +205,7 @@ public class LogReplicationMetadataManager {
         return queryMetadata(LogReplicationMetadataType.LAST_LOG_ENTRY_APPLIED);
     }
 
-    public ResponseMsg getMetadataResponse(HeaderMsg header) {
+    public ResponseMsg getMetadataResponse(HeaderMsg header, ReplicationSession sourceSession) {
         LogReplication.LogReplicationMetadataResponseMsg metadataMsg = LogReplication.LogReplicationMetadataResponseMsg
                 .newBuilder()
                 .setTopologyConfigID(getTopologyConfigId())
@@ -212,6 +213,12 @@ public class LogReplicationMetadataManager {
                 .setSnapshotStart(getLastStartedSnapshotTimestamp())
                 .setSnapshotTransferred(getLastTransferredSnapshotTimestamp())
                 .setSnapshotApplied(getLastAppliedSnapshotTimestamp())
+                .setSessionInfo(LogReplication.ReplicationSessionMsg.newBuilder()
+                        .setRemoteClusterId(replicationSession.getRemoteClusterId())
+                        .setLocalClusterId(replicationSession.getLocalClusterId())
+                        .setClient(replicationSession.getSubscriber().getClient())
+                        .setReplicationModel(replicationSession.getSubscriber().getReplicationModel())
+                        .build())
                 .setLastLogEntryTimestamp(getLastProcessedLogEntryBatchTimestamp()).build();
         CorfuMessage.ResponsePayloadMsg payload = CorfuMessage.ResponsePayloadMsg.newBuilder()
                 .setLrMetadataResponse(metadataMsg).build();
@@ -406,11 +413,12 @@ public class LogReplicationMetadataManager {
      *
      * Note: TransactionAbortedException has been handled by upper level.
      *
-     * @param clusterId sink cluster id
+     * @param session
      */
-    public void updateSnapshotSyncStatusOngoing(String clusterId, boolean forced, UUID eventId,
+    public void updateSnapshotSyncStatusOngoing(ReplicationSession session, boolean forced, UUID eventId,
                                                 long baseVersion, long remainingEntries) {
-        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(clusterId).build();
+        LogReplication.ReplicationSessionMsg sessionKey = buildReplicationStatusKey(session);
+        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(session.getRemoteClusterId()).build();
 
         SnapshotSyncInfo.SnapshotSyncType syncType = forced ?
                 SnapshotSyncInfo.SnapshotSyncType.FORCED :
@@ -438,8 +446,7 @@ public class LogReplicationMetadataManager {
         // Start the timer for log replication snapshot sync duration metrics.
         snapshotSyncTimerSample = MeterRegistryProvider.getInstance().map(Timer::start);
 
-        log.debug("syncStatus :: set snapshot sync status to ONGOING, clusterId: {}, syncInfo: [{}]",
-                clusterId, syncInfo);
+        log.debug("syncStatus :: set snapshot sync status to ONGOING, session: {}, syncInfo: [{}]", sessionKey, syncInfo);
     }
 
     /**
@@ -448,13 +455,13 @@ public class LogReplicationMetadataManager {
      *
      * Note: TransactionAbortedException has been handled by upper level.
      *
-     * @param clusterId sink cluster id
+     * @param session
      */
-    public void updateSnapshotSyncStatusCompleted(String clusterId, long remainingEntriesToSend, long baseSnapshot) {
+    public void updateSnapshotSyncStatusCompleted(ReplicationSession session, long remainingEntriesToSend, long baseSnapshot) {
         Instant time = Instant.now();
         Timestamp timestamp = Timestamp.newBuilder().setSeconds(time.getEpochSecond())
                 .setNanos(time.getNano()).build();
-        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(clusterId).build();
+        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(session.getRemoteClusterId()).build();
 
         try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
 
@@ -487,8 +494,8 @@ public class LogReplicationMetadataManager {
                                     return sample.stop(timer);
                                 }));
 
-                log.debug("syncStatus :: set snapshot sync to COMPLETED and log entry ONGOING, clusterId: {}," +
-                                " syncInfo: [{}]", clusterId, currentSyncInfo);
+                log.debug("syncStatus :: set snapshot sync to COMPLETED and log entry ONGOING, session: {}," +
+                                " syncInfo: [{}]", key, currentSyncInfo);
             }
         }
     }
@@ -498,10 +505,10 @@ public class LogReplicationMetadataManager {
      *
      * Note: TransactionAbortedException has been handled by upper level.
      *
-     * @param clusterId sink cluster id
+     * @param session
      */
-    public void updateSyncStatus(String clusterId, SyncType lastSyncType, SyncStatus status) {
-        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(clusterId).build();
+    public void updateSyncStatus(ReplicationSession session, SyncType lastSyncType, SyncStatus status) {
+        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(session.getRemoteClusterId()).build();
 
         try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
 
@@ -513,7 +520,7 @@ public class LogReplicationMetadataManager {
             // (STOPPED status is used for other FSM states as well, so cannot rely only on the incoming status)
             if(record.getPayload() == null && status == SyncStatus.STOPPED) {
                 log.debug("syncStatus :: ignoring update for {} to syncType {} and status {} as no record exists for the same",
-                        clusterId, lastSyncType, status);
+                        session.getRemoteClusterId(), lastSyncType, status);
                 return;
             }
 
@@ -532,7 +539,7 @@ public class LogReplicationMetadataManager {
             txn.commit();
         }
 
-        log.debug("syncStatus :: Update, clusterId: {}, type: {}, status: {}", clusterId, lastSyncType, status);
+        log.debug("syncStatus :: Update, session: {}, type: {}, status: {}", key, lastSyncType, status);
     }
 
     /**
@@ -541,18 +548,18 @@ public class LogReplicationMetadataManager {
      *
      * Note: TransactionAbortedException has been handled by upper level.
      *
-     * @param clusterId sink cluster id
+     * @param session
      * @param remainingEntries num of remaining entries to send
      * @param type sync type
      */
-    public void setReplicationStatusTable(String clusterId, long remainingEntries, SyncType type) {
-        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(clusterId).build();
+    public void setReplicationStatusTable(ReplicationSession session, long remainingEntries, SyncType type) {
+        ReplicationStatusKey sessionKey = ReplicationStatusKey.newBuilder().setClusterId(session.getRemoteClusterId()).build();
         SnapshotSyncInfo snapshotStatus = null;
         ReplicationStatusVal current;
         ReplicationStatusVal previous = null;
 
         try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-            CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, Message> record = txn.getRecord(replicationStatusTable, key);
+            CorfuStoreEntry<ReplicationStatusKey, ReplicationStatusVal, Message> record = txn.getRecord(replicationStatusTable, sessionKey);
             if (record.getPayload() != null) {
                 previous = record.getPayload();
                 snapshotStatus = previous.getSnapshotSyncInfo();
@@ -570,7 +577,7 @@ public class LogReplicationMetadataManager {
             }
 
             if (snapshotStatus == null){
-                log.warn("syncStatusPoller [logEntry]:: previous snapshot status is not present for cluster: {}", clusterId);
+                log.warn("syncStatusPoller [logEntry]:: previous snapshot status is not present for session: {}", sessionKey);
                 snapshotStatus = SnapshotSyncInfo.newBuilder().build();
             }
 
@@ -582,17 +589,17 @@ public class LogReplicationMetadataManager {
                     .build();
 
             try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-                txn.putRecord(replicationStatusTable, key, current, null);
+                txn.putRecord(replicationStatusTable, sessionKey, current, null);
                 txn.commit();
             }
 
-            log.debug("syncStatusPoller :: Log Entry status set to ONGOING, clusterId: {}, remainingEntries: {}, " +
-                            "snapshotSyncInfo: {}", clusterId, remainingEntries, snapshotStatus);
+            log.debug("syncStatusPoller :: Log Entry status set to ONGOING, session: {}, remainingEntries: {}, " +
+                            "snapshotSyncInfo: {}", sessionKey, remainingEntries, snapshotStatus);
         } else if (type == SyncType.SNAPSHOT) {
 
             SnapshotSyncInfo currentSnapshotSyncInfo;
             if (snapshotStatus == null){
-                log.warn("syncStatusPoller [snapshot] :: previous status is not present for cluster: {}", clusterId);
+                log.warn("syncStatusPoller [snapshot] :: previous status is not present for session: {}", sessionKey);
                 currentSnapshotSyncInfo = SnapshotSyncInfo.newBuilder().build();
             } else {
 
@@ -616,12 +623,12 @@ public class LogReplicationMetadataManager {
                     .build();
 
             try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
-                txn.putRecord(replicationStatusTable, key, current, null);
+                txn.putRecord(replicationStatusTable, sessionKey, current, null);
                 txn.commit();
             }
 
-            log.debug("syncStatusPoller :: sync status for {} set to ONGOING, clusterId: {}, remainingEntries: {}",
-                    type, clusterId, remainingEntries);
+            log.debug("syncStatusPoller :: sync status for {} set to ONGOING, session: {}, remainingEntries: {}",
+                    type, sessionKey, remainingEntries);
         }
     }
 
@@ -657,24 +664,21 @@ public class LogReplicationMetadataManager {
      * @param isConsistent data is consistent or not
      */
     public void setDataConsistentOnSink(boolean isConsistent) {
-        ReplicationStatusKey key =
-            ReplicationStatusKey.newBuilder().setClusterId(remoteClusterId).build();
+        ReplicationStatusKey sessionKey = ReplicationStatusKey.newBuilder().setClusterId(this.replicationSession.getRemoteClusterId()).build();
         ReplicationStatusVal val = ReplicationStatusVal.newBuilder()
                 .setDataConsistent(isConsistent)
                 .setStatus(SyncStatus.UNAVAILABLE)
                 .build();
         try (TxnContext txn = getTxnContext()) {
-            txn.putRecord(replicationStatusTable, key, val, null);
+            txn.putRecord(replicationStatusTable, sessionKey, val, null);
             txn.commit();
         }
 
-        log.debug("setDataConsistentOnSink: remoteClusterId: {}, " +
-            "isConsistent: {}", remoteClusterId, isConsistent);
+        log.debug("setDataConsistentOnSink: session: {}, isConsistent: {}", sessionKey, isConsistent);
     }
 
     public void setDataConsistentOnSink(boolean isConsistent, TxnContext txn) {
-        ReplicationStatusKey key =
-            ReplicationStatusKey.newBuilder().setClusterId(remoteClusterId).build();
+        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(this.replicationSession.getRemoteClusterId()).build();
         ReplicationStatusVal val = ReplicationStatusVal.newBuilder()
             .setDataConsistent(isConsistent)
             .setStatus(SyncStatus.UNAVAILABLE)
@@ -693,11 +697,11 @@ public class LogReplicationMetadataManager {
     // Initialize the ReplicationStatus table with a default entry depending on the role.
     // If the role is Source, the default sync type=LOG_ENTRY and status=NOT_STARTED.
     // If the role is Sink and no record for the remote cluster is found, isDataConsistent=false.
-    public void initReplicationStatus(boolean isSource) {
-        ReplicationStatusKey key = ReplicationStatusKey.newBuilder().setClusterId(remoteClusterId).build();
+    public void initReplicationStatus(ReplicationSession session, boolean isSource) {
+        ReplicationStatusKey sessionKey = ReplicationStatusKey.newBuilder().setClusterId(this.replicationSession.getRemoteClusterId()).build();
         try (TxnContext txn = corfuStore.txn(NAMESPACE)) {
             ReplicationStatusVal currentVal =
-                (ReplicationStatusVal) txn.getRecord(REPLICATION_STATUS_TABLE, key).getPayload();
+                (ReplicationStatusVal) txn.getRecord(REPLICATION_STATUS_TABLE, sessionKey).getPayload();
 
             if (currentVal == null) {
                 currentVal = ReplicationStatusVal.newBuilder().build();
@@ -707,7 +711,7 @@ public class LogReplicationMetadataManager {
             if (isSource) {
                 newVal = currentVal.toBuilder().setSyncType(SyncType.LOG_ENTRY).setStatus(SyncStatus.NOT_STARTED).build();
             }
-            txn.putRecord(replicationStatusTable, key, newVal, null);
+            txn.putRecord(replicationStatusTable, sessionKey, newVal, null);
             txn.commit();
         }
     }
@@ -820,6 +824,15 @@ public class LogReplicationMetadataManager {
             txn.commit();
         }
         log.debug("successfully deleted clusterID {} from {}", clusterId, REPLICATION_STATUS_TABLE);
+    }
+
+    private LogReplication.ReplicationSessionMsg buildReplicationStatusKey(ReplicationSession session) {
+        return LogReplication.ReplicationSessionMsg.newBuilder()
+                .setRemoteClusterId(session.getRemoteClusterId())
+                .setLocalClusterId(session.getLocalClusterId())
+                .setClient(session.getSubscriber().getClient())
+                .setReplicationModel(session.getSubscriber().getReplicationModel())
+                .build();
     }
 
     public void shutdown() {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -263,7 +263,6 @@ public class LogReplicationSinkManager implements DataReceiver {
         rxMessageCount.setValue(rxMessageCounter);
 
         log.debug("Sink manager received {} while in {}", message.getMetadata().getEntryType(), rxState);
-
         // Ignore messages that have different topologyConfigId.
         // It could be caused by an out-of-date sender or the local node hasn't done the site discovery yet.
         // If there is a siteConfig change, the discovery service will detect it and reset the state.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -262,7 +262,8 @@ public class LogReplicationSinkManager implements DataReceiver {
         rxMessageCounter++;
         rxMessageCount.setValue(rxMessageCounter);
 
-        log.debug("Sink manager received {} while in {}", message.getMetadata().getEntryType(), rxState);
+        log.debug("Sink manager received {} while in {} from cluster {}", message.getMetadata().getEntryType(), rxState,
+                message.getMetadata().getSessionInfo().getLocalClusterId());
 
         // Ignore messages that have different topologyConfigId.
         // It could be caused by an out-of-date sender or the local node hasn't done the site discovery yet.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -263,6 +263,7 @@ public class LogReplicationSinkManager implements DataReceiver {
         rxMessageCount.setValue(rxMessageCounter);
 
         log.debug("Sink manager received {} while in {}", message.getMetadata().getEntryType(), rxState);
+
         // Ignore messages that have different topologyConfigId.
         // It could be caused by an out-of-date sender or the local node hasn't done the site discovery yet.
         // If there is a siteConfig change, the discovery service will detect it and reset the state.

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SnapshotSinkBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SnapshotSinkBufferManager.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure.logreplication.replication.receive;
 
 import com.google.protobuf.TextFormat;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMetadataMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryType;
@@ -57,9 +58,15 @@ public class SnapshotSinkBufferManager extends SinkBufferManager {
      */
     @Override
     public LogReplicationEntryMetadataMsg generateAckMetadata(LogReplicationEntryMsg entry) {
+        LogReplication.ReplicationSessionMsg entrySession = entry.getMetadata().getSessionInfo();
         LogReplicationEntryMetadataMsg.Builder metadata = LogReplicationEntryMetadataMsg
                 .newBuilder()
-                .mergeFrom(entry.getMetadata());
+                .mergeFrom(entry.getMetadata())
+                .setSessionInfo(LogReplication.ReplicationSessionMsg.newBuilder()
+                        .mergeFrom(entrySession)
+                        .setRemoteClusterId(entrySession.getLocalClusterId())
+                        .setLocalClusterId(entrySession.getRemoteClusterId())
+                        .build());
 
         /*
          * If SNAPSHOT_END message has been processed, send back SNAPSHOT_TRANSFER_COMPLETE to notify

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
@@ -163,7 +163,6 @@ public abstract class SenderBufferManager {
         if (!pendingCompletableFutureForAcks.isEmpty()) {
             ack = (LogReplicationEntryMsg) CompletableFuture.anyOf(pendingCompletableFutureForAcks
                     .values().toArray(new CompletableFuture<?>[pendingCompletableFutureForAcks.size()])).get(timeoutTimer, TimeUnit.MILLISECONDS);
-
             if (ack != null) {
                 updateAck(ack);
                 ackCounter.ifPresent(ac -> ac.addAndGet(pendingCompletableFutureForAcks.size()));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SenderBufferManager.java
@@ -163,6 +163,7 @@ public abstract class SenderBufferManager {
         if (!pendingCompletableFutureForAcks.isEmpty()) {
             ack = (LogReplicationEntryMsg) CompletableFuture.anyOf(pendingCompletableFutureForAcks
                     .values().toArray(new CompletableFuture<?>[pendingCompletableFutureForAcks.size()])).get(timeoutTimer, TimeUnit.MILLISECONDS);
+
             if (ack != null) {
                 updateAck(ack);
                 ackCounter.ifPresent(ac -> ac.addAndGet(pendingCompletableFutureForAcks.size()));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/SnapshotSender.java
@@ -236,6 +236,12 @@ public class SnapshotSender {
                 .setPreviousTimestamp(Address.NON_ADDRESS)
                 .setSnapshotTimestamp(baseSnapshotTimestamp)
                 .setSnapshotSyncSeqNum(Address.NON_ADDRESS)
+                .setSessionInfo(LogReplication.ReplicationSessionMsg.newBuilder()
+                        .setRemoteClusterId(fsm.getReplicationSession().getRemoteClusterId())
+                        .setLocalClusterId(fsm.getReplicationSession().getLocalClusterId())
+                        .setClient(fsm.getReplicationSession().getSubscriber().getClient())
+                        .setReplicationModel(fsm.getReplicationSession().getSubscriber().getReplicationModel())
+                        .build())
                 .build();
         return getLrEntryAckMsg(metadata);
     }
@@ -249,6 +255,12 @@ public class SnapshotSender {
                 .setPreviousTimestamp(Address.NON_ADDRESS)
                 .setSnapshotTimestamp(baseSnapshotTimestamp)
                 .setSnapshotSyncSeqNum(Address.NON_ADDRESS)
+                .setSessionInfo(LogReplication.ReplicationSessionMsg.newBuilder()
+                        .setRemoteClusterId(fsm.getReplicationSession().getRemoteClusterId())
+                        .setLocalClusterId(fsm.getReplicationSession().getLocalClusterId())
+                        .setClient(fsm.getReplicationSession().getSubscriber().getClient())
+                        .setReplicationModel(fsm.getReplicationSession().getSubscriber().getReplicationModel())
+                        .build())
                 .build();
         return getLrEntryAckMsg(metadata);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
@@ -124,6 +124,12 @@ public class StreamsSnapshotReader extends SnapshotReader {
                 .setPreviousTimestamp(preMsgTs)
                 .setSnapshotTimestamp(snapshotTimestamp)
                 .setSnapshotSyncSeqNum(sequence)
+                .setSessionInfo(LogReplication.ReplicationSessionMsg.newBuilder()
+                        .setRemoteClusterId(this.replicationSession.getRemoteClusterId())
+                        .setLocalClusterId(this.replicationSession.getLocalClusterId())
+                        .setClient(this.replicationSession.getSubscriber().getClient())
+                        .setReplicationModel(this.replicationSession.getSubscriber().getReplicationModel())
+                        .build())
                 .build();
 
         LogReplicationEntryMsg txMsg = getLrEntryMsg(unsafeWrap(generatePayload(opaqueEntry)), metadata);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -148,7 +148,7 @@ public class CorfuLogReplicationRuntime {
      */
     private final LinkedBlockingQueue<LogReplicationRuntimeEvent> eventQueue = new LinkedBlockingQueue<>();
 
-    private final LogReplicationSourceRouterHelper router;
+    private final LogReplicationBaseSourceRouter router;
     private final LogReplicationMetadataManager metadataManager;
 
     @Getter
@@ -163,7 +163,7 @@ public class CorfuLogReplicationRuntime {
      * Default Constructor
      */
     public CorfuLogReplicationRuntime(LogReplicationRuntimeParameters parameters, LogReplicationMetadataManager metadataManager,
-        LogReplicationConfigManager replicationConfigManager, ReplicationSession replicationSession, LogReplicationSourceRouterHelper router) {
+        LogReplicationConfigManager replicationConfigManager, ReplicationSession replicationSession, LogReplicationBaseSourceRouter router) {
         this.remoteClusterId = replicationSession.getRemoteClusterId();
         this.metadataManager = metadataManager;
         this.router = router;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -188,7 +188,6 @@ public class CorfuLogReplicationRuntime {
         this.state = states.get(LogReplicationRuntimeStateType.WAITING_FOR_CONNECTIVITY);
 
         log.info("Log Replication Runtime State Machine initialized");
-
     }
 
     /**
@@ -231,7 +230,6 @@ public class CorfuLogReplicationRuntime {
                 // Not accepting events, in stopped state
                 return;
             }
-
             eventQueue.put(event);
         } catch (InterruptedException ex) {
             log.error("Log Replication interrupted Exception: ", ex);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationBaseSourceRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationBaseSourceRouter.java
@@ -39,7 +39,7 @@ import static org.corfudb.protocols.service.CorfuProtocolMessage.getDefaultProto
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
 
 @Slf4j
-public class LogReplicationSourceRouterHelper implements IClientRouter {
+public class LogReplicationBaseSourceRouter implements IClientRouter {
 
     public static String REMOTE_LEADER = "REMOTE_LEADER";
 
@@ -125,9 +125,9 @@ public class LogReplicationSourceRouterHelper implements IClientRouter {
      * @param replicationManager replicationManager to start FSM
      * @param session replication session between current and remote cluster
      */
-    public LogReplicationSourceRouterHelper(ClusterDescriptor remoteCluster, String localClusterId,
-                                            LogReplicationRuntimeParameters parameters, CorfuReplicationManager replicationManager,
-                                            ReplicationSession session, boolean isConnectionInitiator) {
+    public LogReplicationBaseSourceRouter(ClusterDescriptor remoteCluster, String localClusterId,
+                                          LogReplicationRuntimeParameters parameters, CorfuReplicationManager replicationManager,
+                                          ReplicationSession session, boolean isConnectionInitiator) {
         this.timeoutResponse = parameters.getRequestTimeout().toMillis();
         this.remoteClusterDescriptor = remoteCluster;
         this.localClusterId = localClusterId;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
@@ -1,402 +1,47 @@
 package org.corfudb.infrastructure.logreplication.runtime;
 
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
-import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
-import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
-import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
-import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent.LogReplicationRuntimeEventType;
-import org.corfudb.infrastructure.logreplication.transport.client.ChannelAdapterException;
-import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
-import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
-import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
-import org.corfudb.runtime.clients.IClient;
-import org.corfudb.runtime.clients.IClientRouter;
-import org.corfudb.runtime.exceptions.NetworkException;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
-import org.corfudb.runtime.proto.RpcCommon;
 import org.corfudb.runtime.proto.service.CorfuMessage;
-import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
-import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
-import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg.PayloadCase;
-import org.corfudb.util.CFUtils;
 
-import javax.annotation.Nonnull;
-import java.io.File;
-import java.net.URL;
-import java.net.URLClassLoader;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
-
-import static org.corfudb.protocols.CorfuProtocolCommon.getUuidMsg;
-import static org.corfudb.protocols.service.CorfuProtocolMessage.getDefaultProtocolVersionMsg;
-import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
-
-/**
- * This Client Router is used when a custom (client-defined) transport layer is specified for
- * Log Replication Server communication.
- */
-@Slf4j
-public class LogReplicationClientRouter implements IClientRouter {
-
-    public static String REMOTE_LEADER = "REMOTE_LEADER";
-
-    @Getter
-    private final LogReplicationRuntimeParameters parameters;
+public interface LogReplicationClientRouter {
 
     /**
-     * The handlers registered to this router.
+     * Connect to remote cluster through the specified channel adapter
      */
-    private final Map<PayloadCase, IClient> handlerMap;
+    void connect();
 
     /**
-     * The clients registered to this router.
-     */
-    public final List<IClient> clientList;
-
-    /**
-     * Whether or not this router is shutdown.
-     */
-    public volatile boolean shutdown;
-
-    /**
-     * A {@link CompletableFuture} which is completed when a connection,
-     * including a successful handshake completes and messages can be sent
-     * to the remote node.
-     */
-    @Getter
-    private volatile CompletableFuture<Void> remoteLeaderConnectionFuture;
-
-    /**
-     * The current request ID.
-     */
-    @Getter
-    @SuppressWarnings("checkstyle:abbreviation")
-    public AtomicLong requestID;
-
-    /**
-     * Sync call response timeout (milliseconds).
-     */
-    @Getter
-    @Setter
-    public long timeoutResponse;
-
-    /**
-     * The outstanding requests on this router.
-     */
-    public final Map<Long, CompletableFuture> outstandingRequests;
-
-    /**
-     * Adapter to the channel implementation
-     */
-    private IClientChannelAdapter channelAdapter;
-
-    /**
-     * Remote Cluster/Site Full Descriptor
-     */
-    private final ClusterDescriptor remoteClusterDescriptor;
-
-    /**
-     * Remote Cluster/Site unique identifier
-     */
-    private final String remoteClusterId;
-
-    /**
-     * Runtime FSM, to insert connectivity events
-     */
-    private final CorfuLogReplicationRuntime runtimeFSM;
-
-    /**
-     * Log Replication Client Constructor
+     * Connection Up Callback.
      *
-     * @param parameters runtime parameters (including connection settings)
-     * @param runtimeFSM runtime state machine, insert connection related events
+     * @param nodeId id of the remote node to which connection was established.
      */
-    public LogReplicationClientRouter(LogReplicationRuntimeParameters parameters,
-                                      CorfuLogReplicationRuntime runtimeFSM) {
-        this.remoteClusterDescriptor = parameters.getRemoteClusterDescriptor();
-        this.remoteClusterId = remoteClusterDescriptor.getClusterId();
-        this.parameters = parameters;
-        this.timeoutResponse = parameters.getRequestTimeout().toMillis();
-        this.runtimeFSM = runtimeFSM;
-
-        this.handlerMap = new ConcurrentHashMap<>();
-        this.clientList = new ArrayList<>();
-        this.requestID = new AtomicLong();
-        this.outstandingRequests = new ConcurrentHashMap<>();
-        this.remoteLeaderConnectionFuture = new CompletableFuture<>();
-    }
-
-    // ------------------- IClientRouter Interface ----------------------
-
-    @Override
-    public IClientRouter addClient(IClient client) {
-        // Set the client's router to this instance.
-        client.setRouter(this);
-
-        // Iterate through all types of CorfuMsgType, registering the handler
-        try {
-            client.getHandledCases().forEach(x -> {
-                handlerMap.put(x, client);
-                log.info("Registered client to handle messages of type {}", x);
-            });
-        } catch (UnsupportedOperationException ex) {
-            log.trace("No registered CorfuMsg handler for client {}", client, ex);
-        }
-
-        // Register this type
-        clientList.add(client);
-        return this;
-    }
+    void onConnectionUp(String nodeId);
 
     /**
-     * Send a request message and get a completable future to be fulfilled by the reply.
+     * Connection Down Callback.
      *
-     * @param payload
-     * @param <T> The type of completable to return.
-     * @return A completable future which will be fulfilled by the reply,
-     * or a timeout in the case there is no response.
+     * @param nodeId id of the remote node to which connection came down.
      */
-    @Override
-    public <T> CompletableFuture<T> sendRequestAndGetCompletable(
-            @Nonnull RequestPayloadMsg payload,
-            @Nonnull String nodeId) {
-
-        HeaderMsg.Builder header = HeaderMsg.newBuilder()
-                .setVersion(getDefaultProtocolVersionMsg())
-                .setIgnoreClusterId(true)
-                .setIgnoreEpoch(true);
-
-        if (isValidMessage(payload)) {
-            // Get the next request ID.
-            final long requestId = requestID.getAndIncrement();
-
-            // Generate a future and put it in the completion table.
-            final CompletableFuture<T> cf = new CompletableFuture<>();
-            outstandingRequests.put(requestId, cf);
-
-            try {
-                header.setClientId(getUuidMsg(parameters.getClientId()));
-                header.setRequestId(requestId);
-                header.setClusterId(getUuidMsg(
-                    UUID.fromString(parameters.getLocalClusterId())));
-
-                // If no endpoint is specified, the message is to be sent to the remote leader node.
-                // We should block until a connection to the leader is established.
-                if (nodeId.equals(REMOTE_LEADER)) {
-                    // Check the connection future. If connected, continue with sending the message.
-                    // If timed out, return a exceptionally completed with the timeout.
-                    // Because in Log Replication, messages are sent to the leader node, the connection future
-                    // represents a connection to the leader.
-                    try {
-                        remoteLeaderConnectionFuture
-                                .get(getParameters().getConnectionTimeout().toMillis(), TimeUnit.MILLISECONDS);
-                    } catch (InterruptedException e) {
-                        throw new UnrecoverableCorfuInterruptedError(e);
-                    } catch (TimeoutException | ExecutionException te) {
-                        cf.completeExceptionally(te);
-                        return cf;
-                    }
-
-                    // Get Remote Leader
-                    if (runtimeFSM.getRemoteLeaderNodeId().isPresent()) {
-                        nodeId = runtimeFSM.getRemoteLeaderNodeId().get();
-                    } else {
-                        log.error("Leader not found to remote cluster {}", remoteClusterId);
-                        runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEventType.REMOTE_LEADER_LOSS));
-                        throw new ChannelAdapterException(
-                                String.format("Leader not found to remote cluster %s", remoteClusterDescriptor.getClusterId()));
-                    }
-                }
-
-                // In the case the message is intended for a specific endpoint, we do not
-                // block on connection future, this is the case of leader verification.
-                log.info("Send message to {}, type={}", nodeId, payload.getPayloadCase());
-                channelAdapter.send(nodeId, getRequestMsg(header.build(), payload));
-            } catch (NetworkException ne) {
-                log.error("Caught Network Exception while trying to send message to remote leader {}", nodeId);
-                runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEventType.ON_CONNECTION_DOWN,
-                        nodeId));
-                throw ne;
-            } catch (Exception e) {
-                outstandingRequests.remove(requestId);
-                log.error("sendMessageAndGetCompletable: Remove request {} to {} due to exception! Message:{}",
-                        requestId, remoteClusterId, payload.getPayloadCase(), e);
-                cf.completeExceptionally(e);
-                return cf;
-            }
-
-            // Generate a timeout future, which will complete exceptionally
-            // if the main future is not completed.
-            final CompletableFuture<T> cfTimeout =
-                    CFUtils.within(cf, Duration.ofMillis(timeoutResponse));
-            cfTimeout.exceptionally(e -> {
-                if (e.getCause() instanceof TimeoutException) {
-                    outstandingRequests.remove(requestId);
-                    log.debug("sendMessageAndGetCompletable: Remove request {} to {} due to timeout! Message:{}",
-                            requestId, remoteClusterId, payload.getPayloadCase());
-                }
-                return null;
-            });
-
-            return cfTimeout;
-        }
-
-        log.error("Invalid message type {}. Currently only log replication messages are processed.",
-                payload.getPayloadCase());
-        CompletableFuture<T> f = new CompletableFuture<>();
-        f.completeExceptionally(new Throwable("Invalid message type"));
-        return f;
-    }
+    void onConnectionDown(String nodeId);
 
     /**
-     * Send a request message and get a completable future to be fulfilled by the reply.
+     * on error Callback.
      *
-     * @param payload
-     * @param epoch
-     * @param clusterId
-     * @param priority
-     * @param ignoreClusterId
-     * @param ignoreEpoch
-     * @param <T> The type of completable to return.
-     * @return A completable future which will be fulfilled by the reply,
-     * or a timeout in the case there is no response.
      */
-    @Override
-    public <T> CompletableFuture<T> sendRequestAndGetCompletable(RequestPayloadMsg payload, long epoch, RpcCommon.UuidMsg clusterId,
-                                                                 org.corfudb.runtime.proto.service.CorfuMessage.PriorityLevel priority,
-                                                                 ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
-        // This is an empty stub. This method is not being used anywhere in the LR framework.
-        return null;
-    }
+    void  onError(Throwable t);
 
     /**
-     * Send a one way message, without adding a completable future.
+     * Forward the msg received to a source router
      *
-     * @param payload
-     * @param epoch
-     * @param clusterId
-     * @param priority
-     * @param ignoreClusterId
-     * @param ignoreEpoch
+     * @param msg, response msg sent by SINK
      */
-    @Override
-    public void sendRequest(RequestPayloadMsg payload, long epoch, RpcCommon.UuidMsg clusterId,
-                            org.corfudb.runtime.proto.service.CorfuMessage.PriorityLevel priority,
-                            ClusterIdCheck ignoreClusterId, EpochCheck ignoreEpoch) {
-        // This is an empty stub. This method is not being used anywhere in the LR framework.
-    }
-
-    @Override
-    public <T> void completeRequest(long requestID, T completion) {
-        log.trace("Complete request: {}", requestID);
-        CompletableFuture<T> cf;
-        if ((cf = (CompletableFuture<T>) outstandingRequests.remove(requestID)) != null) {
-            cf.complete(completion);
-        } else {
-            log.warn("Attempted to complete request {}, but request not outstanding!", requestID);
-        }
-    }
-
-    @Override
-    public void completeExceptionally(long requestID, Throwable cause) {
-        CompletableFuture cf;
-        if ((cf = outstandingRequests.remove(requestID)) != null) {
-            cf.completeExceptionally(cause);
-            log.debug("completeExceptionally: Remove request {} to {} due to {}.", requestID, remoteClusterId,
-                    cause.getClass().getSimpleName(), cause);
-        } else {
-            log.warn("Attempted to exceptionally complete request {}, but request not outstanding!",
-                    requestID);
-        }
-    }
-
-    @Override
-    public void stop() {
-        log.debug("stop: Shutting down router for {}", remoteClusterId);
-        shutdown = true;
-        channelAdapter.stop();
-        remoteLeaderConnectionFuture = new CompletableFuture<>();
-        remoteLeaderConnectionFuture.completeExceptionally(new NetworkException("Router stopped", remoteClusterId));
-    }
-
-    @Override
-    public Integer getPort() {
-        // For logging purposes return one port (as this abstraction does not make sense for a Log Replication
-        // Client Router) as it is a router to an entire cluster/site.
-        return Integer.valueOf(remoteClusterDescriptor.getNodesDescriptors().iterator().next().getPort());
-    }
-
-    @Override
-    public String getHost() {
-        String host = "";
-        // For logging purposes return all remote cluster nodes host in a concatenated form
-        remoteClusterDescriptor.getNodesDescriptors().forEach(node -> host.concat(node.getHost() + ":"));
-        return host;
-    }
-
-    @Override
-    public void setTimeoutConnect(long timeoutConnect) {
-    }
-
-    @Override
-    public void setTimeoutRetry(long timeoutRetry) {
-    }
-
-    @Override
-    public void setTimeoutResponse(long timeoutResponse) {
-        this.timeoutResponse = timeoutResponse;
-    }
-
-
-    // ---------------------------------------------------------------------------
+    void receive(CorfuMessage.ResponseMsg msg);
 
     /**
-     * Receive Corfu Message from the Channel Adapter for further processing
+     * Forward the msg received to a sink router
      *
-     * @param msg received corfu message
+     * @param msg, request msg sent by SOURCE
      */
-    public void receive(CorfuMessage.ResponseMsg msg) {
-        try {
-            // If it is a Leadership Loss Message re-trigger leadership discovery
-            if (msg.getPayload().getPayloadCase() == PayloadCase.LR_LEADERSHIP_LOSS) {
-                String nodeId = msg.getPayload().getLrLeadershipLoss().getNodeId();
-                runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEventType.REMOTE_LEADER_LOSS, nodeId));
-                return;
-            }
-
-            // We get the handler for this message from the map
-            IClient handler = handlerMap.get(msg.getPayload().getPayloadCase());
-
-            if (handler == null) {
-                // The message was unregistered, we are dropping it.
-                log.warn("Received unregistered message {}, dropping", msg);
-            } else {
-                // Route the message to the handler.
-                if (log.isTraceEnabled()) {
-                    log.trace("Message routed to {}: {}",
-                            handler.getClass().getSimpleName(), msg);
-                }
-                handler.handleMessage(msg, null);
-            }
-        } catch (Exception e) {
-            log.error("Exception caught while receiving message of type {}",
-                    msg.getPayload().getPayloadCase(), e);
-        }
-    }
+    void receive(CorfuMessage.RequestMsg msg);
 
     /**
      * When an error occurs in the Channel Adapter, trigger
@@ -404,94 +49,5 @@ public class LogReplicationClientRouter implements IClientRouter {
      *
      * @param e exception
      */
-    public void completeAllExceptionally(Exception e) {
-        // Exceptionally complete all requests that were waiting for a completion.
-        outstandingRequests.forEach((reqId, reqCompletableFuture) -> {
-            reqCompletableFuture.completeExceptionally(e);
-            // And also remove them.
-            outstandingRequests.remove(reqId);
-        });
-    }
-
-    /**
-     * Connect to remote cluster through the specified channel adapter
-     */
-    public void connect() {
-        LogReplicationPluginConfig config = new LogReplicationPluginConfig(parameters.getPluginFilePath());
-        File jar = new File(config.getTransportAdapterJARPath());
-
-        try (URLClassLoader child = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader())) {
-            // Instantiate Channel Adapter (external implementation of the channel / transport)
-            Class adapterType = Class.forName(config.getTransportClientClassCanonicalName(), true, child);
-            channelAdapter = (IClientChannelAdapter) adapterType.getDeclaredConstructor(String.class, ClusterDescriptor.class, LogReplicationClientRouter.class)
-                    .newInstance(parameters.getLocalClusterId(), remoteClusterDescriptor, this);
-            channelAdapter.setChannelContext(parameters.getChannelContext());
-            log.info("Connect asynchronously to remote cluster... ");
-            // When connection is established to the remote leader node, the remoteLeaderConnectionFuture will be completed.
-            channelAdapter.connectAsync();
-        } catch (Exception e) {
-            log.error("Fatal error: Failed to initialize transport adapter {}", config.getTransportClientClassCanonicalName(), e);
-            throw new UnrecoverableCorfuError(e);
-        }
-    }
-
-    /**
-     * Verify Message is of valid Log Replication type.
-     */
-    private boolean isValidMessage(RequestPayloadMsg message) {
-        return message.getPayloadCase().equals(RequestPayloadMsg.PayloadCase.LR_ENTRY) ||
-                message.getPayloadCase().equals(RequestPayloadMsg.PayloadCase.LR_METADATA_REQUEST) ||
-                message.getPayloadCase().equals(RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_QUERY);
-    }
-
-    /**
-     * Connection Up Callback.
-     *
-     * @param nodeId id of the remote node to which connection was established.
-     */
-    public synchronized void onConnectionUp(String nodeId) {
-        log.info("Connection established to remote node {}", nodeId);
-        runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEventType.ON_CONNECTION_UP, nodeId));
-    }
-
-    /**
-     * Connection Down Callback.
-     *
-     * @param nodeId id of the remote node to which connection came down.
-     */
-    public synchronized void onConnectionDown(String nodeId) {
-        log.info("Connection lost to remote node {} on cluster {}", nodeId, remoteClusterId);
-        runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEventType.ON_CONNECTION_DOWN,
-                nodeId));
-        // Attempt to reconnect to this endpoint
-        channelAdapter.connectAsync(nodeId);
-    }
-
-    /**
-     * Channel Adapter On Error Callback
-     */
-    public synchronized void onError(Throwable t) {
-        runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEventType.ERROR, t));
-    }
-
-    /**
-     * Cluster Change Callback.
-     *
-     * @param clusterDescriptor remote cluster descriptor
-     */
-    public synchronized void onClusterChange(ClusterDescriptor clusterDescriptor) {
-        channelAdapter.clusterChangeNotification(clusterDescriptor);
-    }
-
-    public Optional<String> getRemoteLeaderNodeId() {
-        return runtimeFSM.getRemoteLeaderNodeId();
-    }
-
-    public void resetRemoteLeader() {
-        if (channelAdapter != null) {
-            log.debug("Reset remote leader from channel adapter.");
-            channelAdapter.resetRemoteLeader();
-        }
-    }
-
+    void completeAllExceptionally(Exception e);
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationClientRouter.java
@@ -27,7 +27,7 @@ public interface LogReplicationClientRouter {
      * on error Callback.
      *
      */
-    void  onError(Throwable t);
+    void onError(Throwable t);
 
     /**
      * Forward the msg received to a source router

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationHandler.java
@@ -5,6 +5,7 @@ import io.netty.channel.ChannelHandlerContext;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.runtime.clients.ClientResponseHandler;
 import org.corfudb.runtime.clients.ClientResponseHandler.Handler;
 import org.corfudb.runtime.clients.IClient;
@@ -38,6 +39,12 @@ public class LogReplicationHandler implements IClient, IHandler<LogReplicationCl
     @Setter
     public ClientResponseHandler responseHandler = createResponseHandlers(this, new ConcurrentHashMap<>());
 
+    private ReplicationSession replicationSession;
+
+    public LogReplicationHandler(ReplicationSession replicationSession) {
+        this.replicationSession = replicationSession;
+    }
+
     /**
      * Used for testing and allows for augmenting default member variables.
      *
@@ -62,7 +69,7 @@ public class LogReplicationHandler implements IClient, IHandler<LogReplicationCl
     private static Object handleLogReplicationAck(@Nonnull ResponseMsg response,
                                                   @Nonnull ChannelHandlerContext ctx,
                                                   @Nonnull IClientRouter router) {
-        log.debug("Handle log replication ACK");
+        log.debug("Handle log replication ACK {}", response);
         return response.getPayload().getLrEntryAck();
     }
 
@@ -92,6 +99,6 @@ public class LogReplicationHandler implements IClient, IHandler<LogReplicationCl
 
     @Override
     public LogReplicationClient getClient(long epoch, UUID clusterID) {
-        return new LogReplicationClient(router, epoch);
+        return new LogReplicationClient(router, epoch, replicationSession);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationServerRouter.java
@@ -75,11 +75,20 @@ public class LogReplicationServerRouter implements IServerRouter {
         serverAdapter = getAdapter(serverContext, sessionToSourceServer, sessionToSinkServer);
 
         // set the server adapter in every server router.
+        updateAndSetServerAdapterForRouters(sessionToSourceServer, sessionToSinkServer);
+    }
+
+    public void updateAndSetServerAdapterForRouters(Map<ReplicationSession, LogReplicationSourceServerRouter> sessionToSourceServer,
+                                                    Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServer) {
+        serverAdapter.updateRouters(sessionToSourceServer, sessionToSinkServer);
+        // set the server adapter in every server router.
         if(!sessionToSourceServer.isEmpty()) {
-            sessionToSourceServer.values().forEach(router -> router.setAdapter(serverAdapter));
+            sessionToSourceServer.values().stream().filter(router -> router.serverChannelAdapter == null).forEach(router ->
+                router.setAdapter(serverAdapter));
         }
         if (!sessionToSinkServer.isEmpty()) {
-            sessionToSinkServer.values().forEach(router -> router.setAdapter(serverAdapter));
+            sessionToSinkServer.values().stream().filter(router -> router.getServerAdapter() == null).forEach(router ->
+                router.setAdapter(serverAdapter));
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationServerRouter.java
@@ -50,6 +50,14 @@ public class LogReplicationServerRouter implements IServerRouter {
     /** The {@link AbstractServer}s this {@link LogReplicationSinkServerRouter} routes messages for. */
     final List<AbstractServer> servers;
 
+    /**
+     * Construct a new {@link LogReplicationServerRouter}
+     *
+     * @param serverMap A list of {@link AbstractServer}s this router will route messages for.
+     * @param serverContext
+     * @param sessionToSourceServer A map of session and the corresponding source-server router
+     * @param sessionToSinkServer A map of session and the corresponding sink-server router
+     */
     public LogReplicationServerRouter(Map<Class, AbstractServer> serverMap, ServerContext serverContext,
                                       Map<ReplicationSession, LogReplicationSourceServerRouter> sessionToSourceServer,
                                       Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServer) {
@@ -65,6 +73,8 @@ public class LogReplicationServerRouter implements IServerRouter {
         });
 
         serverAdapter = getAdapter(serverContext, sessionToSourceServer, sessionToSinkServer);
+
+        // set the server adapter in every server router.
         if(!sessionToSourceServer.isEmpty()) {
             sessionToSourceServer.values().forEach(router -> router.setAdapter(serverAdapter));
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSinkClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSinkClientRouter.java
@@ -10,7 +10,7 @@ import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescripto
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
 import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
-import org.corfudb.infrastructure.logreplication.runtime.sinkFsm.SinkVerifyRemoteLeader;
+import org.corfudb.infrastructure.logreplication.runtime.fsm.sink.SinkVerifyRemoteLeader;
 import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
 import org.corfudb.protocols.service.CorfuProtocolMessage;
 import org.corfudb.runtime.LogReplication;
@@ -136,7 +136,7 @@ public class LogReplicationSinkClientRouter extends LogReplicationSinkServerRout
     public LogReplicationSinkClientRouter(ClusterDescriptor remoteCluster, String localClusterId,
                                             String pluginFilePath, long timeoutResponse, ReplicationSession session,
                                           Map<Class, AbstractServer> serverMap) {
-        super(serverMap, true);
+        super(serverMap);
         this.timeoutResponse = timeoutResponse;
         this.remoteClusterDescriptor = remoteCluster;
         this.localClusterId = localClusterId;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSinkClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSinkClientRouter.java
@@ -1,0 +1,551 @@
+package org.corfudb.infrastructure.logreplication.runtime;
+
+import io.netty.channel.ChannelHandlerContext;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.AbstractServer;
+import org.corfudb.infrastructure.IServerRouter;
+import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
+import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
+import org.corfudb.infrastructure.logreplication.runtime.sinkFsm.SinkVerifyRemoteLeader;
+import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
+import org.corfudb.protocols.service.CorfuProtocolMessage;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.clients.IClient;
+import org.corfudb.runtime.clients.IClientRouter;
+import org.corfudb.runtime.exceptions.NetworkException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.proto.RpcCommon;
+import org.corfudb.runtime.proto.service.CorfuMessage;
+import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
+import org.corfudb.util.CFUtils;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.corfudb.protocols.CorfuProtocolCommon.getUuidMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getDefaultProtocolVersionMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getResponseMsg;
+
+
+/**
+ * This client router is used when SINK is the connection starter.
+ * The router connects to a remote cluster via clientAdapter, queries Leadership, and creates a bidirectional stream for
+ * LR replication msgs.
+ *
+ *
+ */
+@Slf4j
+public class LogReplicationSinkClientRouter extends LogReplicationSinkServerRouter implements IClientRouter, LogReplicationClientRouter, IServerRouter {
+
+    /**
+     * The clients registered to this router.
+     */
+    public final List<IClient> clientList;
+
+    /**
+     * Whether or not this router is shutdown.
+     */
+    public volatile boolean shutdown;
+
+    /**
+     * A {@link CompletableFuture} which is completed when a connection,
+     * including a successful handshake completes and messages can be sent
+     * to the remote node.
+     */
+    @Getter
+    private volatile CompletableFuture<Void> remoteLeaderConnectionFuture;
+
+    /**
+     * The current request ID.
+     */
+    @Getter
+    @SuppressWarnings("checkstyle:abbreviation")
+    public AtomicLong requestID;
+
+    /**
+     * Sync call response timeout (milliseconds).
+     */
+    @Getter
+    @Setter
+    public long timeoutResponse;
+
+    /**
+     * The outstanding requests on this router.
+     */
+    public final Map<Long, CompletableFuture> outstandingRequests;
+
+    /**
+     * Remote cluster's clusterDescriptor
+     */
+    private final ClusterDescriptor remoteClusterDescriptor;
+
+    @Getter
+    private String localClusterId;
+
+    /**
+     * The response handlers registered to this router.
+     */
+    protected final Map<CorfuMessage.ResponsePayloadMsg.PayloadCase, IClient> handlerMap;
+
+    /**
+     * Adapter to the channel implementation
+     */
+    @Getter
+    IClientChannelAdapter channelAdapter;
+
+    final String pluginFilePath;
+
+    /**
+     * Session to the remote cluster/endpoint
+     */
+    ReplicationSession session;
+
+    /**
+     * Triggers leadership request and create bidirectional streams to remote endpoints
+     */
+    private final SinkVerifyRemoteLeader verifyLeadership;
+
+
+
+    /**
+     * Log Replication Client Constructor
+     *
+     * @param remoteCluster the remote source cluster
+     * @param localClusterId local cluster ID
+     * @param session replication session between current and remote cluster
+     */
+
+    public LogReplicationSinkClientRouter(ClusterDescriptor remoteCluster, String localClusterId,
+                                            String pluginFilePath, long timeoutResponse, ReplicationSession session,
+                                          Map<Class, AbstractServer> serverMap) {
+        super(serverMap, true);
+        this.timeoutResponse = timeoutResponse;
+        this.remoteClusterDescriptor = remoteCluster;
+        this.localClusterId = localClusterId;
+
+        this.clientList = new ArrayList<>();
+        this.requestID = new AtomicLong();
+        this.outstandingRequests = new ConcurrentHashMap<>();
+        this.remoteLeaderConnectionFuture = new CompletableFuture<>();
+
+        this.pluginFilePath = pluginFilePath;
+        this.localClusterId = localClusterId;
+        // this will be required when the sink is the connection initiator
+        this.session = session;
+        this.handlerMap = new ConcurrentHashMap<>();
+
+        this.verifyLeadership = new SinkVerifyRemoteLeader(session, this);
+    }
+
+    // ------------------- IClientRouter Interface ----------------------
+
+    @Override
+    public IClientRouter addClient(IClient client) {
+
+        // Set the client's router to this instance.
+        client.setRouter(this);
+
+        // Iterate through all types of CorfuMsgType, registering the handler
+        try {
+            client.getHandledCases().forEach(x -> {
+                handlerMap.put(x, client);
+                log.info("Registered client to handle messages of type {}", x);
+            });
+        } catch (UnsupportedOperationException ex) {
+            log.trace("No registered CorfuMsg handler for client {}", client, ex);
+        }
+
+        // Register this type
+        clientList.add(client);
+        return this;
+    }
+
+
+    /**
+     * Send a request message and get a completable future to be fulfilled by the reply.
+     * SINK uses this to send LR_LEADERSHIP_REQUEST msgs
+     *
+     * @param payload
+     * @param <T> The type of completable to return.
+     * @return A completable future which will be fulfilled by the reply,
+     * or a timeout in the case there is no response.
+     */
+    @Override
+    public <T> CompletableFuture<T> sendRequestAndGetCompletable(
+            @Nonnull RequestPayloadMsg payload,
+            @Nonnull String nodeId) {
+
+        CorfuMessage.HeaderMsg.Builder header = CorfuMessage.HeaderMsg.newBuilder()
+                .setVersion(getDefaultProtocolVersionMsg())
+                .setIgnoreClusterId(true)
+                .setIgnoreEpoch(true);
+
+        // Get the next request ID.
+        final long requestId = requestID.getAndIncrement();
+
+        // Generate a future and put it in the completion table.
+        final CompletableFuture<T> cf = new CompletableFuture<>();
+        outstandingRequests.put(requestId, cf);
+        try {
+            header.setRequestId(requestId);
+            header.setClusterId(getUuidMsg(UUID.fromString(this.localClusterId)));
+
+            log.info("Send message to {}, type={}", nodeId, payload.getPayloadCase());
+            getChannelAdapter().send(nodeId, getRequestMsg(header.build(), payload));
+        } catch (NetworkException ne) {
+            log.error("Caught Network Exception while trying to send message to remote node {}", nodeId);
+            verifyLeadership.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.ON_CONNECTION_DOWN,
+                    nodeId));
+            throw ne;
+        } catch (Exception e) {
+            outstandingRequests.remove(requestId);
+            log.error("sendMessageAndGetCompletable: Remove request {} to {} due to exception! Message:{}",
+                    requestId, remoteClusterDescriptor.getClusterId(), payload.getPayloadCase(), e);
+            cf.completeExceptionally(e);
+            return cf;
+        }
+
+        // Generate a timeout future, which will complete exceptionally if the main future is not completed.
+        final CompletableFuture<T> cfTimeout =
+                CFUtils.within(cf, Duration.ofMillis(timeoutResponse));
+        cfTimeout.exceptionally(e -> {
+            if (e.getCause() instanceof TimeoutException) {
+                outstandingRequests.remove(requestId);
+                log.debug("sendMessageAndGetCompletable: Remove request {} to {} due to timeout! Message:{}",
+                        requestId, remoteClusterDescriptor.getClusterId(), payload.getPayloadCase());
+            }
+            return null;
+        });
+
+        return cfTimeout;
+    }
+
+    /**
+     * Send a request message and get a completable future to be fulfilled by the reply.
+     *
+     * @param payload
+     * @param epoch
+     * @param clusterId
+     * @param priority
+     * @param ignoreClusterId
+     * @param ignoreEpoch
+     * @param <T> The type of completable to return.
+     * @return A completable future which will be fulfilled by the reply,
+     * or a timeout in the case there is no response.
+     */
+    @Override
+    public <T> CompletableFuture<T> sendRequestAndGetCompletable(RequestPayloadMsg payload, long epoch, RpcCommon.UuidMsg clusterId,
+                                                                 org.corfudb.runtime.proto.service.CorfuMessage.PriorityLevel priority,
+                                                                 CorfuProtocolMessage.ClusterIdCheck ignoreClusterId, CorfuProtocolMessage.EpochCheck ignoreEpoch) {
+        // This is an empty stub. This method is not being used anywhere in the LR framework.
+        return null;
+    }
+
+    public void sendResponse(@Nonnull CorfuMessage.ResponsePayloadMsg payload, @Nonnull String endpoint) {
+        CorfuMessage.HeaderMsg.Builder header = CorfuMessage.HeaderMsg.newBuilder()
+                .setVersion(getDefaultProtocolVersionMsg())
+                .setIgnoreClusterId(true)
+                .setIgnoreEpoch(true);
+
+        if(payload.getPayloadCase().equals(CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_SUBSCRIBE_REQUEST)) {
+            final long requestId = requestID.getAndIncrement();
+            header.setRequestId(requestId);
+            header.setClusterId(getUuidMsg(UUID.fromString(this.localClusterId)));
+
+            if(verifyLeadership.getRemoteLeaderNodeId().isPresent()) {
+                channelAdapter.send(endpoint, getResponseMsg(header.build(), payload));
+            } else {
+                log.error("Leader not found to remote cluster {}", remoteClusterDescriptor.getClusterId());
+                verifyLeadership.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.REMOTE_LEADER_LOSS));
+            }
+        } else {
+            log.error("Invalid message type {}. Currently only log replication messages are processed.",
+                    payload.getPayloadCase());
+        }
+
+    }
+
+    /**
+     * Send a one way message, without adding a completable future.
+     *
+     * @param payload
+     * @param epoch
+     * @param clusterId
+     * @param priority
+     * @param ignoreClusterId
+     * @param ignoreEpoch
+     */
+    @Override
+    public void sendRequest(RequestPayloadMsg payload, long epoch, RpcCommon.UuidMsg clusterId,
+                            org.corfudb.runtime.proto.service.CorfuMessage.PriorityLevel priority,
+                            CorfuProtocolMessage.ClusterIdCheck ignoreClusterId, CorfuProtocolMessage.EpochCheck ignoreEpoch) {
+        // This is an empty stub. This method is not being used anywhere in the LR framework.
+    }
+
+    @Override
+    public <T> void completeRequest(long requestID, T completion) {
+        // comes here only for leadership request
+        log.trace("Complete request: {}...outstandingRequests {}", requestID, outstandingRequests);
+        CompletableFuture<T> cf;
+        if ((cf = (CompletableFuture<T>) outstandingRequests.remove(requestID)) != null) {
+            cf.complete(completion);
+        } else {
+            log.warn("Attempted to complete request {}, but request not outstanding!", requestID);
+        }
+    }
+
+    @Override
+    public void completeExceptionally(long requestID, Throwable cause) {
+        // only for leadership request
+        CompletableFuture cf;
+        if ((cf = outstandingRequests.remove(requestID)) != null) {
+            cf.completeExceptionally(cause);
+            log.debug("completeExceptionally: Remove request {} to {} due to {}.", requestID,
+                    remoteClusterDescriptor.getClusterId(), cause.getClass().getSimpleName(), cause);
+        } else {
+            log.warn("Attempted to exceptionally complete request {}, but request not outstanding!",
+                    requestID);
+        }
+    }
+
+    @Override
+    public void stop() {
+        log.debug("stop: Shutting down router for {}", session);
+        shutdown = true;
+        channelAdapter.stop();
+        remoteLeaderConnectionFuture = new CompletableFuture<>();
+        remoteLeaderConnectionFuture.completeExceptionally(new NetworkException("Router stopped", remoteClusterDescriptor.getClusterId()));
+    }
+
+    @Override
+    public Integer getPort() {
+        // For logging purposes return one port (as this abstraction does not make sense for a Log Replication
+        // Client Router) as it is a router to an entire cluster/site.
+        return Integer.valueOf(remoteClusterDescriptor.getNodesDescriptors().iterator().next().getPort());
+    }
+
+    @Override
+    public String getHost() {
+        String host = "";
+        // For logging purposes return all remote cluster nodes host in a concatenated form
+        remoteClusterDescriptor.getNodesDescriptors().forEach(node -> host.concat(node.getHost() + ":"));
+        return host;
+    }
+
+    @Override
+    public void setTimeoutConnect(long timeoutConnect) {
+    }
+
+    @Override
+    public void setTimeoutRetry(long timeoutRetry) {
+    }
+
+    @Override
+    public void setTimeoutResponse(long timeoutResponse) {
+        this.timeoutResponse = timeoutResponse;
+    }
+
+
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Receive Corfu Message from the Channel Adapter for further processing
+     *
+     * @param msg received corfu message
+     */
+    public void receive(CorfuMessage.ResponseMsg msg) {
+        log.info("Received : {}", msg);
+        try {
+            // If it is a Leadership Loss Message re-trigger leadership discovery
+            if (msg.getPayload().getPayloadCase() == CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_LEADERSHIP_LOSS) {
+                String nodeId = msg.getPayload().getLrLeadershipLoss().getNodeId();
+                verifyLeadership.input(new LogReplicationRuntimeEvent(
+                        LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.REMOTE_LEADER_LOSS, nodeId));
+                return;
+            }
+
+            // We get the handler for this message from the map
+            IClient handler = handlerMap.get(msg.getPayload().getPayloadCase());
+
+            if (handler == null) {
+                // The message was unregistered, we are dropping it.
+                log.warn("Received unregistered message {}, dropping", msg);
+            } else {
+                // Route the message to the handler.
+                if (log.isTraceEnabled()) {
+                    log.trace("Message routed to {}: {}", handler.getClass().getSimpleName(), msg);
+                }
+                handler.handleMessage(msg, null);
+            }
+        } catch (Exception e) {
+            log.error("Exception caught while receiving message of type {}",
+                    msg.getPayload().getPayloadCase(), e);
+        }
+    }
+
+    /**
+     * Receive messages from the 'custom' serverAdapter implementation. This message will be forwarded
+     * for processing.
+     *
+     * @param message
+     */
+    public void receive(RequestMsg message) {
+        log.debug("Received message {}", message.getPayload().getPayloadCase());
+
+        AbstractServer handler = super.getHandlerMap().get(message.getPayload().getPayloadCase());
+        if (handler == null) {
+            // The message was unregistered, we are dropping it.
+            log.warn("Received unregistered message {}, dropping", message);
+        } else {
+            if (super.validateEpoch(message.getHeader())) {
+                // Route the message to the handler.
+                if (log.isTraceEnabled()) {
+                    log.trace("Message routed to {}: {}", handler.getClass().getSimpleName(), message);
+                }
+
+                try {
+                    handler.handleMessage(message, null,this);
+                } catch (Throwable t) {
+                    log.error("channelRead: Handling {} failed due to {}:{}",
+                            message.getPayload().getPayloadCase(),
+                            t.getClass().getSimpleName(),
+                            t.getMessage(),
+                            t);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void sendResponse(CorfuMessage.ResponseMsg response, ChannelHandlerContext ctx) {
+        channelAdapter.send(getRemoteLeaderNodeId().get(), response);
+    }
+
+    /**
+     * When an error occurs in the Channel Adapter, trigger
+     * exceptional completeness of all pending requests.
+     *
+     * @param e exception
+     */
+    public void completeAllExceptionally(Exception e) {
+        // Exceptionally complete all requests that were waiting for a completion.
+        outstandingRequests.forEach((reqId, reqCompletableFuture) -> {
+            reqCompletableFuture.completeExceptionally(e);
+            // And also remove them.
+            outstandingRequests.remove(reqId);
+        });
+    }
+
+    /**
+     * Verify Message is of valid Log Replication type.
+     */
+    private boolean isValidMessage(RequestPayloadMsg message) {
+        return message.getPayloadCase().equals(RequestPayloadMsg.PayloadCase.LR_ENTRY) ||
+                message.getPayloadCase().equals(RequestPayloadMsg.PayloadCase.LR_METADATA_REQUEST) ||
+                message.getPayloadCase().equals(RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_QUERY);
+    }
+
+    /**
+     * Connect to remote cluster through the specified channel adapter
+     */
+    public void connect() {
+        LogReplicationPluginConfig config = new LogReplicationPluginConfig(this.pluginFilePath);
+        File jar = new File(config.getTransportAdapterJARPath());
+
+        try (URLClassLoader child = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader())) {
+            // Instantiate Channel Adapter (external implementation of the channel / transport)
+            Class adapterType = Class.forName(config.getTransportClientClassCanonicalName(), true, child);
+            channelAdapter = (IClientChannelAdapter) adapterType.getDeclaredConstructor(String.class, ClusterDescriptor.class, LogReplicationSourceClientRouter.class, LogReplicationSinkClientRouter.class)
+                    .newInstance(this.localClusterId, remoteClusterDescriptor, null, this);
+            log.info("Connect asynchronously to remote cluster {} and session {} ", remoteClusterDescriptor.getClusterId(), this.session);
+
+            // When connection is established to the remote leader node, the remoteLeaderConnectionFuture will be completed.
+            LogReplication.ReplicationSessionMsg sessionMsg = LogReplication.ReplicationSessionMsg.newBuilder()
+                    .setRemoteClusterId(session.getRemoteClusterId())
+                    .setLocalClusterId(session.getLocalClusterId())
+                    .setClient(session.getSubscriber().getClient())
+                    .setReplicationModel(session.getSubscriber().getReplicationModel())
+                    .build();
+            channelAdapter.connectAsync(sessionMsg);
+        } catch (Exception e) {
+            log.error("Fatal error: Failed to initialize transport adapter {}", config.getTransportClientClassCanonicalName(), e);
+            throw new UnrecoverableCorfuError(e);
+        }
+    }
+
+    /**
+     * Connection Up Callback.
+     *
+     * @param nodeId id of the remote node to which connection was established.
+     */
+    @Override
+    public synchronized void onConnectionUp(String nodeId) {
+        log.info("Connection established to remote node {}.", nodeId);
+        this.verifyLeadership.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.ON_CONNECTION_UP, nodeId));
+    }
+
+    /**
+     * Connection Down Callback.
+     *
+     * @param nodeId id of the remote node to which connection came down.
+     */
+    @Override
+    public synchronized void onConnectionDown(String nodeId) {
+        log.info("Connection lost to remote node {} on cluster {}", nodeId, this.session.getRemoteClusterId());
+        // Attempt to reconnect to this endpoint
+        LogReplication.ReplicationSessionMsg sessionMsg = LogReplication.ReplicationSessionMsg.newBuilder()
+                .setRemoteClusterId(session.getRemoteClusterId())
+                .setLocalClusterId(session.getLocalClusterId())
+                .setClient(session.getSubscriber().getClient())
+                .setReplicationModel(session.getSubscriber().getReplicationModel())
+                .build();
+        channelAdapter.connectAsync(nodeId, sessionMsg);
+    }
+
+    /**
+     * Channel Adapter On Error Callback
+     */
+    public synchronized void onError(Throwable t) {
+        // no op
+        log.error("Unrecoverable state due to error {}", t.getMessage());
+    }
+
+    /**
+     * Cluster Change Callback.
+     *
+     * @param clusterDescriptor remote cluster descriptor
+     */
+
+    public synchronized void onClusterChange(ClusterDescriptor clusterDescriptor) {
+        //no-op. Any topology change notification goes to discovery-service
+    }
+
+    public Optional<String> getRemoteLeaderNodeId() {
+        return verifyLeadership.getRemoteLeaderNodeId();
+    }
+
+    public void resetRemoteLeader() {
+        if (channelAdapter != null) {
+            log.debug("Reset remote leader from channel adapter.");
+            channelAdapter.resetRemoteLeader();
+        }
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSinkServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSinkServerRouter.java
@@ -1,0 +1,177 @@
+package org.corfudb.infrastructure.logreplication.runtime;
+
+import com.google.common.collect.ImmutableList;
+import io.netty.channel.ChannelHandlerContext;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.AbstractServer;
+import org.corfudb.infrastructure.BaseServer;
+import org.corfudb.infrastructure.IServerRouter;
+import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
+import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
+import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
+import org.corfudb.runtime.view.Layout;
+
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * This class represents the Corfu interface to route incoming messages from external adapters when
+ * custom communication channels are used.
+ *
+ * Created by annym on 14/5/20.
+ */
+@Slf4j
+public class LogReplicationSinkServerRouter implements IServerRouter {
+
+    @Getter
+    private IServerChannelAdapter serverAdapter;
+
+    @Setter
+    IClientChannelAdapter clientAdapter;
+
+    /**
+     * This map stores the mapping from message type to netty server handler.
+     */
+    @Getter
+    private final Map<RequestPayloadMsg.PayloadCase, AbstractServer> handlerMap;
+
+    /**
+     * The epoch of this router. This is managed by the base server implementation.
+     */
+    @Getter
+    @Setter
+    private volatile long serverEpoch;
+
+    /** The {@link AbstractServer}s this {@link LogReplicationSinkServerRouter} routes messages for. */
+    final List<AbstractServer> servers;
+
+    // this constructor is called by the SINK-CLIENT router.
+    /** Construct a new {@link LogReplicationSinkServerRouter}.
+     *
+     * @param serverMap   A map of {@link AbstractServer}s this router will route
+     *                  messages for.
+     */
+    public LogReplicationSinkServerRouter(Map<Class, AbstractServer> serverMap, boolean isConnectionStarter) {
+        this.serverEpoch = ((BaseServer) serverMap.get(BaseServer.class)).serverContext.getServerEpoch();
+        this.servers = ImmutableList.copyOf(serverMap.values());
+        this.handlerMap = new EnumMap<>(RequestPayloadMsg.PayloadCase.class);
+
+        servers.forEach(server -> {
+            try {
+                server.getHandlerMethods().getHandledTypes().forEach(x -> handlerMap.put(x, server));
+            } catch (UnsupportedOperationException ex) {
+                log.trace("No registered CorfuMsg handler for server {}", server, ex);
+            }
+        });
+    }
+
+    public void setAdapter(IServerChannelAdapter serverAdapter) {
+        this.serverAdapter = serverAdapter;
+    }
+
+    // ============ IServerRouter Methods =============
+
+    @Override
+    public void sendResponse(ResponseMsg response, ChannelHandlerContext ctx) {
+        log.trace("Ready to send response {}", response.getPayload().getPayloadCase());
+        try {
+                serverAdapter.send(response);
+            log.trace("Sent response: {}", response);
+        } catch (IllegalArgumentException e) {
+            log.warn("Illegal response type. Ignoring message.", e);
+        }
+    }
+
+    @Override
+    public Optional<Layout> getCurrentLayout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<AbstractServer> getServers() {
+        return servers;
+    }
+
+    @Override
+    public void setServerContext(ServerContext serverContext) {
+
+    }
+
+    // ================================================
+
+    /**
+     * Receive messages from the 'custom' serverAdapter implementation. This message will be forwarded
+     * for processing.
+     *
+     * @param message
+     */
+    public void receive(RequestMsg message) {
+        log.debug("Received message {}", message.getPayload().getPayloadCase());
+
+        AbstractServer handler = handlerMap.get(message.getPayload().getPayloadCase());
+        if (handler == null) {
+            // The message was unregistered, we are dropping it.
+            log.warn("Received unregistered message {}, dropping", message);
+        } else {
+            if (validateEpoch(message.getHeader())) {
+                // Route the message to the handler.
+                if (log.isTraceEnabled()) {
+                    log.trace("Message routed to {}: {}", handler.getClass().getSimpleName(), message);
+                }
+
+                try {
+                    handler.handleMessage(message, null,  this);
+                } catch (Throwable t) {
+                    log.error("channelRead: Handling {} failed due to {}:{}",
+                            message.getPayload().getPayloadCase(),
+                            t.getClass().getSimpleName(),
+                            t.getMessage(),
+                            t);
+                }
+            }
+        }
+    }
+
+    public void receive(ResponseMsg message) {
+        // no op.
+    }
+
+    /**
+     * Validate the epoch of a CorfuMsg, and send a WRONG_EPOCH response if
+     * the server is in the wrong epoch. Ignored if the message type is reset (which
+     * is valid in any epoch).
+     *
+     * @param header The incoming header to validate.
+     * @return True, if the epoch is correct, but false otherwise.
+     */
+    protected boolean validateEpoch(HeaderMsg header) {
+        long serverEpoch = getServerEpoch();
+        if (!header.getIgnoreEpoch() && header.getEpoch()!= serverEpoch) {
+            log.trace("Incoming message with wrong epoch, got {}, expected {}",
+                    header.getEpoch(), serverEpoch);
+            sendWrongEpochError(header, null);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated This operation is no longer supported. The router will only route messages for
+     * servers provided at construction time.
+     */
+    @Override
+    @Deprecated
+    public void addServer(AbstractServer server) {
+        throw new UnsupportedOperationException("No longer supported");
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSinkServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSinkServerRouter.java
@@ -59,7 +59,7 @@ public class LogReplicationSinkServerRouter implements IServerRouter {
      * @param serverMap   A map of {@link AbstractServer}s this router will route
      *                  messages for.
      */
-    public LogReplicationSinkServerRouter(Map<Class, AbstractServer> serverMap, boolean isConnectionStarter) {
+    public LogReplicationSinkServerRouter(Map<Class, AbstractServer> serverMap) {
         this.serverEpoch = ((BaseServer) serverMap.get(BaseServer.class)).serverContext.getServerEpoch();
         this.servers = ImmutableList.copyOf(serverMap.values());
         this.handlerMap = new EnumMap<>(RequestPayloadMsg.PayloadCase.class);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceClientRouter.java
@@ -1,0 +1,189 @@
+package org.corfudb.infrastructure.logreplication.runtime;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
+import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationManager;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
+import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
+import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent.LogReplicationRuntimeEventType;
+import org.corfudb.infrastructure.logreplication.transport.client.ChannelAdapterException;
+import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
+import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
+import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.clients.IClient;
+import org.corfudb.runtime.clients.IClientRouter;
+import org.corfudb.runtime.exceptions.NetworkException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.runtime.proto.RpcCommon;
+import org.corfudb.runtime.proto.service.CorfuMessage;
+import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg.PayloadCase;
+import org.corfudb.util.CFUtils;
+
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.corfudb.protocols.CorfuProtocolCommon.getUuidMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getDefaultProtocolVersionMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
+
+/**
+ * This Client Router is used when a custom (client-defined) transport layer is specified for
+ * Log Replication Server communication.
+ */
+@Slf4j
+public class LogReplicationSourceClientRouter extends LogReplicationSourceRouterHelper implements IClientRouter, LogReplicationClientRouter {
+
+
+    /**
+     * Log Replication Client Constructor
+     *
+     * @param remoteCluster the remote source cluster
+     * @param localClusterId local cluster ID
+     * @param parameters runtime parameters (including connection settings)
+     * @param replicationManager replicationManager to start FSM
+     * @param session replication session between current and remote cluster
+     */
+    public LogReplicationSourceClientRouter(ClusterDescriptor remoteCluster, String localClusterId,
+                                            LogReplicationRuntimeParameters parameters, CorfuReplicationManager replicationManager,
+                                            ReplicationSession session) {
+        super(remoteCluster, localClusterId, parameters, replicationManager, session, true);
+    }
+
+
+    /**
+     * Receive Corfu Message from the Channel Adapter for further processing
+     *
+     * @param msg received corfu message
+     */
+    public void receive(CorfuMessage.ResponseMsg msg) {
+        super.receive(msg);
+    }
+
+    public void receive(CorfuMessage.RequestMsg msg) {
+        log.info("recevied request msg {}", msg.getPayload());
+    }
+
+    /**
+     * When an error occurs in the Channel Adapter, trigger
+     * exceptional completeness of all pending requests.
+     *
+     * @param e exception
+     */
+    public void completeAllExceptionally(Exception e) {
+        // Exceptionally complete all requests that were waiting for a completion.
+        outstandingRequests.forEach((reqId, reqCompletableFuture) -> {
+            reqCompletableFuture.completeExceptionally(e);
+            // And also remove them.
+            outstandingRequests.remove(reqId);
+        });
+    }
+
+
+    /**
+     * Connect to remote cluster through the specified channel adapter
+     */
+    public void connect() {
+        LogReplicationPluginConfig config = new LogReplicationPluginConfig(this.pluginFilePath);
+        File jar = new File(config.getTransportAdapterJARPath());
+
+        try (URLClassLoader child = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader())) {
+            // Instantiate Channel Adapter (external implementation of the channel / transport)
+            Class adapterType = Class.forName(config.getTransportClientClassCanonicalName(), true, child);
+            this.clientChannelAdapter = (IClientChannelAdapter) adapterType.getDeclaredConstructor(String.class, ClusterDescriptor.class, LogReplicationSourceClientRouter.class, LogReplicationSinkClientRouter.class)
+                    .newInstance(this.localClusterId, remoteClusterDescriptor, this, null);
+            log.info("Connect asynchronously to remote cluster {} and session {} ", remoteClusterDescriptor.getClusterId(), this.session);
+            // When connection is established to the remote leader node, the remoteLeaderConnectionFuture will be completed.
+            LogReplication.ReplicationSessionMsg sessionMsg = LogReplication.ReplicationSessionMsg.newBuilder()
+                    .setRemoteClusterId(session.getRemoteClusterId())
+                    .setLocalClusterId(session.getLocalClusterId())
+                    .setClient(session.getSubscriber().getClient())
+                    .setReplicationModel(session.getSubscriber().getReplicationModel())
+                    .build();
+            this.clientChannelAdapter.connectAsync(sessionMsg);
+        } catch (Exception e) {
+            log.error("Fatal error: Failed to initialize transport adapter {}", config.getTransportClientClassCanonicalName(), e);
+            throw new UnrecoverableCorfuError(e);
+        }
+    }
+
+    /**
+     * Connection Up Callback.
+     *
+     * @param nodeId id of the remote node to which connection was established.
+     */
+    @Override
+    public synchronized void onConnectionUp(String nodeId) {
+        log.info("Connection established to remote node {}", nodeId);
+        this.startReplication(nodeId);
+    }
+
+    /**
+     * Connection Down Callback.
+     *
+     * @param nodeId id of the remote node to which connection came down.
+     */
+    @Override
+    public synchronized void onConnectionDown(String nodeId) {
+        log.info("Connection lost to remote node {} on cluster {}", nodeId, this.session.getRemoteClusterId());
+        runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEventType.ON_CONNECTION_DOWN,
+                nodeId));
+        // Attempt to reconnect to this endpoint
+        LogReplication.ReplicationSessionMsg sessionMsg = LogReplication.ReplicationSessionMsg.newBuilder()
+                .setRemoteClusterId(session.getRemoteClusterId())
+                .setLocalClusterId(session.getLocalClusterId())
+                .setClient(session.getSubscriber().getClient())
+                .setReplicationModel(session.getSubscriber().getReplicationModel())
+                .build();
+        this.clientChannelAdapter.connectAsync(nodeId, sessionMsg);
+    }
+
+    /**
+     * Channel Adapter On Error Callback
+     */
+    public synchronized void onError(Throwable t) {
+        runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEventType.ERROR, t));
+    }
+
+    /**
+     * Cluster Change Callback.
+     *
+     * @param clusterDescriptor remote cluster descriptor
+     */
+    public synchronized void onClusterChange(ClusterDescriptor clusterDescriptor) {
+        this.clientChannelAdapter.clusterChangeNotification(clusterDescriptor);
+    }
+
+    public Optional<String> getRemoteLeaderNodeId() {
+        return runtimeFSM.getRemoteLeaderNodeId();
+    }
+
+    public void resetRemoteLeader() {
+        if (this.clientChannelAdapter != null) {
+            log.debug("Reset remote leader from channel adapter.");
+            this.clientChannelAdapter.resetRemoteLeader();
+        }
+    }
+
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceClientRouter.java
@@ -1,7 +1,5 @@
 package org.corfudb.infrastructure.logreplication.runtime;
 
-import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
@@ -10,43 +8,16 @@ import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSessi
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.LogReplicationPluginConfig;
 import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
 import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent.LogReplicationRuntimeEventType;
-import org.corfudb.infrastructure.logreplication.transport.client.ChannelAdapterException;
 import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
-import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
-import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import org.corfudb.runtime.LogReplication;
-import org.corfudb.runtime.clients.IClient;
 import org.corfudb.runtime.clients.IClientRouter;
-import org.corfudb.runtime.exceptions.NetworkException;
 import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
-import org.corfudb.runtime.proto.RpcCommon;
 import org.corfudb.runtime.proto.service.CorfuMessage;
-import org.corfudb.runtime.proto.service.CorfuMessage.HeaderMsg;
-import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
-import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg.PayloadCase;
-import org.corfudb.util.CFUtils;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicLong;
-
-import static org.corfudb.protocols.CorfuProtocolCommon.getUuidMsg;
-import static org.corfudb.protocols.service.CorfuProtocolMessage.getDefaultProtocolVersionMsg;
-import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
 
 /**
  * This Client Router is used when a custom (client-defined) transport layer is specified for

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceClientRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceClientRouter.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  * Log Replication Server communication.
  */
 @Slf4j
-public class LogReplicationSourceClientRouter extends LogReplicationSourceRouterHelper implements IClientRouter, LogReplicationClientRouter {
+public class LogReplicationSourceClientRouter extends LogReplicationBaseSourceRouter implements IClientRouter, LogReplicationClientRouter {
 
 
     /**

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceRouterHelper.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceRouterHelper.java
@@ -341,6 +341,10 @@ public class LogReplicationSourceRouterHelper implements IClientRouter {
             log.warn("Attempted to exceptionally complete request {}, but request not outstanding!",
                     requestID);
         }
+
+        if(cause.getCause().getMessage().contains("Network closed")) {
+
+        }
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceRouterHelper.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceRouterHelper.java
@@ -1,0 +1,452 @@
+package org.corfudb.infrastructure.logreplication.runtime;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
+import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationManager;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
+import org.corfudb.infrastructure.logreplication.transport.client.ChannelAdapterException;
+import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
+import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
+import org.corfudb.protocols.service.CorfuProtocolMessage;
+import org.corfudb.runtime.clients.IClient;
+import org.corfudb.runtime.clients.IClientRouter;
+import org.corfudb.runtime.exceptions.NetworkException;
+import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+import org.corfudb.runtime.proto.RpcCommon;
+import org.corfudb.runtime.proto.service.CorfuMessage;
+import org.corfudb.util.CFUtils;
+
+import javax.annotation.Nonnull;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.corfudb.protocols.CorfuProtocolCommon.getUuidMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getDefaultProtocolVersionMsg;
+import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
+
+@Slf4j
+public class LogReplicationSourceRouterHelper implements IClientRouter {
+
+    public static String REMOTE_LEADER = "REMOTE_LEADER";
+
+    /**
+     * The handlers registered to this router.
+     */
+    protected final Map<CorfuMessage.ResponsePayloadMsg.PayloadCase, IClient> handlerMap;
+
+    /**
+     * The clients registered to this router.
+     */
+    public final List<IClient> clientList;
+
+    /**
+     * Whether or not this router is shutdown.
+     */
+    public volatile boolean shutdown;
+
+    /**
+     * A {@link CompletableFuture} which is completed when a connection,
+     * including a successful handshake completes and messages can be sent
+     * to the remote node.
+     */
+    @Getter
+    protected volatile CompletableFuture<Void> remoteLeaderConnectionFuture;
+
+    /**
+     * The current request ID.
+     */
+    @Getter
+    @SuppressWarnings("checkstyle:abbreviation")
+    public AtomicLong requestID;
+
+    /**
+     * Sync call response timeout (milliseconds).
+     */
+    @Getter
+    @Setter
+    public long timeoutResponse;
+
+    /**
+     * The outstanding requests on this router.
+     */
+    public final Map<Long, CompletableFuture> outstandingRequests;
+
+    /**
+     * Runtime FSM, to insert connectivity events
+     */
+    @Getter
+    protected CorfuLogReplicationRuntime runtimeFSM;
+
+    /**
+     * Remote cluster's clusterDescriptor
+     */
+    protected ClusterDescriptor remoteClusterDescriptor;
+
+    /**
+     * The replicationManager
+     */
+    protected final CorfuReplicationManager replicationManager;
+
+    protected String localClusterId;
+
+    protected boolean isConnectionInitiator;
+
+    @Setter
+    protected IClientChannelAdapter clientChannelAdapter;
+
+    @Setter
+    protected IServerChannelAdapter serverChannelAdapter;
+
+    protected final String pluginFilePath;
+
+    @Getter
+    ReplicationSession session;
+
+    /**
+     * Log Replication Client Constructor
+     *
+     * @param remoteCluster the remote source cluster
+     * @param localClusterId local cluster ID
+     * @param parameters runtime parameters (including connection settings)
+     * @param replicationManager replicationManager to start FSM
+     * @param session replication session between current and remote cluster
+     */
+    public LogReplicationSourceRouterHelper(ClusterDescriptor remoteCluster, String localClusterId,
+                                            LogReplicationRuntimeParameters parameters, CorfuReplicationManager replicationManager,
+                                            ReplicationSession session, boolean isConnectionInitiator) {
+        this.timeoutResponse = parameters.getRequestTimeout().toMillis();
+        this.remoteClusterDescriptor = remoteCluster;
+        this.localClusterId = localClusterId;
+        this.replicationManager = replicationManager;
+        this.session = session;
+        this.pluginFilePath = parameters.getPluginFilePath();
+
+        this.handlerMap = new ConcurrentHashMap<>();
+        this.clientList = new ArrayList<>();
+        this.requestID = new AtomicLong();
+        this.outstandingRequests = new ConcurrentHashMap<>();
+        this.remoteLeaderConnectionFuture = new CompletableFuture<>();
+        this.isConnectionInitiator = isConnectionInitiator;
+        this.clientChannelAdapter = null;
+        this.serverChannelAdapter = null;
+    }
+
+
+    // ------------------- IClientRouter Interface ----------------------
+
+    @Override
+    public IClientRouter addClient(IClient client) {
+        // Set the client's router to this instance.
+        client.setRouter(this);
+
+        // Iterate through all types of CorfuMsgType, registering the handler
+        try {
+            client.getHandledCases().forEach(x -> {
+                handlerMap.put(x, client);
+                log.info("Registered client to handle messages of type {}", x);
+            });
+        } catch (UnsupportedOperationException ex) {
+            log.trace("No registered CorfuMsg handler for client {}", client, ex);
+        }
+
+        // Register this type
+        clientList.add(client);
+        return this;
+    }
+
+    /**
+     * set runtimeFSM of the router
+     * @param runtimeFSM runtime state machine, insert connection related events
+     */
+    public void setRuntimeFSM(CorfuLogReplicationRuntime runtimeFSM) {
+        this.runtimeFSM = runtimeFSM;
+    }
+
+    /**
+     * Send a request message and get a completable future to be fulfilled by the reply.
+     *
+     * @param payload
+     * @param <T> The type of completable to return.
+     * @return A completable future which will be fulfilled by the reply,
+     * or a timeout in the case there is no response.
+     */
+    @Override
+    public <T> CompletableFuture<T> sendRequestAndGetCompletable(
+            @Nonnull CorfuMessage.RequestPayloadMsg payload,
+            @Nonnull String nodeId) {
+
+        CorfuMessage.HeaderMsg.Builder header = CorfuMessage.HeaderMsg.newBuilder()
+                .setVersion(getDefaultProtocolVersionMsg())
+                .setIgnoreClusterId(true)
+                .setIgnoreEpoch(true);
+
+        if (isValidMessage(payload)) {
+            // Get the next request ID.
+            final long requestId = requestID.getAndIncrement();
+
+            // Generate a future and put it in the completion table.
+            final CompletableFuture<T> cf = new CompletableFuture<>();
+            outstandingRequests.put(requestId, cf);
+
+            try {
+                LogReplicationRuntimeParameters parameters =  this.runtimeFSM.getSourceManager().getParameters();
+                header.setClientId(getUuidMsg(parameters.getClientId()));
+                header.setRequestId(requestId);
+                header.setClusterId(getUuidMsg(UUID.fromString(this.localClusterId)));
+
+                // If no endpoint is specified, the message is to be sent to the remote leader node.
+                // We should block until a connection to the leader is established.
+                if (nodeId.equals(REMOTE_LEADER)) {
+                    // Check the connection future. If connected, continue with sending the message.
+                    // If timed out, return a exceptionally completed with the timeout.
+                    // Because in Log Replication, messages are sent to the leader node, the connection future
+                    // represents a connection to the leader.
+                    try {
+                        remoteLeaderConnectionFuture
+                                .get(parameters.getConnectionTimeout().toMillis(), TimeUnit.MILLISECONDS);
+                    } catch (InterruptedException e) {
+                        throw new UnrecoverableCorfuInterruptedError(e);
+                    } catch (TimeoutException | ExecutionException te) {
+                        cf.completeExceptionally(te);
+                        return cf;
+                    }
+
+                    // Get Remote Leader
+                    if (runtimeFSM.getRemoteLeaderNodeId().isPresent()) {
+                        nodeId = runtimeFSM.getRemoteLeaderNodeId().get();
+                    } else {
+                        log.error("Leader not found to remote cluster {}", remoteClusterDescriptor.getClusterId());
+                        runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.REMOTE_LEADER_LOSS));
+                        throw new ChannelAdapterException(
+                                String.format("Leader not found to remote cluster %s", remoteClusterDescriptor.getClusterId()));
+                    }
+                }
+
+                // In the case the message is intended for a specific endpoint, we do not
+                // block on connection future, this is the case of leader verification.
+//                log.info("#243 Send message to {}, type={}", nodeId, payload.getPayloadCase());
+                if(isConnectionInitiator) {
+                    clientChannelAdapter.send(nodeId, getRequestMsg(header.build(), payload));
+                } else {
+                    serverChannelAdapter.send(nodeId, getRequestMsg(header.build(), payload));
+                }
+            } catch (NetworkException ne) {
+                log.error("Caught Network Exception while trying to send message to remote leader {}", nodeId);
+                runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.ON_CONNECTION_DOWN,
+                        nodeId));
+                throw ne;
+            } catch (Exception e) {
+//                log.info("sendRequestAndGetCompletable removing reqId outstandingRequests {}", requestId);
+                outstandingRequests.remove(requestId);
+                log.error("sendMessageAndGetCompletable: Remove request {} to {} due to exception! Message:{}",
+                        requestId, remoteClusterDescriptor.getClusterId(), payload.getPayloadCase(), e);
+                cf.completeExceptionally(e);
+                return cf;
+            }
+
+            // Generate a timeout future, which will complete exceptionally
+            // if the main future is not completed.
+            final CompletableFuture<T> cfTimeout =
+                    CFUtils.within(cf, Duration.ofMillis(timeoutResponse));
+            cfTimeout.exceptionally(e -> {
+                if (e.getCause() instanceof TimeoutException) {
+                    outstandingRequests.remove(requestId);
+                    log.debug("sendMessageAndGetCompletable: Remove request {} to {} due to timeout! Message:{}",
+                            requestId, remoteClusterDescriptor.getClusterId(), payload.getPayloadCase());
+                }
+                return null;
+            });
+
+            return cfTimeout;
+        }
+
+        log.error("Invalid message type {}. Currently only log replication messages are processed.",
+                payload.getPayloadCase());
+        CompletableFuture<T> f = new CompletableFuture<>();
+        f.completeExceptionally(new Throwable("Invalid message type"));
+        return f;
+    }
+
+    /**
+     * Send a request message and get a completable future to be fulfilled by the reply.
+     *
+     * @param payload
+     * @param epoch
+     * @param clusterId
+     * @param priority
+     * @param ignoreClusterId
+     * @param ignoreEpoch
+     * @param <T> The type of completable to return.
+     * @return A completable future which will be fulfilled by the reply,
+     * or a timeout in the case there is no response.
+     */
+    @Override
+    public <T> CompletableFuture<T> sendRequestAndGetCompletable(CorfuMessage.RequestPayloadMsg payload, long epoch, RpcCommon.UuidMsg clusterId,
+                                                                 org.corfudb.runtime.proto.service.CorfuMessage.PriorityLevel priority,
+                                                                 CorfuProtocolMessage.ClusterIdCheck ignoreClusterId, CorfuProtocolMessage.EpochCheck ignoreEpoch) {
+        // This is an empty stub. This method is not being used anywhere in the LR framework.
+        return null;
+    }
+
+    /**
+     * Send a one way message, without adding a completable future.
+     *
+     * @param payload
+     * @param epoch
+     * @param clusterId
+     * @param priority
+     * @param ignoreClusterId
+     * @param ignoreEpoch
+     */
+    @Override
+    public void sendRequest(CorfuMessage.RequestPayloadMsg payload, long epoch, RpcCommon.UuidMsg clusterId,
+                            org.corfudb.runtime.proto.service.CorfuMessage.PriorityLevel priority,
+                            CorfuProtocolMessage.ClusterIdCheck ignoreClusterId, CorfuProtocolMessage.EpochCheck ignoreEpoch) {
+        // This is an empty stub. This method is not being used anywhere in the LR framework.
+    }
+
+    @Override
+    public <T> void completeRequest(long requestID, T completion) {
+        log.trace("Complete request: {}...outstandingRequests {}", requestID, outstandingRequests);
+        CompletableFuture<T> cf;
+        if ((cf = (CompletableFuture<T>) outstandingRequests.remove(requestID)) != null) {
+            cf.complete(completion);
+        } else {
+            log.warn("Attempted to complete request {}, but request not outstanding!", requestID);
+        }
+    }
+
+    @Override
+    public void completeExceptionally(long requestID, Throwable cause) {
+        CompletableFuture cf;
+        if ((cf = outstandingRequests.remove(requestID)) != null) {
+            cf.completeExceptionally(cause);
+//            log.debug("completeExceptionally: Remove request {} to {} due to {}.", requestID,
+//                    remoteClusterDescriptor.getClusterId(), cause.getClass().getSimpleName(), cause);
+        } else {
+            log.warn("Attempted to exceptionally complete request {}, but request not outstanding!",
+                    requestID);
+        }
+    }
+
+    @Override
+    public void stop() {
+        log.debug("stop: Shutting down router for {}", remoteClusterDescriptor.getClusterId());
+        shutdown = true;
+        clientChannelAdapter.stop();
+        remoteLeaderConnectionFuture = new CompletableFuture<>();
+        remoteLeaderConnectionFuture.completeExceptionally(new NetworkException("Router stopped", remoteClusterDescriptor.getClusterId()));
+    }
+
+    @Override
+    public Integer getPort() {
+        // For logging purposes return one port (as this abstraction does not make sense for a Log Replication
+        // Client Router) as it is a router to an entire cluster/site.
+        return Integer.valueOf(remoteClusterDescriptor.getNodesDescriptors().iterator().next().getPort());
+    }
+
+    @Override
+    public String getHost() {
+        String host = "";
+        // For logging purposes return all remote cluster nodes host in a concatenated form
+        remoteClusterDescriptor.getNodesDescriptors().forEach(node -> host.concat(node.getHost() + ":"));
+        return host;
+    }
+
+    @Override
+    public void setTimeoutConnect(long timeoutConnect) {
+    }
+
+    @Override
+    public void setTimeoutRetry(long timeoutRetry) {
+    }
+
+    @Override
+    public void setTimeoutResponse(long timeoutResponse) {
+        this.timeoutResponse = timeoutResponse;
+    }
+
+
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Receive Corfu Message from the Channel Adapter for further processing
+     *
+     * @param msg received corfu message
+     */
+    protected void receive(CorfuMessage.ResponseMsg msg) {
+        try {
+            // If it is a Leadership Loss Message re-trigger leadership discovery
+            if (msg.getPayload().getPayloadCase() == CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_LEADERSHIP_LOSS) {
+                String nodeId = msg.getPayload().getLrLeadershipLoss().getNodeId();
+                this.runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.REMOTE_LEADER_LOSS, nodeId));
+                return;
+            }
+
+            // We get the handler for this message from the map
+            IClient handler = handlerMap.get(msg.getPayload().getPayloadCase());
+
+            if (handler == null) {
+                // The message was unregistered, we are dropping it.
+                log.warn("Received unregistered message {}, dropping", msg);
+            } else {
+                // Route the message to the handler.
+                if (log.isTraceEnabled()) {
+                    log.trace("Message routed to {}: {}",
+                            handler.getClass().getSimpleName(), msg);
+                }
+                handler.handleMessage(msg, null);
+            }
+        } catch (Exception e) {
+            log.error("Exception caught while receiving message of type {}",
+                    msg.getPayload().getPayloadCase(), e);
+        }
+    }
+
+
+    /**
+     * Verify Message is of valid Log Replication type.
+     */
+    private boolean isValidMessage(CorfuMessage.RequestPayloadMsg message) {
+        return message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_ENTRY) ||
+                message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_METADATA_REQUEST) ||
+                message.getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_QUERY);
+    }
+
+    public void startReplication(String nodeId) {
+        replicationManager.startRuntime(session);
+        log.debug("runtimeFSM started for session {}", session);
+        runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.ON_CONNECTION_UP, nodeId));
+    }
+
+    /**
+     * Cluster Change Callback.
+     *
+     * @param clusterDescriptor remote cluster descriptor
+     */
+    public synchronized void onClusterChange(ClusterDescriptor clusterDescriptor) {
+        this.clientChannelAdapter.clusterChangeNotification(clusterDescriptor);
+    }
+
+    public Optional<String> getRemoteLeaderNodeId() {
+        return Optional.empty();
+    }
+
+    public void resetRemoteLeader() {
+
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceRouterHelper.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceRouterHelper.java
@@ -203,7 +203,7 @@ public class LogReplicationSourceRouterHelper implements IClientRouter {
             outstandingRequests.put(requestId, cf);
 
             try {
-                LogReplicationRuntimeParameters parameters =  this.runtimeFSM.getSourceManager().getParameters();
+                LogReplicationRuntimeParameters parameters = this.runtimeFSM.getSourceManager().getParameters();
                 header.setClientId(getUuidMsg(parameters.getClientId()));
                 header.setRequestId(requestId);
                 header.setClusterId(getUuidMsg(UUID.fromString(this.localClusterId)));
@@ -238,7 +238,6 @@ public class LogReplicationSourceRouterHelper implements IClientRouter {
 
                 // In the case the message is intended for a specific endpoint, we do not
                 // block on connection future, this is the case of leader verification.
-//                log.info("#243 Send message to {}, type={}", nodeId, payload.getPayloadCase());
                 if(isConnectionInitiator) {
                     clientChannelAdapter.send(nodeId, getRequestMsg(header.build(), payload));
                 } else {
@@ -250,7 +249,6 @@ public class LogReplicationSourceRouterHelper implements IClientRouter {
                         nodeId));
                 throw ne;
             } catch (Exception e) {
-//                log.info("sendRequestAndGetCompletable removing reqId outstandingRequests {}", requestId);
                 outstandingRequests.remove(requestId);
                 log.error("sendMessageAndGetCompletable: Remove request {} to {} due to exception! Message:{}",
                         requestId, remoteClusterDescriptor.getClusterId(), payload.getPayloadCase(), e);
@@ -335,8 +333,8 @@ public class LogReplicationSourceRouterHelper implements IClientRouter {
         CompletableFuture cf;
         if ((cf = outstandingRequests.remove(requestID)) != null) {
             cf.completeExceptionally(cause);
-//            log.debug("completeExceptionally: Remove request {} to {} due to {}.", requestID,
-//                    remoteClusterDescriptor.getClusterId(), cause.getClass().getSimpleName(), cause);
+            log.debug("completeExceptionally: Remove request {} to {} due to {}.", requestID,
+                    remoteClusterDescriptor.getClusterId(), cause.getClass().getSimpleName(), cause);
         } else {
             log.warn("Attempted to exceptionally complete request {}, but request not outstanding!",
                     requestID);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceServerRouter.java
@@ -1,0 +1,178 @@
+package org.corfudb.infrastructure.logreplication.runtime;
+
+import io.netty.channel.ChannelHandlerContext;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.AbstractServer;
+import org.corfudb.infrastructure.BaseServer;
+import org.corfudb.infrastructure.IServerRouter;
+import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
+import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationManager;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
+import org.corfudb.runtime.proto.service.CorfuMessage;
+import org.corfudb.runtime.view.Layout;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Slf4j
+public class LogReplicationSourceServerRouter extends LogReplicationSourceRouterHelper implements IServerRouter {
+
+    /**
+     * The epoch of this router. This is managed by the base server implementation.
+     */
+    @Getter
+    @Setter
+    private volatile long serverEpoch;
+
+    /**
+     * This map stores the mapping from message type to netty server handler.
+     */
+    private final Map<CorfuMessage.RequestPayloadMsg.PayloadCase, AbstractServer> msgHandlerMap;
+
+    /** Construct a new {@link LogReplicationSourceServerRouter}.
+     *
+     */
+    public LogReplicationSourceServerRouter(ClusterDescriptor remoteCluster, String localClusterId,
+                                            LogReplicationRuntimeParameters parameters, CorfuReplicationManager replicationManager,
+                                            ReplicationSession session, Map<Class, AbstractServer> serverMap) {
+        super(remoteCluster, localClusterId, parameters, replicationManager, session, false);
+        this.serverEpoch = ((BaseServer) serverMap.get(BaseServer.class)).serverContext.getServerEpoch();
+        this.msgHandlerMap = new EnumMap<>(CorfuMessage.RequestPayloadMsg.PayloadCase.class);
+
+        serverMap.values().forEach(server -> {
+            try {
+                server.getHandlerMethods().getHandledTypes().forEach(x -> msgHandlerMap.put(x, server));
+            } catch (UnsupportedOperationException ex) {
+                log.trace("No registered CorfuMsg handler for server {}", server, ex);
+            }
+        });
+    }
+
+    public void setAdapter(IServerChannelAdapter serverAdapter) {
+        this.setServerChannelAdapter(serverAdapter);
+    }
+
+    // ============ IServerRouter Methods =============
+
+    @Override
+    public void sendResponse(CorfuMessage.ResponseMsg response, ChannelHandlerContext ctx) {
+        log.info("Ready to send response {}", response.getPayload().getPayloadCase());
+        try {
+            this.serverChannelAdapter.send(response);
+            log.info("Sent response: {}", response);
+        } catch (IllegalArgumentException e) {
+            log.warn("Illegal response type. Ignoring message.", e);
+        }
+    }
+
+    @Override
+    public Optional<Layout> getCurrentLayout() {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<AbstractServer> getServers() {
+        return new ArrayList<>();
+    }
+
+    @Override
+    public void setServerContext(ServerContext serverContext) {
+
+    }
+
+    // ================================================
+
+    /**
+     * When the SOURCE is the connection endpoint, the only request it can receive is the leadership_Query.
+     * This request is received and passed to an appropriate handler.
+     *
+     * @param message
+     */
+    public void receive(CorfuMessage.RequestMsg message) {
+        log.info("Received message {}.", message.getPayload().getPayloadCase());
+
+        AbstractServer handler = msgHandlerMap.get(message.getPayload().getPayloadCase());
+        if (handler == null) {
+            // The message was unregistered, we are dropping it.
+            log.warn("Received unregistered message {}, dropping", message);
+        } else {
+            if (validateEpoch(message.getHeader())) {
+                // Route the message to the handler.
+                if (log.isTraceEnabled()) {
+                    log.trace("Message routed to {}: {}", handler.getClass().getSimpleName(), message);
+                }
+
+                try {
+                    handler.handleMessage(message, null, this);
+                } catch (Throwable t) {
+                    log.error("channelRead: Handling {} failed due to {}:{}",
+                            message.getPayload().getPayloadCase(),
+                            t.getClass().getSimpleName(),
+                            t.getMessage(),
+                            t);
+                }
+                String remoteLeaderId = message.getPayload().getLrLeadershipQuery().getSessionInfo().getLocalClusterId();
+                runtimeFSM.setRemoteLeaderNodeId(remoteLeaderId);
+            }
+        }
+    }
+
+    /**
+     * Receive messages from the 'custom' serverAdapter implementation. This message will be forwarded
+     * for processing.
+     *
+     * @param message
+     */
+    public void receive(CorfuMessage.ResponseMsg message) {
+        log.info("Received message {}", message.getPayload().getPayloadCase());
+
+        if (validateEpoch(message.getHeader())) {
+            if(message.getPayload().getPayloadCase().equals(CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_SUBSCRIBE_REQUEST)) {
+                this.startReplication(runtimeFSM.getRemoteLeaderNodeId().get());
+            } else {
+                super.receive(message);
+            }
+
+        }
+    }
+
+    /**
+     * Validate the epoch of a CorfuMsg, and send a WRONG_EPOCH response if
+     * the server is in the wrong epoch. Ignored if the message type is reset (which
+     * is valid in any epoch).
+     *
+     * @param header The incoming header to validate.
+     * @return True, if the epoch is correct, but false otherwise.
+     */
+    private boolean validateEpoch(CorfuMessage.HeaderMsg header) {
+        long serverEpoch = getServerEpoch();
+        if (!header.getIgnoreEpoch() && header.getEpoch()!= serverEpoch) {
+            log.trace("Incoming message with wrong epoch, got {}, expected {}",
+                    header.getEpoch(), serverEpoch);
+            sendWrongEpochError(header, null);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated This operation is no longer supported. The router will only route messages for
+     * servers provided at construction time.
+     */
+    @Override
+    @Deprecated
+    public void addServer(AbstractServer server) {
+        throw new UnsupportedOperationException("No longer supported");
+    }
+
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceServerRouter.java
@@ -12,6 +12,7 @@ import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
 import org.corfudb.infrastructure.logreplication.infrastructure.CorfuReplicationManager;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
 import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.runtime.view.Layout;
@@ -23,7 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Slf4j
-public class LogReplicationSourceServerRouter extends LogReplicationSourceRouterHelper implements IServerRouter {
+public class LogReplicationSourceServerRouter extends LogReplicationBaseSourceRouter implements IServerRouter {
 
     /**
      * The epoch of this router. This is managed by the base server implementation.
@@ -172,6 +173,13 @@ public class LogReplicationSourceServerRouter extends LogReplicationSourceRouter
     @Deprecated
     public void addServer(AbstractServer server) {
         throw new UnsupportedOperationException("No longer supported");
+    }
+
+
+    public void connectionDown() {
+        log.debug("Caught Network Exception for session {}", session);
+        runtimeFSM.input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.ON_CONNECTION_DOWN,
+                session.getRemoteClusterId()));
     }
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceServerRouter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/LogReplicationSourceServerRouter.java
@@ -155,8 +155,7 @@ public class LogReplicationSourceServerRouter extends LogReplicationSourceRouter
     private boolean validateEpoch(CorfuMessage.HeaderMsg header) {
         long serverEpoch = getServerEpoch();
         if (!header.getIgnoreEpoch() && header.getEpoch()!= serverEpoch) {
-            log.trace("Incoming message with wrong epoch, got {}, expected {}",
-                    header.getEpoch(), serverEpoch);
+            log.trace("Incoming message with wrong epoch, got {}, expected {}", header.getEpoch(), serverEpoch);
             sendWrongEpochError(header, null);
             return false;
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -7,7 +7,6 @@ import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationE
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationEventMetadata;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceClientRouter;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceRouterHelper;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.LogReplication;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/NegotiatingState.java
@@ -7,7 +7,7 @@ import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationE
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationEventMetadata;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceRouterHelper;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationBaseSourceRouter;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationMetadataResponseMsg;
@@ -36,13 +36,13 @@ public class NegotiatingState implements LogReplicationRuntimeState {
 
     private final ThreadPoolExecutor worker;
 
-    private final LogReplicationSourceRouterHelper router;
+    private final LogReplicationBaseSourceRouter router;
 
     private final LogReplicationMetadataManager metadataManager;
 
     private final LogReplicationConfigManager tableManagerPlugin;
 
-    public NegotiatingState(CorfuLogReplicationRuntime fsm, ThreadPoolExecutor worker, LogReplicationSourceRouterHelper router,
+    public NegotiatingState(CorfuLogReplicationRuntime fsm, ThreadPoolExecutor worker, LogReplicationBaseSourceRouter router,
                             LogReplicationMetadataManager metadataManager, LogReplicationConfigManager tableManagerPlugin) {
         this.fsm = fsm;
         this.metadataManager = metadataManager;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteLeaderState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/VerifyingRemoteLeaderState.java
@@ -2,10 +2,8 @@ package org.corfudb.infrastructure.logreplication.runtime.fsm;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
-import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceClientRouter;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceRouterHelper;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationBaseSourceRouter;
 import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationLeadershipResponseMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage;
@@ -30,10 +28,10 @@ public class VerifyingRemoteLeaderState implements LogReplicationRuntimeState {
 
     private ThreadPoolExecutor worker;
 
-    private LogReplicationSourceRouterHelper router;
+    private LogReplicationBaseSourceRouter router;
 
     public VerifyingRemoteLeaderState(CorfuLogReplicationRuntime fsm, ThreadPoolExecutor worker,
-                                      LogReplicationSourceRouterHelper router) {
+                                      LogReplicationBaseSourceRouter router) {
         this.fsm = fsm;
         this.worker = worker;
         this.router = router;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/sink/SinkVerifyRemoteLeader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/sink/SinkVerifyRemoteLeader.java
@@ -1,4 +1,4 @@
-package org.corfudb.infrastructure.logreplication.runtime.sinkFsm;
+package org.corfudb.infrastructure.logreplication.runtime.fsm.sink;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +18,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
 @Slf4j

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/sink/SinkVerifyRemoteLeader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/fsm/sink/SinkVerifyRemoteLeader.java
@@ -90,17 +90,7 @@ public class SinkVerifyRemoteLeader {
                 String nodeIdDown = event.getNodeId();
                 log.debug("Detected connection down from node={}", nodeIdDown);
                 updateDisconnectedNodes(nodeIdDown);
-
-                // If no connection exists, establish a connection again
-                if (connectedNodes.size() == 0) {
-                    LogReplication.ReplicationSessionMsg sessionMsg = LogReplication.ReplicationSessionMsg.newBuilder()
-                            .setRemoteClusterId(session.getRemoteClusterId())
-                            .setLocalClusterId(session.getLocalClusterId())
-                            .setClient(session.getSubscriber().getClient())
-                            .setReplicationModel(session.getSubscriber().getReplicationModel())
-                            .build();
-                    router.getChannelAdapter().connectAsync(sessionMsg);
-                }
+                resetRemoteLeader();
                 break;
             case REMOTE_LEADER_NOT_FOUND:
                 log.info("Remote Leader not found. Retrying...");
@@ -120,6 +110,11 @@ public class SinkVerifyRemoteLeader {
                 log.warn("Unexpected communication event {}", event.getType());
             }
         }
+    }
+
+    private void resetRemoteLeader() {
+        log.debug("Reset remote leader");
+        leaderNodeId = Optional.empty();
     }
 
     private void updateConnectedNodes(String nodeId) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/sinkFsm/SinkVerifyRemoteLeader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/sinkFsm/SinkVerifyRemoteLeader.java
@@ -1,0 +1,241 @@
+package org.corfudb.infrastructure.logreplication.runtime.sinkFsm;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkClientRouter;
+import org.corfudb.infrastructure.logreplication.runtime.fsm.LogReplicationRuntimeEvent;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.proto.service.CorfuMessage;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+public class SinkVerifyRemoteLeader {
+
+    /**
+     * Executor service for FSM event queue consume
+     */
+    private final ExecutorService communicationFSMConsumer;
+
+    private final Set<String> connectedNodes;
+
+    /**
+     * A queue of events.
+     */
+    private final LinkedBlockingQueue<LogReplicationRuntimeEvent> eventQueue = new LinkedBlockingQueue<>();
+
+    private final ReplicationSession session;
+
+    private final LogReplicationSinkClientRouter router;
+
+    private volatile Optional<String> leaderNodeId = Optional.empty();
+
+    public SinkVerifyRemoteLeader(ReplicationSession session, LogReplicationSinkClientRouter router) {
+        this.session = session;
+        this.router = router;
+        this.connectedNodes = new HashSet<>();
+
+        String remoteClusterId = session.getRemoteClusterId();
+
+        this.communicationFSMConsumer = Executors.newSingleThreadExecutor(new
+                ThreadFactoryBuilder().setNameFormat(
+                "sink-consumer-"+remoteClusterId).build());
+
+
+        communicationFSMConsumer.submit(this::consume);
+    }
+
+    public synchronized void input(LogReplicationRuntimeEvent event) {
+        try {
+            log.info("adding to the queue {}", event);
+            eventQueue.put(event);
+        } catch (InterruptedException ex) {
+            log.error("Log Replication interrupted Exception: ", ex);
+        }
+    }
+
+    /**
+     * Consumer of the eventQueue.
+     * <p>
+     * This method consumes the log replication events and does the state transition.
+     */
+    private void consume() {
+        try {
+            //  Block until an event shows up in the queue.
+            LogReplicationRuntimeEvent event = eventQueue.take();
+            processEvent(event);
+
+            communicationFSMConsumer.submit(this::consume);
+
+        } catch (Throwable t) {
+            log.error("Error on event consumer: ", t);
+        }
+    }
+
+    private void processEvent(LogReplicationRuntimeEvent event) {
+        log.info("processing event {}", event);
+        switch (event.getType()) {
+            case ON_CONNECTION_DOWN:
+                String nodeIdDown = event.getNodeId();
+                log.debug("Detected connection down from node={}", nodeIdDown);
+                updateDisconnectedNodes(nodeIdDown);
+
+                // If no connection exists, establish a connection again
+                if (connectedNodes.size() == 0) {
+                    LogReplication.ReplicationSessionMsg sessionMsg = LogReplication.ReplicationSessionMsg.newBuilder()
+                            .setRemoteClusterId(session.getRemoteClusterId())
+                            .setLocalClusterId(session.getLocalClusterId())
+                            .setClient(session.getSubscriber().getClient())
+                            .setReplicationModel(session.getSubscriber().getReplicationModel())
+                            .build();
+                    router.getChannelAdapter().connectAsync(sessionMsg);
+                }
+                break;
+            case REMOTE_LEADER_NOT_FOUND:
+                log.info("Remote Leader not found. Retrying...");
+                verifyLeadership();
+                break;
+            case ON_CONNECTION_UP:
+                log.debug("Detected connection up from endpoint={}", event.getNodeId());
+                // Add new connected node, for leadership verification
+                updateConnectedNodes(event.getNodeId());
+                verifyLeadership();
+                break;
+            case REMOTE_LEADER_FOUND:
+                log.debug("Remote Leader is found: {}", event.getNodeId());
+                subscribeAndStartReplication();
+                break;
+            default: {
+                log.warn("Unexpected communication event {}", event.getType());
+            }
+        }
+    }
+
+    private void updateConnectedNodes(String nodeId) {
+        this.connectedNodes.add(nodeId);
+    }
+
+    private void updateDisconnectedNodes(String nodeId) {
+        this.connectedNodes.remove(nodeId);
+    }
+
+    public synchronized void setRemoteLeaderNodeId(String leaderId) {
+        log.debug("Set remote leader node id {}", leaderId);
+        leaderNodeId = Optional.ofNullable(leaderId);
+    }
+
+    public synchronized Optional<String> getRemoteLeaderNodeId() {
+        log.trace("Retrieve remote leader node id {}", leaderNodeId);
+        return leaderNodeId;
+    }
+
+    private synchronized void verifyLeadership() {
+
+        log.debug("Enter :: leadership verification");
+
+        String leader = "";
+
+        Map<String, CompletableFuture<LogReplication.LogReplicationLeadershipResponseMsg>> pendingLeadershipQueries = new HashMap<>();
+
+        // Verify leadership on remote cluster, only if no leader is currently selected.
+        if (!getRemoteLeaderNodeId().isPresent()) {
+
+            log.debug("Verify leader on remote cluster {}", session.getRemoteClusterId());
+
+            try {
+                for (String nodeId : connectedNodes) {
+                    log.debug("Verify leadership status for node {}", nodeId);
+                    // Check Leadership
+                    LogReplication.ReplicationSessionMsg sessionMsg = LogReplication.ReplicationSessionMsg.newBuilder()
+                            .setRemoteClusterId(session.getRemoteClusterId())
+                            .setLocalClusterId(session.getLocalClusterId())
+                            .setClient(session.getSubscriber().getClient())
+                            .setReplicationModel(session.getSubscriber().getReplicationModel())
+                            .build();
+                    log.info("sessions in veryfingLeadership {}", sessionMsg);
+                    CorfuMessage.RequestPayloadMsg payload =
+                            CorfuMessage.RequestPayloadMsg.newBuilder().setLrLeadershipQuery(
+                                    LogReplication.LogReplicationLeadershipRequestMsg
+                                            .newBuilder()
+                                            .setSessionInfo(sessionMsg)
+                                            .build()
+                            ).build();
+
+                    CompletableFuture<LogReplication.LogReplicationLeadershipResponseMsg> leadershipRequestCf =
+                            router.sendRequestAndGetCompletable(payload, nodeId);
+                    pendingLeadershipQueries.put(nodeId, leadershipRequestCf);
+                }
+
+                // Block until all leadership requests are completed, or a leader is discovered.
+                while (pendingLeadershipQueries.size() != 0) {
+                    LogReplication.LogReplicationLeadershipResponseMsg leadershipResponse = (LogReplication.LogReplicationLeadershipResponseMsg)
+                            CompletableFuture.anyOf(pendingLeadershipQueries.values()
+                                    .toArray(new CompletableFuture<?>[pendingLeadershipQueries.size()])).get(CorfuLogReplicationRuntime.DEFAULT_TIMEOUT, TimeUnit.MILLISECONDS);
+
+                    if (leadershipResponse.getIsLeader()) {
+                        log.info("Received Leadership Response :: leader for remote cluster, node={}", leadershipResponse.getNodeId());
+                        leader = leadershipResponse.getNodeId();
+                        setRemoteLeaderNodeId(leader);
+
+                        // Remove all CF, based on the assumption that one leader response is the expectation.
+                        pendingLeadershipQueries.clear();
+
+                        // A new leader has been found,
+                        input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.REMOTE_LEADER_FOUND, leader));
+                        log.debug("Exit :: leadership verification");
+                        return;
+                    } else {
+                        log.debug("Received Leadership Response :: node {} is not the leader", leadershipResponse.getNodeId());
+
+                        // Remove CF for completed request
+                        pendingLeadershipQueries.remove(leadershipResponse.getNodeId());
+                    }
+                }
+
+                // No remote leader was found, retry leadership
+                input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.REMOTE_LEADER_NOT_FOUND, leader));
+
+            } catch (Exception ex) {
+                log.warn("Exception caught while verifying remote leader.", ex);
+                input(new LogReplicationRuntimeEvent(LogReplicationRuntimeEvent.LogReplicationRuntimeEventType.REMOTE_LEADER_NOT_FOUND, leader));
+            }
+        } else {
+            log.info("Remote Leader already present {}. Skip leader verification.", getRemoteLeaderNodeId().get());
+        }
+
+        log.debug("Exit :: leadership verification");
+    }
+
+    private void subscribeAndStartReplication() {
+        //Session as seen from the SOURCE
+        LogReplication.ReplicationSessionMsg sessionMsg = LogReplication.ReplicationSessionMsg.newBuilder()
+                .setRemoteClusterId(session.getRemoteClusterId())
+                .setLocalClusterId(session.getLocalClusterId())
+                .setClient(session.getSubscriber().getClient())
+                .setReplicationModel(session.getSubscriber().getReplicationModel())
+                .build();
+        CorfuMessage.ResponsePayloadMsg payload =
+                CorfuMessage.ResponsePayloadMsg.newBuilder().setLrSubscribeRequest(
+                        LogReplication.LogReplicationSubscribeMsg
+                                .newBuilder()
+                                .setSessionInfo(sessionMsg)
+                                .build()
+                ).build();
+
+        log.info("Sending the subscribe msg {}", payload);
+        router.sendResponse(payload, getRemoteLeaderNodeId().get());
+    }
+
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
@@ -44,6 +44,7 @@ public abstract class IClientChannelAdapter {
      * @param localClusterId local cluster unique identifier
      * @param remoteClusterDescriptor descriptor of the remote cluster (sink)
      * @param sourceRouter interface to forward
+     * @param sinkRouter interface to forward
      */
     public IClientChannelAdapter(@Nonnull String localClusterId,
                                  @Nonnull ClusterDescriptor remoteClusterDescriptor,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/client/IClientChannelAdapter.java
@@ -2,8 +2,10 @@ package org.corfudb.infrastructure.logreplication.transport.client;
 
 import lombok.Getter;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientRouter;
 import org.corfudb.infrastructure.logreplication.transport.IChannelContext;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkClientRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceClientRouter;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 
@@ -28,7 +30,10 @@ public abstract class IClientChannelAdapter {
     private final ClusterDescriptor remoteClusterDescriptor;
 
     @Getter
-    private final LogReplicationClientRouter router;
+    private final LogReplicationSourceClientRouter sourceRouter;
+
+    @Getter
+    private final LogReplicationSinkClientRouter sinkRouter;
 
     @Getter
     private IChannelContext channelContext;
@@ -38,25 +43,27 @@ public abstract class IClientChannelAdapter {
      *
      * @param localClusterId local cluster unique identifier
      * @param remoteClusterDescriptor descriptor of the remote cluster (sink)
-     * @param router interface to forward
+     * @param sourceRouter interface to forward
      */
     public IClientChannelAdapter(@Nonnull String localClusterId,
                                  @Nonnull ClusterDescriptor remoteClusterDescriptor,
-                                 @Nonnull LogReplicationClientRouter router) {
+                                 @Nonnull LogReplicationSourceClientRouter sourceRouter,
+                                 @Nonnull LogReplicationSinkClientRouter sinkRouter) {
         this.localClusterId = localClusterId;
         this.remoteClusterDescriptor = remoteClusterDescriptor;
-        this.router = router;
+        this.sourceRouter = sourceRouter;
+        this.sinkRouter = sinkRouter;
     }
 
     /**
      * Connect Asynchronously to all endpoints specified in the Cluster Descriptor.
      */
-    public void connectAsync() {}
+    public void connectAsync(LogReplication.ReplicationSessionMsg sessionMsg) {}
 
     /**
      * If connection is lost to a specific endpoint, attempt to reconnect to the specific node.
      */
-    public void connectAsync(String nodeId) {}
+    public void connectAsync(String nodeId, LogReplication.ReplicationSessionMsg sessionMsg) {}
 
     /**
      * Stop communication across Clusters.
@@ -79,6 +86,14 @@ public abstract class IClientChannelAdapter {
     public abstract void send(String nodeId, RequestMsg request);
 
     /**
+     * Send a message across the channel to a specific endpoint.
+     *
+     * @param nodeId remote node id
+     * @param request corfu message to be sent
+     */
+    public abstract void send(String nodeId, ResponseMsg request);
+
+    /**
      * Notify adapter of cluster change or reconfiguration.
      *
      * Since the adapter manages the connections to the remote site it must close or open
@@ -95,18 +110,34 @@ public abstract class IClientChannelAdapter {
      * @param msg received corfu message
      */
     public void receive(ResponseMsg msg) {
-        getRouter().receive(msg);
+        if (getSinkRouter() != null) {
+            getSinkRouter().receive(msg);
+        } else {
+            getSourceRouter().receive(msg);
+        }
+    }
+
+    public void receive(RequestMsg msg) {
+        if (getSinkRouter() != null) {
+            getSinkRouter().receive(msg);
+        } else {
+            getSourceRouter().receive(msg);
+        }
     }
 
     /**
      * Callback upon connectivity.
      *
-     * The implementer of the adapter must notify back on a connection being stablished.
+     * The implementer of the adapter must notify back on a connection being established.
      *
      * @param nodeId remote node id for which the connection was established.
      */
     public void onConnectionUp(String nodeId) {
-        getRouter().onConnectionUp(nodeId);
+        if (getSinkRouter() != null) {
+            getSinkRouter().onConnectionUp(nodeId);
+        } else {
+            getSourceRouter().onConnectionUp(nodeId);
+        }
     }
 
     /**
@@ -117,7 +148,11 @@ public abstract class IClientChannelAdapter {
      * @param nodeId remote node id for which the connection was lost.
      */
     public void onConnectionDown(String nodeId) {
-        getRouter().onConnectionDown(nodeId);
+        if (getSinkRouter() != null) {
+            getSinkRouter().onConnectionDown(nodeId);
+        } else {
+            getSourceRouter().onConnectionDown(nodeId);
+        }
     }
 
     /**
@@ -128,7 +163,11 @@ public abstract class IClientChannelAdapter {
      * @param t
      */
     public void onError(Throwable t) {
-        getRouter().onError(t);
+        if (getSinkRouter() != null) {
+            getSinkRouter().onError(t);
+        } else {
+            getSourceRouter().onError(t);
+        }
     }
 
     /**
@@ -137,7 +176,10 @@ public abstract class IClientChannelAdapter {
      * @return leader in remote cluster
      */
     public Optional<String> getRemoteLeader() {
-        return getRouter().getRemoteLeaderNodeId();
+        if(getSourceRouter() != null) {
+            return getSourceRouter().getRemoteLeaderNodeId();
+        }
+        return Optional.empty();
     }
 
     public abstract void resetRemoteLeader();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyClientChannel.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyClientChannel.java
@@ -1,311 +1,311 @@
-package org.corfudb.infrastructure.logreplication.transport.sample;
-
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import com.google.protobuf.TextFormat;
-import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.handler.codec.LengthFieldPrepender;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.timeout.IdleStateHandler;
-import lombok.Getter;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
-import org.corfudb.infrastructure.logreplication.infrastructure.NodeDescriptor;
-import org.corfudb.protocols.wireprotocol.NettyCorfuMessageDecoder;
-import org.corfudb.protocols.wireprotocol.NettyCorfuMessageEncoder;
-import org.corfudb.runtime.exceptions.NetworkException;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
-import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
-import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
-import org.corfudb.security.sasl.SaslUtils;
-import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyClient;
-import org.corfudb.security.tls.SslContextConstructor;
-import org.corfudb.util.Sleep;
-
-import javax.annotation.Nonnull;
-import javax.net.ssl.SSLException;
-import java.util.concurrent.ThreadFactory;
-
-@Slf4j
-@ChannelHandler.Sharable
-public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<ResponseMsg> {
-
-    /**
-     * The currently registered channel.
-     */
-    private volatile Channel channel = null;
-
-    /**
-     * Whether or not this channel is shutdown.
-     */
-    public volatile boolean shutdown;
-
-    /**
-     * New connection timeout (milliseconds).
-     */
-    @Getter
-    @Setter
-    public long timeoutConnect;
-
-    /**
-     * Sync call response timeout (milliseconds).
-     */
-    @Getter
-    @Setter
-    public long timeoutResponse;
-
-    /**
-     * Retry interval after timeout (milliseconds).
-     */
-    @Getter
-    @Setter
-    public long timeoutRetry;
-
-    /**
-     * Thread pool for this channel to use
-     */
-    private final EventLoopGroup eventLoopGroup;
-
-    private SslContext sslContext;
-
-    private final LogReplicationRuntimeParameters parameters;
-
-    private final NettyLogReplicationClientChannelAdapter adapter;
-
-    private final NodeDescriptor node;
-
-    public CorfuNettyClientChannel(@Nonnull NodeDescriptor node,
-                                   @Nonnull EventLoopGroup eventLoopGroup,
-                                   @Nonnull NettyLogReplicationClientChannelAdapter adapter) {
-        this.node = node;
-        this.parameters = adapter.getSourceRouter().getRuntimeFSM().getSourceManager().getParameters();
-        this.adapter = adapter;
-        this.eventLoopGroup = eventLoopGroup == null ? getNewEventLoopGroup()
-                : eventLoopGroup;
-
-        timeoutConnect = parameters.getConnectionTimeout().toMillis();
-        timeoutResponse = parameters.getRequestTimeout().toMillis();
-        timeoutRetry = parameters.getConnectionRetryRate().toMillis();
-
-        if (parameters.isTlsEnabled()) {
-            setSslContext();
-        }
-
-        // Initialize the channel
-        Bootstrap b = initializeChannel();
-
-        // Asynchronously connect, retrying until shut down.
-        connectAsync(b);
-    }
-
-    private Bootstrap initializeChannel() {
-        shutdown = false;
-        Bootstrap b = new Bootstrap();
-        b.group(eventLoopGroup);
-        b.channel(parameters.getSocketType().getChannelClass());
-        parameters.getNettyChannelOptions().forEach(b::option);
-        b.handler(getChannelInitializer());
-        b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) timeoutConnect);
-        return b;
-    }
-
-    private void setSslContext() {
-         try {
-            sslContext = SslContextConstructor.constructSslContext(
-                    false,
-                    parameters.getKeyStoreConfig(),
-                    parameters.getTrustStoreConfig()
-            );
-        } catch (SSLException e) {
-            throw new UnrecoverableCorfuError(e);
-        }
-    }
-
-    @Override
-    protected void channelRead0(ChannelHandlerContext ctx, ResponseMsg msg) {
-        log.info("Received msg type={}", msg.getPayload().getPayloadCase());
-        adapter.receive(msg);
-    }
-
-    /**
-     * Channel event that is triggered when a new connected channel is created.
-     *
-     * @param ctx channel handler context
-     * @throws Exception exception
-     */
-    @Override
-    public void channelActive(ChannelHandlerContext ctx) {
-        log.info("channelActive: Outgoing connection established to: {} from id={}", ctx.channel().remoteAddress(), ctx.channel().localAddress());
-        channel = ctx.channel();
-        adapter.onConnectionUp(node.getNodeId());
-    }
-
-    /**
-     * Channel event that is triggered when the channel is closed.
-     *
-     * @param ctx channel handler context
-     * @throws Exception
-     */
-    @Override
-    public void channelInactive(ChannelHandlerContext ctx) {
-        log.info("channelActive: Outgoing connection lost to: {} from id={}", ctx.channel().remoteAddress(), ctx.channel().localAddress());
-        adapter.onConnectionDown(node.getNodeId());
-    }
-
-    public void close() {
-        log.debug("Close channel to {}", node.getNodeId());
-        shutdown = true;
-        adapter.onError(new NetworkException("Channel closed", node.getClusterId()));
-        if (channel != null && channel.isOpen()) {
-            channel.close();
-        }
-
-        this.eventLoopGroup.shutdownGracefully();
-    }
-
-    /**
-     * Get the {@link ChannelInitializer} used for initializing the Netty channel pipeline.
-     *
-     * @return A {@link ChannelInitializer} which initializes the pipeline.
-     */
-    private ChannelInitializer getChannelInitializer() {
-        return new ChannelInitializer() {
-            @Override
-            protected void initChannel(@Nonnull Channel ch) throws Exception {
-                ch.pipeline().addLast(new IdleStateHandler(parameters.getIdleConnectionTimeout(),
-                        parameters.getKeepAlivePeriod(), 0));
-                if (parameters.isTlsEnabled()) {
-                    ch.pipeline().addLast("ssl", sslContext.newHandler(ch.alloc()));
-                }
-                ch.pipeline().addLast(new LengthFieldPrepender(4));
-                ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE,
-                        0, 4, 0,
-                        4));
-                if (parameters.isSaslPlainTextEnabled()) {
-                    PlainTextSaslNettyClient saslNettyClient =
-                            SaslUtils.enableSaslPlainText(parameters.getUsernameFile(),
-                                    parameters.getPasswordFile());
-                    ch.pipeline().addLast("sasl/plain-text", saslNettyClient);
-                }
-                ch.pipeline().addLast(new NettyCorfuMessageDecoder());
-                ch.pipeline().addLast(new NettyCorfuMessageEncoder());
-
-                ch.pipeline().addLast(CorfuNettyClientChannel.this);
-            }
-        };
-    }
-
-    public void send(RequestMsg message) {
-        // Write the message out to the channel.
-        channel.writeAndFlush(message, channel.voidPromise());
-        log.info("Sent message: {}", TextFormat.shortDebugString(message));
-    }
-
-    /**
-     * Connect to a remote server asynchronously.
-     *
-     * @param bootstrap The channel bootstrap to use
-     */
-    private void connectAsync(@Nonnull Bootstrap bootstrap) {
-        // If shutdown, return a ChannelFuture that is exceptionally completed.
-        if (shutdown) {
-            return;
-        }
-        log.info("Connect Async {}", node.getNodeId());
-        // Use the bootstrap to create a new channel.
-        ChannelFuture f = bootstrap.connect(node.getHost(), Integer.valueOf(node.getPort()));
-        f.addListener((ChannelFuture cf) -> channelConnectionFutureHandler(cf, bootstrap));
-    }
-
-    /** Handle when a channel is connected.
-     *
-     * @param future        The future that is completed when the channel is connected/
-     * @param bootstrap     The bootstrap to connect a new channel (used on reconnect).
-     */
-    private void channelConnectionFutureHandler(@Nonnull ChannelFuture future,
-                                                @Nonnull Bootstrap bootstrap) {
-        if (future.isSuccess()) {
-            // Register a future to reconnect in case we get disconnected
-            addReconnectionOnCloseFuture(future.channel(), bootstrap);
-            log.info("connectAsync[{}]: Channel connected.", node);
-        } else {
-            // Otherwise, the connection failed. If we're not shutdown, try reconnecting after
-            // a sleep period.
-            if (!shutdown) {
-                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
-                log.info("connectAsync[{}]: Channel connection failed, reconnecting...", node);
-                // Call connect, which will retry the call again.
-                // Note that this is not recursive, because it is called in the
-                // context of the handler future.
-                connectAsync(bootstrap);
-            }
-        }
-    }
-
-    /** Add a future which reconnects the server.
-     *
-     * @param channel       The channel to use
-     * @param bootstrap     The channel bootstrap to use
-     */
-    private void addReconnectionOnCloseFuture(@Nonnull Channel channel,
-                                              @Nonnull Bootstrap bootstrap) {
-        channel.closeFuture().addListener((r) -> {
-            log.debug("addReconnectionOnCloseFuture[{}]: disconnected", node);
-            // Remove the current completion future, forcing clients to wait for reconnection.
-            adapter.completeExceptionally(new NetworkException("Disconnected", node.getClusterId()));
-
-            // If we aren't shutdown, reconnect.
-            if (!shutdown) {
-                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
-                log.debug("addReconnectionOnCloseFuture[{}]: reconnecting...", node);
-                // Asynchronously connect again.
-                connectAsync(bootstrap);
-            }
-        });
-    }
-
-    /**
-     * Get a new {@link EventLoopGroup} for scheduling threads for Netty. The
-     * {@link EventLoopGroup} is typically passed to a router.
-     *
-     * @return An {@link EventLoopGroup}.
-     */
-    private EventLoopGroup getNewEventLoopGroup() {
-        // Calculate the number of threads which should be available in the thread pool.
-        int numThreads = parameters.getNettyEventLoopThreads() == 0
-                ? Runtime.getRuntime().availableProcessors() * 2 :
-                parameters.getNettyEventLoopThreads();
-        ThreadFactory factory = new ThreadFactoryBuilder()
-                .setDaemon(true)
-                .setNameFormat(parameters.getNettyEventLoopThreadFormat())
-                .setUncaughtExceptionHandler(this::handleUncaughtThread)
-                .build();
-        return parameters.getSocketType().getGenerator().generate(numThreads, factory);
-    }
-
-    /**
-     * Function which is called whenever the runtime encounters an uncaught thread.
-     *
-     * @param thread    The thread which terminated.
-     * @param throwable The throwable which caused the thread to terminate.
-     */
-    private void handleUncaughtThread(@Nonnull Thread thread, @Nonnull Throwable throwable) {
-        if (parameters.getUncaughtExceptionHandler() != null) {
-            parameters.getUncaughtExceptionHandler().uncaughtException(thread, throwable);
-        } else {
-            log.error("handleUncaughtThread: {} terminated with throwable of type {}",
-                    thread.getName(),
-                    throwable.getClass().getSimpleName(),
-                    throwable);
-        }
-    }
-}
+//package org.corfudb.infrastructure.logreplication.transport.sample;
+//
+//import com.google.common.util.concurrent.ThreadFactoryBuilder;
+//import com.google.protobuf.TextFormat;
+//import io.netty.bootstrap.Bootstrap;
+//import io.netty.channel.Channel;
+//import io.netty.channel.ChannelFuture;
+//import io.netty.channel.ChannelHandler;
+//import io.netty.channel.ChannelHandlerContext;
+//import io.netty.channel.ChannelInitializer;
+//import io.netty.channel.ChannelOption;
+//import io.netty.channel.EventLoopGroup;
+//import io.netty.channel.SimpleChannelInboundHandler;
+//import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+//import io.netty.handler.codec.LengthFieldPrepender;
+//import io.netty.handler.ssl.SslContext;
+//import io.netty.handler.timeout.IdleStateHandler;
+//import lombok.Getter;
+//import lombok.Setter;
+//import lombok.extern.slf4j.Slf4j;
+//import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
+//import org.corfudb.infrastructure.logreplication.infrastructure.NodeDescriptor;
+//import org.corfudb.protocols.wireprotocol.NettyCorfuMessageDecoder;
+//import org.corfudb.protocols.wireprotocol.NettyCorfuMessageEncoder;
+//import org.corfudb.runtime.exceptions.NetworkException;
+//import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuError;
+//import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
+//import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
+//import org.corfudb.security.sasl.SaslUtils;
+//import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyClient;
+//import org.corfudb.security.tls.SslContextConstructor;
+//import org.corfudb.util.Sleep;
+//
+//import javax.annotation.Nonnull;
+//import javax.net.ssl.SSLException;
+//import java.util.concurrent.ThreadFactory;
+//
+//@Slf4j
+//@ChannelHandler.Sharable
+//public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<ResponseMsg> {
+//
+//    /**
+//     * The currently registered channel.
+//     */
+//    private volatile Channel channel = null;
+//
+//    /**
+//     * Whether or not this channel is shutdown.
+//     */
+//    public volatile boolean shutdown;
+//
+//    /**
+//     * New connection timeout (milliseconds).
+//     */
+//    @Getter
+//    @Setter
+//    public long timeoutConnect;
+//
+//    /**
+//     * Sync call response timeout (milliseconds).
+//     */
+//    @Getter
+//    @Setter
+//    public long timeoutResponse;
+//
+//    /**
+//     * Retry interval after timeout (milliseconds).
+//     */
+//    @Getter
+//    @Setter
+//    public long timeoutRetry;
+//
+//    /**
+//     * Thread pool for this channel to use
+//     */
+//    private final EventLoopGroup eventLoopGroup;
+//
+//    private SslContext sslContext;
+//
+//    private final LogReplicationRuntimeParameters parameters;
+//
+//    private final NettyLogReplicationClientChannelAdapter adapter;
+//
+//    private final NodeDescriptor node;
+//
+//    public CorfuNettyClientChannel(@Nonnull NodeDescriptor node,
+//                                   @Nonnull EventLoopGroup eventLoopGroup,
+//                                   @Nonnull NettyLogReplicationClientChannelAdapter adapter) {
+//        this.node = node;
+//        this.parameters = adapter.getSourceRouter().getRuntimeFSM().getSourceManager().getParameters();
+//        this.adapter = adapter;
+//        this.eventLoopGroup = eventLoopGroup == null ? getNewEventLoopGroup()
+//                : eventLoopGroup;
+//
+//        timeoutConnect = parameters.getConnectionTimeout().toMillis();
+//        timeoutResponse = parameters.getRequestTimeout().toMillis();
+//        timeoutRetry = parameters.getConnectionRetryRate().toMillis();
+//
+//        if (parameters.isTlsEnabled()) {
+//            setSslContext();
+//        }
+//
+//        // Initialize the channel
+//        Bootstrap b = initializeChannel();
+//
+//        // Asynchronously connect, retrying until shut down.
+//        connectAsync(b);
+//    }
+//
+//    private Bootstrap initializeChannel() {
+//        shutdown = false;
+//        Bootstrap b = new Bootstrap();
+//        b.group(eventLoopGroup);
+//        b.channel(parameters.getSocketType().getChannelClass());
+//        parameters.getNettyChannelOptions().forEach(b::option);
+//        b.handler(getChannelInitializer());
+//        b.option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) timeoutConnect);
+//        return b;
+//    }
+//
+//    private void setSslContext() {
+//         try {
+//            sslContext = SslContextConstructor.constructSslContext(
+//                    false,
+//                    parameters.getKeyStoreConfig(),
+//                    parameters.getTrustStoreConfig()
+//            );
+//        } catch (SSLException e) {
+//            throw new UnrecoverableCorfuError(e);
+//        }
+//    }
+//
+//    @Override
+//    protected void channelRead0(ChannelHandlerContext ctx, ResponseMsg msg) {
+//        log.info("Received msg type={}", msg.getPayload().getPayloadCase());
+//        adapter.receive(msg);
+//    }
+//
+//    /**
+//     * Channel event that is triggered when a new connected channel is created.
+//     *
+//     * @param ctx channel handler context
+//     * @throws Exception exception
+//     */
+//    @Override
+//    public void channelActive(ChannelHandlerContext ctx) {
+//        log.info("channelActive: Outgoing connection established to: {} from id={}", ctx.channel().remoteAddress(), ctx.channel().localAddress());
+//        channel = ctx.channel();
+//        adapter.onConnectionUp(node.getNodeId());
+//    }
+//
+//    /**
+//     * Channel event that is triggered when the channel is closed.
+//     *
+//     * @param ctx channel handler context
+//     * @throws Exception
+//     */
+//    @Override
+//    public void channelInactive(ChannelHandlerContext ctx) {
+//        log.info("channelActive: Outgoing connection lost to: {} from id={}", ctx.channel().remoteAddress(), ctx.channel().localAddress());
+//        adapter.onConnectionDown(node.getNodeId());
+//    }
+//
+//    public void close() {
+//        log.debug("Close channel to {}", node.getNodeId());
+//        shutdown = true;
+//        adapter.onError(new NetworkException("Channel closed", node.getClusterId()));
+//        if (channel != null && channel.isOpen()) {
+//            channel.close();
+//        }
+//
+//        this.eventLoopGroup.shutdownGracefully();
+//    }
+//
+//    /**
+//     * Get the {@link ChannelInitializer} used for initializing the Netty channel pipeline.
+//     *
+//     * @return A {@link ChannelInitializer} which initializes the pipeline.
+//     */
+//    private ChannelInitializer getChannelInitializer() {
+//        return new ChannelInitializer() {
+//            @Override
+//            protected void initChannel(@Nonnull Channel ch) throws Exception {
+//                ch.pipeline().addLast(new IdleStateHandler(parameters.getIdleConnectionTimeout(),
+//                        parameters.getKeepAlivePeriod(), 0));
+//                if (parameters.isTlsEnabled()) {
+//                    ch.pipeline().addLast("ssl", sslContext.newHandler(ch.alloc()));
+//                }
+//                ch.pipeline().addLast(new LengthFieldPrepender(4));
+//                ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE,
+//                        0, 4, 0,
+//                        4));
+//                if (parameters.isSaslPlainTextEnabled()) {
+//                    PlainTextSaslNettyClient saslNettyClient =
+//                            SaslUtils.enableSaslPlainText(parameters.getUsernameFile(),
+//                                    parameters.getPasswordFile());
+//                    ch.pipeline().addLast("sasl/plain-text", saslNettyClient);
+//                }
+//                ch.pipeline().addLast(new NettyCorfuMessageDecoder());
+//                ch.pipeline().addLast(new NettyCorfuMessageEncoder());
+//
+//                ch.pipeline().addLast(CorfuNettyClientChannel.this);
+//            }
+//        };
+//    }
+//
+//    public void send(RequestMsg message) {
+//        // Write the message out to the channel.
+//        channel.writeAndFlush(message, channel.voidPromise());
+//        log.info("Sent message: {}", TextFormat.shortDebugString(message));
+//    }
+//
+//    /**
+//     * Connect to a remote server asynchronously.
+//     *
+//     * @param bootstrap The channel bootstrap to use
+//     */
+//    private void connectAsync(@Nonnull Bootstrap bootstrap) {
+//        // If shutdown, return a ChannelFuture that is exceptionally completed.
+//        if (shutdown) {
+//            return;
+//        }
+//        log.info("Connect Async {}", node.getNodeId());
+//        // Use the bootstrap to create a new channel.
+//        ChannelFuture f = bootstrap.connect(node.getHost(), Integer.valueOf(node.getPort()));
+//        f.addListener((ChannelFuture cf) -> channelConnectionFutureHandler(cf, bootstrap));
+//    }
+//
+//    /** Handle when a channel is connected.
+//     *
+//     * @param future        The future that is completed when the channel is connected/
+//     * @param bootstrap     The bootstrap to connect a new channel (used on reconnect).
+//     */
+//    private void channelConnectionFutureHandler(@Nonnull ChannelFuture future,
+//                                                @Nonnull Bootstrap bootstrap) {
+//        if (future.isSuccess()) {
+//            // Register a future to reconnect in case we get disconnected
+//            addReconnectionOnCloseFuture(future.channel(), bootstrap);
+//            log.info("connectAsync[{}]: Channel connected.", node);
+//        } else {
+//            // Otherwise, the connection failed. If we're not shutdown, try reconnecting after
+//            // a sleep period.
+//            if (!shutdown) {
+//                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
+//                log.info("connectAsync[{}]: Channel connection failed, reconnecting...", node);
+//                // Call connect, which will retry the call again.
+//                // Note that this is not recursive, because it is called in the
+//                // context of the handler future.
+//                connectAsync(bootstrap);
+//            }
+//        }
+//    }
+//
+//    /** Add a future which reconnects the server.
+//     *
+//     * @param channel       The channel to use
+//     * @param bootstrap     The channel bootstrap to use
+//     */
+//    private void addReconnectionOnCloseFuture(@Nonnull Channel channel,
+//                                              @Nonnull Bootstrap bootstrap) {
+//        channel.closeFuture().addListener((r) -> {
+//            log.debug("addReconnectionOnCloseFuture[{}]: disconnected", node);
+//            // Remove the current completion future, forcing clients to wait for reconnection.
+//            adapter.completeExceptionally(new NetworkException("Disconnected", node.getClusterId()));
+//
+//            // If we aren't shutdown, reconnect.
+//            if (!shutdown) {
+//                Sleep.sleepUninterruptibly(parameters.getConnectionRetryRate());
+//                log.debug("addReconnectionOnCloseFuture[{}]: reconnecting...", node);
+//                // Asynchronously connect again.
+//                connectAsync(bootstrap);
+//            }
+//        });
+//    }
+//
+//    /**
+//     * Get a new {@link EventLoopGroup} for scheduling threads for Netty. The
+//     * {@link EventLoopGroup} is typically passed to a router.
+//     *
+//     * @return An {@link EventLoopGroup}.
+//     */
+//    private EventLoopGroup getNewEventLoopGroup() {
+//        // Calculate the number of threads which should be available in the thread pool.
+//        int numThreads = parameters.getNettyEventLoopThreads() == 0
+//                ? Runtime.getRuntime().availableProcessors() * 2 :
+//                parameters.getNettyEventLoopThreads();
+//        ThreadFactory factory = new ThreadFactoryBuilder()
+//                .setDaemon(true)
+//                .setNameFormat(parameters.getNettyEventLoopThreadFormat())
+//                .setUncaughtExceptionHandler(this::handleUncaughtThread)
+//                .build();
+//        return parameters.getSocketType().getGenerator().generate(numThreads, factory);
+//    }
+//
+//    /**
+//     * Function which is called whenever the runtime encounters an uncaught thread.
+//     *
+//     * @param thread    The thread which terminated.
+//     * @param throwable The throwable which caused the thread to terminate.
+//     */
+//    private void handleUncaughtThread(@Nonnull Thread thread, @Nonnull Throwable throwable) {
+//        if (parameters.getUncaughtExceptionHandler() != null) {
+//            parameters.getUncaughtExceptionHandler().uncaughtException(thread, throwable);
+//        } else {
+//            log.error("handleUncaughtThread: {} terminated with throwable of type {}",
+//                    thread.getName(),
+//                    throwable.getClass().getSimpleName(),
+//                    throwable);
+//        }
+//    }
+//}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyClientChannel.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyClientChannel.java
@@ -87,7 +87,7 @@ public class CorfuNettyClientChannel extends SimpleChannelInboundHandler<Respons
                                    @Nonnull EventLoopGroup eventLoopGroup,
                                    @Nonnull NettyLogReplicationClientChannelAdapter adapter) {
         this.node = node;
-        this.parameters = adapter.getRouter().getParameters();
+        this.parameters = adapter.getSourceRouter().getRuntimeFSM().getSourceManager().getParameters();
         this.adapter = adapter;
         this.eventLoopGroup = eventLoopGroup == null ? getNewEventLoopGroup()
                 : eventLoopGroup;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyServerChannel.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyServerChannel.java
@@ -36,7 +36,7 @@ public class CorfuNettyServerChannel extends ChannelInboundHandlerAdapter {
         try {
             RequestMsg message = (RequestMsg) msg;
 
-            log.trace("Received message {}", message.getPayload().getPayloadCase());
+            log.debug("Received message {}", message.getPayload().getPayloadCase());
 
             // Hold ChannelHandlerContexts to send response back
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyServerChannel.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/CorfuNettyServerChannel.java
@@ -1,117 +1,117 @@
-package org.corfudb.infrastructure.logreplication.transport.sample;
-
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
-import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
-import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
-import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
-import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
-import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
-import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
-
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-
-@Slf4j
-@ChannelHandler.Sharable
-public class CorfuNettyServerChannel extends ChannelInboundHandlerAdapter {
-
-    private NettyLogReplicationServerChannelAdapter adapter;
-
-    private Map<Pair<UuidMsg, Long>, ChannelHandlerContext> contextMap;
-
-    private Map<Pair<UuidMsg, Long>, ChannelHandlerContext> contextMapLogEntries;
-
-    public CorfuNettyServerChannel(NettyLogReplicationServerChannelAdapter adapter) {
-        this.adapter = adapter;
-        this.contextMap = new ConcurrentHashMap<>();
-        this.contextMapLogEntries = new ConcurrentHashMap<>();
-    }
-
-    @Override
-    public void channelRead(ChannelHandlerContext ctx, Object msg) {
-        try {
-            RequestMsg message = (RequestMsg) msg;
-
-            log.debug("Received message {}", message.getPayload().getPayloadCase());
-
-            // Hold ChannelHandlerContexts to send response back
-
-            // Note: log replication entries send a single summarized ACK as response for a batch of entries
-            // for this reason, we will hold in a separate map so we can remove all context handlers for requests lower
-            // than the one being served and avoid a memory leak.
-            Map<Pair<UuidMsg, Long>, ChannelHandlerContext> contexts =
-                    message.getPayload().getPayloadCase() == RequestPayloadMsg.PayloadCase.LR_ENTRY ?
-                    contextMapLogEntries : contextMap;
-            contexts.put(Pair.of(message.getHeader().getClusterId(),
-                message.getHeader().getRequestId()),
-                ctx);
-
-            // Send to the adapter for further processing.
-            adapter.receive(message);
-        } catch (Exception e) {
-            log.error("Exception during read!", e);
-        }
-    }
-
-    /**
-     * Channel event that is triggered when a new connected channel is created.
-     *
-     * @param ctx channel handler context
-     * @throws Exception
-     */
-    @Override
-    public void channelActive(final ChannelHandlerContext ctx) {
-        log.info("channelActive: Incoming connection established from: {} Start Read Timeout.",
-                ctx.channel().remoteAddress());
-    }
-
-    /**
-     * Send a netty message through this channel.
-     *
-     * @param outMsg Outgoing message.
-     */
-    public synchronized void sendResponse(ResponseMsg outMsg) {
-        ChannelHandlerContext ctx = getContext(outMsg);
-        if (ctx != null) {
-            ctx.writeAndFlush(outMsg, ctx.voidPromise());
-            log.trace("Sent response: {}", outMsg);
-        } else {
-            log.warn("Netty context not found for request id={}. Dropping message type={}",
-                    outMsg.getHeader().getRequestId(),
-                    outMsg.getPayload().getPayloadCase());
-        }
-    }
-
-    private ChannelHandlerContext getContext(ResponseMsg message) {
-
-        ChannelHandlerContext context;
-
-        if (message.getPayload().getPayloadCase() == ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK) {
-            // Because ACKs are aggregated (summarized) for a batch of messages, remove all
-            // contexts from this remote cluster which are lower than this request ID (to prevent memory leak, as those
-            // other messages, will never be served)
-            context =
-                contextMapLogEntries.remove(Pair.of(message.getHeader().getClusterId(),
-                    message.getHeader().getRequestId()));
-            contextMapLogEntries.keySet().removeIf(id ->
-                id.getRight() <= message.getHeader().getRequestId() &&
-                Objects.equals(id.getLeft(), message.getHeader().getClusterId()));
-        } else {
-            context =
-                contextMap.remove(Pair.of(message.getHeader().getClusterId(),
-                    message.getHeader().getRequestId()));
-        }
-
-        return context;
-    }
-
-    @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-        log.error("Error in handling inbound message.", cause);
-        ctx.close();
-    }
-}
+//package org.corfudb.infrastructure.logreplication.transport.sample;
+//
+//import io.netty.channel.ChannelHandler;
+//import io.netty.channel.ChannelHandlerContext;
+//import io.netty.channel.ChannelInboundHandlerAdapter;
+//import lombok.extern.slf4j.Slf4j;
+//import org.apache.commons.lang3.tuple.Pair;
+//import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
+//import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
+//import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
+//import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
+//import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
+//
+//import java.util.Map;
+//import java.util.Objects;
+//import java.util.concurrent.ConcurrentHashMap;
+//
+//@Slf4j
+//@ChannelHandler.Sharable
+//public class CorfuNettyServerChannel extends ChannelInboundHandlerAdapter {
+//
+//    private NettyLogReplicationServerChannelAdapter adapter;
+//
+//    private Map<Pair<UuidMsg, Long>, ChannelHandlerContext> contextMap;
+//
+//    private Map<Pair<UuidMsg, Long>, ChannelHandlerContext> contextMapLogEntries;
+//
+//    public CorfuNettyServerChannel(NettyLogReplicationServerChannelAdapter adapter) {
+//        this.adapter = adapter;
+//        this.contextMap = new ConcurrentHashMap<>();
+//        this.contextMapLogEntries = new ConcurrentHashMap<>();
+//    }
+//
+//    @Override
+//    public void channelRead(ChannelHandlerContext ctx, Object msg) {
+//        try {
+//            RequestMsg message = (RequestMsg) msg;
+//
+//            log.debug("Received message {}", message.getPayload().getPayloadCase());
+//
+//            // Hold ChannelHandlerContexts to send response back
+//
+//            // Note: log replication entries send a single summarized ACK as response for a batch of entries
+//            // for this reason, we will hold in a separate map so we can remove all context handlers for requests lower
+//            // than the one being served and avoid a memory leak.
+//            Map<Pair<UuidMsg, Long>, ChannelHandlerContext> contexts =
+//                    message.getPayload().getPayloadCase() == RequestPayloadMsg.PayloadCase.LR_ENTRY ?
+//                    contextMapLogEntries : contextMap;
+//            contexts.put(Pair.of(message.getHeader().getClusterId(),
+//                message.getHeader().getRequestId()),
+//                ctx);
+//
+//            // Send to the adapter for further processing.
+//            adapter.receive(message);
+//        } catch (Exception e) {
+//            log.error("Exception during read!", e);
+//        }
+//    }
+//
+//    /**
+//     * Channel event that is triggered when a new connected channel is created.
+//     *
+//     * @param ctx channel handler context
+//     * @throws Exception
+//     */
+//    @Override
+//    public void channelActive(final ChannelHandlerContext ctx) {
+//        log.info("channelActive: Incoming connection established from: {} Start Read Timeout.",
+//                ctx.channel().remoteAddress());
+//    }
+//
+//    /**
+//     * Send a netty message through this channel.
+//     *
+//     * @param outMsg Outgoing message.
+//     */
+//    public synchronized void sendResponse(ResponseMsg outMsg) {
+//        ChannelHandlerContext ctx = getContext(outMsg);
+//        if (ctx != null) {
+//            ctx.writeAndFlush(outMsg, ctx.voidPromise());
+//            log.trace("Sent response: {}", outMsg);
+//        } else {
+//            log.warn("Netty context not found for request id={}. Dropping message type={}",
+//                    outMsg.getHeader().getRequestId(),
+//                    outMsg.getPayload().getPayloadCase());
+//        }
+//    }
+//
+//    private ChannelHandlerContext getContext(ResponseMsg message) {
+//
+//        ChannelHandlerContext context;
+//
+//        if (message.getPayload().getPayloadCase() == ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK) {
+//            // Because ACKs are aggregated (summarized) for a batch of messages, remove all
+//            // contexts from this remote cluster which are lower than this request ID (to prevent memory leak, as those
+//            // other messages, will never be served)
+//            context =
+//                contextMapLogEntries.remove(Pair.of(message.getHeader().getClusterId(),
+//                    message.getHeader().getRequestId()));
+//            contextMapLogEntries.keySet().removeIf(id ->
+//                id.getRight() <= message.getHeader().getRequestId() &&
+//                Objects.equals(id.getLeft(), message.getHeader().getClusterId()));
+//        } else {
+//            context =
+//                contextMap.remove(Pair.of(message.getHeader().getClusterId(),
+//                    message.getHeader().getRequestId()));
+//        }
+//
+//        return context;
+//    }
+//
+//    @Override
+//    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+//        log.error("Error in handling inbound message.", cause);
+//        ctx.close();
+//    }
+//}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
@@ -1,31 +1,39 @@
 package org.corfudb.infrastructure.logreplication.transport.sample;
 
+import io.grpc.Context;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.grpc.stub.StreamObserver;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.corfudb.infrastructure.logreplication.LogReplicationChannelGrpc;
 import org.corfudb.infrastructure.logreplication.LogReplicationChannelGrpc.LogReplicationChannelBlockingStub;
 import org.corfudb.infrastructure.logreplication.LogReplicationChannelGrpc.LogReplicationChannelStub;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
 import org.corfudb.infrastructure.logreplication.infrastructure.NodeDescriptor;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkClientRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceClientRouter;
 import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 import org.corfudb.util.NodeLocator;
 
 import javax.annotation.Nonnull;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 /**
@@ -40,13 +48,20 @@ import java.util.stream.Collectors;
 @Slf4j
 public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapter {
 
+    private final int MAX_STREAMS_IN_CHANNEL = 100;
+
+    private static Map<String, Set<LogReplication.ReplicationSessionMsg>> channelToStreamsMap = new HashMap<>();
+    private static final ReentrantLock lock = new ReentrantLock();
+
     private final Map<String, ManagedChannel> channelMap;
-    private final Map<String, LogReplicationChannelBlockingStub> blockingStubMap;
-    private final Map<String, LogReplicationChannelStub> asyncStubMap;
+    private final Map<LogReplication.ReplicationSessionMsg, LogReplicationChannelBlockingStub> blockingStubMap;
+    private final Map<LogReplication.ReplicationSessionMsg, LogReplicationChannelStub> asyncStubMap;
     private final ExecutorService executorService;
 
-    private final ConcurrentMap<Long, StreamObserver<RequestMsg>> requestObserverMap;
-    private final ConcurrentMap<Long, StreamObserver<ResponseMsg>> responseObserverMap;
+    private final ConcurrentMap<LogReplication.ReplicationSessionMsg, StreamObserver<RequestMsg>> requestObserverMap;
+    private final ConcurrentMap<LogReplication.ReplicationSessionMsg, StreamObserver<ResponseMsg>> responseObserverMap;
+    private final ConcurrentMap<Pair<LogReplication.ReplicationSessionMsg, Long>, StreamObserver<RequestMsg>> replicationReqObserverMap;
+    private final ConcurrentMap<Pair<LogReplication.ReplicationSessionMsg, Long>, StreamObserver<ResponseMsg>> replicationResObserverMap;
 
     /** A {@link CompletableFuture} which is completed when a connection to a remote leader is set,
      * and  messages can be sent to the remote node.
@@ -54,12 +69,14 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
     @Getter
     volatile CompletableFuture<Void> connectionFuture;
 
+    Context context;
+
     /** Construct client for accessing LogReplicationService server using the existing channel. */
     public GRPCLogReplicationClientChannelAdapter(
             String localClusterId,
             ClusterDescriptor remoteClusterDescriptor,
-            LogReplicationClientRouter adapter) {
-        super(localClusterId, remoteClusterDescriptor, adapter);
+            LogReplicationSourceClientRouter sourceRouter, LogReplicationSinkClientRouter sinkRouter ) {
+        super(localClusterId, remoteClusterDescriptor, sourceRouter, sinkRouter);
 
         this.channelMap = new HashMap<>();
         this.blockingStubMap = new HashMap<>();
@@ -68,30 +85,45 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
         this.connectionFuture = new CompletableFuture<>();
         this.requestObserverMap = new ConcurrentHashMap<>();
         this.responseObserverMap = new ConcurrentHashMap<>();
+        this.replicationReqObserverMap = new ConcurrentHashMap<>();
+        this.replicationResObserverMap = new ConcurrentHashMap<>();
+        context = Context.current();
     }
 
     @Override
-    public void connectAsync() {
+    public void connectAsync(LogReplication.ReplicationSessionMsg session) {
         this.executorService.submit(() ->
         getRemoteClusterDescriptor().getNodesDescriptors().forEach(node -> {
             try {
                 NodeLocator nodeLocator = NodeLocator.parseString(node.getEndpoint());
-                log.info("GRPC create connection to node{}@{}:{}", node.getNodeId(), nodeLocator.getHost(), nodeLocator.getPort());
-                ManagedChannel channel = ManagedChannelBuilder.forAddress(nodeLocator.getHost(), nodeLocator.getPort())
-                        .usePlaintext()
-                        .build();
-                channelMap.put(node.getNodeId(), channel);
-                blockingStubMap.put(node.getNodeId(), LogReplicationChannelGrpc.newBlockingStub(channel));
-                asyncStubMap.put(node.getNodeId(), LogReplicationChannelGrpc.newStub(channel));
+                ManagedChannel channel;
+
+                lock.lock();
+                if(!channelToStreamsMap.containsKey(node.getNodeId()) || channelToStreamsMap.get(node.getNodeId()).size() >= MAX_STREAMS_IN_CHANNEL) {
+                    log.info("GRPC create new channel to node{}@{}:{}", node.getNodeId(), nodeLocator.getHost(), nodeLocator.getPort());
+                    channel = ManagedChannelBuilder.forAddress(nodeLocator.getHost(), nodeLocator.getPort())
+                            .usePlaintext()
+                            .build();
+                    channelMap.put(node.getNodeId(), channel);
+                } else {
+                    channel = channelMap.get(node.getNodeId());
+                }
+                channelToStreamsMap.putIfAbsent(node.getNodeId(), new HashSet<>());
+                channelToStreamsMap.get(node.getNodeId()).add(session);
+                lock.unlock();
+
+                blockingStubMap.put(session, LogReplicationChannelGrpc.newBlockingStub(channel));
+                asyncStubMap.put(session, LogReplicationChannelGrpc.newStub(channel));
                 onConnectionUp(node.getNodeId());
             } catch (Exception e) {
+                log.error("Error: {} :::: {}", e.getCause(), e.getStackTrace());
                 onConnectionDown(node.getNodeId());
             }
         }));
     }
 
     @Override
-    public void connectAsync(String nodeId) {
+    public void connectAsync(String nodeId, LogReplication.ReplicationSessionMsg session) {
         Optional<String> endpoint = getRemoteClusterDescriptor().getNodesDescriptors()
                 .stream()
                 .filter(nodeDescriptor -> nodeDescriptor.getNodeId().toString().equals(nodeId))
@@ -107,13 +139,27 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
         }
         this.executorService.submit(() -> {
             try {
-                log.info("GRPC create connection to node {}@{}:{}", nodeId, nodeLocator.getHost(), nodeLocator.getPort());
-                ManagedChannel channel = ManagedChannelBuilder.forAddress(nodeLocator.getHost(), nodeLocator.getPort()).usePlaintext().build();
-                channelMap.put(nodeId, channel);
-                blockingStubMap.put(nodeId, LogReplicationChannelGrpc.newBlockingStub(channel));
-                asyncStubMap.put(nodeId, LogReplicationChannelGrpc.newStub(channel));
+                ManagedChannel channel;
+
+                lock.lock();
+                if(!channelToStreamsMap.containsKey(nodeId) || channelToStreamsMap.get(nodeId).size() >= MAX_STREAMS_IN_CHANNEL) {
+                    log.info("GRPC create new channel to node{}@{}:{}", nodeId, nodeLocator.getHost(), nodeLocator.getPort());
+                    channel = ManagedChannelBuilder.forAddress(nodeLocator.getHost(), nodeLocator.getPort())
+                            .usePlaintext()
+                            .build();
+                    channelMap.put(nodeId, channel);
+                } else {
+                    channel = channelMap.get(nodeId);
+                }
+                channelToStreamsMap.putIfAbsent(nodeId, new HashSet<>());
+                channelToStreamsMap.get(nodeId).add(session);
+                lock.unlock();
+
+                blockingStubMap.put(session, LogReplicationChannelGrpc.newBlockingStub(channel));
+                asyncStubMap.put(session, LogReplicationChannelGrpc.newStub(channel));
                 onConnectionUp(nodeId);
             } catch (Exception e) {
+                log.error("Error2: {}", e.getMessage());
                 onConnectionDown(nodeId);
             }
         });
@@ -138,10 +184,78 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
         }
     }
 
+    // Used when connection is triggered from SINK
+    @Override
+    public void send(String nodeId, ResponseMsg response) {
+        if(nodeId == null) {
+            nodeId = this.getSinkRouter().getRemoteLeaderNodeId().get();
+        }
+
+        LogReplication.ReplicationSessionMsg sessionMsg;
+        //SINK sends subscribe, Negotiation and ACKs
+        if(response.getPayload().getPayloadCase().equals(CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_METADATA_RESPONSE)) {
+            sessionMsg = response.getPayload().getLrMetadataResponse().getSessionInfo();
+        } else if(response.getPayload().getPayloadCase().equals(CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK)) {
+            sessionMsg = response.getPayload().getLrEntryAck().getMetadata().getSessionInfo();
+        } else if(response.getPayload().getPayloadCase().equals(CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_SUBSCRIBE_REQUEST)) {
+            sessionMsg = response.getPayload().getLrSubscribeRequest().getSessionInfo();
+        } else {
+            sessionMsg = null;
+            log.info("Unexpected payloadType {}", response.getPayload().getPayloadCase());
+        }
+
+        if (!responseObserverMap.containsKey(sessionMsg)) {
+            StreamObserver<RequestMsg> requestObserver = new StreamObserver<RequestMsg>() {
+                @Override
+                public void onNext(RequestMsg request) {
+                    try {
+                        log.info("Received request {}", request.getHeader().getRequestId());
+                        receive(request);
+                    } catch (Exception e) {
+                        log.error("Caught exception while receiving Requests", e);
+                        getSinkRouter().completeExceptionally(request.getHeader().getRequestId(), e);
+                        responseObserverMap.remove(sessionMsg);
+                    }
+                }
+
+                @Override
+                public void onError(Throwable t) {
+                    log.error("Error from response observer", t);
+                    long requestId = response.getHeader().getRequestId();
+                    getSinkRouter().completeExceptionally(requestId, t);
+                    responseObserverMap.remove(sessionMsg);
+                }
+
+                @Override
+                public void onCompleted() {
+                    responseObserverMap.remove(sessionMsg);
+                }
+            };
+
+            requestObserverMap.put(sessionMsg, requestObserver);
+
+            if(asyncStubMap.containsKey(sessionMsg)) {
+                StreamObserver<ResponseMsg> responseObserver = asyncStubMap.get(sessionMsg).subscribeAndStartreplication(requestObserver);
+                responseObserverMap.put(sessionMsg, responseObserver);
+            } else {
+                log.error("No stub found for remote node {}@{}. Message dropped type={}",
+                        nodeId, getRemoteClusterDescriptor().getEndpointByNodeId(nodeId),
+                        response.getPayload().getPayloadCase());
+            }
+        }
+
+        if (requestObserverMap.containsKey(sessionMsg)) {
+            // Send negotiation and log replication ACKs across channel
+            responseObserverMap.get(sessionMsg).onNext(response);
+        }
+    }
+
     private void queryLeadership(String nodeId, RequestMsg request) {
         try {
-            if (blockingStubMap.containsKey(nodeId)) {
-                ResponseMsg response = blockingStubMap.get(nodeId).withWaitForReady().queryLeadership(request);
+            LogReplication.ReplicationSessionMsg session = request.getPayload().getLrLeadershipQuery().getSessionInfo();
+            log.info("queryLeadership session {}", session);
+            if (blockingStubMap.containsKey(session)) {
+                ResponseMsg response = blockingStubMap.get(session).withWaitForReady().queryLeadership(request);
                 receive(response);
             } else {
                 log.warn("Stub not found for remote endpoint {}. Dropping message of type {}",
@@ -150,14 +264,15 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
         } catch (Exception e) {
             log.error("Caught exception while sending message to query leadership status id {}",
                     request.getHeader().getRequestId(), e);
-            getRouter().completeExceptionally(request.getHeader().getRequestId(), e);
+            getSourceRouter().completeExceptionally(request.getHeader().getRequestId(), e);
         }
     }
 
     private void requestMetadata(String nodeId, RequestMsg request) {
         try {
-            if (blockingStubMap.containsKey(nodeId)) {
-                ResponseMsg response = blockingStubMap.get(nodeId).withWaitForReady().negotiate(request);
+            LogReplication.ReplicationSessionMsg session = request.getPayload().getLrMetadataRequest().getSessionInfo();
+            if (blockingStubMap.containsKey(session)) {
+                ResponseMsg response = blockingStubMap.get(session).withWaitForReady().negotiate(request);
                 receive(response);
             } else {
                 log.warn("Stub not found for remote endpoint {}. Dropping message of type {}",
@@ -166,13 +281,15 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
         } catch (Exception e) {
             log.error("Caught exception while sending message to query metadata id={}",
                     request.getHeader().getRequestId(), e);
-            getRouter().completeExceptionally(request.getHeader().getRequestId(), e);
+            getSourceRouter().completeExceptionally(request.getHeader().getRequestId(), e);
         }
     }
 
     private void replicate(String nodeId, RequestMsg request) {
+        LogReplication.ReplicationSessionMsg sessionMsg = request.getPayload().getLrEntry().getMetadata().getSessionInfo();
         long requestId = request.getHeader().getRequestId();
-        if (!requestObserverMap.containsKey(requestId)) {
+
+        if (!replicationReqObserverMap.containsKey(Pair.of(sessionMsg, requestId))) {
             StreamObserver<ResponseMsg> responseObserver = new StreamObserver<ResponseMsg>() {
                 @Override
                 public void onNext(ResponseMsg response) {
@@ -181,32 +298,32 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
                         receive(response);
                     } catch (Exception e) {
                         log.error("Caught exception while receiving ACK", e);
-                        getRouter().completeExceptionally(response.getHeader().getRequestId(), e);
-                        requestObserverMap.remove(requestId);
+                        getSourceRouter().completeExceptionally(response.getHeader().getRequestId(), e);
+                        replicationReqObserverMap.remove(Pair.of(sessionMsg, requestId));
                     }
                 }
 
                 @Override
                 public void onError(Throwable t) {
                     log.error("Error from response observer", t);
-                    getRouter().completeExceptionally(requestId, t);
-                    requestObserverMap.remove(requestId);
+                    long requestId = request.getHeader().getRequestId();
+                    getSourceRouter().completeExceptionally(requestId, t);
+                    replicationReqObserverMap.remove(Pair.of(sessionMsg, requestId));
                 }
 
                 @Override
                 public void onCompleted() {
-                    log.info("Completed");
-                    requestObserverMap.remove(requestId);
+//                    log.info("Completed");
+                    replicationReqObserverMap.remove(Pair.of(sessionMsg, requestId));
                 }
             };
+            replicationResObserverMap.put(Pair.of(sessionMsg, requestId), responseObserver);
 
-            responseObserverMap.put(requestId, responseObserver);
+//            log.info("Initiate stub for replication");
 
-            log.info("Initiate stub for replication");
-
-            if(asyncStubMap.containsKey(nodeId)) {
-                StreamObserver<RequestMsg> requestObserver = asyncStubMap.get(nodeId).replicate(responseObserver);
-                requestObserverMap.put(requestId, requestObserver);
+            if(asyncStubMap.containsKey(sessionMsg)) {
+                StreamObserver<RequestMsg> requestObserver = asyncStubMap.get(sessionMsg).replicate(responseObserver);
+                replicationReqObserverMap.put(Pair.of(sessionMsg, requestId), requestObserver);
             } else {
                 log.error("No stub found for remote node {}@{}. Message dropped type={}",
                         nodeId, getRemoteClusterDescriptor().getEndpointByNodeId(nodeId),
@@ -214,11 +331,12 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
             }
         }
 
+//        log.info("request: {}", request);
         log.info("Send replication entry: {} to node {}@{}", request.getHeader().getRequestId(),
                 nodeId, getRemoteClusterDescriptor().getEndpointByNodeId(nodeId));
-        if (responseObserverMap.containsKey(requestId)) {
+        if (replicationResObserverMap.containsKey(Pair.of(sessionMsg, requestId))) {
             // Send log replication entries across channel
-            requestObserverMap.get(requestId).onNext(request);
+            replicationReqObserverMap.get(Pair.of(sessionMsg, requestId)).onNext(request);
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
@@ -386,6 +386,7 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
                 });
             }
         });
+        nodeIdToChannelMap.keySet().forEach(node -> log.debug("Channel is closed for node {}", node));
         lock.unlock();
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationClientChannelAdapter.java
@@ -113,6 +113,8 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
                     log.info("GRPC create new channel to node{}@{}:{}", node.getNodeId(), nodeLocator.getHost(), nodeLocator.getPort());
                     channel = ManagedChannelBuilder.forAddress(nodeLocator.getHost(), nodeLocator.getPort())
                             .usePlaintext()
+                            .defaultServiceConfig(getRetryingServiceConfig())
+                            .enableRetry()
                             .build();
                     nodeIdToChannelMap.putIfAbsent(node.getNodeId(), new HashSet<>());
                     nodeIdToChannelMap.get(node.getNodeId()).add(channel);
@@ -173,8 +175,8 @@ public class GRPCLogReplicationClientChannelAdapter extends IClientChannelAdapte
                     log.info("GRPC create new channel to node{}@{}:{}", nodeId, nodeLocator.getHost(), nodeLocator.getPort());
                     channel = ManagedChannelBuilder.forAddress(nodeLocator.getHost(), nodeLocator.getPort())
                             .usePlaintext()
-//                            .defaultServiceConfig(getRetryingServiceConfig())
-//                            .enableRetry()
+                            .defaultServiceConfig(getRetryingServiceConfig())
+                            .enableRetry()
                             .build();
                     nodeIdToChannelMap.putIfAbsent(nodeId, new HashSet<>());
                     nodeIdToChannelMap.get(nodeId).add(channel);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
@@ -46,6 +46,14 @@ public class GRPCLogReplicationServerChannelAdapter extends IServerChannelAdapte
     }
 
     @Override
+    public void updateRouters(Map<ReplicationSession, LogReplicationSourceServerRouter> sessionToSourceServerRouter,
+                              Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServerRouter) {
+        this.getIncomingSessionToSourceServerRouter().putAll(sessionToSourceServerRouter);
+        this.getIncomingSessionToSinkServerRouter().putAll(sessionToSinkServerRouter);
+        this.service.updateRouterInfo(sessionToSourceServerRouter, sessionToSinkServerRouter);
+    }
+
+    @Override
     public void send(CorfuMessage.ResponseMsg msg) {
         log.info("Server send response message {}", msg.getPayload().getPayloadCase());
         service.send(msg);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
@@ -42,11 +42,7 @@ public class GRPCLogReplicationServerChannelAdapter extends IServerChannelAdapte
         super(serverContext, sessionToSourceServer, sessionToSinkServer);
         this.service = new GRPCLogReplicationServerHandler(sessionToSourceServer, sessionToSinkServer);
         this.port = Integer.parseInt((String) serverContext.getServerConfig().get("<port>"));
-        // The executor of GRPCLogReplicationServerHandler needs to be single-threaded, otherwise the ordering of
-        // requests and their acks cannot be guaranteed. By default, grpc utilizes thread-pool, so we need to provide
-        // a single-threaded executor here.
-        this.server = ServerBuilder.forPort(port).addService(service)
-                .executor(Executors.newSingleThreadScheduledExecutor()).build();
+        this.server = ServerBuilder.forPort(port).addService(service).executor(Executors.newSingleThreadScheduledExecutor()).build();
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
@@ -4,10 +4,13 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.ServerContext;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkServerRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceServerRouter;
 import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 
@@ -33,9 +36,11 @@ public class GRPCLogReplicationServerChannelAdapter extends IServerChannelAdapte
 
     private CompletableFuture<Boolean> serverCompletable;
 
-    public GRPCLogReplicationServerChannelAdapter(ServerContext serverContext, LogReplicationServerRouter router) {
-        super(serverContext, router);
-        this.service = new GRPCLogReplicationServerHandler(router);
+    public GRPCLogReplicationServerChannelAdapter(ServerContext serverContext,
+                                                  Map<ReplicationSession, LogReplicationSourceServerRouter> sessionToSourceServer,
+                                                  Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServer) {
+        super(serverContext, sessionToSourceServer, sessionToSinkServer);
+        this.service = new GRPCLogReplicationServerHandler(sessionToSourceServer, sessionToSinkServer);
         this.port = Integer.parseInt((String) serverContext.getServerConfig().get("<port>"));
         // The executor of GRPCLogReplicationServerHandler needs to be single-threaded, otherwise the ordering of
         // requests and their acks cannot be guaranteed. By default, grpc utilizes thread-pool, so we need to provide
@@ -47,6 +52,12 @@ public class GRPCLogReplicationServerChannelAdapter extends IServerChannelAdapte
     @Override
     public void send(CorfuMessage.ResponseMsg msg) {
         log.info("Server send message {}", msg.getPayload().getPayloadCase());
+        service.send(msg);
+    }
+
+    @Override
+    public void send(String nodeId, CorfuMessage.RequestMsg msg) {
+        log.info("Server send Request message {}", msg.getPayload().getPayloadCase());
         service.send(msg);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerChannelAdapter.java
@@ -51,7 +51,7 @@ public class GRPCLogReplicationServerChannelAdapter extends IServerChannelAdapte
 
     @Override
     public void send(CorfuMessage.ResponseMsg msg) {
-        log.info("Server send message {}", msg.getPayload().getPayloadCase());
+        log.info("Server send response message {}", msg.getPayload().getPayloadCase());
         service.send(msg);
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerHandler.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/GRPCLogReplicationServerHandler.java
@@ -1,11 +1,17 @@
 package org.corfudb.infrastructure.logreplication.transport.sample;
 
+import io.grpc.Context;
 import io.grpc.stub.StreamObserver;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.corfudb.infrastructure.logreplication.LogReplicationChannelGrpc;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkServerRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceServerRouter;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
+import org.corfudb.runtime.proto.service.CorfuMessage;
 import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
@@ -25,9 +31,14 @@ import java.util.concurrent.ConcurrentHashMap;
 public class GRPCLogReplicationServerHandler extends LogReplicationChannelGrpc.LogReplicationChannelImplBase {
 
     /*
-     * Corfu Message Router (internal to Corfu)
+     * Map of session to SINK Router (internal to Corfu)
      */
-    LogReplicationServerRouter router;
+    final Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServer;
+
+    /*
+     * Map of session to SOURCE Router (internal to Corfu)
+     */
+    final Map<ReplicationSession, LogReplicationSourceServerRouter> sessionToSourceServer;
 
     /*
      * Map of (Remote Cluster Id, Request Id) pair to Stream Observer to send responses back to the client. Used for
@@ -44,28 +55,52 @@ public class GRPCLogReplicationServerHandler extends LogReplicationChannelGrpc.L
      */
     Map<Pair<UuidMsg, Long>, StreamObserver<ResponseMsg>> replicationStreamObserverMap;
 
-    public GRPCLogReplicationServerHandler(LogReplicationServerRouter router) {
-        this.router = router;
+    Map<ReplicationSession, StreamObserver<RequestMsg>> sessionToStreamObserverRequestMap;
+
+    public GRPCLogReplicationServerHandler(Map<ReplicationSession, LogReplicationSourceServerRouter> sessionToSourceServer,
+                                           Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServer) {
+        this.sessionToSourceServer = sessionToSourceServer;
+        this.sessionToSinkServer = sessionToSinkServer;
         this.streamObserverMap = new ConcurrentHashMap<>();
         this.replicationStreamObserverMap = new ConcurrentHashMap<>();
+        this.sessionToStreamObserverRequestMap = new ConcurrentHashMap<>();
     }
 
     @Override
     public void negotiate(RequestMsg request, StreamObserver<ResponseMsg> responseObserver) {
-        log.trace("Received[{}]: {}", request.getHeader().getRequestId(),
+        log.info("Received[{}]: {}", request.getHeader().getRequestId(),
                 request.getPayload().getPayloadCase().name());
-        router.receive(request);
-        streamObserverMap.put(Pair.of(request.getHeader().getClusterId(), request.getHeader().getRequestId()),
-            responseObserver);
+        ReplicationSession session = convertSessionMsg(request, null);
+        if (sessionToSinkServer.containsKey(session)) {
+            sessionToSinkServer.get(session).receive(request);
+            streamObserverMap.put(Pair.of(request.getHeader().getClusterId(), request.getHeader().getRequestId()),
+                    responseObserver);
+        } else {
+            log.info("Dropping msg as the cluster is not SINK for the session {}", session);
+        }
     }
 
     @Override
     public void queryLeadership(RequestMsg request, StreamObserver<ResponseMsg> responseObserver) {
-        log.trace("Received[{}]: {}", request.getHeader().getRequestId(),
+        log.info("Received[{}]: {}", request.getHeader().getRequestId(),
                 request.getPayload().getPayloadCase().name());
+
+        ReplicationSession session = convertSessionMsg(request, null);
+        log.info("Received: {}", request);
+//        log.info("sessionToSinkServer {}", sessionToSinkServer);
+//        log.info("sessionToSourceServer {}", sessionToSourceServer);
+//        log.info("session {}",session);
+        if(sessionToSinkServer.containsKey(session)) {
+            sessionToSinkServer.get(session).receive(request);
+        } else if(sessionToSourceServer.containsKey(session)) {
+            sessionToSourceServer.get(session).receive(request);
+        }
         streamObserverMap.put(Pair.of(request.getHeader().getClusterId(), request.getHeader().getRequestId()),
             responseObserver);
-        router.receive(request);
+
+//        log.info("in LRS, send. streamObserverMap hash {}", streamObserverMap.hashCode());
+//        log.info("requestID {}", request.getHeader().getRequestId());
+//        log.info("in LRS, send. streamObserverMap {}", streamObserverMap);
     }
 
     @Override
@@ -76,8 +111,9 @@ public class GRPCLogReplicationServerHandler extends LogReplicationChannelGrpc.L
             public void onNext(RequestMsg replicationCorfuMessage) {
                 long requestId = replicationCorfuMessage.getHeader().getRequestId();
                 String name = replicationCorfuMessage.getPayload().getPayloadCase().name();
-                log.trace("Received[{}]: {}", requestId, name);
+                log.info("Received[{}]: {}", requestId, name);
 
+//                log.info("#114 the request is {}", replicationCorfuMessage);
                 // Register at the observable first.
                 try {
                     replicationStreamObserverMap.putIfAbsent(
@@ -88,7 +124,13 @@ public class GRPCLogReplicationServerHandler extends LogReplicationChannelGrpc.L
                 }
 
                 // Forward the received message to the router
-                router.receive(replicationCorfuMessage);
+                ReplicationSession session = convertSessionMsg(replicationCorfuMessage, null);
+//                log.info("lr entry session: {}", session);
+                if(sessionToSinkServer.containsKey(session)) {
+                    sessionToSinkServer.get(session).receive(replicationCorfuMessage);
+                } else if(sessionToSourceServer.containsKey(session)) {
+                    sessionToSourceServer.get(session).receive(replicationCorfuMessage);
+                }
             }
 
             @Override
@@ -103,6 +145,62 @@ public class GRPCLogReplicationServerHandler extends LogReplicationChannelGrpc.L
         };
     }
 
+    @Override
+    public StreamObserver<ResponseMsg> subscribeAndStartreplication(StreamObserver<RequestMsg> responseObserver) {
+
+        return new StreamObserver<ResponseMsg>() {
+            @Override
+            public void onNext(ResponseMsg lrResponseMsg) {
+                long requestId = lrResponseMsg.getHeader().getRequestId();
+                String name = lrResponseMsg.getPayload().getPayloadCase().name();
+//                log.info("#159 Received[{}]: {}", requestId, name);
+//
+//                log.info("#161 received is {}", lrResponseMsg);
+
+                ReplicationSession session = convertSessionMsg(null, lrResponseMsg);
+
+                // For ACKs, the SINK copies the metadata of the lr_msg. Hence convert the incoming session to reflect session as seen by SINK
+//                if(lrResponseMsg.getPayload().getPayloadCase().equals(LR_ENTRY_ACK)) {
+//                    ReplicationSession ackSession =
+//                    session = ackSession;
+//                }
+                // create an outgoing session from incoming session. This will be used to query the streamObserver in the BiDirectional Stream.
+
+
+                try {
+//                    log.info("the senderClusterId  is {}, observerSession:: {}", session.getRemoteClusterId(), session);
+                    sessionToStreamObserverRequestMap.putIfAbsent(session, responseObserver);
+//                    log.info("after putting in key: {}, value: {}, sessionToStreamObserverRequestMap {}", session,
+//                            responseObserver, sessionToStreamObserverRequestMap);
+                } catch (Exception e) {
+                    log.error("Exception caught when unpacking log replication entry {}. Skipping message.",
+                            requestId, e);
+                }
+
+                // Forward the received message to the router
+//                log.info("lr entry session: {}", session);
+//                log.info("looking for: {}", session);
+//                log.info("sessionToSourceServer {}", sessionToSourceServer);
+//                log.info("sessionToSinkServer {}", sessionToSinkServer);
+                if(sessionToSourceServer.containsKey(session)) {
+                    sessionToSourceServer.get(session).receive(lrResponseMsg);
+                }
+            }
+
+            @Override
+            public void onError(Throwable t) {
+                log.error("Encountered error while attempting replication.", t);
+            }
+
+            @Override
+            public void onCompleted() {
+                log.info("Client has completed snapshot replication.");
+            }
+        };
+    }
+
+
+
     public void send(ResponseMsg msg) {
         long requestId = msg.getHeader().getRequestId();
         UuidMsg clusterId = msg.getHeader().getClusterId();
@@ -110,17 +208,18 @@ public class GRPCLogReplicationServerHandler extends LogReplicationChannelGrpc.L
         // Case: message to send is an ACK (async observers)
         if (msg.getPayload().getPayloadCase().equals(ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK)) {
             try {
-                if (!replicationStreamObserverMap.containsKey(
-                    Pair.of(clusterId, requestId))) {
+//                log.info("Shama: in send response {}", msg);
+                if (!replicationStreamObserverMap.containsKey(Pair.of(clusterId, requestId))) {
                     log.warn("Corfu Message {} has no pending observer. Message {} will not be sent.",
                         msg.getHeader().getRequestId(), msg.getPayload().getPayloadCase().name());
-                    log.info("Stream observers in map: {}", replicationStreamObserverMap.keySet());
+//                    log.info("Stream observers in map: {}", replicationStreamObserverMap.keySet());
                     return;
                 }
 
                 StreamObserver<ResponseMsg> observer = replicationStreamObserverMap.get(Pair.of(clusterId, requestId));
-                log.info("Sending[{}:{}]: {}", clusterId, requestId,
-                    msg.getPayload().getPayloadCase().name());
+                log.info("Sending[{}:{}]: {}", clusterId, requestId, msg.getPayload().getPayloadCase().name());
+                log.info("requestID {}", requestId);
+                log.info("replicationStreamObserverMap {}", replicationStreamObserverMap);
                 observer.onNext(msg);
                 observer.onCompleted();
 
@@ -139,18 +238,104 @@ public class GRPCLogReplicationServerHandler extends LogReplicationChannelGrpc.L
             if (!streamObserverMap.containsKey(Pair.of(clusterId, requestId))) {
                 log.warn("Corfu Message {} has no pending observer. Message {} will not be sent.",
                     requestId, msg.getPayload().getPayloadCase().name());
-                log.info("Stream observers in map: {}", streamObserverMap.keySet());
+//                log.info("Stream observers in map: {}", streamObserverMap.keySet());
                 return;
             }
 
             StreamObserver<ResponseMsg> observer = streamObserverMap.get(Pair.of(clusterId, requestId));
-            log.info("Sending[{}]: {}", requestId, msg.getPayload().getPayloadCase().name());
+//            log.info("#255 Sending[{}]: {}", requestId, msg.getPayload().getPayloadCase().name());
             observer.onNext(msg);
             observer.onCompleted();
 
             // Remove observer as response was already sent
             streamObserverMap.remove(Pair.of(clusterId, requestId));
         }
+    }
+
+    public void send(RequestMsg msg) {
+        long requestId = msg.getHeader().getRequestId();
+        UuidMsg clusterId = msg.getHeader().getClusterId();
+//        log.info("#267 requestId {}", requestId);
+        // Case: message to send is an ACK (async observers)
+        if (msg.getPayload().getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_METADATA_REQUEST) ||
+                msg.getPayload().getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_ENTRY)) {
+            try {
+//                log.info("Shama: in send request {}", msg);
+//                log.info("sessionToStreamObserverRequestMap hash {}", sessionToStreamObserverRequestMap.hashCode());
+//                log.info("contents of sessionToStreamObserverRequestMap {}", sessionToStreamObserverRequestMap);
+                ReplicationSession session = convertSessionMsg(msg, null);
+                ReplicationSession observerLookupSession = new ReplicationSession(session.getLocalClusterId(),
+                        session.getRemoteClusterId(), session.getSubscriber());
+//                log.info("looking for {} ", observerLookupSession);
+                if (!sessionToStreamObserverRequestMap.containsKey(observerLookupSession)) {
+                    log.warn("Corfu Message {} has no pending observer. Message {} will not be sent.",
+                            msg.getHeader().getRequestId(), msg.getPayload().getPayloadCase().name());
+//                    log.info("Stream observers in map: {}", replicationStreamObserverMap.keySet());
+                    return;
+                }
+
+                StreamObserver<RequestMsg> observer = sessionToStreamObserverRequestMap.get(observerLookupSession);
+//                log.info("#285 Sending[{}:{}]: {}", clusterId, requestId, msg.getPayload().getPayloadCase().name());
+//                log.info("#285 observer from the map {}", observer);
+                observer.onNext(msg);
+
+                // Remove observer as request was already sent.
+                // Since we send summarized ACKs (to avoid memory leaks) remove all observers lower or equal than
+                // the one for which a response is being sent.
+//                log.info("removing the observer");
+//                replicationStreamObserverMap.remove(session);
+            } catch (Exception e) {
+                log.error("Caught exception while trying to send message {}", msg.getHeader().getRequestId(), e);
+            }
+
+        } else {
+            log.error("UnExpected request msg {}", msg);
+        }
+    }
+
+    private ReplicationSession convertSessionMsg( RequestMsg requestMsg, ResponseMsg responseMsg) {
+        String payloadCase;
+        if(requestMsg != null) {
+            payloadCase = requestMsg.getPayload().getPayloadCase().toString();
+        } else {
+            payloadCase = responseMsg.getPayload().getPayloadCase().toString();
+        }
+
+        LogReplication.ReplicationSessionMsg sessionMsg = null;
+        switch(payloadCase) {
+            case "LR_ENTRY" :
+                if(requestMsg != null) {
+                    sessionMsg = requestMsg.getPayload().getLrEntry().getMetadata().getSessionInfo();
+                } else {
+                    sessionMsg = responseMsg.getPayload().getLrEntryAck().getMetadata().getSessionInfo();
+                }
+                break;
+            case "LR_METADATA_REQUEST" :
+                sessionMsg = requestMsg.getPayload().getLrMetadataRequest().getSessionInfo();
+                break;
+            case "LR_LEADERSHIP_QUERY" :
+                sessionMsg = requestMsg.getPayload().getLrLeadershipQuery().getSessionInfo();
+                break;
+            case "LR_METADATA_RESPONSE" :
+                sessionMsg = responseMsg.getPayload().getLrMetadataResponse().getSessionInfo();
+                break;
+            case "LR_LEADERSHIP_RESPONSE" :
+                sessionMsg = responseMsg.getPayload().getLrLeadershipResponse().getSessionInfo();
+                break;
+            case "LR_LEADERSHIP_LOSS" :
+                sessionMsg = responseMsg.getPayload().getLrLeadershipLoss().getSessionInfo();
+                break;
+            case "LR_SUBSCRIBE_REQUEST" :
+                sessionMsg = responseMsg.getPayload().getLrSubscribeRequest().getSessionInfo();
+                break;
+            case "LR_ENTRY_ACK" :
+                sessionMsg = responseMsg.getPayload().getLrEntryAck().getMetadata().getSessionInfo();
+                break;
+            default:
+                log.error("Unexpected payloadcase received : {}", payloadCase);
+        }
+        ReplicationSubscriber subscriber = new ReplicationSubscriber(sessionMsg.getReplicationModel(), sessionMsg.getClient());
+        return new ReplicationSession(sessionMsg.getRemoteClusterId(),sessionMsg.getLocalClusterId(), subscriber);
     }
 
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationClientChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationClientChannelAdapter.java
@@ -1,121 +1,121 @@
-package org.corfudb.infrastructure.logreplication.transport.sample;
-
-import lombok.NonNull;
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
-import org.corfudb.infrastructure.logreplication.infrastructure.NodeDescriptor;
-
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkClientRouter;
-import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceClientRouter;
-import org.corfudb.runtime.LogReplication;
-import org.corfudb.runtime.exceptions.NetworkException;
-import org.corfudb.runtime.proto.service.CorfuMessage;
-import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
-
-import javax.annotation.Nonnull;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-
-@Slf4j
-public class NettyLogReplicationClientChannelAdapter extends IClientChannelAdapter {
-
-    /**
-     * Map of remote node id to Channel
-     */
-    private volatile Map<String, CorfuNettyClientChannel> channels;
-
-    private final ExecutorService executorService;
-
-    /**
-     * Constructor
-     *
-     * @param remoteClusterDescriptor
-     * @param sourceRouter not null when the connection initiator is the source
-     * @param sinkRouter not null when the connection initiator is the sink
-     */
-    public NettyLogReplicationClientChannelAdapter(@NonNull String localClusterId,
-                                                   @NonNull ClusterDescriptor remoteClusterDescriptor,
-                                                    LogReplicationSourceClientRouter sourceRouter,
-                                                   LogReplicationSinkClientRouter sinkRouter ) {
-        super(localClusterId, remoteClusterDescriptor, sourceRouter, sinkRouter);
-        this.channels = new ConcurrentHashMap<>();
-        this.executorService = Executors.newSingleThreadExecutor();
-    }
-
-    @Override
-    public void connectAsync(LogReplication.ReplicationSessionMsg session) {
-        executorService.submit(() -> {
-            ClusterDescriptor remoteCluster = getRemoteClusterDescriptor();
-            for (NodeDescriptor node : remoteCluster.getNodesDescriptors()) {
-                log.info("Create Netty Channel to remote node {}@{}:{}", node.getNodeId(), node.getHost(), node.getPort());
-                CorfuNettyClientChannel channel = null;
-                if (getSourceRouter() != null ) {
-                    log.trace("initializing the channel with existing nettyEventLoop");
-                    channel = new CorfuNettyClientChannel(node,
-                            getSourceRouter().getRuntimeFSM().getSourceManager().getParameters().getNettyEventLoop(),
-                            this);
-                } else {
-                    log.trace("Creating a new netty even loop and initializing the channel");
-                    channel = new CorfuNettyClientChannel(node, null, this);
-                }
-                this.channels.put(node.getNodeId(), channel);
-            }
-        });
-    }
-
-    @Override
-    public void stop() {
-        channels.values().forEach(ch -> ch.close());
-    }
-
-    @Override
-    public void send(@Nonnull String nodeId, @NonNull RequestMsg request) {
-        // Check the connection future. If connected, continue with sending the message.
-        // If timed out, return a exceptionally completed with the timeout.
-        if (channels.containsKey(nodeId)) {
-            log.info("Sending message to {} on cluster {}, type={}",
-                    nodeId, getRemoteClusterDescriptor().getClusterId(),
-                    request.getPayload().getPayloadCase());
-            channels.get(nodeId).send(request);
-        } else {
-            log.warn("Channel to node {}@{} does not exist, message of type={} is dropped",
-                    nodeId, getRemoteClusterDescriptor().getEndpointByNodeId(nodeId),
-                    request.getPayload().getPayloadCase());
-        }
-    }
-
-    @Override
-    public void send(String nodeId, CorfuMessage.ResponseMsg response) {}
-
-    @Override
-    public void onConnectionUp(String nodeId) {
-        executorService.submit(() -> {
-            super.onConnectionUp(nodeId);
-        });
-    }
-
-    private String getLeaderEndpoint() {
-        if (getRemoteLeader().isPresent()) {
-            return getRemoteLeader().get();
-        } else {
-            log.warn("No remote leader on cluster id={}", getRemoteClusterDescriptor().getClusterId());
-            throw new NetworkException("No connection to leader.", getRemoteClusterDescriptor().getClusterId());
-        }
-    }
-
-    public void completeExceptionally(Exception exception) {
-        if (getSourceRouter() != null) {
-            getSourceRouter().completeAllExceptionally(exception);
-        } else {
-            getSinkRouter().completeAllExceptionally(exception);
-        }
-    }
-
-    @Override
-    public void resetRemoteLeader() {
-        // No-op
-    }
-}
+//package org.corfudb.infrastructure.logreplication.transport.sample;
+//
+//import lombok.NonNull;
+//import lombok.extern.slf4j.Slf4j;
+//import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+//import org.corfudb.infrastructure.logreplication.infrastructure.NodeDescriptor;
+//
+//import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkClientRouter;
+//import org.corfudb.infrastructure.logreplication.transport.client.IClientChannelAdapter;
+//import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceClientRouter;
+//import org.corfudb.runtime.LogReplication;
+//import org.corfudb.runtime.exceptions.NetworkException;
+//import org.corfudb.runtime.proto.service.CorfuMessage;
+//import org.corfudb.runtime.proto.service.CorfuMessage.RequestMsg;
+//
+//import javax.annotation.Nonnull;
+//import java.util.Map;
+//import java.util.concurrent.ConcurrentHashMap;
+//import java.util.concurrent.ExecutorService;
+//import java.util.concurrent.Executors;
+//
+//@Slf4j
+//public class NettyLogReplicationClientChannelAdapter extends IClientChannelAdapter {
+//
+//    /**
+//     * Map of remote node id to Channel
+//     */
+//    private volatile Map<String, CorfuNettyClientChannel> channels;
+//
+//    private final ExecutorService executorService;
+//
+//    /**
+//     * Constructor
+//     *
+//     * @param remoteClusterDescriptor
+//     * @param sourceRouter not null when the connection initiator is the source
+//     * @param sinkRouter not null when the connection initiator is the sink
+//     */
+//    public NettyLogReplicationClientChannelAdapter(@NonNull String localClusterId,
+//                                                   @NonNull ClusterDescriptor remoteClusterDescriptor,
+//                                                    LogReplicationSourceClientRouter sourceRouter,
+//                                                   LogReplicationSinkClientRouter sinkRouter ) {
+//        super(localClusterId, remoteClusterDescriptor, sourceRouter, sinkRouter);
+//        this.channels = new ConcurrentHashMap<>();
+//        this.executorService = Executors.newSingleThreadExecutor();
+//    }
+//
+//    @Override
+//    public void connectAsync(LogReplication.ReplicationSessionMsg session) {
+//        executorService.submit(() -> {
+//            ClusterDescriptor remoteCluster = getRemoteClusterDescriptor();
+//            for (NodeDescriptor node : remoteCluster.getNodesDescriptors()) {
+//                log.info("Create Netty Channel to remote node {}@{}:{}", node.getNodeId(), node.getHost(), node.getPort());
+//                CorfuNettyClientChannel channel = null;
+//                if (getSourceRouter() != null ) {
+//                    log.trace("initializing the channel with existing nettyEventLoop");
+//                    channel = new CorfuNettyClientChannel(node,
+//                            getSourceRouter().getRuntimeFSM().getSourceManager().getParameters().getNettyEventLoop(),
+//                            this);
+//                } else {
+//                    log.trace("Creating a new netty even loop and initializing the channel");
+//                    channel = new CorfuNettyClientChannel(node, null, this);
+//                }
+//                this.channels.put(node.getNodeId(), channel);
+//            }
+//        });
+//    }
+//
+//    @Override
+//    public void stop() {
+//        channels.values().forEach(ch -> ch.close());
+//    }
+//
+//    @Override
+//    public void send(@Nonnull String nodeId, @NonNull RequestMsg request) {
+//        // Check the connection future. If connected, continue with sending the message.
+//        // If timed out, return a exceptionally completed with the timeout.
+//        if (channels.containsKey(nodeId)) {
+//            log.info("Sending message to {} on cluster {}, type={}",
+//                    nodeId, getRemoteClusterDescriptor().getClusterId(),
+//                    request.getPayload().getPayloadCase());
+//            channels.get(nodeId).send(request);
+//        } else {
+//            log.warn("Channel to node {}@{} does not exist, message of type={} is dropped",
+//                    nodeId, getRemoteClusterDescriptor().getEndpointByNodeId(nodeId),
+//                    request.getPayload().getPayloadCase());
+//        }
+//    }
+//
+//    @Override
+//    public void send(String nodeId, CorfuMessage.ResponseMsg response) {}
+//
+//    @Override
+//    public void onConnectionUp(String nodeId) {
+//        executorService.submit(() -> {
+//            super.onConnectionUp(nodeId);
+//        });
+//    }
+//
+//    private String getLeaderEndpoint() {
+//        if (getRemoteLeader().isPresent()) {
+//            return getRemoteLeader().get();
+//        } else {
+//            log.warn("No remote leader on cluster id={}", getRemoteClusterDescriptor().getClusterId());
+//            throw new NetworkException("No connection to leader.", getRemoteClusterDescriptor().getClusterId());
+//        }
+//    }
+//
+//    public void completeExceptionally(Exception exception) {
+//        if (getSourceRouter() != null) {
+//            getSourceRouter().completeAllExceptionally(exception);
+//        } else {
+//            getSinkRouter().completeAllExceptionally(exception);
+//        }
+//    }
+//
+//    @Override
+//    public void resetRemoteLeader() {
+//        // No-op
+//    }
+//}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationServerChannelAdapter.java
@@ -61,6 +61,13 @@ public class NettyLogReplicationServerChannelAdapter extends IServerChannelAdapt
     // ================== IServerChannelAdapter ==================
 
     @Override
+    public void updateRouters(Map<ReplicationSession, LogReplicationSourceServerRouter> sesionToSourceServerRouter,
+                              Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServerRouter) {
+        this.getIncomingSessionToSinkServerRouter().putAll(sessionToSinkServerRouter);
+        this.getIncomingSessionToSourceServerRouter().putAll(sesionToSourceServerRouter);
+    }
+
+    @Override
     public void send(@Nonnull ResponseMsg msg) {
         nettyServerChannel.sendResponse(msg);
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/sample/NettyLogReplicationServerChannelAdapter.java
@@ -1,283 +1,283 @@
-package org.corfudb.infrastructure.logreplication.transport.sample;
-
-import io.netty.bootstrap.ServerBootstrap;
-import io.netty.buffer.PooledByteBufAllocator;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelOption;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.ServerChannel;
-import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import io.netty.handler.codec.LengthFieldPrepender;
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslHandler;
-import lombok.extern.slf4j.Slf4j;
-import org.corfudb.common.config.ConfigParamNames;
-import org.corfudb.infrastructure.ServerContext;
-import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkServerRouter;
-import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceServerRouter;
-import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
-import org.corfudb.protocols.wireprotocol.NettyCorfuMessageDecoder;
-import org.corfudb.protocols.wireprotocol.NettyCorfuMessageEncoder;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
-import org.corfudb.runtime.proto.service.CorfuMessage;
-import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
-import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyServer;
-import org.corfudb.security.tls.SslContextConstructor;
-import org.corfudb.security.tls.TlsUtils.CertStoreConfig.KeyStoreConfig;
-import org.corfudb.security.tls.TlsUtils.CertStoreConfig.TrustStoreConfig;
-
-import javax.annotation.Nonnull;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.regex.Pattern;
-
-@Slf4j
-public class NettyLogReplicationServerChannelAdapter extends IServerChannelAdapter {
-
-    private CorfuNettyServerChannel nettyServerChannel;
-
-    private ChannelFuture bindFuture;
-
-    private final int port;
-
-    private CompletableFuture<Boolean> connectionEnded;
-
-    public NettyLogReplicationServerChannelAdapter(@Nonnull ServerContext serverContext,
-                                                   Map<ReplicationSession, LogReplicationSourceServerRouter> sourceServerRouter,
-                                                   Map<ReplicationSession, LogReplicationSinkServerRouter> sinkServerrouter) {
-        super(serverContext, sourceServerRouter, sinkServerrouter);
-        this.port = Integer.parseInt((String) serverContext.getServerConfig().get("<port>"));
-        this.nettyServerChannel = new CorfuNettyServerChannel(this);
-    }
-
-    // ================== IServerChannelAdapter ==================
-
-    @Override
-    public void updateRouters(Map<ReplicationSession, LogReplicationSourceServerRouter> sesionToSourceServerRouter,
-                              Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServerRouter) {
-        this.getIncomingSessionToSinkServerRouter().putAll(sessionToSinkServerRouter);
-        this.getIncomingSessionToSourceServerRouter().putAll(sesionToSourceServerRouter);
-    }
-
-    @Override
-    public void send(@Nonnull ResponseMsg msg) {
-        nettyServerChannel.sendResponse(msg);
-    }
-
-    @Override
-    public void send(String nodeId, @Nonnull CorfuMessage.RequestMsg msg) {
-
-    }
-
-    @Override
-    public CompletableFuture<Boolean> start() {
-        startServer().channel().closeFuture().syncUninterruptibly();
-        connectionEnded = new CompletableFuture<>();
-        log.info("Server started, listening on {}", port);
-        return connectionEnded;
-    }
-
-    @Override
-    public void stop() {
-        bindFuture.channel().close().syncUninterruptibly();
-        if (connectionEnded != null) {
-            connectionEnded.complete(true);
-        }
-    }
-
-    // ==========================================================
-
-    /**
-     * Bind the Corfu server to the given {@code port} using the provided
-     * {@code channelType}. It is the callers' responsibility to shutdown the
-     * {@link EventLoopGroup}s. For implementations which listen on multiple ports,
-     * {@link EventLoopGroup}s may be reused.
-     *
-     * @param serverContext       A current server context.
-     * @param bootstrapConfigurer A {@link BootstrapConfigurer} which will receive the
-     *                            {@link ServerBootstrap} to set options.
-     * @param port                The port will be created on.
-     * @return A {@link ChannelFuture} which can be used to wait for the server to be shutdown.
-     */
-    public ChannelFuture bindServer(@Nonnull ServerContext serverContext,
-                                    @Nonnull BootstrapConfigurer bootstrapConfigurer,
-                                    String address,
-                                    int port) {
-        try {
-            ServerBootstrap bootstrap = new ServerBootstrap();
-            bootstrap.group(serverContext.getWorkerGroup())
-                    .channel(serverContext.getChannelImplementation().getServerChannelClass());
-            bootstrapConfigurer.configure(bootstrap);
-            bootstrap.childHandler(getServerChannelInitializer(serverContext));
-            boolean bindToAllInterfaces =
-                    Optional.ofNullable(getServerContext().getServerConfig(Boolean.class, "--bind-to-all-interfaces"))
-                            .orElse(false);
-            if (bindToAllInterfaces) {
-                log.info("Log Replication Server listening on all interfaces on port:{}", port);
-                return bootstrap.bind(port).sync();
-            } else {
-                log.info("Log Replication Server listening on {}:{}", address, port);
-                return bootstrap.bind(address, port).sync();
-            }
-        } catch (InterruptedException ie) {
-            throw new UnrecoverableCorfuInterruptedError(ie);
-        }
-    }
-
-
-    /**
-     * Start the Corfu Replication Server by listening on the specified port.
-     */
-    private ChannelFuture startServer() {
-        bindFuture = bindServer(getServerContext(),
-                this::configureBootstrapOptions,
-                (String) getServerContext().getServerConfig().get("--address"),
-                port);
-
-        return bindFuture.syncUninterruptibly();
-    }
-
-    /**
-     * Configure server bootstrap per-channel options, such as TCP options, etc.
-     *
-     * @param bootstrap The {@link ServerBootstrap} to be configured.
-     */
-    public void configureBootstrapOptions(@Nonnull ServerBootstrap bootstrap) {
-        bootstrap.option(ChannelOption.SO_BACKLOG, 100)
-                .childOption(ChannelOption.SO_KEEPALIVE, true)
-                .childOption(ChannelOption.SO_REUSEADDR, true)
-                .childOption(ChannelOption.TCP_NODELAY, true)
-                .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
-    }
-
-
-    /**
-     * Obtain a {@link ChannelInitializer} which initializes the channel pipeline
-     * for a new {@link ServerChannel}.
-     *
-     * @param context The {@link ServerContext} to use.
-     * @return A {@link ChannelInitializer} to initialize the channel.
-     */
-    private ChannelInitializer<Channel> getServerChannelInitializer(@Nonnull ServerContext context) {
-
-        // Generate the initializer.
-        return new ChannelInitializer<Channel>() {
-            @Override
-            protected void initChannel(@Nonnull Channel ch) throws Exception {
-
-                // Security variables
-                final SslContext sslContext;
-                final String[] enabledTlsProtocols;
-                final String[] enabledTlsCipherSuites;
-
-                // Security Initialization
-                Boolean tlsEnabled = context.getServerConfig(Boolean.class, "--enable-tls");
-                Boolean tlsMutualAuthEnabled = context.getServerConfig(Boolean.class,
-                        "--enable-tls-mutual-auth");
-                if (tlsEnabled) {
-                    // Get the TLS cipher suites to enable
-                    String ciphs = context.getServerConfig(String.class, "--tls-ciphers");
-                    if (ciphs != null) {
-                        enabledTlsCipherSuites = Pattern.compile(",")
-                                .splitAsStream(ciphs)
-                                .map(String::trim)
-                                .toArray(String[]::new);
-                    } else {
-                        enabledTlsCipherSuites = new String[]{};
-                    }
-
-                    // Get the TLS protocols to enable
-                    String protos = context.getServerConfig(String.class, "--tls-protocols");
-                    if (protos != null) {
-                        enabledTlsProtocols = Pattern.compile(",")
-                                .splitAsStream(protos)
-                                .map(String::trim)
-                                .toArray(String[]::new);
-                    } else {
-                        enabledTlsProtocols = new String[]{};
-                    }
-
-                    try {
-                        KeyStoreConfig keyStoreConfig = KeyStoreConfig.from(
-                                context.getServerConfig(String.class, ConfigParamNames.KEY_STORE),
-                                context.getServerConfig(String.class, ConfigParamNames.KEY_STORE_PASS_FILE)
-                        );
-
-                        Path certExpiryFile = context
-                                .<String>getServerConfig(ConfigParamNames.DISABLE_CERT_EXPIRY_CHECK_FILE)
-                                .map(Paths::get)
-                                .orElse(TrustStoreConfig.DEFAULT_DISABLE_CERT_EXPIRY_CHECK_FILE);
-
-                        TrustStoreConfig trustStoreConfig = TrustStoreConfig.from(
-                                context.getServerConfig(String.class, ConfigParamNames.TRUST_STORE),
-                                context.getServerConfig(String.class, ConfigParamNames.TRUST_STORE_PASS_FILE),
-                                certExpiryFile
-                        );
-
-                        sslContext = SslContextConstructor.constructSslContext(true, keyStoreConfig, trustStoreConfig);
-                    } catch (SSLException e) {
-                        log.error("Could not build the SSL context", e);
-                        throw new RuntimeException("Couldn't build the SSL context", e);
-                    }
-                } else {
-                    enabledTlsCipherSuites = new String[]{};
-                    enabledTlsProtocols = new String[]{};
-                    sslContext = null;
-                }
-
-                Boolean saslPlainTextAuth = context.getServerConfig(Boolean.class,
-                        "--enable-sasl-plain-text-auth");
-
-                // If TLS is enabled, setup the encryption pipeline.
-                if (tlsEnabled) {
-                    SSLEngine engine = sslContext.newEngine(ch.alloc());
-                    engine.setEnabledCipherSuites(enabledTlsCipherSuites);
-                    engine.setEnabledProtocols(enabledTlsProtocols);
-                    if (tlsMutualAuthEnabled) {
-                        engine.setNeedClientAuth(true);
-                    }
-                    ch.pipeline().addLast("ssl", new SslHandler(engine));
-                }
-                // Add/parse a length field
-                ch.pipeline().addLast(new LengthFieldPrepender(4));
-                ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer
-                        .MAX_VALUE, 0, 4,
-                        0, 4));
-                // If SASL authentication is requested, perform a SASL plain-text auth.
-                if (saslPlainTextAuth) {
-                    ch.pipeline().addLast("sasl/plain-text", new
-                            PlainTextSaslNettyServer());
-                }
-                // Transform the framed message into a Corfu message.
-                ch.pipeline().addLast(new NettyCorfuMessageDecoder());
-                ch.pipeline().addLast(new NettyCorfuMessageEncoder());
-                // Route the message to the server class.
-                ch.pipeline().addLast(nettyServerChannel);
-            }
-        };
-    }
-
-
-    /**
-     * A functional interface for receiving and configuring a {@link ServerBootstrap}.
-     */
-    @FunctionalInterface
-    public interface BootstrapConfigurer {
-
-        /**
-         * Configure a {@link ServerBootstrap}.
-         *
-         * @param serverBootstrap The {@link ServerBootstrap} to configure.
-         */
-        void configure(ServerBootstrap serverBootstrap);
-    }
-
-}
+//package org.corfudb.infrastructure.logreplication.transport.sample;
+//
+//import io.netty.bootstrap.ServerBootstrap;
+//import io.netty.buffer.PooledByteBufAllocator;
+//import io.netty.channel.Channel;
+//import io.netty.channel.ChannelFuture;
+//import io.netty.channel.ChannelInitializer;
+//import io.netty.channel.ChannelOption;
+//import io.netty.channel.EventLoopGroup;
+//import io.netty.channel.ServerChannel;
+//import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+//import io.netty.handler.codec.LengthFieldPrepender;
+//import io.netty.handler.ssl.SslContext;
+//import io.netty.handler.ssl.SslHandler;
+//import lombok.extern.slf4j.Slf4j;
+//import org.corfudb.common.config.ConfigParamNames;
+//import org.corfudb.infrastructure.ServerContext;
+//import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+//import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkServerRouter;
+//import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceServerRouter;
+//import org.corfudb.infrastructure.logreplication.transport.server.IServerChannelAdapter;
+//import org.corfudb.protocols.wireprotocol.NettyCorfuMessageDecoder;
+//import org.corfudb.protocols.wireprotocol.NettyCorfuMessageEncoder;
+//import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
+//import org.corfudb.runtime.proto.service.CorfuMessage;
+//import org.corfudb.runtime.proto.service.CorfuMessage.ResponseMsg;
+//import org.corfudb.security.sasl.plaintext.PlainTextSaslNettyServer;
+//import org.corfudb.security.tls.SslContextConstructor;
+//import org.corfudb.security.tls.TlsUtils.CertStoreConfig.KeyStoreConfig;
+//import org.corfudb.security.tls.TlsUtils.CertStoreConfig.TrustStoreConfig;
+//
+//import javax.annotation.Nonnull;
+//import javax.net.ssl.SSLEngine;
+//import javax.net.ssl.SSLException;
+//import java.nio.file.Path;
+//import java.nio.file.Paths;
+//import java.util.Map;
+//import java.util.Optional;
+//import java.util.concurrent.CompletableFuture;
+//import java.util.regex.Pattern;
+//
+//@Slf4j
+//public class NettyLogReplicationServerChannelAdapter extends IServerChannelAdapter {
+//
+//    private CorfuNettyServerChannel nettyServerChannel;
+//
+//    private ChannelFuture bindFuture;
+//
+//    private final int port;
+//
+//    private CompletableFuture<Boolean> connectionEnded;
+//
+//    public NettyLogReplicationServerChannelAdapter(@Nonnull ServerContext serverContext,
+//                                                   Map<ReplicationSession, LogReplicationSourceServerRouter> sourceServerRouter,
+//                                                   Map<ReplicationSession, LogReplicationSinkServerRouter> sinkServerrouter) {
+//        super(serverContext, sourceServerRouter, sinkServerrouter);
+//        this.port = Integer.parseInt((String) serverContext.getServerConfig().get("<port>"));
+//        this.nettyServerChannel = new CorfuNettyServerChannel(this);
+//    }
+//
+//    // ================== IServerChannelAdapter ==================
+//
+//    @Override
+//    public void updateRouters(Map<ReplicationSession, LogReplicationSourceServerRouter> sesionToSourceServerRouter,
+//                              Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServerRouter) {
+//        this.getIncomingSessionToSinkServerRouter().putAll(sessionToSinkServerRouter);
+//        this.getIncomingSessionToSourceServerRouter().putAll(sesionToSourceServerRouter);
+//    }
+//
+//    @Override
+//    public void send(@Nonnull ResponseMsg msg) {
+//        nettyServerChannel.sendResponse(msg);
+//    }
+//
+//    @Override
+//    public void send(String nodeId, @Nonnull CorfuMessage.RequestMsg msg) {
+//
+//    }
+//
+//    @Override
+//    public CompletableFuture<Boolean> start() {
+//        startServer().channel().closeFuture().syncUninterruptibly();
+//        connectionEnded = new CompletableFuture<>();
+//        log.info("Server started, listening on {}", port);
+//        return connectionEnded;
+//    }
+//
+//    @Override
+//    public void stop() {
+//        bindFuture.channel().close().syncUninterruptibly();
+//        if (connectionEnded != null) {
+//            connectionEnded.complete(true);
+//        }
+//    }
+//
+//    // ==========================================================
+//
+//    /**
+//     * Bind the Corfu server to the given {@code port} using the provided
+//     * {@code channelType}. It is the callers' responsibility to shutdown the
+//     * {@link EventLoopGroup}s. For implementations which listen on multiple ports,
+//     * {@link EventLoopGroup}s may be reused.
+//     *
+//     * @param serverContext       A current server context.
+//     * @param bootstrapConfigurer A {@link BootstrapConfigurer} which will receive the
+//     *                            {@link ServerBootstrap} to set options.
+//     * @param port                The port will be created on.
+//     * @return A {@link ChannelFuture} which can be used to wait for the server to be shutdown.
+//     */
+//    public ChannelFuture bindServer(@Nonnull ServerContext serverContext,
+//                                    @Nonnull BootstrapConfigurer bootstrapConfigurer,
+//                                    String address,
+//                                    int port) {
+//        try {
+//            ServerBootstrap bootstrap = new ServerBootstrap();
+//            bootstrap.group(serverContext.getWorkerGroup())
+//                    .channel(serverContext.getChannelImplementation().getServerChannelClass());
+//            bootstrapConfigurer.configure(bootstrap);
+//            bootstrap.childHandler(getServerChannelInitializer(serverContext));
+//            boolean bindToAllInterfaces =
+//                    Optional.ofNullable(getServerContext().getServerConfig(Boolean.class, "--bind-to-all-interfaces"))
+//                            .orElse(false);
+//            if (bindToAllInterfaces) {
+//                log.info("Log Replication Server listening on all interfaces on port:{}", port);
+//                return bootstrap.bind(port).sync();
+//            } else {
+//                log.info("Log Replication Server listening on {}:{}", address, port);
+//                return bootstrap.bind(address, port).sync();
+//            }
+//        } catch (InterruptedException ie) {
+//            throw new UnrecoverableCorfuInterruptedError(ie);
+//        }
+//    }
+//
+//
+//    /**
+//     * Start the Corfu Replication Server by listening on the specified port.
+//     */
+//    private ChannelFuture startServer() {
+//        bindFuture = bindServer(getServerContext(),
+//                this::configureBootstrapOptions,
+//                (String) getServerContext().getServerConfig().get("--address"),
+//                port);
+//
+//        return bindFuture.syncUninterruptibly();
+//    }
+//
+//    /**
+//     * Configure server bootstrap per-channel options, such as TCP options, etc.
+//     *
+//     * @param bootstrap The {@link ServerBootstrap} to be configured.
+//     */
+//    public void configureBootstrapOptions(@Nonnull ServerBootstrap bootstrap) {
+//        bootstrap.option(ChannelOption.SO_BACKLOG, 100)
+//                .childOption(ChannelOption.SO_KEEPALIVE, true)
+//                .childOption(ChannelOption.SO_REUSEADDR, true)
+//                .childOption(ChannelOption.TCP_NODELAY, true)
+//                .childOption(ChannelOption.ALLOCATOR, PooledByteBufAllocator.DEFAULT);
+//    }
+//
+//
+//    /**
+//     * Obtain a {@link ChannelInitializer} which initializes the channel pipeline
+//     * for a new {@link ServerChannel}.
+//     *
+//     * @param context The {@link ServerContext} to use.
+//     * @return A {@link ChannelInitializer} to initialize the channel.
+//     */
+//    private ChannelInitializer<Channel> getServerChannelInitializer(@Nonnull ServerContext context) {
+//
+//        // Generate the initializer.
+//        return new ChannelInitializer<Channel>() {
+//            @Override
+//            protected void initChannel(@Nonnull Channel ch) throws Exception {
+//
+//                // Security variables
+//                final SslContext sslContext;
+//                final String[] enabledTlsProtocols;
+//                final String[] enabledTlsCipherSuites;
+//
+//                // Security Initialization
+//                Boolean tlsEnabled = context.getServerConfig(Boolean.class, "--enable-tls");
+//                Boolean tlsMutualAuthEnabled = context.getServerConfig(Boolean.class,
+//                        "--enable-tls-mutual-auth");
+//                if (tlsEnabled) {
+//                    // Get the TLS cipher suites to enable
+//                    String ciphs = context.getServerConfig(String.class, "--tls-ciphers");
+//                    if (ciphs != null) {
+//                        enabledTlsCipherSuites = Pattern.compile(",")
+//                                .splitAsStream(ciphs)
+//                                .map(String::trim)
+//                                .toArray(String[]::new);
+//                    } else {
+//                        enabledTlsCipherSuites = new String[]{};
+//                    }
+//
+//                    // Get the TLS protocols to enable
+//                    String protos = context.getServerConfig(String.class, "--tls-protocols");
+//                    if (protos != null) {
+//                        enabledTlsProtocols = Pattern.compile(",")
+//                                .splitAsStream(protos)
+//                                .map(String::trim)
+//                                .toArray(String[]::new);
+//                    } else {
+//                        enabledTlsProtocols = new String[]{};
+//                    }
+//
+//                    try {
+//                        KeyStoreConfig keyStoreConfig = KeyStoreConfig.from(
+//                                context.getServerConfig(String.class, ConfigParamNames.KEY_STORE),
+//                                context.getServerConfig(String.class, ConfigParamNames.KEY_STORE_PASS_FILE)
+//                        );
+//
+//                        Path certExpiryFile = context
+//                                .<String>getServerConfig(ConfigParamNames.DISABLE_CERT_EXPIRY_CHECK_FILE)
+//                                .map(Paths::get)
+//                                .orElse(TrustStoreConfig.DEFAULT_DISABLE_CERT_EXPIRY_CHECK_FILE);
+//
+//                        TrustStoreConfig trustStoreConfig = TrustStoreConfig.from(
+//                                context.getServerConfig(String.class, ConfigParamNames.TRUST_STORE),
+//                                context.getServerConfig(String.class, ConfigParamNames.TRUST_STORE_PASS_FILE),
+//                                certExpiryFile
+//                        );
+//
+//                        sslContext = SslContextConstructor.constructSslContext(true, keyStoreConfig, trustStoreConfig);
+//                    } catch (SSLException e) {
+//                        log.error("Could not build the SSL context", e);
+//                        throw new RuntimeException("Couldn't build the SSL context", e);
+//                    }
+//                } else {
+//                    enabledTlsCipherSuites = new String[]{};
+//                    enabledTlsProtocols = new String[]{};
+//                    sslContext = null;
+//                }
+//
+//                Boolean saslPlainTextAuth = context.getServerConfig(Boolean.class,
+//                        "--enable-sasl-plain-text-auth");
+//
+//                // If TLS is enabled, setup the encryption pipeline.
+//                if (tlsEnabled) {
+//                    SSLEngine engine = sslContext.newEngine(ch.alloc());
+//                    engine.setEnabledCipherSuites(enabledTlsCipherSuites);
+//                    engine.setEnabledProtocols(enabledTlsProtocols);
+//                    if (tlsMutualAuthEnabled) {
+//                        engine.setNeedClientAuth(true);
+//                    }
+//                    ch.pipeline().addLast("ssl", new SslHandler(engine));
+//                }
+//                // Add/parse a length field
+//                ch.pipeline().addLast(new LengthFieldPrepender(4));
+//                ch.pipeline().addLast(new LengthFieldBasedFrameDecoder(Integer
+//                        .MAX_VALUE, 0, 4,
+//                        0, 4));
+//                // If SASL authentication is requested, perform a SASL plain-text auth.
+//                if (saslPlainTextAuth) {
+//                    ch.pipeline().addLast("sasl/plain-text", new
+//                            PlainTextSaslNettyServer());
+//                }
+//                // Transform the framed message into a Corfu message.
+//                ch.pipeline().addLast(new NettyCorfuMessageDecoder());
+//                ch.pipeline().addLast(new NettyCorfuMessageEncoder());
+//                // Route the message to the server class.
+//                ch.pipeline().addLast(nettyServerChannel);
+//            }
+//        };
+//    }
+//
+//
+//    /**
+//     * A functional interface for receiving and configuring a {@link ServerBootstrap}.
+//     */
+//    @FunctionalInterface
+//    public interface BootstrapConfigurer {
+//
+//        /**
+//         * Configure a {@link ServerBootstrap}.
+//         *
+//         * @param serverBootstrap The {@link ServerBootstrap} to configure.
+//         */
+//        void configure(ServerBootstrap serverBootstrap);
+//    }
+//
+//}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/server/IServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/server/IServerChannelAdapter.java
@@ -34,6 +34,15 @@ public abstract class IServerChannelAdapter {
     @Getter
     private final ServerContext serverContext;
 
+    /**
+     * Constructs a new {@link IServerChannelAdapter}
+     *
+     * @param serverContext
+     * @param sesionToSourceServerRouter map of session-> source-server router. Using this, the adapter forwards the
+     *                                   msg to the correct source router.
+     * @param sessionToSinkServerRouter map of session-> sink-server router. Using this, the adapter forwards the
+     *                                  msg to the correct source router.
+     */
     public IServerChannelAdapter(ServerContext serverContext,
                                  Map<ReplicationSession, LogReplicationSourceServerRouter> sesionToSourceServerRouter,
                                  Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServerRouter) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/server/IServerChannelAdapter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/transport/server/IServerChannelAdapter.java
@@ -5,8 +5,16 @@ import lombok.Setter;
 import org.corfudb.infrastructure.ServerContext;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationServerRouter;
 import org.corfudb.infrastructure.logreplication.transport.IChannelContext;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.ServerContext;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSubscriber;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSinkServerRouter;
+import org.corfudb.infrastructure.logreplication.runtime.LogReplicationSourceServerRouter;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.proto.service.CorfuMessage;
 
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -17,21 +25,21 @@ import java.util.concurrent.CompletableFuture;
  *
  * @author annym 05/15/2020
  */
+@Slf4j
 public abstract class IServerChannelAdapter {
 
-    @Getter
-    private final LogReplicationServerRouter router;
+    private final Map<ReplicationSession, LogReplicationSourceServerRouter> sesionToSourceServerRouter;
+    private final Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServerRouter;
 
     @Getter
     private final ServerContext serverContext;
 
-    @Getter
-    @Setter
-    private IChannelContext channelContext;
-
-    public IServerChannelAdapter(ServerContext serverContext, LogReplicationServerRouter adapter) {
+    public IServerChannelAdapter(ServerContext serverContext,
+                                 Map<ReplicationSession, LogReplicationSourceServerRouter> sesionToSourceServerRouter,
+                                 Map<ReplicationSession, LogReplicationSinkServerRouter> sessionToSinkServerRouter) {
         this.serverContext = serverContext;
-        this.router = adapter;
+        this.sesionToSourceServerRouter = sesionToSourceServerRouter;
+        this.sessionToSinkServerRouter = sessionToSinkServerRouter;
     }
 
     /**
@@ -42,12 +50,51 @@ public abstract class IServerChannelAdapter {
     public abstract void send(CorfuMessage.ResponseMsg msg);
 
     /**
-     * Receive a message from Client.
+     * Send a message across the channel to a specific endpoint.
+     *
+     * @param nodeId remote node id
+     * @param request corfu message to be sent
+     */
+    public abstract void send(String nodeId, CorfuMessage.RequestMsg request);
+
+    /**
+     * Receive a message from Server.
+     * The adapter will forward this message to the router for further processing.
      *
      * @param msg received corfu message
      */
+    public void receive(CorfuMessage.ResponseMsg msg) {
+        ReplicationSession session = null;
+        if (msg.getPayload().getPayloadCase().equals(CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_METADATA_RESPONSE)) {
+            session = convertSessionMsg(msg.getPayload().getLrMetadataResponse().getSessionInfo());
+        } else if (msg.getPayload().getPayloadCase().equals(CorfuMessage.ResponsePayloadMsg.PayloadCase.LR_ENTRY_ACK)) {
+            session = convertSessionMsg(msg.getPayload().getLrEntryAck().getMetadata().getSessionInfo());
+        }
+        if(sesionToSourceServerRouter.containsKey(session)) {
+            sesionToSourceServerRouter.get(session).receive(msg);
+        } else if(sessionToSinkServerRouter.containsKey(session)){
+            sessionToSinkServerRouter.get(session).receive(msg);
+        }
+    }
+
+    /**
+     * Receive a message from Client.
+     * @param msg received corfu message
+     */
     public void receive(CorfuMessage.RequestMsg msg) {
-        getRouter().receive(msg);
+        ReplicationSession session = null;
+        if(msg.getPayload().getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_LEADERSHIP_QUERY)) {
+            session = convertSessionMsg(msg.getPayload().getLrLeadershipQuery().getSessionInfo());
+        } else if (msg.getPayload().getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_METADATA_REQUEST)) {
+            session = convertSessionMsg(msg.getPayload().getLrMetadataRequest().getSessionInfo());
+        } else if (msg.getPayload().getPayloadCase().equals(CorfuMessage.RequestPayloadMsg.PayloadCase.LR_ENTRY)) {
+            session = convertSessionMsg(msg.getPayload().getLrEntry().getMetadata().getSessionInfo());
+        }
+        if(sesionToSourceServerRouter.containsKey(session)) {
+            sesionToSourceServerRouter.get(session).receive(msg);
+        } else if(sessionToSinkServerRouter.containsKey(session)){
+            sessionToSinkServerRouter.get(session).receive(msg);
+        }
     }
 
     /**
@@ -61,4 +108,11 @@ public abstract class IServerChannelAdapter {
      * Close connections or gracefully shutdown the channel.
      */
     public void stop() {}
+
+
+    private ReplicationSession convertSessionMsg(LogReplication.ReplicationSessionMsg sessionMsg) {
+        log.info("sessionMsg : {}", sessionMsg);
+        ReplicationSubscriber subscriber = new ReplicationSubscriber(sessionMsg.getReplicationModel(), sessionMsg.getClient());
+        return new ReplicationSession(sessionMsg.getRemoteClusterId(), sessionMsg.getLocalClusterId(), subscriber);
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -92,6 +92,7 @@ public class LogReplicationConfigManager {
     @Getter
     private LogReplicationConfig config;
 
+    @Getter
     private ServerContext serverContext;
 
     /**

--- a/infrastructure/src/main/resources/org/corfudb/infrastructure/logreplication/transport/sample/lr_service_config.json
+++ b/infrastructure/src/main/resources/org/corfudb/infrastructure/logreplication/transport/sample/lr_service_config.json
@@ -1,0 +1,21 @@
+{
+  "methodConfig": [
+    {
+      "name": [
+        {
+          "service": "LogReplicationChannel"
+        }
+      ],
+
+      "retryPolicy": {
+        "maxAttempts": 5,
+        "initialBackoff": "0.5s",
+        "maxBackoff": "30s",
+        "backoffMultiplier": 2,
+        "retryableStatusCodes": [
+          "UNAVAILABLE"
+        ]
+      }
+    }
+  ]
+}

--- a/infrastructure/src/main/resources/org/corfudb/infrastructure/logreplication/transport/sample/lr_service_config.json
+++ b/infrastructure/src/main/resources/org/corfudb/infrastructure/logreplication/transport/sample/lr_service_config.json
@@ -3,13 +3,13 @@
     {
       "name": [
         {
-          "service": "LogReplicationChannel"
+          "service": "org.corfudb.infrastructure.logreplication.LogReplicationChannel"
         }
       ],
 
       "retryPolicy": {
         "maxAttempts": 5,
-        "initialBackoff": "0.5s",
+        "initialBackoff": "1s",
         "maxBackoff": "30s",
         "backoffMultiplier": 2,
         "retryableStatusCodes": [

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import static org.corfudb.infrastructure.LogReplicationClientTest.SAMPLE_CLUSTER;
 import static org.corfudb.protocols.CorfuProtocolCommon.getUUID;
 import static org.corfudb.protocols.service.CorfuProtocolMessage.getRequestMsg;
 import static org.mockito.ArgumentMatchers.same;
@@ -47,7 +48,7 @@ public class LogReplicationServerTest {
     UuidMsg clusterId = UuidMsg.newBuilder().setLsb(5).setMsb(5).build();
     String sourceClusterId = getUUID(clusterId).toString();
     ReplicationSession replicationSession =
-        ReplicationSession.getDefaultReplicationSessionForCluster(sourceClusterId);
+        ReplicationSession.getDefaultReplicationSessionForCluster(sourceClusterId, SAMPLE_CLUSTER);
 
     /**
      * Stub most of the {@link LogReplicationServer} functionality, but spy on the actual instance.
@@ -79,13 +80,13 @@ public class LogReplicationServerTest {
 
         lrServer.setLeadership(true);
         doReturn(metadataManager).when(sinkManager).getLogReplicationMetadataManager();
-        doReturn(response).when(metadataManager).getMetadataResponse(any());
+        doReturn(response).when(metadataManager).getMetadataResponse(any(), replicationSession);
 
         lrServer.getHandlerMethods().handle(request, mockHandlerContext,
             mockServerRouter);
 
         verify(sinkManager).getLogReplicationMetadataManager();
-        verify(metadataManager).getMetadataResponse(any());
+        verify(metadataManager).getMetadataResponse(any(), replicationSession);
     }
 
     /**

--- a/runtime/proto/service/corfu_message.proto
+++ b/runtime/proto/service/corfu_message.proto
@@ -148,6 +148,7 @@ message ResponsePayloadMsg {
     LogReplicationLeadershipResponseMsg lr_leadership_response = 72;
 
     LogReplicationLeadershipLossResponseMsg lr_leadership_loss = 73;
+    LogReplicationSubscribeMsg lr_subscribe_request = 77;
 
     // Server Error
     ServerErrorMsg server_error = 200;

--- a/runtime/proto/service/log_replication.proto
+++ b/runtime/proto/service/log_replication.proto
@@ -13,6 +13,7 @@ message LogReplicationEntryMetadataMsg {
   UuidMsg syncRequestId = 5;
   int64 snapshotTimestamp = 6;
   int64 snapshotSyncSeqNum = 7;
+  ReplicationSessionMsg sessionInfo = 8;
 }
 
 message LogReplicationEntryMsg {
@@ -21,6 +22,7 @@ message LogReplicationEntryMsg {
 }
 
 message LogReplicationMetadataRequestMsg {
+  ReplicationSessionMsg sessionInfo = 1;
 }
 
 message LogReplicationMetadataResponseMsg {
@@ -30,18 +32,46 @@ message LogReplicationMetadataResponseMsg {
   uint64 snapshotTransferred = 4;
   uint64 snapshotApplied = 5;
   uint64 lastLogEntryTimestamp = 6;
+  ReplicationSessionMsg sessionInfo = 7;
 }
 
 message LogReplicationLeadershipLossResponseMsg {
   string nodeId = 1;
+  ReplicationSessionMsg sessionInfo = 2;
 }
 
 message LogReplicationLeadershipRequestMsg {
+  ReplicationSessionMsg sessionInfo = 1;
 }
 
 message LogReplicationLeadershipResponseMsg {
   bool isLeader = 2;
   string nodeId = 3;
+  ReplicationSessionMsg sessionInfo = 4;
+}
+
+// when the source is the connection endpoint
+message LogReplicationReplicationRequestMsg {
+  LogReplicationEntryMsg msg = 1;
+}
+
+enum ReplicationModel {
+  FULL_TABLE = 0;                 // Full table replication (Single Source to Single Sink = 1:1)
+  ROUTING_QUEUES = 1;             // Routing queue replication (used for entry-level replication) (1:1)
+  LOGICAL_GROUPS = 2;             // Table association to logical group (1:1)
+  MULTI_SOURCE_MERGE = 3;         // Same table replication from multiple sources to single sink (n:1)
+}
+
+message ReplicationSessionMsg {
+  string remoteClusterId = 1;
+  string localClusterId = 2;
+  string client = 3;
+  // TODO: shama to remove this once we have the tag.
+  ReplicationModel replicationModel = 4;
+}
+
+message LogReplicationSubscribeMsg {
+  ReplicationSessionMsg sessionInfo = 1;
 }
 
 enum LogReplicationEntryType {

--- a/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogReplication.java
+++ b/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogReplication.java
@@ -162,8 +162,7 @@ public final class CorfuProtocolLogReplication {
         return buf.array();
     }
 
-    public static ResponseMsg getLeadershipResponse(
-            HeaderMsg header, boolean isLeader, String nodeId) {
+    public static ResponseMsg getLeadershipResponse(HeaderMsg header, boolean isLeader, String nodeId) {
         LogReplication.LogReplicationLeadershipResponseMsg request = LogReplication.LogReplicationLeadershipResponseMsg
                 .newBuilder()
                 .setIsLeader(isLeader)

--- a/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/IClientRouter.java
@@ -1,5 +1,6 @@
 package org.corfudb.runtime.clients;
 
+import io.netty.channel.ChannelHandlerContext;
 import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
 import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
 import java.util.concurrent.CompletableFuture;
@@ -122,4 +123,8 @@ public interface IClientRouter {
      * @param timeoutResponse Response timeout in milliseconds.
      */
     void setTimeoutResponse(long timeoutResponse);
+
+    default void sendResponse(CorfuMessage.ResponseMsg response, ChannelHandlerContext ctx) {
+
+    }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogEntryWriterTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogEntryWriterTest.java
@@ -35,6 +35,7 @@ public class LogEntryWriterTest extends AbstractViewTest {
     private int numOpaqueEntries;
     private int topologyConfigId;
     private String remoteClusterId = "Remote Cluster";
+    private String localClusterId = "Local Cluster";
 
     @Before
     public void setUp() {
@@ -45,7 +46,7 @@ public class LogEntryWriterTest extends AbstractViewTest {
 
         // Create the default replication session
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(remoteClusterId);
+            ReplicationSession.getDefaultReplicationSessionForCluster(remoteClusterId, localClusterId);
 
         metadataManager = Mockito.mock(LogReplicationMetadataManager.class);
         initMocksForMetadataManager();

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationConfigManagerTest.java
@@ -14,6 +14,7 @@ import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManag
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.collections.CorfuStore;
 import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.view.AbstractViewTest;
 
 import org.corfudb.runtime.view.TableRegistry;

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -467,7 +467,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(runtime, null);
         ReplicationSession replicationSession = ReplicationSession.getDefaultReplicationSessionForCluster(
-            TEST_LOCAL_CLUSTER_ID);
+            TEST_LOCAL_CLUSTER_ID, TEST_LOCAL_CLUSTER_ID);
 
         switch(readerImpl) {
             case EMPTY:
@@ -486,7 +486,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
                         .streamName(fullyQualifiedStreamName)
                         .batchSize(BATCH_SIZE).build();
 
-                snapshotReader = new TestSnapshotReader(testConfig);
+                snapshotReader = new TestSnapshotReader(testConfig, replicationSession);
                 dataSender = new TestDataSender();
                 break;
             case STREAMS:
@@ -499,7 +499,8 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         }
 
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(runtime, TEST_TOPOLOGY_CONFIG_ID,
-            TEST_LOCAL_CLUSTER_ID);
+                replicationSession);
+
         ackReader = new LogReplicationAckReader(metadataManager, configManager, runtime, replicationSession);
 
         fsm = new LogReplicationFSM(runtime, snapshotReader, dataSender, logEntryReader,

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/MetadataManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/MetadataManagerTest.java
@@ -36,7 +36,7 @@ public class MetadataManagerTest extends AbstractViewTest {
     private TestUtils utils;
     private String remoteClusterId = "Remote Cluster";
     private ReplicationSession replicationSession =
-        ReplicationSession.getDefaultReplicationSessionForCluster(remoteClusterId);
+        ReplicationSession.getDefaultReplicationSessionForCluster(remoteClusterId, localClusterId);
 
     @Before
     public void setUp() {
@@ -61,7 +61,7 @@ public class MetadataManagerTest extends AbstractViewTest {
     public void testMetadataAfterLogEntrySync() {
 
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(corfuRuntime, topologyConfigId,
-            localClusterId);
+            replicationSession);
         LogEntryWriter writer = new LogEntryWriter(configManager, metadataManager, replicationSession);
 
         Long numOpaqueEntries = 3L;
@@ -98,7 +98,7 @@ public class MetadataManagerTest extends AbstractViewTest {
     public void testInitTsForSnapshotAndLogEntryProcessed() {
 
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(corfuRuntime,
-            topologyConfigId, localClusterId);
+            topologyConfigId, replicationSession);
 
         long lastApppliedSnapshotTimestamp = metadataManager.getLastAppliedSnapshotTimestamp();
         long lastProcessedLogEntryTimestamp = metadataManager.getLastProcessedLogEntryBatchTimestamp();
@@ -119,7 +119,7 @@ public class MetadataManagerTest extends AbstractViewTest {
     public void testConcurrentTopologyChange() throws Exception {
 
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(corfuRuntime, topologyConfigId,
-            localClusterId);
+            replicationSession);
         LogEntryWriter writer = new LogEntryWriter(configManager, metadataManager, replicationSession);
 
         // Create a message with 50 opaque entries

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -507,7 +507,7 @@ public class AbstractIT extends AbstractCorfuTest {
         private boolean noAutoCommit = true;
         private String keyStore = null;
         private String keyStorePassword = null;
-        private String logLevel = "INFO";
+        private String logLevel = "DEBUG";
         private String logPath = null;
         private String trustStore = null;
         private String logSizeLimitPercentage = null;
@@ -611,7 +611,7 @@ public class AbstractIT extends AbstractCorfuTest {
         private boolean tlsEnabled = false;
         private String keyStore = null;
         private String keyStorePassword = null;
-        private String logLevel = "INFO";
+        private String logLevel = "DEBUG";
         private String trustStore = null;
         private String trustStorePassword = null;
         private String compressionCodec = null;

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationBiDirectional.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationBiDirectional.java
@@ -3,17 +3,14 @@ package org.corfudb.integration;
 
 import com.google.protobuf.Message;
 import lombok.extern.slf4j.Slf4j;
-import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.proto.Sample;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.runtime.ExampleSchemas;
-import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
-import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.CountDownLatch;

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationBiDirectional.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationBiDirectional.java
@@ -1,0 +1,263 @@
+package org.corfudb.integration;
+
+
+import com.google.protobuf.Message;
+import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.proto.Sample;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.runtime.ExampleSchemas;
+import org.corfudb.runtime.LogReplication;
+import org.corfudb.runtime.collections.Table;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.concurrent.CountDownLatch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.REPLICATION_STATUS_TABLE;
+
+@Slf4j
+@SuppressWarnings("checkstyle:magicnumber")
+public class CorfuReplicationBiDirectional extends LogReplicationAbstractIT {
+
+    private Table<ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg> configTable;
+
+    // TO run this test, add another replication model to streamsToReplicateMap and have metadataMangaer update LRstatus using sessionKey
+
+    /**
+     * This test verifies the behaviour when cluster1 acts as both source and sink(orphaned sink, ie., sink has no remote source),
+     * and cluster2 acts as a sink for cluster1
+     *
+     * 1. Init with corfu 9000 source and 9001 sink
+     * 2. Topology: cluster1 as SOURCE for cluster2 and cluster1 SINK for no cluster. This is emulated by having
+     * different replication models for SOURCE and SINK on cluster1
+     * 3. Write 10 entries to source map
+     * 4. Start log replication: Node 9010 - source, Node 9020 - sink
+     * 5. Wait for Snapshot Sync, both maps have size 10
+     * 6. Verify data is replicated
+     * 7. Verify the replication status for SINKs on both cluster1/cluster2
+     */
+//    @Test
+//    public void test_whenClusterSourceAndOrphanedSink() throws Exception {
+//        //setup source and sink corfu
+//        setupSourceAndSinkCorfu();
+//        // Add a new kind of topology where a cluster is both source and destination, but the remote just acts as a sink
+//        init();
+//
+//        //open Maps
+//        log.debug("Open map on Source and Sink");
+//        openMaps(2, false);
+//
+//        // Subscribe to replication status table on Sink (to be sure data change on status are captured)
+//        Table<LogReplicationMetadata.ReplicationSessionKey, LogReplicationMetadata.ReplicationStatusVal, Message>
+//                cluster2ReplicationStatus = corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
+//                LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
+//                LogReplicationMetadata.ReplicationSessionKey.class,
+//                LogReplicationMetadata.ReplicationStatusVal.class,
+//                null,
+//                TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+//
+//        // (1) On startup, init the replication status for each session(2 sessions = 2 updates)
+//        // (2) When starting snapshot sync apply : is_data_consistent = false
+//        // (3) When completing snapshot sync apply : is_data_consistent = true
+//        CountDownLatch cluster2StatusUpdateLatch = new CountDownLatch(4);
+//        ReplicationStatusListener cluster2SinkListener =
+//                new ReplicationStatusListener(cluster2StatusUpdateLatch, false);
+//        corfuStoreSink.subscribeListener(cluster2SinkListener, LogReplicationMetadataManager.NAMESPACE,
+//                LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
+//
+//
+//        corfuStoreSource.openTable(LogReplicationMetadataManager.NAMESPACE,
+//                LogReplicationMetadataManager.REPLICATION_STATUS_TABLE,
+//                LogReplicationMetadata.ReplicationSessionKey.class,
+//                LogReplicationMetadata.ReplicationStatusVal.class,
+//                null,
+//                TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+//
+//        CountDownLatch cluster1StatusUpdateLatch = new CountDownLatch(1);
+//        ReplicationStatusListener cluster1SinkListener =
+//                new ReplicationStatusListener(cluster1StatusUpdateLatch, false);
+//        corfuStoreSource.subscribeListener(cluster1SinkListener, LogReplicationMetadataManager.NAMESPACE,
+//                LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
+//
+//
+//        //write to source maps
+//        writeToSource(0, 10);
+//
+//        // Confirm data does exist on Source Cluster
+//        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSource.values()) {
+//            assertThat(map.count()).isEqualTo(10);
+//        }
+//
+//        //validate sink cluster is still empty
+//        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSink.values()) {
+//            assertThat(map.count()).isEqualTo(0);
+//        }
+//
+//        // startReplication
+//        startLogReplicatorServers();
+//
+//        //validate that data is replicated
+//        log.info(">> Wait ... Snapshot log replication in progress ...");
+//        verifyDataOnSink(10);
+//
+//        // validate the status of replication table. Status -> COMPLETE
+//        cluster2StatusUpdateLatch.await();
+//        assertThat(cluster2SinkListener.getAccumulatedStatus().size()).isEqualTo(4);
+//        //check is_data_consistent flag is set true
+//        Assert.assertTrue(cluster2SinkListener.getAccumulatedStatus().get(3));
+//
+//
+//        cluster1StatusUpdateLatch.await();
+//        Assert.assertFalse(cluster1SinkListener.getAccumulatedStatus().get(0));
+//
+//        // Verify Sync Status for SINK on cluster1
+//        LogReplicationMetadata.ReplicationSessionKey key =
+//                LogReplicationMetadata.ReplicationSessionKey
+//                        .newBuilder()
+//                        .setRemoteClusterId(new DefaultClusterConfig().getSinkClusterIds().get(0))
+//                        .setReplicationModel(LogReplicationMetadata.ReplicationModels.MOVE_DATA)
+//                        .setClient("SampleClient")
+//                        .build();
+//        LogReplicationMetadata.ReplicationStatusVal replicationStatusVal;
+//        try (TxnContext txn = corfuStoreSource.txn(LogReplicationMetadataManager.NAMESPACE)) {
+//            replicationStatusVal = (LogReplicationMetadata.ReplicationStatusVal)txn.getRecord(LogReplicationMetadataManager.REPLICATION_STATUS_TABLE, key).getPayload();
+//            txn.commit();
+//        }
+//        assertThat(replicationStatusVal.getSyncType())
+//                .isEqualTo(LogReplicationMetadata.ReplicationStatusVal.SyncType.LOG_ENTRY);
+//        assertThat(replicationStatusVal.getStatus())
+//                .isEqualTo(LogReplicationMetadata.SyncStatus.NOT_STARTED);
+//
+//
+//    }
+//
+//
+//    private void init() throws Exception {
+//        configTable = corfuStoreSource.openTable(
+//                DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
+//                ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
+//                TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class)
+//        );
+//        try (TxnContext txn = corfuStoreSource.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
+//            txn.putRecord(configTable, DefaultClusterManager.OP_BIDIR_ORPH_SINK,
+//                    DefaultClusterManager.OP_BIDIR_ORPH_SINK, DefaultClusterManager.OP_BIDIR_ORPH_SINK);
+//            txn.commit();
+//        }
+//    }
+
+    /**
+     * This test verifies the behaviour when cluster1 acts as both source and sink(orphaned sink, ie., sink has no remote source),
+     * and cluster2 acts as a sink for cluster1
+     *
+     * 1. Init with corfu 9000 source and 9001 sink
+     * 2. Topology: cluster1 as SOURCE cluster2 as SINK, but cluster2 is connectionInitiator
+     * 3. Write 10 entries to source map
+     * 4. Start log replication: Node 9010 - source, Node 9020 - sink
+     * 5. Wait for Snapshot Sync, both maps have size 10
+     * 6. Verify data is replicated
+     * 7. Verify the replication status for SINKs on both cluster1/cluster2
+     */
+    @Test
+    public void test_whenSinkIsConnectionInit() throws Exception {
+        pluginConfigFilePath = grpcConfig;
+        //setup source and sink corfu
+        setupSourceAndSinkCorfu();
+        // Add a new kind of topology where a cluster is both source and destination, but the remote just acts as a sink
+        init();
+
+        //open Maps
+        log.info("Open map on Source and Sink");
+        openMaps(1, false);
+
+        // Subscribe to replication status table on Sink (to be sure data change on status are captured)
+        Table<LogReplicationMetadata.ReplicationStatusKey, LogReplicationMetadata.ReplicationStatusVal, Message> sinkStatusTable =
+                corfuStoreSink.openTable(LogReplicationMetadataManager.NAMESPACE,
+                REPLICATION_STATUS_TABLE,
+                LogReplicationMetadata.ReplicationStatusKey.class,
+                LogReplicationMetadata.ReplicationStatusVal.class,
+                null,
+                TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+
+        // (1) On startup, init the replication status for each session(2 sessions = 2 updates)
+        // (2) When starting snapshot sync apply : is_data_consistent = false
+        // (3) When completing snapshot sync apply : is_data_consistent = true
+        CountDownLatch cluster2StatusUpdateLatch = new CountDownLatch(3);
+        ReplicationStatusListener cluster2SinkListener =
+                new ReplicationStatusListener(cluster2StatusUpdateLatch, false);
+        corfuStoreSink.subscribeListener(cluster2SinkListener, LogReplicationMetadataManager.NAMESPACE,
+                LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
+
+
+        Table<LogReplicationMetadata.ReplicationStatusKey, LogReplicationMetadata.ReplicationStatusVal, Message> sourceStatusTable = corfuStoreSource.openTable(LogReplicationMetadataManager.NAMESPACE,
+                REPLICATION_STATUS_TABLE,
+                LogReplicationMetadata.ReplicationStatusKey.class,
+                LogReplicationMetadata.ReplicationStatusVal.class,
+                null,
+                TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+
+        CountDownLatch cluster1StatusUpdateLatch = new CountDownLatch(1);
+        ReplicationStatusListener cluster1SinkListener =
+                new ReplicationStatusListener(cluster1StatusUpdateLatch, false);
+        corfuStoreSource.subscribeListener(cluster1SinkListener, LogReplicationMetadataManager.NAMESPACE,
+                LogReplicationMetadataManager.LR_STATUS_STREAM_TAG);
+
+
+        //write to source maps
+        writeToSource(0, numWrites);
+
+        // Confirm data does exist on Source Cluster
+        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSource.values()) {
+            assertThat(map.count()).isEqualTo(numWrites);
+        }
+
+        //validate sink cluster is still empty
+        for(Table<Sample.StringKey, Sample.IntValueTag, Sample.Metadata> map : mapNameToMapSink.values()) {
+            assertThat(map.count()).isEqualTo(0);
+        }
+
+        // startReplication
+        startLogReplicatorServers();
+
+        //validate that data is replicated
+        log.info(">> Wait ... Snapshot log replication in progress ...");
+        verifyDataOnSink(numWrites);
+        log.info("Snapshot completed!. But the latch's value is " + cluster2StatusUpdateLatch.getCount());
+
+        // validate the status of replication table. Status -> COMPLETE
+        cluster2StatusUpdateLatch.await();
+
+        // Verify replication status
+        verifyReplicationStatusFromSource();
+
+        log.info(">> Write deltas");
+        writeToSource(numWrites, 5);
+
+        log.info(">> Wait ... Delta log replication in progress ...");
+        verifyDataOnSink((numWrites + 5));
+
+        assertThat(cluster2SinkListener.getAccumulatedStatus().size()).isEqualTo(3);
+        // Confirm last updates are set to true (corresponding to snapshot sync completed and log entry sync started)
+        assertThat(cluster2SinkListener.getAccumulatedStatus().get(cluster2SinkListener.getAccumulatedStatus().size() - 1)).isTrue();
+        assertThat(cluster2SinkListener.getAccumulatedStatus()).contains(false);
+    }
+
+
+    private void init() throws Exception {
+        configTable = corfuStoreSource.openTable(
+                DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
+                ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
+                TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class)
+        );
+        try (TxnContext txn = corfuStoreSource.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
+            txn.putRecord(configTable, DefaultClusterManager.OP_SINK_CONNECT_INIT,
+                    DefaultClusterManager.OP_SINK_CONNECT_INIT, DefaultClusterManager.OP_SINK_CONNECT_INIT);
+            txn.commit();
+        }
+    }
+}

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationBiDirectional.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationBiDirectional.java
@@ -149,7 +149,7 @@ public class CorfuReplicationBiDirectional extends LogReplicationAbstractIT {
 //    }
 
     /**
-     * This test verifies the behaviour when cluster1 acts as both source and sink(orphaned sink, ie., sink has no remote source),
+     * This test verifies the behaviour when the sink connection starter,
      * and cluster2 acts as a sink for cluster1
      *
      * 1. Init with corfu 9000 source and 9001 sink
@@ -165,7 +165,7 @@ public class CorfuReplicationBiDirectional extends LogReplicationAbstractIT {
         pluginConfigFilePath = grpcConfig;
         //setup source and sink corfu
         setupSourceAndSinkCorfu();
-        // Add a new kind of topology where a cluster is both source and destination, but the remote just acts as a sink
+        // Add a new kind of topology where the SINK is connection starter
         init();
 
         //open Maps
@@ -252,8 +252,8 @@ public class CorfuReplicationBiDirectional extends LogReplicationAbstractIT {
                 TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class)
         );
         try (TxnContext txn = corfuStoreSource.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
-            txn.putRecord(configTable, DefaultClusterManager.OP_SINK_CONNECT_INIT,
-                    DefaultClusterManager.OP_SINK_CONNECT_INIT, DefaultClusterManager.OP_SINK_CONNECT_INIT);
+            txn.putRecord(configTable, DefaultClusterManager.OP_SINK_CONNECTION_INIT,
+                    DefaultClusterManager.OP_SINK_CONNECTION_INIT, DefaultClusterManager.OP_SINK_CONNECTION_INIT);
             txn.commit();
         }
     }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -3,7 +3,6 @@ package org.corfudb.integration;
 import com.google.common.reflect.TypeToken;
 import com.google.protobuf.Message;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
@@ -20,7 +19,6 @@ import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata;
-import org.corfudb.runtime.ExampleSchemas;
 import org.corfudb.runtime.ExampleSchemas.ClusterUuidMsg;
 import org.corfudb.runtime.MultiCheckpointWriter;
 import org.corfudb.runtime.collections.CorfuDynamicKey;
@@ -45,15 +43,12 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -130,8 +125,8 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     @Parameterized.Parameters
     public static List<ClusterUuidMsg> input() {
         return Arrays.asList(
-                DefaultClusterManager.OP_SINGLE_SOURCE_SINK,
-                DefaultClusterManager.OP_SINK_CONNECTION_INIT
+                DefaultClusterManager.TP_SINGLE_SOURCE_SINK,
+                DefaultClusterManager.TP_SINGLE_SOURCE_SINK_REV_CONNECTION
         );
 
     }
@@ -259,7 +254,7 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
      */
     @Test
     public void testNewConfigWithSwitchRole() throws Exception {
-        if(skipTest()) {
+        if(topologyType.equals(DefaultClusterManager.TP_SINGLE_SOURCE_SINK_REV_CONNECTION)) {
             return;
         }
         // Write 10 entries to source map
@@ -744,10 +739,6 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
      */
     @Test
     public void testClusterSyncStatus() throws Exception {
-        //TODO shama : for rev connection, the source has to know when the sink (connectionInit) is down
-        if(skipTest()) {
-            return;
-        }
         final int waitInMillis = 500;
         final int deltaSeconds = 5;
 
@@ -1760,12 +1751,5 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
             log.error(errorMsg, throwable);
             fail(errorMsg + throwable.toString());
         }
-    }
-
-    private boolean skipTest() {
-        if(topologyType.equals(DefaultClusterManager.OP_SINK_CONNECTION_INIT)) {
-            return true;
-        }
-        return false;
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
@@ -33,8 +33,8 @@ public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
         );
 
         List<ExampleSchemas.ClusterUuidMsg> topologyTypes = Arrays.asList(
-                DefaultClusterManager.OP_SINGLE_SOURCE_SINK,
-                DefaultClusterManager.OP_SINK_CONNECTION_INIT
+                DefaultClusterManager.TP_SINGLE_SOURCE_SINK,
+                DefaultClusterManager.TP_SINGLE_SOURCE_SINK_REV_CONNECTION
         );
 
         List<Pair<String, ExampleSchemas.ClusterUuidMsg>> absolutePathPlugins = new ArrayList<>();

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationE2EIT.java
@@ -24,8 +24,9 @@ public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
     public static Collection<String> input() {
 
         List<String> transportPlugins = Arrays.asList(
-                "src/test/resources/transport/grpcConfig.properties",
-                "src/test/resources/transport/nettyConfig.properties");
+                "src/test/resources/transport/grpcConfig.properties"
+//                "src/test/resources/transport/nettyConfig.properties"
+        );
 
         if(runProcess) {
             List<String> absolutePathPlugins = new ArrayList<>();
@@ -57,26 +58,26 @@ public class CorfuReplicationE2EIT extends LogReplicationAbstractIT {
     @Test
     public void testLogReplicationEndToEnd() throws Exception {
         log.debug("Using plugin :: {}", pluginConfigFilePath);
-        testEndToEndSnapshotAndLogEntrySyncUFO(false, true);
+        testEndToEndSnapshotAndLogEntrySyncUFO(false, true, 1);
     }
 
     @Test
     public void testSnapshotSyncMultipleTables() throws Exception {
         log.debug("Using plugin :: {}", pluginConfigFilePath);
         final int totalNumMaps = 3;
-        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, false, true);
+        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, false, true, 1);
     }
 
     @Test
     public void testDiskBasedLogReplicationEndToEnd() throws Exception {
         log.debug("Using plugin :: {}", pluginConfigFilePath);
-        testEndToEndSnapshotAndLogEntrySyncUFO(true, true);
+        testEndToEndSnapshotAndLogEntrySyncUFO(true, true, 1);
     }
 
     @Test
     public void testDiskBasedSnapshotSyncMultipleTables() throws Exception {
         log.debug("Using plugin :: {}", pluginConfigFilePath);
         final int totalNumMaps = 3;
-        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, true, true);
+        testEndToEndSnapshotAndLogEntrySyncUFO(totalNumMaps, true, true, 1);
     }
 }

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
@@ -74,6 +74,7 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
                                 int expectedStreamingUpdatesPerTable) throws Exception {
         log.debug("Setup Source and Sink Corfu's");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         log.debug("Open map on Source and Sink");
         openMaps(2, false);

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
@@ -1,6 +1,7 @@
 package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
 import org.corfudb.runtime.ExampleSchemas;
 import org.corfudb.runtime.collections.TableOptions;
@@ -47,11 +48,6 @@ public class CorfuReplicationMultiSinkIT extends CorfuReplicationMultiSourceSink
         return absolutePathPlugins;
     }
 
-    @Before
-    public void setUp() throws Exception {
-        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.OP_MULTI_SINK);
-    }
-
     /**
      * The test verifies snapshot and log entry sync on a topology with 1 Source clusters and 3 Sink clusters.
      * The Source cluster replicates to all Sink clusters.  The set of streams to replicate as received from the
@@ -66,12 +62,21 @@ public class CorfuReplicationMultiSinkIT extends CorfuReplicationMultiSourceSink
      * verifies that they were applied correctly.
      */
     @Test
-    public void testUpdatesOnReplicatedTables() throws Exception {
+    public void testUpdatesOnReplicatedTables_sourceConnectionInit() throws Exception {
+        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.OP_MULTI_SINK);
+        verifySnapshotAndLogEntrySink(false);
+    }
+
+    @Test
+    public void testUpdatesOnReplicatedTables_sinkConnectionInit() throws Exception {
+        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.OP_MULTI_SINK_REV_CONNECTION);
         verifySnapshotAndLogEntrySink(false);
     }
 
     @Test
     public void testRoleChange() throws Exception {
+        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.OP_MULTI_SINK);
+
         verifySnapshotAndLogEntrySink(false);
         log.info("Preparing for role change");
         prepareTestTopologyForRoleChange(MAX_REMOTE_CLUSTERS, 1);

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
@@ -1,12 +1,7 @@
 package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
-import org.corfudb.runtime.ExampleSchemas;
-import org.corfudb.runtime.collections.TableOptions;
-import org.corfudb.runtime.collections.TxnContext;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -63,19 +58,19 @@ public class CorfuReplicationMultiSinkIT extends CorfuReplicationMultiSourceSink
      */
     @Test
     public void testUpdatesOnReplicatedTables_sourceConnectionInit() throws Exception {
-        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.OP_MULTI_SINK);
+        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.TP_MULTI_SINK);
         verifySnapshotAndLogEntrySink(false);
     }
 
     @Test
     public void testUpdatesOnReplicatedTables_sinkConnectionInit() throws Exception {
-        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.OP_MULTI_SINK_REV_CONNECTION);
+        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.TP_MULTI_SINK_REV_CONNECTION);
         verifySnapshotAndLogEntrySink(false);
     }
 
     @Test
     public void testRoleChange() throws Exception {
-        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.OP_MULTI_SINK);
+        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.TP_MULTI_SINK);
 
         verifySnapshotAndLogEntrySink(false);
         log.info("Preparing for role change");

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
@@ -1,6 +1,10 @@
 package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
+import org.corfudb.runtime.ExampleSchemas;
+import org.corfudb.runtime.collections.TableOptions;
+import org.corfudb.runtime.collections.TxnContext;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +48,7 @@ public class CorfuReplicationMultiSinkIT extends CorfuReplicationMultiSourceSink
 
     @Before
     public void setUp() throws Exception {
-        super.setUp(1, MAX_REMOTE_CLUSTERS);
+        super.setUp(1, MAX_REMOTE_CLUSTERS, DefaultClusterManager.OP_MULTI_SINK);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSinkIT.java
@@ -34,8 +34,9 @@ public class CorfuReplicationMultiSinkIT extends CorfuReplicationMultiSourceSink
     public static Collection input() {
 
         List<String> transportPlugins = Arrays.asList(
-            "src/test/resources/transport/grpcConfig.properties",
-            "src/test/resources/transport/nettyConfig.properties");
+            "src/test/resources/transport/grpcConfig.properties"
+//            "src/test/resources/transport/nettyConfig.properties"
+        );
 
         List<String> absolutePathPlugins = new ArrayList<>();
         transportPlugins.forEach(plugin -> {

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
@@ -32,8 +32,9 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
     public static Collection input() {
 
         List<String> transportPlugins = Arrays.asList(
-            "src/test/resources/transport/grpcConfig.properties",
-            "src/test/resources/transport/nettyConfig.properties");
+            "src/test/resources/transport/grpcConfig.properties"
+//            "src/test/resources/transport/nettyConfig.properties"
+        );
 
         List<String> absolutePathPlugins = new ArrayList<>();
         transportPlugins.forEach(plugin -> {

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
@@ -1,6 +1,7 @@
 package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -45,7 +46,7 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
     @Before
     public void setUp() throws Exception {
         // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
-        super.setUp(MAX_REMOTE_CLUSTERS, 1);
+        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.OP_MULTI_SOURCE);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
@@ -1,10 +1,7 @@
 package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang3.tuple.Pair;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
-import org.corfudb.runtime.ExampleSchemas;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -66,14 +63,14 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
     @Test
     public void testUpdatesOnReplicatedTables_sourceConnectionInit() throws Exception {
         // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
-        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.OP_MULTI_SOURCE);
+        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.TP_MULTI_SOURCE);
         verifySnapshotAndLogEntrySink(false);
     }
 
     @Test
     public void testUpdatesOnReplicatedTables_sinkConnectionInit() throws Exception {
         // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
-        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.OP_MULTI_SOURCE_REV_CONNECTION);
+        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.TP_MULTI_SOURCE_REV_CONNECTION);
         verifySnapshotAndLogEntrySink(false);
     }
 
@@ -86,7 +83,7 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
     @Test
     public void testRoleChange() throws Exception {
         // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
-        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.OP_MULTI_SOURCE);
+        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.TP_MULTI_SOURCE);
 
         verifySnapshotAndLogEntrySink(false);
         log.info("Preparing for role change");

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceIT.java
@@ -1,7 +1,9 @@
 package org.corfudb.integration;
 
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.tuple.Pair;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
+import org.corfudb.runtime.ExampleSchemas;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,12 +46,6 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
         return absolutePathPlugins;
     }
 
-    @Before
-    public void setUp() throws Exception {
-        // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
-        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.OP_MULTI_SOURCE);
-    }
-
     /**
      * The test verifies snapshot and log entry sync on a topology with 3 Source clusters and 1 Sink cluster.
      * The 3 Source clusters replicate to the same Sink cluster.  The set of streams to replicate as received from the
@@ -68,7 +64,16 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
      *
      */
     @Test
-    public void testUpdatesOnReplicatedTables() throws Exception {
+    public void testUpdatesOnReplicatedTables_sourceConnectionInit() throws Exception {
+        // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
+        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.OP_MULTI_SOURCE);
+        verifySnapshotAndLogEntrySink(false);
+    }
+
+    @Test
+    public void testUpdatesOnReplicatedTables_sinkConnectionInit() throws Exception {
+        // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
+        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.OP_MULTI_SOURCE_REV_CONNECTION);
         verifySnapshotAndLogEntrySink(false);
     }
 
@@ -80,6 +85,9 @@ public class CorfuReplicationMultiSourceIT extends CorfuReplicationMultiSourceSi
      */
     @Test
     public void testRoleChange() throws Exception {
+        // Setup Corfu on 3 LR Source Sites and 1 LR Sink Site
+        super.setUp(MAX_REMOTE_CLUSTERS, 1, DefaultClusterManager.OP_MULTI_SOURCE);
+
         verifySnapshotAndLogEntrySink(false);
         log.info("Preparing for role change");
         prepareTestTopologyForRoleChange(1, MAX_REMOTE_CLUSTERS);

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceSinkIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationMultiSourceSinkIT.java
@@ -93,11 +93,13 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
 
     // Listens to replication status updates on a Sink cluster
     private List<ReplicationStatusListener> replicationStatusListeners = new ArrayList<>();
+    private Table<ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg> configTable;
 
-    protected void setUp(int numSourceClusters, int numSinkClusters) throws Exception {
+    protected void setUp(int numSourceClusters, int numSinkClusters, ExampleSchemas.ClusterUuidMsg topologyType) throws Exception {
         this.numSourceClusters = numSourceClusters;
         this.numSinkClusters = numSinkClusters;
         setupSourceAndSinkCorfu(numSourceClusters, numSinkClusters);
+        initMultiSinkTopology(topologyType);
     }
 
     private void setupSourceAndSinkCorfu(int numSourceClusters, int numSinkClusters) throws Exception {
@@ -173,6 +175,43 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
         }
     }
 
+
+    private void initMultiSinkTopology(ExampleSchemas.ClusterUuidMsg topologyType) throws Exception {
+        for (int i = 0; i < numSourceClusters; i++) {
+            configTable = sourceCorfuStores.get(i).openTable(
+                    DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
+                    ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
+                    TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class)
+            );
+            try (TxnContext txn = sourceCorfuStores.get(i).txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
+                writeTopologyTypeToConfig(txn, topologyType);
+                txn.commit();
+            }
+        }
+
+        for (int i = 0; i < numSinkClusters; i++) {
+            configTable = sinkCorfuStores.get(i).openTable(
+                    DefaultClusterManager.CONFIG_NAMESPACE, DefaultClusterManager.CONFIG_TABLE_NAME,
+                    ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
+                    TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class)
+            );
+            try (TxnContext txn = sinkCorfuStores.get(i).txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
+                writeTopologyTypeToConfig(txn, topologyType);
+                txn.commit();
+            }
+        }
+    }
+
+    private void writeTopologyTypeToConfig(TxnContext txn, ExampleSchemas.ClusterUuidMsg topologyType) {
+        if(topologyType.equals(DefaultClusterManager.OP_MULTI_SINK)) {
+            txn.putRecord(configTable, DefaultClusterManager.OP_MULTI_SINK,
+                    DefaultClusterManager.OP_MULTI_SINK, DefaultClusterManager.OP_MULTI_SINK);
+        } else if (topologyType.equals(DefaultClusterManager.OP_MULTI_SOURCE)) {
+            txn.putRecord(configTable, DefaultClusterManager.OP_MULTI_SOURCE,
+                    DefaultClusterManager.OP_MULTI_SOURCE, DefaultClusterManager.OP_MULTI_SOURCE);
+        }
+    }
+
     protected void writeData(CorfuStore corfuStore, String tableName, Table table, int startIndex, int numRecords) {
         for (int i = startIndex; i < (startIndex + numRecords); i++) {
             Sample.StringKey key = Sample.StringKey.newBuilder().setKey(tableName + " key " + i).build();
@@ -223,8 +262,8 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
         // On startup, an initial default replication status is written for each remote cluster
         // (NUM_INITIAL_REPLICATION_STATUS_UPDATES).  Subsequently, the table will be updated on snapshot sync from
         // each Source cluster.
-        int numExpectedUpdates = NUM_INITIAL_REPLICATION_STATUS_UPDATES +
-            calculateSnapshotSyncUpdatesOnSinkStatusTable(numSourceClusters);
+        int numExpectedUpdates = numSourceClusters +
+                calculateSnapshotSyncUpdatesOnSinkStatusTable(numSourceClusters);
         List<CountDownLatch> statusLatches = new ArrayList<>();
         CountDownLatch statusLatch;
         ReplicationStatusListener statusListener;
@@ -243,31 +282,30 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
 
             // Replication Status Listeners
             sinkCorfuStores.get(i).openTable(LogReplicationMetadataManager.NAMESPACE,
-                LogReplicationMetadataManager.REPLICATION_STATUS_TABLE, LogReplicationMetadata.ReplicationStatusKey.class,
-                LogReplicationMetadata.ReplicationStatusVal.class, null,
-                TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
+                    LogReplicationMetadataManager.REPLICATION_STATUS_TABLE, LogReplicationMetadata.ReplicationStatusKey.class,
+                    LogReplicationMetadata.ReplicationStatusVal.class, null,
+                    TableOptions.fromProtoSchema(LogReplicationMetadata.ReplicationStatusVal.class));
             statusLatch = new CountDownLatch(numExpectedUpdates);
             statusLatches.add(statusLatch);
 
             statusListener = new ReplicationStatusListener(statusLatch);
             replicationStatusListeners.add(statusListener);
             sinkCorfuStores.get(i).subscribeListener(statusListener, LogReplicationMetadataManager.NAMESPACE,
-                LR_STATUS_STREAM_TAG);
+                    LR_STATUS_STREAM_TAG);
         }
 
         if (changeRole) {
             Table<ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg, ExampleSchemas.ClusterUuidMsg>
-                configTable = sinkCorfuStores.get(0).openTable(DefaultClusterManager.CONFIG_NAMESPACE,
+                    configTable = sinkCorfuStores.get(0).openTable(DefaultClusterManager.CONFIG_NAMESPACE,
                     DefaultClusterManager.CONFIG_TABLE_NAME, ExampleSchemas.ClusterUuidMsg.class,
                     ExampleSchemas.ClusterUuidMsg.class, ExampleSchemas.ClusterUuidMsg.class,
                     TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class));
             try (TxnContext txn = sinkCorfuStores.get(0).txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
                 txn.putRecord(configTable, DefaultClusterManager.OP_SWITCH, DefaultClusterManager.OP_SWITCH,
-                    DefaultClusterManager.OP_SWITCH);
+                        DefaultClusterManager.OP_SWITCH);
                 txn.commit();
             }
             Assert.assertEquals(1, configTable.count());
-
         } else {
             // Start Log Replication
             startReplicationServers();
@@ -277,17 +315,17 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
         // During snapshot sync, a 'clear' followed by 'update' for each record is received.  So there should be
         // 1 Clear + NUM_RECORDS_IN_TABLE Update records for each table on each Sink cluster.
         List<CorfuStreamEntry.OperationType> expectedOpsList = Arrays.asList(CorfuStreamEntry.OperationType.CLEAR,
-            CorfuStreamEntry.OperationType.UPDATE, CorfuStreamEntry.OperationType.UPDATE,
-            CorfuStreamEntry.OperationType.UPDATE);
+                CorfuStreamEntry.OperationType.UPDATE, CorfuStreamEntry.OperationType.UPDATE,
+                CorfuStreamEntry.OperationType.UPDATE);
         for (int i = 0; i < numSinkClusters; i++) {
             statusLatches.get(i).await();
             snapshotWritesLatches.get(i).await();
 
             for (int j = 0; j < srcTables.size(); j++) {
                 Assert.assertEquals(NUM_RECORDS_IN_TABLE + 1,
-                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(j)).size());
+                        dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(j)).size());
                 Assert.assertTrue(Objects.equals(expectedOpsList,
-                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(j))));
+                        dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(j))));
             }
         }
 
@@ -306,6 +344,7 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
             dataListeners.get(i).clearTableToOpTypeMap();
             dataListeners.get(i).setSnapshotSync(false);
         }
+
         log.info("Add a record on table on Sender-1, Table-1");
         writeData(sourceCorfuStores.get(0), tableNames.get(0), srcTables.get(0), NUM_RECORDS_IN_TABLE, 1);
 
@@ -325,10 +364,10 @@ public class CorfuReplicationMultiSourceSinkIT extends AbstractIT {
                 // 1 Operation received for each table on the Sink cluster
                 Assert.assertEquals(1, dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).size());
                 Assert.assertEquals(CorfuStreamEntry.OperationType.UPDATE,
-                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).get(0));
+                        dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).get(0));
                 Assert.assertEquals(1, dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(1)).size());
                 Assert.assertEquals(CorfuStreamEntry.OperationType.DELETE,
-                    dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(1)).get(0));
+                        dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(1)).get(0));
             } else {
                 // 2 operations received for the same table on the Sink cluster
                 Assert.assertEquals(2, dataListeners.get(i).getTableToOpTypeMap().get(tableNames.get(0)).size());

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationReconfigurationIT.java
@@ -98,7 +98,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
     public void testSinkClusterReset() throws Exception {
         // (1) Snapshot and Log Entry Sync
         log.debug(">>> (1) Start Snapshot and Log Entry Sync");
-        testEndToEndSnapshotAndLogEntrySyncUFO(false, false);
+        testEndToEndSnapshotAndLogEntrySyncUFO(false, false, 1);
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
@@ -136,7 +136,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
 
         // (1) Snapshot and Log Entry Sync
         log.debug(">>> (1) Start Snapshot and Log Entry Sync");
-        testEndToEndSnapshotAndLogEntrySyncUFO(false, false);
+        testEndToEndSnapshotAndLogEntrySyncUFO(false, false, 1);
 
         ExecutorService writerService = Executors.newSingleThreadExecutor();
 
@@ -464,6 +464,7 @@ public class CorfuReplicationReconfigurationIT extends LogReplicationAbstractIT 
             final int totalEntries = 20;
 
             setupSourceAndSinkCorfu();
+            initSingleSourceSinkCluster();
             openMaps();
 
             Set<UUID> tablesToListen = getTablesToListen();

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationTrimIT.java
@@ -75,6 +75,7 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
 
             log.debug("Start source Log Replicator again ...");
             startSourceLogReplicator();
+            initSingleSourceSinkCluster();
 
             log.debug("Verify Data on Sink ...");
             verifyDataOnSinkNonUFO((numWrites*2));
@@ -199,6 +200,10 @@ public class CorfuReplicationTrimIT extends LogReplicationAbstractIT {
 
             // Checkpoint and Trim Before Starting
             checkpointAndTrim(true);
+
+            //initiate the topology buckets with a single source/sink topology.
+            // This needs to be done after checkpoint trim as defaultClusterManager starts the listener at trimMark
+            initSingleSourceSinkCluster();
 
             startLogReplicatorServers();
 

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationUpgradeIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationUpgradeIT.java
@@ -36,7 +36,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
 
     // The number of updates on the ReplicationStatus table on the Sink during initial startup is 3(one for each
     // Source cluster)
-    private static final int NUM_INIT_UPDATES_ON_SINK_STATUS_TABLE = 3;
+    private static final int NUM_INIT_UPDATES_ON_SINK_STATUS_TABLE = 1;
 
     // The number of subsequent updates on the ReplicationStatus Table
     // (1) When starting snapshot sync apply : is_data_consistent = false
@@ -77,6 +77,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testLogEntrySyncAfterSinkUpgraded() throws Exception {
         log.info(">> Setup source and sink Corfu's");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         log.info(">> Open map(s) on source and sink");
         openMaps(FIVE, false);
@@ -132,8 +133,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
 
         // Upgrade the sink site
         log.info(">> Upgrading the sink site ...");
@@ -171,6 +172,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testSnapshotSyncAfterSinkUpgraded() throws Exception {
         log.info(">> Setup source and sink Corfu's");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         log.info(">> Open map(s) on source and sink");
         openMaps(FIVE, false);
@@ -226,8 +228,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
         corfuStoreSink.unsubscribeListener(sinkListener);
         corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
 
@@ -253,13 +255,14 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         checkpointAndTrim(true);
         pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
         startSourceLogReplicator();
+        initSingleSourceSinkCluster();
 
         // Verify that snapshot sync between the different versions was successful
         latchSnapshotSyncPlugin.await();
         statusUpdateLatch.await();
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
         verifyDataOnSink(NUM_WRITES);
 
         corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
@@ -284,6 +287,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testSnapshotSyncAfterSinkAndSourceUpgraded() throws Exception {
         log.info(">> Setup source and sink Corfu");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         // Two updates are expected onStart of snapshot sync and onEnd.
         CountDownLatch latchSnapshotSyncPlugin = new CountDownLatch(2);
@@ -339,8 +343,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
         corfuStoreSink.unsubscribeListener(sinkListener);
         corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
 
@@ -376,8 +380,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
 
         verifyDataOnSink(NUM_WRITES);
 
@@ -404,6 +408,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testLogEntrySyncAfterSinkUpgradedStreamsAddedAndRemoved() throws Exception {
         log.info(">> Setup source and sink Corfu");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         Set<String> streamsToReplicateSource = new HashSet<>();
         for (int i = 1; i <= 2; i++) {
@@ -464,8 +469,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
 
         Set<String> streamsToReplicateSink = new HashSet<>();
         for (int i = 2; i <= 3; i++) {
@@ -512,6 +517,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testSnapshotSyncAfterSinkUpgradedStreamsAddedAndRemoved() throws Exception {
         log.info(">> Setup source and sink Corfu's");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         Set<String> streamsToReplicateSource = new HashSet<>();
         for (int i = 1; i <= 2; i++) {
@@ -571,8 +577,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
         corfuStoreSink.unsubscribeListener(sinkListener);
         corfuStoreSink.unsubscribeListener(snapshotSyncPluginListener);
 
@@ -627,13 +633,13 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         checkpointAndTrim(true);
         pluginConfigFilePath = TEST_PLUGIN_CONFIG_PATH_SOURCE;
         startSourceLogReplicator();
-
+        initSingleSourceSinkCluster();
         // Verify that snapshot sync between the different versions was successful
         latchSnapshotSyncPlugin.await();
         statusUpdateLatch.await();
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
 
         verifyDataOnSink(sourceOnlyStreams, NUM_WRITES);
 
@@ -652,6 +658,7 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
     public void testSnapshotSyncAfterBothUpgradedStreamsAddedAndRemoved() throws Exception {
         log.info(">> Setup source and sink Corfu's");
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
 
         Set<String> streamsToReplicateSource = new HashSet<>();
         for (int i = 1; i <= 2; i++) {
@@ -712,8 +719,8 @@ public class CorfuReplicationUpgradeIT extends LogReplicationAbstractIT {
         statusUpdateLatch.await();
 
         Assert.assertEquals(TOTAL_SINK_UPDATES_INIT_SNAPSHOT_SYNC, sinkListener.getAccumulatedStatus().size());
-        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(4));
-        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(3));
+        Assert.assertTrue(sinkListener.getAccumulatedStatus().get(2));
+        Assert.assertFalse(sinkListener.getAccumulatedStatus().get(1));
 
         Set<String> streamsToReplicateSink = new HashSet<>();
         for (int i = 2; i <= 3; i++) {

--- a/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationAbstractIT.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.fail;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -123,7 +122,7 @@ public class LogReplicationAbstractIT extends AbstractIT {
     public CorfuStore corfuStoreSink;
 
     // default is single Source-Sink topology
-    public ExampleSchemas.ClusterUuidMsg topologyType = DefaultClusterManager.OP_SINGLE_SOURCE_SINK;
+    public ExampleSchemas.ClusterUuidMsg topologyType = DefaultClusterManager.TP_SINGLE_SOURCE_SINK;
 
     private final long longInterval = 20L;
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationDynamicStreamIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationDynamicStreamIT.java
@@ -85,8 +85,8 @@ public class LogReplicationDynamicStreamIT extends LogReplicationAbstractIT {
                 TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class)
         );
         try (TxnContext txn = corfuStoreSource.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
-            txn.putRecord(configTableSource, DefaultClusterManager.OP_SINGLE_SOURCE_SINK,
-                    DefaultClusterManager.OP_SINGLE_SOURCE_SINK, DefaultClusterManager.OP_SINGLE_SOURCE_SINK);
+            txn.putRecord(configTableSource, DefaultClusterManager.TP_SINGLE_SOURCE_SINK,
+                    DefaultClusterManager.TP_SINGLE_SOURCE_SINK, DefaultClusterManager.TP_SINGLE_SOURCE_SINK);
             txn.commit();
         }
 
@@ -96,8 +96,8 @@ public class LogReplicationDynamicStreamIT extends LogReplicationAbstractIT {
                 TableOptions.fromProtoSchema(ExampleSchemas.ClusterUuidMsg.class)
         );
         try (TxnContext txn = corfuStoreSink.txn(DefaultClusterManager.CONFIG_NAMESPACE)) {
-            txn.putRecord(configTableSink, DefaultClusterManager.OP_SINGLE_SOURCE_SINK,
-                    DefaultClusterManager.OP_SINGLE_SOURCE_SINK, DefaultClusterManager.OP_SINGLE_SOURCE_SINK);
+            txn.putRecord(configTableSink, DefaultClusterManager.TP_SINGLE_SOURCE_SINK,
+                    DefaultClusterManager.TP_SINGLE_SOURCE_SINK, DefaultClusterManager.TP_SINGLE_SOURCE_SINK);
             txn.commit();
         }
     }

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -238,7 +238,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
 
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
+            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID, SOURCE_CLUSTER_ID);
 
         StreamsSnapshotReader reader = new StreamsSnapshotReader(rt, configManager, replicationSession);
 
@@ -268,14 +268,12 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     }
 
     public static void writeSnapshotMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt) {
-
+        ReplicationSession replicationSession =
+                ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID, SOURCE_CLUSTER_ID);
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
-            0, SINK_CLUSTER_ID);
+            0, replicationSession);
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
-
-        ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
 
         StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, configManager, logReplicationMetadataManager,
             replicationSession);
@@ -302,9 +300,9 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
 
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
-
+            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID, SOURCE_CLUSTER_ID);
         StreamsLogEntryReader reader = new StreamsLogEntryReader(rt, configManager, replicationSession);
+
         reader.setGlobalBaseSnapshot(Address.NON_ADDRESS, Address.NON_ADDRESS);
 
         LogReplicationEntryMsg entry;
@@ -333,14 +331,12 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
     }
 
     public static void writeLogEntryMsgs(List<LogReplicationEntryMsg> msgQ, CorfuRuntime rt) {
-
+        ReplicationSession replicationSession =
+                ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID, SOURCE_CLUSTER_ID);
         LogReplicationMetadataManager logReplicationMetadataManager = new LogReplicationMetadataManager(rt,
-            0, SOURCE_CLUSTER_ID);
+            0, replicationSession);
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
-
-        ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
 
         LogEntryWriter writer = new LogEntryWriter(configManager, logReplicationMetadataManager, replicationSession);
 

--- a/test/src/test/java/org/corfudb/integration/LogReplicationSinkWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationSinkWriterIT.java
@@ -53,6 +53,7 @@ public class LogReplicationSinkWriterIT extends LogReplicationAbstractIT {
     @SuppressWarnings("checkstyle:magicnumber")
     public void testFilterAndApplyRegistryTableEntries() throws Exception {
         setupSourceAndSinkCorfu();
+        initSingleSourceSinkCluster();
         openLogReplicationStatusTable();
 
         // Initial setup for streams to replicate for both source and sink side

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -109,12 +109,9 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
         this.destinationDataControl = new DefaultDataControl(new DefaultDataControlConfig(
             false, 0));
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(testConfig.getRemoteClusterId());
-
-        // TODO pankti: This test-only constructor can be removed
-        this.destinationLogReplicationManager = new LogReplicationSinkManager(runtime.getLayoutServers().get(0),
-            configManager, metadataManager, pluginConfigFilePath, replicationSession);
-
+            ReplicationSession.getDefaultReplicationSessionForCluster(testConfig.getRemoteClusterId(), testConfig.getRemoteClusterId());
+        this.destinationLogReplicationManager = new LogReplicationSinkManager(runtime.getLayoutServers().get(0), configManager,
+            metadataManager, pluginConfigFilePath, replicationSession);
         this.ifDropMsg = testConfig.getDropMessageLevel();
         this.delayedApplyCycles = testConfig.getDelayedApplyCycles();
         this.metadataResponseObservable = new ObservableValue<>(null);


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
This change has:
1. Given a topology, APIs to get: RemoteSink, RemoteSource, and replication Models supported between local cluster and a remote cluster.
		- CorfuReplicationClusterManagerAdapter -> has the API definition
		- TopologyDescriptor -> uses the new APIs to find remote source/sink clusters
		- DefaultClusterManager -> default implementation of the APIs, used during testing

2. Allow a cluster to be both Source and Sink for multiple replication models at the same time
		- DiscoveryService -> Create source/sink components on demand.
		- CorfuReplicationManager -> create source/sink routers, create FSMs if Source for any model. Start connection if cluster connection-starter.
		
3. Manage remote cluster add/remove.
4. Allow a cluster to be connection starter or a connection endpoint (i.e., accept an incoming connection)
		- DiscoveryService -> trigger creation of source/sink router.
		- CorfuInterClusterReplicationServerNode -> start the server and cleanup on LR stop.
		- router classes :
				- LogReplicationServerRouter : helps starting the server. Sets the server in sink Routers. 
				- LogReplicationSinkClientRouter : when Sink is the connection starter. Extends LogReplicationSinkServerRouter as the handling of replication requests remain the same as before
				- LogReplicationSourceClientRouter : when Source is the connection starter. 
				- LogReplicationSourceServerRouter : when Source is the connection endpoint
				- LogReplicationBaseSourceRouter : inherited by both LogReplicationSourceClientRouter and LogReplicationSourceServerRouter. Has existing implemetations of sending negotiation/replication requests, and handling ACKs.
5. Allow sink to query leadership when connection starter
   	         - SinkVerifyRemoteLeader -> queries leadership, and on remote leadership details aquired, setup a long living bidirectional stream for replication to start
6. Start source FSM only when a connection is established.


Tests: 

- Most of the existing test has been leveraged to ensure that LR works as before when connection is started from SINK.
    
```
- E2E tests    
         - testEndToEndSnapshotAndLogEntrySyncUFO (all variations)

      - CorfuReplicationMultiSinkIT
         - verifySnapshotAndLogEntrySink

      - CorfuReplicationMultiSourceIT
         - verifySnapshotAndLogEntrySink

      - CorfuReplicationClusterConfigIT (all the below tests start with snapsho/logEntry sync validation)
         - testBackupRestoreWorkflow (modified the test such that a addition of Source is also tested)
         - testClusterSyncStatus (Test all combinations of source/sink LR start/stopped and the output of sync status)
         - testDataConsistentForEmptyStreams
         - testEnforceSnapshotSync
         - testNewConfigWithAllSink
         - testNewConfigWithInvalidClusters
         - testNewConfigWithSwitchRole (This will be skipped for reverse connection. But while running confirmed that 1 role change happens. Failing in multiple role changes  => Not required for PI-1)
         - testNewConfigWithTwoSource (topology changed to have 2 SOURCEs)
         - testSnapshotSyncOfUnopenedTrimmedStreams
         - testSourceLockRelease

      -CorfuReplicationReconfigurationIT (all the below tests start with snapsho/logEntry sync validation)
         - testSinkClusterReset (Sink is restarted in between)
         - testSinkStreaming
         - testSnapshotSyncApplyInterrupted
         - testSourceClusterReset 
           
```

_To summarize the scenarios tested:_ 

> 1. E2E - Snapshot and LogEntry sync
> 2. Multiple Sink to a cluster (E2E)
> 3. Multiple Source to a cluster (E2E)
> 4. Sink going down
> 5. Source going down 
> 6. Backup restore
> 7. Adding a source to topology (via the testBackupRestoreWorkflow)
> 8. Having INVALID clusters
> 9. A topology with only SOURCEs

- BIDirectional Test -> Currently commented out. I verified that a cluster can be both SOURCE/SINK, but had to do some hacks to be able to specify different replication models. Have kept the file as it can used (for commented and new tests) once the Dynamic-streams service is in.  

**_Please note: The Netty transport plugin for LR is commented out in interest of time._**





Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
