### PR TITLE
Bump netty version from 4.1.77 to 4.1.89

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,8 @@
 
         <!-- Dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>
-        <netty.version>4.1.77.Final</netty.version>
-        <netty.tcnative.version>2.0.52.Final</netty.tcnative.version>
+        <netty.version>4.1.87.Final</netty.version>
+        <netty.tcnative.version>2.0.56.Final</netty.tcnative.version>
         <protobuf.version>3.6.1</protobuf.version>
         <commons.io.version>2.11.0</commons.io.version>
         <lombok.version>1.18.24</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
         <!-- Dependency versions -->
         <slf4j.version>1.7.32</slf4j.version>
-        <netty.version>4.1.87.Final</netty.version>
+        <netty.version>4.1.89.Final</netty.version>
         <netty.tcnative.version>2.0.56.Final</netty.tcnative.version>
         <protobuf.version>3.6.1</protobuf.version>
         <commons.io.version>2.11.0</commons.io.version>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -24,7 +24,7 @@
         <annotations.api.version>6.0.53</annotations.api.version>
         <ehcahce.sizeOf.version>0.4.0</ehcahce.sizeOf.version>
 
-        <grpc.version>1.46.0</grpc.version>
+        <grpc.version>1.54.0</grpc.version>
     </properties>
 
     <build>


### PR DESCRIPTION
## Overview
Description:
Bump netty versions to fix [CVE-2022-41881](https://nvd.nist.gov/vuln/detail/CVE-2022-41881).
Compatibility: https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty.

```
grpc.version 1.54.0
netty.version 4.1.89.Final
netty.tcnative.version 2.0.56.Final
```
grpc-java version upgrade PR: https://github.com/grpc/grpc-java/pull/9784


Why should this be merged: Fixes Vulnerabilities.

Related issue(s) (if applicable): #<number>


## Checklist (Definition of Done):

- [x] There are no TODOs left in the code
- [x] [Coding conventions](https://github.com/CorfuDB/CorfuDB/wiki/Corfu-Style-Guidelines) (e.g. for logging, unit tests) have been followed
- [x] Change is covered by automated tests
- [x] Public API has Javadoc
