### PR TITLE
Fix failing unit tests.

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/collections/TableOptions.java
+++ b/runtime/src/main/java/org/corfudb/runtime/collections/TableOptions.java
@@ -50,12 +50,15 @@ public class TableOptions {
             tableOptionsBuilder = tableOptions.toBuilder();
         }
 
-        V defaultValueMessage = (V) vClass.getMethod("getDefaultInstance").invoke(null);
-        return tableOptionsBuilder.schemaOptions(defaultValueMessage
-                .getDescriptorForType()
-                .getOptions()
-                .getExtension(CorfuOptions.tableSchema))
-                .build();
+        if (vClass != null) { // some test cases pass vClass as null to verify behavior
+            V defaultValueMessage = (V) vClass.getMethod("getDefaultInstance").invoke(null);
+            tableOptionsBuilder.schemaOptions(defaultValueMessage
+                    .getDescriptorForType()
+                    .getOptions()
+                    .getExtension(CorfuOptions.tableSchema));
+        }
+
+        return tableOptionsBuilder.build();
     }
 
     public static <V extends Message> TableOptions fromProtoSchema(@Nonnull Class<V> vClass)

--- a/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/DiskBackedCorfuClientTest.java
@@ -565,17 +565,17 @@ public class DiskBackedCorfuClientTest extends AbstractViewTest implements AutoC
                     .withMessage("Secondary Index anotherKey is not defined.");
         }
         { // Negative test.
-            final Table<Uuid, ExampleValue, SampleSchema.ManagedResources> table1 =
-                    corfuStore.openTable(namespace, tableName,
+            final Table<Uuid, ExampleValue, SampleSchema.ManagedResources> table =
+                    corfuStore.openTable(namespace, tableName + tableName,
                             Uuid.class, ExampleValue.class,
                             SampleSchema.ManagedResources.class,
                             // TableOptions includes option to choose - Memory/Disk based corfu table.
                             TableOptions.fromProtoSchema(ExampleValue.class).toBuilder()
-                                    .persistentDataPath(Paths.get(diskBackedDirectory, tableName))
+                                    .persistentDataPath(Paths.get(diskBackedDirectory, tableName + tableName))
                                     .build());
 
             // Negative test. No throw.
-            table1.getByIndex(ANOTHER_KEY_INDEX, 0L);
+            table.getByIndex(ANOTHER_KEY_INDEX, 0L);
         }
     }
 


### PR DESCRIPTION
For TableOptions, explicit null-checking is requred as javax.annotation.Nonnull does not enforce the check during runtime.

For DiskBackedCorfuClientTest::disableSecondaryIndexes negative test, open a seperate Corfu Table.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
