### PR TITLE
Add drop table support

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/LogUnitServer.java
@@ -14,6 +14,7 @@ import org.corfudb.infrastructure.log.InMemoryStreamLog;
 import org.corfudb.infrastructure.log.StreamLog;
 import org.corfudb.infrastructure.log.StreamLogCompaction;
 import org.corfudb.infrastructure.log.StreamLogFiles;
+import org.corfudb.protocols.CorfuProtocolCommon;
 import org.corfudb.protocols.CorfuProtocolLogData;
 import org.corfudb.protocols.service.CorfuProtocolMessage.ClusterIdCheck;
 import org.corfudb.protocols.service.CorfuProtocolMessage.EpochCheck;
@@ -59,6 +60,7 @@ import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getFlushCacheRe
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getInspectAddressesResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getKnownAddressResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getLogAddressSpaceResponseMsg;
+import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getLogUnitDeleteStreamsResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getRangeWriteLogResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getReadLogResponseMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getResetLogUnitResponseMsg;
@@ -451,6 +453,19 @@ public class LogUnitServer extends AbstractServer {
         // Note: we reuse the request header as the ignore_cluster_id and
         // ignore_epoch fields are the same in both cases.
         router.sendResponse(getResponseMsg(getHeaderMsg(req.getHeader()), getCompactResponseMsg()), ctx);
+    }
+
+    @RequestHandler(type = PayloadCase.LOG_UNIT_DELETE_STREAMS_REQUEST)
+    private void handleDeleteStreamsRequest(RequestMsg req, ChannelHandlerContext ctx, IServerRouter router) {
+        log.debug("handleDeleteStreamsRequest: {}", TextFormat.shortDebugString(req));
+
+        List<UUID> streamIds = req.getPayload().getLogUnitDeleteStreamsRequest().getStreamIdsList()
+                .stream().map(CorfuProtocolCommon::getUUID).collect(Collectors.toList());
+        streamLog.deleteStreams(streamIds);
+
+        // Note: we reuse the request header as the ignore_cluster_id and
+        // ignore_epoch fields are the same in both cases.
+        router.sendResponse(getResponseMsg(getHeaderMsg(req.getHeader()), getLogUnitDeleteStreamsResponseMsg()), ctx);
     }
 
     @RequestHandler(type = PayloadCase.FLUSH_CACHE_REQUEST)

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/InMemoryStreamLog.java
@@ -221,6 +221,11 @@ public class InMemoryStreamLog implements StreamLog {
     }
 
     @Override
+    public synchronized void deleteStreams(List<UUID> streamIds) {
+        logMetadata.deleteStreams(streamIds);
+    }
+
+    @Override
     public void reset() {
         startingAddress = 0;
         logMetadata = new LogMetadata();

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/LogMetadata.java
@@ -158,4 +158,12 @@ public class LogMetadata {
             streamAddressMap.getValue().trim(address);
         }
     }
+
+    public void deleteStreams(List<UUID> streamIds) {
+        log.info("deleteStreams: delete streams {}", streamIds);
+        for (UUID uuid : streamIds) {
+            streamTails.remove(uuid);
+            streamsAddressSpaceMap.remove(uuid);
+        }
+    }
 }

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLog.java
@@ -63,6 +63,12 @@ public interface StreamLog {
     void compact();
 
     /**
+     * Remove the address space of given streams
+     * @param streamIds the id of streams to remove
+     */
+    void deleteStreams(List<UUID> streamIds);
+
+    /**
      * Get the global tail and stream tails.
      */
     TailsResponse getTails(List<UUID> streams);

--- a/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/log/StreamLogFiles.java
@@ -328,6 +328,15 @@ public class StreamLogFiles implements StreamLog {
     }
 
     /**
+     * Remove the address space of given streams
+     * @param streamIds the id of streams to remove
+     */
+    @Override
+    public synchronized void deleteStreams(List<UUID> streamIds) {
+        logMetadata.deleteStreams(streamIds);
+    }
+
+    /**
      * Return a SegmentHandle for a corresponding log address.
      *
      * @param address global log address.

--- a/runtime/proto/service/corfu_message.proto
+++ b/runtime/proto/service/corfu_message.proto
@@ -63,6 +63,7 @@ message RequestPayloadMsg {
     SequencerTrimRequestMsg sequencer_trim_request = 32;
     SequencerMetricsRequestMsg sequencer_metrics_request = 33;
     StreamsAddressRequestMsg streams_address_request = 34;
+    SequencerDeleteStreamsRequestMsg sequencer_delete_streams_request = 35;
 
     // LogUnit Requests
     WriteLogRequestMsg write_log_request = 40;
@@ -79,6 +80,7 @@ message RequestPayloadMsg {
     CommittedTailRequestMsg committed_tail_request = 51;
     UpdateCommittedTailRequestMsg update_committed_tail_request = 52;
     ResetLogUnitRequestMsg reset_log_unit_request = 53;
+    LogUnitDeleteStreamsRequestMsg log_unit_delete_streams_request = 54;
 
     // Management Requests
     QueryNodeRequestMsg query_node_request = 60;
@@ -117,6 +119,7 @@ message ResponsePayloadMsg {
     SequencerTrimResponseMsg sequencer_trim_response = 32;
     SequencerMetricsResponseMsg sequencer_metrics_response = 33;
     StreamsAddressResponseMsg streams_address_response = 34;
+    SequencerDeleteStreamsResponseMsg sequencer_delete_streams_response = 35;
 
     // LogUnit Responses
     WriteLogResponseMsg write_log_response = 40;
@@ -133,6 +136,7 @@ message ResponsePayloadMsg {
     CommittedTailResponseMsg committed_tail_response = 51;
     UpdateCommittedTailResponseMsg update_committed_tail_response = 52;
     ResetLogUnitResponseMsg reset_log_unit_response = 53;
+    LogUnitDeleteStreamsResponseMsg log_unit_delete_streams_response = 54;
 
     // Management Responses
     QueryNodeResponseMsg query_node_response = 60;

--- a/runtime/proto/service/log_unit.proto
+++ b/runtime/proto/service/log_unit.proto
@@ -137,3 +137,10 @@ message ResetLogUnitRequestMsg {
 
 message ResetLogUnitResponseMsg {
 }
+
+message LogUnitDeleteStreamsRequestMsg {
+  repeated UuidMsg streamIds = 1;
+}
+
+message LogUnitDeleteStreamsResponseMsg {
+}

--- a/runtime/proto/service/sequencer.proto
+++ b/runtime/proto/service/sequencer.proto
@@ -138,3 +138,10 @@ message StreamsAddressResponseMsg {
   int64 epoch = 2;
   repeated UuidToStreamAddressSpacePairMsg address_map = 3;
 }
+
+message SequencerDeleteStreamsRequestMsg {
+  repeated UuidMsg streamIds = 1;
+}
+
+message SequencerDeleteStreamsResponseMsg {
+}

--- a/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogUnit.java
+++ b/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolLogUnit.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.corfudb.protocols.CorfuProtocolCommon;
 import org.corfudb.protocols.CorfuProtocolLogData;
 import org.corfudb.protocols.wireprotocol.InspectAddressesResponse;
 import org.corfudb.protocols.wireprotocol.KnownAddressResponse;
@@ -30,6 +31,8 @@ import org.corfudb.runtime.proto.service.LogUnit.KnownAddressRequestMsg;
 import org.corfudb.runtime.proto.service.LogUnit.KnownAddressResponseMsg;
 import org.corfudb.runtime.proto.service.LogUnit.LogAddressSpaceRequestMsg;
 import org.corfudb.runtime.proto.service.LogUnit.LogAddressSpaceResponseMsg;
+import org.corfudb.runtime.proto.service.LogUnit.LogUnitDeleteStreamsRequestMsg;
+import org.corfudb.runtime.proto.service.LogUnit.LogUnitDeleteStreamsResponseMsg;
 import org.corfudb.runtime.proto.service.LogUnit.RangeWriteLogRequestMsg;
 import org.corfudb.runtime.proto.service.LogUnit.RangeWriteLogResponseMsg;
 import org.corfudb.runtime.proto.service.LogUnit.ReadLogRequestMsg;
@@ -348,6 +351,32 @@ public final class CorfuProtocolLogUnit {
     public static ResponsePayloadMsg getFlushCacheResponseMsg() {
         return ResponsePayloadMsg.newBuilder()
                 .setFlushCacheResponse(FlushCacheResponseMsg.getDefaultInstance())
+                .build();
+    }
+
+    /**
+     * Returns a LOG_UNIT_DELETE_STREAMS request that can be sent by the client.
+     *
+     * @return  a RequestPayloadMsg containing the LOG_UNIT_DELETE_STREAMS request
+     */
+    public static RequestPayloadMsg getLogUnitDeleteStreamsRequestMsg(List<UUID> streamIds) {
+        return RequestPayloadMsg.newBuilder().setLogUnitDeleteStreamsRequest(
+                LogUnitDeleteStreamsRequestMsg
+                        .newBuilder().addAllStreamIds(streamIds.stream()
+                                .map(CorfuProtocolCommon::getUuidMsg)
+                                .collect(Collectors.toList()))
+                        .build())
+                .build();
+    }
+
+    /**
+     * Returns a LOG_UNIT_DELETE_STREAMS response that can be sent by the server.
+     *
+     * @return  a ResponsePayloadMsg containing the LOG_UNIT_DELETE_STREAMS response
+     */
+    public static ResponsePayloadMsg getLogUnitDeleteStreamsResponseMsg() {
+        return ResponsePayloadMsg.newBuilder()
+                .setLogUnitDeleteStreamsResponse(LogUnitDeleteStreamsResponseMsg.getDefaultInstance())
                 .build();
     }
 

--- a/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolSequencer.java
+++ b/runtime/src/main/java/org/corfudb/protocols/service/CorfuProtocolSequencer.java
@@ -17,6 +17,8 @@ import org.corfudb.runtime.proto.service.CorfuMessage.RequestPayloadMsg;
 import org.corfudb.runtime.proto.service.CorfuMessage.ResponsePayloadMsg;
 import org.corfudb.runtime.proto.service.Sequencer.BootstrapSequencerRequestMsg;
 import org.corfudb.runtime.proto.service.Sequencer.BootstrapSequencerResponseMsg;
+import org.corfudb.runtime.proto.service.Sequencer.SequencerDeleteStreamsRequestMsg;
+import org.corfudb.runtime.proto.service.Sequencer.SequencerDeleteStreamsResponseMsg;
 import org.corfudb.runtime.proto.service.Sequencer.SequencerMetricsRequestMsg;
 import org.corfudb.runtime.proto.service.Sequencer.SequencerMetricsResponseMsg;
 import org.corfudb.runtime.proto.service.Sequencer.SequencerTrimRequestMsg;
@@ -252,6 +254,35 @@ public final class CorfuProtocolSequencer {
     public static ResponsePayloadMsg getSequencerTrimResponseMsg() {
         return ResponsePayloadMsg.newBuilder()
                 .setSequencerTrimResponse(SequencerTrimResponseMsg.getDefaultInstance())
+                .build();
+    }
+
+    /**
+     * Returns a new {@link RequestPayloadMsg} Protobuf object consisting of a
+     * {@link SequencerDeleteStreamsRequestMsg} object with the list of stream Ids from the parameter.
+     *
+     * @param streamIds the list of stream Ids required on the SequencerDeleteStreamsRequestMsg.
+     * @return a new {@link RequestPayloadMsg} Protobuf object
+     */
+    public static RequestPayloadMsg getSequencerDeleteStreamsRequestMsg(List<UUID> streamIds) {
+        return RequestPayloadMsg.newBuilder().setSequencerDeleteStreamsRequest(
+                SequencerDeleteStreamsRequestMsg
+                        .newBuilder().addAllStreamIds(streamIds.stream()
+                                .map(CorfuProtocolCommon::getUuidMsg)
+                                .collect(Collectors.toList()))
+                        .build())
+                .build();
+    }
+
+    /**
+     * Returns a new {@link ResponsePayloadMsg} Protobuf object consisting of a default
+     * {@link SequencerDeleteStreamsResponseMsg} object.
+     *
+     * @return the {@link ResponsePayloadMsg} Protobuf object
+     */
+    public static ResponsePayloadMsg getSequencerDeleteStreamsResponseMsg() {
+        return ResponsePayloadMsg.newBuilder()
+                .setSequencerDeleteStreamsResponse(SequencerDeleteStreamsResponseMsg.getDefaultInstance())
                 .build();
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitClient.java
@@ -27,6 +27,7 @@ import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getFlushCacheRe
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getInspectAddressesRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getKnownAddressRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getLogAddressSpaceRequestMsg;
+import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getLogUnitDeleteStreamsRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getRangeWriteLogRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getReadLogRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolLogUnit.getResetLogUnitRequestMsg;
@@ -225,6 +226,15 @@ public class LogUnitClient extends AbstractClient {
      */
     public CompletableFuture<Void> compact() {
         return sendRequestWithFuture(getCompactRequestMsg(), ClusterIdCheck.CHECK, EpochCheck.IGNORE);
+    }
+
+    /**
+     * Send a delete stream requests that will delete the stream address space.
+     * @param streamIds a list of streams to delete
+     */
+    public CompletableFuture<Void> deleteStreams(List<UUID> streamIds) {
+        return sendRequestWithFuture(getLogUnitDeleteStreamsRequestMsg(streamIds),
+                ClusterIdCheck.CHECK, EpochCheck.IGNORE);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/LogUnitHandler.java
@@ -168,6 +168,19 @@ public class LogUnitHandler implements IClient, IHandler<LogUnitClient> {
     }
 
     /**
+     * Handle a delete streams response from the server.
+     *
+     * @param msg      The flush cache response message.
+     * @param ctx      The context the message was sent under.
+     * @param router   A reference to the router.
+     * @return Always True, since the deletion was successful.
+     */
+    @ResponseHandler(type = PayloadCase.LOG_UNIT_DELETE_STREAMS_RESPONSE)
+    private static Object handleDeleteStreamsResponse(ResponseMsg msg, ChannelHandlerContext ctx, IClientRouter router) {
+        return true;
+    }
+
+    /**
      * Handle a log address space response from the server.
      *
      * @param msg      The log address space response message.

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerClient.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CompletableFuture;
 
 import static org.corfudb.protocols.service.CorfuProtocolSequencer.getBootstrapSequencerRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolSequencer.getDefaultSequencerMetricsRequestMsg;
+import static org.corfudb.protocols.service.CorfuProtocolSequencer.getSequencerDeleteStreamsRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolSequencer.getSequencerTrimRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolSequencer.getStreamsAddressRequestMsg;
 import static org.corfudb.protocols.service.CorfuProtocolSequencer.getTokenRequestMsg;
@@ -81,6 +82,12 @@ public class SequencerClient extends AbstractClient {
 
     public CompletableFuture<Void> trimCache(Long address) {
         return sendRequestWithFuture(getSequencerTrimRequestMsg(address),
+                ClusterIdCheck.CHECK, EpochCheck.CHECK);
+    }
+
+    public CompletableFuture<Boolean> deleteStreams(List<UUID> streamIds) {
+        return sendRequestWithFuture(
+                getSequencerDeleteStreamsRequestMsg(streamIds),
                 ClusterIdCheck.CHECK, EpochCheck.CHECK);
     }
 

--- a/runtime/src/main/java/org/corfudb/runtime/clients/SequencerHandler.java
+++ b/runtime/src/main/java/org/corfudb/runtime/clients/SequencerHandler.java
@@ -124,4 +124,19 @@ public class SequencerHandler implements IClient, IHandler<SequencerClient> {
                 msg.getPayload().getStreamsAddressResponse().getEpoch(),
                 msg.getPayload().getStreamsAddressResponse().getAddressMapList());
     }
+
+    /**
+     * Handle a sequencer delete streams response from the server.
+     *
+     * @param msg      The sequencer metrics response message.
+     * @param ctx      The context the message was sent under.
+     * @param router   A reference to the router.
+     * @return Always True, since the stream deletion were successful.
+     */
+    @ResponseHandler(type = PayloadCase.SEQUENCER_DELETE_STREAMS_RESPONSE)
+    private static Object handleDeleteStreamsResponse(ResponseMsg msg,
+                                                      ChannelHandlerContext ctx,
+                                                      IClientRouter router) {
+        return true;
+    }
 }

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -165,13 +165,32 @@ public class CorfuStore {
     }
 
     /**
-     * Deletes a table instance. [NOT SUPPORTED.]
+     * Clear all entries of a table.
      *
      * @param namespace Namespace of the table.
      * @param tableName Table name.
      */
-    public void deleteTable(String namespace, String tableName) {
-        runtime.getTableRegistry().deleteTable(namespace, tableName);
+    public void clearTable(String namespace, String tableName) {
+        runtime.getTableRegistry().clearTable(namespace, tableName);
+    }
+
+    /**
+     * Drops a table. It includes deleting all table entries, deleting it in
+     * RegistryTable, and deleting its stream address space in Sequencer Server and
+     * LogUnit Server. It does not proactively release the local client memory held
+     * by this table or its snapshots.
+     *
+     * It is the user's responsibility to ensure that there is no other clients still
+     * operating on this table before which is dropped.
+     *
+     * The table does not need to be opened by this CorfuStore instance in oder to
+     * run the dropTable().
+     *
+     * @param namespace namespace this table
+     * @param tableName name this table
+     */
+    public void dropTable(String namespace, String tableName) {
+        runtime.getTableRegistry().dropTable(namespace, tableName);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStore.java
@@ -165,32 +165,40 @@ public class CorfuStore {
     }
 
     /**
-     * Clear all entries of a table.
+     * Deletes a table instance. [NOT SUPPORTED.]
      *
      * @param namespace Namespace of the table.
      * @param tableName Table name.
      */
-    public void clearTable(String namespace, String tableName) {
-        runtime.getTableRegistry().clearTable(namespace, tableName);
+    public void deleteTable(String namespace, String tableName) {
+        runtime.getTableRegistry().deleteTable(namespace, tableName);
     }
 
     /**
-     * Drops a table. It includes deleting all table entries, deleting it in
-     * RegistryTable, and deleting its stream address space in Sequencer Server and
-     * LogUnit Server. It does not proactively release the local client memory held
-     * by this table or its snapshots.
-     *
-     * It is the user's responsibility to ensure that there is no other clients still
-     * operating on this table before which is dropped.
-     *
-     * The table does not need to be opened by this CorfuStore instance in oder to
-     * run the dropTable().
+     * Unregister a table, and clear the table empty. This will cause the table
+     * to be trimmed upon next compaction cycle. This method combined with
+     * dropTrimmedTable() accomplishes deep clean up of tables. User should
+     * call this method first, then make sure compaction actually trims this
+     * table, and finally call dropTrimmedTable() to finish the cleanup.
      *
      * @param namespace namespace this table
-     * @param tableName name this table
+     * @param tableName name of this table
      */
-    public void dropTable(String namespace, String tableName) {
-        runtime.getTableRegistry().dropTable(namespace, tableName);
+    public void unregisterTable(String namespace, String tableName) {
+        runtime.getTableRegistry().clearAndUnregisterTable(namespace, tableName);
+    }
+
+    /**
+     * Delete the table and its checkpoint stream from the sequencer server and
+     * log unit server to clean up the in-mem maps. Since the table has been trimmed,
+     * future server restarts will not reload the previously trimmed address space.
+     * After calling this method, accesses to this table will not hit TrimmedException.
+     *
+     * @param namespace Namespace of the table.
+     * @param tableName Name of the table.
+     */
+    public void dropTrimmedTable(String namespace, String tableName) {
+        runtime.getTableRegistry().dropTrimmedTable(namespace, tableName);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreShim.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreShim.java
@@ -97,7 +97,7 @@ public class CorfuStoreShim {
      * @param tableName Table name.
      */
     public void deleteTable(String namespace, String tableName) {
-        corfuStore.clearTable(namespace, tableName);
+        corfuStore.deleteTable(namespace, tableName);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreShim.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/CorfuStoreShim.java
@@ -97,7 +97,7 @@ public class CorfuStoreShim {
      * @param tableName Table name.
      */
     public void deleteTable(String namespace, String tableName) {
-        corfuStore.deleteTable(namespace, tableName);
+        corfuStore.clearTable(namespace, tableName);
     }
 
     /**

--- a/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
+++ b/runtime/src/main/java/org/corfudb/runtime/object/transactions/OptimisticTransactionalContext.java
@@ -72,7 +72,6 @@ public class OptimisticTransactionalContext extends AbstractTransactionalContext
                                                 Object[] conflictObject) {
         long startAccessTime = System.nanoTime();
         try {
-            log.debug("Access[{},{}] conflictObj={}", this, proxy, conflictObject);
 
             // First, we add this access to the read set
             addToReadSet(proxy, conflictObject);

--- a/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/SequencerView.java
@@ -141,4 +141,9 @@ public class SequencerView extends AbstractView {
     public void trimCache(long address) {
         runtime.getLayoutView().getRuntimeLayout().getPrimarySequencerClient().trimCache(address);
     }
+
+    public void deleteStreams(List<UUID> streamIds) {
+        layoutHelper(e -> CFUtils.getUninterruptibly(e.getPrimarySequencerClient()
+                .deleteStreams(streamIds)));
+    }
 }

--- a/test/src/test/java/org/corfudb/integration/AbstractIT.java
+++ b/test/src/test/java/org/corfudb/integration/AbstractIT.java
@@ -521,6 +521,7 @@ public class AbstractIT extends AbstractCorfuTest {
         private String disableCertExpiryCheckFile = null;
         private String compressionCodec = null;
         private boolean disableHost = false;
+        private boolean disableLogUnitServerCache = false;
         private String networkInterface = null;
         private NetworkInterfaceVersion networkInterfaceVersion = null;
 
@@ -534,8 +535,12 @@ public class AbstractIT extends AbstractCorfuTest {
         public String getOptionsString() {
             StringBuilder command = new StringBuilder();
 
+            if (disableLogUnitServerCache) {
+                command.append("-c ").append(0);
+            }
+
             if (!disableHost) {
-                command.append("-a ").append(host);
+                command.append(" -a ").append(host);
             }
 
             if (logPath != null) {

--- a/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
+++ b/test/src/test/java/org/corfudb/integration/CorfuStoreIT.java
@@ -30,6 +30,7 @@ import org.corfudb.runtime.collections.Table;
 import org.corfudb.runtime.collections.TableOptions;
 import org.corfudb.runtime.collections.TxnContext;
 import org.corfudb.runtime.exceptions.TransactionAbortedException;
+import org.corfudb.runtime.exceptions.TrimmedException;
 import org.corfudb.runtime.object.ICorfuVersionPolicy;
 import org.corfudb.runtime.proto.RpcCommon;
 import org.corfudb.runtime.view.ObjectOpenOption;
@@ -47,7 +48,6 @@ import org.junit.Test;
 import org.rocksdb.Options;
 
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -59,7 +59,6 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -67,6 +66,7 @@ import java.util.function.Supplier;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.corfudb.runtime.view.TableRegistry.CORFU_SYSTEM_NAMESPACE;
+import static org.corfudb.runtime.view.TableRegistry.getFullyQualifiedTableName;
 import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.spy;
@@ -440,7 +440,7 @@ public class CorfuStoreIT extends AbstractIT {
                 ManagedResources.newBuilder().setCreateUser("CreateUser").build());
         tx.commit();
 
-        corfuStore.clearTable(nsxManager, tableName);
+        corfuStore.deleteTable(nsxManager, tableName);
 
         MultiCheckpointWriter<PersistentCorfuTable<?, ?>> mcw = new MultiCheckpointWriter<>();
         PersistentCorfuTable<Uuid, CorfuRecord<SampleSchema.EventInfo, ManagedResources>> corfuTable =
@@ -478,562 +478,80 @@ public class CorfuStoreIT extends AbstractIT {
     }
 
     /**
-     * step 1 - write data into tableA and tableB
-     * step 2 - start a new corfu runtime, drop tableB, verify data in tableA and tableB
-     * step 3 - restart corfu server, start a new corfu runtime, verify data in tableA and tableB
+     * 1. Write key to the test table
+     * 2. Unregister the table, run checkpoint to trim the table
+     * 3. Verify table.get(key) hit TrimmedException
+     * 4. Invoke dropTrimmedTable(), verify table.get(key) returns null
+     * 5. Restart corfu server, verify table.get(key) still returns null
      */
     @Test
-    public void basicDropTableTest() throws Exception {
+    public void basicUnregisterAndDropTableTest() throws Exception {
         Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
 
-        // PHASE 1 - Start a Corfu runtime & a CorfuStore instance
         runtime = createRuntime(singleNodeEndpoint);
-
-        // Creating Corfu Store using a connected corfu client.
         CorfuStore corfuStore = new CorfuStore(runtime);
 
-        // Define a namespace for the table.
         final String namespace = "test-namespace";
-        // Define table names.
-        final String tableNameA = "test-table-a";
-        final String tableNameB = "test-table-b";
+        final String tableName = "test-table-name";
+        final String fullyQualifiedTableName = getFullyQualifiedTableName(namespace, tableName);
 
-        // Create & Register the table.
-        // This is required to initialize the table for the current corfu client.
-        Table<Uuid, Uuid, Uuid> tableA = corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-        Table<Uuid, Uuid, Uuid> tableB = corfuStore.openTable(
-                namespace,
-                tableNameB,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-
-        Uuid key1 = Uuid.newBuilder().setLsb(1L).setMsb(1L).build();
-        Uuid key2 = Uuid.newBuilder().setLsb(2L).setMsb(2L).build();
-
-        TxnContext tx = corfuStore.txn(namespace);
-        tx.putRecord(tableA, key1, key1, null);
-        tx.commit();
-
-        tx = corfuStore.txn(namespace);
-        tx.putRecord(tableB, key2, key2, null);
-        tx.commit();
-
-        runtime.shutdown();
-
-        // ---------------------------------------------------------------------------------------------
-
-        runtime = createRuntime(singleNodeEndpoint);
-
-        corfuStore = new CorfuStore(runtime);
-        corfuStore.dropTable(namespace, tableNameB);
-
-        // Re-Create & Register the table.
-        // This is required to initialize the table for the current corfu client.
-        corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-        corfuStore.openTable(
-                namespace,
-                tableNameB,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-
-        tx = corfuStore.txn(namespace);
-        assertThat(tx.getRecord(tableNameA, key1).getPayload()).isEqualTo(key1);
-        assertThat(tx.getRecord(tableNameB, key2).getPayload()).isNull();
-        tx.commit();
-        runtime.shutdown();
-
-        // ---------------------------------------------------------------------------------------------
-        // Restart Corfu Server
-        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
-        runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
-
-        // Reopen the dropped table
-        runtime = createRuntime(singleNodeEndpoint);
-
-        corfuStore = new CorfuStore(runtime);
-
-        // Re-Create & Register the table.
-        // This is required to initialize the table for the current corfu client.
-        corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-        corfuStore.openTable(
-                namespace,
-                tableNameB,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-
-        tx = corfuStore.txn(namespace);
-        assertThat(tx.getRecord(tableNameA, key1).getPayload()).isEqualTo(key1);
-        assertThat(tx.getRecord(tableNameB, key2).getPayload()).isNull();
-        tx.commit();
-
-        runtime.shutdown();
-        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
-    }
-
-    @Test
-    public void dropUnregisteredRawCorfuTableTest() throws Exception {
-        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
-
-        runtime = createRuntime(singleNodeEndpoint);
-        CorfuStore corfuStore = new CorfuStore(runtime);
-
-        // Define table names.
-        final String tableNameA = "test-table-a";
-
-        CorfuTable<String, String> tableA = runtime.getObjectsView()
+        // Load data in the table
+        CorfuTable<String, String> table = runtime.getObjectsView()
                 .build()
-                .setStreamName(tableNameA)
+                .setStreamName(fullyQualifiedTableName)
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {
                 })
                 .open();
-
         String key1 = "key1";
         String value1 = "value1";
-        tableA.put(key1, value1);
+        table.put(key1, value1);
 
-        corfuStore.dropTable("", tableNameA);
+        // unregisterTable
+        corfuStore.unregisterTable(namespace, tableName);
         runtime.shutdown();
 
-        // Restart Corfu Server
-        assertThat(shutdownCorfuServer(corfuServer)).isTrue();
-        runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
-
-        // Reopen the dropped table
+        // Run checkpoint to trim the table
         runtime = createRuntime(singleNodeEndpoint);
+        MultiCheckpointWriter<PersistentCorfuTable<?, ?>> mcw = new MultiCheckpointWriter<>();
+        mcw.addMap(runtime.getTableRegistry().getRegistryTable());
+        mcw.addMap(runtime.getTableRegistry().getProtobufDescriptorTable());
+        Token trimPoint = mcw.appendCheckpoints(runtime, "checkpointer");
+        runtime.getAddressSpaceView().prefixTrim(trimPoint);
+        runtime.shutdown();
 
-        // Re-Create & Register the table.
-        // This is required to initialize the table for the current corfu client.
-        tableA = runtime.getObjectsView()
+        // Verify that accessing the table hit TrimmedException
+        runtime = createRuntime(singleNodeEndpoint);
+        table = runtime.getObjectsView()
                 .build()
-                .setStreamName(tableNameA)
+                .setStreamName(fullyQualifiedTableName)
                 .setTypeToken(new TypeToken<CorfuTable<String, String>>() {
                 })
                 .open();
 
-        assertThat(tableA.get(key1)).isNull();
+        CorfuTable<String, String> finalTable = table;
+        assertThatThrownBy(() -> finalTable.get(key1))
+                .isInstanceOf(TrimmedException.class);
+
+        // dropTrimmedTable and verify the table is empty
+        corfuStore = new CorfuStore(runtime);
+        corfuStore.dropTrimmedTable(namespace, tableName);
+
+        assertThat(table.get(key1)).isNull();
         runtime.shutdown();
         assertThat(shutdownCorfuServer(corfuServer)).isTrue();
-    }
 
-    /**
-     * step 1 - write data into tableA, checkpoint tableA, trim the log
-     * step 2 - open new corfu runtime, call dropTable on tableA, reopen and read tableA, verify it's empty
-     */
-    @Test
-    public void dropTableTestWithCheckpointing() throws Exception {
-        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
-
-        // PHASE 1 - Start a Corfu runtime & a CorfuStore instance
-        runtime = createRuntime(singleNodeEndpoint);
-
-        // Creating Corfu Store using a connected corfu client.
-        CorfuStore corfuStore = new CorfuStore(runtime);
-
-        // Define a namespace for the table.
-        final String namespace = "test-namespace";
-        // Define table names.
-        final String tableNameA = "test-table-a";
-
-        // Create & Register the table.
-        // This is required to initialize the table for the current corfu client.
-        Table<Uuid, Uuid, Uuid> tableA = corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-
-        Uuid key1 = Uuid.newBuilder().setLsb(1L).setMsb(1L).build();
-
-        TxnContext tx = corfuStore.txn(namespace);
-        tx.putRecord(tableA, key1, key1, null);
-        tx.commit();
-
-        // Checkpoint table A and trim
-        MultiCheckpointWriter<PersistentCorfuTable<?, ?>> mcw = new MultiCheckpointWriter<>();
-        PersistentCorfuTable<Uuid, CorfuRecord<Uuid, Uuid>> corfuTableA =
-                createCorfuTable(runtime, tableA.getFullyQualifiedTableName());
-        mcw.addMap(corfuTableA);
-        mcw.addMap(runtime.getTableRegistry().getRegistryTable());
-        mcw.addMap(runtime.getTableRegistry().getProtobufDescriptorTable());
-        Token trimPoint = mcw.appendCheckpoints(runtime, "checkpointer");
-        runtime.getAddressSpaceView().prefixTrim(trimPoint);
-        runtime.shutdown();
-
-        // ---------------------------------------------------------------------------------------------
+        // Restart corfu server and verify the table is still empty
+        runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
 
         runtime = createRuntime(singleNodeEndpoint);
-        corfuStore = new CorfuStore(runtime);
-
-        corfuStore.dropTable(namespace, tableNameA);
-
-        corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-
-        tx = corfuStore.txn(namespace);
-        assertThat(tx.getRecord(tableNameA, key1).getPayload()).isNull();
-        tx.commit();
+        table = runtime.getObjectsView()
+                .build()
+                .setStreamName(fullyQualifiedTableName)
+                .setTypeToken(new TypeToken<CorfuTable<String, String>>() {
+                })
+                .open();
+        assertThat(table.get(key1)).isNull();
         runtime.shutdown();
-        shutdownCorfuServer(corfuServer);
-    }
-
-    /**
-     * step 1 - write data into tableA, call dropTable on tableA, reopen tableA
-     * step 2 - restart corfu server, verify tableA is empty
-     */
-    @Test
-    public void dropTableTestWithReopening() throws Exception {
-        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
-
-        // PHASE 1 - Start a Corfu runtime & a CorfuStore instance
-        runtime = createRuntime(singleNodeEndpoint);
-
-        // Creating Corfu Store using a connected corfu client.
-        CorfuStore corfuStore = new CorfuStore(runtime);
-
-        // Define a namespace for the table.
-        final String namespace = "test-namespace";
-        // Define table names.
-        final String tableNameA = "test-table-a";
-
-        // Create & Register the table.
-        // This is required to initialize the table for the current corfu client.
-        Table<Uuid, Uuid, Uuid> tableA = corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-
-        Uuid key1 = Uuid.newBuilder().setLsb(1L).setMsb(1L).build();
-
-        TxnContext tx = corfuStore.txn(namespace);
-        tx.putRecord(tableA, key1, key1, null);
-        tx.commit();
-
-        corfuStore.dropTable(namespace, tableNameA);
-
-        corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-        tx = corfuStore.txn(namespace);
-        assertThat(tx.getRecord(tableNameA, key1).getPayload()).isNull();
-        tx.commit();
-
-        runtime.shutdown();
-        shutdownCorfuServer(corfuServer);
-
-        // ---------------------------------------------------------------------------------------------
-        corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
-        TimeUnit.SECONDS.sleep(1);
-        runtime = createRuntime(singleNodeEndpoint);
-        corfuStore = new CorfuStore(runtime);
-
-        corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-
-        tx = corfuStore.txn(namespace);
-        assertThat(tx.getRecord(tableNameA, key1).getPayload()).isNull();
-        tx.commit();
-        runtime.shutdown();
-        shutdownCorfuServer(corfuServer);
-    }
-
-    /**
-     * step 1 - open tableA, write data into tableA, then drop tableA
-     * step 2 - restart corfu server, reopen and read tableA, verify that it's empty
-     */
-    @Test
-    @SuppressWarnings("checkstyle:magicnumber")
-    public void restartServerAfterDroppingTableTest() throws Exception {
-        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
-        runtime = createRuntime(singleNodeEndpoint);
-        CorfuStore corfuStore = new CorfuStore(runtime);
-
-        final String namespace = "test-namespace";
-        final String tableNameA = "test-table-a";
-
-        Table<Uuid, Uuid, Uuid> tableA = corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-        Uuid key1 = Uuid.newBuilder().setLsb(1L).setMsb(1L).build();
-        TxnContext tx = corfuStore.txn(namespace);
-        tx.putRecord(tableA, key1, key1, null);
-        tx.commit();
-
-        corfuStore.dropTable(namespace, tableNameA);
-
-        corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-        tx = corfuStore.txn(namespace);
-        assertThat(tx.getRecord(tableNameA, key1).getPayload()).isNull();
-        tx.commit();
-        runtime.shutdown();
-        shutdownCorfuServer(corfuServer);
-
-        // Restart Corfu Server
-        corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort);
-        TimeUnit.SECONDS.sleep(1);
-        runtime = createRuntime(singleNodeEndpoint);
-        corfuStore = new CorfuStore(runtime);
-        corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-        tx = corfuStore.txn(namespace);
-        // The table should be empty after the restart
-        assertThat(tx.getRecord(tableNameA, key1).getPayload()).isNull();
-        tx.commit();
-        runtime.shutdown();
-        shutdownCorfuServer(corfuServer);
-    }
-
-    /**
-     * step 1 - write data into tableA and tableB, only checkpoint tableA, trim the log
-     * step 2 - call dropTable on tableB, read tableB and verify it's empty
-     */
-    @Test
-    public void dropATrimmedTableTest() throws Exception {
-        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
-
-        // PHASE 1 - Start a Corfu runtime & a CorfuStore instance
-        runtime = createRuntime(singleNodeEndpoint);
-
-        // Creating Corfu Store using a connected corfu client.
-        CorfuStore corfuStore = new CorfuStore(runtime);
-
-        // Define a namespace for the table.
-        final String namespace = "test-namespace";
-        // Define table names.
-        final String tableNameA = "test-table-a";
-        final String tableNameB = "test-table-b";
-
-        // Create & Register the table.
-        // This is required to initialize the table for the current corfu client.
-        Table<Uuid, Uuid, Uuid> tableA = corfuStore.openTable(
-                namespace,
-                tableNameA,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-        Table<Uuid, Uuid, Uuid> tableB = corfuStore.openTable(
-                namespace,
-                tableNameB,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-
-        Uuid key1 = Uuid.newBuilder().setLsb(1L).setMsb(1L).build();
-        Uuid key2 = Uuid.newBuilder().setLsb(2L).setMsb(2L).build();
-
-        TxnContext tx = corfuStore.txn(namespace);
-        tx.putRecord(tableA, key1, key1, null);
-        tx.commit();
-
-        tx = corfuStore.txn(namespace);
-        tx.putRecord(tableB, key2, key2, null);
-        tx.commit();
-
-        // Checkpoint table A and trim
-        MultiCheckpointWriter<PersistentCorfuTable<?, ?>> mcw = new MultiCheckpointWriter<>();
-        PersistentCorfuTable<Uuid, CorfuRecord<Uuid, Uuid>> corfuTableA =
-                createCorfuTable(runtime, tableA.getFullyQualifiedTableName());
-        mcw.addMap(corfuTableA);
-        mcw.addMap(runtime.getTableRegistry().getRegistryTable());
-        mcw.addMap(runtime.getTableRegistry().getProtobufDescriptorTable());
-        Token trimPoint = mcw.appendCheckpoints(runtime, "checkpointer");
-        runtime.getAddressSpaceView().prefixTrim(trimPoint);
-
-        corfuStore.dropTable(namespace, tableNameB);
-
-        corfuStore.openTable(
-                namespace,
-                tableNameB,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-        tx = corfuStore.txn(namespace);
-        assertThat(tx.getRecord(tableNameA, key1).getPayload()).isEqualTo(key1);
-        assertThat(tx.getRecord(tableNameB, key2).getPayload()).isNull();
-        tx.commit();
-        runtime.shutdown();
-        shutdownCorfuServer(corfuServer);
-    }
-
-    /**
-     * Thread 1                      Thread 2
-     * --------------------------------------------------------
-     * Write key1 to table
-     *                               Verify key1 is in table
-     * Drop table
-     *                               Verify key1 is not in table
-     * Compactor trims table
-     *                               Verify key1 is not in table
-     *                               Write key2 to table, and verify TAE with invalid stream set
-     */
-    @Test
-    public void differentRuntimeReadingDroppedTableTest() throws Exception {
-
-        Process corfuServer = runSinglePersistentServer(corfuSingleNodeHost, corfuStringNodePort, true);
-
-        runtime = createRuntime(singleNodeEndpoint);
-        CorfuStore corfuStore = new CorfuStore(runtime);
-
-        // Define a namespace for the table.
-        final String namespace = "test-namespace";
-        // Define table names.
-        final String tableName = "test-table";
-
-        Table<Uuid, Uuid, Uuid> table = corfuStore.openTable(
-                namespace,
-                tableName,
-                Uuid.class,
-                Uuid.class,
-                null,
-                TableOptions.builder().build());
-
-        Uuid key = Uuid.newBuilder().setLsb(1L).setMsb(1L).build();
-        TxnContext tx = corfuStore.txn(namespace);
-        tx.putRecord(table, key, key, null);
-        tx.commit();
-
-        CountDownLatch latch1 = new CountDownLatch(1);
-        CountDownLatch latch2 = new CountDownLatch(1);
-        CountDownLatch latch3 = new CountDownLatch(1);
-
-        Thread secondRuntimeThread = new Thread(() -> {
-            CorfuRuntime runtime2 = createRuntime(singleNodeEndpoint);
-            CorfuStore corfuStore2 = new CorfuStore(runtime2);
-
-            Table table2;
-            try {
-                table2 = corfuStore2.openTable(
-                        namespace,
-                        tableName,
-                        Uuid.class,
-                        Uuid.class,
-                        null,
-                        TableOptions.builder().build());
-            } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
-
-            TxnContext tx2 = corfuStore2.txn(namespace);
-            assertThat(tx2.getRecord(tableName, key).getPayload()).isEqualTo(key);
-            tx2.commit();
-
-            latch1.countDown();
-
-            try {
-                latch2.await();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-
-            tx2 = corfuStore2.txn(namespace);
-            assertThat(tx2.getRecord(tableName, key).getPayload()).isNull();
-            tx2.commit();
-
-            try {
-                latch3.await();
-            } catch (InterruptedException e) {
-                throw new RuntimeException(e);
-            }
-
-            Token trimToken = runtime2.getAddressSpaceView().getTrimMark();
-            runtime2.getObjectsView().gc(trimToken.getSequence());
-
-            tx2 = corfuStore2.txn(namespace);
-            assertThat(tx2.getRecord(tableName, key).getPayload()).isNull();
-            tx2.commit();
-
-            boolean exception = false;
-            try {
-                TxnContext tx3 = corfuStore2.txn(namespace);
-                Uuid key2 = Uuid.newBuilder().setLsb(2L).setMsb(2L).build();
-                tx3.putRecord(table2, key2, key2, null);
-                tx3.commit();
-            } catch (TransactionAbortedException tae) {
-                exception = true;
-            }
-            assertThat(exception).isTrue();
-            runtime2.shutdown();
-        });
-        secondRuntimeThread.start();
-
-        latch1.await();
-
-        corfuStore.dropTable(namespace, tableName);
-        latch2.countDown();
-        runtime.shutdown();
-
-        // Checkpoint table B and trim.
-        runtime = createRuntime(singleNodeEndpoint);
-        MultiCheckpointWriter<PersistentCorfuTable<?, ?>> mcw = new MultiCheckpointWriter<>();
-        mcw.addMap(runtime.getTableRegistry().getRegistryTable());
-        mcw.addMap(runtime.getTableRegistry().getProtobufDescriptorTable());
-        Token trimPoint = mcw.appendCheckpoints(runtime, "checkpointer");
-        runtime.getAddressSpaceView().prefixTrim(trimPoint);
-        runtime.shutdown();
-
-        latch3.countDown();
-
-        secondRuntimeThread.join();
         assertThat(shutdownCorfuServer(corfuServer)).isTrue();
     }
 


### PR DESCRIPTION
## Overview

Description:
Added a CorfuTable dropTable API which removesa table
from TableRegistry and clear its record in the sequencer's
in-memory maps. The effects of invoking this API is
persisted even after server restarts.

Why should this be merged: 
Avoid RegistryTable leak, and its consequence of TrimmedException when reopening a trimmed table.

Related issue(s) (if applicable): #3251 

## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
