### PR TITLE
Skip maxWriteSize check for CheckpointWriter

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointWriter.java
@@ -267,7 +267,7 @@ public class CheckpointWriter<T extends ICorfuTable<?, ?>> {
      *  Append an object to a stream without caching the entries.
      */
     private long nonCachedAppend(Object object, UUID ... streamIDs) {
-        return sv.append(object, null, CacheOption.WRITE_AROUND, streamIDs);
+        return sv.append(object, null, CacheOption.WRITE_AROUND, true, streamIDs);
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
+++ b/test/src/test/java/org/corfudb/runtime/checkpoint/CheckpointSmokeTest.java
@@ -686,12 +686,12 @@ public class CheckpointSmokeTest extends AbstractViewTest {
     /**
      * When log entry compression is set to NONE and BATCH_THRESHOLD_PERCENTAGE is very small,
      * although the total size of SMR entries could pass the check in appendObjectState(), it
-     * could fail in writing the CheckpointEntry into stream (WriteSizeException) due to the
+     * shouldn't fail in writing the CheckpointEntry as we skip maxWriteSizeLimit check even with
      * slight overhead of packing SMR entries into CheckpointEntry.
      */
-    @Test(expected = WriteSizeException.class)
+    @Test
     @SuppressWarnings("checkstyle:magicnumber")
-    public void checkpointWriterSizeLimitViolationTest() throws Exception {
+    public void checkpointWriterSizeLimitViolationTest() {
         final String streamName = "mystream7";
         final UUID streamId = CorfuRuntime.getStreamID(streamName);
         final String keyPrefix = "a-prefix";


### PR DESCRIPTION
The CheckpointWriter has a check for the max write size limit before calling the StreamsView.append() method. This check is sufficient for the compactor and hence skipping the additional check in StreamsView for CheckpointWriter.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
