### PR TITLE
Make updateCompactionControlsTable public

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointerHelper.java
+++ b/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointerHelper.java
@@ -140,7 +140,7 @@ public class DistributedCheckpointerHelper {
         return isCompactionInProgress;
     }
 
-    private void updateCompactionControlsTable(TxnContext txn,
+    public void updateCompactionControlsTable(TxnContext txn,
                                               Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable,
                                               StringKey stringKey,
                                               UpdateAction action) {


### PR DESCRIPTION
## Overview

Description:
DistributedCheckpointerHelper:: updateCompactionControlsTable 
should be `public` since LR needs to directly call this method.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
