### PR TITLE
LR: remove reliance on in-memory structure during Apply phase.

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -42,7 +42,7 @@ public class InitializedState implements LogReplicationState {
                 log.info("Snapshot Sync transfer completed. Wait for snapshot apply to complete.");
                 WaitSnapshotApplyState waitSnapshotApplyState = (WaitSnapshotApplyState)fsm.getStates().get(LogReplicationStateType.WAIT_SNAPSHOT_APPLY);
                 waitSnapshotApplyState.setTransitionEventId(event.getEventId());
-                waitSnapshotApplyState.setBaseSnapshotTimestamp(fsm.getBaseSnapshot());
+                waitSnapshotApplyState.setBaseSnapshotTimestamp(event.getMetadata().getLastTransferredBaseSnapshot());
                 fsm.setBaseSnapshot(event.getMetadata().getLastTransferredBaseSnapshot());
                 fsm.setAckedTimestamp(event.getMetadata().getLastLogEntrySyncedTimestamp());
                 return waitSnapshotApplyState;


### PR DESCRIPTION
## Overview

Description:
cherry-pick: https://github.com/CorfuDB/CorfuDB/pull/3459

The Apply phase relies on replicatedStreamIds to filter out the shadow streams that has evidenced data from SOURCE. This is an issue when the leader changes or leader restarts between the Apply phase.

This change fixes the issue by not relying on the in-memory structure, but use the shadow streams themselves to determine if the stream has evidenced data.



Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
