### PR TITLE
Add check for disable compaction key

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -145,8 +145,6 @@ public class CompactorLeaderServices {
             if (statusToChange == LivenessValidator.Status.FINISH) {
                 log.info("Invoking finishCompactionCycle");
                 finishCompactionCycle();
-                livenessValidator.clearLivenessMap();
-                livenessValidator.clearLivenessValidator();
             }
         }
 
@@ -247,6 +245,8 @@ public class CompactorLeaderServices {
                     tableNames.size(), finalStatus);
             MicroMeterUtils.time(Duration.ofMillis(totalTimeElapsed), "compaction.total.timer",
                     "nodeEndpoint", nodeEndpoint);
+            livenessValidator.clearLivenessMap();
+            livenessValidator.clearLivenessValidator();
         } catch (RuntimeException re) {
             //Do not retry here, the compactor service will trigger this method again
             // The txn should succeed otherwise the status is FAILED

--- a/runtime/src/main/java/org/corfudb/runtime/ServerTriggeredCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/ServerTriggeredCheckpointer.java
@@ -76,6 +76,7 @@ public class ServerTriggeredCheckpointer extends DistributedCheckpointer {
                         .setSerializer(serializer)
                         .addOpenOption(ObjectOpenOption.NO_CACHE);
         if (this.checkpointerBuilder.persistedCacheRoot.isPresent()) {
+            log.info("Opening table in diskBacked mode");
             String persistentCacheDirName = String.format("compactor_%s_%s",
                     tableName.getNamespace(), tableName.getTableName());
             Path persistedCacheLocation = Paths.get(this.checkpointerBuilder.persistedCacheRoot.get()).resolve(persistentCacheDirName);


### PR DESCRIPTION
If disable key is added while the compaction cycle is ongoing, the leader needs to force complete the cycle and mark the status as COMPLETED/FAILED

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
