### PR TITLE
Backport sudo Process builder & Min token on snapshot start to 4.1.0

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorLeaderServices.java
@@ -75,6 +75,7 @@ public class CompactorLeaderServices {
      */
     public LeaderInitStatus initCompactionCycle() {
         log.info("=============Initiating Distributed Compaction============");
+        long minAddressBeforeCycleStarts;
 
         try (TxnContext txn = corfuStore.txn(CORFU_SYSTEM_NAMESPACE)) {
             CheckpointingStatus managerStatus = (CheckpointingStatus) txn.getRecord(
@@ -99,9 +100,12 @@ public class CompactorLeaderServices {
             }
 
             // Also record the minToken as the earliest token BEFORE checkpointing is initiated
+            // We take the current transaction's snapshot timestamp as this safe point
+            // Either the transaction fails and gets retried or it gets committed at which point
+            // future sequencer regressions will not regress to an earlier point.
             // This is the safest point to trim from, since all data up to this point will surely
             // be included in the upcoming checkpoint cycle
-            long minAddressBeforeCycleStarts = corfuRuntime.getAddressSpaceView().getLogTail();
+            minAddressBeforeCycleStarts = txn.getTxnSequence();
             txn.putRecord(compactorMetadataTables.getCompactionControlsTable(), CompactorMetadataTables.MIN_CHECKPOINT,
                     RpcCommon.TokenMsg.newBuilder()
                             .setSequence(minAddressBeforeCycleStarts)
@@ -118,7 +122,7 @@ public class CompactorLeaderServices {
             log.error("Exception while initiating Compaction cycle {}. Stack Trace {}", e, e.getStackTrace());
             return LeaderInitStatus.FAIL;
         }
-        log.info("Init compaction cycle is successful");
+        log.info("Init compaction cycle is successful. Min token {}", minAddressBeforeCycleStarts);
         return LeaderInitStatus.SUCCESS;
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/InvokeCheckpointingJvm.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/InvokeCheckpointingJvm.java
@@ -40,7 +40,7 @@ public class InvokeCheckpointingJvm implements InvokeCheckpointing {
                     shutdown();
                 }
 
-                ProcessBuilder pb = new ProcessBuilder(compactorScriptPath, "--hostname", hostName, "--port",
+                ProcessBuilder pb = new ProcessBuilder("sudo", compactorScriptPath, "--hostname", hostName, "--port",
                         port, "--compactorConfig", compactorConfigPath, "--startCheckpointing=true");
                 pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
                 pb.redirectError(ProcessBuilder.Redirect.PIPE);

--- a/test/src/test/java/org/corfudb/infrastructure/CompactorLeaderServicesUnitTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/CompactorLeaderServicesUnitTest.java
@@ -68,17 +68,11 @@ public class CompactorLeaderServicesUnitTest {
 
     @Test
     public void initCompactionCycleTest() {
-        RpcCommon.TokenMsg freezeToken = RpcCommon.TokenMsg.newBuilder().setSequence(System.currentTimeMillis()).build();
-        when(corfuStoreEntry.getPayload()).thenReturn(freezeToken);
-        Assert.assertEquals(CompactorLeaderServices.LeaderInitStatus.FAIL, compactorLeaderServices.initCompactionCycle());
-
         when(corfuStoreEntry.getPayload())
-                .thenReturn(null) //makes isCheckpointFrozen method to return false
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.STARTED).build());
         Assert.assertEquals(CompactorLeaderServices.LeaderInitStatus.FAIL, compactorLeaderServices.initCompactionCycle());
 
         when(corfuStoreEntry.getPayload())
-                .thenReturn(null)
                 .thenReturn(CheckpointingStatus.newBuilder().setStatus(StatusType.FAILED).build());
         when(corfuStore.listTables(null)).thenReturn(Collections.singletonList(tableName));
         when(corfuRuntime.getAddressSpaceView()).thenReturn(mock(AddressSpaceView.class));

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
@@ -8,6 +8,7 @@ import com.google.protobuf.Message;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.protocols.wireprotocol.LogData;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
+import org.corfudb.protocols.wireprotocol.Token;
 import org.corfudb.protocols.wireprotocol.TokenResponse;
 import org.corfudb.runtime.CorfuOptions;
 import org.corfudb.runtime.CorfuRuntime;
@@ -485,6 +486,9 @@ public class CorfuStoreShimTest extends AbstractViewTest {
             // Verify that the write in TX2 was successful
             try (TxnContext txnContext = corfuStore.txn(namespace)) {
                 Assert.assertEquals(newVal, txnContext.getRecord(tableName1, conflictKey).getPayload());
+                assertThat(txnContext.getTxnSequence()).isNotEqualTo(Token.UNINITIALIZED.getSequence());
+                assertThat(txnContext.getEpoch()).isNotEqualTo(Token.UNINITIALIZED.getEpoch());
+                txnContext.commit();
             }
 
             // Clear the tables after each iteration


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 
Backports ...
Add sudo to process builder
initCompactionCycle: Pick txn's snapshot as min point
TxnContext now returns the correct transaction timestamp
Co-authored-by: Zachary Frenette

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
