### PR TITLE
Optimize disk usage for disk-backed compaction

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -107,6 +107,7 @@ public class CheckpointWriter<T extends ICorfuTable<?, ?>> {
     /** Local ref to the object that we're dumping.
      *  TODO: generalize to all SMR objects.
      */
+    @Getter
     private final T corfuTable;
 
     @Getter

--- a/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
+++ b/runtime/src/main/java/org/corfudb/runtime/DistributedCheckpointer.java
@@ -172,6 +172,7 @@ public abstract class DistributedCheckpointer {
             try {
                 CheckpointWriter<ICorfuTable<?,?>> cpw = checkpointWriterFn.apply(tableName);
                 cpw.appendCheckpoint(Optional.of(livenessUpdater));
+                cpw.getCorfuTable().close();
                 returnStatus = StatusType.COMPLETED;
                 break;
             } catch (RuntimeException re) {

--- a/runtime/src/main/java/org/corfudb/runtime/collections/ICorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/ICorfuTable.java
@@ -49,6 +49,8 @@ public interface ICorfuTable<K, V> {
 
     void clear();
 
+    void close();
+
     boolean isTableCached();
 
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/PersistentCorfuTable.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/PersistentCorfuTable.java
@@ -53,6 +53,11 @@ public class PersistentCorfuTable<K, V> implements ICorfuTable<K, V>, ICorfuSMR<
     }
 
     @Override
+    public void close() {
+        // NO OP
+    }
+
+    @Override
     public boolean isTableCached() {
         return ((MVOCorfuCompileProxy)proxy).isObjectCached();
     }

--- a/test/src/test/java/org/corfudb/runtime/DistributedCheckpointerUnitTest.java
+++ b/test/src/test/java/org/corfudb/runtime/DistributedCheckpointerUnitTest.java
@@ -68,6 +68,7 @@ public class DistributedCheckpointerUnitTest {
         doNothing().when(txn).putRecord(any(), any(), any(), any());
         doNothing().when(txn).delete(anyString(), any(TableName.class));
         when(txn.commit()).thenReturn(Timestamp.getDefaultInstance());
+        when(cpw.getCorfuTable()).thenReturn(mock(CorfuTable.class));
     }
 
     @Test

--- a/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
@@ -482,6 +482,21 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
     }
 
     /**
+     * Verify RocksDB persisted cache is cleaned up
+     */
+    @Property(tries = NUM_OF_TRIES)
+    void verifyPersistedCacheCleanUp() {
+        resetTests();
+        assertThat(persistedCacheLocation).doesNotExist();
+        try (final CorfuTable<String, String> table1 = setupTable(alternateMapName)) {
+            table1.put(defaultNewMapEntry, defaultNewMapEntry);
+            assertThat(persistedCacheLocation).exists();
+            table1.close();
+            assertThat(persistedCacheLocation).doesNotExist();
+        }
+    }
+
+    /**
      * A custom generator for a set of {@link Uuid}.
      */
     @Provide


### PR DESCRIPTION
Delete RocksDB files for every corfu table right after the checkpointing finishes.

## Overview

Description:

Delete RocksDB files for every corfu table right after the checkpointing finishes.


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
