### PR TITLE
fix(sec): upgrade com.google.protobuf:protobuf-java to 3.16.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <slf4j.version>1.7.32</slf4j.version>
         <netty.version>4.1.77.Final</netty.version>
         <netty.tcnative.version>2.0.52.Final</netty.tcnative.version>
-        <protobuf.version>3.6.1</protobuf.version>
+        <protobuf.version>3.21.7</protobuf.version>
         <commons.io.version>2.11.0</commons.io.version>
         <lombok.version>1.18.24</lombok.version>
         <guava.version>28.0-jre</guava.version>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.google.protobuf:protobuf-java 3.6.1
- [CVE-2021-22569](https://www.oscs1024.com/hd/CVE-2021-22569)


### What did I do？
Upgrade com.google.protobuf:protobuf-java from 3.6.1 to 3.16.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS