### PR TITLE
Rename checkpoint table to CompactorUtilsTable (#3442)

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/compactor/CorfuStoreCompactorMain.java
+++ b/corfudb-tools/src/main/java/org/corfudb/compactor/CorfuStoreCompactorMain.java
@@ -32,7 +32,7 @@ public class CorfuStoreCompactorMain {
     private final CorfuStoreCompactorConfig config;
     private final DistributedCheckpointerHelper distributedCheckpointerHelper;
     private final UpgradeDescriptorTable upgradeDescriptorTable;
-    private final Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable;
+    private final Table<StringKey, RpcCommon.TokenMsg, Message> compactorUtilsTable;
 
     private static final int RETRY_CHECKPOINTING = 5;
     private static final int RETRY_CHECKPOINTING_SLEEP_SECOND = 10;
@@ -49,7 +49,7 @@ public class CorfuStoreCompactorMain {
         this.upgradeDescriptorTable = new UpgradeDescriptorTable(corfuRuntime);
 
         this.compactorMetadataTables = new CompactorMetadataTables(corfuStore);
-        this.checkpointTable = compactorMetadataTables.getCheckpointTable();
+        this.compactorUtilsTable = compactorMetadataTables.getCompactorUtilsTable();
         this.distributedCheckpointerHelper = new DistributedCheckpointerHelper(corfuStore);
     }
 
@@ -72,10 +72,10 @@ public class CorfuStoreCompactorMain {
     private void doCompactorAction() {
         if (config.isFreezeCompaction()) {
             log.info("Freezing compaction...");
-            distributedCheckpointerHelper.updateCheckpointTable(checkpointTable, CompactorMetadataTables.FREEZE_TOKEN, UpdateAction.PUT);
+            distributedCheckpointerHelper.updateCompactorUtilsTable(compactorUtilsTable, CompactorMetadataTables.FREEZE_TOKEN, UpdateAction.PUT);
         } else if (config.isUnfreezeCompaction()) {
             log.info("Unfreezing compaction...");
-            distributedCheckpointerHelper.updateCheckpointTable(checkpointTable, CompactorMetadataTables.FREEZE_TOKEN, UpdateAction.DELETE);
+            distributedCheckpointerHelper.updateCompactorUtilsTable(compactorUtilsTable, CompactorMetadataTables.FREEZE_TOKEN, UpdateAction.DELETE);
         }
         if (config.isUpgradeDescriptorTable()) {
             log.info("Upgrading descriptor table...");
@@ -84,11 +84,11 @@ public class CorfuStoreCompactorMain {
         if (config.isInstantTriggerCompaction()) {
             if (config.isTrim()) {
                 log.info("Enabling instant compaction trigger with trim...");
-                distributedCheckpointerHelper.updateCheckpointTable(checkpointTable,
+                distributedCheckpointerHelper.updateCompactorUtilsTable(compactorUtilsTable,
                         CompactorMetadataTables.INSTANT_TIGGER_WITH_TRIM, UpdateAction.PUT);
             } else {
                 log.info("Enabling instant compactor trigger...");
-                distributedCheckpointerHelper.updateCheckpointTable(checkpointTable,
+                distributedCheckpointerHelper.updateCompactorUtilsTable(compactorUtilsTable,
                         CompactorMetadataTables.INSTANT_TIGGER, UpdateAction.PUT);
             }
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -76,7 +76,7 @@ public class CompactorLeaderServices {
 
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
 
             if (managerStatus != null && managerStatus.getStatus() == StatusType.STARTED) {
@@ -100,7 +100,7 @@ public class CompactorLeaderServices {
             // This is the safest point to trim from, since all data up to this point will surely
             // be included in the upcoming checkpoint cycle
             long minAddressBeforeCycleStarts = corfuRuntime.getAddressSpaceView().getLogTail();
-            txn.putRecord(compactorMetadataTables.getCheckpointTable(), CompactorMetadataTables.MIN_CHECKPOINT,
+            txn.putRecord(compactorMetadataTables.getCompactorUtilsTable(), CompactorMetadataTables.MIN_CHECKPOINT,
                     RpcCommon.TokenMsg.newBuilder()
                             .setSequence(minAddressBeforeCycleStarts)
                             .build(),
@@ -167,7 +167,7 @@ public class CompactorLeaderServices {
                 txn.delete(CompactorMetadataTables.ACTIVE_CHECKPOINTS_TABLE_NAME, table);
 
                 CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                        CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                        CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                         CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
                 txn.putRecord(compactorMetadataTables.getCompactionManagerTable(), CompactorMetadataTables.COMPACTION_MANAGER_KEY,
                         buildCheckpointStatus(
@@ -213,7 +213,7 @@ public class CompactorLeaderServices {
         StatusType finalStatus = StatusType.UNRECOGNIZED;
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
 
             if (managerStatus == null || managerStatus.getStatus() != StatusType.STARTED) {
@@ -267,9 +267,9 @@ public class CompactorLeaderServices {
         for (int i = 0; i < MAX_RETRIES; i++) {
             try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
                 RpcCommon.TokenMsg instantTrimToken = (RpcCommon.TokenMsg) txn.getRecord(
-                        CompactorMetadataTables.CHECKPOINT_TABLE_NAME, CompactorMetadataTables.INSTANT_TIGGER_WITH_TRIM).getPayload();
+                        CompactorMetadataTables.COMPACTION_CONTROLS_TABLE, CompactorMetadataTables.INSTANT_TIGGER_WITH_TRIM).getPayload();
                 if (instantTrimToken != null) {
-                    txn.delete(CompactorMetadataTables.CHECKPOINT_TABLE_NAME, CompactorMetadataTables.INSTANT_TIGGER_WITH_TRIM);
+                    txn.delete(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE, CompactorMetadataTables.INSTANT_TIGGER_WITH_TRIM);
                     txn.commit();
                     log.info("Invoking trimlog() due to InstantTrigger with trim found");
                     trimLog.invokePrefixTrim();
@@ -277,9 +277,9 @@ public class CompactorLeaderServices {
                 }
 
                 RpcCommon.TokenMsg instantToken = (RpcCommon.TokenMsg) txn.getRecord(
-                        CompactorMetadataTables.CHECKPOINT_TABLE_NAME, CompactorMetadataTables.INSTANT_TIGGER).getPayload();
+                        CompactorMetadataTables.COMPACTION_CONTROLS_TABLE, CompactorMetadataTables.INSTANT_TIGGER).getPayload();
                 if (instantToken != null) {
-                    txn.delete(CompactorMetadataTables.CHECKPOINT_TABLE_NAME, CompactorMetadataTables.INSTANT_TIGGER);
+                    txn.delete(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE, CompactorMetadataTables.INSTANT_TIGGER);
                 }
                 txn.commit();
                 return;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -125,7 +125,7 @@ public class CompactorService implements ManagementService {
             CheckpointingStatus managerStatus = null;
             try (TxnContext txn = getCorfuStore().txn(CORFU_SYSTEM_NAMESPACE)) {
                 managerStatus = (CheckpointingStatus) txn.getRecord(
-                        CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                        CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                         CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
                 txn.commit();
                 log.trace("ManagerStatus: {}", managerStatus.getStatus().toString());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DynamicTriggerPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DynamicTriggerPolicy.java
@@ -31,9 +31,9 @@ public class DynamicTriggerPolicy implements CompactionTriggerPolicy {
 
     private boolean shouldForceTrigger(CorfuStore corfuStore) {
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            RpcCommon.TokenMsg instantTrigger = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.CHECKPOINT_TABLE_NAME,
+            RpcCommon.TokenMsg instantTrigger = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE,
                     CompactorMetadataTables.INSTANT_TIGGER).getPayload();
-            RpcCommon.TokenMsg instantTrimTrigger = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.CHECKPOINT_TABLE_NAME,
+            RpcCommon.TokenMsg instantTrimTrigger = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE,
                     CompactorMetadataTables.INSTANT_TIGGER_WITH_TRIM).getPayload();
             txn.commit();
             if (instantTrigger != null || instantTrimTrigger != null) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LivenessValidator.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LivenessValidator.java
@@ -156,7 +156,7 @@ public class LivenessValidator {
         Optional<CheckpointingStatus> managerStatus = Optional.empty();
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             managerStatus = Optional.ofNullable((CheckpointingStatus) txn.getRecord(
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload());
             txn.commit();
             log.trace("ManagerStatus: {}", managerStatus.get().getStatus().toString());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/TrimLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/TrimLog.java
@@ -30,10 +30,10 @@ public class TrimLog {
         Optional<Long> trimAddress = Optional.empty();
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
             if (managerStatus.getStatus() == CheckpointingStatus.StatusType.COMPLETED) {
-                RpcCommon.TokenMsg trimToken = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.CHECKPOINT_TABLE_NAME,
+                RpcCommon.TokenMsg trimToken = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE,
                         CompactorMetadataTables.MIN_CHECKPOINT).getPayload();
                 trimAddress = Optional.of(trimToken.getSequence());
             } else {

--- a/runtime/src/main/java/org/corfudb/runtime/CompactorMetadataTables.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CompactorMetadataTables.java
@@ -20,12 +20,12 @@ public class CompactorMetadataTables {
     private Table<StringKey, CheckpointingStatus, Message> compactionManagerTable;
     private Table<TableName, CheckpointingStatus, Message> checkpointingStatusTable;
     private Table<TableName, ActiveCPStreamMsg, Message> activeCheckpointsTable;
-    private Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable;
+    private Table<StringKey, RpcCommon.TokenMsg, Message> compactorUtilsTable;
 
-    public static final String COMPACTION_MANAGER_TABLE_NAME = "CompactionManagerTable";
+    public static final String COMPACTION_CYCLE_STATUS_TABLE = "CompactionCycleStatusTable";
     public static final String CHECKPOINT_STATUS_TABLE_NAME = "CheckpointStatusTable";
     public static final String ACTIVE_CHECKPOINTS_TABLE_NAME = "ActiveCheckpointsTable";
-    public static final String CHECKPOINT_TABLE_NAME = "checkpoint";
+    public static final String COMPACTION_CONTROLS_TABLE = "CompactionControlsTable";
 
     public static final StringKey COMPACTION_MANAGER_KEY = StringKey.newBuilder().setKey("CompactionManagerKey").build();
     public static final StringKey MIN_CHECKPOINT = StringKey.newBuilder().setKey("MinCheckpointToken").build();
@@ -39,7 +39,7 @@ public class CompactorMetadataTables {
         for (int retry = 0; ; retry++) {
             try {
                 this.compactionManagerTable = corfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
-                        COMPACTION_MANAGER_TABLE_NAME,
+                        COMPACTION_CYCLE_STATUS_TABLE,
                         StringKey.class,
                         CheckpointingStatus.class,
                         null,
@@ -59,8 +59,8 @@ public class CompactorMetadataTables {
                         null,
                         TableOptions.fromProtoSchema(ActiveCPStreamMsg.class));
 
-                this.checkpointTable = corfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
-                        CHECKPOINT_TABLE_NAME,
+                this.compactorUtilsTable = corfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
+                        COMPACTION_CONTROLS_TABLE,
                         StringKey.class,
                         RpcCommon.TokenMsg.class,
                         null,

--- a/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
@@ -51,7 +51,7 @@ public abstract class DistributedCheckpointer {
         for (int retry = 0; retry < MAX_RETRIES; retry++) {
             try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
                 CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                        CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                        CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                         CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
                 if (managerStatus.getStatus() != StatusType.STARTED) {
                     txn.commit();
@@ -95,7 +95,7 @@ public abstract class DistributedCheckpointer {
         for (int retry = 0; retry < MAX_RETRIES; retry++) {
             try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
                 CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                        CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                        CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                         CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
                 if (epoch != managerStatus.getEpoch() ||
                         managerStatus.getStatus() == StatusType.COMPLETED ||

--- a/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointerHelper.java
+++ b/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointerHelper.java
@@ -28,9 +28,9 @@ public class DistributedCheckpointerHelper {
         DELETE
     }
 
-    public void updateCheckpointTable(Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable,
-                                      StringKey stringKey,
-                                      UpdateAction action) {
+    public void updateCompactorUtilsTable(Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable,
+                                          StringKey stringKey,
+                                          UpdateAction action) {
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             if (action == UpdateAction.PUT) {
                 txn.putRecord(checkpointTable, stringKey,
@@ -46,7 +46,7 @@ public class DistributedCheckpointerHelper {
 
     public boolean isCheckpointFrozen() {
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            RpcCommon.TokenMsg freezeToken = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.CHECKPOINT_TABLE_NAME,
+            RpcCommon.TokenMsg freezeToken = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE,
                     CompactorMetadataTables.FREEZE_TOKEN).getPayload();
             final long patience = 2 * 60 * 60 * 1000;
             if (freezeToken != null) {
@@ -54,7 +54,7 @@ public class DistributedCheckpointerHelper {
                 long frozeAt = freezeToken.getSequence();
                 Date frozeAtDate = new Date(frozeAt);
                 if (now - frozeAt > patience) {
-                    txn.delete(CompactorMetadataTables.CHECKPOINT_TABLE_NAME, CompactorMetadataTables.FREEZE_TOKEN);
+                    txn.delete(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE, CompactorMetadataTables.FREEZE_TOKEN);
                     log.warn("Checkpointer asked to freeze at {} but run out of patience",
                             frozeAtDate);
                 } else {
@@ -75,7 +75,7 @@ public class DistributedCheckpointerHelper {
         }
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             final CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
             txn.commit();
             if (managerStatus == null || managerStatus.getStatus() != StatusType.STARTED) {

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -212,7 +212,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     private Table<StringKey, CheckpointingStatus, Message> openCompactionManagerTable(CorfuStore corfuStore) {
         try {
             return corfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     StringKey.class,
                     CheckpointingStatus.class,
                     null,
@@ -254,7 +254,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     private Table<StringKey, RpcCommon.TokenMsg, Message> openCheckpointTable() {
         try {
             return corfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
-                    CompactorMetadataTables.CHECKPOINT_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CONTROLS_TABLE,
                     StringKey.class,
                     RpcCommon.TokenMsg.class,
                     null,
@@ -269,7 +269,7 @@ public class CompactorServiceTest extends AbstractViewTest {
         openCompactionManagerTable(corfuStore);
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
             log.info("ManagerStatus: " + managerStatus);
             if (managerStatus.getStatus() == targetStatus) {
@@ -300,7 +300,7 @@ public class CompactorServiceTest extends AbstractViewTest {
         openCheckpointTable();
         RpcCommon.TokenMsg token;
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            token = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.CHECKPOINT_TABLE_NAME, targetRecord).getPayload();
+            token = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE, targetRecord).getPayload();
             txn.commit();
         }
         log.info("VerifyCheckpointTable Token: {}", token == null ? "null" : token.toString());
@@ -311,7 +311,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     private boolean pollForFinishCheckpointing() {
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
             txn.commit();
             if (managerStatus != null && (managerStatus.getStatus() == StatusType.COMPLETED

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/DistributedCheckpointerTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/DistributedCheckpointerTest.java
@@ -176,7 +176,7 @@ public class DistributedCheckpointerTest extends AbstractViewTest {
     private Table<StringKey, CheckpointingStatus, Message> openCompactionManagerTable() {
         try {
             return corfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     StringKey.class,
                     CheckpointingStatus.class,
                     null,
@@ -204,7 +204,7 @@ public class DistributedCheckpointerTest extends AbstractViewTest {
     private Table<StringKey, TokenMsg, Message> openCheckpointTable() {
         try {
             return corfuStore.openTable(CORFU_SYSTEM_NAMESPACE,
-                    CompactorMetadataTables.CHECKPOINT_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CONTROLS_TABLE,
                     StringKey.class,
                     TokenMsg.class,
                     null,
@@ -233,7 +233,7 @@ public class DistributedCheckpointerTest extends AbstractViewTest {
         openCompactionManagerTable();
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
             if (managerStatus.getStatus() == targetStatus) {
                 return true;
@@ -267,7 +267,7 @@ public class DistributedCheckpointerTest extends AbstractViewTest {
 
         TokenMsg token;
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            token = (TokenMsg) txn.getRecord(CompactorMetadataTables.CHECKPOINT_TABLE_NAME, CompactorMetadataTables.MIN_CHECKPOINT).getPayload();
+            token = (TokenMsg) txn.getRecord(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE, CompactorMetadataTables.MIN_CHECKPOINT).getPayload();
             txn.commit();
         }
 
@@ -424,7 +424,7 @@ public class DistributedCheckpointerTest extends AbstractViewTest {
     private boolean pollForFinishCheckpointing() {
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
-                    CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
+                    CompactorMetadataTables.COMPACTION_CYCLE_STATUS_TABLE,
                     CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
             txn.commit();
             log.debug("managerStatus in test: {}", managerStatus == null ? "null" : managerStatus.getStatus());


### PR DESCRIPTION
* Rename checkpoint table to CompactorUtilsTable

* Rename CompactionManagerTable and CompactorUtilsTable

## Overview

Description:
cherry-pick into 4.1.0 branch

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
