### PR TITLE
Fix runOrchestrator when managerStatus is null

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -147,7 +147,8 @@ public class CompactorService implements ManagementService {
                 }
                 txn.commit();
             } catch (Exception e) {
-                log.warn("Unable to acquire manager status: ", e);
+                log.error("Unable to acquire manager status: ", e);
+                return;
             }
             try {
                 if (isLeader) {


### PR DESCRIPTION
Return on cases when managerStatus is unable to be acquires as the runOrchestrator method runs every 10s

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
