### PR TITLE
Fix log level for CheckpointLivenessUpdater logs

### DIFF
--- a/runtime/src/main/java/org/corfudb/runtime/CheckpointLivenessUpdater.java
+++ b/runtime/src/main/java/org/corfudb/runtime/CheckpointLivenessUpdater.java
@@ -67,7 +67,7 @@ public class CheckpointLivenessUpdater implements LivenessUpdater {
         try {
             table = currentTable.get();
         } catch (NoSuchElementException e) {
-            log.info("Encountered NoSuchElementException while accessing currentTable, ", e);
+            log.debug("Encountered NoSuchElementException while accessing currentTable, ", e);
             return;
         }
 


### PR DESCRIPTION
The CheckpointLivenessUpdater has misleading log level causing uncertainity while debugging

## Overview

Description:

Why should this be merged: 

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [ ] There are no TODOs left in the code
- [ ] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [ ] Change is covered by automated tests
- [ ] Public API has Javadoc
