### PR TITLE
SessionInfo in the LR msgs

### DIFF
--- a/infrastructure/proto/log_replication_metadata.proto
+++ b/infrastructure/proto/log_replication_metadata.proto
@@ -106,10 +106,3 @@ message ReplicationEvent {
   string eventId = 2;
   ReplicationEventType type = 3;
 }
-
-enum ReplicationModel {
-  FULL_TABLE = 0;                 // Full table replication (Single Source to Single Sink = 1:1)
-  ROUTING_QUEUES = 1;             // Routing queue replication (used for entry-level replication) (1:1)
-  LOGICAL_GROUPS = 2;             // Table association to logical group (1:1)
-  MULTI_SOURCE_MERGE = 3;         // Same table replication from multiple sources to single sink (n:1)
-}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationDiscoveryService.java
@@ -378,7 +378,8 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
                 logReplicationConfig.getReplicationSubscriberToStreamsMap().keySet()) {
                 LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(getCorfuRuntime(),
                     topologyDescriptor.getTopologyConfigId(), remoteClusterId);
-                ReplicationSession replicationSession = new ReplicationSession(remoteClusterId, subscriber);
+                ReplicationSession replicationSession = new ReplicationSession(remoteClusterId,
+                        localClusterDescriptor.getClusterId(), subscriber);
                 remoteSessionToMetadataManagerMap.put(replicationSession, metadataManager);
             }
         }
@@ -393,7 +394,7 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
                 LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(getCorfuRuntime(),
                     topologyDescriptor.getTopologyConfigId(), remoteClusterId);
                 ReplicationSession replicationSession = ReplicationSession.getDefaultReplicationSessionForCluster(
-                    remoteClusterId);
+                    remoteClusterId, localClusterDescriptor.getClusterId());
                 remoteSessionToMetadataManagerMap.put(replicationSession, metadataManager);
             }
         }
@@ -738,7 +739,8 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
             for (String remoteClusterId : sinksToRemove) {
                 for (ReplicationSubscriber subscriber :
                     logReplicationConfig.getReplicationSubscriberToStreamsMap().keySet()) {
-                    ReplicationSession sessionToRemove = new ReplicationSession(remoteClusterId, subscriber);
+                    ReplicationSession sessionToRemove = new ReplicationSession(remoteClusterId,
+                            localClusterDescriptor.getClusterId(), subscriber);
                     removeClusterInfoFromStatusTable(sessionToRemove);
                     remoteSessionToMetadataManagerMap.remove(sessionToRemove);
                 }
@@ -889,7 +891,8 @@ public class CorfuReplicationDiscoveryService implements CorfuReplicationDiscove
         //  whole cluster?
         // For now, get the only supported(default) replication model and client for this cluster and trigger the
         // operation on it.
-        remoteSessionToMetadataManagerMap.get(ReplicationSession.getDefaultReplicationSessionForCluster(clusterId))
+        remoteSessionToMetadataManagerMap.get(ReplicationSession.getDefaultReplicationSessionForCluster(clusterId,
+                localClusterDescriptor.getClusterId()))
             .updateLogReplicationEventTable(key, event);
         return forceSyncId;
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/CorfuReplicationManager.java
@@ -7,8 +7,6 @@ import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicat
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationConfigManager;
 import org.corfudb.runtime.CorfuRuntime;
-import org.corfudb.runtime.exceptions.TransactionAbortedException;
-import org.corfudb.runtime.exceptions.unrecoverable.UnrecoverableCorfuInterruptedError;
 import org.corfudb.util.retry.IRetry;
 import org.corfudb.util.retry.IntervalRetry;
 import org.corfudb.util.retry.RetryNeededException;

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSession.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSession.java
@@ -1,8 +1,12 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.Getter;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.runtime.LogReplication;
 
 import java.util.Objects;
+
+import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.SAMPLE_CLIENT;
 
 
 /**
@@ -26,11 +30,15 @@ public class ReplicationSession {
     @Getter
     private final String remoteClusterId;
 
+    @Getter
+    private final String localClusterId;
+
    @Getter
    private final ReplicationSubscriber subscriber;
 
-    public ReplicationSession(String remoteClusterId, ReplicationSubscriber subscriber) {
+    public ReplicationSession(String remoteClusterId, String localClusterId, ReplicationSubscriber subscriber) {
         this.remoteClusterId = remoteClusterId;
+        this.localClusterId = localClusterId;
         this.subscriber = subscriber;
     }
 
@@ -43,17 +51,19 @@ public class ReplicationSession {
             return false;
         }
         ReplicationSession that = (ReplicationSession) o;
-        return remoteClusterId.equals(that.remoteClusterId) && subscriber.equals(that.subscriber);
+        return remoteClusterId.equals(that.remoteClusterId) && localClusterId.equals(that.localClusterId)
+                && subscriber.equals(that.subscriber);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(remoteClusterId, subscriber);
+        return Objects.hash(remoteClusterId, localClusterId, subscriber);
     }
 
     // TODO: To be removed after session is introduced in connections
-    public static ReplicationSession getDefaultReplicationSessionForCluster(String remoteClusterId) {
-        return new ReplicationSession(remoteClusterId, ReplicationSubscriber.getDefaultReplicationSubscriber());
+    public static ReplicationSession getDefaultReplicationSessionForCluster(String remoteClusterId, String localClusterId) {
+        return new ReplicationSession(remoteClusterId, localClusterId,
+            new ReplicationSubscriber(LogReplication.ReplicationModel.FULL_TABLE, SAMPLE_CLIENT));
     }
 
     @Override
@@ -61,7 +71,9 @@ public class ReplicationSession {
         return new StringBuffer()
             .append("Remote Cluster: ")
             .append(remoteClusterId)
-            .append(" Replication Subscriber: ")
+            .append("Local Cluster: ")
+            .append(localClusterId)
+            .append("Replication Subscriber: ")
             .append(subscriber)
             .toString();
     }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSubscriber.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/infrastructure/ReplicationSubscriber.java
@@ -1,7 +1,9 @@
 package org.corfudb.infrastructure.logreplication.infrastructure;
 
 import lombok.Getter;
-import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata.ReplicationModel;
+import org.corfudb.infrastructure.logreplication.proto.LogReplicationMetadata;
+import org.corfudb.runtime.LogReplication;
+
 import java.util.Objects;
 
 import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.SAMPLE_CLIENT;
@@ -19,19 +21,17 @@ import static org.corfudb.infrastructure.logreplication.LogReplicationConfig.SAM
 public class ReplicationSubscriber {
 
     @Getter
-    private final ReplicationModel replicationModel;
+    private final LogReplication.ReplicationModel replicationModel;
 
     @Getter
     private final String client;
 
-    public ReplicationSubscriber(ReplicationModel model, String client) {
+
+    public ReplicationSubscriber(LogReplication.ReplicationModel model, String client) {
         this.replicationModel = model;
         this.client = client;
     }
-
-    public static ReplicationSubscriber getDefaultReplicationSubscriber() {
-        return new ReplicationSubscriber(ReplicationModel.FULL_TABLE, SAMPLE_CLIENT);
-    }
+    
 
     @Override
     public boolean equals(Object o) {
@@ -42,7 +42,11 @@ public class ReplicationSubscriber {
             return false;
         }
         ReplicationSubscriber that = (ReplicationSubscriber) o;
-        return replicationModel == that.getReplicationModel() && client.equals(that.getClient());
+        return replicationModel == that.replicationModel && client.equals(that.client);
+    }
+
+    public static ReplicationSubscriber getDefaultReplicationSubscriber() {
+        return new ReplicationSubscriber(LogReplication.ReplicationModel.FULL_TABLE, SAMPLE_CLIENT);
     }
 
     @Override

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/runtime/CorfuLogReplicationRuntime.java
@@ -162,11 +162,13 @@ public class CorfuLogReplicationRuntime {
     /**
      * Default Constructor
      */
-    public CorfuLogReplicationRuntime(LogReplicationRuntimeParameters parameters, LogReplicationMetadataManager metadataManager,
-        LogReplicationConfigManager replicationConfigManager, ReplicationSession replicationSession) {
+    public CorfuLogReplicationRuntime(LogReplicationRuntimeParameters parameters,
+                                      LogReplicationMetadataManager metadataManager,
+                                      LogReplicationConfigManager replicationConfigManager,
+                                      ReplicationSession replicationSession) {
         this.remoteClusterId = replicationSession.getRemoteClusterId();
         this.metadataManager = metadataManager;
-        this.router = new LogReplicationClientRouter(parameters, this);
+        this.router = new LogReplicationClientRouter(parameters, this, replicationSession);
         this.router.addClient(new LogReplicationHandler());
         this.sourceManager = new LogReplicationSourceManager(parameters,
             new LogReplicationClient(router, remoteClusterId), metadataManager, replicationConfigManager, replicationSession);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/utils/LogReplicationConfigManager.java
@@ -92,6 +92,7 @@ public class LogReplicationConfigManager {
     @Getter
     private LogReplicationConfig config;
 
+    @Getter
     private ServerContext serverContext;
 
     /**

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationClientTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationClientTest.java
@@ -3,6 +3,7 @@ package org.corfudb.infrastructure;
 import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.corfudb.infrastructure.logreplication.infrastructure.ClusterDescriptor;
+import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSession;
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClient;
 import org.corfudb.infrastructure.logreplication.runtime.LogReplicationClientRouter;
@@ -52,7 +53,8 @@ public class LogReplicationClientTest {
         lrFsm = mock(CorfuLogReplicationRuntime.class);
         lrRuntimeParameters = mock(LogReplicationRuntimeParameters.class);
         doReturn(new ClusterDescriptor(SAMPLE_CLUSTER)).when(lrRuntimeParameters).getRemoteClusterDescriptor();
-        lrClient = spy(new LogReplicationClientRouter(lrRuntimeParameters, lrFsm));
+        ReplicationSession session = ReplicationSession.getDefaultReplicationSessionForCluster(SAMPLE_CLUSTER, SAMPLE_CLUSTER);
+        lrClient = spy(new LogReplicationClientRouter(lrRuntimeParameters, lrFsm, session));
 
         lrClientHandler = spy(new LogReplicationHandler());
         responseHandler = spy(lrClientHandler.createResponseHandlers(lrClientHandler, handlerMap));

--- a/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
+++ b/infrastructure/src/test/java/org/corfudb/infrastructure/LogReplicationServerTest.java
@@ -7,6 +7,7 @@ import org.corfudb.infrastructure.logreplication.infrastructure.ReplicationSessi
 import org.corfudb.infrastructure.logreplication.infrastructure.LogReplicationServer;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationMetadataManager;
 import org.corfudb.infrastructure.logreplication.replication.receive.LogReplicationSinkManager;
+import org.corfudb.runtime.LogReplication;
 import org.corfudb.runtime.LogReplication.LogReplicationEntryMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationLeadershipRequestMsg;
 import org.corfudb.runtime.LogReplication.LogReplicationMetadataRequestMsg;
@@ -47,7 +48,7 @@ public class LogReplicationServerTest {
     UuidMsg clusterId = UuidMsg.newBuilder().setLsb(5).setMsb(5).build();
     String sourceClusterId = getUUID(clusterId).toString();
     ReplicationSession replicationSession =
-        ReplicationSession.getDefaultReplicationSessionForCluster(sourceClusterId);
+        ReplicationSession.getDefaultReplicationSessionForCluster(sourceClusterId, sourceClusterId);
 
     /**
      * Stub most of the {@link LogReplicationServer} functionality, but spy on the actual instance.
@@ -72,7 +73,14 @@ public class LogReplicationServerTest {
         final LogReplicationMetadataRequestMsg metadataRequest = LogReplicationMetadataRequestMsg
                 .newBuilder().build();
         final RequestMsg request =
-            getRequestMsg(HeaderMsg.newBuilder().setClusterId(clusterId).build(),
+            getRequestMsg(HeaderMsg.newBuilder()
+                            .setClusterId(clusterId)
+                            .setSessionInfo(LogReplication.ReplicationSessionMsg.newBuilder()
+                                    .setLocalClusterId(replicationSession.getRemoteClusterId())
+                                    .setRemoteClusterId(replicationSession.getLocalClusterId())
+                                    .setClient(replicationSession.getSubscriber().getClient())
+                                    .build())
+                            .build(),
                 CorfuMessage.RequestPayloadMsg.newBuilder()
                 .setLrMetadataRequest(metadataRequest).build());
         final ResponseMsg response = ResponseMsg.newBuilder().build();
@@ -133,7 +141,14 @@ public class LogReplicationServerTest {
         final LogReplicationEntryMsg logEntry = LogReplicationEntryMsg
                 .newBuilder().build();
         final RequestMsg request =
-            getRequestMsg(HeaderMsg.newBuilder().setClusterId(clusterId).build(),
+            getRequestMsg(HeaderMsg.newBuilder()
+                            .setClusterId(clusterId)
+                            .setSessionInfo(LogReplication.ReplicationSessionMsg.newBuilder()
+                                    .setLocalClusterId(replicationSession.getRemoteClusterId())
+                                    .setRemoteClusterId(replicationSession.getLocalClusterId())
+                                    .setClient(replicationSession.getSubscriber().getClient())
+                                    .build())
+                            .build(),
                 CorfuMessage.RequestPayloadMsg.newBuilder()
                         .setLrEntry(logEntry).build());
         final LogReplicationEntryMsg ack = LogReplicationEntryMsg.newBuilder().build();

--- a/runtime/proto/service/corfu_message.proto
+++ b/runtime/proto/service/corfu_message.proto
@@ -39,6 +39,8 @@ message HeaderMsg {
   UuidMsg client_id = 6;
   bool ignore_cluster_id = 7;
   bool ignore_epoch = 8;
+  // LR sessions
+  ReplicationSessionMsg sessionInfo = 9;
 }
 
 message RequestPayloadMsg {

--- a/runtime/proto/service/log_replication.proto
+++ b/runtime/proto/service/log_replication.proto
@@ -53,3 +53,18 @@ enum LogReplicationEntryType {
   SNAPSHOT_END = 5;
   SNAPSHOT_TRANSFER_COMPLETE = 6;
 }
+
+message ReplicationSessionMsg {
+  string remoteClusterId = 1;
+  string localClusterId = 2;
+  string client = 3;
+  // TODO: this can be replaced with the replication tag
+  ReplicationModel replicationModel = 4;
+}
+
+enum ReplicationModel {
+  FULL_TABLE = 0;                 // Full table replication (Single Source to Single Sink = 1:1)
+  ROUTING_QUEUES = 1;             // Routing queue replication (used for entry-level replication) (1:1)
+  LOGICAL_GROUPS = 2;             // Table association to logical group (1:1)
+  MULTI_SOURCE_MERGE = 3;         // Same table replication from multiple sources to single sink (n:1)
+}

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogEntryWriterTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogEntryWriterTest.java
@@ -35,6 +35,7 @@ public class LogEntryWriterTest extends AbstractViewTest {
     private int numOpaqueEntries;
     private int topologyConfigId;
     private String remoteClusterId = "Remote Cluster";
+    private String localClusterId = "Local Cluster";
 
     @Before
     public void setUp() {
@@ -45,7 +46,7 @@ public class LogEntryWriterTest extends AbstractViewTest {
 
         // Create the default replication session
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(remoteClusterId);
+            ReplicationSession.getDefaultReplicationSessionForCluster(remoteClusterId, localClusterId);
 
         metadataManager = Mockito.mock(LogReplicationMetadataManager.class);
         initMocksForMetadataManager();

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -467,7 +467,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
 
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(runtime, null);
         ReplicationSession replicationSession = ReplicationSession.getDefaultReplicationSessionForCluster(
-            TEST_LOCAL_CLUSTER_ID);
+            TEST_LOCAL_CLUSTER_ID, TEST_LOCAL_CLUSTER_ID);
 
         switch(readerImpl) {
             case EMPTY:

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/MetadataManagerTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/MetadataManagerTest.java
@@ -36,7 +36,7 @@ public class MetadataManagerTest extends AbstractViewTest {
     private TestUtils utils;
     private String remoteClusterId = "Remote Cluster";
     private ReplicationSession replicationSession =
-        ReplicationSession.getDefaultReplicationSessionForCluster(remoteClusterId);
+        ReplicationSession.getDefaultReplicationSessionForCluster(remoteClusterId, localClusterId);
 
     @Before
     public void setUp() {

--- a/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationIT.java
@@ -79,6 +79,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
     private static final int WRITER_PORT = DEFAULT_PORT + 1;
     private static final String DESTINATION_ENDPOINT = DEFAULT_HOST + ":" + WRITER_PORT;
     private static final String REMOTE_CLUSTER_ID = UUID.randomUUID().toString();
+    private static final String SOURCE_CLUSTER_ID = UUID.randomUUID().toString();
     private static final int CORFU_PORT = 9000;
     private static final String TABLE_PREFIX = "test";
 
@@ -1225,7 +1226,7 @@ public class LogReplicationIT extends AbstractIT implements Observer {
             logReplicationMetadataManager, nettyConfig, function);
 
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(REMOTE_CLUSTER_ID);
+            ReplicationSession.getDefaultReplicationSessionForCluster(REMOTE_CLUSTER_ID, SOURCE_CLUSTER_ID);
 
         // Source Manager
         LogReplicationSourceManager logReplicationSourceManager = new LogReplicationSourceManager(

--- a/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
+++ b/test/src/test/java/org/corfudb/integration/LogReplicationReaderWriterIT.java
@@ -238,7 +238,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
 
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
+            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID, SOURCE_CLUSTER_ID);
 
         StreamsSnapshotReader reader = new StreamsSnapshotReader(rt, configManager, replicationSession);
 
@@ -275,7 +275,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
 
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
+            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID, SOURCE_CLUSTER_ID);
 
         StreamsSnapshotWriter writer = new StreamsSnapshotWriter(rt, configManager, logReplicationMetadataManager,
             replicationSession);
@@ -302,7 +302,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
 
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
+            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID, SOURCE_CLUSTER_ID);
 
         StreamsLogEntryReader reader = new StreamsLogEntryReader(rt, configManager, replicationSession);
         reader.setGlobalBaseSnapshot(Address.NON_ADDRESS, Address.NON_ADDRESS);
@@ -340,7 +340,7 @@ public class LogReplicationReaderWriterIT extends AbstractIT {
         LogReplicationConfigManager configManager = new LogReplicationConfigManager(rt);
 
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID);
+            ReplicationSession.getDefaultReplicationSessionForCluster(SINK_CLUSTER_ID, SOURCE_CLUSTER_ID);
 
         LogEntryWriter writer = new LogEntryWriter(configManager, logReplicationMetadataManager, replicationSession);
 

--- a/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
+++ b/test/src/test/java/org/corfudb/integration/SourceForwardingDataSender.java
@@ -109,7 +109,7 @@ public class SourceForwardingDataSender extends AbstractIT implements DataSender
         this.destinationDataControl = new DefaultDataControl(new DefaultDataControlConfig(
             false, 0));
         ReplicationSession replicationSession =
-            ReplicationSession.getDefaultReplicationSessionForCluster(testConfig.getRemoteClusterId());
+            ReplicationSession.getDefaultReplicationSessionForCluster(testConfig.getRemoteClusterId(), testConfig.getRemoteClusterId());
 
         // TODO pankti: This test-only constructor can be removed
         this.destinationLogReplicationManager = new LogReplicationSinkManager(runtime.getLayoutServers().get(0),


### PR DESCRIPTION
## Overview

Description:
This change introduces sessionInfo in the headerMsg. The field is specific to LR and will only be used by LR

No new tests added. The existing tests go through the paths that have changed


Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
