### PR TITLE
Flaky test fix: CorfuReplicationClusterConfigIT.testBackupRestoreWorkflow

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterConfig.java
@@ -48,6 +48,10 @@ public final class DefaultClusterConfig {
     private static final String standbyLogReplicationPort = "9020";
 
     @Getter
+    private static final String backupClusterId = "456e4567-e89b-12d3-a456-556642440003";
+
+
+    @Getter
     private static final String backupLogReplicationPort = "9030";
 
     @Getter

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/plugins/DefaultClusterManager.java
@@ -331,7 +331,7 @@ public class DefaultClusterManager extends CorfuReplicationClusterManagerBaseAda
 
         List<ClusterDescriptor> newActiveClusters = new ArrayList<>();
         newActiveClusters.add(new ClusterDescriptor(
-                currentActive.getClusterId(), ClusterRole.ACTIVE, BACKUP_CORFU_PORT));
+                DefaultClusterConfig.getBackupClusterId(), ClusterRole.ACTIVE, BACKUP_CORFU_PORT));
 
         NodeDescriptor backupNode = new NodeDescriptor(
                 DefaultClusterConfig.getDefaultHost(),

--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationClusterConfigIT.java
@@ -6,6 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterManager;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.LogReplicationMetadataKey;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.LogReplicationMetadataVal;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusKey;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal;
 import org.corfudb.infrastructure.logreplication.proto.Sample;
@@ -15,6 +17,7 @@ import org.corfudb.infrastructure.logreplication.proto.Sample.Metadata;
 import org.corfudb.infrastructure.logreplication.proto.Sample.StringKey;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationAckReader;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
+import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LogReplicationMetadataType;
 import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
@@ -25,6 +28,7 @@ import org.corfudb.runtime.collections.CorfuDynamicKey;
 import org.corfudb.runtime.collections.CorfuDynamicRecord;
 import org.corfudb.runtime.collections.CorfuRecord;
 import org.corfudb.runtime.collections.CorfuStore;
+import org.corfudb.runtime.collections.CorfuStoreEntry;
 import org.corfudb.runtime.collections.CorfuStreamEntries;
 import org.corfudb.runtime.collections.PersistentCorfuTable;
 import org.corfudb.runtime.collections.StreamListener;
@@ -55,6 +59,7 @@ import java.util.function.IntPredicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.METADATA_TABLE_PREFIX_NAME;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 
@@ -88,6 +93,9 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
     private static final String backupCorfuEndpoint = DEFAULT_HOST + ":" + backupClusterCorfuPort;
 
     private static final String REPLICATION_STATUS_TABLE = "LogReplicationStatus";
+
+    private static final String BACKUP_METADATA_TABLE = METADATA_TABLE_PREFIX_NAME +
+            DefaultClusterConfig.getBackupClusterId();
 
     private Process activeCorfuServer = null;
     private Process standbyCorfuServer = null;
@@ -1560,6 +1568,14 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         backupRuntime.parseConfigurationString(backupCorfuEndpoint).connect();
         CorfuStore backupCorfuStore = new CorfuStore(backupRuntime);
 
+        Table<LogReplicationMetadataKey, LogReplicationMetadataVal, Message> backupMetadataTable = backupCorfuStore.openTable(
+                CORFU_SYSTEM_NAMESPACE,
+                BACKUP_METADATA_TABLE,
+                LogReplicationMetadataKey.class,
+                LogReplicationMetadataVal.class,
+                null,
+                TableOptions.fromProtoSchema(LogReplicationMetadataVal.class));
+
         Table<StringKey, IntValue, Metadata> mapBackup = backupCorfuStore.openTable(
                 NAMESPACE,
                 streamName,
@@ -1629,13 +1645,21 @@ public class CorfuReplicationClusterConfigIT extends AbstractIT {
         // Change the topology - brings up the backup cluster
         updateTopology(activeCorfuStore, DefaultClusterManager.OP_BACKUP);
         log.info("Change the topology!!!");
-
-        TimeUnit.SECONDS.sleep(shortInterval);
-
+        // Note that the backup cluster will be the new source that drives the following forced snapshot sync.
+        CorfuStoreEntry topologyConfigRecord = null;
+        while (topologyConfigRecord == null) {
+            log.debug("Block until new topology config takes effect (persisted into metadata table)");
+            LogReplicationMetadataKey txKey = LogReplicationMetadataKey.newBuilder()
+                    .setKey(LogReplicationMetadataType.TOPOLOGY_CONFIG_ID.getVal())
+                    .build();
+            try (TxnContext txn = backupCorfuStore.txn(NAMESPACE)) {
+                topologyConfigRecord = txn.getRecord(backupMetadataTable, txKey);
+                txn.commit();
+            }
+        }
 
         // Perform an enforce full snapshot sync
         updateTopology(activeCorfuStore, DefaultClusterManager.OP_ENFORCE_SNAPSHOT_FULL_SYNC);
-        TimeUnit.SECONDS.sleep(mediumInterval);
 
         // Standby map size should be 10
         waitForReplication(size -> size == firstBatch, mapStandby, firstBatch);


### PR DESCRIPTION
## Overview

Description:

Flaky test fix:
* `CorfuReplicationClusterConfigIT.testBackupRestoreWorkflow()`: Cannot reproduce locally with hundreds of reruns. Found a potential cause while examining the code in `DefaultClusterManager`. When we bring up backup cluster, we just put a sleep interval for the topology config to update, which could make it possible that for following forced snapshot sync is still performed by original source (state config cached in DefaultClusterManager) (#3468)

Why should this be merged: 

Related issue(s) (if applicable): #3468


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
