### PR TITLE
Fix Flaky SequencerServerTest Suite

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/SequencerServer.java
@@ -212,11 +212,7 @@ public class SequencerServer extends AbstractServer {
         );
         streamsAddressMap = sequencerFactoryHelper.getStreamAddressSpaceMap();
         streamTailToGlobalTailMap = sequencerFactoryHelper.getStreamTailToGlobalTailMap();
-        healthReportScheduler = Executors.newSingleThreadScheduledExecutor(
-                new ThreadFactoryBuilder()
-                        .setDaemon(true)
-                        .setNameFormat("sequencer-health")
-                        .build());
+        healthReportScheduler = sequencerFactoryHelper.getHealthReportScheduler("sequencer-health");
         HealthMonitor.reportIssue(Issue.createInitIssue(Component.SEQUENCER));
         healthReportScheduler.scheduleAtFixedRate(this::reportSequencerHealth, INIT_DELAY, DELAY_NUM, DELAY_UNITS);
     }
@@ -916,6 +912,14 @@ public class SequencerServer extends AbstractServer {
 
         Long getGlobalLogTail() {
             return Address.getMinAddress();
+        }
+
+        ScheduledExecutorService getHealthReportScheduler(@Nonnull String name) {
+            return Executors.newSingleThreadScheduledExecutor(
+                    new ThreadFactoryBuilder()
+                            .setDaemon(true)
+                            .setNameFormat(name)
+                            .build());
         }
     }
 }


### PR DESCRIPTION
This patch addresses flakiness in the SequencerServerTest suite. Since the reportSequencerHealth method is executing on a separate thread, its periodic invocation can interfere with the mocked behaviour of other objects unpredictably. This issue is addressed by mocking the health report scheduler, making the tests deterministic.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #3460 #3487


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
