### PR TITLE
Fix Clojure Script's Get Host Method

### DIFF
--- a/cmdlets/src/main/clojure/org/corfudb/shell.clj
+++ b/cmdlets/src/main/clojure/org/corfudb/shell.clj
@@ -91,8 +91,8 @@ The variable *r holds the last runtime obtrained, and *o holds the last router o
 
 
 ; Util functions to get a host or port from an endpoint string.
-(defn get-port [endpoint] (URLUtils/getPortFromEndpointURL (endpoint)))
-(defn get-host [endpoint] (URLUtils/getVersionFormattedHostAddress (endpoint)))
+(defn get-port [endpoint] (Integer/parseInt (URLUtils/getPortFromEndpointURL endpoint)))
+(defn get-host [endpoint] (URLUtils/getHostFromEndpointURL endpoint))
 
 ; Get a runtime or a router, and add it to the runtime/router corfuTable
 (defn add-client ([client] (.. *o (addClient client)))


### PR DESCRIPTION
## Overview

Description:

Correct syntactical errors -
1. Remove parentheses for the method's parameters.
2. Call the correct method getHostFromEndpointURL().

Why should this be merged: Fixes errors in the code.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
