### PR TITLE
Handle exception thrown during init of CompactorService

### DIFF
--- a/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
+++ b/infrastructure/src/main/java/org/corfudb/infrastructure/CompactorService.java
@@ -40,9 +40,9 @@ public class CompactorService implements ManagementService {
     private final InvokeCheckpointing checkpointerJvmManager;
     private final CompactionTriggerPolicy compactionTriggerPolicy;
 
-    private Optional<CompactorLeaderServices> compactorLeaderServices = Optional.empty();
-    private Optional<CorfuStore> corfuStore = Optional.empty();
-    private Optional<DistributedCheckpointerHelper> distributedCheckpointerHelper = Optional.empty();
+    private Optional<CompactorLeaderServices> optionalCompactorLeaderServices = Optional.empty();
+    private Optional<CorfuStore> optionalCorfuStore = Optional.empty();
+    private Optional<DistributedCheckpointerHelper> optionalDistributedCheckpointerHelper = Optional.empty();
     private TrimLog trimLog;
     private final Logger log;
     private static final Duration LIVENESS_TIMEOUT = Duration.ofMinutes(1);
@@ -79,7 +79,6 @@ public class CompactorService implements ManagementService {
             return;
         }
 
-        getCompactorLeaderServices();
         this.trimLog = new TrimLog(getCorfuRuntime(), getCorfuStore());
 
         orchestratorThread.scheduleWithFixedDelay(
@@ -92,36 +91,38 @@ public class CompactorService implements ManagementService {
     }
 
     @VisibleForTesting
-    public CompactorLeaderServices getCompactorLeaderServices() {
-        if (!compactorLeaderServices.isPresent()) {
+    public CompactorLeaderServices getCompactorLeaderServices() throws Exception {
+        if (!optionalCompactorLeaderServices.isPresent()) {
             try {
-                compactorLeaderServices = Optional.of(new CompactorLeaderServices(getCorfuRuntime(),
+                optionalCompactorLeaderServices = Optional.of(new CompactorLeaderServices(getCorfuRuntime(),
                         serverContext.getLocalEndpoint(), getCorfuStore(),
                         new LivenessValidator(getCorfuRuntime(), getCorfuStore(), LIVENESS_TIMEOUT)));
-            } catch (Exception e) {
-                log.error("Unable to create CompactorLeaderServices object. Will retry on next attempt. Exception: ", e);
+            } catch (Exception ex) {
+                log.error("Unable to create CompactorLeaderServices object. Will retry on next attempt. Exception: ", ex);
+                throw ex;
             }
         }
-        return compactorLeaderServices.get();
+        return optionalCompactorLeaderServices.get();
     }
 
     @VisibleForTesting
     public CorfuStore getCorfuStore() {
-        if (!this.corfuStore.isPresent()) {
-            this.corfuStore = Optional.of(new CorfuStore(getCorfuRuntime()));
+        if (!this.optionalCorfuStore.isPresent()) {
+            this.optionalCorfuStore = Optional.of(new CorfuStore(getCorfuRuntime()));
         }
-        return this.corfuStore.get();
+        return this.optionalCorfuStore.get();
     }
 
-    private DistributedCheckpointerHelper getDistributedCheckpointerHelper() {
-        if (!distributedCheckpointerHelper.isPresent()) {
+    private DistributedCheckpointerHelper getDistributedCheckpointerHelper() throws Exception {
+        if (!optionalDistributedCheckpointerHelper.isPresent()) {
             try {
-                distributedCheckpointerHelper = Optional.of(new DistributedCheckpointerHelper(getCorfuStore()));
-            } catch (Exception e) {
-                log.error("Failed to obtain a DistributedCheckpointerHelper. Will retry on next attempt. Exception: ", e);
+                optionalDistributedCheckpointerHelper = Optional.of(new DistributedCheckpointerHelper(getCorfuStore()));
+            } catch (Exception ex) {
+                log.error("Failed to obtain a DistributedCheckpointerHelper. Will retry on next attempt. Exception: ", ex);
+                throw ex;
             }
         }
-        return distributedCheckpointerHelper.get();
+        return optionalDistributedCheckpointerHelper.get();
     }
 
     /**
@@ -135,50 +136,50 @@ public class CompactorService implements ManagementService {
             boolean isLeader = isNodePrimarySequencer(updateLayoutAndGet());
             log.trace("Current node isLeader: {}", isLeader);
 
+            CompactorLeaderServices compactorLeaderServices = getCompactorLeaderServices();
+
             CheckpointingStatus managerStatus = null;
             try (TxnContext txn = getCorfuStore().txn(CORFU_SYSTEM_NAMESPACE)) {
                 managerStatus = (CheckpointingStatus) txn.getRecord(
                         CompactorMetadataTables.COMPACTION_MANAGER_TABLE_NAME,
                         CompactorMetadataTables.COMPACTION_MANAGER_KEY).getPayload();
                 if (managerStatus == null && isLeader) {
-                    txn.putRecord(getCompactorLeaderServices().getCompactorMetadataTables().getCompactionManagerTable(),
+                    txn.putRecord(compactorLeaderServices.getCompactorMetadataTables().getCompactionManagerTable(),
                             CompactorMetadataTables.COMPACTION_MANAGER_KEY,
                             CheckpointingStatus.newBuilder().setStatus(StatusType.IDLE).setCycleCount(0).build(), null);
                 }
                 txn.commit();
-            } catch (Exception e) {
-                log.error("Unable to acquire manager status: ", e);
+            } catch (Exception ex) {
+                log.error("Unable to acquire manager status: ", ex);
                 return;
             }
-            try {
-                if (isLeader) {
-                    if (managerStatus != null && managerStatus.getStatus() == StatusType.STARTED) {
-                        if (getDistributedCheckpointerHelper().isCompactionDisabled()) {
-                            log.info("Compaction has been disabled. Force finish compaction cycle as it already started");
-                            getCompactorLeaderServices().finishCompactionCycle();
-                        } else {
-                            getCompactorLeaderServices().validateLiveness();
-                        }
-                    } else if (compactionTriggerPolicy.shouldTrigger(
-                            getCorfuRuntime().getParameters().getCheckpointTriggerFreqMillis(), getCorfuStore())) {
-                        trimLog.invokePrefixTrim();
-                        compactionTriggerPolicy.markCompactionCycleStart();
-                        getCompactorLeaderServices().initCompactionCycle();
+            if (isLeader) {
+                if (managerStatus != null && managerStatus.getStatus() == StatusType.STARTED) {
+                    if (getDistributedCheckpointerHelper().isCompactionDisabled()) {
+                        log.info("Compaction has been disabled. Force finish compaction cycle as it already started");
+                        compactorLeaderServices.finishCompactionCycle();
+                    } else {
+                        compactorLeaderServices.validateLiveness();
                     }
+                } else if (compactionTriggerPolicy.shouldTrigger(
+                        getCorfuRuntime().getParameters().getCheckpointTriggerFreqMillis(), getCorfuStore())) {
+                    trimLog.invokePrefixTrim();
+                    compactionTriggerPolicy.markCompactionCycleStart();
+                    compactorLeaderServices.initCompactionCycle();
                 }
-                if (managerStatus != null) {
-                    if (managerStatus.getStatus() == StatusType.FAILED || managerStatus.getStatus() == StatusType.COMPLETED) {
-                        checkpointerJvmManager.shutdown();
-                    } else if (managerStatus.getStatus() == StatusType.STARTED && !checkpointerJvmManager.isRunning()
-                            && !checkpointerJvmManager.isInvoked()) {
-                        checkpointerJvmManager.invokeCheckpointing();
-                    }
-                }
-            } catch (Exception ex) {
-                log.warn("Exception in runOrcestrator(): ", ex);
             }
+            if (managerStatus != null) {
+                if (managerStatus.getStatus() == StatusType.FAILED || managerStatus.getStatus() == StatusType.COMPLETED) {
+                    checkpointerJvmManager.shutdown();
+                } else if (managerStatus.getStatus() == StatusType.STARTED && !checkpointerJvmManager.isRunning()
+                        && !checkpointerJvmManager.isInvoked()) {
+                    checkpointerJvmManager.invokeCheckpointing();
+                }
+            }
+        } catch (Exception ex) {
+          log.error("Exception in runOrchestrator(): ", ex);
         } catch (Throwable t) {
-            log.error("Encountered unexpected exception in runOrchestrator: ", t);
+            log.error("Encountered unexpected exception in runOrchestrator(): ", t);
             throw t;
         }
     }


### PR DESCRIPTION
When initializing optional variables in CompactorService, if there's any exception, it's not handled and hence results in the CompactorService thread being killed. This leads to the runOrchestrator not being invoked and so compactor never gets triggered. This commit fixes the above issue.

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
