### PR TITLE
CompactorControls: Allow caller to start transaction

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointerHelper.java
+++ b/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointerHelper.java
@@ -31,39 +31,51 @@ public class DistributedCheckpointerHelper {
     public void updateCompactionControlsTable(Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable,
                                               StringKey stringKey,
                                               UpdateAction action) {
+
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            if (action == UpdateAction.PUT) {
-                txn.putRecord(checkpointTable, stringKey,
-                        RpcCommon.TokenMsg.newBuilder().setSequence(System.currentTimeMillis()).build(), null);
-            } else if (action == UpdateAction.DELETE) {
-                txn.delete(checkpointTable, stringKey);
-            }
+            updateCompactionControlsTable(txn, checkpointTable, stringKey, action);
             txn.commit();
         } catch (Exception e) {
             log.warn("Unable to write UpgradeKey to checkpoint table, ", e);
         }
     }
+    public void updateCompactionControlsTable(TxnContext txn,
+                                              Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable,
+                                              StringKey stringKey,
+                                              UpdateAction action) {
+        if (action == UpdateAction.PUT) {
+            txn.putRecord(checkpointTable, stringKey,
+                    RpcCommon.TokenMsg.newBuilder().setSequence(System.currentTimeMillis()).build(), null);
+        } else if (action == UpdateAction.DELETE) {
+            txn.delete(checkpointTable, stringKey);
+        }
+    }
 
     public boolean isCheckpointFrozen() {
+        boolean isFrozen;
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
-            RpcCommon.TokenMsg freezeToken = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE,
-                    CompactorMetadataTables.FREEZE_TOKEN).getPayload();
-            final long patience = 2 * 60 * 60 * 1000;
-            if (freezeToken != null) {
-                long now = System.currentTimeMillis();
-                long frozeAt = freezeToken.getSequence();
-                Date frozeAtDate = new Date(frozeAt);
-                if (now - frozeAt > patience) {
-                    txn.delete(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE, CompactorMetadataTables.FREEZE_TOKEN);
-                    log.warn("Checkpointer asked to freeze at {} but run out of patience",
-                            frozeAtDate);
-                } else {
-                    log.warn("Checkpointer asked to freeze at {}", frozeAtDate);
-                    txn.commit();
-                    return true;
-                }
-            }
+            isFrozen = isCheckpointFrozen(txn);
             txn.commit();
+        }
+        return isFrozen;
+    }
+
+    public boolean isCheckpointFrozen(TxnContext txn) {
+        RpcCommon.TokenMsg freezeToken = (RpcCommon.TokenMsg) txn.getRecord(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE,
+                CompactorMetadataTables.FREEZE_TOKEN).getPayload();
+        final long patience = 2 * 60 * 60 * 1000;
+        if (freezeToken != null) {
+            long now = System.currentTimeMillis();
+            long frozeAt = freezeToken.getSequence();
+            Date frozeAtDate = new Date(frozeAt);
+            if (now - frozeAt > patience) {
+                txn.delete(CompactorMetadataTables.COMPACTION_CONTROLS_TABLE, CompactorMetadataTables.FREEZE_TOKEN);
+                log.warn("Checkpointer asked to freeze at {} but run out of patience",
+                        frozeAtDate);
+            } else {
+                log.warn("Checkpointer asked to freeze at {}", frozeAtDate);
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION

## Overview

Description:

Why should this be merged: 

This is needed for cases like rolling upgrade where the freeze token needs to be examined and updated
transactionally with other operations.
So we need a variant of the api which allows the
caller to control the lifecycle of the transaction.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
