### PR TITLE
Set MVO Cache size to 0 when disableCache is true

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CorfuRuntime.java
@@ -225,17 +225,19 @@ public class CorfuRuntime {
         boolean cacheEntryMetricsDisabled = true;
 
         /*
-         * Whether or not to disable the cache.
+         * Whether to disable the cache (both AddressSpaceView readCache and MVO Cache).
          */
         boolean cacheDisabled = false;
 
         /*
          * The maximum number of entries in the AddressSpaceView cache.
+         * This will be overridden to 0 if cacheDisabled is true.
          */
-        long maxCacheEntries = 2500;
+        long maxCacheEntries = 500;
 
         /*
          * The maximum number of entries in the MVOCache.
+         * This will be overridden to 0 if cacheDisabled is true.
          */
         long maxMvoCacheEntries = 2500;
 

--- a/runtime/src/main/java/org/corfudb/runtime/object/MVOCache.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/MVOCache.java
@@ -34,8 +34,17 @@ public class MVOCache<T extends ICorfuSMR<T>> {
     private final Cache<VersionedObjectIdentifier, T> objectCache;
 
     public MVOCache(@Nonnull CorfuRuntime corfuRuntime) {
+
+        // If not explicitly set by user, it takes default value in CorfuRuntimeParameters
+        long maxCacheSize = corfuRuntime.getParameters().getMaxMvoCacheEntries();
+        if (corfuRuntime.getParameters().isCacheDisabled()) {
+            // Do not allocate memory when cache is disabled.
+            maxCacheSize = 0;
+        }
+        log.info("MVO cache size is set to {}", maxCacheSize);
+
         this.objectCache = CacheBuilder.newBuilder()
-                .maximumSize(corfuRuntime.getParameters().getMaxMvoCacheEntries())
+                .maximumSize(maxCacheSize)
                 .removalListener(this::handleEviction)
                 .recordStats()
                 .build();

--- a/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamAddressDiscoveryIT.java
@@ -273,7 +273,7 @@ public class StreamAddressDiscoveryIT extends AbstractIT {
                     .snapshot(new Token(maxCheckpointAddress.getEpoch(), snapshotAddress))
                     .build()
                     .begin();
-            assertThat(table1.size()).isEqualTo(sizeAtSnapshot);
+            assertThat(table1rt.size()).isEqualTo(sizeAtSnapshot);
             readRuntime.getObjectsView().TXEnd();
         } catch (Exception e) {
             fail("Exception thrown", e);

--- a/test/src/test/java/org/corfudb/integration/StreamingIT.java
+++ b/test/src/test/java/org/corfudb/integration/StreamingIT.java
@@ -478,7 +478,7 @@ public class StreamingIT extends AbstractIT {
     public void testStreamingPrevValue() throws Exception {
         // Run a corfu server and start runtime
         Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
-        runtime = createRuntime(singleNodeEndpoint);
+        runtime = createRuntimeWithCache(singleNodeEndpoint);
         CorfuStore store = new CorfuStore(runtime);
         String ns = "test_namespace";
         String tn = "tableA";

--- a/test/src/test/java/org/corfudb/integration/WorkflowIT.java
+++ b/test/src/test/java/org/corfudb/integration/WorkflowIT.java
@@ -387,7 +387,7 @@ public class WorkflowIT extends AbstractIT {
     public void testRuntimeGCForActiveTransactionsInTrimRangeSingleThread() throws Exception {
         // Run single node server and create runtime
         runDefaultServer();
-        runtime = createDefaultRuntime();
+        runtime = createRuntimeWithCache();
 
         final int numDataEntries = 10;
 

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -1259,7 +1259,7 @@ public class CheckpointSmokeTest extends AbstractViewTest {
 
         // Open map.
         final String streamA = "streamA";
-        PersistentCorfuTable<String, Long> mA = instantiateTable(streamA);
+        PersistentCorfuTable<String, Long> mA = instantiateTable(streamA, r);
 
         // (1) Write 25 Entries
         for (int i = 0; i < numEntries; i++) {
@@ -1272,6 +1272,8 @@ public class CheckpointSmokeTest extends AbstractViewTest {
         Token cp2Token = cpw2.appendCheckpoint(new Token(0, snapshotAddress2 - 1), Optional.empty());
 
         // Checkpoint Writer 1 @10
+        r = getNewRuntime(getDefaultNode()).setCacheDisabled(true).connect();
+        mA = instantiateTable(streamA, r);
         CheckpointWriter<PersistentCorfuTable<String, Long>> cpw1 =
                 new CheckpointWriter<>(r, CorfuRuntime.getStreamID(streamA), "checkpointer-1", mA);
         cpw1.appendCheckpoint(new Token(0, snapshotAddress1 - 1), Optional.empty());


### PR DESCRIPTION
Simplify the cache setting logic

## Overview

Description:
1. 'disableCache' as a CorfuRuntime parameter should disable MVO Cache.
2. Today the cache size is set at multiple places - client property files, CorfuRuntimeParameters, and variables such as AddressSpaceView::DEFAULT_MAX_CACHE_ENTRIES. This change cleans up this logic.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
