### PR TITLE
Init manager status with IDLE status

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure;
 
+import lombok.Getter;
 import org.corfudb.common.metrics.micrometer.MicroMeterUtils;
 import org.corfudb.infrastructure.health.HealthMonitor;
 import org.corfudb.infrastructure.health.Issue;
@@ -39,6 +40,7 @@ public class CompactorLeaderServices {
     private final TrimLog trimLog;
     private final Logger log;
     private final LivenessValidator livenessValidator;
+    @Getter
     private final CompactorMetadataTables compactorMetadataTables;
 
     public static final int MAX_RETRIES = 5;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -130,7 +130,7 @@ public class CompactorService implements ManagementService {
                 if (managerStatus == null && isLeader) {
                     txn.putRecord(getCompactorLeaderServices().getCompactorMetadataTables().getCompactionManagerTable(),
                             CompactorMetadataTables.COMPACTION_MANAGER_KEY,
-                            CheckpointingStatus.newBuilder().setStatus(StatusType.IDLE).setEpoch(0).build(), null);
+                            CheckpointingStatus.newBuilder().setStatus(StatusType.IDLE).setCycleCount(0).build(), null);
                 }
                 txn.commit();
             } catch (Exception e) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -127,8 +127,12 @@ public class CompactorService implements ManagementService {
                 managerStatus = (CheckpointingStatus) txn.getRecord(
                         CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
                         CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
+                if (managerStatus == null && isLeader) {
+                    txn.putRecord(getCompactorLeaderServices().getCompactorMetadataTables().getCompactionManagerTable(),
+                            CompactorMetadataTables.COMPACTION_MANAGER_KEY,
+                            CheckpointingStatus.newBuilder().setStatus(StatusType.IDLE).setEpoch(0).build(), null);
+                }
                 txn.commit();
-                log.trace("ManagerStatus: {}", managerStatus.getStatus().toString());
             } catch (Exception e) {
                 log.warn("Unable to acquire manager status: ", e);
             }

--- a/runtime/proto/corfu_compactor_management.proto
+++ b/runtime/proto/corfu_compactor_management.proto
@@ -21,7 +21,7 @@ message CheckpointingStatus {
   string client_name = 2;
   int64 table_size = 3;
   int64 time_taken = 4;
-  int64 epoch = 5;
+  int64 cycle_count = 5;
 }
 
 message StringKey {

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -271,7 +271,14 @@ public class CompactorServiceTest extends AbstractViewTest {
             CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
                     CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
-            log.info("ManagerStatus: " + managerStatus);
+            log.info("ManagerStatus: " + (managerStatus == null ? "null" : managerStatus.toString()));
+            if (managerStatus == null) {
+                if (targetStatus == null) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
             if (managerStatus.getStatus() == targetStatus) {
                 return true;
             }
@@ -532,6 +539,39 @@ public class CompactorServiceTest extends AbstractViewTest {
 
         assert verifyManagerStatus(StatusType.FAILED);
         assert verifyCheckpointStatusTable(StatusType.COMPLETED, 1);
+    }
+
+    @Test
+    public void runOrchestratorLeaderInitManagerStatusTest() {
+        testSetup(logSizeLimitPercentageFull);
+        SingletonResource<CorfuRuntime> runtimeSingletonResource0 = SingletonResource.withInitial(() -> runtime0);
+        CompactorService compactorService0 = new CompactorService(sc0, runtimeSingletonResource0, mockInvokeJvm0, new DynamicTriggerPolicy());
+        when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(false);
+        compactorService0.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
+
+        try {
+            TimeUnit.MILLISECONDS.sleep(WAIT_TO_TIMEOUT);
+        } catch (InterruptedException e) {
+            log.warn(SLEEP_INTERRUPTED_EXCEPTION_MSG, e);
+        }
+
+        assert verifyManagerStatus(StatusType.IDLE);
+    }
+
+    @Test
+    public void runOrchestratorNonLeaderInitManagerStatusTest() {
+        testSetup(logSizeLimitPercentageFull);
+        SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime1);
+        CompactorService compactorService1 = new CompactorService(sc1, runtimeSingletonResource1, mockInvokeJvm1, new DynamicTriggerPolicy());
+        compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
+
+        try {
+            TimeUnit.MILLISECONDS.sleep(WAIT_TO_TIMEOUT);
+        } catch (InterruptedException e) {
+            log.warn(SLEEP_INTERRUPTED_EXCEPTION_MSG, e);
+        }
+
+        assert verifyManagerStatus(null);
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -273,11 +273,7 @@ public class CompactorServiceTest extends AbstractViewTest {
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
             log.info("ManagerStatus: " + (managerStatus == null ? "null" : managerStatus.toString()));
             if (managerStatus == null) {
-                if (targetStatus == null) {
-                    return true;
-                } else {
-                    return false;
-                }
+                return targetStatus == null;
             }
             if (managerStatus.getStatus() == targetStatus) {
                 return true;

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/DistributedCheckpointerUnitTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/DistributedCheckpointerUnitTest.java
@@ -131,11 +131,11 @@ public class DistributedCheckpointerUnitTest {
         verify(txn, times(numTimesMethodInvoked * putInvokedPerMethodCall))
                 .putRecord(any(), any(), captor.capture(), any());
         Assert.assertEquals(StatusType.COMPLETED, captor.getAllValues().get(getIndex(++i, putInvokedPerMethodCall)).getStatus());
-        Assert.assertEquals(0, captor.getAllValues().get(getIndex(i, putInvokedPerMethodCall)).getEpoch());
+        Assert.assertEquals(0, captor.getAllValues().get(getIndex(i, putInvokedPerMethodCall)).getCycleCount());
         Assert.assertEquals(StatusType.FAILED, captor.getAllValues().get(getIndex(++i, putInvokedPerMethodCall)).getStatus());
-        Assert.assertEquals(0, captor.getAllValues().get(getIndex(i, putInvokedPerMethodCall)).getEpoch());
+        Assert.assertEquals(0, captor.getAllValues().get(getIndex(i, putInvokedPerMethodCall)).getCycleCount());
         Assert.assertEquals(StatusType.COMPLETED, captor.getAllValues().get(getIndex(++i, putInvokedPerMethodCall)).getStatus());
-        Assert.assertEquals(0, captor.getAllValues().get(getIndex(i, putInvokedPerMethodCall)).getEpoch());
+        Assert.assertEquals(0, captor.getAllValues().get(getIndex(i, putInvokedPerMethodCall)).getCycleCount());
     }
 
     private int getIndex(int i, int putInvokedPerMethodCall) {
@@ -171,8 +171,8 @@ public class DistributedCheckpointerUnitTest {
         when((CheckpointingStatus) corfuStoreEntry.getPayload())
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).build())
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.IDLE).build())
-                .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).setEpoch(1).build());
-        //Fail on different epoch values
+                .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).setCycleCount(1).build());
+        //Fail on different cycleCount values
         assert !distributedCheckpointer.tryCheckpointTable(tableName, t -> cpw);
 
         when((CheckpointingStatus) corfuStoreEntry.getPayload())


### PR DESCRIPTION
+The leader initializes the compaction manager status with IDLE status. Otherwise the status remains null until the first compactor cycle.
+Rename epoch field of CheckpointStatus proto msg

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
