### PR TITLE
Allow clients to disable secondary indexes

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/TableParameters.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TableParameters.java
@@ -57,4 +57,7 @@ public class TableParameters<K extends Message, V extends Message, M extends Mes
     // like stream_tags, secondary indexes, backup_restore, log replication etc
     @Getter
     private final CorfuOptions.SchemaOptions schemaOptions;
+
+    @Getter
+    private final boolean secondaryIndexesDisabled;
 }

--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -589,6 +589,7 @@ public class TableRegistry {
                         .valueSchema(defaultValueMessage)
                         .metadataSchema(defaultMetadataMessage)
                         .schemaOptions(tableSchemaOptions)
+                        .secondaryIndexesDisabled(tableOptions.isSecondaryIndexesDisabled())
                         .build(),
                 this.runtime,
                 this.protobufSerializer,
@@ -781,6 +782,7 @@ public class TableRegistry {
                         .valueSchema(defaultValueMessage)
                         .metadataSchema(defaultMetadataMessage)
                         .schemaOptions(tableSchemaOptions)
+                        .secondaryIndexesDisabled(tableOptions.isSecondaryIndexesDisabled())
                         .build(),
                 this.runtime,
                 this.protobufSerializer,

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreSecondaryIndexTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreSecondaryIndexTest.java
@@ -7,6 +7,7 @@ import org.corfudb.runtime.ExampleSchemas.ExampleValue;
 import org.corfudb.runtime.ExampleSchemas.ActivitySchedule;
 import org.corfudb.runtime.ExampleSchemas.ManagedMetadata;
 import org.corfudb.runtime.ExampleSchemas.Adult;
+import org.corfudb.runtime.exceptions.TransactionAbortedException;
 import org.corfudb.runtime.proto.RpcCommon.UuidMsg;
 import org.corfudb.runtime.view.AbstractViewTest;
 import org.junit.Test;
@@ -20,6 +21,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -31,10 +33,56 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @SuppressWarnings("checkstyle:magicnumber")
 public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
 
+    private static final String ANOTHER_KEY_INDEX = "anotherKey";
+    
     private CorfuRuntime getTestRuntime() {
         return getDefaultRuntime();
     }
 
+    @Test
+    public void testDisableSecondaryIndexes() throws Exception {
+
+        // Get a Corfu Runtime instance.
+        CorfuRuntime corfuRuntime = getTestRuntime();
+
+        // Creating Corfu Store using a connected corfu client.
+        CorfuStoreShim shimStore = new CorfuStoreShim(corfuRuntime);
+
+        // Define a namespace for the table.
+        final String someNamespace = "some-namespace";
+        // Define table name.
+        final String tableName = "ManagedMetadata";
+
+        { // Positive test.
+            Table<UuidMsg, ExampleValue, ManagedMetadata> table = shimStore.openTable(
+                    someNamespace,
+                    tableName,
+                    UuidMsg.class,
+                    ExampleValue.class,
+                    ManagedMetadata.class,
+                    TableOptions.fromProtoSchema(ExampleValue.class)
+                            .toBuilder().secondaryIndexesDisabled(true).build());
+            
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
+                assertThatExceptionOfType(TransactionAbortedException.class)
+                        .isThrownBy(() -> txn.getByIndex(table, ANOTHER_KEY_INDEX, 0L))
+                        .withCauseInstanceOf(IllegalArgumentException.class);
+            }
+        }
+        { // Negative test.
+            Table<UuidMsg, ExampleValue, ManagedMetadata> table = shimStore.openTable(
+                    someNamespace,
+                    tableName + tableName,
+                    UuidMsg.class,
+                    ExampleValue.class,
+                    ManagedMetadata.class,
+                    TableOptions.fromProtoSchema(ExampleValue.class));
+
+            try (ManagedTxnContext txn = shimStore.tx(someNamespace)) {
+                txn.getByIndex(table,ANOTHER_KEY_INDEX, 0L);
+            }
+        }
+    }
     /**
      * Simple example to see how secondary indexes work. Please see example_schemas.proto.
      *
@@ -90,7 +138,7 @@ public class CorfuStoreSecondaryIndexTest extends AbstractViewTest {
 
         try (ManagedTxnContext readWriteTxn = shimStore.tx(someNamespace)) {
             List<CorfuStoreEntry<UuidMsg, ExampleValue, ManagedMetadata>> entries = readWriteTxn
-                    .getByIndex(table, "anotherKey", eventTime);
+                    .getByIndex(table, ANOTHER_KEY_INDEX, eventTime);
             assertThat(entries.size()).isEqualTo(1);
             assertThat(entries.get(0).getPayload().getPayload()).isEqualTo("abc");
             readWriteTxn.commit();


### PR DESCRIPTION
In some cases, a client might choose to load a table without a secondary index support in order to reduce memory usage. This can be done by providing an appropriate flag in TableOptions.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
