### PR TITLE
Instantiate SnapSyncPlugin with runtime

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultSnapshotSyncPlugin.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultSnapshotSyncPlugin.java
@@ -32,6 +32,9 @@ public class DefaultSnapshotSyncPlugin implements ISnapshotSyncPlugin {
     public static final String ON_START_VALUE = "Hello I executed the start! Checkpoint is freezed!";
     public static final String ON_END_VALUE = "I executed the end! Checkpoint unfreezed, bye!";
 
+    public DefaultSnapshotSyncPlugin(CorfuRuntime runtime) {
+    }
+
     @Override
     public void onSnapshotSyncStart(CorfuRuntime runtime) {
         try {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationSinkManager.java
@@ -211,7 +211,8 @@ public class LogReplicationSinkManager implements DataReceiver {
         File jar = new File(config.getSnapshotSyncPluginJARPath());
         try (URLClassLoader child = new URLClassLoader(new URL[]{jar.toURI().toURL()}, this.getClass().getClassLoader())) {
             Class plugin = Class.forName(config.getSnapshotSyncPluginCanonicalName(), true, child);
-            return (ISnapshotSyncPlugin) plugin.getDeclaredConstructor().newInstance();
+            return (ISnapshotSyncPlugin) plugin.getDeclaredConstructor(CorfuRuntime.class)
+                    .newInstance(runtime);
         } catch (Throwable t) {
             log.error("Fatal error: Failed to get snapshot sync plugin {}", config.getSnapshotSyncPluginCanonicalName(), t);
             throw new UnrecoverableCorfuError(t);


### PR DESCRIPTION
The snapshot sync plugin will need to migrate any
freeze tokens placed in the old format into the new format so checkpointing freeze can be honored.
It needs the runtime at constructor to do so.

## Overview

Description:

cherry-pick of https://github.com/CorfuDB/CorfuDB/pull/3437

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
