### PR TITLE
Additional APIs for LR Client: setDestination

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/LogReplicationLogicalGroupClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/LogReplicationLogicalGroupClient.java
@@ -34,6 +34,8 @@ import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
 
 /**
  * A client to interface with log replication utilizing the logical groups replication model.
+ * <p>
+ * Thread safety of client operations enforced by utilization of transactions.
  */
 @Slf4j
 public class LogReplicationLogicalGroupClient {

--- a/test/src/test/java/org/corfudb/runtime/LogReplicationLogicalGroupClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/LogReplicationLogicalGroupClientTest.java
@@ -381,6 +381,10 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         Assert.assertEquals(expectedNumberRegisteredGroups1, sourceMetadataTable.count());
     }
 
+    /**
+     * Test sample usage of client APIs.
+     *
+     */
     @Test
     public void testClientOperations() {
         final String logicalGroup = "LOGICAL-GROUP";

--- a/test/src/test/java/org/corfudb/runtime/LogReplicationLogicalGroupClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/LogReplicationLogicalGroupClientTest.java
@@ -90,134 +90,37 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     }
 
     /**
-     * Test adding a singular destination at a time.
-     *
-     */
-    @Test
-    public void testAddDestination() {
-        // Test adding a destination with null/empty logicalGroup.
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestination("", "DESTINATION"));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestination(null, "DESTINATION"));
-
-        // Test adding a destination with null/empty name.
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestination("LOGICAL-GROUP", ""));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestination("LOGICAL-GROUP", (String) null));
-
-        // Test destinations are added successfully.
-        final int expectedNumberDestinations = 1;
-        final String currentTableEntryKey = "LOGICAL-GROUP";
-        client.addDestination("LOGICAL-GROUP", "DESTINATION");
-        Assert.assertEquals(expectedNumberDestinations, sourceMetadataTable.entryStream()
-                .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
-                .findFirst().get().getPayload().getDestinationIdsList().size());
-
-        // Test adding a duplicate of an existing destination, duplicate should not be added
-        // and a warning is logged here.
-        final List<String> expectedDestinations = Collections.singletonList("DESTINATION");
-        final String currentTableEntryKey1 = "LOGICAL-GROUP";
-        client.addDestination("LOGICAL-GROUP", "DESTINATION");
-        Assert.assertEquals(expectedDestinations, sourceMetadataTable.entryStream()
-                .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey1))
-                .findFirst().get().getPayload().getDestinationIdsList());
-
-        // Test adding destinations to a second logical group.
-        final int expectedNumberDestinations1 = 2;
-        final String currentTableEntryKey2 = "LOGICAL-GROUP1";
-        client.addDestination("LOGICAL-GROUP1", "DESTINATION");
-        client.addDestination("LOGICAL-GROUP1", "DESTINATION1");
-        Assert.assertEquals(expectedNumberDestinations1, sourceMetadataTable.entryStream()
-                .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey2))
-                .findFirst().get().getPayload().getDestinationIdsList().size());
-
-        // Test that the overall table size is correct, 2 expected since 2 groups created.
-        final int expectedNumberRegisteredGroups = 2;
-        Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
-    }
-
-    /**
-     * Test removing a singular destination at a time.
-     *
-     */
-    @Test
-    public void testRemoveDestination() {
-        // Test removing a destination with null/empty logicalGroup.
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestination("", "DESTINATION"));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestination(null, "DESTINATION"));
-
-        // Test removing a destination with null/empty name.
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestination("LOGICAL-GROUP", ""));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestination("LOGICAL-GROUP", (String) null));
-
-        // Test add then remove, group should be deleted once empty.
-        final int expectedNumberRegisteredGroups = 0;
-        client.addDestination("LOGICAL-GROUP", "DESTINATION");
-        client.removeDestination("LOGICAL-GROUP", "DESTINATION");
-        Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
-
-        // Test destinations are removed successfully.
-        final Set<String> expectedDestinations = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION2"));
-        final String currentTableEntryKey = "LOGICAL-GROUP";
-        client.addDestination("LOGICAL-GROUP", "DESTINATION");
-        client.addDestination("LOGICAL-GROUP", "DESTINATION1");
-        client.addDestination("LOGICAL-GROUP", "DESTINATION2");
-        client.removeDestination("LOGICAL-GROUP", "DESTINATION1");
-        // DESTINATION1 does not exist after removal, a warning is logged here but an error
-        // should not be thrown.
-        client.removeDestination("LOGICAL-GROUP", "DESTINATION1");
-        Assert.assertEquals(expectedDestinations, new HashSet<>(sourceMetadataTable.entryStream()
-                .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
-                .findFirst().get().getPayload().getDestinationIdsList()));
-
-        // Test removal from a group that does not exist, a warning is logged here but an error
-        // should not be thrown.
-        final Set<String> expectedDestinations1 = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION2"));
-        final String currentTableEntryKey1 = "LOGICAL-GROUP";
-        client.removeDestination("LOGICAL-GROUP1", "DESTINATION");
-        Assert.assertEquals(expectedDestinations1, new HashSet<>(sourceMetadataTable.entryStream()
-                .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey1))
-                .findFirst().get().getPayload().getDestinationIdsList()));
-    }
-
-    /**
      * Test adding multiple destinations.
      *
      */
     @Test
-    public void testAddListOfDestination() {
+    public void testAddListOfDestinations() {
         // Test adding multiple destinations with request having a malformed logicalGroup.
         final List<String> destinationsToAdd = Collections.singletonList("DESTINATION");
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestination("", destinationsToAdd));
+                () -> client.addDestinations("", destinationsToAdd));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestination(null, destinationsToAdd));
+                () -> client.addDestinations(null, destinationsToAdd));
 
         // Test adding multiple destinations with request having a malformed destination.
         final List<String> destinationsToAdd1 = Collections.singletonList("");
         final List<String> destinationsToAdd2 = Collections.singletonList(null);
         final List<String> destinationsToAdd3 = new ArrayList<>();
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestination("LOGICAL-GROUP", destinationsToAdd1));
+                () -> client.addDestinations("LOGICAL-GROUP", destinationsToAdd1));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestination("LOGICAL-GROUP", destinationsToAdd2));
+                () -> client.addDestinations("LOGICAL-GROUP", destinationsToAdd2));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestination("LOGICAL-GROUP", destinationsToAdd3));
+                () -> client.addDestinations("LOGICAL-GROUP", destinationsToAdd3));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestination("LOGICAL-GROUP", (List<String>) null));
+                () -> client.addDestinations("LOGICAL-GROUP", (List<String>) null));
 
         // Test adding list of destinations that contain a duplicate, list gets de-duplicated
         // and a warning is logged here.
         final int expectedNumberDestinations = 1;
         final String currentTableEntryKey = "LOGICAL-GROUP";
         final List<String> destinationsToAdd4 = Arrays.asList("DESTINATION", "DESTINATION");
-        client.addDestination("LOGICAL-GROUP", destinationsToAdd4);
+        client.addDestinations("LOGICAL-GROUP", destinationsToAdd4);
         Assert.assertEquals(expectedNumberDestinations, sourceMetadataTable.entryStream()
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
@@ -227,10 +130,10 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         final String currentTableEntryKey2 = "LOGICAL-GROUP1";
         final List<String> destinationsToAdd5 = Arrays.asList("DESTINATION", "DESTINATION1");
         final List<String> destinationsToAdd6 = Arrays.asList("DESTINATION2", "DESTINATION3");
-        client.addDestination("LOGICAL-GROUP1", destinationsToAdd5);
+        client.addDestinations("LOGICAL-GROUP1", destinationsToAdd5);
         // Test adding destinations that already exist, warning is logged here.
-        client.addDestination("LOGICAL-GROUP1", destinationsToAdd5);
-        client.addDestination("LOGICAL-GROUP1", destinationsToAdd6);
+        client.addDestinations("LOGICAL-GROUP1", destinationsToAdd5);
+        client.addDestinations("LOGICAL-GROUP1", destinationsToAdd6);
         Assert.assertEquals(expectedNumberDestinations2, sourceMetadataTable.entryStream()
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey2))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
@@ -249,28 +152,28 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         // Test removing multiple destinations with request having a malformed logicalGroup.
         final List<String> destinationsToRemove = Collections.singletonList("DESTINATION");
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestination("", destinationsToRemove));
+                () -> client.removeDestinations("", destinationsToRemove));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestination(null, destinationsToRemove));
+                () -> client.removeDestinations(null, destinationsToRemove));
 
         // Test removing multiple destinations with request having a malformed destination.
         final List<String> destinationsToRemove1 = Collections.singletonList("");
         final List<String> destinationsToRemove2 = Collections.singletonList(null);
         final List<String> destinationsToRemove3 = new ArrayList<>();
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestination("LOGICAL-GROUP", destinationsToRemove1));
+                () -> client.removeDestinations("LOGICAL-GROUP", destinationsToRemove1));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestination("LOGICAL-GROUP", destinationsToRemove2));
+                () -> client.removeDestinations("LOGICAL-GROUP", destinationsToRemove2));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestination("LOGICAL-GROUP", destinationsToRemove3));
+                () -> client.removeDestinations("LOGICAL-GROUP", destinationsToRemove3));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestination("LOGICAL-GROUP", (List<String>) null));
+                () -> client.removeDestinations("LOGICAL-GROUP", (List<String>) null));
 
         // Test add then remove, group should be deleted once empty.
         final int expectedNumberRegisteredGroups = 0;
         final List<String> destinationsToRemove4 = Arrays.asList("DESTINATION", "DESTINATION1");
-        client.addDestination("LOGICAL-GROUP", destinationsToRemove4);
-        client.removeDestination("LOGICAL-GROUP", destinationsToRemove4);
+        client.addDestinations("LOGICAL-GROUP", destinationsToRemove4);
+        client.removeDestinations("LOGICAL-GROUP", destinationsToRemove4);
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
 
         // Test removal of multiple destinations.
@@ -278,13 +181,13 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         final String currentTableEntryKey = "LOGICAL-GROUP";
         final List<String> destinationsToAdd = Arrays.asList("DESTINATION", "DESTINATION1", "DESTINATION2", "DESTINATION3");
         final List<String> destinationsToRemove5 = Arrays.asList("DESTINATION1", "DESTINATION3", "DESTINATION4", "DESTINATION5");
-        client.addDestination("LOGICAL-GROUP", destinationsToAdd);
+        client.addDestinations("LOGICAL-GROUP", destinationsToAdd);
         // Some destinations in destinationsToRemove5 do not exist, a waning is logged here but an
         // exception should not be thrown.
-        client.removeDestination("LOGICAL-GROUP", destinationsToRemove5);
+        client.removeDestinations("LOGICAL-GROUP", destinationsToRemove5);
         // No destinations in destinationsToRemove5 should exist after removal, a warning is logged
         // here but an exception should not be thrown.
-        client.removeDestination("LOGICAL-GROUP", destinationsToRemove5);
+        client.removeDestinations("LOGICAL-GROUP", destinationsToRemove5);
         Assert.assertEquals(expectedDestinations, new HashSet<>(sourceMetadataTable.entryStream()
                         .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
                         .findFirst().get().getPayload().getDestinationIdsList()));
@@ -292,7 +195,7 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         // Test removal from a group that does not exist, warning is logged here.
         final Set<String> expectedDestinations1 = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION2"));
         final String currentTableEntryKey1 = "LOGICAL-GROUP";
-        client.removeDestination("LOGICAL-GROUP1", Collections.singletonList("DESTINATION"));
+        client.removeDestinations("LOGICAL-GROUP1", Collections.singletonList("DESTINATION"));
         Assert.assertEquals(expectedDestinations1, new HashSet<>(sourceMetadataTable.entryStream()
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey1))
                 .findFirst().get().getPayload().getDestinationIdsList()));
@@ -306,20 +209,20 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     public void testGetDestinations() {
         // Test get destinations with null/empty group.
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.getDestination(null));
+                () -> client.getDestinations(null));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.getDestination(""));
+                () -> client.getDestinations(""));
 
         // Add destinations to get later.
         final List<String> destinationsToSet = Arrays.asList("DESTINATION", "DESTINATION1");
-        client.setDestination("LOGICAL-GROUP", destinationsToSet);
+        client.setDestinations("LOGICAL-GROUP", destinationsToSet);
 
         // Test getting destinations.
         final Set<String> expectedDestinations = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION1"));
-        Assert.assertEquals(expectedDestinations, new HashSet<>(client.getDestination("LOGICAL-GROUP")));
+        Assert.assertEquals(expectedDestinations, new HashSet<>(client.getDestinations("LOGICAL-GROUP")));
 
         // Test get destinations on an invalid group.
-        Assert.assertNull(client.getDestination("LOGICAL-GROUP1"));
+        Assert.assertNull(client.getDestinations("LOGICAL-GROUP1"));
     }
 
     /**
@@ -331,28 +234,28 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         // Test setting with request having a malformed logicalGroup.
         final List<String> destinationsToSet = Collections.singletonList("DESTINATION");
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestination("", destinationsToSet));
+                () -> client.setDestinations("", destinationsToSet));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestination(null, destinationsToSet));
+                () -> client.setDestinations(null, destinationsToSet));
 
         // Test setting  with request having a malformed destination.
         final List<String> destinationsToSet1 = Collections.singletonList("");
         final List<String> destinationsToSet2 = Collections.singletonList(null);
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestination("LOGICAL-GROUP", destinationsToSet1));
+                () -> client.setDestinations("LOGICAL-GROUP", destinationsToSet1));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestination("LOGICAL-GROUP", destinationsToSet2));
+                () -> client.setDestinations("LOGICAL-GROUP", destinationsToSet2));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestination("LOGICAL-GROUP", null));
+                () -> client.setDestinations("LOGICAL-GROUP", null));
 
         // Test clearing existing destination with passing empty list.
         final int expectedNumberRegisteredGroups = 0;
         final List<String> destinationsToSet3 = Arrays.asList("DESTINATION", "DESTINATION1");
-        client.setDestination("LOGICAL-GROUP", destinationsToSet3);
+        client.setDestinations("LOGICAL-GROUP", destinationsToSet3);
         // Check that destinations for the logical group is not empty.
         Assert.assertEquals(new HashSet<>(destinationsToSet3),
-                new HashSet<>(client.getDestination("LOGICAL-GROUP")));
-        client.setDestination("LOGICAL-GROUP", new ArrayList<>());
+                new HashSet<>(client.getDestinations("LOGICAL-GROUP")));
+        client.setDestinations("LOGICAL-GROUP", new ArrayList<>());
         // Check that the logical group was deleted after being emptied.
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
 
@@ -361,7 +264,7 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         final int expectedNumberDestinations = 1;
         final String currentTableEntryKey = "LOGICAL-GROUP";
         final List<String> destinationsToSet4 = Arrays.asList("DESTINATION", "DESTINATION");
-        client.setDestination("LOGICAL-GROUP", destinationsToSet4);
+        client.setDestinations("LOGICAL-GROUP", destinationsToSet4);
         Assert.assertEquals(expectedNumberDestinations, sourceMetadataTable.entryStream()
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
@@ -369,12 +272,12 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         // Test init and consequent overwrite of a new logical group using setDestinations.
         final List<String> destinationsToSet5 = Arrays.asList("DESTINATION", "DESTINATION1");
         final List<String> destinationsToSet6 = Arrays.asList("DESTINATION", "DESTINATION1");
-        client.setDestination("LOGICAL-GROUP1", destinationsToSet5);
+        client.setDestinations("LOGICAL-GROUP1", destinationsToSet5);
         Assert.assertEquals(new HashSet<>(destinationsToSet5),
-                new HashSet<>(client.getDestination("LOGICAL-GROUP1")));
-        client.setDestination("LOGICAL-GROUP1", destinationsToSet6);
+                new HashSet<>(client.getDestinations("LOGICAL-GROUP1")));
+        client.setDestinations("LOGICAL-GROUP1", destinationsToSet6);
         Assert.assertEquals(new HashSet<>(destinationsToSet6),
-                new HashSet<>(client.getDestination("LOGICAL-GROUP1")));
+                new HashSet<>(client.getDestinations("LOGICAL-GROUP1")));
 
         // Test that the overall table size is correct.
         final int expectedNumberRegisteredGroups1 = 2;
@@ -388,29 +291,29 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     @Test
     public void testClientOperations() {
         final String logicalGroup = "LOGICAL-GROUP";
-        final String destination = "DESTINATION";
+        final List<String> destination = Collections.singletonList("DESTINATION");
         final List<String> destinations = Arrays.asList("DESTINATION", "DESTINATION1");
 
         // Test addDestination does not add same destination twice.
-        client.addDestination(logicalGroup, destination);
-        client.addDestination(logicalGroup, destinations);
+        client.addDestinations(logicalGroup, destination);
+        client.addDestinations(logicalGroup, destinations);
         Assert.assertEquals(new HashSet<>(destinations),
-                new HashSet<>(client.getDestination(logicalGroup)));
+                new HashSet<>(client.getDestinations(logicalGroup)));
 
         final List<String> destinations1 = Arrays.asList("DESTINATION1", "DESTINATION2");
         // Test overwrite with setDestinations.
-        client.setDestination(logicalGroup, destinations1);
+        client.setDestinations(logicalGroup, destinations1);
         Assert.assertEquals(new HashSet<>(destinations1),
-                new HashSet<>(client.getDestination(logicalGroup)));
+                new HashSet<>(client.getDestinations(logicalGroup)));
 
         // Test removal of single destination, and consequent removal or remaining.
-        final String destination1 = "DESTINATION1";
+        final List<String> destination1 = Collections.singletonList("DESTINATION1");
         final int expectedNumberRegisteredGroups = 0;
         final List<String> destinationsAfterRemoval = Collections.singletonList("DESTINATION2");
-        client.removeDestination(logicalGroup, destination1);
+        client.removeDestinations(logicalGroup, destination1);
         Assert.assertEquals(new HashSet<>(destinationsAfterRemoval),
-                new HashSet<>(client.getDestination(logicalGroup)));
-        client.removeDestination(logicalGroup, destinations1);
+                new HashSet<>(client.getDestinations(logicalGroup)));
+        client.removeDestinations(logicalGroup, destinations1);
         // Number of groups should be 0 after logical group is emptied and deleted.
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
     }

--- a/test/src/test/java/org/corfudb/runtime/LogReplicationLogicalGroupClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/LogReplicationLogicalGroupClientTest.java
@@ -61,28 +61,28 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     }
 
     /**
-     * Test registering replication client
+     * Test registering replication client.
      *
      */
     @Test
     public void testRegisterReplicationClient()
             throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
-        // Test registering client with null/empty client name
+        // Test registering client with null/empty client name.
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> new LogReplicationLogicalGroupClient(runtime, null));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> new LogReplicationLogicalGroupClient(runtime, ""));
 
-        // Check to see if client was registered from the @Before function
+        // Check to see if client was registered from the @Before function.
         final int expectedNumberRegisteredClients = 1;
         Assert.assertEquals(expectedNumberRegisteredClients, replicationRegistrationTable.count());
 
-        // Test registering a duplicate client
+        // Test registering a duplicate client.
         new LogReplicationLogicalGroupClient(runtime, clientName);
         final int expectedNumberRegisteredClients1 = 1;
         Assert.assertEquals(expectedNumberRegisteredClients1, replicationRegistrationTable.count());
 
-        // Test registering 2 additional clients
+        // Test registering 2 additional clients.
         new LogReplicationLogicalGroupClient(runtime, "client1");
         new LogReplicationLogicalGroupClient(runtime, "client2");
         final int expectedNumberRegisteredClients2 = 3;
@@ -90,24 +90,24 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     }
 
     /**
-     * Test add destination
+     * Test adding a singular destination at a time.
      *
      */
     @Test
     public void testAddDestination() {
-        // Test adding a destination with null/empty logicalGroup
+        // Test adding a destination with null/empty logicalGroup.
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.addDestination("", "DESTINATION"));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.addDestination(null, "DESTINATION"));
 
-        // Test adding a destination with null/empty name
+        // Test adding a destination with null/empty name.
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.addDestination("LOGICAL-GROUP", ""));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.addDestination("LOGICAL-GROUP", (String) null));
 
-        // Test adding a destination
+        // Test destinations are added successfully.
         final int expectedNumberDestinations = 1;
         final String currentTableEntryKey = "LOGICAL-GROUP";
         client.addDestination("LOGICAL-GROUP", "DESTINATION");
@@ -115,7 +115,8 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
 
-        // Test adding a duplicate of an existing destination, duplicate should not be added and log warning
+        // Test adding a duplicate of an existing destination, duplicate should not be added
+        // and a warning is logged here.
         final List<String> expectedDestinations = Collections.singletonList("DESTINATION");
         final String currentTableEntryKey1 = "LOGICAL-GROUP";
         client.addDestination("LOGICAL-GROUP", "DESTINATION");
@@ -123,7 +124,7 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey1))
                 .findFirst().get().getPayload().getDestinationIdsList());
 
-        // Test adding destinations to a second logical group
+        // Test adding destinations to a second logical group.
         final int expectedNumberDestinations1 = 2;
         final String currentTableEntryKey2 = "LOGICAL-GROUP1";
         client.addDestination("LOGICAL-GROUP1", "DESTINATION");
@@ -132,49 +133,51 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey2))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
 
-        // Test that the overall table size is correct, 2 expected since 2 groups created
+        // Test that the overall table size is correct, 2 expected since 2 groups created.
         final int expectedNumberRegisteredGroups = 2;
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
     }
 
     /**
-     * Test remove destination
+     * Test removing a singular destination at a time.
      *
      */
     @Test
     public void testRemoveDestination() {
-        // Test adding a destination with null/empty logicalGroup
+        // Test removing a destination with null/empty logicalGroup.
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.removeDestination("", "DESTINATION"));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.removeDestination(null, "DESTINATION"));
 
-        // Test adding a destination with null/empty name
+        // Test removing a destination with null/empty name.
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.removeDestination("LOGICAL-GROUP", ""));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.removeDestination("LOGICAL-GROUP", (String) null));
 
-        // Test add then remove, group should be deleted once empty
+        // Test add then remove, group should be deleted once empty.
         final int expectedNumberRegisteredGroups = 0;
         client.addDestination("LOGICAL-GROUP", "DESTINATION");
         client.removeDestination("LOGICAL-GROUP", "DESTINATION");
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
 
-        // Test removal of destinations
+        // Test destinations are removed successfully.
         final Set<String> expectedDestinations = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION2"));
         final String currentTableEntryKey = "LOGICAL-GROUP";
         client.addDestination("LOGICAL-GROUP", "DESTINATION");
         client.addDestination("LOGICAL-GROUP", "DESTINATION1");
         client.addDestination("LOGICAL-GROUP", "DESTINATION2");
         client.removeDestination("LOGICAL-GROUP", "DESTINATION1");
-        // DESTINATION1 does not exist after removal, log warning here but should not throw exception
+        // DESTINATION1 does not exist after removal, a warning is logged here but an error
+        // should not be thrown.
         client.removeDestination("LOGICAL-GROUP", "DESTINATION1");
         Assert.assertEquals(expectedDestinations, new HashSet<>(sourceMetadataTable.entryStream()
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
                 .findFirst().get().getPayload().getDestinationIdsList()));
 
-        // Test removal from a group that does not exist, noop and log warning
+        // Test removal from a group that does not exist, a warning is logged here but an error
+        // should not be thrown.
         final Set<String> expectedDestinations1 = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION2"));
         final String currentTableEntryKey1 = "LOGICAL-GROUP";
         client.removeDestination("LOGICAL-GROUP1", "DESTINATION");
@@ -184,19 +187,19 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     }
 
     /**
-     * Test add multiple destinations
+     * Test adding multiple destinations.
      *
      */
     @Test
     public void testAddListOfDestination() {
-        // Test adding with request having a malformed logicalGroup
+        // Test adding multiple destinations with request having a malformed logicalGroup.
         final List<String> destinationsToAdd = Collections.singletonList("DESTINATION");
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.addDestination("", destinationsToAdd));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.addDestination(null, destinationsToAdd));
 
-        // Test adding with request having a malformed destination
+        // Test adding multiple destinations with request having a malformed destination.
         final List<String> destinationsToAdd1 = Collections.singletonList("");
         final List<String> destinationsToAdd2 = Collections.singletonList(null);
         final List<String> destinationsToAdd3 = new ArrayList<>();
@@ -209,7 +212,8 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.addDestination("LOGICAL-GROUP", (List<String>) null));
 
-        // Test adding list of destinations that contain a duplicate, list gets de-duplicated and log warning here
+        // Test adding list of destinations that contain a duplicate, list gets de-duplicated
+        // and a warning is logged here.
         final int expectedNumberDestinations = 1;
         final String currentTableEntryKey = "LOGICAL-GROUP";
         final List<String> destinationsToAdd4 = Arrays.asList("DESTINATION", "DESTINATION");
@@ -218,38 +222,38 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
 
-        // Test adding destinations to a second logical group
+        // Test adding destinations to a second logical group.
         final int expectedNumberDestinations2 = 4;
         final String currentTableEntryKey2 = "LOGICAL-GROUP1";
         final List<String> destinationsToAdd5 = Arrays.asList("DESTINATION", "DESTINATION1");
         final List<String> destinationsToAdd6 = Arrays.asList("DESTINATION2", "DESTINATION3");
         client.addDestination("LOGICAL-GROUP1", destinationsToAdd5);
-        // Test adding destinations that already exist, log warning here
+        // Test adding destinations that already exist, warning is logged here.
         client.addDestination("LOGICAL-GROUP1", destinationsToAdd5);
         client.addDestination("LOGICAL-GROUP1", destinationsToAdd6);
         Assert.assertEquals(expectedNumberDestinations2, sourceMetadataTable.entryStream()
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey2))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
 
-        // Test that the overall table size is correct
+        // Test that the overall table size is correct.
         final int expectedNumberRegisteredGroups = 2;
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
     }
 
     /**
-     * Test removal of multiple destinations
+     * Test removing multiple destinations.
      *
      */
     @Test
     public void testRemoveListOfDestinations() {
-        // Test adding with request having a malformed logicalGroup
+        // Test removing multiple destinations with request having a malformed logicalGroup.
         final List<String> destinationsToRemove = Collections.singletonList("DESTINATION");
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.removeDestination("", destinationsToRemove));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.removeDestination(null, destinationsToRemove));
 
-        // Test adding with request having a malformed destination
+        // Test removing multiple destinations with request having a malformed destination.
         final List<String> destinationsToRemove1 = Collections.singletonList("");
         final List<String> destinationsToRemove2 = Collections.singletonList(null);
         final List<String> destinationsToRemove3 = new ArrayList<>();
@@ -262,28 +266,30 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.removeDestination("LOGICAL-GROUP", (List<String>) null));
 
-        // Test add then remove, group should be deleted once empty
+        // Test add then remove, group should be deleted once empty.
         final int expectedNumberRegisteredGroups = 0;
         final List<String> destinationsToRemove4 = Arrays.asList("DESTINATION", "DESTINATION1");
         client.addDestination("LOGICAL-GROUP", destinationsToRemove4);
         client.removeDestination("LOGICAL-GROUP", destinationsToRemove4);
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
 
-        // Test removal of multiple destinations
+        // Test removal of multiple destinations.
         final Set<String> expectedDestinations = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION2"));
         final String currentTableEntryKey = "LOGICAL-GROUP";
         final List<String> destinationsToAdd = Arrays.asList("DESTINATION", "DESTINATION1", "DESTINATION2", "DESTINATION3");
         final List<String> destinationsToRemove5 = Arrays.asList("DESTINATION1", "DESTINATION3", "DESTINATION4", "DESTINATION5");
         client.addDestination("LOGICAL-GROUP", destinationsToAdd);
-        // Some in destinationsToRemove5 do not exist, log warning here but should not throw exception
+        // Some destinations in destinationsToRemove5 do not exist, a waning is logged here but an
+        // exception should not be thrown.
         client.removeDestination("LOGICAL-GROUP", destinationsToRemove5);
-        // None in destinationsToRemove5 should exist after removal, log warning here but should not throw exception
+        // No destinations in destinationsToRemove5 should exist after removal, a warning is logged
+        // here but an exception should not be thrown.
         client.removeDestination("LOGICAL-GROUP", destinationsToRemove5);
         Assert.assertEquals(expectedDestinations, new HashSet<>(sourceMetadataTable.entryStream()
                         .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
                         .findFirst().get().getPayload().getDestinationIdsList()));
 
-        // Test removal from a group that does not exist, noop and log warning
+        // Test removal from a group that does not exist, warning is logged here.
         final Set<String> expectedDestinations1 = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION2"));
         final String currentTableEntryKey1 = "LOGICAL-GROUP";
         client.removeDestination("LOGICAL-GROUP1", Collections.singletonList("DESTINATION"));
@@ -293,27 +299,27 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     }
 
     /**
-     * Test getting destinations for a logical group
+     * Test getting destinations for a logical group.
      *
      */
     @Test
     public void testGetDestinations() {
-        // Test get destinations with null/empty group
+        // Test get destinations with null/empty group.
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.getDestinations(null));
+                () -> client.getDestination(null));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.getDestinations(""));
+                () -> client.getDestination(""));
 
-        // Add destinations to get later
-        client.addDestination("LOGICAL-GROUP", "DESTINATION");
-        client.addDestination("LOGICAL-GROUP", "DESTINATION1");
+        // Add destinations to get later.
+        final List<String> destinationsToSet = Arrays.asList("DESTINATION", "DESTINATION1");
+        client.setDestination("LOGICAL-GROUP", destinationsToSet);
 
-        // Test getting destinations
+        // Test getting destinations.
         final Set<String> expectedDestinations = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION1"));
-        Assert.assertEquals(expectedDestinations, new HashSet<>(client.getDestinations("LOGICAL-GROUP")));
+        Assert.assertEquals(expectedDestinations, new HashSet<>(client.getDestination("LOGICAL-GROUP")));
 
-        // Test get destinations on an invalid group
-        Assert.assertNull(client.getDestinations("LOGICAL-GROUP1"));
+        // Test get destinations on an invalid group.
+        Assert.assertNull(client.getDestination("LOGICAL-GROUP1"));
     }
 
     /**
@@ -322,48 +328,86 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
      */
     @Test
     public void testSetDestinations() {
-        // Test setting with request having a malformed logicalGroup
+        // Test setting with request having a malformed logicalGroup.
         final List<String> destinationsToSet = Collections.singletonList("DESTINATION");
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestinations("", destinationsToSet));
+                () -> client.setDestination("", destinationsToSet));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestinations(null, destinationsToSet));
+                () -> client.setDestination(null, destinationsToSet));
 
-        // Test setting  with request having a malformed destination
+        // Test setting  with request having a malformed destination.
         final List<String> destinationsToSet1 = Collections.singletonList("");
         final List<String> destinationsToSet2 = Collections.singletonList(null);
-        final List<String> destinationsToSet3 = new ArrayList<>();
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestinations("LOGICAL-GROUP", destinationsToSet1));
+                () -> client.setDestination("LOGICAL-GROUP", destinationsToSet1));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestinations("LOGICAL-GROUP", destinationsToSet2));
+                () -> client.setDestination("LOGICAL-GROUP", destinationsToSet2));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestinations("LOGICAL-GROUP", destinationsToSet3));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestinations("LOGICAL-GROUP", null));
+                () -> client.setDestination("LOGICAL-GROUP", null));
 
-        // Test setting list of destinations that contain a duplicate, list gets de-duplicated and log warning here
+        // Test clearing existing destination with passing empty list.
+        final int expectedNumberRegisteredGroups = 0;
+        final List<String> destinationsToSet3 = Arrays.asList("DESTINATION", "DESTINATION1");
+        client.setDestination("LOGICAL-GROUP", destinationsToSet3);
+        // Check that destinations for the logical group is not empty.
+        Assert.assertEquals(new HashSet<>(destinationsToSet3),
+                new HashSet<>(client.getDestination("LOGICAL-GROUP")));
+        client.setDestination("LOGICAL-GROUP", new ArrayList<>());
+        // Check that the logical group was deleted after being emptied.
+        Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
+
+        // Test setting list of destinations that contain a duplicate, list gets de-duplicated
+        // and a warning is logged here.
         final int expectedNumberDestinations = 1;
         final String currentTableEntryKey = "LOGICAL-GROUP";
         final List<String> destinationsToSet4 = Arrays.asList("DESTINATION", "DESTINATION");
-        client.setDestinations("LOGICAL-GROUP", destinationsToSet4);
+        client.setDestination("LOGICAL-GROUP", destinationsToSet4);
         Assert.assertEquals(expectedNumberDestinations, sourceMetadataTable.entryStream()
                 .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
 
-
-        // Test init and consequent overwrite of a new logical group using setDestinations
+        // Test init and consequent overwrite of a new logical group using setDestinations.
         final List<String> destinationsToSet5 = Arrays.asList("DESTINATION", "DESTINATION1");
         final List<String> destinationsToSet6 = Arrays.asList("DESTINATION", "DESTINATION1");
-        client.setDestinations("LOGICAL-GROUP1", destinationsToSet5);
+        client.setDestination("LOGICAL-GROUP1", destinationsToSet5);
         Assert.assertEquals(new HashSet<>(destinationsToSet5),
-                new HashSet<>(client.getDestinations("LOGICAL-GROUP1")));
-        client.setDestinations("LOGICAL-GROUP1", destinationsToSet6);
+                new HashSet<>(client.getDestination("LOGICAL-GROUP1")));
+        client.setDestination("LOGICAL-GROUP1", destinationsToSet6);
         Assert.assertEquals(new HashSet<>(destinationsToSet6),
-                new HashSet<>(client.getDestinations("LOGICAL-GROUP1")));
+                new HashSet<>(client.getDestination("LOGICAL-GROUP1")));
 
-        // Test that the overall table size is correct
-        final int expectedNumberRegisteredGroups = 2;
+        // Test that the overall table size is correct.
+        final int expectedNumberRegisteredGroups1 = 2;
+        Assert.assertEquals(expectedNumberRegisteredGroups1, sourceMetadataTable.count());
+    }
+
+    @Test
+    public void testClientOperations() {
+        final String logicalGroup = "LOGICAL-GROUP";
+        final String destination = "DESTINATION";
+        final List<String> destinations = Arrays.asList("DESTINATION", "DESTINATION1");
+
+        // Test addDestination does not add same destination twice.
+        client.addDestination(logicalGroup, destination);
+        client.addDestination(logicalGroup, destinations);
+        Assert.assertEquals(new HashSet<>(destinations),
+                new HashSet<>(client.getDestination(logicalGroup)));
+
+        final List<String> destinations1 = Arrays.asList("DESTINATION1", "DESTINATION2");
+        // Test overwrite with setDestinations.
+        client.setDestination(logicalGroup, destinations1);
+        Assert.assertEquals(new HashSet<>(destinations1),
+                new HashSet<>(client.getDestination(logicalGroup)));
+
+        // Test removal of single destination, and consequent removal or remaining.
+        final String destination1 = "DESTINATION1";
+        final int expectedNumberRegisteredGroups = 0;
+        final List<String> destinationsAfterRemoval = Collections.singletonList("DESTINATION2");
+        client.removeDestination(logicalGroup, destination1);
+        Assert.assertEquals(new HashSet<>(destinationsAfterRemoval),
+                new HashSet<>(client.getDestination(logicalGroup)));
+        client.removeDestination(logicalGroup, destinations1);
+        // Number of groups should be 0 after logical group is emptied and deleted.
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
     }
 }

--- a/test/src/test/java/org/corfudb/runtime/LogReplicationLogicalGroupClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/LogReplicationLogicalGroupClientTest.java
@@ -26,7 +26,19 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     private static final String namespace = "CorfuSystem";
     private static final String registrationTableName = "LogReplicationRegistrationTable";
     private static final String metadataTableName = "LogReplicationModelMetadataTable";
+
+    // Sample variables used for testing.
     private static final String clientName = "client";
+    private static final String client1 = "client1";
+    private static final String client2 = "client2";
+    private static final String logicalGroup = "LOGICAL-GROUP";
+    private static final String logicalGroup1 = "LOGICAL-GROUP1";
+    private static final String destination = "DESTINATION";
+    private static final String destination1 = "DESTINATION1";
+    private static final String destination2 = "DESTINATION2";
+    private static final String destination3 = "DESTINATION3";
+    private static final String destination4 = "DESTINATION4";
+    private static final String destination5 = "DESTINATION5";
 
     private static Table<ClientRegistrationId, ClientRegistrationInfo, ManagedResources> replicationRegistrationTable;
     private static Table<ClientDestinationInfoKey, DestinationInfoVal, ManagedResources> sourceMetadataTable;
@@ -39,7 +51,7 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
 
     @Before
     public void loadProperties() throws Exception {
-        runtime = getTestRuntime();
+        runtime = getTestRuntime().connect();
         CorfuStore store = new CorfuStore(runtime);
 
         replicationRegistrationTable = store.openTable(
@@ -83,8 +95,8 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         Assert.assertEquals(expectedNumberRegisteredClients1, replicationRegistrationTable.count());
 
         // Test registering 2 additional clients.
-        new LogReplicationLogicalGroupClient(runtime, "client1");
-        new LogReplicationLogicalGroupClient(runtime, "client2");
+        new LogReplicationLogicalGroupClient(runtime, client1);
+        new LogReplicationLogicalGroupClient(runtime, client2);
         final int expectedNumberRegisteredClients2 = 3;
         Assert.assertEquals(expectedNumberRegisteredClients2, replicationRegistrationTable.count());
     }
@@ -96,7 +108,7 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     @Test
     public void testAddListOfDestinations() {
         // Test adding multiple destinations with request having a malformed logicalGroup.
-        final List<String> destinationsToAdd = Collections.singletonList("DESTINATION");
+        final List<String> destinationsToAdd = Collections.singletonList(destination);
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.addDestinations("", destinationsToAdd));
         Assert.assertThrows(IllegalArgumentException.class,
@@ -107,35 +119,33 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         final List<String> destinationsToAdd2 = Collections.singletonList(null);
         final List<String> destinationsToAdd3 = new ArrayList<>();
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestinations("LOGICAL-GROUP", destinationsToAdd1));
+                () -> client.addDestinations(logicalGroup, destinationsToAdd1));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestinations("LOGICAL-GROUP", destinationsToAdd2));
+                () -> client.addDestinations(logicalGroup, destinationsToAdd2));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestinations("LOGICAL-GROUP", destinationsToAdd3));
+                () -> client.addDestinations(logicalGroup, destinationsToAdd3));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.addDestinations("LOGICAL-GROUP", (List<String>) null));
+                () -> client.addDestinations(logicalGroup, null));
 
         // Test adding list of destinations that contain a duplicate, list gets de-duplicated
         // and a warning is logged here.
         final int expectedNumberDestinations = 1;
-        final String currentTableEntryKey = "LOGICAL-GROUP";
-        final List<String> destinationsToAdd4 = Arrays.asList("DESTINATION", "DESTINATION");
-        client.addDestinations("LOGICAL-GROUP", destinationsToAdd4);
+        final List<String> destinationsToAdd4 = Arrays.asList(destination, destination);
+        client.addDestinations(logicalGroup, destinationsToAdd4);
         Assert.assertEquals(expectedNumberDestinations, sourceMetadataTable.entryStream()
-                .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
+                .filter(e -> e.getKey().getGroupName().equals(logicalGroup))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
 
         // Test adding destinations to a second logical group.
         final int expectedNumberDestinations2 = 4;
-        final String currentTableEntryKey2 = "LOGICAL-GROUP1";
-        final List<String> destinationsToAdd5 = Arrays.asList("DESTINATION", "DESTINATION1");
-        final List<String> destinationsToAdd6 = Arrays.asList("DESTINATION2", "DESTINATION3");
-        client.addDestinations("LOGICAL-GROUP1", destinationsToAdd5);
+        final List<String> destinationsToAdd5 = Arrays.asList(destination, destination1);
+        final List<String> destinationsToAdd6 = Arrays.asList(destination2, destination3);
+        client.addDestinations(logicalGroup1, destinationsToAdd5);
         // Test adding destinations that already exist, warning is logged here.
-        client.addDestinations("LOGICAL-GROUP1", destinationsToAdd5);
-        client.addDestinations("LOGICAL-GROUP1", destinationsToAdd6);
+        client.addDestinations(logicalGroup1, destinationsToAdd5);
+        client.addDestinations(logicalGroup1, destinationsToAdd6);
         Assert.assertEquals(expectedNumberDestinations2, sourceMetadataTable.entryStream()
-                .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey2))
+                .filter(e -> e.getKey().getGroupName().equals(logicalGroup1))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
 
         // Test that the overall table size is correct.
@@ -150,7 +160,7 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     @Test
     public void testRemoveListOfDestinations() {
         // Test removing multiple destinations with request having a malformed logicalGroup.
-        final List<String> destinationsToRemove = Collections.singletonList("DESTINATION");
+        final List<String> destinationsToRemove = Collections.singletonList(destination);
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.removeDestinations("", destinationsToRemove));
         Assert.assertThrows(IllegalArgumentException.class,
@@ -161,43 +171,41 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         final List<String> destinationsToRemove2 = Collections.singletonList(null);
         final List<String> destinationsToRemove3 = new ArrayList<>();
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestinations("LOGICAL-GROUP", destinationsToRemove1));
+                () -> client.removeDestinations(logicalGroup, destinationsToRemove1));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestinations("LOGICAL-GROUP", destinationsToRemove2));
+                () -> client.removeDestinations(logicalGroup, destinationsToRemove2));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestinations("LOGICAL-GROUP", destinationsToRemove3));
+                () -> client.removeDestinations(logicalGroup, destinationsToRemove3));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.removeDestinations("LOGICAL-GROUP", (List<String>) null));
+                () -> client.removeDestinations(logicalGroup, null));
 
         // Test add then remove, group should be deleted once empty.
         final int expectedNumberRegisteredGroups = 0;
-        final List<String> destinationsToRemove4 = Arrays.asList("DESTINATION", "DESTINATION1");
-        client.addDestinations("LOGICAL-GROUP", destinationsToRemove4);
-        client.removeDestinations("LOGICAL-GROUP", destinationsToRemove4);
+        final List<String> destinationsToRemove4 = Arrays.asList(destination, destination1);
+        client.addDestinations(logicalGroup, destinationsToRemove4);
+        client.removeDestinations(logicalGroup, destinationsToRemove4);
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
 
         // Test removal of multiple destinations.
-        final Set<String> expectedDestinations = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION2"));
-        final String currentTableEntryKey = "LOGICAL-GROUP";
-        final List<String> destinationsToAdd = Arrays.asList("DESTINATION", "DESTINATION1", "DESTINATION2", "DESTINATION3");
-        final List<String> destinationsToRemove5 = Arrays.asList("DESTINATION1", "DESTINATION3", "DESTINATION4", "DESTINATION5");
-        client.addDestinations("LOGICAL-GROUP", destinationsToAdd);
+        final Set<String> expectedDestinations = new HashSet<>(Arrays.asList(destination, destination2));
+        final List<String> destinationsToAdd = Arrays.asList(destination, destination1, destination2, destination3);
+        final List<String> destinationsToRemove5 = Arrays.asList(destination1, destination3, destination4, destination5);
+        client.addDestinations(logicalGroup, destinationsToAdd);
         // Some destinations in destinationsToRemove5 do not exist, a waning is logged here but an
         // exception should not be thrown.
-        client.removeDestinations("LOGICAL-GROUP", destinationsToRemove5);
+        client.removeDestinations(logicalGroup, destinationsToRemove5);
         // No destinations in destinationsToRemove5 should exist after removal, a warning is logged
         // here but an exception should not be thrown.
-        client.removeDestinations("LOGICAL-GROUP", destinationsToRemove5);
+        client.removeDestinations(logicalGroup, destinationsToRemove5);
         Assert.assertEquals(expectedDestinations, new HashSet<>(sourceMetadataTable.entryStream()
-                        .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
-                        .findFirst().get().getPayload().getDestinationIdsList()));
+                .filter(e -> e.getKey().getGroupName().equals(logicalGroup))
+                .findFirst().get().getPayload().getDestinationIdsList()));
 
         // Test removal from a group that does not exist, warning is logged here.
-        final Set<String> expectedDestinations1 = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION2"));
-        final String currentTableEntryKey1 = "LOGICAL-GROUP";
-        client.removeDestinations("LOGICAL-GROUP1", Collections.singletonList("DESTINATION"));
+        final Set<String> expectedDestinations1 = new HashSet<>(Arrays.asList(destination, destination2));
+        client.removeDestinations(logicalGroup1, Collections.singletonList(destination));
         Assert.assertEquals(expectedDestinations1, new HashSet<>(sourceMetadataTable.entryStream()
-                .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey1))
+                .filter(e -> e.getKey().getGroupName().equals(logicalGroup))
                 .findFirst().get().getPayload().getDestinationIdsList()));
     }
 
@@ -214,15 +222,15 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
                 () -> client.getDestinations(""));
 
         // Add destinations to get later.
-        final List<String> destinationsToSet = Arrays.asList("DESTINATION", "DESTINATION1");
-        client.setDestinations("LOGICAL-GROUP", destinationsToSet);
+        final List<String> destinationsToSet = Arrays.asList(destination, destination1);
+        client.setDestinations(logicalGroup, destinationsToSet);
 
         // Test getting destinations.
-        final Set<String> expectedDestinations = new HashSet<>(Arrays.asList("DESTINATION", "DESTINATION1"));
-        Assert.assertEquals(expectedDestinations, new HashSet<>(client.getDestinations("LOGICAL-GROUP")));
+        final Set<String> expectedDestinations = new HashSet<>(Arrays.asList(destination, destination1));
+        Assert.assertEquals(expectedDestinations, new HashSet<>(client.getDestinations(logicalGroup)));
 
         // Test get destinations on an invalid group.
-        Assert.assertNull(client.getDestinations("LOGICAL-GROUP1"));
+        Assert.assertNull(client.getDestinations(logicalGroup1));
     }
 
     /**
@@ -232,7 +240,7 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     @Test
     public void testSetDestinations() {
         // Test setting with request having a malformed logicalGroup.
-        final List<String> destinationsToSet = Collections.singletonList("DESTINATION");
+        final List<String> destinationsToSet = Collections.singletonList(destination);
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> client.setDestinations("", destinationsToSet));
         Assert.assertThrows(IllegalArgumentException.class,
@@ -242,42 +250,41 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
         final List<String> destinationsToSet1 = Collections.singletonList("");
         final List<String> destinationsToSet2 = Collections.singletonList(null);
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestinations("LOGICAL-GROUP", destinationsToSet1));
+                () -> client.setDestinations(logicalGroup, destinationsToSet1));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestinations("LOGICAL-GROUP", destinationsToSet2));
+                () -> client.setDestinations(logicalGroup, destinationsToSet2));
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.setDestinations("LOGICAL-GROUP", null));
+                () -> client.setDestinations(logicalGroup, null));
 
         // Test clearing existing destination with passing empty list.
         final int expectedNumberRegisteredGroups = 0;
-        final List<String> destinationsToSet3 = Arrays.asList("DESTINATION", "DESTINATION1");
-        client.setDestinations("LOGICAL-GROUP", destinationsToSet3);
+        final List<String> destinationsToSet3 = Arrays.asList(destination, destination1);
+        client.setDestinations(logicalGroup, destinationsToSet3);
         // Check that destinations for the logical group is not empty.
         Assert.assertEquals(new HashSet<>(destinationsToSet3),
-                new HashSet<>(client.getDestinations("LOGICAL-GROUP")));
-        client.setDestinations("LOGICAL-GROUP", new ArrayList<>());
+                new HashSet<>(client.getDestinations(logicalGroup)));
+        client.setDestinations(logicalGroup, new ArrayList<>());
         // Check that the logical group was deleted after being emptied.
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
 
         // Test setting list of destinations that contain a duplicate, list gets de-duplicated
         // and a warning is logged here.
         final int expectedNumberDestinations = 1;
-        final String currentTableEntryKey = "LOGICAL-GROUP";
-        final List<String> destinationsToSet4 = Arrays.asList("DESTINATION", "DESTINATION");
-        client.setDestinations("LOGICAL-GROUP", destinationsToSet4);
+        final List<String> destinationsToSet4 = Arrays.asList(destination, destination);
+        client.setDestinations(logicalGroup, destinationsToSet4);
         Assert.assertEquals(expectedNumberDestinations, sourceMetadataTable.entryStream()
-                .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
+                .filter(e -> e.getKey().getGroupName().equals(logicalGroup))
                 .findFirst().get().getPayload().getDestinationIdsList().size());
 
         // Test init and consequent overwrite of a new logical group using setDestinations.
-        final List<String> destinationsToSet5 = Arrays.asList("DESTINATION", "DESTINATION1");
-        final List<String> destinationsToSet6 = Arrays.asList("DESTINATION", "DESTINATION1");
-        client.setDestinations("LOGICAL-GROUP1", destinationsToSet5);
+        final List<String> destinationsToSet5 = Arrays.asList(destination, destination1);
+        final List<String> destinationsToSet6 = Arrays.asList(destination, destination1);
+        client.setDestinations(logicalGroup1, destinationsToSet5);
         Assert.assertEquals(new HashSet<>(destinationsToSet5),
-                new HashSet<>(client.getDestinations("LOGICAL-GROUP1")));
-        client.setDestinations("LOGICAL-GROUP1", destinationsToSet6);
+                new HashSet<>(client.getDestinations(logicalGroup1)));
+        client.setDestinations(logicalGroup1, destinationsToSet6);
         Assert.assertEquals(new HashSet<>(destinationsToSet6),
-                new HashSet<>(client.getDestinations("LOGICAL-GROUP1")));
+                new HashSet<>(client.getDestinations(logicalGroup1)));
 
         // Test that the overall table size is correct.
         final int expectedNumberRegisteredGroups1 = 2;
@@ -290,30 +297,29 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
      */
     @Test
     public void testClientOperations() {
-        final String logicalGroup = "LOGICAL-GROUP";
-        final List<String> destination = Collections.singletonList("DESTINATION");
-        final List<String> destinations = Arrays.asList("DESTINATION", "DESTINATION1");
-
+        final List<String> destinationsToAdd = Collections.singletonList(destination);
+        final List<String> destinationsToAdd1 = Arrays.asList(destination, destination1);
         // Test addDestination does not add same destination twice.
-        client.addDestinations(logicalGroup, destination);
-        client.addDestinations(logicalGroup, destinations);
-        Assert.assertEquals(new HashSet<>(destinations),
+        client.addDestinations(logicalGroup, destinationsToAdd);
+        client.addDestinations(logicalGroup, destinationsToAdd1);
+        Assert.assertEquals(new HashSet<>(destinationsToAdd1),
                 new HashSet<>(client.getDestinations(logicalGroup)));
 
-        final List<String> destinations1 = Arrays.asList("DESTINATION1", "DESTINATION2");
+        final List<String> destinationsToSet = Arrays.asList(destination1, destination2);
         // Test overwrite with setDestinations.
-        client.setDestinations(logicalGroup, destinations1);
-        Assert.assertEquals(new HashSet<>(destinations1),
+        client.setDestinations(logicalGroup, destinationsToSet);
+        Assert.assertEquals(new HashSet<>(destinationsToSet),
                 new HashSet<>(client.getDestinations(logicalGroup)));
 
         // Test removal of single destination, and consequent removal or remaining.
-        final List<String> destination1 = Collections.singletonList("DESTINATION1");
+        final List<String> destinationsToRemove = Collections.singletonList(destination1);
+        final List<String> destinationsToRemove2 = Arrays.asList(destination1, destination2);
         final int expectedNumberRegisteredGroups = 0;
-        final List<String> destinationsAfterRemoval = Collections.singletonList("DESTINATION2");
-        client.removeDestinations(logicalGroup, destination1);
-        Assert.assertEquals(new HashSet<>(destinationsAfterRemoval),
+        final List<String> expectedDestinations = Collections.singletonList(destination2);
+        client.removeDestinations(logicalGroup, destinationsToRemove);
+        Assert.assertEquals(new HashSet<>(expectedDestinations),
                 new HashSet<>(client.getDestinations(logicalGroup)));
-        client.removeDestinations(logicalGroup, destinations1);
+        client.removeDestinations(logicalGroup, destinationsToRemove2);
         // Number of groups should be 0 after logical group is emptied and deleted.
         Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
     }

--- a/test/src/test/java/org/corfudb/runtime/LogReplicationLogicalGroupClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/LogReplicationLogicalGroupClientTest.java
@@ -65,10 +65,13 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
      *
      */
     @Test
-    public void testRegisterReplicationClient() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+    public void testRegisterReplicationClient()
+            throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         // Test registering client with null/empty client name
-        Assert.assertThrows(IllegalArgumentException.class, () -> new LogReplicationLogicalGroupClient(runtime, null));
-        Assert.assertThrows(IllegalArgumentException.class, () -> new LogReplicationLogicalGroupClient(runtime, ""));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new LogReplicationLogicalGroupClient(runtime, null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> new LogReplicationLogicalGroupClient(runtime, ""));
 
         // Check to see if client was registered from the @Before function
         final int expectedNumberRegisteredClients = 1;
@@ -93,12 +96,16 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     @Test
     public void testAddDestination() {
         // Test adding a destination with null/empty logicalGroup
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.addDestination("", "DESTINATION"));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.addDestination(null, "DESTINATION"));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.addDestination("", "DESTINATION"));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.addDestination(null, "DESTINATION"));
 
         // Test adding a destination with null/empty name
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.addDestination("LOGICAL-GROUP", ""));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.addDestination("LOGICAL-GROUP", (String) null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.addDestination("LOGICAL-GROUP", ""));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.addDestination("LOGICAL-GROUP", (String) null));
 
         // Test adding a destination
         final int expectedNumberDestinations = 1;
@@ -137,12 +144,16 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     @Test
     public void testRemoveDestination() {
         // Test adding a destination with null/empty logicalGroup
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.removeDestination("", "DESTINATION"));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.removeDestination(null, "DESTINATION"));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.removeDestination("", "DESTINATION"));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.removeDestination(null, "DESTINATION"));
 
         // Test adding a destination with null/empty name
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.removeDestination("LOGICAL-GROUP", ""));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.removeDestination("LOGICAL-GROUP", (String) null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.removeDestination("LOGICAL-GROUP", ""));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.removeDestination("LOGICAL-GROUP", (String) null));
 
         // Test add then remove, group should be deleted once empty
         final int expectedNumberRegisteredGroups = 0;
@@ -180,17 +191,23 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     public void testAddListOfDestination() {
         // Test adding with request having a malformed logicalGroup
         final List<String> destinationsToAdd = Collections.singletonList("DESTINATION");
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.addDestination("", destinationsToAdd));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.addDestination(null, destinationsToAdd));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.addDestination("", destinationsToAdd));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.addDestination(null, destinationsToAdd));
 
         // Test adding with request having a malformed destination
         final List<String> destinationsToAdd1 = Collections.singletonList("");
         final List<String> destinationsToAdd2 = Collections.singletonList(null);
         final List<String> destinationsToAdd3 = new ArrayList<>();
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.addDestination("LOGICAL-GROUP", destinationsToAdd1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.addDestination("LOGICAL-GROUP", destinationsToAdd2));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.addDestination("LOGICAL-GROUP", destinationsToAdd3));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.addDestination("LOGICAL-GROUP", (List<String>) null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.addDestination("LOGICAL-GROUP", destinationsToAdd1));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.addDestination("LOGICAL-GROUP", destinationsToAdd2));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.addDestination("LOGICAL-GROUP", destinationsToAdd3));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.addDestination("LOGICAL-GROUP", (List<String>) null));
 
         // Test adding list of destinations that contain a duplicate, list gets de-duplicated and log warning here
         final int expectedNumberDestinations = 1;
@@ -227,17 +244,23 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     public void testRemoveListOfDestinations() {
         // Test adding with request having a malformed logicalGroup
         final List<String> destinationsToRemove = Collections.singletonList("DESTINATION");
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.removeDestination("", destinationsToRemove));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.removeDestination(null, destinationsToRemove));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.removeDestination("", destinationsToRemove));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.removeDestination(null, destinationsToRemove));
 
         // Test adding with request having a malformed destination
         final List<String> destinationsToRemove1 = Collections.singletonList("");
         final List<String> destinationsToRemove2 = Collections.singletonList(null);
         final List<String> destinationsToRemove3 = new ArrayList<>();
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.removeDestination("LOGICAL-GROUP", destinationsToRemove1));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.removeDestination("LOGICAL-GROUP", destinationsToRemove2));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.removeDestination("LOGICAL-GROUP", destinationsToRemove3));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.removeDestination("LOGICAL-GROUP", (List<String>) null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.removeDestination("LOGICAL-GROUP", destinationsToRemove1));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.removeDestination("LOGICAL-GROUP", destinationsToRemove2));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.removeDestination("LOGICAL-GROUP", destinationsToRemove3));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.removeDestination("LOGICAL-GROUP", (List<String>) null));
 
         // Test add then remove, group should be deleted once empty
         final int expectedNumberRegisteredGroups = 0;
@@ -276,8 +299,10 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
     @Test
     public void testGetDestinations() {
         // Test get destinations with null/empty group
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.getDestinations(null));
-        Assert.assertThrows(IllegalArgumentException.class, () -> client.getDestinations(""));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.getDestinations(null));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.getDestinations(""));
 
         // Add destinations to get later
         client.addDestination("LOGICAL-GROUP", "DESTINATION");
@@ -289,5 +314,56 @@ public class LogReplicationLogicalGroupClientTest extends AbstractViewTest {
 
         // Test get destinations on an invalid group
         Assert.assertNull(client.getDestinations("LOGICAL-GROUP1"));
+    }
+
+    /**
+     * Test setting destinations for a logical group.
+     *
+     */
+    @Test
+    public void testSetDestinations() {
+        // Test setting with request having a malformed logicalGroup
+        final List<String> destinationsToSet = Collections.singletonList("DESTINATION");
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.setDestinations("", destinationsToSet));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.setDestinations(null, destinationsToSet));
+
+        // Test setting  with request having a malformed destination
+        final List<String> destinationsToSet1 = Collections.singletonList("");
+        final List<String> destinationsToSet2 = Collections.singletonList(null);
+        final List<String> destinationsToSet3 = new ArrayList<>();
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.setDestinations("LOGICAL-GROUP", destinationsToSet1));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.setDestinations("LOGICAL-GROUP", destinationsToSet2));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.setDestinations("LOGICAL-GROUP", destinationsToSet3));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> client.setDestinations("LOGICAL-GROUP", null));
+
+        // Test setting list of destinations that contain a duplicate, list gets de-duplicated and log warning here
+        final int expectedNumberDestinations = 1;
+        final String currentTableEntryKey = "LOGICAL-GROUP";
+        final List<String> destinationsToSet4 = Arrays.asList("DESTINATION", "DESTINATION");
+        client.setDestinations("LOGICAL-GROUP", destinationsToSet4);
+        Assert.assertEquals(expectedNumberDestinations, sourceMetadataTable.entryStream()
+                .filter(e -> e.getKey().getGroupName().equals(currentTableEntryKey))
+                .findFirst().get().getPayload().getDestinationIdsList().size());
+
+
+        // Test init and consequent overwrite of a new logical group using setDestinations
+        final List<String> destinationsToSet5 = Arrays.asList("DESTINATION", "DESTINATION1");
+        final List<String> destinationsToSet6 = Arrays.asList("DESTINATION", "DESTINATION1");
+        client.setDestinations("LOGICAL-GROUP1", destinationsToSet5);
+        Assert.assertEquals(new HashSet<>(destinationsToSet5),
+                new HashSet<>(client.getDestinations("LOGICAL-GROUP1")));
+        client.setDestinations("LOGICAL-GROUP1", destinationsToSet6);
+        Assert.assertEquals(new HashSet<>(destinationsToSet6),
+                new HashSet<>(client.getDestinations("LOGICAL-GROUP1")));
+
+        // Test that the overall table size is correct
+        final int expectedNumberRegisteredGroups = 2;
+        Assert.assertEquals(expectedNumberRegisteredGroups, sourceMetadataTable.count());
     }
 }


### PR DESCRIPTION
## Overview

Description:
Added setDestination() api for the log replication client.

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
