### PR TITLE
LR-IT: Fix MaxWriteSize to account for serialized size increase

### DIFF
--- a/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuReplicationLargeTxIT.java
@@ -44,7 +44,7 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
         Sample.Metadata>> mapNameToMapStandby = new HashMap<>();
 
     private static final int NUM_ENTRIES_PER_TABLE = 20;
-    private static final int MAX_WRITE_SIZE = 7000;
+    private static final int MAX_WRITE_SIZE = 8000;
 
     /**
      * With the max write size of MAX_WRITE_SIZE, it was empirically
@@ -59,8 +59,8 @@ public class CorfuReplicationLargeTxIT extends LogReplicationAbstractIT {
     }
 
     /**
-     * With the max write size of SEVEN_THOUSAND, it was empirically
-     * determined that 20 entries in a table had a serialized size of 5.5K
+     * With the max write size of EIGHT_THOUSAND, it was empirically
+     * determined that 20 entries in a table had a serialized size of 7.5K
      * approx.  Hence, a snapshot sync with twice the data(40 entries) will be
      * applied in 2 transactions.
      * @throws Exception


### PR DESCRIPTION
## Overview

Description:

Why should this be merged: 

With new schema options the default serialized size of table entries goes up causing tests that assumed a previous max write size to fail.
So correcting the write size for these tests to pass

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
