### PR TITLE
LR: remove dependence of in-memory structure during Apply Phase

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -42,7 +42,7 @@ public class InitializedState implements LogReplicationState {
                 log.info("Snapshot Sync transfer completed. Wait for snapshot apply to complete.");
                 WaitSnapshotApplyState waitSnapshotApplyState = (WaitSnapshotApplyState)fsm.getStates().get(LogReplicationStateType.WAIT_SNAPSHOT_APPLY);
                 waitSnapshotApplyState.setTransitionEventId(event.getEventId());
-                waitSnapshotApplyState.setBaseSnapshotTimestamp(fsm.getBaseSnapshot());
+                waitSnapshotApplyState.setBaseSnapshotTimestamp(event.getMetadata().getLastTransferredBaseSnapshot());
                 fsm.setBaseSnapshot(event.getMetadata().getLastTransferredBaseSnapshot());
                 fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                 return waitSnapshotApplyState;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -304,17 +304,24 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         // as these streams will get trimmed and 'clear' will be a 'data loss'.
         if (MERGE_ONLY_STREAMS.contains(streamId)) {
             log.debug("Do not clear stream={} (merge stream)", streamId);
-        } else if (!replicatedStreamIds.contains(streamId)) {
-            log.trace("No data was written to stream {} on source or sink." +
-                "  Do not clear.", streamId);
-            return;
-        } else {
-            smrEntries.add(CLEAR_ENTRY);
         }
 
+        boolean shouldAddClearRecord = !MERGE_ONLY_STREAMS.contains(streamId);
         while (iterator.hasNext()) {
+            // append a clear record at the beginning of every non-merge-only streams
+            if(shouldAddClearRecord) {
+                smrEntries.add(CLEAR_ENTRY);
+                shouldAddClearRecord = false;
+            }
+
             OpaqueEntry opaqueEntry = iterator.next();
             smrEntries.addAll(opaqueEntry.getEntries().get(shadowStreamId));
+        }
+
+        // if clear record has not been added by now,indicates that shadow stream is empty.
+        if (shouldAddClearRecord) {
+            log.trace("No data was written to stream {} on source or sink. Do not clear.", streamId);
+            return;
         }
 
         if (streamId.equals(REGISTRY_TABLE_ID)) {


### PR DESCRIPTION
## Overview

Description:
The Apply phase relies on replicatedStreamIds to filter out the shadow streams that has evidenced data from SOURCE. This is an issue when the leader changes or leader restarts between the Apply phase.

This change fixes the issue by not relying on the in-memory structure, but use the shadow streams themselves to determine if the stream has evidenced data.



Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
