### PR TITLE
Mark compaction cycle status through finishCompactionCycle() only

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
@@ -76,7 +76,7 @@ public abstract class DistributedCheckpointer {
                 break;
             } catch (TransactionAbortedException e) {
                 if (e.getAbortCause() == AbortCause.CONFLICT) {
-                    log.info("My opened table {}${} is being checkpointed by someone else",
+                    log.info("Table {}${} is being checkpointed by someone else",
                             tableName.getNamespace(), tableName.getTableName());
                     return false;
                 }

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -512,6 +512,15 @@ public class CompactorServiceTest extends AbstractViewTest {
         when(dynamicTriggerPolicy0.shouldTrigger(Matchers.anyLong(), Matchers.any())).thenReturn(true).thenReturn(false);
         compactorService1.start(Duration.ofMillis(COMPACTOR_SERVICE_INTERVAL));
 
+        Table<StringKey, RpcCommon.TokenMsg, Message> checkpointTable = openCompactionControlsTable();
+        try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
+            txn.putRecord(checkpointTable,
+                    CompactorMetadataTables.INSTANT_TIGGER,
+                    RpcCommon.TokenMsg.newBuilder().setSequence(System.currentTimeMillis()).build(),
+                    null);
+            txn.commit();
+        }
+
         try {
             TimeUnit.MILLISECONDS.sleep(LIVENESS_TIMEOUT.toMillis() / 2);
             Table<TableName, ActiveCPStreamMsg, Message> activeCheckpointTable = openActiveCheckpointsTable();
@@ -538,6 +547,7 @@ public class CompactorServiceTest extends AbstractViewTest {
 
         assert verifyManagerStatus(StatusType.FAILED);
         assert verifyCheckpointStatusTable(StatusType.COMPLETED, 1);
+        assert verifyCompactionControlsTable(CompactorMetadataTables.INSTANT_TIGGER) == 0;
     }
 
     @Test
@@ -614,7 +624,7 @@ public class CompactorServiceTest extends AbstractViewTest {
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             txn.putRecord(checkpointTable,
                     CompactorMetadataTables.INSTANT_TIGGER_WITH_TRIM,
-                    RpcCommon.TokenMsg.getDefaultInstance(),
+                    RpcCommon.TokenMsg.newBuilder().setSequence(System.currentTimeMillis()).build(),
                     null);
             txn.commit();
         }

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorServiceTest.java
@@ -323,7 +323,6 @@ public class CompactorServiceTest extends AbstractViewTest {
             if (managerStatus != null && (managerStatus.getStatus() == StatusType.COMPLETED
                     || managerStatus.getStatus() == StatusType.FAILED)) {
                 log.info("done pollForFinishCp: {}", managerStatus.getStatus());
-                System.out.println("done pollForFinishCp: " + managerStatus.getStatus());
                 return true;
             }
         }


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
