### PR TITLE
Segment Space-Efficient Index

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/BoundedMap.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/BoundedMap.java
@@ -1,0 +1,106 @@
+package org.corfudb.infrastructure.log;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Iterator;
+import java.util.concurrent.atomic.AtomicLongArray;
+
+/**
+ * A BoundedMap provides an array backed map that can map long -> long where the indices are in the range of
+ * (Long.MIN_VALUE, Long.MAX_VALUE - Integer.MAX_VALUE)
+ */
+public class BoundedMap {
+
+    private final long offset;
+    private final AtomicLongArray array;
+    public static final long NOT_SET = Long.MIN_VALUE;
+
+    public BoundedMap(long offset, int size) {
+        Preconditions.checkArgument(offset >= 0);
+        Preconditions.checkArgument(size > 0);
+        Preconditions.checkArgument(Math.addExact(offset, size) < Integer.MAX_VALUE);
+        this.offset = offset;
+        this.array = new AtomicLongArray(size);
+        for (int idx = 0; idx < array.length(); idx++) {
+            this.array.set(idx, NOT_SET);
+        }
+    }
+
+    private void checkRange(long num) {
+        if (num < offset || num >= offset + array.length()) {
+            throw new IllegalArgumentException(num + " not in [" + offset + ", " + (offset + array.length()) + ")");
+        }
+    }
+
+    private void checkValue(long value) {
+        Preconditions.checkArgument(NOT_SET != value, "invalid %s value", value);
+    }
+
+    private int mapIdx(long idx) {
+        return Math.toIntExact(idx - offset);
+    }
+
+    public boolean set(long idx, long value) {
+        checkRange(idx);
+        checkValue(value);
+        return array.compareAndSet(mapIdx(idx), NOT_SET, value);
+    }
+
+    public long get(long idx) {
+        checkRange(idx);
+        return array.get(mapIdx(idx));
+    }
+
+    public boolean contains(long idx) {
+        checkRange(idx);
+        return array.get(mapIdx(idx)) != NOT_SET;
+    }
+
+    public int capacity() {
+        return array.length();
+    }
+
+    /**
+     * Iterators are only used for initialization and therefore are not optimized. For instance, the running time
+     * for iterating is not a function of the number of elements set in the index, but rather the size of the index.
+     */
+    public Iterator<Long> iterator() {
+        return new IndexIterator(array);
+    }
+
+    public Iterable<Long> iterable() {
+        final Iterator<Long> iter = iterator();
+        return () -> iter;
+    }
+
+    private final class IndexIterator implements Iterator<Long> {
+
+        private final AtomicLongArray array;
+        private int idx = 0;
+        private IndexIterator(AtomicLongArray array) {
+            this.array = array;
+            findNextIdx();
+        }
+
+        private void findNextIdx() {
+            while (idx < array.length() && array.get(idx) == NOT_SET) {
+                idx++;
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            return idx < array.length();
+        }
+
+        @Override
+        public Long next() {
+            long ret = array.get(idx);
+            Preconditions.checkState(ret != NOT_SET);
+            long retVal = idx + offset;
+            idx++;
+            findNextIdx();
+            return retVal;
+        }
+    }
+}

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -336,7 +336,7 @@ public class StreamLogFiles implements StreamLog {
     Segment getSegmentHandleForAddress(long address) {
         long segmentId = address / RECORDS_PER_LOG_FILE;
         Segment handle = openSegments.computeIfAbsent(segmentId,
-                a -> new Segment(a, logDir, logSizeQuota));
+                a -> new Segment(a, RECORDS_PER_LOG_FILE, logDir, logSizeQuota));
         handle.retain();
         return handle;
     }

--- a/test/src/test/java/org/corfudb/infrastructure/log/BoundedMapTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/BoundedMapTest.java
@@ -1,0 +1,125 @@
+package org.corfudb.infrastructure.log;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class BoundedMapTest {
+
+    @Test
+    public void testIndexSet() {
+        BoundedMap index = new BoundedMap(0, 10_000);
+        assertThat(index.contains(10L)).isFalse();
+        assertThat(index.set(10, 1000L)).isTrue();
+        assertThat(index.set(10, 1000L)).isFalse();
+        assertThat(index.get(10)).isEqualTo(1000L);
+        assertThat(index.capacity()).isEqualTo(10_000);
+    }
+
+    @Test
+    public void testIndexOutOfRange() {
+        BoundedMap index = new BoundedMap(0, 10);
+        String errorMsg = "10 not in [0, 10)";
+        assertThatThrownBy(() -> index.contains(10L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(errorMsg);
+
+        assertThatThrownBy(() -> index.set(10, 1000L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(errorMsg);
+
+        assertThatThrownBy(() -> index.get(10))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(errorMsg);
+
+        assertThatThrownBy(() -> index.set(1, Long.MIN_VALUE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid %s value", Long.MIN_VALUE);
+
+        assertThatThrownBy(() -> index.set(Long.MIN_VALUE, 1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testInvalidSet() {
+        BoundedMap index = new BoundedMap(0, 10);
+        assertThatThrownBy(() -> index.set(0, BoundedMap.NOT_SET))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testConstructorConditions() {
+        assertThatThrownBy(() -> new BoundedMap(-1, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new BoundedMap(0, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> new BoundedMap(Long.MAX_VALUE, 1))
+                .isInstanceOf(ArithmeticException.class);
+
+        assertThatThrownBy(() -> new BoundedMap(Long.MAX_VALUE - 10, 5))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testEmptyIterator() {
+        BoundedMap index = new BoundedMap(0, 10);
+
+        assertThat(index.iterator().hasNext())
+                .isFalse();
+
+        assertThat(index.set(0L, 1L)).isTrue();
+
+        Iterator<Long> iter = index.iterator();
+
+        assertThat(iter.hasNext())
+                .isTrue();
+        assertThat(iter.next()).isEqualTo(0L);
+        assertThat(iter.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testSparseIndex() {
+        BoundedMap index = new BoundedMap(0, 10);
+
+        assertThat(index.iterator().hasNext())
+                .isFalse();
+
+        assertThat(index.set(5L, 5L)).isTrue();
+        assertThat(index.set(9L, 9L)).isTrue();
+
+        Iterator<Long> iter = index.iterator();
+
+        assertThat(iter.hasNext())
+                .isTrue();
+        assertThat(iter.next()).isEqualTo(5L);
+        assertThat(iter.next()).isEqualTo(9L);
+        assertThat(iter.hasNext()).isFalse();
+    }
+
+    @Test
+    public void testIterable() {
+        BoundedMap index = new BoundedMap(0, 10);
+
+        for (long i : index.iterable()) {
+            assertThat(i).isNotEqualTo(i);
+        }
+
+        assertThat(index.set(1L, 1L)).isTrue();
+        assertThat(index.set(2L, 2L)).isTrue();
+
+        List<Long> contents = new ArrayList<>();
+
+        for (long l : index.iterable()) {
+            contents.add(l);
+        }
+
+        assertThat(contents).containsExactly(1L, 2L);
+    }
+}

--- a/test/src/test/java/org/corfudb/infrastructure/log/SegmentIndexTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/log/SegmentIndexTest.java
@@ -1,0 +1,36 @@
+package org.corfudb.infrastructure.log;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+public class SegmentIndexTest {
+
+    @Test
+    public void testSegmentIndex() {
+        Segment.Index index = new Segment.Index(0L, 10_000);
+
+        index.put(1, Segment.MAX_SEGMENT_SIZE, Segment.MAX_WRITE_SIZE);
+        assertThatThrownBy(() -> index.put(1, Segment.Index.highBitsNum, Segment.Index.lowBitsNum))
+                .isInstanceOf(IllegalStateException.class);
+
+        assertThatThrownBy(() -> index.put(2, Segment.MAX_SEGMENT_SIZE + 1, Segment.MAX_WRITE_SIZE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid offset %s", Segment.MAX_SEGMENT_SIZE + 1);
+        assertThatThrownBy(() -> index.put(2, Segment.MAX_SEGMENT_SIZE, Segment.MAX_WRITE_SIZE + 1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid length %s", Segment.MAX_WRITE_SIZE + 1);
+        assertThatThrownBy(() -> index.put(2, 0, Segment.MAX_WRITE_SIZE))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid offset 0");
+        assertThatThrownBy(() -> index.put(2, Segment.MAX_SEGMENT_SIZE, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid length 0");
+
+        assertThat(index.contains(1)).isTrue();
+        assertThat(index.getPacked(1)).isEqualTo(-1);
+        assertThat(index.unpackOffset(index.getPacked(1))).isEqualTo(Segment.MAX_SEGMENT_SIZE);
+        assertThat(index.unpackLength(index.getPacked(1))).isEqualTo(Segment.MAX_WRITE_SIZE);
+    }
+}

--- a/test_checks.xml
+++ b/test_checks.xml
@@ -50,7 +50,6 @@
     <property name="fileExtensions" value="java, properties, xml"/>
 
     <module name="TreeWalker">
-        <module name="MagicNumber"/>
 
         <module name="SuppressWarningsHolder" />
     </module>


### PR DESCRIPTION
## Overview

    This patch replaces the Segment's ConcurrentHashMap index with a
    space-efficient index. Memory overhead is reduced from
    943120 to 80856 bytes, ~11x.



## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
