### PR TITLE
[Backport] Update registry table when CorfuRecord is changed (#3270)

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
+++ b/runtime/src/main/java/org/corfudb/runtime/view/TableRegistry.java
@@ -6,6 +6,7 @@ import com.google.protobuf.DescriptorProtos.FileDescriptorProto;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FileDescriptor;
 import com.google.protobuf.Message;
+import com.google.protobuf.ProtocolStringList;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.corfudb.runtime.CorfuOptions;
@@ -234,6 +235,7 @@ public class TableRegistry {
         } else {
             metadataBuilder.setTableOptions(tableOptions.getSchemaOptions());
         }
+        TableMetadata tableMetadata = metadataBuilder.build();
 
         int numRetries = 9; // Since this is an internal transaction, retry a few times before giving up.
         while (numRetries-- > 0) {
@@ -253,12 +255,17 @@ public class TableRegistry {
                 throw new IllegalThreadStateException("openTable: Called on an existing transaction");
             }
             try {
-                this.runtime.getObjectsView().TXBuild().type(TransactionType.WRITE_AFTER_WRITE).build().begin();
+                this.runtime.getObjectsView().TXBuild()
+                        .type(TransactionType.WRITE_AFTER_WRITE)
+                        .build()
+                        .begin();
+                CorfuRecord<TableDescriptors, TableMetadata> oldRecord =
+                        this.registryTable.get(tableNameKey);
+                CorfuRecord<TableDescriptors, TableMetadata> newRecord =
+                        new CorfuRecord<>(tableDescriptors, tableMetadata);
                 boolean protoFileChanged = tryUpdateTableSchemas(allDescriptors);
-                CorfuRecord<TableDescriptors, TableMetadata> oldRecord = this.registryTable.get(tableNameKey);
-                if (oldRecord == null || protoFileChanged) {
-                    this.registryTable.put(tableNameKey,
-                        new CorfuRecord<>(tableDescriptors, metadataBuilder.build()));
+                if (oldRecord == null || protoFileChanged || tableRecordChanged(oldRecord, newRecord)) {
+                    this.registryTable.insert(tableNameKey, newRecord);
                 }
                 this.runtime.getObjectsView().TXEnd();
                 break;
@@ -273,6 +280,62 @@ public class TableRegistry {
                 }
             }
         }
+    }
+
+    /**
+     * A helper method for comparing CorfuRecord. If the new record is different from old record, the entry
+     * of registry table should be updated accordingly.
+     *
+     * @param oldRecord The record already present in registry table.
+     * @param newRecord The new record that is being registered.
+     * @return True if the two records are different. Otherwise, return false.
+     */
+    private boolean tableRecordChanged(@Nonnull CorfuRecord<TableDescriptors, TableMetadata> oldRecord,
+                                       @Nonnull CorfuRecord<TableDescriptors, TableMetadata> newRecord) {
+        // Both record should have the same table name as TableName is the key of registry table.
+        TableName tableName = newRecord.getMetadata().getTableName();
+        TableDescriptors oldDescriptors = oldRecord.getPayload();
+        TableDescriptors newDescriptors = newRecord.getPayload();
+        CorfuOptions.SchemaOptions oldOptions = oldRecord.getMetadata().getTableOptions();
+        CorfuOptions.SchemaOptions newOptions = newRecord.getMetadata().getTableOptions();
+
+        // Compare TableDescriptors including the types of Key, Value and Metadata.
+        if (!oldDescriptors.getKey().getTypeUrl().equals(newDescriptors.getKey().getTypeUrl()) ||
+            !oldDescriptors.getValue().getTypeUrl().equals(newDescriptors.getValue().getTypeUrl()) ||
+            !oldDescriptors.getMetadata().getTypeUrl().equals(newDescriptors.getMetadata().getTypeUrl())) {
+            log.debug("The record of {} will be updated as TableDescriptors was changed", tableName);
+            return true;
+        }
+
+        // Compare the primitive types in SchemaOptions
+        if (oldOptions.getSecondaryKeyDeprecated() != newOptions.getSecondaryKeyDeprecated() ||
+            oldOptions.getVersion() != newOptions.getVersion() ||
+            oldOptions.getRequiresBackupSupport() != newOptions.getRequiresBackupSupport() ||
+            oldOptions.getIsFederated() != newOptions.getIsFederated() ||
+            oldOptions.getStreamTagCount() != newOptions.getStreamTagCount() ||
+            oldOptions.getSecondaryKeyCount() != newOptions.getSecondaryKeyCount()) {
+            log.debug("The record of {} will be updated as SchemaOptions was changed", tableName);
+            return true;
+        }
+
+
+        ProtocolStringList oldStreamTagList = oldOptions.getStreamTagList();
+        ProtocolStringList newStreamTagList = newOptions.getStreamTagList();
+        // Only needs to check in one direction as their sizes have been compared.
+        if (!oldStreamTagList.containsAll(newStreamTagList)) {
+            log.debug("The record of {} will be updated as stream tags were changed", tableName);
+            return true;
+        }
+
+        List<CorfuOptions.SecondaryIndex> oldSecondaryIndices = oldOptions.getSecondaryKeyList();
+        List<CorfuOptions.SecondaryIndex> newSecondaryIndices = newOptions.getSecondaryKeyList();
+        // Only needs to check in one direction as their sizes have been compared.
+        if (!oldSecondaryIndices.containsAll(newSecondaryIndices)) {
+            log.debug("The record of {} will be updated as secondary keys were changed", tableName);
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
+++ b/test/src/test/java/org/corfudb/runtime/collections/CorfuStoreShimTest.java
@@ -32,6 +32,7 @@ import org.corfudb.test.SampleSchema;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -1203,5 +1204,108 @@ public class CorfuStoreShimTest extends AbstractViewTest {
             CorfuStoreMetadata.Timestamp ts = txnContext.commit();
             assertThat(ts.getSequence()).isPositive();
         }
+    }
+
+    /**
+     * This test verifies that registry table will be updated when a table is opened
+     * again with different schema options.
+     */
+    @Test
+    public void testRegistryTableUpdateOnRecordChange() throws Exception {
+        // Get a Corfu Runtime instance.
+        CorfuRuntime corfuRuntime = getDefaultRuntime();
+
+        // Creating Corfu Store using a connected corfu client.
+        CorfuStoreShim shimStore = new CorfuStoreShim(corfuRuntime);
+
+        // Define a namespace for the table.
+        final String someNamespace = "some-namespace";
+        // Define table name.
+        final String tableName = "EventInfo";
+
+        // Create & Register the table.
+        // This is required to initialize the table for the current corfu client.
+        shimStore.openTable(
+                someNamespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.SampleTableAMsg.class,
+                null,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        CorfuStoreMetadata.TableName tableNameKey =
+                CorfuStoreMetadata.TableName.newBuilder()
+                        .setNamespace(someNamespace)
+                        .setTableName(tableName)
+                        .build();
+        CorfuRecord<CorfuStoreMetadata.TableDescriptors, CorfuStoreMetadata.TableMetadata> record
+                = corfuRuntime.getTableRegistry().getRegistryTable().get(tableNameKey);
+        CorfuOptions.SchemaOptions options = record.getMetadata().getTableOptions();
+
+        assertThat(options.getIsFederated()).isTrue();
+        assertThat(options.getRequiresBackupSupport()).isTrue();
+        assertThat(options.getStreamTag(0)).isEqualTo("sample_streamer_1");
+        assertThat(options.getStreamTag(1)).isEqualTo("sample_streamer_2");
+
+        // Open the same table again with different schema options, verify that registry table
+        // gets updated
+        shimStore.openTable(
+                someNamespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.SampleTableBMsg.class,
+                null,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        record = corfuRuntime.getTableRegistry().getRegistryTable().get(tableNameKey);
+        options = record.getMetadata().getTableOptions();
+
+        assertThat(options.getIsFederated()).isTrue();
+        assertThat(options.getRequiresBackupSupport()).isFalse();
+        assertThat(options.getStreamTag(0)).isEqualTo("sample_streamer_2");
+        assertThat(options.getStreamTag(1)).isEqualTo("sample_streamer_3");
+
+        // Open the same table again with different schema options, verify that registry table
+        // gets updated
+        shimStore.openTable(
+                someNamespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.SampleTableBMsg.class,
+                null,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        record = corfuRuntime.getTableRegistry().getRegistryTable().get(tableNameKey);
+        options = record.getMetadata().getTableOptions();
+
+        assertThat(options.getIsFederated()).isTrue();
+        assertThat(options.getRequiresBackupSupport()).isFalse();
+        assertThat(options.getStreamTagCount()).isEqualTo(2);
+        assertThat(options.getStreamTag(0)).isEqualTo("sample_streamer_2");
+        assertThat(options.getStreamTag(1)).isEqualTo("sample_streamer_3");
+
+        // Open the same table again with different schema options, verify that registry table
+        // gets updated
+        shimStore.openTable(
+                someNamespace,
+                tableName,
+                SampleSchema.Uuid.class,
+                SampleSchema.SampleTableEMsg.class,
+                null,
+                // TableOptions includes option to choose - Memory/Disk based corfu table.
+                TableOptions.builder().build());
+
+        record = corfuRuntime.getTableRegistry().getRegistryTable().get(tableNameKey);
+        options = record.getMetadata().getTableOptions();
+
+        assertThat(options.getIsFederated()).isTrue();
+        assertThat(options.getRequiresBackupSupport()).isFalse();
+        assertThat(options.getStreamTagCount()).isEqualTo(1);
+        assertThat(options.getStreamTag(0)).isEqualTo("sample_streamer_4");
+        assertThat(options.getSecondaryKeyCount()).isEqualTo(1);
+        assertThat(options.getSecondaryKey(0).getIndexPath()).isEqualTo("event_time");
     }
 }

--- a/test/src/test/resources/proto/sample_schema.proto
+++ b/test/src/test/resources/proto/sample_schema.proto
@@ -97,6 +97,16 @@ message SampleTableDMsg {
     optional string payload = 1;
 }
 
+message SampleTableEMsg {
+    option (org.corfudb.runtime.table_schema).stream_tag = "sample_streamer_4";
+    option (org.corfudb.runtime.table_schema).requires_backup_support = false;
+    option (org.corfudb.runtime.table_schema).is_federated = true;
+    option (org.corfudb.runtime.table_schema).secondary_key = { index_path: "event_time"};
+
+    optional string payload = 1;
+    optional int64 event_time = 2;
+}
+
 extend google.protobuf.MessageOptions {
     optional ManagedResourceOptionsMsg mgoptions = 54312;
 }


### PR DESCRIPTION
Registry table needs to be updated when the CorfuRecord for a table is changed, even if there is already an entry for that table.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [X] There are no TODOs left in the code
- [X] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [X] Change is covered by automated tests
- [X] Public API has Javadoc
