### PR TITLE
Disable compaction during Restore (#3452)

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactionTriggerPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactionTriggerPolicy.java
@@ -3,7 +3,7 @@ package org.corfudb.infrastructure;
 import org.corfudb.runtime.collections.CorfuStore;
 
 public interface CompactionTriggerPolicy {
-    boolean shouldTrigger(long interval, CorfuStore corfuStore);
+    boolean shouldTrigger(long interval, CorfuStore corfuStore) throws Exception;
 
     void markCompactionCycleStart();
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/DynamicTriggerPolicy.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/DynamicTriggerPolicy.java
@@ -52,7 +52,7 @@ public class DynamicTriggerPolicy implements CompactionTriggerPolicy {
      * @return true if compaction cycle should run, false otherwise
      */
     @Override
-    public boolean shouldTrigger(long interval, CorfuStore corfuStore) {
+    public boolean shouldTrigger(long interval, CorfuStore corfuStore) throws Exception {
         DistributedCheckpointerHelper distributedCheckpointerHelper = new DistributedCheckpointerHelper(corfuStore);
 
         if (distributedCheckpointerHelper.isCompactionDisabled()) {

--- a/runtime/src/main/java/org/corfudb/runtime/CompactorMetadataTables.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CompactorMetadataTables.java
@@ -33,7 +33,9 @@ public class CompactorMetadataTables {
     public static final StringKey DISABLE_COMPACTION = StringKey.newBuilder().setKey("DisableCompaction").build();
     public static final StringKey INSTANT_TIGGER_WITH_TRIM = StringKey.newBuilder().setKey("InstantTriggerTrim").build();
 
-    private static final int MAX_RETRIES = 5;
+    public static final int MAX_RETRIES = 5;
+
+    public static final int TABLE_UPDATE_RETRY_SLEEP_SECONDS = 2;
 
     public CompactorMetadataTables(CorfuStore corfuStore) throws Exception {
         for (int retry = 0; ; retry++) {
@@ -68,9 +70,10 @@ public class CompactorMetadataTables {
                 break;
             } catch (Exception e) {
                 if (retry == MAX_RETRIES) {
+                    log.error("Failed to open Compactor metadata tables after retry for {} times", MAX_RETRIES);
                     throw e;
                 }
-                log.error("Caught an exception while opening Compaction metadata tables ", e);
+                log.warn("Caught an exception while opening Compaction metadata tables. Retrying...", e);
             }
         }
     }

--- a/runtime/src/main/java/org/corfudb/runtime/Restore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/Restore.java
@@ -68,6 +68,9 @@ public class Restore {
     // Cache the mapping from table uuid to requires_backup_support in RegistryTable
     private Map<UUID, Boolean> tableTagged = new HashMap<>();
 
+    //
+    private DistributedCheckpointerHelper cpHelper;
+
     /**
      * Unpacked files from backup tar file are stored under RESTORE_TEMP_DIR. They are deleted after restore finishes.
      */
@@ -96,6 +99,7 @@ public class Restore {
         try {
             // The cleanup() in finally block is not guaranteed to have
             // been run in previous restore if there was OOM
+            disableCompaction();
             cleanup();
             openTarFile();
             verify();
@@ -104,9 +108,29 @@ public class Restore {
             log.error("failed to run restore.", e);
             throw new BackupRestoreException("failed to restore from backup file " + filePath, e);
         } finally {
+            enableCompaction();
             cleanup();
         }
         log.info("restore completed");
+    }
+
+    private void disableCompaction() throws Exception {
+        log.info("Disabling compaction...");
+        if (cpHelper == null) {
+            try {
+                cpHelper = new DistributedCheckpointerHelper(corfuStore);
+            } catch (Exception e) {
+                log.error("Failed to obtain a DistributedCheckpointerHelper.", e);
+                throw e;
+            }
+        }
+
+        cpHelper.disableCompactionWithWait();
+    }
+
+    private void enableCompaction() {
+        log.info("Enabling compaction...");
+        cpHelper.enableCompaction();
     }
 
     private void restore() throws IOException {

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -368,7 +368,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     }
 
     @Test
-    public void singleServerTest() {
+    public void singleServerTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
         SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime0);
 
@@ -390,7 +390,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     }
 
     @Test
-    public void multipleServerTest() {
+    public void multipleServerTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
 
         SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime0);
@@ -419,7 +419,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     }
 
     @Test
-    public void leaderFailureTest() {
+    public void leaderFailureTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
 
         SingletonResource<CorfuRuntime> runtimeSingletonResource0 = SingletonResource.withInitial(() -> runtime0);
@@ -460,7 +460,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     }
 
     @Test
-    public void nonLeaderFailureTest() {
+    public void nonLeaderFailureTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
 
         SingletonResource<CorfuRuntime> runtimeSingletonResource0 = SingletonResource.withInitial(() -> runtime0);
@@ -501,7 +501,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     }
 
     @Test
-    public void checkpointFailureTest() {
+    public void checkpointFailureTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
         SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime0);
 
@@ -538,7 +538,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     }
 
     @Test
-    public void runOrchestratorLeaderInitManagerStatusTest() {
+    public void runOrchestratorLeaderInitManagerStatusTest() throws Exception {
         testSetup(logSizeLimitPercentageFull);
         SingletonResource<CorfuRuntime> runtimeSingletonResource0 = SingletonResource.withInitial(() -> runtime0);
         CompactorService compactorService0 = new CompactorService(sc0, runtimeSingletonResource0, mockInvokeJvm0, new DynamicTriggerPolicy());
@@ -571,7 +571,7 @@ public class CompactorServiceTest extends AbstractViewTest {
     }
 
     @Test
-    public void quotaExceededTest() {
+    public void quotaExceededTest() throws Exception {
         testSetup(logSizeLimitPercentageLow);
         SingletonResource<CorfuRuntime> runtimeSingletonResource1 = SingletonResource.withInitial(() -> runtime0);
         CompactorService compactorService0 = new CompactorService(sc0, runtimeSingletonResource1, mockInvokeJvm0, dynamicTriggerPolicy0);

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceUnitTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceUnitTest.java
@@ -99,7 +99,7 @@ public class CompactorServiceUnitTest {
     }
 
     @Test
-    public void runOrchestratorLeaderTest() {
+    public void runOrchestratorLeaderTest() throws Exception {
         Layout mockLayout = mock(Layout.class);
         when(corfuRuntime.invalidateLayout()).thenReturn(CompletableFuture.completedFuture(mockLayout));
         //isLeader becomes true
@@ -129,7 +129,7 @@ public class CompactorServiceUnitTest {
     }
 
     @Test
-    public void runOrchestratorSchedulerTest() {
+    public void runOrchestratorSchedulerTest() throws Exception {
         Layout mockLayout = mock(Layout.class);
         CompletableFuture invalidateLayoutFuture = mock(CompletableFuture.class);
         when(corfuRuntime.invalidateLayout()).thenReturn(invalidateLayoutFuture);

--- a/test/src/test/java/org/corfudb/infrastructure/DynamicTriggerPolicyUnitTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/DynamicTriggerPolicyUnitTest.java
@@ -42,7 +42,7 @@ public class DynamicTriggerPolicyUnitTest {
     }
 
     @Test
-    public void testShouldTrigger() {
+    public void testShouldTrigger() throws Exception {
         //this makes shouldForceTrigger and isCheckpointFrozen to return false
         when(corfuStoreEntry.getPayload()).thenReturn(null);
 
@@ -58,7 +58,7 @@ public class DynamicTriggerPolicyUnitTest {
     }
 
     @Test
-    public void testShouldForceTrigger() {
+    public void testShouldForceTrigger() throws Exception {
         when((RpcCommon.TokenMsg) corfuStoreEntry.getPayload()).thenReturn(null)
                 .thenReturn(null)
                 .thenReturn(RpcCommon.TokenMsg.getDefaultInstance());
@@ -66,20 +66,20 @@ public class DynamicTriggerPolicyUnitTest {
     }
 
     @Test
-    public void testDisableCompaction() {
+    public void testDisableCompaction() throws Exception {
         when((RpcCommon.TokenMsg) corfuStoreEntry.getPayload()).thenReturn(RpcCommon.TokenMsg.getDefaultInstance()).thenReturn(null);
         assert !dynamicTriggerPolicy.shouldTrigger(INTERVAL, corfuStore);
     }
 
     @Test
-    public void testCheckpointFrozen() {
+    public void testCheckpointFrozen() throws Exception {
         when((RpcCommon.TokenMsg) corfuStoreEntry.getPayload()).thenReturn(null).thenReturn(RpcCommon.TokenMsg.newBuilder()
                 .setSequence(System.currentTimeMillis()).build());
         assert !dynamicTriggerPolicy.shouldTrigger(INTERVAL, corfuStore);
     }
 
     @Test
-    public void testCheckpointFrozenReturnFalse() {
+    public void testCheckpointFrozenReturnFalse() throws Exception {
         final long patience = 3 * 60 * 60 * 1000; //freezeToken found but expired
         when((RpcCommon.TokenMsg) corfuStoreEntry.getPayload())
                 .thenReturn(null)


### PR DESCRIPTION
* Disabled compaction during Restore

* Add wait after disable compactor key is written to controls table

* Abort retrying if update hits conflict

* fix Codacy failure

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
