### PR TITLE
Retry on TXnAbortedException during unlockTableAfterCheckpoint

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
@@ -107,6 +107,7 @@ public abstract class DistributedCheckpointer {
                 CheckpointingStatus tableStatus = (CheckpointingStatus) txn.getRecord(
                         CompactorMetadataTables.CHECKPOINT_STATUS_TABLE_NAME, tableName).getPayload();
                 if (tableStatus.getStatus() == StatusType.FAILED) {
+                    //Leader marked me as failed
                     log.error("Table status for {}${} has already been marked as FAILED",
                             tableName.getNamespace(), tableName.getTableName());
                     txn.commit();
@@ -120,7 +121,6 @@ public abstract class DistributedCheckpointer {
             } catch (TransactionAbortedException e) {
                 log.error("TransactionAbortedException exception while trying to unlock table {}${}: {}",
                         tableName.getNamespace(), tableName.getTableName(), e.getMessage());
-                break; //Leader marked me as failed
             } catch (RuntimeException re) {
                 if (isCriticalRuntimeException(re, retry, MAX_RETRIES)) {
                     throw new IllegalStateException(re);

--- a/test/src/test/java/org/corfudb/runtime/DistributedCheckpointerUnitTest.java
+++ b/test/src/test/java/org/corfudb/runtime/DistributedCheckpointerUnitTest.java
@@ -173,6 +173,17 @@ public class DistributedCheckpointerUnitTest {
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).build())
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.IDLE).build())
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).build());
+        when(txn.commit()).thenReturn(Timestamp.getDefaultInstance()) //commit in tryLockTableToCheckpoint()
+                .thenThrow(new TransactionAbortedException(
+                        new TxResolutionInfo(UUID.randomUUID(), new Token(0, 0)),
+                        AbortCause.CONFLICT, new Throwable(), null))
+                .thenReturn(Timestamp.getDefaultInstance());
+        assert distributedCheckpointer.tryCheckpointTable(tableName, t -> cpw);
+
+        when((CheckpointingStatus) corfuStoreEntry.getPayload())
+                .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).build())
+                .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.IDLE).build())
+                .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).build());
         when(txn.commit()).thenReturn(Timestamp.getDefaultInstance())
                 .thenThrow(new TransactionAbortedException(
                         new TxResolutionInfo(UUID.randomUUID(), new Token(0, 0)),


### PR DESCRIPTION
This exception could be caused on txn.delete(activeCheckpointTable) as well. For this case, we need to retry. In case of TAE due to updating checkpoint status of the current table, retrying still won't cause an issue since we have the method protected with compactorCycleCount, managerStatus and the tableStatus.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
