### PR TITLE
Use correct logging level when null metadata is detected during showTable().

### DIFF
--- a/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
+++ b/corfudb-tools/src/main/java/org/corfudb/browser/CorfuStoreBrowserEditor.java
@@ -254,7 +254,7 @@ public class CorfuStoreBrowserEditor {
     private void printMetadata(Map.Entry<CorfuDynamicKey, CorfuDynamicRecord> entry) {
         StringBuilder builder;
         if (entry.getValue().getMetadata() == null) {
-            log.error("metadata is NULL");
+            log.warn("metadata is NULL");
             return;
         }
         try {


### PR DESCRIPTION
The logging level is currently ERROR which is inaccurate.  It can be WARN.

Why should this be merged: Null metadata does not indicate an error.

