### PR TITLE
Checkpoint legacy tables used by Compactor

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.corfudb.infrastructure.health.Component.COMPACTOR;
 import static org.corfudb.infrastructure.health.Issue.IssueId.COMPACTION_CYCLE_FAILED;
@@ -89,7 +90,13 @@ public class CompactorLeaderServices {
 
             long newCycleCount = managerStatus == null ? 0 : managerStatus.getCycleCount() + 1;
             List<TableName> tableNames = new ArrayList<>(corfuStore.listTables(null));
-            tableNames.addAll(CompactorMetadataTables.legacyTables);
+            tableNames.addAll(CompactorMetadataTables.allLegacyTables
+                    .stream()
+                    .map(table -> TableName.newBuilder()
+                            .setNamespace("")
+                            .setTableName(table)
+                            .build())
+                    .collect(Collectors.toList()));
             CheckpointingStatus idleStatus = buildCheckpointStatus(StatusType.IDLE, newCycleCount);
 
             txn.clear(CompactorMetadataTables.CHECKPOINT_STATUS_TABLE_NAME);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -89,6 +89,7 @@ public class CompactorLeaderServices {
 
             long newCycleCount = managerStatus == null ? 0 : managerStatus.getCycleCount() + 1;
             List<TableName> tableNames = new ArrayList<>(corfuStore.listTables(null));
+            tableNames.addAll(CompactorMetadataTables.legacyTables);
             CheckpointingStatus idleStatus = buildCheckpointStatus(StatusType.IDLE, newCycleCount);
 
             txn.clear(CompactorMetadataTables.CHECKPOINT_STATUS_TABLE_NAME);

--- a/runtime/src/main/java/org/corfudb/runtime/CompactorMetadataTables.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CompactorMetadataTables.java
@@ -12,6 +12,9 @@ import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.proto.RpcCommon;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 @Slf4j
@@ -25,6 +28,12 @@ public class CompactorMetadataTables {
     public static final String CHECKPOINT_STATUS_TABLE_NAME = "CheckpointStatusTable";
     public static final String ACTIVE_CHECKPOINTS_TABLE_NAME = "ActiveCheckpointsTable";
     public static final String COMPACTION_CONTROLS_TABLE = "CompactionControlsTable";
+
+    public static final List<TableName> legacyTables = new ArrayList<>();
+
+    public static final String LEGACY_CHECKPOINT_TABLE_NAME = "checkpoint";
+    public static final String LEGACY_NODE_TOKEN_TABLE_NAME = "node-token";
+    public static final String LEGACY_ALL_OPENED_CLUSTERING_STREAMS_TABLE_NAME = "CLUSTERING_ALL_STREAMS";
 
     public static final StringKey COMPACTION_MANAGER_KEY = StringKey.newBuilder().setKey("CompactionManagerKey").build();
     public static final StringKey MIN_CHECKPOINT = StringKey.newBuilder().setKey("MinCheckpointToken").build();
@@ -76,5 +85,12 @@ public class CompactorMetadataTables {
                 log.warn("Caught an exception while opening Compaction metadata tables. Retrying...", e);
             }
         }
+
+        legacyTables.add(TableName.newBuilder().setNamespace("")
+                .setTableName(LEGACY_CHECKPOINT_TABLE_NAME).build());
+        legacyTables.add(TableName.newBuilder().setNamespace("")
+                .setTableName(LEGACY_NODE_TOKEN_TABLE_NAME).build());
+        legacyTables.add(TableName.newBuilder().setNamespace("")
+                .setTableName(LEGACY_ALL_OPENED_CLUSTERING_STREAMS_TABLE_NAME).build());
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/CompactorMetadataTables.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CompactorMetadataTables.java
@@ -12,7 +12,7 @@ import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.proto.RpcCommon;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
@@ -29,11 +29,12 @@ public class CompactorMetadataTables {
     public static final String ACTIVE_CHECKPOINTS_TABLE_NAME = "ActiveCheckpointsTable";
     public static final String COMPACTION_CONTROLS_TABLE = "CompactionControlsTable";
 
-    public static final List<TableName> legacyTables = new ArrayList<>();
-
     public static final String LEGACY_CHECKPOINT_TABLE_NAME = "checkpoint";
     public static final String LEGACY_NODE_TOKEN_TABLE_NAME = "node-token";
     public static final String LEGACY_ALL_OPENED_CLUSTERING_STREAMS_TABLE_NAME = "CLUSTERING_ALL_STREAMS";
+
+    public static final List<String> allLegacyTables = Arrays.asList(LEGACY_CHECKPOINT_TABLE_NAME,
+            LEGACY_NODE_TOKEN_TABLE_NAME, LEGACY_ALL_OPENED_CLUSTERING_STREAMS_TABLE_NAME);
 
     public static final StringKey COMPACTION_MANAGER_KEY = StringKey.newBuilder().setKey("CompactionManagerKey").build();
     public static final StringKey MIN_CHECKPOINT = StringKey.newBuilder().setKey("MinCheckpointToken").build();
@@ -85,12 +86,9 @@ public class CompactorMetadataTables {
                 log.warn("Caught an exception while opening Compaction metadata tables. Retrying...", e);
             }
         }
+    }
 
-        legacyTables.add(TableName.newBuilder().setNamespace("")
-                .setTableName(LEGACY_CHECKPOINT_TABLE_NAME).build());
-        legacyTables.add(TableName.newBuilder().setNamespace("")
-                .setTableName(LEGACY_NODE_TOKEN_TABLE_NAME).build());
-        legacyTables.add(TableName.newBuilder().setNamespace("")
-                .setTableName(LEGACY_ALL_OPENED_CLUSTERING_STREAMS_TABLE_NAME).build());
+    public static boolean isLegacy(TableName tableName) {
+        return tableName.getNamespace().equals("") && allLegacyTables.contains(tableName.getTableName());
     }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/ServerTriggeredCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/ServerTriggeredCheckpointer.java
@@ -59,7 +59,7 @@ public class ServerTriggeredCheckpointer extends DistributedCheckpointer {
         UUID streamId;
         CorfuTable corfuTable;
 
-        if (CompactorMetadataTables.legacyTables.contains(tableName)) {
+        if (CompactorMetadataTables.isLegacy(tableName)) {
             // Legacy tables do not have namespace
             streamId = CorfuRuntime.getStreamID(tableName.getTableName());
             log.info("Legacy table {} UUID is {}", tableName.getTableName(), streamId);
@@ -80,7 +80,7 @@ public class ServerTriggeredCheckpointer extends DistributedCheckpointer {
     private CorfuTable openLegacyTable(TableName tableName, CorfuRuntime rt) {
         log.info("Opening legacy table {} in namespace {}", tableName.getTableName(), tableName.getNamespace());
 
-        Preconditions.checkState(CompactorMetadataTables.legacyTables.contains(tableName),
+        Preconditions.checkState(CompactorMetadataTables.isLegacy(tableName),
                 "Cannot open unknown legacy table %s", tableName);
 
         if (tableName.getTableName().equals(CompactorMetadataTables.LEGACY_CHECKPOINT_TABLE_NAME) ||

--- a/runtime/src/main/java/org/corfudb/runtime/ServerTriggeredCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/ServerTriggeredCheckpointer.java
@@ -56,15 +56,17 @@ public class ServerTriggeredCheckpointer extends DistributedCheckpointer {
 
     private CheckpointWriter<ICorfuTable<?,?>> getCheckpointWriter(TableName tableName,
                                                               KeyDynamicProtobufSerializer keyDynamicProtobufSerializer) {
-        UUID streamId = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(tableName));
-
+        UUID streamId;
         CorfuTable corfuTable;
+
         if (CompactorMetadataTables.legacyTables.contains(tableName)) {
-            corfuTable = openLegacyTable(tableName,
-                    checkpointerBuilder.cpRuntime.get());
+            // Legacy tables do not have namespace
+            streamId = CorfuRuntime.getStreamID(tableName.getTableName());
+            log.info("Legacy table {} UUID is {}", tableName.getTableName(), streamId);
+            corfuTable = openLegacyTable(tableName, checkpointerBuilder.cpRuntime.get());
         } else {
-            corfuTable = openTable(tableName, keyDynamicProtobufSerializer,
-                    checkpointerBuilder.cpRuntime.get());
+            streamId = CorfuRuntime.getStreamID(TableRegistry.getFullyQualifiedTableName(tableName));
+            corfuTable = openTable(tableName, keyDynamicProtobufSerializer, checkpointerBuilder.cpRuntime.get());
         }
 
         CheckpointWriter<ICorfuTable<?,?>> cpw =


### PR DESCRIPTION
There are three legacy tables used by old Compactor. 
checkpoint, node-token and ALL_OPENED_CLUSTERING_STREAMS. 
Until when we have a proper solution to clear the
address space info in sequencer, we should keep
checkpointing these tables, otherwise it causes
TrimmedException in rollback scenarios.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
