### PR TITLE
Use transaction snapshot as min address for compaction cycle start

### DIFF
--- a/test/src/test/java/org/corfudb/infrastructure/CompactorLeaderServicesUnitTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorLeaderServicesUnitTest.java
@@ -68,17 +68,11 @@ public class CompactorLeaderServicesUnitTest {
 
     @Test
     public void initCompactionCycleTest() {
-        RpcCommon.TokenMsg freezeToken = RpcCommon.TokenMsg.newBuilder().setSequence(System.currentTimeMillis()).build();
-        when(corfuStoreEntry.getPayload()).thenReturn(freezeToken);
-        Assert.assertEquals(CompactorLeaderServices.LeaderInitStatus.FAIL, compactorLeaderServices.initCompactionCycle());
-
         when(corfuStoreEntry.getPayload())
-                .thenReturn(null) //makes isCheckpointFrozen method to return false
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).build());
         Assert.assertEquals(CompactorLeaderServices.LeaderInitStatus.FAIL, compactorLeaderServices.initCompactionCycle());
 
         when(corfuStoreEntry.getPayload())
-                .thenReturn(null)
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.FAILED).build());
         when(corfuStore.listTables(null)).thenReturn(Collections.singletonList(tableName));
         when(corfuRuntime.getAddressSpaceView()).thenReturn(mock(AddressSpaceView.class));

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
@@ -8,6 +8,7 @@ import com.google.protobuf.Message;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
@@ -485,6 +486,9 @@ public class CorfuStoreShimTest extends AbstractViewTest {
             // Verify that the write in TX2 was successful
             try (TxnContext txnContext = corfuStore.txn(namespace)) {
                 Assert.assertEquals(newVal, txnContext.getRecord(tableName1, conflictKey).getPayload());
+                assertThat(txnContext.getTxnSequence()).isNotEqualTo(Token.UNINITIALIZED.getSequence());
+                assertThat(txnContext.getEpoch()).isNotEqualTo(Token.UNINITIALIZED.getEpoch());
+                txnContext.commit();
             }
 
             // Clear the tables after each iteration


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
If there is a race between listTables() and the time the min token is computed, we could miss a table in the checkpoint cycle and trim it.
To avoid this race, use the transaction's snapshot timestamp.

Co-authored by: @zfrenette 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
