### PR TITLE
Codecov: Allow 0.2% coverage threshold

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,4 @@
+# Ref: https://docs.codecov.com/docs/codecov-yaml
 coverage:
   precision: 2
   round: nearest
@@ -5,5 +6,11 @@ coverage:
   ignore:
     - "generator/src/main/java/**/*"
     - "samples/**/*"
+  # Ref: https://docs.codecov.com/docs/commit-status
   status:
-    patch: off
+    patch:
+      off
+    project:
+      default:
+        target: auto
+        threshold: 0.2%


### PR DESCRIPTION

## Overview

Description:
- Add a 0.2% code coverage threshold to account for flaky tests.
Due to Flaky tests, their coverage ends up missing or is reported incorrectly.
This leads to a negative coverage value in the aggregated report even when the PRs do not actually reduce the coverage. This erroneous diff usually is less than -0.2% (https://app.codecov.io/gh/CorfuDB/CorfuDB/commits).

- Configuration Reference: https://docs.codecov.com/docs/commit-status#threshold
  > "Allow the coverage to drop by X%, and posting a success status."

Why should this be merged: 
Corrects check marks to green in GitHub Actions for code coverage.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
