### PR TITLE
Fix Sync Status Initialization

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -2,7 +2,6 @@ package org.corfudb.infrastructure.logreplication.replication.fsm;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.LogReplication.SyncType;
-import org.corfudb.runtime.LogReplication.SyncStatus;
 import org.corfudb.infrastructure.logreplication.replication.send.LogEntrySender;
 
 import java.util.UUID;
@@ -156,9 +155,6 @@ public class InLogEntrySyncState implements LogReplicationState {
             log.error("Error on entry of InLogEntrySyncState", t);
         }
     }
-
-    @Override
-    public void onExit(LogReplicationState to) {}
 
     @Override
     public void setTransitionEventId(UUID eventId) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InLogEntrySyncState.java
@@ -158,12 +158,7 @@ public class InLogEntrySyncState implements LogReplicationState {
     }
 
     @Override
-    public void onExit(LogReplicationState to) {
-        if (to.getType().equals(LogReplicationStateType.INITIALIZED)) {
-            fsm.getAckReader().markSyncStatus(SyncStatus.STOPPED);
-            log.debug("Log Entry replication status changed to STOPPED");
-        }
-    }
+    public void onExit(LogReplicationState to) {}
 
     @Override
     public void setTransitionEventId(UUID eventId) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InSnapshotSyncState.java
@@ -5,8 +5,9 @@ import io.micrometer.core.instrument.Timer;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.common.metrics.micrometer.MeterRegistryProvider;
-import org.corfudb.runtime.LogReplication.SyncStatus;
 import org.corfudb.infrastructure.logreplication.replication.send.SnapshotSender;
+import org.corfudb.runtime.LogReplication.SyncStatus;
+import org.corfudb.runtime.LogReplication.SyncType;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -152,6 +153,7 @@ public class InSnapshotSyncState implements LogReplicationState {
         try {
             // If the transition is to itself, the snapshot sync is continuing, no need to reset the sender
             if (from != this) {
+                fsm.getAckReader().setSyncType(SyncType.SNAPSHOT);
                 snapshotSender.reset();
                 fsm.getAckReader().markSnapshotSyncInfoOngoing(forcedSnapshotSync, transitionEventId);
                 snapshotSyncTransferTimerSample = MeterRegistryProvider.getInstance().map(Timer::start);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -70,6 +70,7 @@ public class InitializedState implements LogReplicationState {
     public void onEntry(LogReplicationState from) {
         if (from != this) {
             fsm.getAckReader().markSyncStatus(SyncStatus.STOPPED);
+            log.debug("Replication status changed to STOPPED");
             // Disable periodic sync status periodic task while in initialized state (no actual replication occurring)
             fsm.getAckReader().stopSyncStatusUpdatePeriodicTask();
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -2,6 +2,7 @@ package org.corfudb.infrastructure.logreplication.replication.fsm;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.LogReplication.SyncStatus;
+import org.corfudb.runtime.LogReplication.SyncType;
 
 /**
  * This class represents the Init state of the Log Replication State Machine.
@@ -78,12 +79,12 @@ public class InitializedState implements LogReplicationState {
     @Override
     public void onExit(LogReplicationState to) {
         LogReplicationStateType type = to.getType();
-        LogReplicationMetadata.SyncType toSyncType = null;
+        SyncType toSyncType = null;
 
         if (type.equals(LogReplicationStateType.IN_SNAPSHOT_SYNC) || type.equals(LogReplicationStateType.WAIT_SNAPSHOT_APPLY)) {
-            toSyncType = LogReplicationMetadata.SyncType.SNAPSHOT;
+            toSyncType = SyncType.SNAPSHOT;
         } else if (type.equals(LogReplicationStateType.IN_LOG_ENTRY_SYNC)) {
-            toSyncType = LogReplicationMetadata.SyncType.LOG_ENTRY;
+            toSyncType = SyncType.LOG_ENTRY;
         }
 
         if (to != this && to.getType() != LogReplicationStateType.ERROR) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -2,7 +2,6 @@ package org.corfudb.infrastructure.logreplication.replication.fsm;
 
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.LogReplication.SyncStatus;
-import org.corfudb.runtime.LogReplication.SyncType;
 
 /**
  * This class represents the Init state of the Log Replication State Machine.
@@ -78,17 +77,8 @@ public class InitializedState implements LogReplicationState {
 
     @Override
     public void onExit(LogReplicationState to) {
-        LogReplicationStateType type = to.getType();
-        SyncType toSyncType = null;
-
-        if (type.equals(LogReplicationStateType.IN_SNAPSHOT_SYNC) || type.equals(LogReplicationStateType.WAIT_SNAPSHOT_APPLY)) {
-            toSyncType = SyncType.SNAPSHOT;
-        } else if (type.equals(LogReplicationStateType.IN_LOG_ENTRY_SYNC)) {
-            toSyncType = SyncType.LOG_ENTRY;
-        }
-
         if (to != this && to.getType() != LogReplicationStateType.ERROR) {
-            fsm.getAckReader().startSyncStatusUpdatePeriodicTask(toSyncType);
+            fsm.getAckReader().startSyncStatusUpdatePeriodicTask();
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -78,10 +78,14 @@ public class InitializedState implements LogReplicationState {
     @Override
     public void onExit(LogReplicationState to) {
         LogReplicationStateType type = to.getType();
-        LogReplicationMetadata.SyncType toSyncType =
-                type.equals(LogReplicationStateType.IN_SNAPSHOT_SYNC) ? LogReplicationMetadata.SyncType.SNAPSHOT :
-                type.equals(LogReplicationStateType.IN_LOG_ENTRY_SYNC) ? LogReplicationMetadata.SyncType.LOG_ENTRY :
-                null;
+        LogReplicationMetadata.SyncType toSyncType = null;
+
+        if (type.equals(LogReplicationStateType.IN_SNAPSHOT_SYNC) || type.equals(LogReplicationStateType.WAIT_SNAPSHOT_APPLY)) {
+            toSyncType = LogReplicationMetadata.SyncType.SNAPSHOT;
+        } else if (type.equals(LogReplicationStateType.IN_LOG_ENTRY_SYNC)) {
+            toSyncType = LogReplicationMetadata.SyncType.LOG_ENTRY;
+        }
+
         if (to != this && to.getType() != LogReplicationStateType.ERROR) {
             fsm.getAckReader().startSyncStatusUpdatePeriodicTask(toSyncType);
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/InitializedState.java
@@ -77,8 +77,13 @@ public class InitializedState implements LogReplicationState {
 
     @Override
     public void onExit(LogReplicationState to) {
+        LogReplicationStateType type = to.getType();
+        LogReplicationMetadata.SyncType toSyncType =
+                type.equals(LogReplicationStateType.IN_SNAPSHOT_SYNC) ? LogReplicationMetadata.SyncType.SNAPSHOT :
+                type.equals(LogReplicationStateType.IN_LOG_ENTRY_SYNC) ? LogReplicationMetadata.SyncType.LOG_ENTRY :
+                null;
         if (to != this && to.getType() != LogReplicationStateType.ERROR) {
-            fsm.getAckReader().startSyncStatusUpdatePeriodicTask();
+            fsm.getAckReader().startSyncStatusUpdatePeriodicTask(toSyncType);
         }
     }
 

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/fsm/WaitSnapshotApplyState.java
@@ -9,6 +9,7 @@ import org.corfudb.infrastructure.logreplication.replication.send.LogReplication
 import org.corfudb.infrastructure.logreplication.runtime.CorfuLogReplicationRuntime;
 import org.corfudb.infrastructure.logreplication.utils.LogReplicationUpgradeManager;
 import org.corfudb.runtime.LogReplication.LogReplicationMetadataResponseMsg;
+import org.corfudb.runtime.LogReplication.SyncType;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -157,6 +158,7 @@ public class WaitSnapshotApplyState implements LogReplicationState {
     public void onEntry(LogReplicationState from) {
         log.info("OnEntry :: wait snapshot apply state");
         if (from.getType().equals(LogReplicationStateType.INITIALIZED)) {
+            fsm.getAckReader().setSyncType(SyncType.SNAPSHOT);
             stopSnapshotApply.set(false);
             fsm.getAckReader().markSnapshotSyncInfoOngoing();
         }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -702,19 +702,20 @@ public class LogReplicationMetadataManager {
                     session);
 
             ReplicationStatus previous = entry.getPayload();
-            SnapshotSyncInfo snapshotStatus = previous.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo();
+            SnapshotSyncInfo previousSnapshotSyncInfo = previous.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo();
 
             if (type == SyncType.LOG_ENTRY && (previous.getSourceStatus().getReplicationInfo().getStatus().equals(SyncStatus.NOT_STARTED)
-                            || snapshotStatus.getStatus().equals(SyncStatus.STOPPED))) {
+                            || previousSnapshotSyncInfo.getStatus().equals(SyncStatus.STOPPED))) {
                 // Skip update of sync status, it will be updated once replication is resumed or started
                 log.info("syncStatusPoller :: skip replication status update, log entry replication is {}",
                         previous.getSourceStatus().getReplicationInfo().getStatus());
                 txn.commit();
                 return;
-            } else if (type == SyncType.SNAPSHOT && (snapshotStatus.getStatus().equals(SyncStatus.NOT_STARTED)
-                    || snapshotStatus.getStatus().equals(SyncStatus.STOPPED))) {
+            } else if (type == SyncType.SNAPSHOT && (previousSnapshotSyncInfo.getStatus().equals(SyncStatus.NOT_STARTED)
+                    || previousSnapshotSyncInfo.getStatus().equals(SyncStatus.STOPPED))) {
                 // Skip update of sync status, it will be updated once replication is resumed or started
-                log.info("syncStatusPoller :: skip replication status update, snapshot sync is {}", snapshotStatus);
+                log.info("syncStatusPoller :: skip replication status update, snapshot sync is {}",
+                        previousSnapshotSyncInfo.getStatus());
                 txn.commit();
                 return;
             }
@@ -728,7 +729,7 @@ public class LogReplicationMetadataManager {
             txn.commit();
 
             log.debug("syncStatusPoller :: remaining entries updated for {}, session: {}, remainingEntries: {}" +
-                    "snapshotSyncInfo: {}", type, session, remainingEntries, snapshotStatus);
+                    "snapshotSyncInfo: {}", type, session, remainingEntries, previousSnapshotSyncInfo);
         }
         log.debug("syncStatusPoller :: polling task ran for {}, session: {}, remainingEntries: {}",
                 type, session, remainingEntries);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/receive/LogReplicationMetadataManager.java
@@ -721,7 +721,9 @@ public class LogReplicationMetadataManager {
                 if (snapshotStatus == null) {
                     log.warn("syncStatusPoller [logEntry]:: previous snapshot status is not present for session: {}",
                             session);
-                    snapshotStatus = SnapshotSyncInfo.newBuilder().build();
+                    snapshotStatus = SnapshotSyncInfo.newBuilder()
+                            .setStatus(SyncStatus.NOT_STARTED)
+                            .build();
                 }
 
                 current = ReplicationStatus.newBuilder()
@@ -744,7 +746,9 @@ public class LogReplicationMetadataManager {
                 SnapshotSyncInfo currentSnapshotSyncInfo;
                 if (snapshotStatus == null) {
                     log.warn("syncStatusPoller [snapshot] :: previous status is not present for session: {}", session);
-                    currentSnapshotSyncInfo = SnapshotSyncInfo.newBuilder().build();
+                    currentSnapshotSyncInfo = SnapshotSyncInfo.newBuilder()
+                            .setStatus(SyncStatus.NOT_STARTED)
+                            .build();
                 } else {
                     if (snapshotStatus.getStatus().equals(SyncStatus.NOT_STARTED)
                                 || snapshotStatus.getStatus().equals(SyncStatus.STOPPED)) {

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
@@ -53,7 +53,7 @@ public class LogReplicationAckReader {
     // Last ack'd timestamp from Receiver
     private long lastAckedTimestamp = Address.NON_ADDRESS;
 
-    // Sync Type for which last Ack was received. Default to LOG_ENTRY as this is the initial FSM state
+    // Sync Type for which last Ack was received.
     private SyncType lastSyncType = null;
 
     private LogEntryReader logEntryReader;
@@ -446,9 +446,9 @@ public class LogReplicationAckReader {
     /**
      * Start periodic replication status update task (completion percentage)
      */
-    public void startSyncStatusUpdatePeriodicTask(SyncType toStateTransition) {
+    public void startSyncStatusUpdatePeriodicTask(SyncType syncType) {
         log.info("Start sync status update periodic task");
-        lastSyncType = toStateTransition;
+        lastSyncType = syncType;
         lastAckedTsPoller = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat("ack-timestamp-reader-"+ session.hashCode()).build());
         lastAckedTsPoller.scheduleWithFixedDelay(new TsPollingTask(), 0, ACKED_TS_READ_INTERVAL_SECONDS,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
@@ -54,7 +54,7 @@ public class LogReplicationAckReader {
     private long lastAckedTimestamp = Address.NON_ADDRESS;
 
     // Sync Type for which last Ack was received. Default to LOG_ENTRY as this is the initial FSM state
-    private SyncType lastSyncType = SyncType.LOG_ENTRY;
+    private SyncType lastSyncType = null;
 
     private LogEntryReader logEntryReader;
 
@@ -446,8 +446,9 @@ public class LogReplicationAckReader {
     /**
      * Start periodic replication status update task (completion percentage)
      */
-    public void startSyncStatusUpdatePeriodicTask() {
+    public void startSyncStatusUpdatePeriodicTask(SyncType toStateTransition) {
         log.info("Start sync status update periodic task");
+        lastSyncType = toStateTransition;
         lastAckedTsPoller = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setNameFormat("ack-timestamp-reader-"+ session.hashCode()).build());
         lastAckedTsPoller.scheduleWithFixedDelay(new TsPollingTask(), 0, ACKED_TS_READ_INTERVAL_SECONDS,

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/logreplication/replication/send/LogReplicationAckReader.java
@@ -53,7 +53,7 @@ public class LogReplicationAckReader {
     // Last ack'd timestamp from Receiver
     private long lastAckedTimestamp = Address.NON_ADDRESS;
 
-    // Sync Type for which last Ack was received.
+    // Sync Type for which last Ack was received, it is initialized where the timestamp polling task is created.
     private SyncType lastSyncType = null;
 
     private LogEntryReader logEntryReader;
@@ -476,7 +476,7 @@ public class LogReplicationAckReader {
                     try {
                         lock.lock();
                         long entriesToSend = calculateRemainingEntriesToSend(lastAckedTimestamp);
-                        metadataManager.setReplicationStatusTable(session, entriesToSend, lastSyncType);
+                        metadataManager.updateRemainingEntriesToSend(session, entriesToSend, lastSyncType);
                     } catch (TransactionAbortedException tae) {
                         log.error("Error while attempting to set replication status for remote session {} with " +
                                 "lastSyncType {}.", session, lastSyncType, tae);

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -180,13 +180,13 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
      */
     @Test
     public void testSyncStatusUpdatesForSnapshotOnInit() throws Exception {
-        final int UPDATE_TO_STATUS_TABLE_FROM_ON_ENTRY = 1;
+        final int updateToStatusTableFromOnEntry = 1;
         initLogReplicationFSM(ReaderImplementation.EMPTY);
 
         final Table<LogReplicationSession, LogReplicationMetadata.ReplicationStatus, Message> statusTable =
                 this.corfuStore.getTable(NAMESPACE, REPLICATION_STATUS_TABLE_NAME);
 
-        CountDownLatch statusTableLatch = new CountDownLatch(UPDATE_TO_STATUS_TABLE_FROM_ON_ENTRY);
+        CountDownLatch statusTableLatch = new CountDownLatch(updateToStatusTableFromOnEntry);
         TestStreamListener streamListener = new TestStreamListener(statusTableLatch);
         corfuStore.subscribeListener(streamListener, NAMESPACE, LR_STATUS_STREAM_TAG);
 
@@ -238,13 +238,13 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
      */
     @Test
     public void testSyncStatusUpdatesForLogEntryOnInit() throws Exception {
-        final int UPDATE_TO_STATUS_TABLE_FROM_ON_ENTRY = 1;
+        final int updateToStatusTableFromOnEntry = 1;
         initLogReplicationFSM(ReaderImplementation.EMPTY);
 
         final Table<LogReplicationSession, LogReplicationMetadata.ReplicationStatus, Message> statusTable =
                 this.corfuStore.getTable(NAMESPACE, REPLICATION_STATUS_TABLE_NAME);
 
-        CountDownLatch statusTableLatch = new CountDownLatch(UPDATE_TO_STATUS_TABLE_FROM_ON_ENTRY);
+        CountDownLatch statusTableLatch = new CountDownLatch(updateToStatusTableFromOnEntry);
         TestStreamListener streamListener = new TestStreamListener(statusTableLatch);
         corfuStore.subscribeListener(streamListener, NAMESPACE, LR_STATUS_STREAM_TAG);
 
@@ -768,8 +768,8 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
                 LogReplicationMetadata.ReplicationStatus status = (LogReplicationMetadata.ReplicationStatus) entry.get(0).getPayload();
                 LogReplicationMetadata.SyncType syncType = status.getSourceStatus().getReplicationInfo().getSyncType();
                 LogReplicationMetadata.SyncStatus syncStatus = status.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getStatus();
-                if ((syncType == LogReplicationMetadata.SyncType.LOG_ENTRY && syncStatus == LogReplicationMetadata.SyncStatus.COMPLETED)
-                        || syncType == LogReplicationMetadata.SyncType.SNAPSHOT && syncStatus == LogReplicationMetadata.SyncStatus.ONGOING) {
+                if (syncType == LogReplicationMetadata.SyncType.LOG_ENTRY && syncStatus == LogReplicationMetadata.SyncStatus.COMPLETED ||
+                        syncType == LogReplicationMetadata.SyncType.SNAPSHOT && syncStatus == LogReplicationMetadata.SyncStatus.ONGOING) {
                     countDownLatch.countDown();
                 }
             }

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -11,12 +11,14 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -214,8 +216,9 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         Set<LogReplicationMetadata.SyncType> actualSyncTypes = new HashSet<>();
         List<LogReplicationMetadata.SyncStatus> actualSyncStatus = new ArrayList<>();
 
-        for (CorfuStreamEntries entries : streamListener.getEntries()) {
-            for (List<CorfuStreamEntry> entry : entries.getEntries().values()) {
+        Iterator<CorfuStreamEntries> entriesIterator = streamListener.getEntries().iterator();
+        while (entriesIterator.hasNext()) {
+            for (List<CorfuStreamEntry> entry : entriesIterator.next().getEntries().values()) {
                 LogReplicationMetadata.ReplicationStatus status = (LogReplicationMetadata.ReplicationStatus) entry.get(0).getPayload();
                 actualSyncTypes.add(status.getSourceStatus().getReplicationInfo().getSyncType());
                 actualSyncStatus.add(status.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getStatus());
@@ -272,8 +275,9 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         Set<LogReplicationMetadata.SyncType> actualSyncTypes = new HashSet<>();
         List<LogReplicationMetadata.SyncStatus> actualSyncStatus = new ArrayList<>();
 
-        for (CorfuStreamEntries entries : streamListener.getEntries()) {
-            for (List<CorfuStreamEntry> entry : entries.getEntries().values()) {
+        Iterator<CorfuStreamEntries> entriesIterator = streamListener.getEntries().iterator();
+        while (entriesIterator.hasNext()) {
+            for (List<CorfuStreamEntry> entry : entriesIterator.next().getEntries().values()) {
                 LogReplicationMetadata.ReplicationStatus status = (LogReplicationMetadata.ReplicationStatus) entry.get(0).getPayload();
                 actualSyncTypes.add(status.getSourceStatus().getReplicationInfo().getSyncType());
                 actualSyncStatus.add(status.getSourceStatus().getReplicationInfo().getSnapshotSyncInfo().getStatus());
@@ -751,7 +755,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
      */
     class TestStreamListener implements StreamListener {
         @Getter
-        List<CorfuStreamEntries> entries = new ArrayList<>();
+        CopyOnWriteArrayList<CorfuStreamEntries> entries = new CopyOnWriteArrayList<>();
 
         @Getter
         Throwable throwable;

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -669,7 +669,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
                 DefaultClusterConfig topologyConfig = new DefaultClusterConfig();
                 defaultClusterManager.setLocalNodeId(topologyConfig.getSourceNodeUuids().get(0));
                 TopologyDescriptor topology = defaultClusterManager.generateSingleSourceSinkTopolgy();
-                SessionManager sessionManager = new SessionManager(topology, this.runtime);
+                new SessionManager(topology, this.runtime);
                 break;
             default:
                 break;

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -882,8 +882,9 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
                 "test:" + SERVERS.PORT_0, true);
         LogReplicationMetadataManager metadataManager = new LogReplicationMetadataManager(runtime, context);
 
-        // Manually initialize the replication status table
-        metadataManager.addSession(DEFAULT_SESSION, 0, true);
+        // Manually initialize the replication status table, needed for tests that check the
+        // source status so incoming needs to be set to false
+        metadataManager.addSession(DEFAULT_SESSION, 0, false);
 
         ackReader = new LogReplicationAckReader(metadataManager, runtime, DEFAULT_SESSION, context);
         fsm = new LogReplicationFSM(runtime, snapshotReader, dataSender, logEntryReader,

--- a/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
+++ b/test/src/test/java/org/corfudb/infrastructure/logreplication/LogReplicationFSMTest.java
@@ -207,6 +207,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         transition(LogReplicationEventType.SNAPSHOT_SYNC_REQUEST, LogReplicationStateType.IN_SNAPSHOT_SYNC);
 
         statusTableLatch.await();
+        corfuStore.unsubscribeListener(streamListener);
 
         Set<LogReplicationMetadata.SyncType> expectedSyncTypes = new HashSet<>(
                 Collections.singletonList(LogReplicationMetadata.SyncType.SNAPSHOT));
@@ -264,6 +265,7 @@ public class LogReplicationFSMTest extends AbstractViewTest implements Observer 
         transition(LogReplicationEventType.LOG_ENTRY_SYNC_REQUEST, LogReplicationStateType.IN_LOG_ENTRY_SYNC);
 
         statusTableLatch.await();
+        corfuStore.unsubscribeListener(streamListener);
 
         Set<LogReplicationMetadata.SyncType> expectedSyncTypes = new HashSet<>(
                 Collections.singletonList(LogReplicationMetadata.SyncType.LOG_ENTRY));


### PR DESCRIPTION
## Overview

Description:

LR sync status init value was set to log entry which is not accurate, this change sets the field dynamically.

Why should this be merged: 

When transitioning states there exists a window between the exit of InitializedState to the next state where the lastSyncType is marked as LOG_ENTRY regardless of the actual last sync type. This is due to the lastSyncType being set on or after entry of the next state and not on exit of InitializedState. In this window any query to lastSyncType is not guaranteed to be accurate. This change adds the logic to set the lastSyncType on exit of InitializedState since the information of the next state is already present at this point.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
