### PR TITLE
Re-org/cleanup LogReplicationContext / LogReplicationConfig / LogReplicationConfigManager

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/LogReplicationConfig.java
@@ -50,7 +50,7 @@ public class LogReplicationConfig {
         getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, TableRegistry.REGISTRY_TABLE_NAME));
 
     // A map consisting of the streams to replicate for each supported replication model
-    private Map<ReplicationSubscriber, Set<String>> replicationSubscriberToStreamsMap = new HashMap<>();
+    private Map<ReplicationSubscriber, Set<String>> replicationSubscriberToStreamsMap;
 
     public static final UUID PROTOBUF_TABLE_ID = CorfuRuntime.getStreamID(
             getFullyQualifiedTableName(CORFU_SYSTEM_NAMESPACE, TableRegistry.PROTOBUF_DESCRIPTOR_TABLE_NAME));

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -9,7 +9,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.config.ConfigParamNames;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.infrastructure.ServerContext;
-import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.DiscoveryServiceEvent.DiscoveryServiceEventType;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.CorfuReplicationClusterManagerAdapter;
 import org.corfudb.infrastructure.logreplication.infrastructure.plugins.DefaultClusterConfig;
@@ -103,12 +102,6 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
     private static final int SYSTEM_EXIT_ERROR_CODE = -3;
 
     /**
-     * Used for managing the set of streams to replicate, and also used for upgrading path
-     * in Log Replication
-     */
-    private LogReplicationConfigManager replicationConfigManager;
-
-    /**
      * Responsible for version management
      */
     private LogReplicationUpgradeManager upgradeManager;
@@ -188,7 +181,6 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
 
     private LockClient lockClient;
 
-    private LogReplicationConfig logReplicationConfig;
 
     /**
      * Indicates that bootstrap has been completed. Bootstrap is done once it
@@ -356,16 +348,16 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
 
         // Through the config manager, retrieve system-specific configurations such as streams to replicate
         // for supported replication models and version
-        replicationConfigManager = new LogReplicationConfigManager(getCorfuRuntime(), serverContext);
+        LogReplicationConfigManager replicationConfigManager =
+                new LogReplicationConfigManager(getCorfuRuntime(), serverContext);
+        replicationContext = new LogReplicationContext(replicationConfigManager,
+                topologyDescriptor.getTopologyConfigId(), localCorfuEndpoint);
         upgradeManager = new LogReplicationUpgradeManager(getCorfuRuntime(), serverContext.getPluginConfigFilePath());
-        logReplicationConfig = replicationConfigManager.getConfig();
-
         Set<String> remoteClusterIds = new HashSet<>();
 
         if (role == ClusterRole.SOURCE) {
             remoteClusterIds.addAll(topologyDescriptor.getSinkClusters().keySet());
             createMetadataManagers(remoteClusterIds);
-            replicationContext = new LogReplicationContext(logReplicationConfig, topologyDescriptor, localCorfuEndpoint);
             logReplicationEventListener = new LogReplicationEventListener(this, getCorfuRuntime());
             logReplicationEventListener.start();
         } else {
@@ -373,7 +365,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
             remoteClusterIds.addAll(topologyDescriptor.getSourceClusters().keySet());
             createMetadataManagers(remoteClusterIds);
 
-            LogReplicationServer server = new LogReplicationServer(serverContext, localNodeId, replicationConfigManager,
+            LogReplicationServer server = new LogReplicationServer(serverContext, localNodeId, replicationContext,
                 localCorfuEndpoint, topologyDescriptor.getTopologyConfigId(), remoteSessionToMetadataManagerMap);
             interClusterServerNode = new CorfuInterClusterReplicationServerNode(serverContext, server);
         }
@@ -382,7 +374,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
     private void createMetadataManagers(Set<String> remoteClusterIds) {
         for (String remoteClusterId : remoteClusterIds) {
             for (ReplicationSubscriber subscriber :
-                logReplicationConfig.getReplicationSubscriberToStreamsMap().keySet()) {
+                    replicationContext.getConfig().getReplicationSubscriberToStreamsMap().keySet()) {
                 LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(getCorfuRuntime(),
                     topologyDescriptor.getTopologyConfigId(), remoteClusterId);
                 ReplicationSession replicationSession = new ReplicationSession(remoteClusterId, subscriber);
@@ -506,14 +498,18 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
                 log.info("Start as Source (sender/replicator)");
                 if (replicationManager == null) {
                     replicationManager = new CorfuReplicationManager(replicationContext, localNodeDescriptor,
-                        remoteSessionToMetadataManagerMap, serverContext.getPluginConfigFilePath(), getCorfuRuntime(),
-                        replicationConfigManager, upgradeManager);
+                        remoteSessionToMetadataManagerMap, serverContext.getPluginConfigFilePath(),
+                            getCorfuRuntime(), upgradeManager);
                 } else {
                     // Replication Context contains the topology which
                     // must be updated if it has changed
-                    replicationManager.setContext(replicationContext);
+                    replicationManager.setReplicationContext(replicationContext);
                 }
-                replicationManager.start();
+
+                // Start log replication manager for each Sink
+                for (ClusterDescriptor remoteCluster : topologyDescriptor.getSinkClusters().values()) {
+                    replicationManager.start(remoteCluster, replicationContext);
+                }
 
                 // Set initial/default replication status for newly added Sink clusters
                 initReplicationStatusForRemoteClusters(true);
@@ -744,7 +740,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
 
             for (String remoteClusterId : sinksToRemove) {
                 for (ReplicationSubscriber subscriber :
-                    logReplicationConfig.getReplicationSubscriberToStreamsMap().keySet()) {
+                    replicationContext.getConfig().getReplicationSubscriberToStreamsMap().keySet()) {
                     ReplicationSession sessionToRemove = new ReplicationSession(remoteClusterId, subscriber);
                     removeClusterInfoFromStatusTable(sessionToRemove);
                     remoteSessionToMetadataManagerMap.remove(sessionToRemove);
@@ -752,7 +748,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
             }
             createMetadataManagers(sinksToAdd);
             initReplicationStatusForRemoteClusters(true);
-            replicationContext.setTopology(discoveredTopology);
+            replicationContext.setTopologyConfigId(discoveredTopology.getTopologyConfigId());
             replicationManager.processSinkChange(discoveredTopology, sinksToAdd, sinksToRemove, intersection);
         } else {
             // Update the topology config id on the Sink components

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationUpgradeManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.util.retry.IRetry;
@@ -26,7 +25,7 @@ public class CorfuReplicationManager {
     private final Map<ReplicationSession, CorfuLogReplicationRuntime> runtimeToRemoteSession = new HashMap<>();
 
     @Setter
-    private LogReplicationContext context;
+    private LogReplicationContext replicationContext;
 
     private final NodeDescriptor localNodeDescriptor;
 
@@ -36,42 +35,34 @@ public class CorfuReplicationManager {
 
     private final String pluginFilePath;
 
-    private final LogReplicationConfigManager replicationConfigManager;
-
     private final LogReplicationUpgradeManager upgradeManager;
 
     /**
      * Constructor
      */
-    public CorfuReplicationManager(LogReplicationContext context, NodeDescriptor localNodeDescriptor,
+    public CorfuReplicationManager(LogReplicationContext replicationContext, NodeDescriptor localNodeDescriptor,
                                    Map<ReplicationSession, LogReplicationMetadataManager> metadataManagerMap,
-                                   String pluginFilePath, CorfuRuntime corfuRuntime,
-                                   LogReplicationConfigManager replicationConfigManager,
-                                   LogReplicationUpgradeManager upgradeManager) {
-        this.context = context;
+                                   String pluginFilePath, CorfuRuntime corfuRuntime, LogReplicationUpgradeManager upgradeManager) {
+        this.replicationContext = replicationContext;
         this.metadataManagerMap = metadataManagerMap;
         this.pluginFilePath = pluginFilePath;
         this.corfuRuntime = corfuRuntime;
         this.localNodeDescriptor = localNodeDescriptor;
-        this.replicationConfigManager = replicationConfigManager;
         this.upgradeManager = upgradeManager;
     }
 
     /**
-     * Start Log Replication Manager, this will initiate a runtime against
-     * each Sink session(cluster + replication model + client), to further start log replication.
+     * Start log replication runtime for a given remote cluster (sink), which further drives the log replication.
      */
-    public void start() {
-        for (ClusterDescriptor remoteCluster : context.getTopology().getSinkClusters().values()) {
-            for (ReplicationSubscriber subscriber : context.getConfig().getReplicationSubscriberToStreamsMap().keySet()) {
-                try {
-                    startLogReplicationRuntime(remoteCluster, new ReplicationSession(remoteCluster.getClusterId(),
-                        subscriber));
-                } catch (Exception e) {
-                    log.error("Failed to start log replication runtime for remote session {}, replication model {}, " +
-                        "client {}", remoteCluster.getClusterId(), subscriber.getReplicationModel(),
-                        subscriber.getClient());
-                }
+    public void start(ClusterDescriptor remoteCluster, LogReplicationContext context) {
+        for (ReplicationSubscriber subscriber : context.getConfig().getReplicationSubscriberToStreamsMap().keySet()) {
+            try {
+                startLogReplicationRuntime(remoteCluster, new ReplicationSession(remoteCluster.getClusterId(),
+                    subscriber));
+            } catch (Exception e) {
+                log.error("Failed to start log replication runtime for remote session {}, replication model {}, " +
+                    "client {}", remoteCluster.getClusterId(), subscriber.getReplicationModel(),
+                    subscriber.getClient());
             }
         }
     }
@@ -120,12 +111,12 @@ public class CorfuReplicationManager {
             IRetry.build(IntervalRetry.class, () -> {
                 try {
                     LogReplicationRuntimeParameters parameters = LogReplicationRuntimeParameters.builder()
-                            .localCorfuEndpoint(context.getLocalCorfuEndpoint())
+                            .localCorfuEndpoint(replicationContext.getLocalCorfuEndpoint())
                             .remoteClusterDescriptor(remoteCluster)
                             .localClusterId(localNodeDescriptor.getClusterId())
-                            .replicationConfig(context.getConfig())
+                            .replicationConfig(replicationContext.getConfig())
                             .pluginFilePath(pluginFilePath)
-                            .topologyConfigId(context.getTopology().getTopologyConfigId())
+                            .topologyConfigId(replicationContext.getTopologyConfigId())
                             .keyStore(corfuRuntime.getParameters().getKeyStore())
                             .tlsEnabled(corfuRuntime.getParameters().isTlsEnabled())
                             .ksPasswordFile(corfuRuntime.getParameters().getKsPasswordFile())
@@ -134,7 +125,7 @@ public class CorfuReplicationManager {
                             .maxWriteSize(corfuRuntime.getParameters().getMaxWriteSize())
                             .build();
                     CorfuLogReplicationRuntime replicationRuntime = new CorfuLogReplicationRuntime(parameters,
-                        metadataManagerMap.get(session), upgradeManager, replicationConfigManager, session);
+                        metadataManagerMap.get(session), upgradeManager, replicationContext, session);
                     replicationRuntime.start();
                     runtimeToRemoteSession.put(session, replicationRuntime);
                 } catch (Exception e) {
@@ -182,11 +173,11 @@ public class CorfuReplicationManager {
     public void processSinkChange(TopologyDescriptor newConfig, Set<String> sinksToAdd, Set<String> sinksToRemove,
                                   Set<String> intersection) {
 
-        long oldTopologyConfigId = context.getTopology().getTopologyConfigId();
-        context.setTopology(newConfig);
+        long oldTopologyConfigId = replicationContext.getTopologyConfigId();
+        replicationContext.setTopologyConfigId(newConfig.getTopologyConfigId());
 
         // Get all subscribers
-        Set<ReplicationSubscriber> subscribers = context.getConfig().getReplicationSubscriberToStreamsMap().keySet();
+        Set<ReplicationSubscriber> subscribers = replicationContext.getConfig().getReplicationSubscriberToStreamsMap().keySet();
 
         // Remove Sinks that are not in the new config
         for (String clusterId : sinksToRemove) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationContext.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationContext.java
@@ -3,6 +3,10 @@ package org.corfudb.infrastructure.logreplication.infrastructure;
 import lombok.Getter;
 import lombok.Setter;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
+import org.corfudb.util.serializer.ISerializer;
+
+import static org.corfudb.util.serializer.ProtobufSerializer.PROTOBUF_SERIALIZER_CODE;
 
 /**
  * This class represents the Log Replication Context.
@@ -15,21 +19,52 @@ import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 public class LogReplicationContext {
 
     @Getter
-    private LogReplicationConfig config;
+    private final LogReplicationConfigManager configManager;
+
+    @Getter
+    private final String localCorfuEndpoint;
 
     @Getter
     @Setter
-    private TopologyDescriptor topology;
+    private long topologyConfigId;
 
-    @Getter
-    private String localCorfuEndpoint;
 
     /**
      * Constructor
      **/
-    public LogReplicationContext(LogReplicationConfig config,  TopologyDescriptor topology, String localCorfuEndpoint) {
-        this.config = config;
-        this.topology = topology;
+    public LogReplicationContext(LogReplicationConfigManager configManager, long topologyConfigId, String localCorfuEndpoint) {
+        this.configManager = configManager;
+        this.topologyConfigId = topologyConfigId;
         this.localCorfuEndpoint = localCorfuEndpoint;
+    }
+
+    /**
+     * This method will be invoked when it is needed to check if registry has new entries, to get the up-to-date
+     * LogReplicationConfig, which mainly includes streams to replicate and data streams to tags map.
+     *
+     * @return The updated LogReplicationConfig that is up-to-date with registry table
+     */
+    public LogReplicationConfig refresh() {
+        return this.configManager.getUpdatedConfig();
+    }
+
+    /**
+     * Exposed method for log replicator to get current config.
+     *
+     * @return Current config in config manager.
+     */
+    public LogReplicationConfig getConfig() {
+        return this.configManager.getConfig();
+    }
+
+    /**
+     * In general, log replication is happening in stream layer and data should not be materialized. Currently,
+     * the only case we need to deserialize data is in log replication writers, where registry table entries need
+     * to be deserialized to read the schema options.
+     *
+     * @return ProtobufSerializer for deserialize registry table entries in log replication writer.
+     */
+    public ISerializer getProtobufSerializer() {
+        return configManager.getRuntime().getSerializers().getSerializer(PROTOBUF_SERIALIZER_CODE);
     }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/LogReplicationServer.java
@@ -71,11 +71,11 @@ public class LogReplicationServer extends AbstractServer {
     }
 
     public LogReplicationServer(@Nonnull ServerContext context, String localNodeId,
-                                LogReplicationConfigManager configManager,
+                                LogReplicationContext replicationContext,
                                 String localEndpoint, long topologyConfigId,
                                 Map<ReplicationSession, LogReplicationMetadataManager> sourceSessionToMetadataManagerMap) {
         this.localNodeId = localNodeId;
-        createSinkManagers(configManager, localEndpoint, context, sourceSessionToMetadataManagerMap, topologyConfigId);
+        createSinkManagers(replicationContext, localEndpoint, context, sourceSessionToMetadataManagerMap, topologyConfigId);
         this.executor = context.getExecutorService(1, EXECUTOR_NAME_PREFIX);
     }
 
@@ -87,13 +87,13 @@ public class LogReplicationServer extends AbstractServer {
         this.executor = context.getExecutorService(1, EXECUTOR_NAME_PREFIX);
     }
 
-     private void createSinkManagers(LogReplicationConfigManager configManager, String localEndpoint,
+     private void createSinkManagers(LogReplicationContext replicationContext, String localEndpoint,
                                      ServerContext serverContext,
                                      Map<ReplicationSession, LogReplicationMetadataManager> sourceSessionToMetadataManagerMap,
                                      long topologyConfigId) {
         for (Map.Entry<ReplicationSession, LogReplicationMetadataManager> entry :
             sourceSessionToMetadataManagerMap.entrySet()) {
-            LogReplicationSinkManager sinkManager = new LogReplicationSinkManager(localEndpoint, configManager,
+            LogReplicationSinkManager sinkManager = new LogReplicationSinkManager(localEndpoint, replicationContext,
                 entry.getValue(), serverContext, topologyConfigId, entry.getKey());
             sourceSessionToSinkManagerMap.put(entry.getKey(), sinkManager);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationAckReader.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure.logreplication.replication;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.SyncStatus;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationStatusVal.SyncType;
@@ -10,7 +11,6 @@ import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicat
 import org.corfudb.infrastructure.logreplication.replication.send.LogEntrySender;
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.LogEntryReader;
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.LogEntryReader.StreamIteratorMetadata;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.protocols.wireprotocol.StreamAddressRange;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
@@ -36,7 +36,9 @@ import java.util.concurrent.locks.ReentrantLock;
 @Slf4j
 public class LogReplicationAckReader {
     private final LogReplicationMetadataManager metadataManager;
-    private final LogReplicationConfigManager configManager;
+
+    private final LogReplicationContext replicationContext;
+
     private final CorfuRuntime runtime;
     private final String remoteClusterId;
     private final ReplicationSession replicationSession;
@@ -65,10 +67,10 @@ public class LogReplicationAckReader {
 
     private final Lock lock = new ReentrantLock();
 
-    public LogReplicationAckReader(LogReplicationMetadataManager metadataManager, LogReplicationConfigManager configManager,
+    public LogReplicationAckReader(LogReplicationMetadataManager metadataManager, LogReplicationContext replicationContext,
                                    CorfuRuntime runtime, ReplicationSession replicationSession) {
         this.metadataManager = metadataManager;
-        this.configManager = configManager;
+        this.replicationContext = replicationContext;
         this.runtime = runtime;
         this.remoteClusterId = replicationSession.getRemoteClusterId();
         this.replicationSession = replicationSession;
@@ -176,7 +178,7 @@ public class LogReplicationAckReader {
      */
     private long getMaxReplicatedStreamsTail(Map<UUID, Long> tailMap) {
         long maxTail = Address.NON_ADDRESS;
-        Set<String> streamsToReplicate = configManager.getUpdatedConfig().getReplicationSubscriberToStreamsMap()
+        Set<String> streamsToReplicate = replicationContext.refresh().getReplicationSubscriberToStreamsMap()
             .getOrDefault(replicationSession.getSubscriber(), new HashSet<>());
         for (String streamName : streamsToReplicate) {
             UUID streamUuid = CorfuRuntime.getStreamID(streamName);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/LogReplicationSourceManager.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.DataSender;
-import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent.LogReplicationEventType;
@@ -18,7 +18,6 @@ import org.corfudb.infrastructure.logreplication.replication.send.LogReplication
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.DefaultReadProcessor;
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.ReadProcessor;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClient;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationUpgradeManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuRuntime.CorfuRuntimeParameters;
@@ -50,8 +49,6 @@ public class LogReplicationSourceManager {
 
     private final LogReplicationRuntimeParameters parameters;
 
-    private final LogReplicationConfig config;
-
     private final LogReplicationMetadataManager metadataManager;
 
     private final LogReplicationAckReader ackReader;
@@ -72,16 +69,18 @@ public class LogReplicationSourceManager {
      */
     public LogReplicationSourceManager(LogReplicationRuntimeParameters params, LogReplicationClient client,
                                        LogReplicationMetadataManager metadataManager,
-                                       LogReplicationConfigManager configManager,
+                                       LogReplicationContext replicationContext,
                                        LogReplicationUpgradeManager upgradeManager,
                                        ReplicationSession replicationSession) {
-        this(params, metadataManager, new CorfuDataSender(client), configManager, upgradeManager, replicationSession);
+        this(params, metadataManager, new CorfuDataSender(client), replicationContext, upgradeManager, replicationSession);
     }
 
     @VisibleForTesting
     public LogReplicationSourceManager(LogReplicationRuntimeParameters params,
-                                       LogReplicationMetadataManager metadataManager, DataSender dataSender,
-                                       LogReplicationConfigManager configManager, LogReplicationUpgradeManager upgradeManager,
+                                       LogReplicationMetadataManager metadataManager,
+                                       DataSender dataSender,
+                                       LogReplicationContext replicationContext,
+                                       LogReplicationUpgradeManager upgradeManager,
                                        ReplicationSession replicationSession) {
 
         // This runtime is used exclusively for the snapshot and log entry reader which do not require a cache
@@ -100,10 +99,8 @@ public class LogReplicationSourceManager {
 
         this.parameters = params;
 
-        this.config = parameters.getReplicationConfig();
-
         Set<String> streamsToReplicate =
-            config.getReplicationSubscriberToStreamsMap().get(replicationSession.getSubscriber());
+            replicationContext.getConfig().getReplicationSubscriberToStreamsMap().get(replicationSession.getSubscriber());
         if (streamsToReplicate == null || streamsToReplicate.isEmpty()) {
             // Avoid FSM being initialized if there are no streams to replicate
             throw new IllegalArgumentException("Invalid Log Replication: Streams to replicate is EMPTY");
@@ -117,9 +114,9 @@ public class LogReplicationSourceManager {
         this.metadataManager = metadataManager;
 
         // Ack Reader for Snapshot and LogEntry Sync
-        this.ackReader = new LogReplicationAckReader(this.metadataManager, configManager, runtime, replicationSession);
+        this.ackReader = new LogReplicationAckReader(this.metadataManager, replicationContext, runtime, replicationSession);
 
-        this.logReplicationFSM = new LogReplicationFSM(this.runtime, configManager, dataSender, readProcessor,
+        this.logReplicationFSM = new LogReplicationFSM(this.runtime, replicationContext, dataSender, readProcessor,
             logReplicationFSMWorkers, ackReader, upgradeManager, replicationSession);
 
         this.logReplicationFSM.setTopologyConfigId(params.getTopologyConfigId());

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/LogReplicationFSM.java
@@ -7,6 +7,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.logreplication.DataSender;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationAckReader;
 import org.corfudb.infrastructure.logreplication.replication.fsm.LogReplicationEvent.LogReplicationEventType;
@@ -21,7 +22,6 @@ import org.corfudb.infrastructure.logreplication.replication.send.logreader.Rout
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.RoutingQueuesSnapshotReader;
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.StreamsLogEntryReader;
 import org.corfudb.infrastructure.logreplication.replication.send.logreader.StreamsSnapshotReader;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationUpgradeManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.view.Address;
@@ -176,11 +176,6 @@ public class LogReplicationFSM {
     private final SnapshotReader snapshotReader;
 
     /**
-     * Used for checking if LR is in upgrading path
-     */
-    private final LogReplicationUpgradeManager upgradeManager;
-
-    /**
      * Version on which snapshot sync is based on.
      */
     @Getter
@@ -215,7 +210,7 @@ public class LogReplicationFSM {
      * Constructor for LogReplicationFSM, custom read processor for data transformation.
      *
      * @param runtime Corfu Runtime
-     * @param configManager log replication configuration manager
+     * @param replicationContext replication context that provides configuration
      * @param dataSender implementation of a data sender, both snapshot and log entry, this represents
      *                   the application callback for data transmission
      * @param readProcessor read processor for data transformation
@@ -224,23 +219,22 @@ public class LogReplicationFSM {
      * @param upgradeManager version and upgrade related utility
      * @param session Replication Session to the remote(Sink) cluster
      */
-    public LogReplicationFSM(CorfuRuntime runtime, LogReplicationConfigManager configManager, DataSender dataSender,
+    public LogReplicationFSM(CorfuRuntime runtime, LogReplicationContext replicationContext, DataSender dataSender,
                              ReadProcessor readProcessor, ExecutorService workers, LogReplicationAckReader ackReader,
                              LogReplicationUpgradeManager upgradeManager, ReplicationSession session) {
 
-        this.snapshotReader = createSnapshotReader(runtime, configManager, session);
-        this.logEntryReader = createLogEntryReader(runtime, configManager, session);
+        this.snapshotReader = createSnapshotReader(runtime, replicationContext, session);
+        this.logEntryReader = createLogEntryReader(runtime, replicationContext, session);
         this.ackReader = ackReader;
-        this.upgradeManager = upgradeManager;
         this.snapshotSender = new SnapshotSender(runtime, snapshotReader, dataSender, readProcessor,
-                configManager.getConfig().getMaxNumMsgPerBatch(), this);
+                replicationContext.getConfig().getMaxNumMsgPerBatch(), this);
         this.logEntrySender = new LogEntrySender(logEntryReader, dataSender, this);
         this.logReplicationFSMWorkers = workers;
         this.logReplicationFSMConsumer = Executors.newSingleThreadExecutor(new
                 ThreadFactoryBuilder().setNameFormat("replication-fsm-consumer-" + session.getRemoteClusterId())
                 .build());
 
-        init(dataSender, session);
+        init(dataSender, session, upgradeManager);
     }
 
     /**
@@ -257,39 +251,38 @@ public class LogReplicationFSM {
     @VisibleForTesting
     public LogReplicationFSM(CorfuRuntime runtime, SnapshotReader snapshotReader, DataSender dataSender,
                              LogEntryReader logEntryReader, ReadProcessor readProcessor,
-                             LogReplicationConfigManager configManager,
+                             LogReplicationContext replicationContext,
                              ExecutorService workers, LogReplicationAckReader ackReader,
                              LogReplicationUpgradeManager upgradeManager, ReplicationSession session) {
 
         this.snapshotReader = snapshotReader;
         this.logEntryReader = logEntryReader;
         this.ackReader = ackReader;
-        this.upgradeManager = upgradeManager;
         this.snapshotSender = new SnapshotSender(runtime, snapshotReader, dataSender, readProcessor,
-                configManager.getConfig().getMaxNumMsgPerBatch(), this);
+                replicationContext.getConfig().getMaxNumMsgPerBatch(), this);
         this.logEntrySender = new LogEntrySender(logEntryReader, dataSender, this);
         this.logReplicationFSMWorkers = workers;
         this.logReplicationFSMConsumer = Executors.newSingleThreadExecutor(new
                 ThreadFactoryBuilder().setNameFormat("replication-fsm-consumer-" + session.getRemoteClusterId())
                 .build());
 
-        init(dataSender, session);
+        init(dataSender, session, upgradeManager);
     }
 
-    private SnapshotReader createSnapshotReader(CorfuRuntime runtime, LogReplicationConfigManager configManager,
+    private SnapshotReader createSnapshotReader(CorfuRuntime runtime, LogReplicationContext replicationContext,
                                                 ReplicationSession replicationSession) {
         SnapshotReader snapshotReader;
         switch (replicationSession.getSubscriber().getReplicationModel()) {
             case FULL_TABLE:
-                snapshotReader = new StreamsSnapshotReader(runtime, configManager, replicationSession);
+                snapshotReader = new StreamsSnapshotReader(runtime, replicationContext, replicationSession);
                 break;
 
             case LOGICAL_GROUPS:
-                snapshotReader = new LogicalGroupSnapshotReader(runtime, configManager, replicationSession);
+                snapshotReader = new LogicalGroupSnapshotReader(runtime, replicationContext, replicationSession);
                 break;
 
             case ROUTING_QUEUES:
-                snapshotReader = new RoutingQueuesSnapshotReader(runtime, configManager, replicationSession);
+                snapshotReader = new RoutingQueuesSnapshotReader(runtime, replicationContext, replicationSession);
                 break;
 
             default:
@@ -302,21 +295,21 @@ public class LogReplicationFSM {
         return snapshotReader;
     }
 
-    private LogEntryReader createLogEntryReader(CorfuRuntime runtime, LogReplicationConfigManager configManager,
+    private LogEntryReader createLogEntryReader(CorfuRuntime runtime, LogReplicationContext replicationContext,
                                                 ReplicationSession replicationSession) {
         LogEntryReader logEntryReader;
 
         switch(replicationSession.getSubscriber().getReplicationModel()) {
             case FULL_TABLE:
-                logEntryReader = new StreamsLogEntryReader(runtime, configManager, replicationSession);
+                logEntryReader = new StreamsLogEntryReader(runtime, replicationContext, replicationSession);
                 break;
 
             case LOGICAL_GROUPS:
-                logEntryReader = new LogicalGroupLogEntryReader(runtime, configManager, replicationSession);
+                logEntryReader = new LogicalGroupLogEntryReader(runtime, replicationContext, replicationSession);
                 break;
 
             case ROUTING_QUEUES:
-                logEntryReader = new RoutingQueuesLogEntryReader(runtime, configManager, replicationSession);
+                logEntryReader = new RoutingQueuesLogEntryReader(runtime, replicationContext, replicationSession);
                 break;
 
             default:
@@ -328,9 +321,9 @@ public class LogReplicationFSM {
         return logEntryReader;
     }
 
-    private void init(DataSender dataSender, ReplicationSession session) {
+    private void init(DataSender dataSender, ReplicationSession session, LogReplicationUpgradeManager upgradeManager) {
         // Initialize Log Replication 5 FSM states - single instance per state
-        initializeStates(snapshotSender, logEntrySender, dataSender);
+        initializeStates(snapshotSender, logEntrySender, dataSender, upgradeManager);
         this.state = states.get(LogReplicationStateType.INITIALIZED);
         logReplicationFSMConsumer.submit(this::consume);
         log.info("Log Replication FSM initialized, replicate for session {}", session);
@@ -342,7 +335,8 @@ public class LogReplicationFSM {
      * @param snapshotSender reads and transmits snapshot syncs
      * @param logEntrySender reads and transmits log entry sync
      */
-    private void initializeStates(SnapshotSender snapshotSender, LogEntrySender logEntrySender, DataSender dataSender) {
+    private void initializeStates(SnapshotSender snapshotSender, LogEntrySender logEntrySender,
+                                  DataSender dataSender, LogReplicationUpgradeManager upgradeManager) {
         /*
          * Log Replication State instances are kept in a map to be reused in transitions, avoid creating one
          * per every transition (reduce GC cycles).

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogEntryWriter.java
@@ -2,8 +2,8 @@ package org.corfudb.infrastructure.logreplication.replication.receive;
 
 import com.google.protobuf.TextFormat;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.protocols.service.CorfuProtocolLogReplication;
@@ -38,18 +38,15 @@ public class LogEntryWriter extends SinkWriter {
     // Timestamp of the last message processed.
     private long lastMsgTs;
 
-    private final LogReplicationConfigManager configManager;
-
     private final LogReplicationMetadataManager metadataManager;
 
-    public LogEntryWriter(LogReplicationConfigManager configManager,
+    public LogEntryWriter(LogReplicationContext replicationContext,
                           LogReplicationMetadataManager logReplicationMetadataManager,
                           ReplicationSession replicationSession) {
-        super(configManager, replicationSession);
+        super(replicationContext, replicationSession);
         this.srcGlobalSnapshot = logReplicationMetadataManager.getLastAppliedSnapshotTimestamp();
         this.lastMsgTs = logReplicationMetadataManager.getLastProcessedLogEntryBatchTimestamp();
         this.metadataManager = logReplicationMetadataManager;
-        this.configManager = configManager;
     }
 
     /**
@@ -76,7 +73,7 @@ public class LogEntryWriter extends SinkWriter {
         // Log entry sync could have slow writes. That is, there could be a relatively long duration between last
         // snapshot/log entry sync and the current log entry sync, during which Sink side could have new tables opened.
         // So the config needs to be synced here to capture those updates.
-        configManager.getUpdatedConfig();
+        replicationContext.refresh();
 
         // Boolean value that indicate if the config should sync with registry table or not. Note that primitive boolean
         // value cannot be used here as its value needs to be changed in the lambda function below.
@@ -174,7 +171,7 @@ public class LogEntryWriter extends SinkWriter {
                                 // If stream tags exist for the current stream, it means its intended for streaming
                                 // on the Sink (receiver)
                                 txnContext.logUpdate(streamId, smrEntry,
-                                    configManager.getConfig().getDataStreamToTagsMap().get(streamId));
+                                    replicationContext.getConfig().getDataStreamToTagsMap().get(streamId));
                             }
                         }
                         txnContext.commit();
@@ -187,7 +184,7 @@ public class LogEntryWriter extends SinkWriter {
                             // an abort if concurrent updates to the registry occur. We are currently not implementing
                             // this, as (1) it incurs in additional RPC calls for all updates and (2) LR will filter out
                             // these streams on the next batch.
-                            configManager.getUpdatedConfig();
+                            replicationContext.refresh();
                             registryTableUpdated.set(false);
                         }
                     } catch (TransactionAbortedException tae) {
@@ -258,7 +255,7 @@ public class LogEntryWriter extends SinkWriter {
     public void reset(long snapshot, long ackTimestamp) {
         // Sync with registry table when LogEntryWriter is reset, which will happen when Snapshot sync is completed, and
         // when LogReplicationSinkManager is initialized and reset.
-        configManager.getUpdatedConfig();
+        replicationContext.refresh();
         srcGlobalSnapshot = snapshot;
         lastMsgTs = ackTimestamp;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/SinkWriter.java
@@ -3,8 +3,8 @@ package org.corfudb.infrastructure.logreplication.replication.receive;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.CorfuStoreMetadata.TableDescriptors;
@@ -19,8 +19,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
-import static org.corfudb.util.serializer.ProtobufSerializer.PROTOBUF_SERIALIZER_CODE;
-
 /**
  * A parent class for Sink side StreamsSnapshotWriter and LogEntryWriter, which contains some common
  * utility methods that could be used in both snapshot sync and log entry sync.
@@ -28,22 +26,22 @@ import static org.corfudb.util.serializer.ProtobufSerializer.PROTOBUF_SERIALIZER
 @Slf4j
 public abstract class SinkWriter {
 
-    // Configuration for LR in Source / Sink cluster.
-    private final LogReplicationConfigManager configManager;
-
     private final ISerializer protobufSerializer;
 
     private final ReplicationSession session;
 
+    // Replication context that provides configuration for LR in Source / Sink cluster.
+    LogReplicationContext replicationContext;
+
 
     // Limit the initialization of this class only to its children classes.
-    SinkWriter(LogReplicationConfigManager configManager, ReplicationSession session) {
-        this.configManager = configManager;
+    SinkWriter(LogReplicationContext replicationContext, ReplicationSession session) {
+        this.replicationContext = replicationContext;
         this.session = session;
 
         // The CorfuRuntime in LogReplicationConfigManager used to get the config fields from registry
         // table, and the protobufSerializer is guaranteed to be registered before initializing SinkWriter.
-        this.protobufSerializer = configManager.getRuntime().getSerializers().getSerializer(PROTOBUF_SERIALIZER_CODE);
+        this.protobufSerializer = replicationContext.getProtobufSerializer();
     }
 
     /**
@@ -92,7 +90,7 @@ public abstract class SinkWriter {
      * @return True if the entries should be ignored.
      */
     boolean ignoreEntriesForStream(UUID streamId) {
-        return configManager.getConfig().getSubscriberToNonReplicatedStreamsMap()
+        return replicationContext.getConfig().getSubscriberToNonReplicatedStreamsMap()
             .getOrDefault(session.getSubscriber(), new HashSet<>())
             .contains(streamId);
     }
@@ -107,7 +105,7 @@ public abstract class SinkWriter {
      */
     boolean ignoreEntryForRegistryTable(UUID streamId, CorfuRecord<TableDescriptors, TableMetadata> record) {
 
-        return configManager.getConfig().getSubscriberToNonReplicatedStreamsMap()
+        return replicationContext.getConfig().getSubscriberToNonReplicatedStreamsMap()
             .getOrDefault(session.getSubscriber(), new HashSet<>())
             .contains(streamId) || !record.getMetadata().getTableOptions().getIsFederated();
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/StreamsSnapshotWriter.java
@@ -4,9 +4,9 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager.LogReplicationMetadataType;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.protocols.CorfuProtocolCommon;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
@@ -39,7 +39,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.MERGE_ONLY_STREAMS;
@@ -83,19 +82,16 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
 
     private final ReplicationSession replicationSession;
 
-    private final LogReplicationConfigManager configManager;
-
     private final LogReplicationMetadataManager metadataManager;
 
     @Getter
     private Phase phase;
 
-    public StreamsSnapshotWriter(CorfuRuntime rt, LogReplicationConfigManager configManager,
+    public StreamsSnapshotWriter(CorfuRuntime rt, LogReplicationContext replicationContext,
                                  LogReplicationMetadataManager logReplicationMetadataManager,
                                  ReplicationSession replicationSession) {
-        super(configManager, replicationSession);
+        super(replicationContext, replicationSession);
         this.rt = rt;
-        this.configManager = configManager;
         this.metadataManager = logReplicationMetadataManager;
         this.phase = Phase.TRANSFER_PHASE;
         this.snapshotSyncStartMarker = Optional.empty();
@@ -148,7 +144,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         snapshotSyncStartMarker = Optional.empty();
         replicatedStreamIds.clear();
         // Sync with registry table to capture local updates on Sink side
-        configManager.getUpdatedConfig();
+        replicationContext.refresh();
     }
 
     /**
@@ -205,7 +201,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         metadataManager.appendUpdate(txnContext, LogReplicationMetadataType.LAST_SNAPSHOT_STARTED, srcGlobalSnapshot);
 
         for (SMREntry smrEntry : smrEntries) {
-            txnContext.logUpdate(streamId, smrEntry, configManager.getConfig().getDataStreamToTagsMap().get(streamId));
+            txnContext.logUpdate(streamId, smrEntry, replicationContext.getConfig().getDataStreamToTagsMap().get(streamId));
         }
     }
 
@@ -266,7 +262,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
 
     private void clearStream(UUID streamId, TxnContext txnContext) {
         SMREntry entry = new SMREntry(CLEAR_SMR_METHOD, new Array[0], Serializers.PRIMITIVE);
-        txnContext.logUpdate(streamId, entry, configManager.getConfig().getDataStreamToTagsMap().get(streamId));
+        txnContext.logUpdate(streamId, entry, replicationContext.getConfig().getDataStreamToTagsMap().get(streamId));
     }
 
     @Override
@@ -389,10 +385,10 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         applyShadowStream(REGISTRY_TABLE_ID, snapshot);
 
         // Sync the config with registry table after applying its entries
-        configManager.getUpdatedConfig();
+        replicationContext.refresh();
 
         for (String stream :
-            configManager.getConfig().getReplicationSubscriberToStreamsMap()
+            replicationContext.getConfig().getReplicationSubscriberToStreamsMap()
                 .getOrDefault(replicationSession.getSubscriber(), new HashSet<>())) {
             UUID regularStreamId = CorfuRuntime.getStreamID(stream);
             if (regularStreamId.equals(REGISTRY_TABLE_ID)) {
@@ -444,7 +440,7 @@ public class StreamsSnapshotWriter extends SinkWriter implements SnapshotWriter 
         // checkpoint won't run on these streams
         Set<UUID> streamsToQuery = new HashSet<>();
         for (String replicatedStream :
-            configManager.getConfig().getReplicationSubscriberToStreamsMap().getOrDefault(
+            replicationContext.getConfig().getReplicationSubscriberToStreamsMap().getOrDefault(
                 replicationSession.getSubscriber(), new HashSet<>())) {
             UUID id = CorfuRuntime.getStreamID(replicatedStream);
             if (replicatedStreamIds.contains(id) || MERGE_ONLY_STREAMS.contains(id)) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogicalGroupLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogicalGroupLogEntryReader.java
@@ -1,7 +1,7 @@
 package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.exceptions.TrimmedException;
@@ -16,7 +16,7 @@ import java.util.UUID;
  */
 public class LogicalGroupLogEntryReader extends LogEntryReader {
 
-    public LogicalGroupLogEntryReader(CorfuRuntime runtime, LogReplicationConfigManager configManager,
+    public LogicalGroupLogEntryReader(CorfuRuntime runtime, LogReplicationContext replicationContext,
                                       ReplicationSession session) {
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogicalGroupSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/LogicalGroupSnapshotReader.java
@@ -1,7 +1,7 @@
 package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
 import java.util.UUID;
 
@@ -10,7 +10,7 @@ import java.util.UUID;
  */
 public class LogicalGroupSnapshotReader extends SnapshotReader {
 
-    public LogicalGroupSnapshotReader(CorfuRuntime runtime, LogReplicationConfigManager configManager,
+    public LogicalGroupSnapshotReader(CorfuRuntime runtime, LogReplicationContext replicationContext,
                                       ReplicationSession session) {
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesLogEntryReader.java
@@ -1,7 +1,7 @@
 package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.exceptions.TrimmedException;
@@ -18,7 +18,7 @@ import java.util.UUID;
  */
 public class RoutingQueuesLogEntryReader extends LogEntryReader {
 
-    public RoutingQueuesLogEntryReader(CorfuRuntime runtime, LogReplicationConfigManager configManager,
+    public RoutingQueuesLogEntryReader(CorfuRuntime runtime, LogReplicationContext replicationContext,
                                        ReplicationSession session) {
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/RoutingQueuesSnapshotReader.java
@@ -1,7 +1,7 @@
 package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
 import java.util.UUID;
 
@@ -10,7 +10,7 @@ import java.util.UUID;
  */
 public class RoutingQueuesSnapshotReader extends SnapshotReader {
 
-    public RoutingQueuesSnapshotReader(CorfuRuntime corfuRuntime, LogReplicationConfigManager configManager,
+    public RoutingQueuesSnapshotReader(CorfuRuntime corfuRuntime, LogReplicationContext replicationContext,
                                        ReplicationSession session) {
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsLogEntryReader.java
@@ -8,8 +8,8 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.CorfuRuntime;
@@ -48,7 +48,7 @@ public class StreamsLogEntryReader extends LogEntryReader {
 
     private final LogReplicationEntryType MSG_TYPE = LogReplicationEntryType.LOG_ENTRY_MESSAGE;
 
-    private final LogReplicationConfigManager configManager;
+    private final LogReplicationContext replicationContext;
 
     // Set of UUIDs for the corresponding streams
     private Set<UUID> streamUUIDs;
@@ -81,11 +81,11 @@ public class StreamsLogEntryReader extends LogEntryReader {
 
     private ReplicationSession session;
 
-    public StreamsLogEntryReader(CorfuRuntime runtime, LogReplicationConfigManager configManager,
+    public StreamsLogEntryReader(CorfuRuntime runtime, LogReplicationContext replicationContext,
                                  ReplicationSession replicationSession) {
         runtime.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
-        this.configManager = configManager;
-        this.maxDataSizePerMsg = configManager.getConfig().getMaxDataSizePerMsg();
+        this.replicationContext = replicationContext;
+        this.maxDataSizePerMsg = replicationContext.getConfig().getMaxDataSizePerMsg();
         this.currentProcessedEntryMetadata = new StreamIteratorMetadata(Address.NON_ADDRESS, false);
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
         this.deltaCounter = configureDeltaCounter();
@@ -106,7 +106,7 @@ public class StreamsLogEntryReader extends LogEntryReader {
      * constructor and when LogReplicationConfig is synced with registry table.
      */
     private void refreshStreamUUIDs() {
-        Set<String> streams = configManager.getConfig().getReplicationSubscriberToStreamsMap().get(session.getSubscriber());
+        Set<String> streams = replicationContext.getConfig().getReplicationSubscriberToStreamsMap().get(session.getSubscriber());
         streamUUIDs = new HashSet<>();
         for (String s : streams) {
             streamUUIDs.add(CorfuRuntime.getStreamID(s));
@@ -163,7 +163,7 @@ public class StreamsLogEntryReader extends LogEntryReader {
         // table and add them to the list in that case.
         if (!streamUUIDs.containsAll(txEntryStreamIds)) {
             log.info("There could be additional streams to replicate in tx stream. Checking with registry table.");
-            configManager.getUpdatedConfig();
+            replicationContext.refresh();
             refreshStreamUUIDs();
             // TODO: Add log message here for the newly found streams when we support incremental refresh.
         }
@@ -298,7 +298,7 @@ public class StreamsLogEntryReader extends LogEntryReader {
     @Override
     public void reset(long lastSentBaseSnapshotTimestamp, long lastAckedTimestamp) {
         // Sync with registry when entering into IN_LOG_ENTRY_SYNC state
-        configManager.getUpdatedConfig();
+        replicationContext.refresh();
         refreshStreamUUIDs();
         this.currentProcessedEntryMetadata = new StreamIteratorMetadata(Address.NON_ADDRESS, false);
         setGlobalBaseSnapshot(lastSentBaseSnapshotTimestamp, lastAckedTimestamp);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/logreader/StreamsSnapshotReader.java
@@ -3,14 +3,13 @@ package org.corfudb.infrastructure.logreplication.replication.send.logreader;
 import com.google.protobuf.TextFormat;
 import io.micrometer.core.instrument.DistributionSummary;
 import lombok.Getter;
-import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
 import org.corfudb.common.util.Memory;
 import org.corfudb.common.util.ObservableValue;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.send.IllegalSnapshotEntrySizeException;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.protocols.logprotocol.OpaqueEntry;
 import org.corfudb.protocols.logprotocol.SMREntry;
 import org.corfudb.runtime.CorfuRuntime;
@@ -58,7 +57,7 @@ public class StreamsSnapshotReader extends SnapshotReader {
     private final int maxDataSizePerMsg;
     private final Optional<DistributionSummary> messageSizeDistributionSummary;
     private final CorfuRuntime rt;
-    private final LogReplicationConfigManager configManager;
+    private final LogReplicationContext replicationContext;
     private long snapshotTimestamp;
     private Set<String> streams;
     private PriorityQueue<String> streamsToSend;
@@ -76,14 +75,14 @@ public class StreamsSnapshotReader extends SnapshotReader {
     /**
      * Init runtime and streams to read
      */
-    public StreamsSnapshotReader(CorfuRuntime runtime, LogReplicationConfigManager configManager,
+    public StreamsSnapshotReader(CorfuRuntime runtime, LogReplicationContext replicationContext,
                                  ReplicationSession replicationSession) {
         this.rt = runtime;
-        this.configManager = configManager;
+        this.replicationContext = replicationContext;
         this.replicationSession = replicationSession;
         this.rt.parseConfigurationString(runtime.getLayoutServers().get(0)).connect();
-        this.maxDataSizePerMsg = configManager.getConfig().getMaxDataSizePerMsg();
-        this.streams = configManager.getConfig().getReplicationSubscriberToStreamsMap().get(replicationSession.getSubscriber());
+        this.maxDataSizePerMsg = replicationContext.getConfig().getMaxDataSizePerMsg();
+        this.streams = replicationContext.getConfig().getReplicationSubscriberToStreamsMap().get(replicationSession.getSubscriber());
         this.messageSizeDistributionSummary = configureMessageSizeDistributionSummary();
     }
 
@@ -272,8 +271,8 @@ public class StreamsSnapshotReader extends SnapshotReader {
     public void reset(long ts) {
         // As the config should reflect the latest configuration read from registry table, it will be synced with the
         // latest registry table content instead of the given ts, while the streams to replicate will be read up to ts.
-        streams =
-            configManager.getUpdatedConfig().getReplicationSubscriberToStreamsMap().get(replicationSession.getSubscriber());
+        streams = replicationContext.refresh().getReplicationSubscriberToStreamsMap()
+                .get(replicationSession.getSubscriber());
         streamsToSend = new PriorityQueue<>(streams);
         preMsgTs = Address.NON_ADDRESS;
         currentMsgTs = Address.NON_ADDRESS;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.infrastructure.TopologyDescriptor;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationSourceManager;
@@ -19,7 +20,6 @@ import org.corfudb.infrastructure.logreplication.runtime.fsm.StoppedState;
 import org.corfudb.infrastructure.logreplication.runtime.fsm.UnrecoverableState;
 import org.corfudb.infrastructure.logreplication.runtime.fsm.VerifyingRemoteLeaderState;
 import org.corfudb.infrastructure.logreplication.runtime.fsm.WaitingForConnectionsState;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationUpgradeManager;
 
 import java.util.HashMap;
@@ -119,11 +119,6 @@ public class CorfuLogReplicationRuntime {
     public static final int DEFAULT_TIMEOUT = 5000;
 
     /**
-     * Used for checking if LR is in upgrading path
-     */
-    private final LogReplicationConfigManager replicationConfigManager;
-
-    /**
      * Current state of the FSM.
      */
     private volatile LogReplicationRuntimeState state;
@@ -150,8 +145,6 @@ public class CorfuLogReplicationRuntime {
     private final LinkedBlockingQueue<LogReplicationRuntimeEvent> eventQueue = new LinkedBlockingQueue<>();
 
     private final LogReplicationClientRouter router;
-    private final LogReplicationMetadataManager metadataManager;
-    private final LogReplicationUpgradeManager upgradeManager;
 
     @Getter
     private final LogReplicationSourceManager sourceManager;
@@ -167,16 +160,13 @@ public class CorfuLogReplicationRuntime {
     public CorfuLogReplicationRuntime(LogReplicationRuntimeParameters parameters,
                                       LogReplicationMetadataManager metadataManager,
                                       LogReplicationUpgradeManager upgradeManager,
-                                      LogReplicationConfigManager replicationConfigManager,
+                                      LogReplicationContext replicationContext,
                                       ReplicationSession replicationSession) {
         this.remoteClusterId = replicationSession.getRemoteClusterId();
-        this.metadataManager = metadataManager;
-        this.upgradeManager = upgradeManager;
         this.router = new LogReplicationClientRouter(parameters, this);
         this.router.addClient(new LogReplicationHandler());
         this.sourceManager = new LogReplicationSourceManager(parameters,
-            new LogReplicationClient(router, remoteClusterId), metadataManager, replicationConfigManager,
-            upgradeManager, replicationSession);
+                new LogReplicationClient(router, remoteClusterId), metadataManager, replicationContext, upgradeManager, replicationSession);
         this.connectedNodes = new HashSet<>();
 
         ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("runtime-fsm-worker-"+remoteClusterId)
@@ -189,9 +179,7 @@ public class CorfuLogReplicationRuntime {
                 ThreadFactoryBuilder().setNameFormat(
                     "runtime-fsm-consumer-"+remoteClusterId).build());
 
-        this.replicationConfigManager = replicationConfigManager;
-
-        initializeStates();
+        initializeStates(metadataManager, upgradeManager);
         this.state = states.get(LogReplicationRuntimeStateType.WAITING_FOR_CONNECTIVITY);
 
         log.info("Log Replication Runtime State Machine initialized");
@@ -210,7 +198,7 @@ public class CorfuLogReplicationRuntime {
     /**
      * Initialize all states for the Log Replication Runtime FSM.
      */
-    private void initializeStates() {
+    private void initializeStates(LogReplicationMetadataManager metadataManager, LogReplicationUpgradeManager upgradeManager) {
         /*
          * Log Replication Runtime State instances are kept in a map to be reused in transitions, avoid creating one
          * per every transition (reduce GC cycles).

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -30,7 +30,7 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 import static org.corfudb.runtime.view.TableRegistry.getFullyQualifiedTableName;
 
 /**
- * Handle constuction and maintenance of the streams to replicate for all replication models supported in LR.
+ * Handle construction and maintenance of the streams to replicate for all replication models supported in LR.
  * @author pankti-m
  */
 @Slf4j
@@ -143,9 +143,18 @@ public class LogReplicationConfigManager {
     }
 
     private boolean registryTableHasNewEntries() {
+        // TODO (V2 / Chris): the operation of check current tail + generate updated config + update last log tail
+        //  should be atomic operation in multi replication session env.
         StreamAddressSpace currentAddressSpace = runtime.getSequencerView().getStreamAddressSpace(
             new StreamAddressRange(REGISTRY_TABLE_ID, Long.MAX_VALUE, Address.NON_ADDRESS));
         long currentLogTail = currentAddressSpace.getTail();
-        return currentLogTail != lastRegistryTableLogTail;
+
+        // Check if the log tail of registry table moved ahead
+        if (currentLogTail != lastRegistryTableLogTail) {
+            lastRegistryTableLogTail = currentLogTail;
+            return true;
+        }
+
+        return false;
     }
 }

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogEntryWriterTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogEntryWriterTest.java
@@ -1,5 +1,6 @@
 package org.corfudb.infrastructure.logreplication;
 
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogEntryWriter;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
@@ -55,7 +56,9 @@ public class LogEntryWriterTest extends AbstractViewTest {
         Mockito.doReturn(corfuRuntime).when(mockConfigManager).getRuntime();*/
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(corfuRuntime);
-        logEntryWriter = new LogEntryWriter(configManager, metadataManager, replicationSession);
+        LogReplicationContext replicationContext = new LogReplicationContext(configManager, topologyConfigId,
+                getEndpoint(SERVERS.PORT_0));
+        logEntryWriter = new LogEntryWriter(replicationContext, metadataManager, replicationSession);
         numOpaqueEntries = 3;
         topologyConfigId = 5;
         utils = new TestUtils();

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -17,6 +17,7 @@ import com.google.protobuf.ByteString;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.compression.Codec;
 import org.corfudb.common.util.ObservableValue;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.proto.Sample;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationAckReader;
@@ -66,9 +67,9 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
     private static final String TEST_STREAM_NAME = "StreamA";
     private static final int BATCH_SIZE = 2;
     private static final int WAIT_TIME = 100;
-    private static final int CORFU_PORT = 9000;
     private static final int TEST_TOPOLOGY_CONFIG_ID = 1;
     private static final String TEST_LOCAL_CLUSTER_ID = "local_cluster";
+    private static final String TEST_LOCAL_ENDPOINT_PREFIX = "test:";
 
     // This semaphore is used to block until the triggering event causes the transition to a new state
     private final Semaphore transitionAvailable = new Semaphore(1, true);
@@ -496,7 +497,8 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
                 break;
             case STREAMS:
                 CorfuRuntime runtime = getNewRuntime(getDefaultNode()).connect();
-                snapshotReader = new StreamsSnapshotReader(runtime, configManager, replicationSession);
+                snapshotReader = new StreamsSnapshotReader(runtime, new LogReplicationContext(configManager,
+                        TEST_TOPOLOGY_CONFIG_ID, TEST_LOCAL_ENDPOINT_PREFIX + SERVERS.PORT_0), replicationSession);
                 dataSender = new TestDataSender();
                 break;
             default:
@@ -505,11 +507,12 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(runtime, TEST_TOPOLOGY_CONFIG_ID,
             TEST_LOCAL_CLUSTER_ID);
-        ackReader = new LogReplicationAckReader(metadataManager, configManager, runtime, replicationSession);
+        LogReplicationContext replicationContext = new LogReplicationContext(configManager, TEST_TOPOLOGY_CONFIG_ID,
+                TEST_LOCAL_ENDPOINT_PREFIX + SERVERS.PORT_0);
+        ackReader = new LogReplicationAckReader(metadataManager, replicationContext, runtime, replicationSession);
 
-        fsm = new LogReplicationFSM(runtime, snapshotReader, dataSender, logEntryReader,
-                new DefaultReadProcessor(runtime), configManager,
-                Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("fsm-worker").build()),
+        fsm = new LogReplicationFSM(runtime, snapshotReader, dataSender, logEntryReader, new DefaultReadProcessor(runtime),
+                replicationContext, Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("fsm-worker").build()),
                 ackReader, upgradeManager, replicationSession);
         ackReader.setLogEntryReader(fsm.getLogEntryReader());
         transitionObservable = fsm.getNumTransitions();

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/MetadataManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/MetadataManagerTest.java
@@ -1,6 +1,7 @@
 package org.corfudb.infrastructure.logreplication;
 
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogEntryWriter;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
@@ -30,20 +31,21 @@ public class MetadataManagerTest extends AbstractViewTest {
 
     private CorfuRuntime corfuRuntime;
     private LogReplicationConfigManager configManager;
+    private LogReplicationContext replicationContext;
     private boolean success;
-    private Long topologyConfigId = 5L;
-    private String localClusterId = "Test Cluster";
+    private final Long topologyConfigId = 5L;
+    private final String localClusterId = "Test Cluster";
     private TestUtils utils;
-    private String remoteClusterId = "Remote Cluster";
-    private ReplicationSession replicationSession =
+    private final String remoteClusterId = "Remote Cluster";
+    private final ReplicationSession replicationSession =
         ReplicationSession.getDefaultReplicationSessionForCluster(remoteClusterId);
 
     @Before
     public void setUp() {
         corfuRuntime = getDefaultRuntime();
-
         configManager = Mockito.mock(LogReplicationConfigManager.class);
-
+        replicationContext = new LogReplicationContext(configManager, topologyConfigId,
+                getEndpoint(SERVERS.PORT_0));
         Mockito.doReturn(corfuRuntime).when(configManager).getRuntime();
         utils = new TestUtils();
     }
@@ -62,7 +64,7 @@ public class MetadataManagerTest extends AbstractViewTest {
 
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(corfuRuntime, topologyConfigId,
             localClusterId);
-        LogEntryWriter writer = new LogEntryWriter(configManager, metadataManager, replicationSession);
+        LogEntryWriter writer = new LogEntryWriter(replicationContext, metadataManager, replicationSession);
 
         Long numOpaqueEntries = 3L;
         LogReplication.LogReplicationEntryMsg lrEntryMsg = utils.generateLogEntryMsg(1, numOpaqueEntries,
@@ -120,7 +122,7 @@ public class MetadataManagerTest extends AbstractViewTest {
 
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(corfuRuntime, topologyConfigId,
             localClusterId);
-        LogEntryWriter writer = new LogEntryWriter(configManager, metadataManager, replicationSession);
+        LogEntryWriter writer = new LogEntryWriter(replicationContext, metadataManager, replicationSession);
 
         // Create a message with 50 opaque entries
         Long numOpaqueEntries = 50L;

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -6,6 +6,7 @@ import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.LogReplicationRuntimeParameters;
 import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationClusterInfo;
 import org.corfudb.infrastructure.logreplication.proto.Sample;
@@ -1222,8 +1223,10 @@ public class LogReplicationIT extends AbstractIT implements Observer {
         configManager.getConfig().setMaxMsgSize(SMALL_MSG_SIZE);
         configManager.getConfig().setMaxDataSizePerMsg(SMALL_MSG_SIZE * LogReplicationConfig.DATA_FRACTION_PER_MSG / 100);
 
+        LogReplicationContext replicationContext = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT);
+
         // Data Sender
-        sourceDataSender = new SourceForwardingDataSender(DESTINATION_ENDPOINT, configManager, testConfig,
+        sourceDataSender = new SourceForwardingDataSender(DESTINATION_ENDPOINT, replicationContext, testConfig,
             logReplicationMetadataManager, nettyConfig, function);
 
         ReplicationSession replicationSession =
@@ -1234,7 +1237,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
             LogReplicationRuntimeParameters.builder().remoteClusterDescriptor(new ClusterDescriptor(REMOTE_CLUSTER_ID,
                 LogReplicationClusterInfo.ClusterRole.SOURCE, CORFU_PORT)).replicationConfig(configManager.getConfig())
                 .localCorfuEndpoint(SOURCE_ENDPOINT).build(), logReplicationMetadataManager, sourceDataSender,
-            configManager, upgradeManager, replicationSession);
+                replicationContext, upgradeManager, replicationSession);
 
         // Set Log Replication Source Manager so we can emulate the channel for data & control messages (required
         // for testing)

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -2,6 +2,7 @@ package org.corfudb.integration;
 
 import com.google.common.reflect.TypeToken;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.proto.Sample;
 import org.corfudb.infrastructure.logreplication.proto.Sample.IntValue;
 import org.corfudb.infrastructure.logreplication.proto.Sample.Metadata;
@@ -44,7 +45,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -240,7 +240,9 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         ReplicationSession replicationSession =
             ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
 
-        StreamsSnapshotReader reader = new StreamsSnapshotReader(rt, configManager, replicationSession);
+        LogReplicationContext replicationContext = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT);
+
+        StreamsSnapshotReader reader = new StreamsSnapshotReader(rt, replicationContext, replicationSession);
 
         reader.reset(rt.getAddressSpaceView().getLogTail());
         while (true) {
@@ -277,7 +279,9 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         ReplicationSession replicationSession =
             ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
 
-        StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, configManager, logReplicationMetadataManager,
+        LogReplicationContext replicationContext = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT);
+
+        StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, replicationContext, logReplicationMetadataManager,
             replicationSession);
 
         if (msgQ.isEmpty()) {
@@ -304,7 +308,9 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         ReplicationSession replicationSession =
             ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
 
-        StreamsLogEntryReader reader = new StreamsLogEntryReader(rt, configManager, replicationSession);
+        LogReplicationContext replicationContext = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT);
+
+        StreamsLogEntryReader reader = new StreamsLogEntryReader(rt, replicationContext, replicationSession);
         reader.setGlobalBaseSnapshot(Address.NON_ADDRESS, Address.NON_ADDRESS);
 
         LogReplicationEntryMsg entry;
@@ -342,7 +348,9 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         ReplicationSession replicationSession =
             ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
 
-        LogEntryWriter writer = new LogEntryWriter(configManager, logReplicationMetadataManager, replicationSession);
+        LogReplicationContext replicationContext = new LogReplicationContext(configManager, 0, DEFAULT_ENDPOINT);
+
+        LogEntryWriter writer = new LogEntryWriter(replicationContext, logReplicationMetadataManager, replicationSession);
 
         if (msgQ.isEmpty()) {
             log.debug("msgQ is EMPTY");

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -6,7 +6,7 @@ import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.util.ObservableValue;
 import org.corfudb.infrastructure.logreplication.DataSender;
-import org.corfudb.infrastructure.logreplication.LogReplicationConfig;
+import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationContext;
 import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
@@ -14,7 +14,6 @@ import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicat
 import org.corfudb.infrastructure.logreplication.replication.LogReplicationSourceManager;
 import org.corfudb.infrastructure.logreplication.replication.send.LogReplicationError;
 import org.corfudb.infrastructure.logreplication.replication.fsm.ObservableAckMsg;
-import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
 import org.corfudb.integration.DefaultDataControl.DefaultDataControlConfig;
 import org.corfudb.runtime.LogReplication;
@@ -98,7 +97,7 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
     private static final String REPLICATION_STATUS_TABLE = "LogReplicationStatus";
 
     @SneakyThrows
-    public SourceForwardingDataSender(String destinationEndpoint, LogReplicationConfigManager configManager,
+    public SourceForwardingDataSender(String destinationEndpoint, LogReplicationContext replicationContext,
                                       LogReplicationIT.TestConfig testConfig,
                                       LogReplicationMetadataManager metadataManager,
                                       String pluginConfigFilePath, LogReplicationIT.TransitionSource function) {
@@ -113,7 +112,7 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
 
         // TODO pankti: This test-only constructor can be removed
         this.destinationLogReplicationManager = new LogReplicationSinkManager(runtime.getLayoutServers().get(0),
-            configManager, metadataManager, pluginConfigFilePath, replicationSession);
+            replicationContext, metadataManager, pluginConfigFilePath, replicationSession);
 
         this.ifDropMsg = testConfig.getDropMessageLevel();
         this.delayedApplyCycles = testConfig.getDelayedApplyCycles();


### PR DESCRIPTION
## Overview

Description:

Avoid passing LR config manager and config objects all over the places. They will be accessed via LogReplicationContext. Also, LogReplicationContext is now created for both Source and Sink. (It was only on Source side before this change)

Why should this be merged: 

Facilitate following PRs for log replication v2

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
